### PR TITLE
Phase3: OctoBotシグナルAPIと安全弁ロジックの実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# macOS
+.DS_Store
+
+# Python bytecode
+__pycache__/
+*.pyc
+
+# Phase seed zip files
+phase*_seed_files.zip

--- a/docs/03_directory_structure.md
+++ b/docs/03_directory_structure.md
@@ -1,48 +1,78 @@
 # 03_directory_structure.md
 # ディレクトリ構成
 
+Ultra AutoTrade プロジェクト全体のディレクトリ構成と、  
+各ディレクトリ／ファイルの役割をまとめる。
+
+---
+
 project root/
 ├── backend/
-│ ├── app/
-│ │ ├── main.py                 # FastAPIエントリーポイント
-│ │ ├── ai/                     # AI解析ロジック（Phase2以降）
-│ │ ├── notion/                 # Notion連携モジュール（Phase1）
-│ │ │ ├── __init__.py          # Notion連携パッケージマーカー
-│ │ │ ├── config.py            # Notion API設定（環境変数読み取り）
-│ │ │ ├── client.py            # Notion APIクライアント（HTTP通信）
-│ │ │ ├── service.py           # Notionレコード取得・内部モデル変換サービス層
-│ │ │ ├── schemas.py           # NotionNewsItem / NotionIngestResponse スキーマ
-│ │ │ └── router.py            # /notion/ingest エンドポイント定義
-│ │ ├── bots/                  # OctoBot連携（別フェーズ）
-│ │ ├── aave/                  # Aave運用ロジック（別フェーズ）
-│ │ ├── automation/            # 自動実行・スケジューラ関連
-│ │ └── utils/
-│ │     └── config.py          # 共通環境変数ユーティリティ（get_env など）
-│ ├── tests/
-│ │ ├── test_notion_client.py  # Notion APIクライアントのユニットテスト
-│ │ └── test_notion_router.py  # /notion/ingest APIのテスト
-│ └── requirements.txt         # backend依存パッケージ一覧
+│   ├── app/
+│   │   ├── main.py                 # FastAPI エントリーポイント（create_app, ルータマウント）
+│   │   ├── ai/                     # AI解析ロジック（Phase2 以降）
+│   │   │   ├── __init__.py         # AI モジュールパッケージマーカー
+│   │   │   ├── schemas.py          # AIAnalysisRequest/Response, AIAnalysisResult, TradeAction など
+│   │   │   ├── service.py          # ニュース文から BUY/SELL/HOLD を決定するサービス層
+│   │   │   └── router.py           # POST /ai/analyze エンドポイント
+│   │   ├── notion/                 # Notion 連携モジュール（Phase1）
+│   │   │   ├── __init__.py         # Notion 連携パッケージマーカー
+│   │   │   ├── config.py           # Notion API 設定（環境変数読み取り）
+│   │   │   ├── client.py           # Notion API クライアント（HTTP 通信）
+│   │   │   ├── service.py          # Notion レコード取得・内部モデル変換サービス層
+│   │   │   ├── schemas.py          # NotionNewsItem / NotionIngestResponse スキーマ
+│   │   │   └── router.py           # POST /notion/ingest エンドポイント定義
+│   │   ├── bots/                   # OctoBot 連携モジュール（Phase3）
+│   │   │   ├── __init__.py         # パッケージマーカー
+│   │   │   ├── config.py           # OctoBot API のエンドポイント/キー/タイムアウト設定
+│   │   │   ├── schemas.py          # /octobot/signal 用の Request/Response スキーマ
+│   │   │   ├── client.py           # OctoBot 外部シグナル API クライアント
+│   │   │   ├── service.py          # AIAnalysisResult → シグナル生成・送信ロジック
+│   │   │   └── router.py           # POST /octobot/signal エンドポイント
+│   │   ├── aave/                   # Aave 運用ロジック（別フェーズで実装）
+│   │   ├── automation/             # 自動実行・スケジューラ関連（将来拡張）
+│   │   └── utils/
+│   │       ├── __init__.py         # 共通ユーティリティパッケージマーカー
+│   │       └── config.py           # 共通環境変数ユーティリティ（get_env など）
+│   ├── tests/
+│   │   ├── conftest.py             # テスト共通設定（app インポート・環境変数など）
+│   │   ├── test_notion_client.py   # Notion API クライアントのユニットテスト
+│   │   ├── test_notion_router.py   # /notion/ingest API のテスト
+│   │   ├── test_ai_service.py      # AI 判定ロジック（BUY/SELL/HOLD, 信頼度レンジ）のユニットテスト
+│   │   ├── test_ai_router.py       # /ai/analyze API のテスト
+│   │   ├── test_octobot_client.py  # OctoBotクライアントのユニットテスト
+│   │   ├── test_octobot_service.py # OctoBotサービス（安全弁・レート制限）のテスト
+│   │   ├── test_octobot_router.py  # /octobot/signal API のテスト
+│   │   └── test_smoke.py           # バックエンド全体のスモークテスト
+│   └── requirements.txt            # backend 依存パッケージ一覧
 │
 ├── frontend/
-│ ├── pages/
-│ ├── components/
-│ └── api/
+│   ├── pages/                      # 画面ルーティング（Next.js 等を想定）
+│   ├── components/                 # UI コンポーネント
+│   └── api/                        # フロントエンド側 API 呼び出しラッパ
 │
 ├── docs/
-│ ├── 00_overview.md
-│ ├── 01_requirements.md
-│ ├── 02_phase_plan.md
-│ ├── 03_directory_structure.md
-│ ├── 04_api_design.md
-│ ├── 05_ai_judgement_rules.md
-│ ├── 06_octobot_signal_flow.md
-│ ├── 07_aave_operation_logic.md
-│ ├── 08_automation_rules.md
-│ └── 09_notion_schema.md
+│   ├── 00_overview.md              # プロジェクト全体概要
+│   ├── 01_requirements.md          # 要求仕様・非機能要件
+│   ├── 02_phase_plan.md            # フェーズ別開発計画
+│   ├── 03_directory_structure.md   # 本ファイル（ディレクトリ構成）
+│   ├── 04_api_design.md            # Backend API 設計 (/notion/ingest, /ai/analyze, /octobot/signal, /aave/...)
+│   ├── 05_ai_judgement_rules.md    # AI 判定ルール（BUY/SELL/HOLD 条件 等）
+│   ├── 06_octobot_signal_flow.md   # OctoBot 連携フローとシグナル構造
+│   ├── 07_aave_operation_logic.md  # Aave 運用ロジック・リスク管理
+│   ├── 08_automation_rules.md      # 自動化・監視・アラートルール
+│   ├── 09_notion_schema.md         # Notion DB スキーマと内部モデル対応
+│   ├── 10_next_phase_prompt_generator.md # 次フェーズ用プロンプト生成ルール
+│   ├── 11_prompt_sync_rules.md     # GPT プロンプト同期ルール
+│   ├── 12_phase_operations.md      # フェーズ運用ルール・進め方
+│   ├── 13_security_design.md       # セキュリティ設計
+│   ├── 14_test_strategy.md         # テスト戦略
+│   └── 15_rollback_procedures.md   # ロールバック手順
 │
 ├── scripts/
-│ ├── backup.sh
-│ ├── monitor.sh
-│ └── zip_next_phase.sh
+│   ├── backup.sh                   # バックアップスクリプト
+│   ├── monitor.sh                  # 死活監視・メトリクス監視スクリプト
+│   ├── zip_phase2_seed.sh          # Phase2 用 seed ファイル ZIP 生成
+│   └── zip_phase3_seed.sh          # Phase3 用 seed ファイル ZIP 生成
 │
-└── README.md
+└── README.md                       # プロジェクト概要・セットアップ手順

--- a/docs/04_api_design.md
+++ b/docs/04_api_design.md
@@ -134,7 +134,48 @@ project root/
 │ │ │ └── router.py             # /notion/ingest エンドポイント定義
 
 ### 3. /octobot/signal
-AIの判定をOctoBotに送る。
+
+AI が出した判定結果（AIAnalysisResult相当）をもとに、OctoBot 外部シグナルAPIへ送るための窓口。
+
+- Method: `POST`
+- Path: `/octobot/signal`
+
+#### 3.1 Request
+
+```json
+{
+  "signals": [
+    {
+      "id": "string",              // シグナルの一意なID（NotionレコードIDなど）
+      "url": "string | null",      // ニュースURL（任意）
+      "action": "BUY | SELL | HOLD",
+      "confidence": 85,            // 0〜100
+      "reason": "string",          // なぜそのアクションになったか
+      "timestamp": "2025-01-01T00:00:00Z"
+    }
+  ],
+  "count": 1                        // signals配列の件数（整合チェック用）
+}
+count と signals.length が一致しない場合、400 Bad Request。
+
+3.2 Response
+
+{
+  "success_count": 1,              // OctoBotヘの送信成功件数
+  "skipped_count": 0,              // 安全弁によりスキップされた件数
+  "failed_count": 0,               // 送信エラー件数
+  "details": [
+    {
+      "id": "string",
+      "status": "sent | skipped | failed",
+      "message": "string | null"   // エラー内容やスキップ理由
+    }
+  ]
+}
+
+- 200: リクエスト自体は正常に処理された（success/skipped/failed の内訳は details 参照）。
+- 400: count と signals.length が不整合など、クライアント入力エラー。
+- 500: サーバ内部エラー（OctoBot APIのエラーなど詳細はログで追跡）。
 
 ### 4. /aave/rebalance
 BUY/SELL/HOLDに応じて資産操作。

--- a/docs/06_octobot_signal_flow.md
+++ b/docs/06_octobot_signal_flow.md
@@ -1,16 +1,256 @@
 # 06_octobot_signal_flow.md
 # OctoBot連携仕様
 
-## シグナル構造
+Ultra AutoTrade における  
+**AI → OctoBot → Aave** のうち、  
+本フェーズで扱う **AI → OctoBot（シグナル連携）** の仕様をまとめる。
+
+---
+
+## 1. シグナル構造（OctoBot 外部API向け・基本形）
+
+OctoBot 外部シグナル API に送信されるペイロードの基本形は次のとおり：
+
+```json
 {
   "action": "BUY",
   "confidence": 85,
   "reason": "Positive market sentiment",
-  "timestamp": ""
+  "timestamp": "2025-01-01T00:00:00Z"
+}
+````
+
+* `action`
+
+  * BUY / SELL / HOLD
+  * 判定ロジックは `docs/05_ai_judgement_rules.md` に従う。
+* `confidence`
+
+  * 0〜100 の信頼度スコア。
+  * 低すぎる場合は「シグナルを送らない（HOLD扱い）」方向で扱う。
+* `reason`
+
+  * なぜそのアクションになったかの要約テキスト。
+* `timestamp`
+
+  * AI 判定時刻（ISO8601, UTC 推奨）。
+
+---
+
+## 2. コンポーネントと役割
+
+### 2.1 AI モジュール（backend/app/ai）
+
+* `/ai/analyze` エンドポイントを提供。
+* 入力: `NotionNewsItem[]`（/notion/ingest の出力）。
+* 出力: `AIAnalysisResult[]`
+
+  * `id, url, action, confidence, sentiment, summary, reason, timestamp` など。
+
+### 2.2 OctoBot シグナルAPI（backend/app/bots）
+
+* `/octobot/signal` エンドポイントを提供。
+* 入力: `AIAnalysisResult` をベースにしたシグナル配列。
+* 処理:
+
+  * 信頼度しきい値 / 連続トレード制限などの安全弁を適用。
+  * 送信対象と判断されたシグナルのみ OctoBot 外部 API へ送信。
+* 出力:
+
+  * `success_count / skipped_count / failed_count` と、各シグナルのステータス詳細。
+
+### 2.3 OctoBot 外部シグナルAPI
+
+* 本システムからは `bots.client` 経由で HTTP 通信。
+* 受け取ったシグナルを元に、戦略の切り替えやポジション調整を行う。
+
+### 2.4 Aave 運用モジュール（別フェーズ）
+
+* BUY → deposit, SELL → withdraw, HOLD → 何もしない
+  というマッピングは `docs/07_aave_operation_logic.md` に定義。
+* 本ドキュメントでは詳細ロジックには踏み込まず、
+  「OctoBot のシグナルが Aave 操作に最終的に影響する」という前提のみ記載する。
+
+---
+
+## 3. データフロー詳細
+
+### 3.1 Notion → AI
+
+1. `/notion/ingest`
+
+   * Notion DB から `Status = 未処理` のニュースを取得。
+   * `NotionNewsItem[]` としてバックエンドに返す。
+2. `/ai/analyze`
+
+   * `NotionNewsItem[]` を入力として、ニュースごとに AI 判定を実施。
+   * `AIAnalysisResult[]` を返す。
+
+* `signals[*]` は `AIAnalysisResult` 相当。
+* `id`, `url` は内部トレーサビリティ用の情報として扱う。
+
+3. `/octobot/signal` 内部では `bots.service` が以下を行う：
+
+   * 信頼度がしきい値未満のシグナル → 「skipped（送信しない）」判定。
+   * 連続トレード制限・過剰取引ルールに抵触するシグナル → 「skipped」判定。
+     （ルール詳細は `docs/08_automation_rules.md` を参照）
+   * 送信対象になったシグナル → `bots.client` を通じて OctoBot 外部 API に送信。
+
+### 3.2 AI → /octobot/signal
+
+1. クライアント（もしくはバッチ処理）が `/ai/analyze` の結果 `AIAnalysisResult[]` を取得。
+2. `/octobot/signal` に対して、次のようなボディでリクエストを送る：
+
+```json
+{
+  "signals": [
+    {
+      "id": "notion-page-id-1",
+      "url": "https://example.com/news1",
+      "action": "BUY",
+      "confidence": 80,
+      "reason": "ポジティブなニュースが多く、市場全体の上昇トレンドが継続しているため",
+      "timestamp": "2025-12-07T08:09:35.007682Z"
+    }
+  ],
+  "count": 1
+}
+```
+- 200: リクエスト自体は正常に処理された（success/skipped/failed の内訳は details 参照）。
+- 400: count と signals.length が不整合など、クライアント入力エラー。
+- 500: サーバ内部エラー（OctoBot APIのエラーなど詳細はログで追跡）。
+
+
+---
+
+### 1-3. `docs/06_octobot_signal_flow.md`
+
+**更新対象**
+
+- シグナル構造
+- 処理フロー（安全弁の追加）
+
+**修正案**
+
+```md
+## シグナル構造（AI → /octobot/signal）
+
+```json
+{
+  "action": "BUY",
+  "confidence": 85,
+  "reason": "Positive market sentiment",
+  "timestamp": "2025-01-01T00:00:00Z"
 }
 
-## 処理フロー
-1. AIからの判定を受け取る
-2. OctoBotの外部シグナルAPIへ送信
-3. OctoBotは戦略を切り替えまたはポジション調整
-4. ログを記録
+※ 実際のリクエストボディでは、これに加えて id, url を含む signals[] 配列として送信する。
+処理フロー
+1. /octobot/signal エンドポイントが AI からの判定結果（signals[]）を受け取る
+2. OctoBotService が以下の安全弁を適用
+- 信頼度しきい値チェック（confidence < min_confidence は SKIPPED）
+- 1時間以内の同一アクション回数チェック（max_same_action_per_hour を超過した分は SKIPPED）
+3. 送信対象のシグナルのみ OctoBot 外部シグナルAPIへ送信
+4. 送信結果を success/skipped/failed に集計し、レスポンスとして返す
+5. 主要なイベント（送信成功/失敗、スキップ理由）はログに記録される想定
+
+
+---
+
+### 1-4. `docs/08_automation_rules.md`
+
+**更新対象アイデア**
+
+- 「過剰取引制御」の項目に、現状実装されているレート制限ルールを明文化。
+
+**追記案（イメージ）**
+
+```md
+### 2. 過剰取引制御（OctoBotシグナル生成側）
+
+- 信頼度しきい値
+  - `confidence < min_confidence` のシグナルは `/octobot/signal` 側で SKIPPED とする。
+- 連続トレード制限（Phase3実装）
+  - 1時間以内に同一アクション（BUY / SELL / HOLD）が `max_same_action_per_hour` 回を超える場合、
+    それ以降のシグナルは `/octobot/signal` 側で SKIPPED とする。
+  - Phase3 のデフォルト値: `max_same_action_per_hour = 3`
+
+### 3.3 /octobot/signal → OctoBot 外部API
+
+* `bots.client` は `config.py` で定義された
+
+  * `OCTOBOT_API_BASE_URL`
+  * `OCTOBOT_API_KEY`
+  * `OCTOBOT_TIMEOUT_SECONDS`
+    を用いて外部 API を呼び出す。
+* OctoBot には、基本形 `{action, confidence, reason, timestamp}` の JSON を POST する。
+* OctoBot 側はこのシグナルをトリガに
+
+  * ストラテジ切り替え
+  * 新規ポジション/クローズ
+    などを行う（詳細は OctoBot 側の戦略設定に依存）。
+
+---
+
+## 4. AIAnalysisResult からシグナルへのマッピング
+
+`AIAnalysisResult` から OctoBot シグナル構造への対応表：
+
+| AIAnalysisResult フィールド | OctoBot シグナル フィールド | 備考                      |
+| ---------------------- | ------------------ | ----------------------- |
+| action                 | action             | BUY / SELL / HOLD       |
+| confidence             | confidence         | 0〜100 のスコアをそのまま利用       |
+| reason                 | reason             | なぜその action になったかの要約    |
+| timestamp              | timestamp          | AI 判定時刻（ISO8601, UTC推奨） |
+| id                     | （内部のみ）             | ログ・トレース用。外部には送られない場合あり  |
+| url                    | （内部のみ）             | デバッグや検証時に参照するための補助情報    |
+
+---
+
+## 5. エラー時の扱い（概要）
+
+### 5.1 安全弁ロジック（送信前）
+
+* 信頼度が内部しきい値未満、または
+  `docs/05_ai_judgement_rules.md` / `docs/08_automation_rules.md` で定義された
+  過剰取引・連続トレード制限に抵触する場合：
+
+  * `/octobot/signal` 内部で「skipped」として扱い、外部 API には送信しない。
+  * レスポンスの `skipped_count` と `details[*].status = "skipped"` に反映する。
+
+### 5.2 外部APIエラー
+
+* OctoBot 外部シグナル API が 4xx/5xx を返却、またはタイムアウトした場合：
+
+  * 対象シグナルは「failed」として扱う。
+  * `/octobot/signal` のレスポンスで
+
+    * `failed_count` のカウント増加
+    * `details[*].status = "failed"`
+    * `details[*].message` にエラー内容（機密情報を含まない要約）を格納。
+  * 具体的なリトライ回数・連続エラー時の停止ルールは
+    `docs/08_automation_rules.md` と `docs/15_rollback_procedures.md` に従って設計・実装する。
+
+### 5.3 致命的エラー
+
+* バックエンド内部で予期しない例外が発生した場合：
+
+  * `/octobot/signal` は 500 系のエラーを返却。
+  * ログにはスタックトレースを記録するが、レスポンスには詳細を含めない。
+  * ロールバック／緊急停止条件は `docs/15_rollback_procedures.md` に従う。
+
+---
+
+## 6. ログと監視
+
+* 送信成功・スキップ・失敗それぞれについて、最低限次の情報をログに残す：
+
+  * シグナル ID（`AIAnalysisResult.id`）
+  * action / confidence
+  * status（sent / skipped / failed）
+  * OctoBot からのレスポンスコード（可能な範囲で）
+* ログを元に、`docs/08_automation_rules.md` で定義された
+
+  * エラー率
+  * 応答時間
+  * 連続エラー回数
+    などの監視指標を集計し、アラート／緊急停止をトリガする。

--- a/docs/14_test_strategy.md
+++ b/docs/14_test_strategy.md
@@ -4,90 +4,197 @@ Ultra AutoTrade – テスト戦略
 ---
 
 # 1. テストの目的
+
 Notion → AI → OctoBot → Aave のフローが  
-「誤作動しない」「損失を生まない」「再現性がある」ことを保証する。
+
+- 誤作動しない  
+- 不要な損失を生まない  
+- 同じ入力に対して同じ結果が再現できる  
+
+ことを保証する。
 
 ---
 
-# 2. テスト構成
+# 2. テスト構成（レベル）
 
 - Unit Test（モジュール単体）
+  - 例: AI 判定ロジック, Notion クライアント, OctoBot クライアント, Aave 操作ユーティリティ 等
 - Integration Test（2つ以上の連携）
+  - 例: Notion → AI, AI → OctoBot, OctoBot → Aave
 - Scenario Test（連続動作）
-...
+  - ニュース複数件を時間順に処理するシナリオテスト
+- E2E Test（テストネット）
+  - 実際のテストネット上で Aave スマートコントラクトを叩く検証
+- Regression Test（回帰テスト）
+  - PR 時に自動実行する一括テスト（AI判定・統合フロー）
+
+---
 
 ## 2.1 Unit Test 詳細（AI 周り）
 
-- `backend/tests/test_ai_service.py`  
-  - 入力ニュース文（ポジティブ / ネガティブ / 中立）に対して、  
-    `TradeAction` が BUY / SELL / HOLD の期待値どおりになるかを確認。
-  - 信頼度スコアが 0〜100 の範囲に収まることを確認。
+- 対象ファイル
+  - `backend/tests/test_ai_service.py`  
+  - `backend/tests/test_ai_router.py`
 
-- `backend/tests/test_ai_router.py`  
+  - `backend/tests/test_octobot_client.py`
+  - OctoBotClient の初期化、例外クラス（OctoBotHTTPError が OctoBotClientError を継承していること）を確認。
+- `backend/tests/test_octobot_service.py`
+  - 信頼度しきい値に基づく SKIPPED 判定。
+  - 1時間以内の同一アクション回数がしきい値を超えた場合にレート制限で SKIPPED になること。
+- `backend/tests/test_octobot_router.py`
+  - `/octobot/signal` の 400（count 不整合）を確認。
+  - 正常リクエストで 400 以外（200 or 500）が返ることを確認（OctoBot 側はモック/no-op）。
+
+- `test_ai_service.py`  
+  - 入力ニュース文（ポジティブ / ネガティブ / 中立）に対して、  
+    `TradeAction` が BUY / SELL / HOLD の期待値どおりになるかを確認。  
+  - 信頼度スコアが 0〜100 の範囲に収まることを確認。  
+  - `docs/05_ai_judgement_rules.md` の条件に沿った境界値テスト（しきい値ギリギリ前後）。
+
+- `test_ai_router.py`  
   - `/ai/analyze` エンドポイントの正常系（200）レスポンスを確認。  
-    - モックした `AIService.analyze_items` が返す `AIAnalysisResult` がそのままレスポンスに反映されること。
+    - モックした `AIService.analyze_items` が返す `AIAnalysisResult` がそのままレスポンスに反映されること。  
   - `AIService.analyze_items` が予期しない例外を投げた場合、  
-    ステータスコードが 500 系になることを確認。
+    ステータスコードが 500 系になることを確認。  
+  - バリデーションエラー時に 422 Unprocessable Entity になること。
 
 ---
 
-# 3. Unit Test
+## 2.2 Unit Test 詳細（OctoBot 連携周り）
 
-## 対象
-- AI判定処理（文章→BUY/SELL/HOLD）
-- Aave SDK 操作（deposit, withdraw）
-- Notion APIパーサー
-- OctoBotシグナル送信モジュール
+### 2.2.1 bots.client（OctoBot 外部シグナルAPIクライアント）
 
-## Mock方針
-- 外部APIはすべて Mock
-- 時系列処理は固定日時を使用
+- 対象ファイル
+  - `backend/tests/test_octobot_client.py`
+
+- 目的  
+  OctoBot 外部シグナルAPIへの HTTP 通信が、正常系・異常系ともに想定どおり振る舞うことを保証する。
+
+- 主な観点  
+  - 正常系: 2xx レスポンスを受け取った場合、成功として結果が返却されること。  
+  - 4xx / 5xx レスポンス: 適切な例外クラスに変換され、上位層（service）でハンドリング可能になっていること。  
+  - タイムアウト・接続エラー: 所定の回数リトライした上で、最終的に例外を返すこと。  
+  - ログ出力: APIキーなどの機密情報がログに出力されないこと（メッセージをモック／スパイで検証）。
+
+### 2.2.2 bots.service（シグナル生成・送信ロジック）
+
+- 対象ファイル
+  - `backend/tests/test_octobot_service.py`
+
+- 目的  
+  `AIAnalysisResult` を入力として、過剰取引制限・信頼度しきい値に基づいた  
+  「送信 / スキップ / 失敗」の判定が正しく行われることを保証する。
+
+- 主な観点  
+  - 信頼度がしきい値以上のシグナルのみ、OctoBot 外部API送信対象となること。  
+  - `docs/08_automation_rules.md` で定義された連続トレード制限ルールに抵触するシグナルは「skipped」として扱われること。  
+  - client からエラーが返却された場合、「failed」として集計され、詳細メッセージがレスポンスに含まれること。  
+  - すべてのシグナルがスキップまたは失敗になる場合でも、サービス層が異常終了せず、集計結果を返すこと。
+
+### 2.2.3 bots.router（/octobot/signal エンドポイント）
+
+- 対象ファイル
+  - `backend/tests/test_octobot_router.py`
+
+- 目的  
+  `/octobot/signal` エンドポイントの外部仕様（Request/Response・ステータスコード）が  
+  `docs/04_api_design.md` の定義と一致していることを保証する。
+
+- 主な観点  
+  - 正常なリクエスト → 200 OK とともに、`success_count / skipped_count / failed_count` が整合していること。  
+  - bots.service がシグナル送信失敗を返した場合、設計された HTTP ステータス（例: 502）とエラーボディになること。  
+  - リクエストボディの形式が明らかに不正（`count` と配列長の不一致など）の場合 → 400 Bad Request。  
+  - 必須フィールド欠如や型不一致 → 422 Unprocessable Entity（FastAPI デフォルト）。
+
+---
+
+## 2.3 Unit Test 詳細（Notion / Aave / その他）
+
+- Notion クライアント / ルータ
+  - `backend/tests/test_notion_client.py`  
+    - Notion API レスポンスのパース・エラーハンドリング。  
+  - `backend/tests/test_notion_router.py`  
+    - `/notion/ingest` の正常系・エラー系動作。
+
+- Aave 関連（別フェーズで詳細実装）
+  - Aave SDK ラッパの deposit / withdraw / borrow / repay の単体テスト。  
+  - ガス計算・リトライロジック等。
+
+---
+
+# 3. Unit Test（サマリ）
+
+## 3.1 対象
+
+- AI 判定処理（文章 → BUY/SELL/HOLD）
+- Notion API パーサ／クライアント
+- OctoBot シグナル送信モジュール（client / service / router）
+- Aave SDK 操作（deposit, withdraw, borrow, repay）※実装フェーズに応じて追加
+
+## 3.2 Mock 方針
+
+- 外部 API（Notion / OctoBot / Aave / 価格フィードなど）は **すべて Mock**。  
+- 時系列処理は固定日時を使用し、同じテストが何度実行されても同じ結果になるようにする。
 
 ---
 
 # 4. Integration Test
 
-## 対象シナリオ
-- Notion → AI  
-- AI → OctoBot  
-- OctoBot → Aave  
+## 4.1 対象シナリオ
 
-## 成功基準
-- 各ステップの遅延 10秒以内
-- 95%以上の成功率
+- Notion → AI  
+  - `/notion/ingest` → `/ai/analyze`
+- AI → OctoBot  
+  - `/ai/analyze` で生成された `AIAnalysisResult[]` を `/octobot/signal` に渡した際、
+    安全弁の適用とシグナル送信の集計（success/skipped/failed）が期待どおりになること。
+- OctoBot → Aave  
+  - OctoBot シグナル → Aave 操作ユーティリティ（将来フェーズ）
+
+## 4.2 成功基準
+
+- 各ステップの遅延: 10秒以内（開発環境の目安）。
+- 95%以上の成功率（ネットワーク障害など一時的要因は別途考慮）。
 
 ---
 
 # 5. Scenario Test
-ニュース10件を順に処理し：
+
+ニュース 10件程度を時系列で処理するシナリオテスト：
 
 - BUY → Aave deposit  
 - SELL → Aave withdraw  
 - HOLD → 何もしない  
 
-各ニュースの結果が期待通りであること。
+を想定シナリオとして、各ニュースの結果が期待どおりであることを確認する。
+
+- 確認観点
+  - 過剰取引ルール（短時間に同一アクション連発しない）が守られている。  
+  - 緊急停止条件に抵触した場合、システムが適切に処理を止める（`docs/08_automation_rules.md`, `docs/15_rollback_procedures.md` 参照）。
 
 ---
 
 # 6. E2E Test（テストネット）
 
-テストネット（Goerli / Sepolia）で以下を確認：
+テストネット（Goerli / Sepolia など）で以下を確認：
 
 - deposit
 - borrow
 - repay
 - withdraw
 
-本番同様のスマートコントラクト動作、gas 計算まで含めて確認。
+本番同様のスマートコントラクト動作、gas 計算まで含めて確認する。  
+E2E テストは頻度を絞り（例: デイリー、リリース前）、コストと安全性のバランスを取る。
 
 ---
 
 # 7. Regression Test
 
-GitHub PR 時に自動実行：
+GitHub PR 時に自動実行する想定：
 
-- AI判定の一括テスト（ニュース50件）
-- 全フローの統合テスト
+- AI 判定の一括テスト（ニュース 50件程度）
+- 全フローの統合テスト（モック OctoBot / モック Aave を利用）
+
+PR マージ前に、既存機能が壊れていないことを担保する。
 
 ---
 
@@ -95,4 +202,7 @@ GitHub PR 時に自動実行：
 
 - エラー率：5% 以下  
 - フロー成功率：95% 以上  
-- 判定精度：80% 以上  
+- AI 判定精度：80% 以上  
+
+上記基準を満たした状態を **MVP の最低ライン** とし、  
+以降は本番運用やフィードバックを通じて閾値を引き上げていく。

--- a/scripts/zip_phase3_seed.sh
+++ b/scripts/zip_phase3_seed.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+ZIP_NAME="phase3_seed_files.zip"
+
+rm -f "$ZIP_NAME"
+
+zip -r "$ZIP_NAME" \
+  backend/app/main.py \
+  backend/app/ai \
+  backend/app/notion/schemas.py \
+  backend/app/utils \
+  backend/tests/test_ai_service.py \
+  backend/tests/test_ai_router.py \
+  docs/00_overview.md \
+  docs/01_requirements.md \
+  docs/02_phase_plan.md \
+  docs/03_directory_structure.md \
+  docs/04_api_design.md \
+  docs/05_ai_judgement_rules.md \
+  docs/06_octobot_signal_flow.md \
+  docs/07_aave_operation_logic.md \
+  docs/08_automation_rules.md \
+  docs/09_notion_schema.md \
+  docs/11_prompt_sync_rules.md \
+  docs/12_phase_operations.md \
+  docs/13_security_design.md \
+  docs/14_test_strategy.md \
+  docs/15_rollback_procedures.md


### PR DESCRIPTION
## 概要

Notion → AI → OctoBot のフローのうち、AI → OctoBot 部分を実装しました。

## 主な変更点

- OctoBot 連携モジュールの追加
  - `backend/app/bots/config.py`
    - OCTOBOT_API_BASE_URL / OCTOBOT_API_KEY / OCTOBOT_TIMEOUT_SECONDS の読み込み
  - `backend/app/bots/schemas.py`
    - OctoBotSignal, OctoBotSignalRequest, OctoBotSignalResponse などの Pydantic モデル
  - `backend/app/bots/client.py`
    - OctoBot 外部シグナルAPIへの HTTP クライアント（httpx）
  - `backend/app/bots/service.py`
    - 信頼度しきい値と 1時間あたり同一アクション回数のレート制限ロジック
  - `backend/app/bots/router.py`
    - `POST /octobot/signal` エンドポイント

- アプリエントリの更新
  - `backend/app/main.py` に OctoBot ルータをマウント

- テストの追加
  - `backend/tests/test_octobot_client.py`
  - `backend/tests/test_octobot_service.py`
  - `backend/tests/test_octobot_router.py`

## 動作確認

```bash
pip install -r backend/requirements.txt
pytest backend/tests
