### PR TITLE
docs: refresh 13_security_design for 2026-04 (no OctoBot, Privy/MetaMask, F-17a)

### DIFF
--- a/docs/13_security_design.md
+++ b/docs/13_security_design.md
@@ -1,276 +1,394 @@
-# 13_security_design.md  
+# 13_security_design.md
 Ultra AutoTrade – セキュリティ設計書（完全版）
 
-本ドキュメントは、Notion → AI → OctoBot → Aave という自動運用システムにおいて  
-「資金を失わない」「GPTの自動生成コードが安全に実行できる」ことを目的に作成する。
+本ドキュメントは、AI 判定 → Bybit 取引 / Aave 自動運用システムにおいて
+「資金を失わない」「外部鍵・ウォレットへの不正アクセスを防ぐ」ことを目的に作成する。
+
+関連ドキュメント:
+- `docs/07_aave_operation_logic.md` — Aave 運用ロジック・リスク制限値
+- `docs/17_staging_environment_config.md` — Staging 環境設定
+- `docs/21_production_environment_config.md` — Production 環境設定
+- `docs/22_production_release_checklist.md` — リリース前チェックリスト
+- `docs/33_emergency_stop_governance.md` — 緊急停止ガバナンス
 
 ---
 
-# 1. APIキー管理（Notion / AI / OctoBot / Aave）
+# 1. APIキー・秘密情報管理
 
 ## 1.1 APIキーの保存場所
-- すべて「環境変数」で管理する  
-- `.env` を使用する場合は **必ず .gitignore に追加**
+
+- すべて **環境変数** で管理する
+- `.env.*` ファイルを使用する場合は必ず `.gitignore` に追加
 - GitHub に push される形で保存してはならない
+- ログ・APM ツールへの API キー出力は禁止（マスキング必須）
 
 ## 1.2 本番／開発キーの分離
-- `NOTION_API_KEY_PROD`
-- `NOTION_API_KEY_DEV`
-- `AAVE_PRIVATE_KEY_PROD`
-- `AAVE_PRIVATE_KEY_DEV`
-
-誤用を防ぐため、環境切替フラグを導入：
 
 ```
-APP_ENV=dev | prod
+AAVE_PRIVATE_KEY_PROD   ← .env.production にのみ定義
+AAVE_PRIVATE_KEY_DEV    ← .env.staging または .env.local
 ```
-- 本番用のキー・秘密情報は **`.env.production` にのみ定義** する
-  - ローカル開発用 `.env.local` や staging 用 `.env.staging` と混在させない
-  - どの環境でどの .env が使われているかは、  
-    staging 用は `docs/17_staging_environment_config.md`、  
-    本番用は `docs/21_production_environment_config.md` に記録しておく
 
-- `.env.staging` と `.env.production` の中身をコピーして使い回さない
-  - 特に API キー・ウォレット関連は環境ごとに **物理的に異なるもの** を用意する
+- 本番用キー・秘密情報は `.env.production` にのみ定義する
+- `.env.staging` と `.env.production` の中身を `sed` で一括コピーしない
+  （2026-04-18 インシデント: 一括書き換えで両ファイルが同一内容になった）
+- 特に API キー・ウォレット秘密鍵は環境ごとに **物理的に異なるもの** を用意する
+- 各環境の設定詳細は `docs/17_staging_environment_config.md` / `docs/21_production_environment_config.md` を参照
 
-- 本番と開発（staging / local）の API キー・ウォレットは、必ず物理的に分離する
-  - 同じ鍵・トークンを複数環境で使い回さない
-- 本番用のキー・秘密情報は **`.env.production` にのみ定義** する
-  - staging 用は `.env.staging`
-  - ローカル開発用は `.env.local` など
-  - 各環境ごとの .env ファイルを必ず分ける
+### BVI 法人設立・HSM 移行（将来対応）
 
-- `.env` 系ファイルはすべて Git 管理外とし、`.gitignore` に含める
-  - 誤って GitHub に push された場合は、即座にキーのローテーションを行う
-
-- 環境ごとの .env に何を定義するかは、次のドキュメントで管理する
-  - staging 環境：`docs/17_staging_environment_config.md`
-  - production 環境：`docs/21_production_environment_config.md`
-
+現状は `chmod 600` + Hetzner VPS 上の `.env.production` による管理。
+将来は BVI 法人設立後に HashiCorp Vault または AWS KMS への移行を検討する。
+詳細: `docs/41_kms_vault_design.md`
 
 ## 1.3 Aave 関連環境変数
 
-- `AAVE_NETWORK`
-- `AAVE_DEFAULT_ASSET_SYMBOL`
-- `AAVE_MAX_SINGLE_TRADE_USD`
-- `AAVE_MIN_HEALTH_FACTOR`
-- `AAVE_TRADE_COOLDOWN_SECONDS`
+| 変数名 | 説明 | デフォルト値 |
+|-------|------|------------|
+| `AAVE_NETWORK` | 接続ネットワーク | `base_sepolia` (Phase 1) |
+| `AAVE_RPC_URL` | メイン RPC エンドポイント | (必須) |
+| `AAVE_DEFAULT_ASSET_SYMBOL` | デフォルト運用資産 | `USDC` |
+| `AAVE_MAX_SINGLE_TRADE_USD` | 1回の最大取引上限(USD) | `100.0` |
+| `AAVE_MIN_HEALTH_FACTOR` | HF 下限（HARD_STOP 閾値） | `1.6` |
+| `AAVE_TRADE_COOLDOWN_SECONDS` | 操作間最小クールダウン | `600`（10分） |
 
-### 方針
+- 未設定時は `backend/app/aave/config.py` の安全なデフォルト値が適用される
+- カスタムリミッター（F-17a）が有効な場合、`AAVE_MIN_HEALTH_FACTOR` より低い値が
+  適用されることがある（ただし絶対ハードリミット 1.2 が下限）。詳細は 3.2 節を参照
 
-- すべて環境変数から読み取るが、Phase4 時点では **必須にはしない**
-- 未設定の場合は Aave モジュール側で安全なデフォルト値を採用する：
-  - `AAVE_NETWORK`: `"sepolia"`
-  - `AAVE_DEFAULT_ASSET_SYMBOL`: `"USDC"`
-  - `AAVE_MAX_SINGLE_TRADE_USD`: `"100.0"`
-  - `AAVE_MIN_HEALTH_FACTOR`: `"1.6"`
-  - `AAVE_TRADE_COOLDOWN_SECONDS`: `600`（10分）
-- 本番環境では `.env` ではなくインフラ側のシークレット管理に移行すること
+## 1.4 Phase 1 期間中の意図的な .env 乖離（2026-09-30 まで）
 
-## 4.x Aave 機能のフェイルセーフ
+本番コンテナは現在以下の値で稼働中:
 
-- Aave 関連設定が不正値の場合、アプリケーション起動時に例外で気づけるようにする
-- ランタイムエラー時は「ポジションを増やさない」挙動（NOOP or ERROR）を優先
-- Aave 機能が無効でも、Notion / AI / OctoBot 部分は単体で動作できるように分離する
+```
+APP_ENV=staging
+BYBIT_SANDBOX=true
+AAVE_NETWORK=base_sepolia
+```
+
+これは **意図的な設定** である。山本さんパートナーテスト（$4,600 相当）が
+Base Sepolia + Bybit Sandbox で行われており、実資金リスクなしに本番フローを
+検証するための Phase 1 運用方針。
+
+- Phase 2（メインネット本格移行）移行後に `AAVE_NETWORK=base` および
+  `BYBIT_SANDBOX=false` へ切り替える
+- 切り替え時には `scripts/check_env_separation.sh` で検証後デプロイすること
+- CI の `.github/workflows/env-separation-check.yml` が `.env.staging` と
+  `.env.production` の意味的差分を自動検証する
 
 ---
 
-# 2. 秘密鍵の保護（Aave運用）
+# 2. 秘密鍵・ウォレット保護
 
-## 2.1 原則
-- Aave運用に使用する秘密鍵は **最低限の金額のみ保持した専用ウォレット**  
+## 2.1 Aave 運用ウォレット原則
+
+- Aave 運用に使用する秘密鍵は **最低限の金額のみ保持した専用ウォレット** に限定する
 - 運用額に応じてウォレットを分割（資産集中を避ける）
+- 秘密鍵は UAT 運営側がコード・ログに書かない設計原則を維持する
 
-## 2.2 ハードウェアウォレットの推奨
-本番環境では可能であれば **Ledger などの HW Wallet を使用**。
+## 2.2 ハードウェアウォレット
 
-## 2.3 マルチシグ設定（任意）
-- Gnosis Safe を利用し、運用の大きなアクションは multi-sig による承認を必要とする
+本番環境では可能であれば Ledger などの HW Wallet を使用する。
+
+## 2.3 マルチシグ設定（将来対応）
+
+Gnosis Safe を利用し、大きなアクションは multi-sig 承認を要件とする（Phase 3 以降）。
+
+## 2.4 Privy / MetaMask ウォレット方式
+
+UAT ユーザー向けのウォレット接続は以下の2方式を採用する:
+
+### Privy (MPC ウォレット)
+
+- `@privy-io/react-auth` による非カストディアル型 MPC ウォレット
+- ユーザーが秘密鍵を直接管理しない。UAT 運営も秘密鍵を保持しない設計
+- フロントエンド: `frontend/lib/wallet/PrivyRootProvider.tsx` → SSR 無効で読み込み
+- ウォレット接続後、`wallet_address` を users テーブルに保存
+  （形式: `wallet_{address_slug}@wallet.local`）
+- デフォルトチェーン: `NEXT_PUBLIC_DEFAULT_CHAIN_ID`（staging: Base Sepolia = 84532）
+- 法的分類は森先生レビュー中（非カストディアル扱いの前提で設計）
+
+### MetaMask / EOA ウォレット
+
+- `useWallets()` フックで外部ウォレット署名を取得
+- `POST /api/auth/wallet` でサーバーサイド署名検証（ECDSA recover）
+- `backend/app/auth/service.py:verify_wallet_signature()` で実装
+- 本番 Base Mainnet 接続時は Cloudflare Tunnel 経由のみ許可
 
 ---
 
 # 3. 操作額制限（スマートコントラクト保護）
 
+## 3.1 標準リミッター（default / strict モード）
+
 ```
-・1回の最大投資額：総資産の 10% 以内  
-・1日最大投資額：総資産の 30% 以内  
-・自動売買は 10分間に 1回まで  
+・1回の最大投資額: 総資産の 10% 以内
+・1日の最大投資額: 総資産の 30% 以内
+・Aave 操作クールダウン: 10 分（600秒）
+・HF 下限: 1.6（HARD_STOP）/ 1.8（SAFE_MODE 遷移）
 ```
+
+実装:
+- 単回 10% チェック: `backend/app/aave/rebalance_service.py:447`
+- HF チェック: `backend/app/aave/config.py:107`, `rebalance_service.py:620`
+- クールダウン: `backend/app/aave/service.py:88`, `rebalance_config.py:151`
+
+## 3.2 カスタムリミッター（F-17a / CUSTOM_LIMITER）
+
+山本さんパートナーテスト（最大 $4,600）対応として、環境変数ベースで
+標準リミッターを緩和する仕組みを実装している。
+
+```
+CUSTOM_LIMITER_ENABLED=true           # 有効化フラグ
+CUSTOM_LIMITER_EXPIRES_ON=2026-05-15  # 自動失効日（YYYY-MM-DD）
+CUSTOM_HF_MIN=1.3                     # カスタム HF 下限
+CUSTOM_SINGLE_TRADE_PCT=20            # 単回上限 (% of total assets)
+CUSTOM_DAILY_TRADE_PCT=60             # 日次上限 (% of total assets)
+CUSTOM_COOLDOWN_SECONDS=120           # クールダウン秒数
+```
+
+### ハードリミット（絶対値 — コード側で強制、env で上書き不可）
+
+| 項目 | ハードリミット |
+|------|-------------|
+| HF 最小値 | **1.2** 以上 |
+| 単回最大 | **40%** 以下 |
+| 日次最大 | **90%** 以下 |
+| クールダウン最小 | **60 秒** 以上 |
+
+実装: `backend/app/aave/risk_limiter.py`（`get_effective_limits()` 関数）
+
+### 動作フロー
+
+1. `CUSTOM_LIMITER_ENABLED` が `true/1/yes` でない → strict デフォルトを使用
+2. `CUSTOM_LIMITER_EXPIRES_ON` が過去の日付 → strict デフォルトに自動復帰（ログ警告）
+3. 有効な場合 → カスタム値をハードリミットでクランプして適用
+4. 起動時に Slack へ `:warning:` 通知（`notify_slack_if_custom()`）
+
+### 現在の状態（2026-04-19 時点）
+
+- F-17a は `.env.production` に未設定（無効）
+- 山本さんテスト用の有効化は Phase 1 テスト計画に従って判断
+- 後継: F-17b で管理画面 UI + 監査ログを実装予定
 
 ---
 
 # 4. 通信暗号化ポリシー
 
-- すべて HTTPS / TLS
-- API通信ログには資格情報を含めない
-- Webhook / OctoBot API は IP 制限を設定（安全な IP のみ許可）
+- すべて HTTPS / TLS（Cloudflare Tunnel 経由）
+- API 通信ログには資格情報を含めない
+- Hetzner VPS への接続は SSH 公開鍵認証 + Cloudflare Tunnel 経由のみ許可
+  - パスワードログインは禁止
+  - 不要なポートは開放しない（8000/3000 はローカルバインドまたは Tunnel 経由）
+- フロントエンド → バックエンド通信は同じ Cloudflare Tunnel ドメイン内で完結
+  （Mixed Content を避けるため HTTP 直 IP アクセスは禁止）
 
 ---
 
 # 5. ログのサニタイズ（匿名化）
 
-ログに以下を出してはならない：
+ログに以下を出力してはならない:
 
-- トークン
-- APIキー
-- 秘密鍵
-- 生のウォレットアドレス（必要に応じて先頭6文字＋末尾4文字）
+- APIキー・シークレット
+- 秘密鍵（private key）
+- JWT トークン全体（先頭12文字 + "..." でよい）
+- Privy 認証トークン（同上）
+- 生のウォレットアドレス → 先頭6文字 + 末尾4文字（例: `0x5a39...eb20`）
+
+実装例（`backend/app/auth/service.py:404`）:
+
+```python
+logger.info("Created wallet user: %s (wallet=%s...)", user.email, wallet_address[:10])
+```
 
 ---
 
 # 6. セキュリティ自動化
 
-- エラー多発時に自動停止
-- AI判定が異常値連続（例：BUY or SELL が5回連続）→ 停止
-- Aaveヘルスファクター < 1.6 → 運用ストップ通知
+- エラー多発時に自動停止（circuit_closed フラグ）
+- AI 判定が異常値連続（例: BUY/SELL が 5 回連続） → SAFE_MODE 遷移
+- Aave HF < `AAVE_MIN_HEALTH_FACTOR`（デフォルト 1.6、カスタムリミッター有効時は最低 1.2） → HARD_STOP 自動発動
+
+## 6.1 ヘルスファクター監視
+
+`MonitoringService.record_health_factor()` が定期的に HF を取得し:
+
+```
+HF >= 1.8          → NORMAL（通常運用）
+1.6 <= HF < 1.8    → SAFE_MODE（取引量抑制）
+HF < 1.6           → HARD_STOP（全操作停止 + Slack 通知）
+```
+
+実装: `backend/app/automation/monitoring_service.py:193`
+
+## 6.2 OR ロジック緊急停止（docs/33 と整合）
+
+`emergency_stop` フラグは **OR 条件** で管理される:
+
+- 一度 `True` になったら、明示的な `clear_emergency_stop()` 呼び出しまで `False` に戻らない
+- HF 回復のみでは自動解除されない（オペレーターの意図的な操作が必要）
+- 再起動時も `state.json` から `emergency_stop=True` を復元する（意図的な停止を引き継ぐ）
+
+実装: `backend/app/automation/monitoring_service.py:239-244`
+
+詳細ガバナンス: `docs/33_emergency_stop_governance.md`
 
 ---
 
-# 7. 緊急停止（Emergency Stop）
+# 7. 緊急停止トリガー条件
+
+以下のいずれかで HARD_STOP が発動する:
 
 ```
-・AI API エラー率 > 20%  
-・OctoBot 応答なし 3回連続  
-・Aave Gas エラー 2回連続  
-・価格変動 > 20% / 1日  
+・Aave HF < 1.6（または CUSTOM_HF_MIN を下回った場合）
+・AI API エラー率 > 20%
+・Aave RPC 応答なし 3回連続
+・Aave Gas エラー 2回連続
+・価格変動 > 20% / 1日（StressController）
 ```
 
-該当したら自動的に：
-
-- Aave から資金を引き出し
-- 運用停止
+発動後:
+- 全 Aave 操作を停止
 - LINE / Slack へ通知
+- `state.json` に `emergency_stop=True` を記録（再起動後も維持）
+
+手動解除: `POST /api/automation/emergency-stop` (ADMIN ロールのみ resume 可能)
 
 ---
 
 # 8. バージョン管理のセキュリティ
 
-- GitHub Personal Token を使用（classic は禁止）
+- GitHub Personal Access Token は Fine-Grained トークン推奨（classic 禁止）
 - SSH 認証必須
-- main ブランチへの push は禁止（PR必須）
-
----
+- `main` ブランチへの直接 push は禁止（PR + レビュー必須）
+- `.env.*` ファイルはすべて `.gitignore` に含める
+- PR #90 以降: CI の `env-separation-check.yml` が `.env.staging` vs `.env.production` の
+  意図的乖離を自動検証する（`scripts/check_env_separation.sh`）
 
 ---
 
 # 9. インフラデプロイ時の秘密情報管理
 
-本番・staging 環境へのデプロイ時も、これまでのポリシー  
-（API キーは環境変数管理 / Git に含めない）を一貫して守る。
+## 9.1 環境ごとの .env 方針
 
-## 9.1 環境ごとの .env / 環境変数方針
+| ファイル | 使用環境 | 配置場所 |
+|---------|---------|---------|
+| `.env.production` | 本番（port 3000/8000） | Hetzner VPS `/opt/ultra-autotrade/` |
+| `.env.staging` | 公開 staging（旧 production） | 同上 |
+| `.env.staging-new` | True Staging / Shadow Mode | 同上 |
+| `.env.local` | ローカル開発 | 開発マシンのみ |
 
-- 本番 / staging / 開発で、**環境ごとに値を分離** する
-  - 例：
-    - `.env.local`（ローカル開発マシン専用）
-    - `.env.staging`（staging サーバ上にのみ配置）
-    - `.env.production`（本番サーバ上にのみ配置）
-- これらの `.env.*` ファイルは **必ず .gitignore に含める**
-- ファイル権限
-  - サーバ上では `chmod 600` を推奨
-  - 所有ユーザはデプロイユーザ（例：`ultra`）のみ
+- ファイル権限: `chmod 600`、所有ユーザー: `ultra`
+- **`sed -i` による両ファイル一括更新は禁止**（2026-04-18 インシデント教訓）
+- 正しい更新手順:
+  1. `.env.staging` を先に編集
+  2. `.env.production` を別コマンドで編集（値が本番固有なら差別化）
+  3. `bash scripts/check_env_separation.sh` で検証
+  4. コミット
 
 ## 9.2 Docker 運用時の秘密情報
 
-- `docker-compose.staging.yml` などから `env_file: .env.staging` として読み込む
-- `.env.staging` は **サーバ上のプロジェクトルート直下** にのみ配置し、Git には含めない
-- Dockerfile には API キーや秘密情報を **絶対に書かない**
-  - すべて `env_file` や `environment` 経由で注入する
-- コンテナログに API キーやトークンを出さないよう、
-  ログ出力時は値のマスク（先頭数文字のみなど）を徹底する
+- `docker-compose.production.yml` から `env_file: .env.production` として読み込む
+- Dockerfile に API キー・秘密情報を**絶対に書かない**（`env_file` / `environment` 経由のみ）
+- コンテナログに API キー・トークンを出さない（マスキング徹底）
+- `NEXT_PUBLIC_*` 変数はビルド時に JS バンドルへ焼き込まれるため、変更時はフロントエンド再ビルドが必須
 
-## 9.3 systemd 運用時の秘密情報
+## 9.3 デプロイ実行環境
 
-- Docker を使わない場合、systemd の `EnvironmentFile` 機能を利用する
-  - 例：`/etc/ultra-autotrade/backend.env`
-- `backend.env` の権限
-  - `chmod 600 /etc/ultra-autotrade/backend.env`
-  - 所有者：`root:root` または、専用デプロイユーザに限定
-- `backend.env` 内のフォーマット例：
-  ```ini
-  NOTION_API_KEY=xxxxxxxx
-  NOTION_DATABASE_ID=yyyyyyyy
-  OCTOBOT_API_BASE_URL=https://octobot-staging.example.com/api
-  OCTOBOT_API_KEY=octo_test_xxx
-  AAVE_NETWORK=polygon-mumbai
-
-  systemd ユニットファイルでは、次のように参照する：
-
-  EnvironmentFile=/etc/ultra-autotrade/backend.env
-
+- **Hetzner VPS 上でのみ** `scripts/deploy_production.sh` を実行する
+- ローカル Mac からの直接デプロイ禁止
+- Hetzner 上で直接 `git commit` / `git merge` / `nano` 編集は禁止
+  （正規フロー: ローカル Mac → GitHub push → Hetzner `git pull origin main`）
 
 ## 9.4 デプロイユーザと権限管理
-- サーバ上に、アプリケーション専用ユーザ（例：ultra）を用意する
-このユーザのみがプロジェクトディレクトリに書き込み可能
-- SSH ログインは公開鍵認証に限定し、パスワードログインは禁止
-- sudo 権限は最小限にし、ultra ユーザでの sudo 実行は必要な場合のみに限定する
+
+- アプリケーション専用ユーザー `ultra` のみプロジェクトディレクトリに書き込み可能
+- SSH ログインは公開鍵認証のみ、パスワードログイン禁止
+- `sudo` 権限は最小限
 
 ## 9.5 ログと秘密情報の取り扱い
-- API レスポンスやリクエストをログに残す場合も、
-アクセストークンやウォレットアドレスなどの機微情報は マスク or 削除 する
-- ログファイルはサーバローカルか、セキュリティが担保されたストレージに保存し、
-公開 S3 バケットなどには置かない
-- ログローテーションを設定し、長期間のログがサーバ上に残りすぎないようにする
 
-## 9.6 環境ごとの .env ファイルと接続先の分離
-- 同じ変数名でも、環境ごとに接続先を必ず分離 する
+- API レスポンス・リクエストをログに記録する場合、アクセストークン・ウォレットアドレスをマスクまたは削除
+- ログは Loki（`ultra-autotrade-loki-staging`）に集約
+- ログローテーション設定済み（長期間の生ログ保持を防止）
 
- - 例：
-  - AAVE_NETWORK / AAVE_RPC_URL：
-   - staging: テストネット（例：polygon-mumbai）
-   - production: 本番ネットワーク（例：polygon）
+## 9.6 環境ごとの接続先分離
 
-  - OCTOBOT_API_BASE_URL / OCTOBOT_API_KEY：
-   - staging: ステージング OctoBot インスタンス
-   - production: 本番 OctoBot インスタンス
+| 変数 | Staging (port 8001) | 本番相当 (port 8000) |
+|-----|---------------------|---------------------|
+| `AAVE_NETWORK` | `base-sepolia` | `base_sepolia`（Phase 1 期間中） |
+| `BYBIT_SANDBOX` | `true` | `true`（Phase 1 期間中） |
+| `APP_ENV` | `staging` | `staging`（Phase 1 期間中） |
+| `AI_SHADOW_MODE` | `true` | `false` |
+| `REBALANCE_SHADOW_MODE` | `true` | `false` |
 
-  - NOTION_API_KEY / NOTION_DATABASE_ID：
-   - staging: 検証用 Notion DB
-   - production: 本番運用用 Notion DB
+Phase 2 以降: `AAVE_NETWORK=base`, `BYBIT_SANDBOX=false`, `APP_ENV=production` に切り替え
 
-- .env.staging と .env.production の中身をコピーして使い回さない
-  - 特に API キー・ウォレット関連は環境ごとに 物理的に異なるもの を用意する
-- どの .env がどのサーバで使われているかを、ドキュメントとして明示する
-  - staging 環境：`docs/17_staging_environment_config.md`
-  - production 環境：`docs/21_production_environment_config.md`
+---
 
-- どの .env がどのサーバで使われているかを、ドキュメントとして明示する
-  - staging 環境：`docs/17_staging_environment_config.md`
-  - production 環境：`docs/21_production_environment_config.md`
-- 新しい環境（例：検証用 sandbox 等）を追加する場合は、  
-  専用の .env とドキュメントを作成し、既存環境のキーと混在させない
-
-  # 10. バックアップ・リストア時のセキュリティ方針
+# 10. バックアップ・リストア時のセキュリティ方針
 
 ## 10.1 バックアップの方針
 
-- `.env.production` を含む設定ファイルは、以下の条件を満たす場合にのみバックアップする：
-  - 暗号化されたストレージ（例：暗号化ボリューム、パスワード付きアーカイブ）に保存する
+- `.env.production` を含む設定ファイルは以下の条件を満たす場合にのみバックアップする:
+  - 暗号化されたストレージに保存
   - バックアップファイル自体も Git / 共有ストレージに無防備に置かない
-  - アクセス権を最小限の運用メンバーに限定する
-
-- バックアップ対象は次を想定する：
-  - `.env.production`（もしくは同等の環境設定）
-  - デプロイスクリプト / systemd unit / docker-compose ファイル
-  - 運用ランブック（`docs/19_operations_runbook.md`） 等の手順書
-
-- バックアップ作成時には、作成日時・作成者・対象環境（staging / production）を記録しておく。
+  - アクセス権を最小限の運用メンバーに限定
+- バックアップ対象: `.env.production`、デプロイスクリプト、docker-compose ファイル、運用ランブック
+- バックアップ作成時は作成日時・作成者・対象環境を記録する
+- Hetzner 上の `.env.production.bak.*` ファイルは5世代まで自動保存（`deploy_production.sh` が管理）
 
 ## 10.2 リストア時のチェック
 
-- バックアップから `.env.production` を復元する際は、必ず次を確認する：
-  - 復元対象が **正しい環境（production）向けのファイル** であること
-  - staging 用のキーやウォレット情報が混入していないこと
-  - 期限切れのキー（API キー・トークン）が含まれていないこと
-
-- 復元後に必ず実施するチェック：
-  - `docs/21_production_environment_config.md` に記載の必須項目が埋まっている
+- バックアップから `.env.production` を復元する際は以下を確認:
+  - 復元対象が正しい環境（production）向けのファイルであること
+  - staging 用のキー・ウォレット情報が混入していないこと
+  - 期限切れのキーが含まれていないこと
+- 復元後に必ず実施:
+  - `docs/21_production_environment_config.md` 記載の必須項目が埋まっている
   - `docs/22_production_release_checklist.md` の「前提条件チェック」を満たす
 
 ## 10.3 インシデント時のキー・秘密情報の扱い
 
-- `.env.production` の内容が漏えいした疑いがある場合：
+- `.env.production` の内容が漏えいした疑いがある場合:
   - 直ちに該当する API キー・秘密鍵をローテーションする
-  - Aave / OctoBot / Notion / 通知サービス側で、古いキーの無効化を行う
+  - Aave / Bybit / Privy 側で古いキーの無効化を行う
   - ログ・監査情報を確認し、不正アクセスや不正トレードがないかを調査する
-  - 詳細な手順は `docs/19_operations_runbook.md` のインシデント対応セクションに従う
+  - 詳細手順: `docs/19_operations_runbook.md` のインシデント対応セクション
+
+---
+
+# 11. パートナー管理画面の権限分離（方式 B）
+
+## 11.1 ロール設計
+
+| ロール | 権限 | 代表ユーザー |
+|-------|------|------------|
+| `admin` | 全操作（緊急停止解除含む） | 運営チーム |
+| `partner` | 資金配分操作、緊急停止発動、proposal 承認 | 山本さん (id=11) |
+| `editor` | 管理画面編集（テスト用途） | partner@ultra-autotrade.com |
+| `viewer` | 閲覧のみ（Privy ウォレット自動登録） | テスターユーザー |
+
+## 11.2 パートナーテスト運用（方式 B）
+
+- 山本さん1アカウント (`partner` ロール) が配下テスターの資金を一元管理
+- `fund_allocations` テーブルで `partner_id` と `tester_user_id` / `tester_name` を紐付け
+- テスターは `viewer` ロールで閲覧のみ（資金操作不可）
+- 招待コードベース登録フロー（`invitations` テーブル）
+
+## 11.3 緊急停止権限の非対称性
+
+- `partner` ロール: 緊急停止の**発動のみ**可能
+- 緊急停止の**解除（resume）は `admin` ロールのみ**
+- 詳細: `docs/33_emergency_stop_governance.md:2`
+
+---
+
+最終更新: 2026-04-19
+主要変更:
+- OctoBot 依存の全記述を削除（アーキテクチャは Knowledge Hub → AI → Bybit/Aave に）
+- Privy / MetaMask ウォレット方式（2.4 節）を追加
+- F-17a カスタムリミッター（3.2 節）を追加（ハードリミット明記）
+- OR ロジック緊急停止（6.2 節）を追加（docs/33 整合）
+- Phase 1 期間中の意図的 .env 乖離（1.4 節）を追加
+- パートナー管理画面の権限分離 方式 B（11 節）を追加


### PR DESCRIPTION
## Summary

- OctoBot 依存の全記述を削除（`backend/app/bots/` は残存するが docs から除外）
- Privy / MetaMask ウォレット方式（Section 2.4）を追加
- F-17a カスタムリミッター（Section 3.2）を追加（ハードリミット明記: HF>=1.2, single<=40%, daily<=90%, cooldown>=60s）
- OR ロジック緊急停止（Section 6.2）を追加（docs/33 整合）
- Phase 1 期間中の意図的 .env 乖離の理由説明（Section 1.4）を追加
- パートナー管理 方式 B 権限分離（Section 11）を追加

## 変更ファイル

- `docs/13_security_design.md`: 276行 → 394行 (全面改訂)

## 実態確認

全変更は grep によるコードベース実態確認後に記述:
- `risk_limiter.py` のハードリミット定数を直接確認
- `monitoring_service.py:239-244` の OR ロジックを直接確認
- `PrivyRootProvider.tsx` / `connect/page.tsx` の Privy 実装を確認
- `check_env_separation.sh` の Phase 1 期間中の挙動を確認

## docs 整合性

| ドキュメント | 整合確認 |
|------------|---------|
| `docs/07_aave_operation_logic.md` | HF 1.6/1.8, 単回 10%, CD 600s ✅ |
| `docs/22_production_release_checklist.md` | check_env_separation.sh 参照 ✅ |
| `docs/33_emergency_stop_governance.md` | OR 条件 / partner 権限 ✅ |

## Test plan

- [ ] `grep -n "octobot\|OctoBot" docs/13_security_design.md` — 本文中に OctoBot 記述がないこと（末尾変更ログのみ許容）
- [ ] docs/33 と Section 6.2 の記述が矛盾していないこと
- [ ] `wc -l docs/13_security_design.md` — 394 行

🤖 Generated with [Claude Code](https://claude.com/claude-code)