### PR TITLE
Phase10: 監視ダッシュボード用集約ロジックと Runbook 反映

### DIFF
--- a/backend/tests/test_automation_dashboard_view.py
+++ b/backend/tests/test_automation_dashboard_view.py
@@ -1,0 +1,83 @@
+# backend/tests/test_automation_dashboard_view.py
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+from app.automation.monitoring_service import MonitoringService
+from app.automation.schemas import ComponentType
+
+
+def _utc(
+    year: int,
+    month: int,
+    day: int,
+    hour: int = 0,
+    minute: int = 0,
+) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+def test_dashboard_snapshot_aggregates_metrics_within_lookback_window() -> None:
+    service = MonitoringService(
+        latency_warning_threshold_s=10.0,
+        latency_alert_threshold_s=30.0,
+    )
+
+    base = _utc(2025, 1, 2, 12, 0)
+
+    # lookback 内（1時間）のイベント: 2件
+    service.record_latency(
+        ComponentType.SYSTEM,
+        timedelta(seconds=11),
+        at=base - timedelta(minutes=30),
+    )
+    service.record_latency(
+        ComponentType.SYSTEM,
+        timedelta(seconds=31),
+        at=base - timedelta(minutes=10),
+    )
+
+    # lookback 外（2時間前）のイベント: 集計対象外
+    service.record_latency(
+        ComponentType.SYSTEM,
+        timedelta(seconds=40),
+        at=base - timedelta(hours=2),
+    )
+
+    snapshot = service.build_dashboard_snapshot(
+        lookback=timedelta(hours=1),
+        now=base,
+    )
+
+    # SYSTEM 向けレイテンシメトリクスが 2件だけ集計されていること
+    agg = snapshot.metric_aggregates.get("latency_system_s")
+    assert agg is not None
+    assert agg.count == 2
+    assert agg.min == Decimal("11.0")
+    assert agg.max == Decimal("31.0")
+    assert agg.last == Decimal("31.0")
+    # 平均値も確認
+    assert agg.avg == Decimal("21.0")
+
+
+def test_dashboard_snapshot_empty_when_no_events_in_lookback() -> None:
+    service = MonitoringService()
+    base = _utc(2025, 1, 2, 12, 0)
+
+    # 過去にイベントがあっても、lookback より前なら集計対象外
+    service.record_latency(
+        ComponentType.SYSTEM,
+        timedelta(seconds=31),
+        at=base - timedelta(hours=2),
+    )
+
+    snapshot = service.build_dashboard_snapshot(
+        lookback=timedelta(hours=1),
+        now=base,
+    )
+
+    # メトリクス集計は空だが、ステータス自体は取得できること
+    assert snapshot.metric_aggregates == {}
+    assert snapshot.status.is_trading_paused is False
+    assert snapshot.period_end == base
+    assert snapshot.period_start == base - timedelta(hours=1)

--- a/backend/tests/test_automation_reporting.py
+++ b/backend/tests/test_automation_reporting.py
@@ -105,3 +105,83 @@ def test_weekly_report_uses_last_7_days_window() -> None:
     assert summary.period == ReportPeriod.WEEKLY
     # 直近7日分なので、件数は 1 のみ
     assert summary.total_events == 1
+    
+def test_daily_report_contains_metric_aggregates_for_events() -> None:
+    service = MonitoringService(
+        latency_warning_threshold_s=10.0,
+        latency_alert_threshold_s=30.0,
+    )
+    reporter = ReportingService(monitoring=service)
+
+    base = _utc(2025, 1, 2, 12, 0)
+
+    # 対象日内のイベント（レイテンシ2件 + 価格変動1件）
+    service.record_latency(
+        ComponentType.SYSTEM,
+        timedelta(seconds=11),
+        at=base - timedelta(hours=1),
+    )
+    service.record_latency(
+        ComponentType.SYSTEM,
+        timedelta(seconds=31),
+        at=base - timedelta(minutes=10),
+    )
+    service.record_price_change_24h(
+        percent_change=25.0,
+        at=base - timedelta(minutes=5),
+    )
+
+    summary = reporter.generate_summary_report(ReportPeriod.DAILY, now=base)
+
+    # latency_system_s の集計
+    latency_agg = summary.metric_aggregates.get("latency_system_s")
+    assert latency_agg is not None
+    assert latency_agg.count == 2
+    assert latency_agg.min == Decimal("11.0")
+    assert latency_agg.max == Decimal("31.0")
+    assert latency_agg.last == Decimal("31.0")
+    assert latency_agg.avg == Decimal("21.0")
+
+    # portfolio_value_change_1d_pct の集計
+    price_agg = summary.metric_aggregates.get("portfolio_value_change_1d_pct")
+    assert price_agg is not None
+    assert price_agg.count == 1
+    assert price_agg.min == Decimal("25.0")
+    assert price_agg.max == Decimal("25.0")
+    assert price_agg.last == Decimal("25.0")
+    assert price_agg.avg == Decimal("25.0")
+
+
+def test_daily_report_contains_metric_aggregate_for_health_factor() -> None:
+    service = MonitoringService()
+    reporter = ReportingService(monitoring=service)
+
+    base = _utc(2025, 1, 2, 12, 0)
+
+    # 同一日内のヘルスファクター履歴（3件）
+    service.record_health_factor(
+        Decimal("2.0"),
+        at=base - timedelta(hours=6),
+    )
+    service.record_health_factor(
+        Decimal("1.7"),
+        at=base - timedelta(hours=3),
+    )
+    service.record_health_factor(
+        Decimal("1.9"),
+        at=base - timedelta(hours=1),
+    )
+
+    summary = reporter.generate_summary_report(ReportPeriod.DAILY, now=base)
+
+    hf_agg = summary.metric_aggregates.get("aave_health_factor_current")
+    assert hf_agg is not None
+    assert hf_agg.count == 3
+    assert hf_agg.min == Decimal("1.7")
+    assert hf_agg.max == Decimal("2.0")
+    assert hf_agg.last == Decimal("1.9")
+
+    # AutomationReportSummary のヘルスファクター集計と整合していること
+    assert summary.min_health_factor == hf_agg.min
+    assert summary.max_health_factor == hf_agg.max
+    assert summary.last_health_factor == hf_agg.last

--- a/docs/14_test_strategy.md
+++ b/docs/14_test_strategy.md
@@ -220,6 +220,32 @@ Notion → AI → OctoBot → Aave のフローが
     含まれることを確認する。
   - EMERGENCY に至った場合は、どのメトリクスが閾値を超えたかがレポート本文に反映されることを確認する。
 
+- `backend/tests/test_automation_reporting.py`
+  - 日次 / 週次サマリーレポートに、メトリクスサマリ（例：平均ヘルスファクター、期間内のエラー件数など）が
+    含まれることを確認する。
+  - EMERGENCY に至った場合は、どのメトリクスが閾値を超えたかがレポート本文に反映されることを確認する。
+
+- `backend/tests/test_automation_reporting.py`
+  - 日次 / 週次サマリーレポートに、メトリクスサマリ（例：平均ヘルスファクター、期間内のエラー件数など）が
+    含まれることを確認する。
+  - EMERGENCY に至った場合は、どのメトリクスが閾値を超えたかがレポート本文に反映されることを確認する。
+  - Phase10 では、`AutomationReportSummary.metric_aggregates` に対して、
+    `latency_*` や `portfolio_value_change_1d_pct`、`aave_health_factor_current` などの代表的メトリクスが
+    正しく集計されていることを確認するテストを追加する。
+
+- `backend/tests/test_automation_dashboard_view.py`
+  - `MonitoringService.build_dashboard_snapshot` により、ダッシュボード向けスナップショット
+    （`DashboardSnapshot`）が期待どおりに構成されることを確認する：
+    - `generated_at` / `period_start` / `period_end` が、テストで固定した現在時刻と `lookback` に整合している。
+    - 対象期間内の `MonitoringEvent.metric` から、`metric_aggregates` に `count` / `min` / `max` / `avg` / `last` が
+      正しく集計されている（範囲外のイベントは含まれない）。
+    - `AutomationStatus` の情報（`is_trading_paused` / `last_health_factor` /
+      `last_price_change_24h` / `last_event_level` / `emergency_reason` など）が、
+      `DashboardSnapshot.status` にそのまま反映されている。
+  - ダッシュボード UI 自体はツール依存であるため、本プロジェクトでは
+    「バックエンドが提供するスナップショット構造」が契約となる。
+    ツール変更時も、このテスト群が通っている限り、ダッシュボードに必要な情報は提供されているとみなす。
+
 ---
 
 # 4. Integration Test


### PR DESCRIPTION
# 🔀 Pull Request Template

## 📝 このPRの目的
（何を実装 / 修正## 概要

監視メトリクス定義（Phase9）を前提に、ダッシュボード／レポート向けの集約ロジックと
Runbook / テスト戦略の反映を行った。

ビジネス要件・トレードロジックの変更は含まない。

## 主な変更

### 1. スキーマ拡張

- `backend/app/automation/schemas.py`
  - `MetricAggregate` を追加
  - `DashboardSnapshot` を追加
  - `AutomationReportSummary` に `metric_aggregates: Dict[str, MetricAggregate]` を追加（後方互換あり）

### 2. MonitoringService のダッシュボード対応

- `backend/app/automation/monitoring_service.py`
  - `build_dashboard_snapshot(lookback, now)` を追加
    - 直近期間内の `MonitoringEvent.metric` を `metric_id` ごとに集計し、`DashboardSnapshot.metric_aggregates` に格納
    - 現在の `AutomationStatus` とまとめて返す

### 3. ReportingService のメトリクス集約

- `backend/app/automation/reporting_service.py`
  - `generate_summary_report` 内で、期間内のメトリクスを `MetricAggregate` に集約
  - ヘルスファクター履歴から `aave_health_factor_current` の集約を追加し、
    `AutomationReportSummary` の HF 集約フィールドと整合させた

### 4. テスト追加・更新

- `backend/tests/test_automation_reporting.py`
  - `metric_aggregates` に対するテストケースを追加
    - レイテンシと 24h 資産変動率
    - ヘルスファクター集約と HF フィールドの整合性
- `backend/tests/test_automation_dashboard_view.py`（新規）
  - `build_dashboard_snapshot` の lookback フィルタリングと集計ロジックのテストを実装

### 5. ドキュメント更新案

- `docs/08_automation_rules.md`
  - `6.3 ダッシュボード / レポートとの対応（Phase10）` を追加
- `docs/19_operations_runbook.md`
  - ダッシュボードの見方 / アラート受信時の確認順序 / 緊急停止解除前チェックリストを追加
- `docs/14_test_strategy.md`
  - `metric_aggregates` と `test_automation_dashboard_view.py` のテスト観点を追記

## 動作確認

- [ ] `pytest backend/tests/test_automation_monitoring.py`
- [ ] `pytest backend/tests/test_automation_reporting.py`
- [ ] `pytest backend/tests/test_automation_dashboard_view.py`
- [ ] docs 差分を確認し、Phase9 のメトリクス定義との矛盾がないことを目視確認
したかを明確に説明）

---

## 🔧 変更内容（概要）
- （主要な変更点を箇条書き）
- 
---

## 📁 変更したファイル
（例）
- backend/app/ai/analyzer.py
- docs/05_ai_judgement_rules.md

---

## 🧪 動作確認
- [ ] ローカルテスト済み
- [ ] フェーズ要件に沿っている
- [ ] .mdとコードの整合性チェック済み
- [ ] 破壊的変更なし

---

## 📘 関連Issue
例：Closes #23

---

## 📚 ドキュメント更新
- [ ] docs/*.md 更新済み  
- [ ] 変更内容が仕様書と一致している

---

## ⚠ 注意事項
- 要件変更が含まれていないこと
- フェーズ範囲外の作業をしていないこと
- 仕様書（.md）が最新と一致していること