### PR TITLE
Phase4: Aave 連携モジュールと /aave/rebalance 実装

### DIFF
--- a/backend/app/aave/client.py
+++ b/backend/app/aave/client.py
@@ -1,0 +1,77 @@
+# backend/app/aave/client.py
+
+"""
+Aave とのやり取りを行うクライアント層。
+
+Phase4 では「実ネットアクセスは行わず、ダミークライアントのみ」を提供する。
+将来的に本番用の AaveClient 実装を追加することを想定。
+"""
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Protocol
+
+from .config import AaveSettings, get_aave_settings
+
+
+class AaveClientError(Exception):
+    """Aave クライアント全般の基底例外。"""
+
+
+class AaveClient(Protocol):
+    """
+    Aave クライアントのインターフェース。
+
+    deposit / withdraw / get_health_factor を備えた実装であれば差し替え可能。
+    """
+
+    def get_health_factor(self) -> Decimal:
+        """現在のポジションのヘルスファクターを返す。"""
+
+    def deposit(self, asset_symbol: str, amount: Decimal) -> str:
+        """
+        指定したトークンを Aave に deposit する。
+
+        :return: トランザクションハッシュ
+        """
+
+    def withdraw(self, asset_symbol: str, amount: Decimal) -> str:
+        """
+        指定したトークンを Aave から withdraw する。
+
+        :return: トランザクションハッシュ
+        """
+
+
+@dataclass
+class DummyAaveClient:
+    """
+    テスト・開発用のダミー Aave クライアント。
+
+    - 実ネットワークには一切アクセスしない
+    - ヘルスファクターは常に安全側の値（例: 2.0）を返す
+    - deposit / withdraw は tx_hash 風の文字列を返すだけ
+    """
+
+    settings: AaveSettings
+
+    def get_health_factor(self) -> Decimal:
+        # 安全側の固定値。実装時にはここを本物の値に差し替える。
+        return Decimal("2.0")
+
+    def deposit(self, asset_symbol: str, amount: Decimal) -> str:
+        return f"dummy-deposit-{asset_symbol}-{amount}"
+
+    def withdraw(self, asset_symbol: str, amount: Decimal) -> str:
+        return f"dummy-withdraw-{asset_symbol}-{amount}"
+
+
+def get_default_aave_client() -> AaveClient:
+    """
+    デフォルトの Aave クライアントを返す。
+
+    Phase4 現時点では DummyAaveClient のみを提供し、
+    実運用時に明示的に差し替える前提とする。
+    """
+    settings = get_aave_settings()
+    return DummyAaveClient(settings=settings)

--- a/backend/app/aave/config.py
+++ b/backend/app/aave/config.py
@@ -1,0 +1,105 @@
+# backend/app/aave/config.py
+
+"""
+Aave 関連の設定値読み出しモジュール。
+
+- 環境変数からネットワークやリスク関連パラメータを取得する
+- デフォルト値は「安全側（小さく・保守的）」に倒す
+"""
+
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Optional
+
+from app.utils.config import get_env
+
+
+@dataclass
+class AaveSettings:
+    """
+    Aave 運用に関する設定値のまとまり。
+
+    NOTE:
+    - Phase4 ではテストネット／ダミークライアント前提のため、
+      RPC URL や秘密鍵はまだ必須にはしない。
+    """
+
+    network: str
+    default_asset_symbol: str
+    max_single_trade_usd: Decimal
+    min_health_factor: Decimal
+    trade_cooldown_seconds: int
+
+
+def _get_env_int(name: str, default: int) -> int:
+    """
+    整数値の環境変数を取得するヘルパー。
+
+    不正な値が入っていた場合は RuntimeError にする。
+    """
+    # ★ Aave 関連の env は必須ではないので required=False
+    raw = get_env(name, required=False)
+    if raw is None or raw == "":
+        return default
+
+    try:
+        return int(raw)
+    except ValueError as exc:  # noqa: TRY003
+        raise RuntimeError(
+            f"Invalid integer value for env var {name}: {raw!r}"
+        ) from exc
+
+
+def _get_env_decimal(name: str, default: str) -> Decimal:
+    """
+    Decimal 値の環境変数を取得するヘルパー。
+
+    :param name: 環境変数名
+    :param default: パースに失敗した場合や未設定時に使用する文字列表現
+    """
+    # ★ こちらも required=False
+    raw = get_env(name, required=False)
+    if raw is None or raw == "":
+        raw = default
+
+    try:
+        return Decimal(raw)
+    except (InvalidOperation, ValueError) as exc:  # noqa: TRY003
+        # 不正な値が入っていた場合も「安全側」のデフォルトに倒す。
+        raise RuntimeError(
+            f"Invalid decimal value for env var {name}: {raw!r}"
+        ) from exc
+
+
+def get_aave_settings() -> AaveSettings:
+    """
+    AaveSettings を構築して返す。
+
+    デフォルト値は「小さく・安全側」に設定している。
+    """
+    # ★ ここも required=False にして、未設定なら安全側デフォルトへ
+    network = get_env("AAVE_NETWORK", required=False) or "sepolia"
+    default_asset_symbol = (
+        get_env("AAVE_DEFAULT_ASSET_SYMBOL", required=False) or "USDC"
+    )
+
+    max_single_trade_usd = _get_env_decimal(
+        "AAVE_MAX_SINGLE_TRADE_USD",
+        default="100.0",  # 1トレードあたり 100 USD 相当を上限にする（デフォルト）
+    )
+    min_health_factor = _get_env_decimal(
+        "AAVE_MIN_HEALTH_FACTOR",
+        default="1.6",  # docs/07_aave_operation_logic.md / 15_rollback_procedures.md を意識した値
+    )
+    trade_cooldown_seconds = _get_env_int(
+        "AAVE_TRADE_COOLDOWN_SECONDS",
+        default=600,  # 10分
+    )
+
+    return AaveSettings(
+        network=network,
+        default_asset_symbol=default_asset_symbol,
+        max_single_trade_usd=max_single_trade_usd,
+        min_health_factor=min_health_factor,
+        trade_cooldown_seconds=trade_cooldown_seconds,
+    )

--- a/backend/app/aave/router.py
+++ b/backend/app/aave/router.py
@@ -1,0 +1,66 @@
+# backend/app/aave/router.py
+
+"""
+Aave 操作用の FastAPI ルーター定義。
+
+- POST /aave/rebalance
+"""
+
+from functools import lru_cache
+from decimal import Decimal
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from .schemas import AaveRebalanceRequest, AaveRebalanceResponse
+from .service import AaveService
+
+router = APIRouter(prefix="/aave", tags=["aave"])
+
+
+@lru_cache()
+def get_aave_service() -> AaveService:
+    """
+    AaveService のシングルトンインスタンスを取得する。
+
+    NOTE:
+    - 内部で DummyAaveClient / get_aave_settings() を使用する。
+    - 実運用時には DI や設定で差し替える想定。
+    """
+    return AaveService()
+
+
+@router.post(
+    "/rebalance",
+    response_model=AaveRebalanceResponse,
+    summary="BUY/SELL/HOLD に応じて Aave ポジションを調整する",
+)
+def rebalance(
+    body: AaveRebalanceRequest,
+    service: AaveService = Depends(get_aave_service),
+) -> AaveRebalanceResponse:
+    """
+    BUY/SELL/HOLD に応じて deposit / withdraw / NOOP を実行する。
+
+    - amount <= 0 の場合は 400
+    - サービス層の想定外エラーは 500
+    """
+    try:
+        result = service.execute_rebalance(
+            action=body.action,
+            amount=Decimal(body.amount),
+            asset_symbol=body.asset_symbol,
+            dry_run=body.dry_run,
+        )
+    except ValueError as exc:
+        # バリデーションをすり抜けた異常値など
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Internal server error while executing Aave rebalance.",
+        ) from exc
+
+    return AaveRebalanceResponse(result=result)

--- a/backend/app/aave/schemas.py
+++ b/backend/app/aave/schemas.py
@@ -1,0 +1,110 @@
+# backend/app/aave/schemas.py
+
+"""
+Aave 操作用の Pydantic スキーマ定義。
+
+- /aave/rebalance のリクエスト / レスポンス
+- 内部で利用する AaveOperationResult など
+"""
+
+from decimal import Decimal
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from app.ai.schemas import TradeAction
+
+
+class AaveOperationType(str, Enum):
+    """Aave へ行う操作の種類。"""
+
+    DEPOSIT = "DEPOSIT"
+    WITHDRAW = "WITHDRAW"
+    NOOP = "NOOP"
+
+
+class AaveOperationStatus(str, Enum):
+    """操作結果のステータス。"""
+
+    SUCCESS = "success"
+    SKIPPED = "skipped"
+    ERROR = "error"
+
+
+class AaveRebalanceRequest(BaseModel):
+    """
+    /aave/rebalance のリクエストボディ。
+
+    BUY / SELL / HOLD のアクションと金額を受け取り、
+    内部で deposit / withdraw / NOOP に変換する。
+    """
+
+    action: TradeAction = Field(
+        ...,
+        description="AI 判定または OctoBot シグナルから受け取るアクション（BUY/SELL/HOLD）。",
+    )
+    amount: Decimal = Field(
+        ...,
+        gt=0,
+        description="対象資産の金額（USD 相当を想定）。0 より大きい必要がある。",
+    )
+    asset_symbol: Optional[str] = Field(
+        None,
+        description="対象となるトークンシンボル。未指定の場合は設定値のデフォルト（例: USDC）を利用する。",
+    )
+    dry_run: bool = Field(
+        False,
+        description=(
+            "True の場合、Aave クライアントに対して実際のトランザクションは送信せず、"
+            "実行されるであろう結果のみを返す。"
+        ),
+    )
+
+
+class AaveOperationResult(BaseModel):
+    """
+    Aave 上での 1 回の操作結果。
+
+    - operation: 実行した（または実行しなかった）操作の種類
+    - status: 成功 / スキップ / エラー
+    - tx_hash: 実際に送信されたトランザクションのハッシュ（NOOP や dry-run では None）
+    """
+
+    operation: AaveOperationType = Field(..., description="実行された操作の種類。")
+    status: AaveOperationStatus = Field(..., description="操作の結果ステータス。")
+    asset_symbol: str = Field(..., description="対象トークンのシンボル。")
+    amount: Decimal = Field(
+        ...,
+        ge=0,
+        description="実際に Aave に対して扱った金額。NOOP 時は 0。",
+    )
+    tx_hash: Optional[str] = Field(
+        None,
+        description="ブロックチェーンのトランザクションハッシュ。NOOP やエラー時は None。",
+    )
+    message: Optional[str] = Field(
+        None,
+        description="人間向けの説明メッセージ（スキップ理由など）。",
+    )
+    before_health_factor: Optional[Decimal] = Field(
+        None,
+        ge=0,
+        description="操作前のヘルスファクター（取得できなかった場合は None）。",
+    )
+    after_health_factor: Optional[Decimal] = Field(
+        None,
+        ge=0,
+        description="操作後のヘルスファクター（取得できなかった場合は None）。",
+    )
+
+
+class AaveRebalanceResponse(BaseModel):
+    """
+    /aave/rebalance のレスポンスボディ。
+    """
+
+    result: AaveOperationResult = Field(
+        ...,
+        description="今回のリバランスで行われた操作結果。",
+    )

--- a/backend/app/aave/service.py
+++ b/backend/app/aave/service.py
@@ -1,0 +1,250 @@
+# backend/app/aave/service.py
+
+"""
+Aave 運用ロジックのサービス層。
+
+責務:
+- TradeAction(BUY/SELL/HOLD) を AaveOperationType(DEPOSIT/WITHDRAW/NOOP) に変換
+- docs/07_aave_operation_logic.md の基本ルールを実装
+- docs/08_automation_rules.md / 13_security_design.md のリスク制御を意識
+- エラー時は「ポジションを増やさない」ことを最優先
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import List, Optional
+
+from app.ai.schemas import TradeAction
+
+from .client import AaveClient, AaveClientError, get_default_aave_client
+from .config import AaveSettings, get_aave_settings
+from .schemas import (
+    AaveOperationResult,
+    AaveOperationStatus,
+    AaveOperationType,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class RiskLimitError(Exception):
+    """
+    リスク制限を超えた操作を行おうとした場合の例外。
+
+    NOTE:
+    - 現時点の実装では通常の「スキップ」は例外ではなく NOOP として扱い、
+      本例外は「明らかに入力が不正な場合」などに限定して使う想定。
+    """
+
+
+class AaveService:
+    """
+    Aave への実際の操作をまとめるサービス層。
+
+    - BUY → deposit
+    - SELL → withdraw
+    - HOLD → 何もしない(NOOP)
+    - 10分以内の連続トレードを抑制
+    - ヘルスファクターがしきい値未満の場合、BUY を抑制
+    """
+
+    def __init__(
+        self,
+        client: AaveClient | None = None,
+        settings: AaveSettings | None = None,
+    ) -> None:
+        self._client: AaveClient = client or get_default_aave_client()
+        self._settings: AaveSettings = settings or get_aave_settings()
+
+        # 直近のトレード時刻を記録する（単純なリストで十分）
+        self._recent_actions: List[datetime] = []
+
+    # ---- 内部ヘルパー -------------------------------------------------
+
+    def _now(self) -> datetime:
+        """テストしやすさのために現在時刻取得をメソッド化。"""
+        return datetime.now(timezone.utc)
+
+    def _cleanup_recent_actions(self, now: datetime) -> None:
+        """トレードクールダウン期間外の履歴を破棄する。"""
+        window_start = now - timedelta(seconds=self._settings.trade_cooldown_seconds)
+        self._recent_actions = [
+            ts for ts in self._recent_actions if ts >= window_start
+        ]
+
+    def _is_in_cooldown(self, now: datetime) -> bool:
+        """
+        クールダウン時間内にトレードが行われているかどうかを判定する。
+        """
+        self._cleanup_recent_actions(now)
+        return len(self._recent_actions) > 0
+
+    def _normalize_amount(self, amount: Decimal) -> Decimal:
+        """
+        入力金額を検証・正規化する。
+
+        - 0 以下なら ValueError
+        - 上限を超えていれば max_single_trade_usd までにクリップ
+        """
+        if amount <= 0:
+            raise ValueError("amount must be greater than 0")
+
+        if amount > self._settings.max_single_trade_usd:
+            return self._settings.max_single_trade_usd
+
+        return amount
+
+    @staticmethod
+    def _normalize_action_value(action: TradeAction | str) -> str:
+        """
+        TradeAction/str のどちらにも対応したアクション文字列の正規化。
+        """
+        if hasattr(action, "value"):
+            return str(getattr(action, "value")).upper()
+        return str(action).upper()
+
+    def _decide_operation(
+        self,
+        action: TradeAction,
+        now: datetime,
+        health_factor: Optional[Decimal],
+    ) -> AaveOperationType:
+        """
+        BUY/SELL/HOLD と現在の状態から、DEPOSIT/WITHDRAW/NOOP を決定する。
+        """
+        action_val = self._normalize_action_value(action)
+
+        # HOLD は常に NOOP
+        if action_val == "HOLD":
+            return AaveOperationType.NOOP
+
+        # 連続トレード制限（10分以内に 1回まで）
+        if self._is_in_cooldown(now):
+            logger.info("Trade skipped by cooldown rule.")
+            return AaveOperationType.NOOP
+
+        # ヘルスファクターがしきい値を下回っているときの BUY 抑制
+        if (
+            health_factor is not None
+            and health_factor < self._settings.min_health_factor
+            and action_val == "BUY"
+        ):
+            logger.warning(
+                "Trade skipped because health factor is below threshold: %s", health_factor
+            )
+            return AaveOperationType.NOOP
+
+        # 基本ルール
+        if action_val == "BUY":
+            return AaveOperationType.DEPOSIT
+        if action_val == "SELL":
+            return AaveOperationType.WITHDRAW
+
+        # 想定外の値は NOOP として安全側に倒す
+        logger.warning("Unknown action %s; treating as NOOP.", action_val)
+        return AaveOperationType.NOOP
+
+    # ---- 公開メソッド -------------------------------------------------
+
+    def execute_rebalance(
+        self,
+        action: TradeAction,
+        amount: Decimal,
+        asset_symbol: str | None = None,
+        dry_run: bool = False,
+    ) -> AaveOperationResult:
+        """
+        BUY/SELL/HOLD に応じて Aave 上のポジションを調整するメイン処理。
+
+        :param action: AI もしくは OctoBot からのアクション（BUY/SELL/HOLD）
+        :param amount: 希望するトレード金額（USD 相当）
+        :param asset_symbol: 対象トークン。None の場合は設定値のデフォルトを使用。
+        :param dry_run: True の場合は実際のトランザクションを送信しない。
+        """
+        normalized_amount = self._normalize_amount(amount)
+        token = asset_symbol or self._settings.default_asset_symbol
+        now = self._now()
+
+        # ヘルスファクター取得（失敗してもエラーにはせず、None として扱う）
+        before_hf: Optional[Decimal]
+        try:
+            before_hf = self._client.get_health_factor()
+        except AaveClientError as exc:
+            logger.error("Failed to fetch health factor: %s", exc)
+            before_hf = None
+
+        operation = self._decide_operation(action, now, before_hf)
+
+        # NOOP の場合は一切トランザクションを送らずに終了
+        if operation is AaveOperationType.NOOP:
+            return AaveOperationResult(
+                operation=operation,
+                status=AaveOperationStatus.SKIPPED,
+                asset_symbol=token,
+                amount=Decimal("0"),
+                tx_hash=None,
+                message="Operation was skipped by safety rules (HOLD / cooldown / health factor).",
+                before_health_factor=before_hf,
+                after_health_factor=before_hf,
+            )
+
+        # dry_run の場合は tx_hash を None とした成功扱い
+        if dry_run:
+            return AaveOperationResult(
+                operation=operation,
+                status=AaveOperationStatus.SUCCESS,
+                asset_symbol=token,
+                amount=normalized_amount,
+                tx_hash=None,
+                message="Dry-run: no transaction was sent to Aave.",
+                before_health_factor=before_hf,
+                after_health_factor=before_hf,
+            )
+
+        # 実際の deposit / withdraw 呼び出し
+        try:
+            if operation is AaveOperationType.DEPOSIT:
+                tx_hash = self._client.deposit(token, normalized_amount)
+            elif operation is AaveOperationType.WITHDRAW:
+                tx_hash = self._client.withdraw(token, normalized_amount)
+            else:
+                # ここに来ることは想定していないが、安全側で NOOP とする
+                logger.warning("Unexpected operation %s; treating as NOOP.", operation)
+                return AaveOperationResult(
+                    operation=AaveOperationType.NOOP,
+                    status=AaveOperationStatus.SKIPPED,
+                    asset_symbol=token,
+                    amount=Decimal("0"),
+                    tx_hash=None,
+                    message="Unexpected operation type; treated as NOOP.",
+                    before_health_factor=before_hf,
+                    after_health_factor=before_hf,
+                )
+        except AaveClientError as exc:
+            logger.error("Aave client error during %s: %s", operation, exc)
+            # 失敗時は「ポジションを増やさない」ことを保証する。
+            return AaveOperationResult(
+                operation=operation,
+                status=AaveOperationStatus.ERROR,
+                asset_symbol=token,
+                amount=Decimal("0"),
+                tx_hash=None,
+                message="Aave client error; no position was changed.",
+                before_health_factor=before_hf,
+                after_health_factor=before_hf,
+            )
+
+        # 正常終了：クールダウン用に履歴を記録
+        self._recent_actions.append(now)
+
+        return AaveOperationResult(
+            operation=operation,
+            status=AaveOperationStatus.SUCCESS,
+            asset_symbol=token,
+            amount=normalized_amount,
+            tx_hash=tx_hash,
+            message="Aave operation executed successfully.",
+            before_health_factor=before_hf,
+            after_health_factor=before_hf,
+        )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,42 +10,33 @@ Phase2 で追加された責務:
 - /ai/analyze エンドポイントを公開する
 """
 
-from fastapi import FastAPI
-
 # backend/app/main.py
 
 from fastapi import FastAPI
 
 from app.ai.router import router as ai_router
-from app.notion.router import router as notion_router
 from app.bots.router import router as octobot_router
+from app.notion.router import router as notion_router  # ★ 復活
+from app.aave.router import router as aave_router      # ★ Phase4 で追加
+
 
 def create_app() -> FastAPI:
-    """
-    FastAPI アプリケーションファクトリ。
+    app = FastAPI(
+        title="Ultra AutoTrade API",
+        version="0.1.0",
+    )
 
-    - Notion 連携エンドポイント (/notion/ingest)
-    - AI 解析エンドポイント (/ai/analyze)
-    - ヘルスチェックエンドポイント (/health)
-    """
-    app = FastAPI(title="Ultra AutoTrade Backend")
-
-    # ルーター登録
-    app.include_router(notion_router)
-    app.include_router(ai_router)
-    app.include_router(octobot_router)
+    # --- ルーター登録 ---
+    app.include_router(notion_router)   # Notion (Phase1)
+    app.include_router(ai_router)       # AI (Phase2)
+    app.include_router(octobot_router)  # OctoBot (Phase3)
+    app.include_router(aave_router)     # Aave (Phase4)
 
     @app.get("/health", tags=["health"])
     def health_check() -> dict:
-        """
-        簡易ヘルスチェックエンドポイント。
-        モニタリングや動作確認用。
-        """
         return {"status": "ok"}
 
     return app
 
 
-# uvicorn 実行時のエントリーポイント
 app = create_app()
-

--- a/backend/tests/test_aave_router.py
+++ b/backend/tests/test_aave_router.py
@@ -1,0 +1,120 @@
+# backend/tests/test_aave_router.py
+
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+
+from app.aave.router import get_aave_service
+from app.aave.schemas import (
+    AaveOperationResult,
+    AaveOperationStatus,
+    AaveOperationType,
+)
+from app.main import create_app
+
+
+class DummyAaveService:
+    """
+    /aave/rebalance ルーター用のダミーサービス。
+
+    呼び出し内容を記録しつつ、固定の結果を返す。
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, object, object, object]] = []
+
+    def execute_rebalance(
+        self,
+        action,
+        amount,
+        asset_symbol=None,
+        dry_run=False,
+    ) -> AaveOperationResult:
+        self.calls.append((action, amount, asset_symbol, dry_run))
+        return AaveOperationResult(
+            operation=AaveOperationType.DEPOSIT,
+            status=AaveOperationStatus.SUCCESS,
+            asset_symbol=asset_symbol or "USDC",
+            amount=Decimal(amount),
+            tx_hash="dummy-tx",
+            message="ok",
+        )
+
+
+def _create_client_with_dummy_service(service: DummyAaveService) -> TestClient:
+    app = create_app()
+    app.dependency_overrides[get_aave_service] = lambda: service
+    return TestClient(app)
+
+
+def test_aave_rebalance_buy_returns_200() -> None:
+    service = DummyAaveService()
+    client = _create_client_with_dummy_service(service)
+
+    payload = {
+        "action": "BUY",
+        "amount": "10",
+        "asset_symbol": "USDC",
+        "dry_run": False,
+    }
+
+    resp = client.post("/aave/rebalance", json=payload)
+    assert resp.status_code == 200
+
+    data = resp.json()
+    assert data["result"]["operation"] == "DEPOSIT"
+    assert data["result"]["status"] == "success"
+    assert service.calls  # 少なくとも 1 回は呼ばれていること
+
+
+def test_aave_rebalance_validation_error_for_negative_amount() -> None:
+    # Pydantic バリデーションで 422 になるケース
+    client = TestClient(create_app())
+
+    payload = {
+        "action": "BUY",
+        "amount": "-1",  # gt=0 に違反
+        "asset_symbol": "USDC",
+    }
+
+    resp = client.post("/aave/rebalance", json=payload)
+    assert resp.status_code == 422
+
+
+def test_aave_rebalance_value_error_from_service_returns_400() -> None:
+    class ErrorService:
+        def execute_rebalance(self, *args, **kwargs):
+            raise ValueError("invalid amount")
+
+    app = create_app()
+    app.dependency_overrides[get_aave_service] = ErrorService  # type: ignore[arg-type]
+    client = TestClient(app)
+
+    payload = {
+        "action": "BUY",
+        "amount": "10",
+        "asset_symbol": "USDC",
+    }
+
+    resp = client.post("/aave/rebalance", json=payload)
+    assert resp.status_code == 400
+    assert "invalid amount" in resp.json()["detail"]
+
+
+def test_aave_rebalance_unexpected_error_returns_500() -> None:
+    class CrashService:
+        def execute_rebalance(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    app = create_app()
+    app.dependency_overrides[get_aave_service] = CrashService  # type: ignore[arg-type]
+    client = TestClient(app)
+
+    payload = {
+        "action": "BUY",
+        "amount": "10",
+        "asset_symbol": "USDC",
+    }
+
+    resp = client.post("/aave/rebalance", json=payload)
+    assert resp.status_code == 500

--- a/backend/tests/test_aave_service.py
+++ b/backend/tests/test_aave_service.py
@@ -1,0 +1,154 @@
+# backend/tests/test_aave_service.py
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from app.ai.schemas import TradeAction
+from app.aave.config import AaveSettings
+from app.aave.schemas import AaveOperationStatus, AaveOperationType
+from app.aave.service import AaveService
+
+
+class FakeAaveClient:
+    """
+    AaveService のユニットテスト用フェイククライアント。
+
+    - deposit / withdraw 呼び出しを記録する
+    - get_health_factor は任意の値を返せる
+    """
+
+    def __init__(self, health_factor: Decimal = Decimal("2.0")) -> None:
+        self.health_factor = health_factor
+        self.deposit_calls: list[tuple[str, Decimal]] = []
+        self.withdraw_calls: list[tuple[str, Decimal]] = []
+
+    def get_health_factor(self) -> Decimal:
+        return self.health_factor
+
+    def deposit(self, asset_symbol: str, amount: Decimal) -> str:
+        self.deposit_calls.append((asset_symbol, amount))
+        return "tx-deposit"
+
+    def withdraw(self, asset_symbol: str, amount: Decimal) -> str:
+        self.withdraw_calls.append((asset_symbol, amount))
+        return "tx-withdraw"
+
+
+def _make_settings(
+    *,
+    cooldown_seconds: int = 600,
+    max_single_trade_usd: str = "1000",
+    min_health_factor: str = "1.6",
+) -> AaveSettings:
+    return AaveSettings(
+        network="sepolia",
+        default_asset_symbol="USDC",
+        max_single_trade_usd=Decimal(max_single_trade_usd),
+        min_health_factor=Decimal(min_health_factor),
+        trade_cooldown_seconds=cooldown_seconds,
+    )
+
+
+def test_buy_executes_deposit_when_safe() -> None:
+    client = FakeAaveClient(health_factor=Decimal("2.0"))
+    settings = _make_settings()
+    service = AaveService(client=client, settings=settings)
+
+    result = service.execute_rebalance(
+        action=TradeAction.BUY,
+        amount=Decimal("10"),
+        asset_symbol="USDC",
+    )
+
+    assert result.operation is AaveOperationType.DEPOSIT
+    assert result.status is AaveOperationStatus.SUCCESS
+    assert client.deposit_calls == [("USDC", Decimal("10"))]
+    assert client.withdraw_calls == []
+
+
+def test_sell_executes_withdraw() -> None:
+    client = FakeAaveClient(health_factor=Decimal("2.0"))
+    settings = _make_settings()
+    service = AaveService(client=client, settings=settings)
+
+    result = service.execute_rebalance(
+        action=TradeAction.SELL,
+        amount=Decimal("5"),
+        asset_symbol="USDC",
+    )
+
+    assert result.operation is AaveOperationType.WITHDRAW
+    assert result.status is AaveOperationStatus.SUCCESS
+    assert client.withdraw_calls == [("USDC", Decimal("5"))]
+    assert client.deposit_calls == []
+
+
+def test_hold_results_in_noop() -> None:
+    client = FakeAaveClient(health_factor=Decimal("2.0"))
+    settings = _make_settings()
+    service = AaveService(client=client, settings=settings)
+
+    result = service.execute_rebalance(
+        action=TradeAction.HOLD,
+        amount=Decimal("10"),
+        asset_symbol="USDC",
+    )
+
+    assert result.operation is AaveOperationType.NOOP
+    assert result.status is AaveOperationStatus.SKIPPED
+    assert client.deposit_calls == []
+    assert client.withdraw_calls == []
+
+
+def test_health_factor_below_threshold_skips_buy() -> None:
+    # ヘルスファクターがしきい値未満のときは BUY を NOOP にする
+    client = FakeAaveClient(health_factor=Decimal("1.0"))
+    settings = _make_settings(min_health_factor="1.6")
+    service = AaveService(client=client, settings=settings)
+
+    result = service.execute_rebalance(
+        action=TradeAction.BUY,
+        amount=Decimal("10"),
+        asset_symbol="USDC",
+    )
+
+    assert result.operation is AaveOperationType.NOOP
+    assert result.status is AaveOperationStatus.SKIPPED
+    assert client.deposit_calls == []
+    assert client.withdraw_calls == []
+
+
+def test_cooldown_skips_second_trade() -> None:
+    client = FakeAaveClient()
+    # クールダウン 600 秒（デフォルト）
+    settings = _make_settings(cooldown_seconds=600)
+    service = AaveService(client=client, settings=settings)
+
+    # 直近にトレードがあったことにする
+    service._recent_actions = [datetime.now(timezone.utc)]
+
+    result = service.execute_rebalance(
+        action=TradeAction.BUY,
+        amount=Decimal("10"),
+        asset_symbol="USDC",
+    )
+
+    assert result.operation is AaveOperationType.NOOP
+    assert result.status is AaveOperationStatus.SKIPPED
+    assert client.deposit_calls == []
+    assert client.withdraw_calls == []
+
+
+def test_negative_amount_raises_value_error() -> None:
+    client = FakeAaveClient()
+    settings = _make_settings()
+    service = AaveService(client=client, settings=settings)
+
+    with pytest.raises(ValueError):
+        service.execute_rebalance(
+            action=TradeAction.BUY,
+            amount=Decimal("-1"),
+            asset_symbol="USDC",
+        )

--- a/backend/tests/test_flow_with_aave_stub.py
+++ b/backend/tests/test_flow_with_aave_stub.py
@@ -1,0 +1,18 @@
+# backend/tests/test_flow_with_aave_stub.py
+
+import pytest
+
+
+@pytest.mark.skip(
+    reason=(
+        "AI → OctoBot → Aave の統合フロー用テストの雛形。"
+        "実際の統合環境が整ったタイミングで具体的なシナリオを実装する。"
+    )
+)
+def test_full_flow_placeholder() -> None:
+    """
+    将来的に Notion → AI → OctoBot → Aave の一連のフローをモックで検証するための枠。
+
+    現時点ではスキップしておき、Phase4 以降で拡充する。
+    """
+    assert True


### PR DESCRIPTION
## 概要

Phase4 として、Aave 連携の最小実装を追加しました。

- `/aave/rebalance` エンドポイント
- BUY/SELL/HOLD → DEPOSIT/WITHDRAW/NOOP 変換ロジック
- ヘルスファクター & クールダウンを用いた簡易リスク制御
- DummyAaveClient によるネットワーク依存排除
- Aave 関連のユニットテスト・APIテスト

## 変更内容

### コード

- `backend/app/aave/config.py`
  - AaveSettings の定義
  - AAVE_* 環境変数の安全側デフォルト読み込み

- `backend/app/aave/client.py`
  - AaveClient プロトコル
  - DummyAaveClient 実装
  - get_default_aave_client()

- `backend/app/aave/schemas.py`
  - AaveOperationType, AaveOperationStatus
  - AaveRebalanceRequest / AaveOperationResult / AaveRebalanceResponse

- `backend/app/aave/service.py`
  - AaveService
  - BUY/SELL/HOLD → DEPOSIT/WITHDRAW/NOOP
  - ヘルスファクター閾値, 最大トレード額クリップ, 10分クールダウン
  - エラー時にポジションを増やさないポリシー

- `backend/app/aave/router.py`
  - POST `/aave/rebalance` 実装
  - AaveService 依存性注入

- `backend/app/main.py`
  - Notion ルーターの再マウント
  - Aave ルーターのマウント

### テスト

- `backend/tests/test_aave_service.py`
  - AaveService のユニットテスト（FakeAaveClient）

- `backend/tests/test_aave_router.py`
  - /aave/rebalance のルーターテスト（依存性 override）

- `backend/tests/test_flow_with_aave_stub.py`
  - 将来の統合テスト用プレースホルダ（現状 skip）

## 動作確認

- [x] `cd backend && pytest tests`
  - 29 passed, 1 skipped

## ドキュメント

以下の .md について、別途反映が必要です（このPR内で更新しても OK）:

- [ ] docs/03_directory_structure.md
- [ ] docs/04_api_design.md
- [ ] docs/07_aave_operation_logic.md
- [ ] docs/08_automation_rules.md
- [ ] docs/13_security_design.md
- [ ] docs/14_test_strategy.md
- [ ] docs/15_rollback_procedures.md