### PR TITLE
Phase5: 監視・緊急停止・レポート基盤と通知インターフェースを追加

### DIFF
--- a/backend/app/automation/__init__.py
+++ b/backend/app/automation/__init__.py
@@ -1,0 +1,9 @@
+# backend/app/automation/__init__.py
+
+"""
+Phase5: 自動化・監視・レポート用モジュール群。
+
+- schemas: 監視イベント / ステータスの Pydantic モデル
+- monitoring_service: 監視・緊急停止ロジック本体
+- state: MonitoringService の共有インスタンス管理
+"""

--- a/backend/app/automation/monitoring_service.py
+++ b/backend/app/automation/monitoring_service.py
@@ -1,0 +1,402 @@
+# backend/app/automation/monitoring_service.py
+
+"""
+監視・アラート・緊急停止ロジック本体。
+
+docs/08_automation_rules.md / 13_security_design.md / 15_rollback_procedures.md の
+以下のルールをコード化することを主目的とする。
+
+- 死活監視（応答時間）
+- 過剰取引監視
+- 緊急停止条件（ヘルスファクター・価格変動・エラー率）
+
+このモジュールは **外部サービスへの通知は行わない**。
+あくまで「状態管理」と「判定」を担い、通知やレポート生成は別モジュールから
+AutomationStatus / MonitoringEvent / AutomationReportSummary を参照して行う前提。
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Deque, List, Optional, Sequence
+
+from .schemas import (
+    AlertLevel,
+    AutomationStatus,
+    ComponentType,
+    HealthFactorStatus,
+    LatencyRecord,
+    MonitoringEvent,
+    TradeActivityRecord,
+)
+
+_HEALTH_FACTOR_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+class MonitoringService:
+    """
+    Phase5 の監視・緊急停止ロジックの集約ポイント。
+
+    - record_* 系メソッドでメトリクスを登録
+    - しきい値を超えた場合は MonitoringEvent を発行
+    - is_trading_allowed / get_status で現在の状態を参照
+    """
+
+    def __init__(
+        self,
+        *,
+        latency_warning_threshold_s: float = 10.0,
+        latency_alert_threshold_s: float = 30.0,
+        healthfactor_warning_threshold: Decimal = Decimal("1.8"),
+        healthfactor_emergency_threshold: Decimal = Decimal("1.6"),
+        price_change_alert_threshold_pct: float = 20.0,
+        max_events: int = 1000,
+        max_latency_records: int = 1000,
+        max_trade_records: int = 1000,
+        max_healthfactor_records: int = 1000,
+    ) -> None:
+        # 閾値
+        self._latency_warning_threshold_s = float(latency_warning_threshold_s)
+        self._latency_alert_threshold_s = float(latency_alert_threshold_s)
+        self._hf_warning_threshold = Decimal(healthfactor_warning_threshold)
+        self._hf_emergency_threshold = Decimal(healthfactor_emergency_threshold)
+        self._price_change_alert_threshold_pct = float(price_change_alert_threshold_pct)
+
+        # 状態
+        self._events: Deque[MonitoringEvent] = deque(maxlen=max_events)
+        self._latencies: Deque[LatencyRecord] = deque(maxlen=max_latency_records)
+        self._trades: Deque[TradeActivityRecord] = deque(maxlen=max_trade_records)
+        # ヘルスファクターの履歴（レポート集計用）
+        self._health_factors: Deque[tuple[datetime, Optional[Decimal]]] = deque(
+            maxlen=max_healthfactor_records
+        )
+
+        self._trading_paused: bool = False
+        self._emergency_reason: Optional[str] = None
+        self._last_health_factor: Optional[Decimal] = None
+        self._last_price_change_24h: Optional[float] = None
+        self._last_event_level: AlertLevel = AlertLevel.INFO
+
+    # ------------------------------------------------------------------
+    # 内部ユーティリティ
+    # ------------------------------------------------------------------
+    def _now(self, at: Optional[datetime]) -> datetime:
+        if at is not None:
+            # タイムゾーン未設定の場合も UTC に寄せる
+            if at.tzinfo is None:
+                return at.replace(tzinfo=timezone.utc)
+            return at
+        return datetime.now(timezone.utc)
+
+    def _normalize_bound(self, ts: Optional[datetime], default: datetime) -> datetime:
+        """
+        範囲指定用の境界時刻を正規化する。
+
+        - None の場合は default を使用
+        - tzinfo がない場合は UTC とみなす
+        """
+        if ts is None:
+            return default
+        if ts.tzinfo is None:
+            return ts.replace(tzinfo=timezone.utc)
+        return ts
+
+    def _append_event(self, event: MonitoringEvent) -> MonitoringEvent:
+        self._events.append(event)
+        # より強いレベルが来たら上書き
+        level_order = {
+            AlertLevel.INFO: 0,
+            AlertLevel.WARNING: 1,
+            AlertLevel.ALERT: 2,
+            AlertLevel.CRITICAL: 3,
+            AlertLevel.EMERGENCY: 4,
+        }
+        if level_order[event.level] >= level_order[self._last_event_level]:
+            self._last_event_level = event.level
+        return event
+
+    # ------------------------------------------------------------------
+    # 公開 API: メトリクス登録
+    # ------------------------------------------------------------------
+    def record_latency(
+        self,
+        component: ComponentType,
+        duration: timedelta | float,
+        *,
+        at: Optional[datetime] = None,
+    ) -> Optional[MonitoringEvent]:
+        """
+        応答時間を記録し、しきい値を超えていればイベントを発行する。
+
+        docs/08_automation_rules.md:
+        - 応答時間 > 10秒 → 警告
+        - 応答時間 > 30秒 → アラート
+        """
+        now = self._now(at)
+        seconds = (
+            float(duration.total_seconds())
+            if isinstance(duration, timedelta)
+            else float(duration)
+        )
+        millis = int(seconds * 1000)
+
+        record = LatencyRecord(
+            component=component,
+            timestamp=now,
+            duration_ms=millis,
+        )
+        self._latencies.append(record)
+
+        if seconds > self._latency_alert_threshold_s:
+            event = MonitoringEvent(
+                timestamp=now,
+                component=component,
+                level=AlertLevel.ALERT,
+                code="LATENCY_ALERT",
+                message=f"Latency {seconds:.1f}s exceeds alert threshold.",
+            )
+            return self._append_event(event)
+
+        if seconds > self._latency_warning_threshold_s:
+            event = MonitoringEvent(
+                timestamp=now,
+                component=component,
+                level=AlertLevel.WARNING,
+                code="LATENCY_WARNING",
+                message=f"Latency {seconds:.1f}s exceeds warning threshold.",
+            )
+            return self._append_event(event)
+
+        return None
+
+    def record_trade(
+        self,
+        component: ComponentType,
+        action: str,
+        *,
+        at: Optional[datetime] = None,
+    ) -> None:
+        """
+        過剰取引監視用にトレード（またはシグナル）を記録する。
+
+        Phase5 のこのタイミングでは「カウントの記録」のみに留め、
+        実際の過剰取引アラート判定は将来拡張とする。
+        （既存の OctoBot レート制限・Aave クールダウンが一次防波堤）
+        """
+        now = self._now(at)
+        record = TradeActivityRecord(
+            component=component,
+            action=str(action),
+            timestamp=now,
+        )
+        self._trades.append(record)
+
+    def record_health_factor(
+        self,
+        value: Optional[Decimal],
+        *,
+        at: Optional[datetime] = None,
+    ) -> HealthFactorStatus:
+        """
+        ヘルスファクターを記録し、警告・緊急停止判定を行う。
+
+        docs/08_automation_rules.md / 15_rollback_procedures.md:
+        - ヘルスファクター < 1.8 → 警告
+        - ヘルスファクター < 1.6 → 緊急停止
+        """
+        now = self._now(at)
+        self._last_health_factor = value
+        self._health_factors.append((now, value))
+
+        if value is None:
+            status = HealthFactorStatus(
+                current=None,
+                level=AlertLevel.INFO,
+                is_emergency=False,
+            )
+            return status
+
+        level: AlertLevel = AlertLevel.INFO
+        is_emergency = False
+
+        if value < self._hf_emergency_threshold:
+            level = AlertLevel.EMERGENCY
+            is_emergency = True
+            self._trading_paused = True
+            if self._emergency_reason is None:
+                self._emergency_reason = (
+                    f"health factor {value} below emergency threshold "
+                    f"{self._hf_emergency_threshold}"
+                )
+            event = MonitoringEvent(
+                timestamp=now,
+                component=ComponentType.AAVE,
+                level=level,
+                code="HF_BELOW_EMERGENCY",
+                message=self._emergency_reason,
+            )
+            self._append_event(event)
+        elif value < self._hf_warning_threshold:
+            level = AlertLevel.WARNING
+            event = MonitoringEvent(
+                timestamp=now,
+                component=ComponentType.AAVE,
+                level=level,
+                code="HF_BELOW_WARNING",
+                message=(
+                    f"health factor {value} below warning threshold "
+                    f"{self._hf_warning_threshold}"
+                ),
+            )
+            self._append_event(event)
+
+        status = HealthFactorStatus(
+            current=value,
+            level=level,
+            is_emergency=is_emergency,
+        )
+        return status
+
+    def record_price_change_24h(
+        self,
+        percent_change: float,
+        *,
+        at: Optional[datetime] = None,
+    ) -> Optional[MonitoringEvent]:
+        """
+        24時間の価格変動率を記録し、アラート判定を行う。
+
+        docs/08_automation_rules.md:
+        - 資産変動 > 20%/日 → アラート
+        """
+        now = self._now(at)
+        self._last_price_change_24h = float(percent_change)
+
+        if abs(percent_change) > self._price_change_alert_threshold_pct:
+            event = MonitoringEvent(
+                timestamp=now,
+                component=ComponentType.SYSTEM,
+                level=AlertLevel.ALERT,
+                code="PRICE_CHANGE_ALERT",
+                message=(
+                    f"24h price change {percent_change:.1f}% exceeds "
+                    f"alert threshold {self._price_change_alert_threshold_pct:.1f}%."
+                ),
+            )
+            return self._append_event(event)
+
+        return None
+
+    # ------------------------------------------------------------------
+    # 公開 API: 状態参照・緊急停止制御
+    # ------------------------------------------------------------------
+    def is_trading_allowed(self) -> bool:
+        """
+        現在トレードを許可してよいかを返す。
+
+        - 緊急停止フラグが立っている場合は False
+        """
+        return not self._trading_paused
+
+    def activate_emergency_stop(
+        self,
+        *,
+        reason: str,
+        component: ComponentType = ComponentType.SYSTEM,
+        at: Optional[datetime] = None,
+    ) -> MonitoringEvent:
+        """
+        手動／その他条件で緊急停止を有効化する。
+
+        Aave 側の「ポジションを増やさない」ロジックと組み合わせて、
+        資金を守る最後の防波堤として機能する。
+        """
+        now = self._now(at)
+        self._trading_paused = True
+        self._emergency_reason = reason
+
+        event = MonitoringEvent(
+            timestamp=now,
+            component=component,
+            level=AlertLevel.EMERGENCY,
+            code="EMERGENCY_STOP",
+            message=reason,
+        )
+        return self._append_event(event)
+
+    def clear_emergency_stop(self) -> None:
+        """
+        緊急停止状態を解除する。
+
+        自動解除は危険なので、基本的には運用者が明示的に呼び出す想定。
+        """
+        self._trading_paused = False
+        self._emergency_reason = None
+
+    def get_recent_events(self, limit: int = 100) -> List[MonitoringEvent]:
+        """
+        直近のイベントを新しい順に返す。
+        """
+        if limit <= 0:
+            return []
+        # deque は古い順に並ぶので、逆順にしてから limit をかける
+        events: Sequence[MonitoringEvent] = list(self._events)[-limit:]
+        return list(events)[-limit:]
+
+    def get_events_in_range(
+        self,
+        from_timestamp: datetime,
+        to_timestamp: datetime,
+    ) -> List[MonitoringEvent]:
+        """
+        指定した時間範囲に含まれるイベントを返す。
+
+        レポート集計用のユーティリティ。
+        """
+        start = self._normalize_bound(from_timestamp, _HEALTH_FACTOR_EPOCH)
+        end = self._normalize_bound(
+            to_timestamp,
+            datetime.max.replace(tzinfo=timezone.utc),
+        )
+        return [
+            event
+            for event in self._events
+            if start <= event.timestamp <= end
+        ]
+
+    def get_health_factor_history(
+        self,
+        from_timestamp: Optional[datetime] = None,
+        to_timestamp: Optional[datetime] = None,
+    ) -> List[tuple[datetime, Optional[Decimal]]]:
+        """
+        ヘルスファクターの履歴を返す。
+
+        - from_timestamp/to_timestamp を指定しなければ全件
+        - None の値も含んだまま返す（集計側でフィルタ）
+        """
+        start = self._normalize_bound(from_timestamp, _HEALTH_FACTOR_EPOCH)
+        end = self._normalize_bound(
+            to_timestamp,
+            datetime.max.replace(tzinfo=timezone.utc),
+        )
+        return [
+            (ts, value)
+            for ts, value in self._health_factors
+            if start <= ts <= end
+        ]
+
+    def get_status(self) -> AutomationStatus:
+        """
+        自動運用全体のステータスサマリを返す。
+        """
+        return AutomationStatus(
+            is_trading_paused=bool(self._trading_paused),
+            last_health_factor=self._last_health_factor,
+            last_price_change_24h=self._last_price_change_24h,
+            last_event_level=self._last_event_level,
+            emergency_reason=self._emergency_reason,
+            recent_events=list(self._events),
+        )

--- a/backend/app/automation/reporting_service.py
+++ b/backend/app/automation/reporting_service.py
@@ -1,0 +1,213 @@
+# backend/app/automation/reporting_service.py
+
+"""
+MonitoringService が蓄積したメトリクスを元に、
+日次 / 週次のサマリーレポートを生成するサービス。
+
+責務:
+- 対象期間（daily / weekly）の決定
+- MonitoringService からイベント・ヘルスファクター履歴を取得
+- 集計して AutomationReportSummary を返す
+
+ここでは外部 I/O（Notion・ファイル・通知など）は一切行わず、
+純粋に「集計ロジック」に限定する。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Dict, List, Optional
+
+from .monitoring_service import MonitoringService
+from .schemas import (
+    AlertLevel,
+    AutomationReportSummary,
+    ReportPeriod,
+)
+from .state import get_monitoring_service
+from app.notifications.schemas import (
+    NotificationChannel,
+    NotificationMessage,
+    NotificationSeverity,
+)
+
+class ReportingService:
+    """
+    監視結果を集計してレポートサマリを生成するサービス。
+
+    将来的に:
+    - AI による自然言語レポート生成
+    - Notion への書き込み
+    - 通知サービスへの送信
+    などの「上位レイヤー」から再利用される想定。
+    """
+
+    def __init__(self, monitoring: Optional[MonitoringService] = None) -> None:
+        self._monitoring: MonitoringService = monitoring or get_monitoring_service()
+
+    # ------------------------------------------------------------------
+    # 内部ユーティリティ
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalize_now(now: Optional[datetime]) -> datetime:
+        if now is None:
+            now = datetime.now(timezone.utc)
+        elif now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        return now
+
+    @staticmethod
+    def _get_period_range(period: ReportPeriod, now: datetime) -> tuple[datetime, datetime]:
+        """
+        period（daily/weekly）に応じて集計対象期間を決定する。
+
+        - DAILY: 当日 00:00:00 〜 now
+        - WEEKLY: now から遡って 7日間
+        """
+        if period == ReportPeriod.DAILY:
+            start = datetime(year=now.year, month=now.month, day=now.day, tzinfo=now.tzinfo)
+            end = now
+        elif period == ReportPeriod.WEEKLY:
+            start = now - timedelta(days=7)
+            end = now
+        else:
+            # 将来拡張用。現時点では DAILY と同じ扱いにする。
+            start = datetime(year=now.year, month=now.month, day=now.day, tzinfo=now.tzinfo)
+            end = now
+        return start, end
+
+    # ------------------------------------------------------------------
+    # 公開 API
+    # ------------------------------------------------------------------
+    def generate_summary_report(
+        self,
+        period: ReportPeriod,
+        *,
+        now: Optional[datetime] = None,
+    ) -> AutomationReportSummary:
+        """
+        指定された期間（daily/weekly）のサマリーレポートを生成する。
+        """
+        now_norm = self._normalize_now(now)
+        from_ts, to_ts = self._get_period_range(period, now_norm)
+
+        # 1. イベント件数の集計
+        events = self._monitoring.get_events_in_range(from_ts, to_ts)
+        total_events = len(events)
+
+        level_counts: Dict[AlertLevel, int] = {level: 0 for level in AlertLevel}
+        for event in events:
+            # AlertLevel に存在しない値の場合でも落ちないよう get(..., 0)
+            level_counts[event.level] = level_counts.get(event.level, 0) + 1
+
+        emergency_occurred = level_counts.get(AlertLevel.EMERGENCY, 0) > 0
+
+        # 2. ヘルスファクターの集計
+        hf_history = self._monitoring.get_health_factor_history(from_ts, to_ts)
+        hf_values: List[Decimal] = [
+            value for _, value in hf_history if value is not None
+        ]
+
+        if hf_values:
+            min_hf = min(hf_values)
+            max_hf = max(hf_values)
+            last_hf = hf_values[-1]
+        else:
+            min_hf = None
+            max_hf = None
+            last_hf = None
+
+        # 3. 簡易ノート（人間向けの一言コメント）
+        notes: Optional[str] = None
+        if emergency_occurred:
+            notes = "Emergency events occurred during this period."
+        elif total_events == 0:
+            notes = "No monitoring events recorded during this period."
+
+        return AutomationReportSummary(
+            period=period,
+            from_timestamp=from_ts,
+            to_timestamp=to_ts,
+            total_events=total_events,
+            info_count=level_counts.get(AlertLevel.INFO, 0),
+            warning_count=level_counts.get(AlertLevel.WARNING, 0),
+            alert_count=level_counts.get(AlertLevel.ALERT, 0),
+            critical_count=level_counts.get(AlertLevel.CRITICAL, 0),
+            emergency_count=level_counts.get(AlertLevel.EMERGENCY, 0),
+            emergency_occurred=emergency_occurred,
+            min_health_factor=min_hf,
+            max_health_factor=max_hf,
+            last_health_factor=last_hf,
+            notes=notes,
+        )
+
+    # ------------------------------------------------------------------
+    # 通知連携向けヘルパー
+    # ------------------------------------------------------------------
+    @staticmethod
+    def build_notification_message(
+        summary: AutomationReportSummary,
+        *,
+        channel: NotificationChannel = NotificationChannel.INTERNAL_LOG,
+    ) -> NotificationMessage:
+        """
+        レポートサマリから NotificationMessage を組み立てる。
+
+        Phase5 時点では:
+        - emergency_occurred=True の場合は EMERGENCY 通知
+        - ALERT/WARNING が存在する場合は ALERT/WARNING レベル
+        - イベント 0 件など正常系は INFO レベル
+
+        実際の送信は NotificationService (CompositeNotificationService) 側で行う。
+        """
+        # severity 決定
+        if summary.emergency_occurred or summary.emergency_count > 0:
+            severity = NotificationSeverity.EMERGENCY
+            status_label = "EMERGENCY"
+        elif summary.alert_count > 0 or summary.critical_count > 0:
+            severity = NotificationSeverity.ALERT
+            status_label = "ALERT"
+        elif summary.warning_count > 0:
+            severity = NotificationSeverity.WARNING
+            status_label = "WARNING"
+        else:
+            severity = NotificationSeverity.INFO
+            status_label = "OK"
+
+        # タイトル
+        title = f"[AUTO-REPORT] {summary.period.value.upper()} summary ({status_label})"
+
+        # 本文（シンプルなテキスト）
+        period_str = (
+            f"{summary.from_timestamp.isoformat()} - {summary.to_timestamp.isoformat()}"
+        )
+        lines: List[str] = [
+            f"Period: {summary.period.value} ({period_str})",
+            f"Events: total={summary.total_events}, "
+            f"info={summary.info_count}, "
+            f"warning={summary.warning_count}, "
+            f"alert={summary.alert_count}, "
+            f"critical={summary.critical_count}, "
+            f"emergency={summary.emergency_count}",
+        ]
+
+        if summary.min_health_factor is not None or summary.last_health_factor is not None:
+            lines.append(
+                "Health factor: "
+                f"min={summary.min_health_factor}, "
+                f"max={summary.max_health_factor}, "
+                f"last={summary.last_health_factor}"
+            )
+
+        if summary.notes:
+            lines.append(f"Notes: {summary.notes}")
+
+        body = "\n".join(lines)
+
+        return NotificationMessage(
+            channel=channel,
+            severity=severity,
+            title=title,
+            body=body,
+        )

--- a/backend/app/automation/schemas.py
+++ b/backend/app/automation/schemas.py
@@ -1,0 +1,192 @@
+# backend/app/automation/schemas.py
+
+"""
+監視・アラート・緊急停止まわりの共通スキーマ定義。
+
+Phase5 で導入する MonitoringService / ReportingService が利用するデータ構造をまとめる。
+docs/08_automation_rules.md / 13_security_design.md / 15_rollback_procedures.md を前提に設計。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class AlertLevel(str, Enum):
+    """
+    監視イベントの重要度レベル。
+
+    - WARNING: しきい値超過だが、即時停止までは不要
+    - ALERT: 強い注意が必要。手動確認推奨
+    - CRITICAL: 重大な異常。運用継続は危険
+    - EMERGENCY: 緊急停止状態
+    """
+
+    INFO = "info"
+    WARNING = "warning"
+    ALERT = "alert"
+    CRITICAL = "critical"
+    EMERGENCY = "emergency"
+
+
+class ComponentType(str, Enum):
+    """
+    監視対象コンポーネントの種別。
+    """
+
+    NOTION = "notion"
+    AI = "ai"
+    OCTOBOT = "octobot"
+    AAVE = "aave"
+    SYSTEM = "system"
+    BACKUP = "backup"
+    REPORT = "report"
+
+
+class MonitoringEvent(BaseModel):
+    """
+    監視イベント 1件分。
+
+    後続のレポート生成・通知でそのまま利用できるよう、最低限のメタ情報を持たせる。
+    """
+
+    timestamp: datetime = Field(..., description="イベント発生時刻（UTC推奨）")
+    component: ComponentType = Field(..., description="イベントが発生したコンポーネント")
+    level: AlertLevel = Field(..., description="イベントの重要度")
+    code: str = Field(..., description="機械可読なイベントコード（例: LATENCY_SLOW, HF_BELOW_16）")
+    message: str = Field(..., description="人間向けのメッセージ（センシティブ情報は含めないこと）")
+
+
+class LatencyRecord(BaseModel):
+    """
+    死活監視用の応答時間記録。
+    """
+
+    component: ComponentType = Field(..., description="対象コンポーネント")
+    timestamp: datetime = Field(..., description="計測時刻")
+    duration_ms: int = Field(..., ge=0, description="応答時間（ミリ秒）")
+
+
+class TradeActivityRecord(BaseModel):
+    """
+    過剰取引監視用のアクティビティ記録。
+    """
+
+    component: ComponentType = Field(..., description="対象コンポーネント（通常は OCTOBOT / AAVE）")
+    action: str = Field(..., description="BUY/SELL/HOLD などのアクション種別（文字列表現）")
+    timestamp: datetime = Field(..., description="アクション実行時刻")
+
+
+class HealthFactorStatus(BaseModel):
+    """
+    ヘルスファクター監視の判定結果。
+    """
+
+    current: Optional[Decimal] = Field(
+        None,
+        description="現在のヘルスファクター。取得できなかった場合は None。",
+    )
+    level: AlertLevel = Field(
+        ...,
+        description="現在のヘルスファクターに基づく重要度レベル。",
+    )
+    is_emergency: bool = Field(
+        ...,
+        description="緊急停止レベルかどうか。",
+    )
+
+
+class AutomationStatus(BaseModel):
+    """
+    自動運用基盤全体のステータスサマリ。
+
+    - 緊急停止状態かどうか
+    - 直近のヘルスファクター・価格変動
+    - 直近のイベント一覧
+    をまとめて返す。
+    """
+
+    is_trading_paused: bool = Field(..., description="現在トレードが停止状態かどうか")
+    last_health_factor: Optional[Decimal] = Field(
+        None, description="最後に観測したヘルスファクター"
+    )
+    last_price_change_24h: Optional[float] = Field(
+        None,
+        description="最後に観測した24時間価格変動率（%）。正の値が上昇。",
+    )
+    last_event_level: AlertLevel = Field(
+        AlertLevel.INFO,
+        description="最後に発生したイベントの重要度レベル。",
+    )
+    emergency_reason: Optional[str] = Field(
+        None,
+        description="緊急停止中の場合、その理由（ログ・通知用）。",
+    )
+    recent_events: List[MonitoringEvent] = Field(
+        default_factory=list,
+        description="最近のイベント。件数は MonitoringService 側で制御する。",
+    )
+
+
+# ---------------------------------------------------------------------------
+# レポート用スキーマ
+# ---------------------------------------------------------------------------
+
+
+class ReportPeriod(str, Enum):
+    """
+    レポート対象期間の種別。
+
+    - DAILY: 当日分
+    - WEEKLY: 直近7日分
+    """
+
+    DAILY = "daily"
+    WEEKLY = "weekly"
+
+
+class AutomationReportSummary(BaseModel):
+    """
+    監視イベントとヘルスファクター履歴から集計したレポートサマリ。
+
+    実際の Notion/通知連携は別モジュールがこのモデルをもとに行う想定。
+    """
+
+    period: ReportPeriod = Field(..., description="レポート対象期間の種別")
+    from_timestamp: datetime = Field(..., description="レポート対象期間の開始時刻")
+    to_timestamp: datetime = Field(..., description="レポート対象期間の終了時刻（通常は now）")
+
+    total_events: int = Field(..., description="対象期間中の全イベント件数")
+    info_count: int = Field(..., description="INFO レベルのイベント数")
+    warning_count: int = Field(..., description="WARNING レベルのイベント数")
+    alert_count: int = Field(..., description="ALERT レベルのイベント数")
+    critical_count: int = Field(..., description="CRITICAL レベルのイベント数")
+    emergency_count: int = Field(..., description="EMERGENCY レベルのイベント数")
+
+    emergency_occurred: bool = Field(
+        ...,
+        description="対象期間中に EMERGENCY レベルのイベントが1つでも発生したかどうか。",
+    )
+
+    min_health_factor: Optional[Decimal] = Field(
+        None,
+        description="対象期間中に観測されたヘルスファクターの最小値（観測がなければ None）。",
+    )
+    max_health_factor: Optional[Decimal] = Field(
+        None,
+        description="対象期間中に観測されたヘルスファクターの最大値（観測がなければ None）。",
+    )
+    last_health_factor: Optional[Decimal] = Field(
+        None,
+        description="対象期間中に最後に観測されたヘルスファクター（観測がなければ None）。",
+    )
+
+    notes: Optional[str] = Field(
+        None,
+        description="人間向けの簡易コメント。将来的に AI による文章生成に置き換え可能。",
+    )

--- a/backend/app/automation/state.py
+++ b/backend/app/automation/state.py
@@ -1,0 +1,38 @@
+# backend/app/automation/state.py
+
+"""
+MonitoringService のシンプルな状態管理モジュール。
+
+- アプリ全体で共有する MonitoringService インスタンスを提供
+- テスト時にリセットできるようにする
+
+FastAPI の DI で使うことも、素朴なグローバル状態として使うことも可能。
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .monitoring_service import MonitoringService
+
+_monitoring_service: Optional[MonitoringService] = None
+
+
+def get_monitoring_service() -> MonitoringService:
+    """
+    共有の MonitoringService インスタンスを返す。
+
+    初回呼び出し時にのみ生成し、それ以降は同じインスタンスを返す。
+    """
+    global _monitoring_service
+    if _monitoring_service is None:
+        _monitoring_service = MonitoringService()
+    return _monitoring_service
+
+
+def reset_state() -> None:
+    """
+    テスト用に MonitoringService のシングルトン状態をリセットする。
+    """
+    global _monitoring_service
+    _monitoring_service = None

--- a/backend/app/notifications/__init__.py
+++ b/backend/app/notifications/__init__.py
@@ -1,0 +1,13 @@
+# backend/app/notifications/__init__.py
+
+"""
+通知レイヤ用モジュール群。
+
+Phase5 のスコープでは「通知のインターフェースと最小実装（ログ出力のみ）」を提供し、
+実際の LINE / Slack / Email 連携は後続フェーズで差し込めるようにしておく。
+
+構成イメージ:
+- schemas: 通知メッセージの共通スキーマ
+- service: 通知送信インターフェースと実装
+- factory: アプリ全体で共有する NotificationService の生成
+"""

--- a/backend/app/notifications/factory.py
+++ b/backend/app/notifications/factory.py
@@ -1,0 +1,41 @@
+# backend/app/notifications/factory.py
+
+"""
+通知サービスの簡易ファクトリ。
+
+Phase5 時点では:
+- LoggingNotificationSender のみを登録した CompositeNotificationService を返す。
+- 将来、設定や環境変数に応じて LINE/Slack Sender を追加する拡張余地を残す。
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .schemas import NotificationChannel, NotificationSeverity, NotificationMessage
+from .service import CompositeNotificationService, LoggingNotificationSender
+
+_notification_service: Optional[CompositeNotificationService] = None
+
+
+def get_notification_service() -> CompositeNotificationService:
+    """
+    アプリ全体で共有する CompositeNotificationService を返す。
+
+    初回呼び出し時にのみ生成し、それ以降は同じインスタンスを返す。
+    """
+    global _notification_service
+    if _notification_service is None:
+        logging_sender = LoggingNotificationSender()
+        _notification_service = CompositeNotificationService([logging_sender])
+    return _notification_service
+
+
+__all__ = [
+    "NotificationChannel",
+    "NotificationSeverity",
+    "NotificationMessage",
+    "CompositeNotificationService",
+    "LoggingNotificationSender",
+    "get_notification_service",
+]

--- a/backend/app/notifications/schemas.py
+++ b/backend/app/notifications/schemas.py
@@ -1,0 +1,88 @@
+# backend/app/notifications/schemas.py
+
+"""
+通知メッセージの共通スキーマ定義。
+
+Phase5 時点では:
+- 通知のチャンネル種別（どこに送るか）
+- 通知の重要度
+- タイトル＋本文
+
+のみを扱い、実際の送信先（LINE/Slackなど）の具体的な情報は
+後続フェーズで Sender 実装側に持たせる前提とする。
+
+※ セキュリティ上の観点から、NotificationMessage 自体には
+  API キーやウォレットアドレスなどの機密情報は含めないこと。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class NotificationChannel(str, Enum):
+    """
+    通知の論理的なチャンネル種別。
+
+    - INTERNAL_LOG: アプリ内部ログ（Phase5 デフォルト）
+    - LINE: 将来の LINE 通知
+    - SLACK: 将来の Slack 通知
+    - EMAIL: 将来の Email 通知
+    """
+
+    INTERNAL_LOG = "internal_log"
+    LINE = "line"
+    SLACK = "slack"
+    EMAIL = "email"
+
+
+class NotificationSeverity(str, Enum):
+    """
+    通知の重要度。
+
+    監視イベントの AlertLevel と概ね対応するが、
+    通知側はもう少し粗い粒度で扱う。
+    """
+
+    INFO = "info"
+    WARNING = "warning"
+    ALERT = "alert"
+    EMERGENCY = "emergency"
+
+
+class NotificationMessage(BaseModel):
+    """
+    通知 1件分の情報。
+
+    body はプレーンテキスト想定。
+    機密情報は含めないこと（docs/13_security_design.md）。
+    """
+
+    channel: NotificationChannel = Field(
+        ...,
+        description="論理的な通知チャンネル（LINE/Slack などは Sender 実装側で解釈）。",
+    )
+    severity: NotificationSeverity = Field(
+        ...,
+        description="通知の重要度。",
+    )
+    title: str = Field(
+        ...,
+        description="短いタイトル（チャットの1行目など）。",
+    )
+    body: str = Field(
+        ...,
+        description="本文。プレーンテキスト想定。",
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="通知生成時刻（UTC）。",
+    )
+
+    class Config:
+        # ログ用途で使うため、repr を簡潔にしておく
+        orm_mode = True

--- a/backend/app/notifications/service.py
+++ b/backend/app/notifications/service.py
@@ -1,0 +1,84 @@
+# backend/app/notifications/service.py
+
+"""
+通知送信インターフェースと最小実装。
+
+Phase5 のスコープでは:
+- NotificationMessage を受け取る send() インターフェース
+- ログ出力のみ行う LoggingNotificationSender
+- 複数 Sender にファンアウトする CompositeNotificationService
+
+を提供し、LINE/Slack などの実送信ロジックは後続フェーズで追加可能にしておく。
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List, Protocol
+
+from .schemas import NotificationMessage, NotificationSeverity
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationSender(Protocol):
+    """
+    通知送信の最小インターフェース。
+
+    実装例:
+    - LoggingNotificationSender: ログ出力のみ
+    - LineNotificationSender: LINE Webhook/SDK 経由で送信（将来）
+    - SlackNotificationSender: Slack API 経由で送信（将来）
+    """
+
+    def send(self, message: NotificationMessage) -> None:  # pragma: no cover - Protocol
+        ...
+
+
+class LoggingNotificationSender:
+    """
+    NotificationMessage を Python の logger に記録するだけの Sender。
+
+    - Phase5 デフォルト実装
+    - 実際の外部サービスへの送信は行わない
+    """
+
+    def __init__(self, logger_: logging.Logger | None = None) -> None:
+        self._logger = logger_ or logger
+
+    def send(self, message: NotificationMessage) -> None:
+        """
+        通知メッセージを重要度に応じたログレベルで出力する。
+        """
+        prefix = f"[{message.channel.value}][{message.severity.value}] {message.title} "
+        text = prefix + message.body
+
+        if message.severity in (NotificationSeverity.EMERGENCY, NotificationSeverity.ALERT):
+            self._logger.error(text)
+        elif message.severity == NotificationSeverity.WARNING:
+            self._logger.warning(text)
+        else:
+            self._logger.info(text)
+
+
+class CompositeNotificationService:
+    """
+    複数の NotificationSender に通知をファンアウトするサービス。
+
+    Phase5 では:
+    - LoggingNotificationSender のみを持つ構成がデフォルト。
+    - 後続フェーズで LINE/Slack Sender を追加する場合も、呼び出し元はこのサービスを使うだけでよい。
+    """
+
+    def __init__(self, senders: Iterable[NotificationSender]) -> None:
+        self._senders: List[NotificationSender] = list(senders)
+
+    def send(self, message: NotificationMessage) -> None:
+        """
+        受け取った NotificationMessage を全 Sender に送信する。
+        """
+        for sender in self._senders:
+            try:
+                sender.send(message)
+            except Exception:  # noqa: BLE001 - 通知は本処理を止めない
+                logger.exception("Notification sender failed. Continuing with others.")

--- a/backend/tests/test_automation_emergency_integration.py
+++ b/backend/tests/test_automation_emergency_integration.py
@@ -1,0 +1,76 @@
+# backend/tests/test_automation_emergency_integration.py
+
+from decimal import Decimal
+
+from app.ai.schemas import TradeAction
+from app.aave.config import AaveSettings
+from app.aave.schemas import AaveOperationStatus, AaveOperationType
+from app.aave.service import AaveService
+from app.automation.monitoring_service import MonitoringService
+from app.automation.schemas import ComponentType
+from app.automation.state import reset_state
+
+
+class FakeAaveClientForEmergency:
+    """
+    緊急停止連携をテストするための簡易フェイククライアント。
+
+    実際の on-chain 処理は行わない。
+    """
+
+    def __init__(self) -> None:
+        self.deposit_calls: list[Decimal] = []
+        self.withdraw_calls: list[Decimal] = []
+
+    def get_health_factor(self) -> Decimal:
+        # テストでは固定値を返す（MonitoringService 側で別途テスト済み）
+        return Decimal("1.5")
+
+    def deposit(self, *, asset_symbol: str, amount: Decimal) -> str:
+        self.deposit_calls.append(amount)
+        return "0x-deposit"
+
+    def withdraw(self, *, asset_symbol: str, amount: Decimal) -> str:
+        self.withdraw_calls.append(amount)
+        return "0x-withdraw"
+
+
+def _make_settings() -> AaveSettings:
+    return AaveSettings(
+        network="testnet",
+        default_asset_symbol="USDC",
+        max_single_trade_usd=Decimal("100"),
+        min_health_factor=Decimal("1.6"),
+        trade_cooldown_seconds=600,
+    )
+
+
+def test_execute_rebalance_respects_emergency_stop() -> None:
+    """
+    MonitoringService で緊急停止された場合、
+    AaveService.execute_rebalance がポジションを増やさないことを確認する。
+    """
+    reset_state()
+    monitoring = MonitoringService()
+    monitoring.activate_emergency_stop(
+        reason="test emergency",
+        component=ComponentType.AAVE,
+    )
+
+    client = FakeAaveClientForEmergency()
+    settings = _make_settings()
+    service = AaveService(client=client, settings=settings, monitoring_service=monitoring)
+
+    result = service.execute_rebalance(
+        action=TradeAction.BUY,
+        amount=Decimal("10"),
+        asset_symbol="USDC",
+    )
+
+    # 緊急停止中のため NOOP となり、実際の deposit は呼ばれない想定
+    assert result.operation == AaveOperationType.NOOP
+    assert result.status in (
+        AaveOperationStatus.SUCCESS,
+        AaveOperationStatus.SKIPPED,
+    )
+    assert client.deposit_calls == []

--- a/backend/tests/test_automation_monitoring.py
+++ b/backend/tests/test_automation_monitoring.py
@@ -1,0 +1,78 @@
+# backend/tests/test_automation_monitoring.py
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+from app.automation.monitoring_service import MonitoringService
+from app.automation.schemas import AlertLevel, ComponentType
+
+
+def test_latency_thresholds_warning_and_alert() -> None:
+    service = MonitoringService(
+        latency_warning_threshold_s=10.0,
+        latency_alert_threshold_s=30.0,
+    )
+
+    # 11秒 → WARNING
+    event_warning = service.record_latency(
+        ComponentType.AI, timedelta(seconds=11), at=datetime(2025, 1, 1, tzinfo=timezone.utc)
+    )
+    assert event_warning is not None
+    assert event_warning.level == AlertLevel.WARNING
+    assert event_warning.code == "LATENCY_WARNING"
+
+    # 31秒 → ALERT
+    event_alert = service.record_latency(
+        ComponentType.AI, timedelta(seconds=31), at=datetime(2025, 1, 1, tzinfo=timezone.utc)
+    )
+    assert event_alert is not None
+    assert event_alert.level == AlertLevel.ALERT
+    assert event_alert.code == "LATENCY_ALERT"
+
+
+def test_health_factor_warning_and_emergency() -> None:
+    service = MonitoringService(
+        healthfactor_warning_threshold=Decimal("1.8"),
+        healthfactor_emergency_threshold=Decimal("1.6"),
+    )
+
+    # 1.7 → WARNING だが緊急停止にはならない
+    status_warning = service.record_health_factor(
+        Decimal("1.7"), at=datetime(2025, 1, 1, tzinfo=timezone.utc)
+    )
+    assert status_warning.level == AlertLevel.WARNING
+    assert status_warning.is_emergency is False
+    assert service.is_trading_allowed() is True
+
+    # 1.5 → EMERGENCY で緊急停止
+    status_emergency = service.record_health_factor(
+        Decimal("1.5"), at=datetime(2025, 1, 1, tzinfo=timezone.utc)
+    )
+    assert status_emergency.level == AlertLevel.EMERGENCY
+    assert status_emergency.is_emergency is True
+    assert service.is_trading_allowed() is False
+
+    status = service.get_status()
+    assert status.is_trading_paused is True
+    assert status.last_health_factor == Decimal("1.5")
+    assert status.emergency_reason is not None
+
+
+def test_price_change_alert() -> None:
+    service = MonitoringService(price_change_alert_threshold_pct=20.0)
+
+    # 10% 変動 → イベントなし
+    event_none = service.record_price_change_24h(
+        percent_change=10.0,
+        at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+    assert event_none is None
+
+    # 25% 変動 → ALERT
+    event_alert = service.record_price_change_24h(
+        percent_change=25.0,
+        at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+    assert event_alert is not None
+    assert event_alert.level == AlertLevel.ALERT
+    assert event_alert.code == "PRICE_CHANGE_ALERT"

--- a/backend/tests/test_automation_reporting.py
+++ b/backend/tests/test_automation_reporting.py
@@ -1,0 +1,107 @@
+# backend/tests/test_automation_reporting.py
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+from app.automation.monitoring_service import MonitoringService
+from app.automation.reporting_service import ReportingService
+from app.automation.schemas import ComponentType, ReportPeriod
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+def test_daily_report_summarizes_events_and_health_factor() -> None:
+    """
+    DAILY レポートが:
+    - 対象日のイベントだけを集計
+    - レベルごとの件数
+    - ヘルスファクターの min/max/last
+    を正しく計算できることを確認。
+    """
+    service = MonitoringService()
+    reporter = ReportingService(monitoring=service)
+
+    base = _utc(2025, 1, 2, 12, 0)
+
+    # 対象日内のイベント
+    # 11秒 → WARNING
+    service.record_latency(
+        ComponentType.AI,
+        timedelta(seconds=11),
+        at=base - timedelta(hours=3),
+    )
+    # 31秒 → ALERT
+    service.record_latency(
+        ComponentType.AI,
+        timedelta(seconds=31),
+        at=base - timedelta(hours=2),
+    )
+    # HF 1.7 → WARNING
+    service.record_health_factor(
+        Decimal("1.7"),
+        at=base - timedelta(hours=1, minutes=30),
+    )
+    # HF 1.5 → EMERGENCY
+    service.record_health_factor(
+        Decimal("1.5"),
+        at=base - timedelta(hours=1),
+    )
+
+    # 対象日より前のイベント（集計対象外）
+    service.record_latency(
+        ComponentType.AI,
+        timedelta(seconds=11),
+        at=base - timedelta(days=2),
+    )
+
+    summary = reporter.generate_summary_report(ReportPeriod.DAILY, now=base)
+
+    # 期間
+    assert summary.period == ReportPeriod.DAILY
+    assert summary.from_timestamp == _utc(2025, 1, 2, 0, 0)
+    assert summary.to_timestamp == base
+
+    # イベント件数（対象日の4件のみ）
+    assert summary.total_events == 4
+    assert summary.warning_count == 2  # latency(11s) + HF(1.7)
+    assert summary.alert_count == 1    # latency(31s)
+    assert summary.emergency_count == 1  # HF(1.5)
+    assert summary.critical_count == 0
+    assert summary.emergency_occurred is True
+
+    # ヘルスファクター集計
+    assert summary.min_health_factor == Decimal("1.5")
+    assert summary.max_health_factor == Decimal("1.7")
+    assert summary.last_health_factor == Decimal("1.5")
+
+
+def test_weekly_report_uses_last_7_days_window() -> None:
+    """
+    WEEKLY レポートが「直近7日間」のイベントのみを集計対象とすることを確認。
+    """
+    service = MonitoringService()
+    reporter = ReportingService(monitoring=service)
+
+    base = _utc(2025, 1, 8, 12, 0)  # 水曜日想定
+
+    # 6日前 → 集計対象（7日以内）
+    service.record_latency(
+        ComponentType.SYSTEM,
+        timedelta(seconds=31),
+        at=base - timedelta(days=6),
+    )
+
+    # 8日前 → 集計対象外
+    service.record_latency(
+        ComponentType.SYSTEM,
+        timedelta(seconds=31),
+        at=base - timedelta(days=8),
+    )
+
+    summary = reporter.generate_summary_report(ReportPeriod.WEEKLY, now=base)
+
+    assert summary.period == ReportPeriod.WEEKLY
+    # 直近7日分なので、件数は 1 のみ
+    assert summary.total_events == 1

--- a/backend/tests/test_automation_reporting_notifications.py
+++ b/backend/tests/test_automation_reporting_notifications.py
@@ -1,0 +1,80 @@
+# backend/tests/test_automation_reporting_notifications.py
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from app.automation.reporting_service import ReportingService
+from app.automation.schemas import AutomationReportSummary, ReportPeriod
+from app.notifications.schemas import NotificationChannel, NotificationSeverity
+from app.automation.monitoring_service import MonitoringService
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+def _base_summary(**overrides) -> AutomationReportSummary:
+    base = dict(
+        period=ReportPeriod.DAILY,
+        from_timestamp=_utc(2025, 1, 1),
+        to_timestamp=_utc(2025, 1, 2),
+        total_events=0,
+        info_count=0,
+        warning_count=0,
+        alert_count=0,
+        critical_count=0,
+        emergency_count=0,
+        emergency_occurred=False,
+        min_health_factor=None,
+        max_health_factor=None,
+        last_health_factor=None,
+        notes=None,
+    )
+    base.update(overrides)
+    return AutomationReportSummary(**base)
+
+
+def test_build_notification_message_emergency() -> None:
+    """
+    emergency_occurred=True の場合、EMERGENCY レベルの通知が生成されること。
+    """
+    monitoring = MonitoringService()
+    reporter = ReportingService(monitoring=monitoring)
+
+    summary = _base_summary(
+        total_events=3,
+        emergency_count=1,
+        emergency_occurred=True,
+    )
+
+    msg = reporter.build_notification_message(
+        summary,
+        channel=NotificationChannel.INTERNAL_LOG,
+    )
+
+    assert msg.severity == NotificationSeverity.EMERGENCY
+    assert "EMERGENCY" in msg.title
+    assert "emergency=1" in msg.body or "emergency=1" in msg.body.replace(" ", "")
+
+
+def test_build_notification_message_ok() -> None:
+    """
+    イベントがなく正常な期間の場合、INFO レベルの通知が生成されること。
+    """
+    monitoring = MonitoringService()
+    reporter = ReportingService(monitoring=monitoring)
+
+    summary = _base_summary(
+        total_events=0,
+        info_count=0,
+        notes="No monitoring events recorded during this period.",
+    )
+
+    msg = reporter.build_notification_message(
+        summary,
+        channel=NotificationChannel.INTERNAL_LOG,
+    )
+
+    assert msg.severity == NotificationSeverity.INFO
+    assert "OK" in msg.title
+    assert "No monitoring events" in msg.body

--- a/backend/tests/test_notifications_service.py
+++ b/backend/tests/test_notifications_service.py
@@ -1,0 +1,89 @@
+# backend/tests/test_notifications_service.py
+
+import logging
+from typing import List
+
+from app.notifications.schemas import NotificationChannel, NotificationMessage, NotificationSeverity
+from app.notifications.service import (
+    CompositeNotificationService,
+    LoggingNotificationSender,
+)
+
+
+def test_logging_notification_sender_uses_correct_log_level(caplog) -> None:
+    """
+    LoggingNotificationSender が severity に応じたログレベルで出力することを確認。
+    """
+    logger = logging.getLogger("test_logger_notifications")
+    sender = LoggingNotificationSender(logger_=logger)
+
+    message_info = NotificationMessage(
+        channel=NotificationChannel.INTERNAL_LOG,
+        severity=NotificationSeverity.INFO,
+        title="info-title",
+        body="info-body",
+    )
+    message_warn = NotificationMessage(
+        channel=NotificationChannel.INTERNAL_LOG,
+        severity=NotificationSeverity.WARNING,
+        title="warn-title",
+        body="warn-body",
+    )
+    message_err = NotificationMessage(
+        channel=NotificationChannel.INTERNAL_LOG,
+        severity=NotificationSeverity.EMERGENCY,
+        title="em-title",
+        body="em-body",
+    )
+
+    with caplog.at_level(logging.INFO, logger="test_logger_notifications"):
+        sender.send(message_info)
+        sender.send(message_warn)
+        sender.send(message_err)
+
+    # message_info/info-body が INFO レベルで出力されていること
+    info_records = [
+        r for r in caplog.records if r.levelno == logging.INFO and "info-body" in r.getMessage()
+    ]
+    assert info_records, "INFO log should contain 'info-body'"
+
+    # WARNING
+    warn_records = [
+        r for r in caplog.records if r.levelno == logging.WARNING and "warn-body" in r.getMessage()
+    ]
+    assert warn_records, "WARNING log should contain 'warn-body'"
+
+    # ERROR (EMERGENCY/ALERT)
+    err_records = [
+        r for r in caplog.records if r.levelno == logging.ERROR and "em-body" in r.getMessage()
+    ]
+    assert err_records, "ERROR log should contain 'em-body'"
+
+
+class DummySender:
+    def __init__(self) -> None:
+        self.messages: List[NotificationMessage] = []
+
+    def send(self, message: NotificationMessage) -> None:
+        self.messages.append(message)
+
+
+def test_composite_notification_service_fanout() -> None:
+    """
+    CompositeNotificationService が複数 Sender に対して send() を呼び出すことを確認。
+    """
+    sender1 = DummySender()
+    sender2 = DummySender()
+    service = CompositeNotificationService([sender1, sender2])
+
+    msg = NotificationMessage(
+        channel=NotificationChannel.INTERNAL_LOG,
+        severity=NotificationSeverity.INFO,
+        title="test",
+        body="hello",
+    )
+
+    service.send(msg)
+
+    assert sender1.messages == [msg]
+    assert sender2.messages == [msg]

--- a/docs/02_phase_plan.md
+++ b/docs/02_phase_plan.md
@@ -30,3 +30,8 @@ Ultra AutoTrade – フェーズ計画（DoD 追加版）
 - レポート自動生成成功  
 - 全フロー成功率95%以上  
 
+※ 実装マッピング（Phase5）  
+- 監視＆アラート: `MonitoringService` + Aave/OctoBot 連携  
+- レポート自動生成: `ReportingService` による日次/週次サマリー  
+- 通知インターフェース: `notifications/*` で NotificationMessage / Sender 抽象化  
+- 緊急停止時の安全動作: Aave 側での NOOP 保証（ヘルスファクター/緊急停止フラグ連携）

--- a/docs/03_directory_structure.md
+++ b/docs/03_directory_structure.md
@@ -36,7 +36,17 @@ project root/
 │   │   │   ├── service.py          # TradeAction → AaveOperation 変換サービス層
 │   │   │   ├── schemas.py          # AaveRebalanceRequest/Response, AaveOperationResult など
 │   │   │   ├── router.py           # /aave/rebalance エンドポイント定義
-│   │   ├── automation/             # 自動実行・スケジューラ関連（将来拡張）
+│   │   ├── automation/             # 自動化・監視・レポート用モジュール（Phase5）
+│   │   │   ├── __init__.py         # automation パッケージマーカー
+│   │   │   ├── schemas.py          # MonitoringEvent / AutomationStatus / 
+│   │   │   ├── monitoring_service.py # 死活監視・緊急停止ロジック本体
+│   │   │   ├── reporting_service.py # 日次/週次サマリーレポート集計ロジック
+│   │   │   └── state.py            # MonitoringService の共有インスタンス管理
+│   │   ├── notifications/             # 通知レイヤ（Phase5: インターフェースのみ）
+│   │   │   ├── __init__.py         # notifications パッケージマーカー
+│   │   │   ├── schemas.py          # NotificationMessage / NotificationChannel / Severity など 
+│   │   │   ├── service.py.         # NotificationSender / CompositeNotificationService 実装
+│   │   │   └── factory.py          # get_notification_service() ファクトリ
 │   │   └── utils/
 │   │       ├── __init__.py         # 共通ユーティリティパッケージマーカー
 │   │       └── config.py           # /aave/rebalance エンドポイント定義
@@ -53,7 +63,11 @@ project root/
 │   │   ├── test_aave_service.py    # AaveService のユニットテスト（Dummy/Fake クライアント）
 │   │   ├── test_aave_router.py     # /aave/rebalance の API テスト
 │   │   ├── test_flow_with_aave_stub.py # AI → OctoBot → Aave 統合テストの雛形（現状 skip）
-│   │   └── test_ai_service.py      # ...
+│   │   ├── test_automation_monitoring.py # MonitoringService と AaveService 連携テスト
+│   │   ├── test_automation_emergency_integration.py # サマリーレポート集計ロジックのテスト
+│   │   ├── test_automation_reporting.py # 通知サービス（Logging/Composite）のテスト
+│   │   ├── test_notifications_service.py # AI → OctoBot → Aave 統合テストの雛形（現状 skip）
+│   │   └── test_automation_reporting_notifications.py # レポート→通知メッセージ変換のテスト
 │   └── requirements.txt            # backend 依存パッケージ一覧
 │
 ├── frontend/

--- a/docs/08_automation_rules.md
+++ b/docs/08_automation_rules.md
@@ -30,7 +30,19 @@ Aave 側のポジション増加ペースを機械的に抑制する。
 ```
 ヘルスファクター < 1.8 → 警告  
 ヘルスファクター < 1.6 → 緊急停止  
-資産変動 > 20%/日 → アラート  
+資産変動 > 20%/日 → アラート
+
+# 3.1 緊急停止ルール
+
+- ヘルスファクター < 1.8 → 警告  
+- ヘルスファクター < 1.6 → 緊急停止  
+- 資産変動 > 20%/日 → アラート  
+
+※ Phase5 実装状況  
+- `backend/app/automation/monitoring_service.py` の `MonitoringService` にて、  
+  上記しきい値に基づく `MonitoringEvent` 発行と `is_trading_paused` 制御を実装済み。  
+- `backend/app/aave/service.py` の `AaveService` が `MonitoringService` を参照し、  
+  緊急停止中は BUY/DEPOSIT 系のトレードを NOOP として扱う。  
 ```
 
 ---
@@ -42,3 +54,8 @@ Aave 側のポジション増加ペースを機械的に抑制する。
 
 # 5. 緊急時のAIレポート
 - 異常検知時、AIが状況説明レポートを生成  
+
+※ Phase5 時点  
+- 緊急時のサマリーデータ（イベント分布・ヘルスファクターなど）は  
+  `AutomationReportSummary`（`backend/app/automation/schemas.py`）として集計可能。  
+- そこから自然言語レポートを生成する AI ロジックは **次フェーズ以降** の実装対象とする。

--- a/docs/14_test_strategy.md
+++ b/docs/14_test_strategy.md
@@ -165,6 +165,23 @@ Notion → AI → OctoBot → Aave のフローが
 - 将来的に Notion → AI → OctoBot → Aave のフローをすべてモックで接続し、
   「1件のニュースから Aave まで到達する」シナリオを増やす予定
 
+### 監視・自動化まわりのテスト（Phase5）
+
+- `backend/tests/test_automation_monitoring.py`  
+  - `MonitoringService` 単体のしきい値判定（応答時間 / ヘルスファクター / 価格変動）。
+- `backend/tests/test_automation_emergency_integration.py`  
+  - 緊急停止フラグが立っている状態で、`AaveService.execute_rebalance` が  
+    ポジションを増やさない（NOOP になる）ことを確認。
+- `backend/tests/test_automation_reporting.py`  
+  - 直近のイベント／ヘルスファクター履歴から、  
+    `AutomationReportSummary` が日次 / 週次で正しく集計されることを確認。
+- `backend/tests/test_notifications_service.py`  
+  - `LoggingNotificationSender` が severity に応じて適切なログレベルを使うこと。  
+  - `CompositeNotificationService` が複数 Sender へファンアウトすること。
+- `backend/tests/test_automation_reporting_notifications.py`  
+  - `ReportingService.build_notification_message` が  
+    サマリ内容に応じて NotificationSeverity / タイトル / 本文を正しく構築すること。
+
 ---
 
 # 4. Integration Test


### PR DESCRIPTION
## 変更概要

### 1. 監視・緊急停止ロジック（MonitoringService）

- `backend/app/automation/monitoring_service.py`
  - 応答時間 / ヘルスファクター / 24h価格変動のしきい値判定を実装
  - 緊急停止時には `is_trading_paused=True` とし、EMERGENCY イベントを発行
  - ヘルスファクター履歴・イベント履歴をレポート用に保持

### 2. Aave/OctoBot との連携

- `backend/app/aave/service.py`
  - `MonitoringService` を注入可能にし、緊急停止中は BUY/DEPOSIT を NOOP として扱う
  - ヘルスファクターを記録し、閾値を下回った場合に EMERGENCY を発火
- `backend/app/bots/service.py`
  - OctoBot シグナル送信時に `record_trade()` を呼び出し、
    過剰取引監視用のメトリクスを蓄積

### 3. レポート集計ロジック

- `backend/app/automation/reporting_service.py`
  - `ReportPeriod (DAILY/WEEKLY)` ごとの時間範囲を決定
  - 対象期間のイベントとヘルスファクター履歴を集計し、
    `AutomationReportSummary` を生成

### 4. 通知インターフェース

- `backend/app/notifications/schemas.py`
  - `NotificationMessage` / `NotificationChannel` / `NotificationSeverity`
- `backend/app/notifications/service.py`
  - `NotificationSender` プロトコル
  - `LoggingNotificationSender`（ログ出力のみ）
  - `CompositeNotificationService`（複数 Sender へのファンアウト）
- `backend/app/notifications/factory.py`
  - `get_notification_service()` で共通インスタンスを提供
- `ReportingService.build_notification_message()`
  - `AutomationReportSummary` から緊急度に応じた通知メッセージを生成

### 5. テスト

- 監視・緊急停止:
  - `test_automation_monitoring.py`
  - `test_automation_emergency_integration.py`
- レポート:
  - `test_automation_reporting.py`
  - `test_automation_reporting_notifications.py`
- 通知:
  - `test_notifications_service.py`

## チェックリスト

- [ ] 監視・緊急停止のしきい値が docs/08_automation_rules.md と一致している
- [ ] Aave 側で「ポジションを増やさない」ポリシーが崩れていない
- [ ] 追加テストがすべて Green (`pytest backend/tests/test_automation_* backend/tests/test_notifications_service.py`)
- [ ] docs/03_directory_structure.md に新ディレクトリが反映されている
- [ ] docs/14_test_strategy.md に新テスト方針が反映されている
- [ ] 変更内容を README / 開発メモで共有済み