### PR TITLE
Phase7: Staging インフラデプロイ & 運用フロー整備

### DIFF
--- a/backend/app/automation/backup_service.py
+++ b/backend/app/automation/backup_service.py
@@ -1,0 +1,172 @@
+# backend/app/automation/backup_service.py
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Callable, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class BackupTargetType(str, Enum):
+    """
+    バックアップ対象の種別。
+
+    Phase6 時点では:
+    - NOTION: Notion 側のニュースデータやメタ情報
+    - AI_ANALYSIS: AI 判定結果
+    - TRADES: 取引履歴やポジション情報
+
+    実際にどのようなストレージに書き出すかは、呼び出し側から注入される
+    バックアップ関数に委ねる。
+    """
+
+    NOTION = "notion"
+    AI_ANALYSIS = "ai_analysis"
+    TRADES = "trades"
+
+
+class BackupStatus(str, Enum):
+    """
+    バックアップ全体のステータス。
+    """
+
+    SUCCESS = "success"
+    PARTIAL = "partial"
+    FAILURE = "failure"
+
+
+class BackupItemResult(BaseModel):
+    """
+    各バックアップ対象ごとの結果。
+    """
+
+    target: BackupTargetType = Field(..., description="バックアップ対象の種別")
+    items_backed_up: int = Field(
+        0,
+        ge=0,
+        description="バックアップされたレコード件数。失敗した場合は 0。",
+    )
+    error: Optional[str] = Field(
+        None,
+        description="失敗した場合のエラーメッセージ（成功時は None）。",
+    )
+
+
+class BackupResult(BaseModel):
+    """
+    バックアップ全体の結果。
+    """
+
+    started_at: datetime = Field(..., description="バックアップ開始時刻（UTC 推奨）")
+    finished_at: datetime = Field(..., description="バックアップ終了時刻（UTC 推奨）")
+    status: BackupStatus = Field(..., description="全体のステータス")
+    items: List[BackupItemResult] = Field(
+        default_factory=list,
+        description="各バックアップ対象の結果一覧。",
+    )
+    message: str = Field(
+        ...,
+        description="人間向けのサマリーメッセージ。",
+    )
+
+
+BackupHandler = Callable[[], int]
+"""バックアップを実行し、バックアップした件数を返すコールバック型。"""
+
+
+class BackupService:
+    """
+    自動バックアップ処理を統括するサービス。
+
+    実際の I/O（ファイル出力・外部ストレージ・Notion API など）は行わず、
+    呼び出し側から渡されたコールバックを順に実行して結果を集約する。
+
+    これにより:
+    - ユニットテストでは純粋に件数を返すダミー関数を渡せる
+    - 本番コードでは Notion / DB / ファイル書き込みの実処理を注入できる
+    """
+
+    def __init__(
+        self,
+        backup_notion: Optional[BackupHandler] = None,
+        backup_ai_analysis: Optional[BackupHandler] = None,
+        backup_trades: Optional[BackupHandler] = None,
+    ) -> None:
+        self._handlers: Dict[BackupTargetType, BackupHandler] = {}
+        if backup_notion is not None:
+            self._handlers[BackupTargetType.NOTION] = backup_notion
+        if backup_ai_analysis is not None:
+            self._handlers[BackupTargetType.AI_ANALYSIS] = backup_ai_analysis
+        if backup_trades is not None:
+            self._handlers[BackupTargetType.TRADES] = backup_trades
+
+    @property
+    def has_handlers(self) -> bool:
+        """
+        1つ以上のバックアップハンドラが登録されているかどうか。
+        """
+        return bool(self._handlers)
+
+    def run_backup(self) -> BackupResult:
+        """
+        登録された全バックアップ処理を順に実行し、結果をまとめて返す。
+
+        例外が発生した場合は:
+        - その対象の BackupItemResult.error にエラーメッセージを格納
+        - 他の対象のバックアップは継続する
+        """
+        started_at = datetime.now(timezone.utc)
+
+        item_results: List[BackupItemResult] = []
+
+        for target, handler in self._handlers.items():
+            try:
+                count = int(handler() or 0)
+                item_results.append(
+                    BackupItemResult(
+                        target=target,
+                        items_backed_up=count,
+                        error=None,
+                    )
+                )
+            except Exception as exc:  # noqa: BLE001 - バックアップ失敗しても他は続行
+                item_results.append(
+                    BackupItemResult(
+                        target=target,
+                        items_backed_up=0,
+                        error=str(exc),
+                    )
+                )
+
+        finished_at = datetime.now(timezone.utc)
+
+        if not item_results:
+            status = BackupStatus.FAILURE
+            message = "No backup handlers configured. Nothing was backed up."
+        else:
+            any_error = any(item.error for item in item_results)
+            all_error = all(item.error for item in item_results)
+
+            if all_error:
+                status = BackupStatus.FAILURE
+            elif any_error:
+                status = BackupStatus.PARTIAL
+            else:
+                status = BackupStatus.SUCCESS
+
+            parts: List[str] = []
+            for item in item_results:
+                if item.error:
+                    parts.append(f"{item.target.value}: failed ({item.error})")
+                else:
+                    parts.append(f"{item.target.value}: ok ({item.items_backed_up} items)")
+            message = "; ".join(parts)
+
+        return BackupResult(
+            started_at=started_at,
+            finished_at=finished_at,
+            status=status,
+            items=item_results,
+            message=message,
+        )

--- a/backend/app/automation/emergency_report_service.py
+++ b/backend/app/automation/emergency_report_service.py
@@ -1,0 +1,141 @@
+# backend/app/automation/emergency_report_service.py
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Sequence
+
+from pydantic import BaseModel, Field
+
+from .schemas import AutomationReportSummary, MonitoringEvent, AlertLevel
+
+
+class EmergencyReport(BaseModel):
+    """
+    緊急時に人間向けに提示するレポート。
+
+    通知（LINE/Slack）の本文や、後続フェーズで Notion に保存する
+    レポートテキストとして再利用できるよう、シンプルな構造にしている。
+    """
+
+    title: str = Field(..., description="レポートタイトル")
+    body: str = Field(..., description="本文（プレーンテキスト）")
+
+
+class EmergencyReportService:
+    """
+    AutomationReportSummary と MonitoringEvent の一覧から、
+    緊急時の状況説明レポートを生成するサービス。
+    """
+
+    @staticmethod
+    def _derive_severity_label(summary: AutomationReportSummary) -> str:
+        # emergency > alert/critical > warning > info の順で判定
+        if getattr(summary, "emergency_occurred", False) or getattr(summary, "emergency_count", 0) > 0:
+            return "EMERGENCY"
+        if getattr(summary, "alert_count", 0) > 0 or getattr(summary, "critical_count", 0) > 0:
+            return "ALERT"
+        if getattr(summary, "warning_count", 0) > 0:
+            return "WARNING"
+        return "INFO"
+
+    @staticmethod
+    def _format_period(summary: AutomationReportSummary) -> str:
+        period = getattr(summary, "period", None)
+        period_label = getattr(period, "value", str(period)) if period is not None else "unknown"
+
+        from_ts: datetime = getattr(summary, "from_timestamp")
+        to_ts: datetime = getattr(summary, "to_timestamp")
+
+        return f"{period_label} {from_ts.isoformat()} – {to_ts.isoformat()}"
+
+    @staticmethod
+    def _select_notable_events(
+        events: Sequence[MonitoringEvent],
+        max_events: int,
+    ) -> List[MonitoringEvent]:
+        """
+        重要度の高いイベントを優先して最大 max_events 件まで抽出する。
+        """
+        if not events:
+            return []
+
+        # EMERGENCY / CRITICAL / ALERT / WARNING / INFO の優先度
+        level_priority = {
+            AlertLevel.EMERGENCY: 4,
+            AlertLevel.CRITICAL: 3,
+            AlertLevel.ALERT: 2,
+            AlertLevel.WARNING: 1,
+            AlertLevel.INFO: 0,
+        }
+
+        sorted_events = sorted(
+            events,
+            key=lambda e: (level_priority.get(e.level, 0), e.timestamp),
+            reverse=True,
+        )
+
+        return list(sorted_events[:max_events])
+
+    def build_emergency_report(
+        self,
+        summary: AutomationReportSummary,
+        events: Sequence[MonitoringEvent],
+        *,
+        max_events: int = 20,
+    ) -> EmergencyReport:
+        """
+        サマリとイベント一覧から緊急時レポートを生成する。
+        """
+        severity_label = self._derive_severity_label(summary)
+        period_str = self._format_period(summary)
+
+        title = f"[{severity_label}] Automation emergency report ({period_str})"
+
+        lines: List[str] = []
+        lines.append(f"Severity: {severity_label}")
+        lines.append(f"Period: {period_str}")
+
+        # イベント件数の概要
+        lines.append(
+            "Event counts: "
+            f"total={summary.total_events}, "
+            f"info={summary.info_count}, "
+            f"warning={summary.warning_count}, "
+            f"alert={summary.alert_count}, "
+            f"critical={summary.critical_count}, "
+            f"emergency={summary.emergency_count}"
+        )
+
+        # ヘルスファクターの情報
+        min_hf = getattr(summary, "min_health_factor", None)
+        max_hf = getattr(summary, "max_health_factor", None)
+        last_hf = getattr(summary, "last_health_factor", None)
+        if any(v is not None for v in (min_hf, max_hf, last_hf)):
+            lines.append(
+                "Health factor: "
+                f"min={min_hf}, max={max_hf}, last={last_hf}"
+            )
+
+        # 重要なイベント一覧
+        notable_events = self._select_notable_events(events, max_events=max_events)
+        if notable_events:
+            lines.append("")
+            lines.append("Recent notable events:")
+            for ev in notable_events:
+                lines.append(
+                    f"- [{ev.level}] {ev.timestamp.isoformat()} "
+                    f"{ev.component}: {ev.code} - {ev.message}"
+                )
+        else:
+            lines.append("")
+            lines.append("Recent notable events: (none)")
+
+        # notes があれば末尾に追記
+        notes = getattr(summary, "notes", None)
+        if notes:
+            lines.append("")
+            lines.append("Notes:")
+            lines.append(notes)
+
+        body = "\n".join(lines)
+        return EmergencyReport(title=title, body=body)

--- a/backend/app/automation/jobs.py
+++ b/backend/app/automation/jobs.py
@@ -1,0 +1,135 @@
+# backend/app/automation/jobs.py
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from app.automation.reporting_service import ReportingService
+from app.automation.schemas import ReportPeriod
+from app.notifications.factory import get_notification_service
+from app.notifications.schemas import NotificationChannel
+from app.notifications.service import CompositeNotificationService
+
+from .backup_service import BackupService
+
+
+def _normalize_now(now: Optional[datetime]) -> datetime:
+    """
+    naive な datetime が渡された場合でも UTC として扱うヘルパー。
+    """
+    if now is None:
+        return datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        return now.replace(tzinfo=timezone.utc)
+    return now
+
+
+def run_daily_jobs(
+    *,
+    reporter: Optional[ReportingService] = None,
+    notification_service: Optional[CompositeNotificationService] = None,
+    backup_service: Optional[BackupService] = None,
+    channel: NotificationChannel = NotificationChannel.INTERNAL_LOG,
+    now: Optional[datetime] = None,
+    run_backup: bool = False,
+) -> None:
+    """
+    日次の自動ジョブを実行する。
+
+    - MonitoringService のイベントを集計して AutomationReportSummary を生成
+    - そのサマリから NotificationMessage を構築して通知送信
+    - オプションでバックアップ処理を実行
+    """
+    reporter = reporter or ReportingService()
+    notification_service = notification_service or get_notification_service()
+    now_norm = _normalize_now(now)
+
+    summary = reporter.generate_summary_report(ReportPeriod.DAILY, now=now_norm)
+    message = ReportingService.build_notification_message(summary, channel=channel)
+    notification_service.send(message)
+
+    if run_backup and backup_service is not None:
+        backup_service.run_backup()
+
+
+def run_weekly_jobs(
+    *,
+    reporter: Optional[ReportingService] = None,
+    notification_service: Optional[CompositeNotificationService] = None,
+    backup_service: Optional[BackupService] = None,
+    channel: NotificationChannel = NotificationChannel.INTERNAL_LOG,
+    now: Optional[datetime] = None,
+    run_backup: bool = False,
+) -> None:
+    """
+    週次の自動ジョブを実行する。
+
+    現時点では日次ジョブと同様に:
+    - サマリレポート生成
+    - 通知送信
+    - （オプションで）バックアップ実行
+    を行う。
+    """
+    reporter = reporter or ReportingService()
+    notification_service = notification_service or get_notification_service()
+    now_norm = _normalize_now(now)
+
+    summary = reporter.generate_summary_report(ReportPeriod.WEEKLY, now=now_norm)
+    message = ReportingService.build_notification_message(summary, channel=channel)
+    notification_service.send(message)
+
+    if run_backup and backup_service is not None:
+        backup_service.run_backup()
+
+
+def run_backup_only(*, backup_service: BackupService) -> None:
+    """
+    バックアップだけを実行するシンプルなヘルパー。
+
+    cron などから「バックアップだけ走らせたい」場合に利用する。
+    """
+    backup_service.run_backup()
+
+
+def main() -> None:
+    """
+    簡易 CLI エントリーポイント。
+
+    例:
+        python -m app.automation.jobs daily
+        python -m app.automation.jobs weekly
+        python -m app.automation.jobs backup-only
+
+    本番運用では、scripts/backup.sh / scripts/monitor.sh から呼び出す想定。
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Automation jobs runner")
+    parser.add_argument(
+        "job",
+        choices=["daily", "weekly", "backup-only"],
+        help="実行するジョブ種別",
+    )
+    args = parser.parse_args()
+
+    reporter = ReportingService()
+    notification_service = get_notification_service()
+
+    if args.job == "daily":
+        run_daily_jobs(
+            reporter=reporter,
+            notification_service=notification_service,
+        )
+    elif args.job == "weekly":
+        run_weekly_jobs(
+            reporter=reporter,
+            notification_service=notification_service,
+        )
+    elif args.job == "backup-only":
+        # バックアップの具体的なハンドラは、後続フェーズで注入する想定。
+        backup_service = BackupService()
+        run_backup_only(backup_service=backup_service)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_automation_backup_service.py
+++ b/backend/tests/test_automation_backup_service.py
@@ -1,0 +1,71 @@
+# backend/tests/test_automation_backup_service.py
+from app.automation.backup_service import (
+    BackupService,
+    BackupStatus,
+    BackupTargetType,
+)
+
+
+def test_backup_service_success() -> None:
+    calls = {}
+
+    def backup_notion() -> int:
+        calls["notion"] = True
+        return 10
+
+    def backup_ai() -> int:
+        calls["ai"] = True
+        return 5
+
+    def backup_trades() -> int:
+        calls["trades"] = True
+        return 2
+
+    service = BackupService(
+        backup_notion=backup_notion,
+        backup_ai_analysis=backup_ai,
+        backup_trades=backup_trades,
+    )
+
+    result = service.run_backup()
+
+    assert result.status == BackupStatus.SUCCESS
+    assert len(result.items) == 3
+    assert sum(item.items_backed_up for item in result.items) == 17
+    assert all(item.error is None for item in result.items)
+    assert calls == {"notion": True, "ai": True, "trades": True}
+
+
+def test_backup_service_partial_failure() -> None:
+    def backup_ok() -> int:
+        return 3
+
+    def backup_fail() -> int:
+        raise RuntimeError("boom")
+
+    service = BackupService(
+        backup_notion=backup_ok,
+        backup_ai_analysis=backup_fail,
+    )
+
+    result = service.run_backup()
+
+    assert result.status == BackupStatus.PARTIAL
+    assert len(result.items) == 2
+
+    errors = [item for item in result.items if item.error]
+    oks = [item for item in result.items if not item.error]
+
+    assert len(errors) == 1
+    assert len(oks) == 1
+    assert "boom" in errors[0].error  # type: ignore[operator]
+
+
+def test_backup_service_all_failure_when_no_handlers() -> None:
+    service = BackupService()
+
+    result = service.run_backup()
+
+    assert result.status == BackupStatus.FAILURE
+    assert result.items == []
+    assert "No backup handlers configured" in result.message

--- a/backend/tests/test_automation_emergency_report_service.py
+++ b/backend/tests/test_automation_emergency_report_service.py
@@ -1,0 +1,89 @@
+# backend/tests/test_automation_emergency_report_service.py
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from app.automation.emergency_report_service import EmergencyReportService
+from app.automation.schemas import (
+    AlertLevel,
+    AutomationReportSummary,
+    ComponentType,
+    MonitoringEvent,
+    ReportPeriod,
+)
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+def _base_summary(**overrides) -> AutomationReportSummary:
+    base = {
+        "period": ReportPeriod.DAILY,
+        "from_timestamp": _utc(2025, 1, 1),
+        "to_timestamp": _utc(2025, 1, 2),
+        "total_events": 0,
+        "info_count": 0,
+        "warning_count": 0,
+        "alert_count": 0,
+        "critical_count": 0,
+        "emergency_count": 0,
+        "emergency_occurred": False,
+        "min_health_factor": None,
+        "max_health_factor": None,
+        "last_health_factor": None,
+        "notes": None,
+    }
+    base.update(overrides)
+    return AutomationReportSummary(**base)
+
+
+def _event(level: AlertLevel, code: str, message: str) -> MonitoringEvent:
+    return MonitoringEvent(
+        timestamp=_utc(2025, 1, 2, 12, 0),
+        component=ComponentType.AAVE,
+        level=level,
+        code=code,
+        message=message,
+    )
+
+
+def test_emergency_report_includes_severity_and_counts() -> None:
+    summary = _base_summary(
+        total_events=5,
+        warning_count=1,
+        alert_count=1,
+        emergency_count=1,
+        emergency_occurred=True,
+        min_health_factor=Decimal("1.2"),
+        max_health_factor=Decimal("1.8"),
+        last_health_factor=Decimal("1.3"),
+    )
+    events = [
+        _event(AlertLevel.EMERGENCY, "HF_BELOW_THRESHOLD", "Health factor dropped below safe threshold"),
+    ]
+
+    service = EmergencyReportService()
+    report = service.build_emergency_report(summary, events)
+
+    assert "[EMERGENCY]" in report.title
+    assert "total=5" in report.body
+    assert "emergency=1" in report.body
+    assert "Health factor" in report.body
+    assert "HF_BELOW_THRESHOLD" in report.body
+
+
+def test_emergency_report_handles_no_events() -> None:
+    summary = _base_summary(
+        total_events=0,
+        info_count=0,
+        notes="No monitoring events recorded during this period.",
+    )
+
+    service = EmergencyReportService()
+    report = service.build_emergency_report(summary, events=[])
+
+    # INFO レベル相当のレポートになっていることをざっくり確認
+    assert "INFO" in report.title or "OK" in report.title or "Automation" in report.title
+    assert "No monitoring events" in report.body or "none" in report.body.lower()
+    assert "Notes" in report.body
+    assert "No monitoring events recorded during this period." in report.body

--- a/backend/tests/test_automation_jobs.py
+++ b/backend/tests/test_automation_jobs.py
@@ -1,0 +1,78 @@
+# backend/tests/test_automation_jobs.py
+from datetime import datetime, timezone
+
+from app.automation.backup_service import BackupService
+from app.automation.jobs import run_backup_only, run_daily_jobs, run_weekly_jobs
+from app.automation.reporting_service import ReportingService
+from app.notifications.schemas import NotificationChannel
+
+
+class DummyNotificationService:
+    def __init__(self) -> None:
+        self.messages = []
+
+    def send(self, message) -> None:
+        self.messages.append(message)
+
+
+class DummyBackupService(BackupService):
+    def __init__(self) -> None:
+        super().__init__()
+        self.ran = False
+
+    def run_backup(self):
+        self.ran = True
+        return super().run_backup()
+
+
+def _utc(year: int, month: int, day: int) -> datetime:
+    return datetime(year, month, day, tzinfo=timezone.utc)
+
+
+def test_run_daily_jobs_sends_notification_and_optionally_runs_backup() -> None:
+    reporter = ReportingService()
+    notification = DummyNotificationService()
+    backup = DummyBackupService()
+
+    now = _utc(2025, 1, 2)
+
+    # backup あり
+    run_daily_jobs(
+        reporter=reporter,
+        notification_service=notification,
+        backup_service=backup,
+        channel=NotificationChannel.INTERNAL_LOG,
+        now=now,
+        run_backup=True,
+    )
+
+    assert len(notification.messages) == 1
+    assert backup.ran is True
+
+
+def test_run_weekly_jobs_sends_notification_without_backup_by_default() -> None:
+    reporter = ReportingService()
+    notification = DummyNotificationService()
+    backup = DummyBackupService()
+
+    now = _utc(2025, 1, 8)
+
+    run_weekly_jobs(
+        reporter=reporter,
+        notification_service=notification,
+        backup_service=backup,
+        channel=NotificationChannel.INTERNAL_LOG,
+        now=now,
+        run_backup=False,
+    )
+
+    assert len(notification.messages) == 1
+    assert backup.ran is False
+
+
+def test_run_backup_only_uses_provided_service() -> None:
+    backup = DummyBackupService()
+
+    run_backup_only(backup_service=backup)
+
+    assert backup.ran is True

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# プロジェクトルート（scripts/ の1つ上）に移動
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${PROJECT_ROOT}/backend"
+
+# Python 仮想環境の管理方法は環境によって異なるため、
+# ここでは poetry があればそれを使い、なければ素の python を使う。
+if command -v poetry >/dev/null 2>&1; then
+  poetry run python -m app.automation.jobs backup-only
+else
+  python -m app.automation.jobs backup-only
+fi

--- a/scripts/monitor.sh
+++ b/scripts/monitor.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# プロジェクトルート（scripts/ の1つ上）に移動
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${PROJECT_ROOT}/backend"
+
+JOB="${1:-daily}"
+
+if [[ "${JOB}" != "daily" && "${JOB}" != "weekly" ]]; then
+  echo "Usage: $0 [daily|weekly]" >&2
+  exit 1
+fi
+
+if command -v poetry >/dev/null 2>&1; then
+  poetry run python -m app.automation.jobs "${JOB}"
+else
+  python -m app.automation.jobs "${JOB}"
+fi


### PR DESCRIPTION
**変更点のまとめ（概要）**

* FastAPI backend を Hetzner 等にデプロイするための Docker / systemd / デプロイスクリプトを追加
* Aave テストネット / OctoBot ステージングへの接続設計をドキュメント化
* `backup.sh` / `monitor.sh` を cron から安全に回すためのスケジュール設計とサンプル crontab を追加
* 緊急停止フラグ・ロールバック手順・運用ランブック・staging リリースチェックリストを整備

**チェックリスト**

* [ ] `docs/*.md` が本 PR の内容と整合している
* [ ] `Dockerfile` / `docker-compose.staging.yml` でローカルビルド・起動確認済み
* [ ] staging サーバで `/health` が 200 を返すことを確認
* [ ] `scripts/backup.sh` / `scripts/monitor.sh` を手動実行し成功したことを確認
* [ ] cron 設定（`18_scheduler_and_cron.md`）に記載したジョブでログが生成されることを確認
* [ ] 緊急停止フラグ ON/OFF によるトレード停止挙動を staging で確認
* [ ] `20_staging_release_checklist.md` の項目をすべてチェック