### PR TITLE
feat(ops): add weekly Docker cleanup runbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -696,6 +696,17 @@ docker compose -f docker-compose.staging.yml --env-file .env.staging-new \
 | docs/28_staging_cors_csp_postmortem.md | CORS/CSPインシデント対策 | CORS/CSP問題発生時 |
 | docs/29_tunnel_ops_guide.md | Cloudflare Tunnel運用手順 | Tunnel再起動時 |
 | docs/34_phase2_protocols_guide.md | Phase 2 マルチプロトコル技術ガイド | Lido/Pendle/Optimizer/Risk Engine実装時 |
+| docs/35_docker_maintenance_runbook.md | Docker 週次クリーンアップ手順 | disk 逼迫時・cron 設定変更時 |
+
+---
+
+## Docker クリーンアップ運用
+
+- 週次自動実行: `scripts/docker_cleanup.sh`（毎週日曜 03:00 JST、Hetzner cron 登録）
+- 使用コマンド: `docker builder prune -f` + `docker image prune -f`
+- **禁止**: `docker system prune -af`（使用中イメージ削除リスク、CLAUDE.md 明記）
+- 閾値: WARN 70% / CRITICAL 85%（Slack `#ultra-auto-project` 通知）
+- 詳細: `docs/35_docker_maintenance_runbook.md`
 
 ---
 

--- a/docs/35_docker_maintenance_runbook.md
+++ b/docs/35_docker_maintenance_runbook.md
@@ -1,0 +1,186 @@
+# 35. Docker Maintenance Runbook
+
+## 概要
+
+Ultra AutoTrade の Hetzner VPS（77.42.46.155）で Docker イメージ・ビルドキャッシュの
+蓄積によるディスク逼迫を防ぐための定期メンテナンス runbook。
+
+## 背景
+
+- 2026-04-19 に disk 79%（57G/75G）まで逼迫
+- `docker builder prune -f` で 27GB 解放（79%→42%）
+- builder cache は 1日 +1GB ペースで再蓄積 → 週次クリーンアップで対応
+- `docker system prune -af` は使用中イメージを削除するリスクがあるため **禁止**（CLAUDE.md 明記）
+
+## 運用ポリシー
+
+| 項目 | 方針 |
+|---|---|
+| 実行スクリプト | `scripts/docker_cleanup.sh` |
+| 実行コマンド | `docker builder prune -f` + `docker image prune -f` |
+| **禁止コマンド** | **`docker system prune -af`**（使用中イメージ削除リスク） |
+| 実行頻度 | 週次（毎週日曜 03:00 JST = 18:00 UTC 土曜） |
+| ログ | `/opt/ultra-autotrade/logs/docker_cleanup.log` |
+| Slack 通知 | `#ultra-auto-project` （`SLACK_WEBHOOK_URL` via `.env.production`） |
+
+## 閾値
+
+| レベル | disk 使用率 | Slack 通知 |
+|---|---|---|
+| :white_check_mark: OK | < 70% | 実行結果のみ |
+| :warning: WARN | 70–84% | 警告メッセージ |
+| :rotating_light: CRITICAL | ≥ 85% | 緊急通知 |
+
+閾値は環境変数でオーバーライド可能:
+
+```bash
+DOCKER_CLEANUP_WARN_THRESHOLD=60 /opt/ultra-autotrade/scripts/docker_cleanup.sh
+```
+
+## cron 登録手順（Hetzner ultra ユーザ）
+
+1. Hetzner に SSH ログイン:
+   ```bash
+   ssh hetzner
+   ```
+
+2. crontab を編集:
+   ```bash
+   crontab -e
+   ```
+
+3. 以下の行を追加:
+   ```
+   # Docker cleanup - 毎週日曜 03:00 JST (18:00 UTC Saturday)
+   0 18 * * 6 /opt/ultra-autotrade/scripts/docker_cleanup.sh
+   ```
+
+4. 登録を確認:
+   ```bash
+   crontab -l | grep docker_cleanup
+   ```
+   既存の `backup_db.sh`（毎日 18:00 UTC）と時刻が重複しないことを確認。
+
+## 手動実行
+
+```bash
+# デフォルト設定で実行
+/opt/ultra-autotrade/scripts/docker_cleanup.sh
+
+# 閾値オーバーライド例
+DOCKER_CLEANUP_WARN_THRESHOLD=60 /opt/ultra-autotrade/scripts/docker_cleanup.sh
+
+# staging の .env を参照する場合
+DOCKER_CLEANUP_ENV_FILE=/opt/ultra-autotrade/.env.staging-new \
+  /opt/ultra-autotrade/scripts/docker_cleanup.sh
+
+# ログ出力先を変える場合
+DOCKER_CLEANUP_LOG=/tmp/docker_cleanup_test.log \
+  /opt/ultra-autotrade/scripts/docker_cleanup.sh
+```
+
+## ログ確認
+
+```bash
+# 直近の実行結果（最終50行）
+tail -50 /opt/ultra-autotrade/logs/docker_cleanup.log
+
+# エラーのみ抽出
+grep "ERROR" /opt/ultra-autotrade/logs/docker_cleanup.log | tail -20
+
+# 実行日時一覧
+grep "Docker cleanup started" /opt/ultra-autotrade/logs/docker_cleanup.log
+```
+
+## トラブルシューティング
+
+### 想定ケース 1: disk 90% 到達（CRITICAL アラート後も高い）
+
+1. 手動でスクリプト即時実行:
+   ```bash
+   /opt/ultra-autotrade/scripts/docker_cleanup.sh
+   ```
+
+2. それでも減らない場合、内訳を確認:
+   ```bash
+   docker system df
+   docker images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" | sort -k2 -h
+   ```
+
+3. 停止中コンテナが大量にある場合（個別に削除）:
+   ```bash
+   docker ps -a --filter "status=exited" --format "{{.Names}}"
+   docker rm <container-name>
+   ```
+
+4. dangling volumes の確認と個別削除（稼働コンテナのボリュームは **削除禁止**）:
+   ```bash
+   docker volume ls -qf dangling=true
+   # 安全確認後に個別削除
+   docker volume rm <volume-name>
+   ```
+
+5. **絶対禁止**: `docker system prune -af` は実行しない（使用中イメージを削除する）
+
+### 想定ケース 2: Slack 通知が来ない
+
+1. SLACK_WEBHOOK_URL が `.env.production` に設定されているか確認:
+   ```bash
+   grep -c SLACK_WEBHOOK_URL /opt/ultra-autotrade/.env.production
+   ```
+   （値は出力しない）
+
+2. 手動で webhook をテスト:
+   ```bash
+   WEBHOOK=$(grep SLACK_WEBHOOK_URL /opt/ultra-autotrade/.env.production | cut -d= -f2-)
+   curl -s -X POST "$WEBHOOK" -H "Content-Type: application/json" \
+     -d '{"text": "test from Hetzner"}' && echo " OK"
+   ```
+
+3. Slack 側でアプリの webhook が有効か確認（Slack ワークスペース管理者）
+
+### 想定ケース 3: cron が実行されない
+
+1. cron サービスの状態確認:
+   ```bash
+   systemctl status cron
+   ```
+
+2. crontab 登録の確認:
+   ```bash
+   crontab -l | grep docker_cleanup
+   ```
+
+3. cron ログでエラー確認:
+   ```bash
+   grep docker_cleanup /var/log/syslog | tail -20
+   # または
+   journalctl -u cron --since "7 days ago" | grep docker_cleanup
+   ```
+
+4. スクリプトの実行権限確認:
+   ```bash
+   ls -la /opt/ultra-autotrade/scripts/docker_cleanup.sh
+   # -rwxr-xr-x になっていること
+   ```
+
+### 想定ケース 4: スクリプトが途中で失敗する
+
+1. ログで ERROR 行を確認:
+   ```bash
+   grep ERROR /opt/ultra-autotrade/logs/docker_cleanup.log | tail -10
+   ```
+
+2. Docker デーモンが動いているか確認:
+   ```bash
+   docker info 2>&1 | head -5
+   ```
+
+3. ディスクが完全に埋まった場合は手動でスペースを確保してから再実行
+
+## 関連ドキュメント
+
+- `docs/19_operations_runbook.md` — 全体的な運用手順
+- `docs/16_infra_deployment_guide.md` — インフラ・デプロイガイド
+- `scripts/backup_db.sh` — 日次 DB バックアップ（同様の cron 運用パターン）
+- `scripts/deploy_production.sh` — `slack_notify()` の参照元実装

--- a/scripts/docker_cleanup.sh
+++ b/scripts/docker_cleanup.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# scripts/docker_cleanup.sh — 週次 Docker クリーンアップ runbook
+#
+# 実行内容:
+#   1. docker builder prune -f （builder cache 削除）
+#   2. docker image prune -f  （dangling image のみ削除、タグ付き image は温存）
+#
+# 禁止: docker system prune -af は絶対に使わない（CLAUDE.md 明記、使用中 image 削除リスク）
+#
+# cron 登録例（Hetzner ultra ユーザ）:
+#   0 3 * * 0 /opt/ultra-autotrade/scripts/docker_cleanup.sh
+#
+# 環境変数オーバーライド:
+#   DOCKER_CLEANUP_LOG              （デフォルト: /opt/ultra-autotrade/logs/docker_cleanup.log）
+#   DOCKER_CLEANUP_ENV_FILE         （デフォルト: /opt/ultra-autotrade/.env.production）
+#   DOCKER_CLEANUP_WARN_THRESHOLD   （デフォルト: 70）
+#   DOCKER_CLEANUP_CRITICAL_THRESHOLD（デフォルト: 85）
+#
+# 関連: docs/35_docker_maintenance_runbook.md
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+LOG_FILE="${DOCKER_CLEANUP_LOG:-/opt/ultra-autotrade/logs/docker_cleanup.log}"
+ENV_FILE="${DOCKER_CLEANUP_ENV_FILE:-${PROJECT_ROOT}/.env.production}"
+WARN_THRESHOLD="${DOCKER_CLEANUP_WARN_THRESHOLD:-70}"
+CRITICAL_THRESHOLD="${DOCKER_CLEANUP_CRITICAL_THRESHOLD:-85}"
+
+mkdir -p "$(dirname "${LOG_FILE}")"
+
+# ── ヘルパー ─────────────────────────────────────────────────────────────────
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "${LOG_FILE}"
+}
+
+err() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $*" | tee -a "${LOG_FILE}" >&2
+}
+
+# deploy_production.sh:45-52 と同じインターフェース
+# ENV_FILE から SLACK_WEBHOOK_URL を grep 読み込みして curl で送信
+slack_notify() {
+  local msg="$1"
+  local webhook
+  webhook="$(grep -E '^SLACK_WEBHOOK_URL=' "${ENV_FILE}" 2>/dev/null | head -1 | cut -d= -f2- || true)"
+  if [[ -n "${webhook}" ]]; then
+    curl -s -X POST "${webhook}" \
+      -H "Content-Type: application/json" \
+      -d "{\"text\": \"${msg}\"}" >/dev/null || true
+  fi
+}
+
+# disk 使用率 (%) を整数で返す
+get_disk_usage_pct() {
+  df / | tail -1 | awk '{gsub(/%/, "", $5); print $5}'
+}
+
+# ── メイン処理 ───────────────────────────────────────────────────────────────
+
+log "=== Docker cleanup started ==="
+
+BEFORE_DISK="$(get_disk_usage_pct)"
+log "Disk usage BEFORE: ${BEFORE_DISK}%"
+log "docker system df BEFORE:"
+docker system df 2>&1 | tee -a "${LOG_FILE}"
+
+# 1. Builder cache prune
+log "Running: docker builder prune -f"
+if ! docker builder prune -f 2>&1 | tee -a "${LOG_FILE}"; then
+  err "docker builder prune failed"
+  slack_notify ":x: [docker_cleanup] builder prune failed on Hetzner. Check ${LOG_FILE}"
+  exit 1
+fi
+
+# 2. Dangling image prune（タグなしのみ。タグ付き image は温存）
+log "Running: docker image prune -f"
+if ! docker image prune -f 2>&1 | tee -a "${LOG_FILE}"; then
+  err "docker image prune failed"
+  slack_notify ":x: [docker_cleanup] image prune failed on Hetzner. Check ${LOG_FILE}"
+  exit 1
+fi
+
+AFTER_DISK="$(get_disk_usage_pct)"
+log "Disk usage AFTER: ${AFTER_DISK}%"
+log "docker system df AFTER:"
+docker system df 2>&1 | tee -a "${LOG_FILE}"
+
+# ── 閾値判定 & Slack 通知 ────────────────────────────────────────────────────
+
+LEVEL=":white_check_mark: OK"
+if (( AFTER_DISK >= CRITICAL_THRESHOLD )); then
+  LEVEL=":rotating_light: CRITICAL"
+elif (( AFTER_DISK >= WARN_THRESHOLD )); then
+  LEVEL=":warning: WARN"
+fi
+
+MSG="${LEVEL} [docker_cleanup] Disk ${BEFORE_DISK}% -> ${AFTER_DISK}% on Hetzner (W=${WARN_THRESHOLD}%, C=${CRITICAL_THRESHOLD}%)"
+log "${MSG}"
+slack_notify "${MSG}"
+
+log "=== Docker cleanup finished ==="


### PR DESCRIPTION
## Summary
- `scripts/docker_cleanup.sh` 新規作成: 週次 builder cache + dangling image prune、disk 閾値判定、Slack 通知
- `docs/35_docker_maintenance_runbook.md` 新規作成: 閾値・cron 登録手順・手動実行・4ケーストラブルシューティング
- `CLAUDE.md` 更新: Docker クリーンアップポリシーサマリーと参照ドキュメントリンク追加

## Background
2026-04-19 disk 79%（57G/75G）逼迫 → `docker builder prune -f` で 27GB 解放済み。
builder cache が 1日 +1GB ペースで再蓄積するため、週次自動クリーンアップを定期化する。
`docker system prune -af` は CLAUDE.md 明記の禁止事項（使用中イメージ削除リスク）。

## Test plan
- [x] `shellcheck scripts/docker_cleanup.sh` → passed（警告ゼロ）
- [x] `ruff check / ruff format / mypy` → passed（Python 変更なし）
- [ ] Hetzner dry-run: PR マージ後に `git pull && ./scripts/docker_cleanup.sh` で手動確認
- [ ] `crontab -e` で週次登録（PR マージ & dry-run 確認後）

Asana: 1214116053639733

🤖 Generated with [Claude Code](https://claude.com/claude-code)