### PR TITLE
fix(scripts): add shebang to zip_next_phase.sh (SC2148)

### DIFF
--- a/scripts/zip_next_phase.sh
+++ b/scripts/zip_next_phase.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash


### PR DESCRIPTION
## 概要
scripts/zip_next_phase.sh に shebang を追加し、shellcheck SC2148 エラーを解消。

## 背景
- 既存tech debt (Asana 1214120548802540)
- PR #98 (dev→main merge) の check-env-separation がこのファイルで fail
- 1行追加のみで解消

## 影響
- shellcheck CI pass
- PR #98 自動 unblock (dev へのマージ後、PR #98 CI再実行で pass する想定)

Asana: 1214120548802540