### PR TITLE
feat: 環境分離ガードレール導入 (根本解決・予防層)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,107 @@
+# Ultra AutoTrade — Production Environment Variables
+# Copy to .env.production and fill in actual values
+# NEVER commit .env.production to git!
+#
+# 2026-04-17 B案リネーム後:
+#   Production = 実資金・実トレード / Base Mainnet / 完全独立DB
+#   Staging は .env.staging を参照すること
+#
+# 2026-04-19 環境分離ガードレール:
+#   scripts/check_env_separation.sh が .env.staging と本ファイルの
+#   意味のある差分を検証する。sed 一斉更新による同値化を防ぐ。
+
+# =============================================================================
+# 環境識別
+# =============================================================================
+APP_ENV=production
+COMPOSE_PROJECT_NAME=ultra-autotrade-project
+
+# =============================================================================
+# Shadow Mode（本番は実トレード — 絶対に true にしない）
+# =============================================================================
+AI_SHADOW_MODE=false
+REBALANCE_SHADOW_MODE=false
+
+# =============================================================================
+# Database（stagingとは完全独立 — ultra_autotrade）
+# =============================================================================
+POSTGRES_USER=ultra
+POSTGRES_PASSWORD=CHANGE_ME_PRODUCTION_PASSWORD
+POSTGRES_DB=ultra_autotrade
+# DATABASE_URL はdocker-compose.production.ymlで自動設定
+# ローカル接続: postgresql://ultra:password@localhost:5432/ultra_autotrade
+
+# =============================================================================
+# CORS / URL
+# =============================================================================
+CORS_ORIGINS=https://app.ultra-auto-trade.com
+NEXT_PUBLIC_BACKEND_BASE_URL=https://api.ultra-auto-trade.com
+NEXT_PUBLIC_API_BASE_URL=https://api.ultra-auto-trade.com
+NEXT_PUBLIC_API_URL=https://api.ultra-auto-trade.com
+
+# =============================================================================
+# AI / LLM
+# =============================================================================
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
+PERPLEXITY_API_KEY=pplx-...
+
+# =============================================================================
+# Exchange（Bybit 本番API — BYBIT_SANDBOX は必ず false）
+# =============================================================================
+BYBIT_API_KEY=...
+BYBIT_API_SECRET=...
+BYBIT_SANDBOX=false
+EXCHANGE_CLIENT_TYPE=bybit
+EXCHANGE_SANDBOX=false
+
+# =============================================================================
+# Aave V3（Base Mainnet — sepolia は絶対に指定しない）
+# =============================================================================
+AAVE_NETWORK=base_mainnet
+AAVE_RPC_URL=https://base-mainnet.g.alchemy.com/v2/YOUR_KEY
+CHAIN_ID=8453
+AAVE_POOL_ADDRESS=0x...  # Base Mainnet Aave V3 Pool
+AAVE_USDC_ADDRESS=0x...  # Base Mainnet USDC
+AAVE_WALLET_PRIVATE_KEY=0x...PRODUCTION_KEY_NEVER_SHARE...
+AAVE_WALLET_ADDRESS=0x...PUBLIC_ADDRESS...
+AAVE_CLIENT_TYPE=web3
+AAVE_MAX_SINGLE_TRADE_USD=100.0
+AAVE_MIN_HEALTH_FACTOR=1.6
+AAVE_STATE_FILE_PATH=/var/run/ultra/state.json
+AAVE_MAX_PRICE_DEVIATION_PCT=2.0
+
+# =============================================================================
+# Auth (JWT)
+# =============================================================================
+JWT_SECRET_KEY=CHANGE_ME_PRODUCTION_RANDOM_SECRET
+JWT_ALGORITHM=HS256
+JWT_ACCESS_TOKEN_EXPIRE_MINUTES=1440
+
+# =============================================================================
+# 内部API認証
+# =============================================================================
+INTERNAL_API_TOKEN=CHANGE_ME_PRODUCTION_INTERNAL_TOKEN
+
+# =============================================================================
+# Monitoring & Notifications
+# =============================================================================
+ENABLE_BACKGROUND_MONITORING=1
+ENABLE_DAILY_REPORTS=1
+ENABLE_WEEKLY_REPORTS=1
+MONITORING_INTERVAL_SECONDS=60
+SLACK_WEBHOOK_URL=
+
+# =============================================================================
+# フロントエンド（ビルド時埋め込み）
+# =============================================================================
+NEXT_PUBLIC_PRIVY_APP_ID=<privy-app-id — app.ultra-auto-trade.com をAllowed Originsに追加要>
+NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=
+NEXT_PUBLIC_DEFAULT_CHAIN=base-mainnet
+NEXT_PUBLIC_DEFAULT_CHAIN_ID=8453
+NEXT_PUBLIC_BASE_MAINNET_RPC=https://base-mainnet.g.alchemy.com/v2/YOUR_KEY
+
+# =============================================================================
+# Cloudflare
+# =============================================================================
+CLOUDFLARE_TUNNEL_TOKEN=

--- a/.github/workflows/env-separation-check.yml
+++ b/.github/workflows/env-separation-check.yml
@@ -1,0 +1,30 @@
+name: Environment Separation Check
+
+on:
+  pull_request:
+    paths:
+      - '.env.staging'
+      - '.env.production'
+      - 'docker-compose*.yml'
+      - 'scripts/check_env_separation.sh'
+  push:
+    branches: [main, dev]
+
+jobs:
+  check-env-separation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify env separation
+        run: |
+          if [ -f .env.production.example ] && [ -f .env.staging.example ]; then
+            cp .env.production.example .env.production
+            cp .env.staging.example .env.staging
+            bash scripts/check_env_separation.sh
+          else
+            echo "::warning::.env.*.example が見つからない、検証スキップ"
+          fi
+      - name: Shellcheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: './scripts'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -623,6 +623,27 @@ git diff main --name-only | grep "^frontend/lib/api/" # 新しいfetch関数 →
   - `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID`
   - `NEXT_PUBLIC_DEFAULT_CHAIN_ID`
 
+## 環境ファイル更新ルール (2026-04-19 根本解決原則)
+
+### 禁止事項
+- sed -i 等で `.env.staging` と `.env.production` を同時更新することは禁止
+  - 理由: 2026-04-18インシデントで両ファイルが完全一致状態に陥り、環境分離の意味を失った
+- `.env.production` に以下の値を設定することは禁止:
+  - `APP_ENV=staging`
+  - `BYBIT_SANDBOX=true`
+  - `AAVE_NETWORK=*sepolia*` (Phase 2メインネット移行後)
+
+### 正しい更新手順
+1. `.env.staging` を先に編集
+2. 内容を確認
+3. `.env.production` を別コマンドで編集 (値が本番固有なら差別化)
+4. `bash scripts/check_env_separation.sh` で検証
+5. コミット
+
+### CIガード
+PR作成時に `.github/workflows/env-separation-check.yml` が自動実行される。
+失敗したPRはmergeできない。
+
 ### 2026-04-15追加（本番DB操作ルール）
 
 **本番DBに対するALTER TABLE / UPDATE / DELETE等の操作手順書を生成する際、コンテナ名・DBユーザー・テーブル名を絶対に推測しない。**

--- a/scripts/check_env_separation.sh
+++ b/scripts/check_env_separation.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# check_env_separation.sh
+#
+# .env.staging と .env.production が意味のある差分を持っているか検証する。
+#
+# 背景:
+#   2026-04-18 の sed 一斉更新インシデントで両ファイルが完全一致状態に陥り、
+#   本番コンテナに APP_ENV=staging / BYBIT_SANDBOX=true / AAVE_NETWORK=base_sepolia
+#   が残存していた。再発防止のために CI / deploy スクリプトから呼び出す。
+#
+# 終了コード:
+#   0: 全チェック通過（ファイルが存在しない場合もスキップして 0）
+#   1: 検証失敗（違反キーを標準出力に列挙）
+#
+# 実行:
+#   bash scripts/check_env_separation.sh
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+STAGING_FILE="${PROJECT_ROOT}/.env.staging"
+PRODUCTION_FILE="${PROJECT_ROOT}/.env.production"
+
+# 両ファイルが揃っていない場合は検証できないのでスキップ（CI で片側のみ存在する場合に配慮）
+if [[ ! -f "${STAGING_FILE}" ]] || [[ ! -f "${PRODUCTION_FILE}" ]]; then
+  echo "ℹ️  .env.staging または .env.production が存在しません。環境分離チェックをスキップします。"
+  echo "    staging:    ${STAGING_FILE}"
+  echo "    production: ${PRODUCTION_FILE}"
+  exit 0
+fi
+
+echo "=== 環境分離チェック: .env.staging vs .env.production ==="
+
+# ---------------------------------------------------------------------------
+# ヘルパー関数
+# ---------------------------------------------------------------------------
+
+# 値取得: 最初にマッチする `KEY=VALUE` の VALUE 部分を返す（コメント行を除外）
+get_value() {
+  local file="$1"
+  local key="$2"
+  grep -E "^${key}=" "${file}" 2>/dev/null | head -n 1 | sed -E "s/^${key}=//"
+}
+
+# 秘密情報っぽいキーか判定
+is_secret_key() {
+  local key="$1"
+  case "${key}" in
+    *API_KEY*|*SECRET*|*PASSWORD*|*PRIVATE_KEY*|*TOKEN*|*DATABASE_URL*|*DB_URL*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# 値をマスク表示（秘密情報の場合は *** に置換）
+# DATABASE_URL 等の URL に埋め込まれたパスワードも誤表示しないよう注意
+display_value() {
+  local key="$1"
+  local value="$2"
+  if is_secret_key "${key}"; then
+    echo "***"
+  else
+    echo "${value}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 違反収集
+# ---------------------------------------------------------------------------
+VIOLATIONS=()
+
+# ---------------------------------------------------------------------------
+# 必須差分キー: 以下のいずれか1個でも同値なら違反
+# ---------------------------------------------------------------------------
+REQUIRED_DIFF_KEYS=(
+  "APP_ENV"
+  "AAVE_NETWORK"
+  "BYBIT_SANDBOX"
+  "POSTGRES_DB"
+  "DATABASE_URL"
+  "CORS_ORIGINS"
+  "NEXT_PUBLIC_API_URL"
+)
+
+echo ""
+echo "--- 必須差分キーチェック ---"
+for key in "${REQUIRED_DIFF_KEYS[@]}"; do
+  staging_val="$(get_value "${STAGING_FILE}" "${key}")"
+  production_val="$(get_value "${PRODUCTION_FILE}" "${key}")"
+
+  # どちらも未定義なら、そのキー自体を使っていないものとしてスキップ
+  if [[ -z "${staging_val}" ]] && [[ -z "${production_val}" ]]; then
+    echo "  - ${key}: 両方未定義 (スキップ)"
+    continue
+  fi
+
+  if [[ "${staging_val}" == "${production_val}" ]]; then
+    VIOLATIONS+=("必須差分キー ${key} が同値: staging=$(display_value "${key}" "${staging_val}") / production=$(display_value "${key}" "${production_val}")")
+    echo "  ❌ ${key}: staging=$(display_value "${key}" "${staging_val}") == production=$(display_value "${key}" "${production_val}")"
+  else
+    echo "  ✅ ${key}: 差分あり"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# 全キー差分ゼロチェック (sed 一斉更新の疑い)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 全キー差分チェック (sed 一斉更新の疑い検出) ---"
+
+# 両ファイルのキーの和集合
+ALL_KEYS="$(
+  {
+    grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "${STAGING_FILE}" | cut -d= -f1
+    grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "${PRODUCTION_FILE}" | cut -d= -f1
+  } | sort -u
+)"
+
+DIFF_COUNT=0
+SHARED_COUNT=0
+for key in ${ALL_KEYS}; do
+  staging_val="$(get_value "${STAGING_FILE}" "${key}")"
+  production_val="$(get_value "${PRODUCTION_FILE}" "${key}")"
+  if [[ "${staging_val}" != "${production_val}" ]]; then
+    DIFF_COUNT=$(( DIFF_COUNT + 1 ))
+  else
+    SHARED_COUNT=$(( SHARED_COUNT + 1 ))
+  fi
+done
+
+echo "  差分キー: ${DIFF_COUNT} / 共通キー: ${SHARED_COUNT}"
+if [[ "${DIFF_COUNT}" -eq 0 ]]; then
+  VIOLATIONS+=("全キーで差分がゼロ: sed 一斉更新によって両ファイルが完全一致した疑いがあります")
+  echo "  ❌ 差分ゼロ: sed 一斉更新の疑い"
+else
+  echo "  ✅ 差分あり"
+fi
+
+# ---------------------------------------------------------------------------
+# 禁止パターン: .env.production
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 禁止パターンチェック (.env.production) ---"
+
+if grep -qE '^APP_ENV=staging[[:space:]]*$' "${PRODUCTION_FILE}"; then
+  VIOLATIONS+=(".env.production に APP_ENV=staging が含まれています")
+  echo "  ❌ APP_ENV=staging を検出"
+else
+  echo "  ✅ APP_ENV=staging なし"
+fi
+
+if grep -qE '^BYBIT_SANDBOX=true[[:space:]]*$' "${PRODUCTION_FILE}"; then
+  VIOLATIONS+=(".env.production に BYBIT_SANDBOX=true が含まれています (本番は false 必須)")
+  echo "  ❌ BYBIT_SANDBOX=true を検出"
+else
+  echo "  ✅ BYBIT_SANDBOX=true なし"
+fi
+
+if grep -qiE '^AAVE_NETWORK=.*sepolia.*' "${PRODUCTION_FILE}"; then
+  VIOLATIONS+=(".env.production に AAVE_NETWORK の sepolia 指定が含まれています (本番は mainnet 必須)")
+  echo "  ❌ AAVE_NETWORK=*sepolia* を検出"
+else
+  echo "  ✅ AAVE_NETWORK に sepolia 含まず"
+fi
+
+# ---------------------------------------------------------------------------
+# 禁止パターン: .env.staging
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 禁止パターンチェック (.env.staging) ---"
+
+if grep -qE '^APP_ENV=production[[:space:]]*$' "${STAGING_FILE}"; then
+  VIOLATIONS+=(".env.staging に APP_ENV=production が含まれています")
+  echo "  ❌ APP_ENV=production を検出"
+else
+  echo "  ✅ APP_ENV=production なし"
+fi
+
+# ---------------------------------------------------------------------------
+# 結果サマリ
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== 結果 ==="
+if [[ "${#VIOLATIONS[@]}" -eq 0 ]]; then
+  echo "✅ 環境分離チェック: 全項目通過"
+  exit 0
+fi
+
+echo "❌ 環境分離チェック: ${#VIOLATIONS[@]} 件の違反を検出"
+for v in "${VIOLATIONS[@]}"; do
+  echo "   - ${v}"
+done
+exit 1

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -136,6 +136,42 @@ if [[ ! -f "${ENV_FILE}" ]]; then
   exit 1
 fi
 
+# === Production deploy guardrails (2026-04-19 根本解決原則) ===
+# .env.production が本番固有の値を持っていることを保証する予防層。
+# 2026-04-18 sed 一斉更新インシデント再発防止。
+
+# Guard 1: .env.production 必須キー検証
+if ! grep -q '^APP_ENV=production$' .env.production; then
+  echo "❌ FAIL: .env.production に APP_ENV=production がない"
+  exit 1
+fi
+
+if grep -qE '^BYBIT_SANDBOX=true' .env.production; then
+  echo "❌ FAIL: .env.production で BYBIT_SANDBOX=true (本番は false 必須)"
+  exit 1
+fi
+
+if grep -qE '^AAVE_NETWORK=.*sepolia' .env.production; then
+  echo "❌ FAIL: .env.production で AAVE_NETWORK に sepolia 含む (本番は mainnet 必須)"
+  exit 1
+fi
+
+# Guard 2: 環境分離チェック
+bash scripts/check_env_separation.sh || {
+  echo "❌ FAIL: 環境分離チェック失敗"
+  exit 1
+}
+
+# Guard 3: compose file 指定確認
+if [[ "${COMPOSE_FILE}" != *production.yml* ]] && [[ -z "${FORCE_OVERRIDE:-}" ]]; then
+  echo "❌ FAIL: 本番デプロイは docker-compose.production.yml 必須"
+  echo "   (テスター期間の例外で staging.yml を使う場合は FORCE_OVERRIDE=1 を設定)"
+  exit 1
+fi
+
+echo "✅ All production deploy guards passed"
+# === End of guardrails ===
+
 DC=$(resolve_dc)
 log "docker compose コマンド: ${DC}"
 


### PR DESCRIPTION
## 背景: Phase 1調査結果 (2026-04-18 sed一斉更新インシデント)

2026-04-18 に sed -i の一斉更新コマンドで `.env.staging` と `.env.production` が完全一致状態となった。
結果として本番コンテナに以下の staging 向け設定が残存:

- `APP_ENV=staging`
- `BYBIT_SANDBOX=true`
- `AAVE_NETWORK=base_sepolia`

環境分離の意味が失われており、本番 Bybit API や Base Mainnet Aave への接続も成立しなかった可能性がある
高リスク状態。運用者の手元で検知するまで気づかなかったため、構造的な予防層を導入する。

## 関連 Asana タスク

- 1214115932870078
- 1214114862476522
- 1214115420877137

## 成果物 (4つ)

### 1. `scripts/check_env_separation.sh` (新規)
- 必須差分キー (APP_ENV / AAVE_NETWORK / BYBIT_SANDBOX / POSTGRES_DB / DATABASE_URL / CORS_ORIGINS / NEXT_PUBLIC_API_URL) の同値検出
- 全キー差分ゼロ検出 (sed 一斉更新の疑い)
- 禁止パターン検出 (.env.production に APP_ENV=staging / BYBIT_SANDBOX=true / AAVE_NETWORK=*sepolia* / .env.staging に APP_ENV=production)
- 秘密情報マスク (API_KEY / SECRET / PASSWORD / PRIVATE_KEY / TOKEN / DATABASE_URL)
- 両ファイル欠落時はスキップして exit 0

### 2. `scripts/deploy_production.sh` ガード追加
- Guard 1: `.env.production` に `APP_ENV=production` / `BYBIT_SANDBOX=false` / `AAVE_NETWORK` に sepolia なし を検証
- Guard 2: `check_env_separation.sh` を呼び出し
- Guard 3: compose file が `*production.yml*` であることを確認 (`FORCE_OVERRIDE=1` で例外許可)

### 3. `.github/workflows/env-separation-check.yml` (新規)
- PR 時 (`.env.*`, `docker-compose*.yml`, `scripts/check_env_separation.sh` 変更時) に自動実行
- `.env.*.example` をコピーして検証
- Shellcheck も同時実行

### 4. `.env.production.example` (新規)
- 本番固有値のプレースホルダ (`APP_ENV=production`, `BYBIT_SANDBOX=false`, `AAVE_NETWORK=base_mainnet` 等)
- `.env.staging.example` と意味のある差分を持つことを保証

### 付随: `CLAUDE.md` 更新
- 「環境ファイル更新ルール (2026-04-19 根本解決原則)」セクション追加
- sed 同時更新禁止 / 禁止値リスト / 正しい更新手順 / CIガードの説明

## テスト結果

- **shellcheck**: `scripts/check_env_separation.sh` / `scripts/deploy_production.sh` ともに警告 0
- **正常系**: `.env.production.example` と `.env.staging.example` をコピーして実行 → exit 0
- **異常系 1** (BYBIT_SANDBOX=true in production): 違反検出 + exit 1
- **異常系 2** (両ファイル完全一致 = sed 一斉更新): 8 件違反検出 + exit 1
- **異常系 3** (AAVE_NETWORK=base-sepolia in production): 違反検出 + exit 1
- **現行 .env 検証**: 既存の `.env.staging` と `.env.production` が同値状態であることを本ツールが正しく検出することを確認 (10 件違反、exit 1)
- **DoD ゲート (`scripts/verify.sh`)**: 全 7 段階通過 (ruff / ruff format / mypy / pytest 80%+ / ruff security / tsc / npm build) — 313s で All checks passed

## 制約遵守

- 本番 Hetzner には触れていません
- `.env.staging` / `.env.production` の実ファイルは変更せず、example ファイルのみ新規作成
- 既存テストを壊していません (verify.sh 通過)

## Test plan

- [ ] CI `env-separation-check` が PR 上で緑になることを確認
- [ ] dev マージ後に staging デプロイへ影響がないことを確認
- [ ] 別 PR で実 `.env.staging` / `.env.production` の分離修正を実施 (本 PR はガードレールのみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)