### PR TITLE
release: Anthropic model validation + env model names alignment

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -45,6 +45,9 @@ NEXT_PUBLIC_API_URL=https://api.ultra-auto-trade.com
 ANTHROPIC_API_KEY=sk-ant-...
 OPENAI_API_KEY=sk-...
 PERPLEXITY_API_KEY=pplx-...
+# Claude model names — must match VALID_CLAUDE_MODELS in backend/app/ai/config.py
+AI_CLAUDE_MODEL=claude-sonnet-4-6-20250929
+AI_FALLBACK_MODEL=claude-haiku-4-5-20251001
 
 # =============================================================================
 # Exchange（Bybit 本番API — BYBIT_SANDBOX は必ず false）

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -38,9 +38,13 @@ NEXT_PUBLIC_API_URL=https://api-staging.ultra-auto-trade.com
 # =============================================================================
 # AI / LLM（productionと同じキーでも動作可。長期的には分離推奨）
 # =============================================================================
+# ANTHROPIC_API_KEY=<staging専用キー発行後ここに設定。prod とは別キーを推奨>
 ANTHROPIC_API_KEY=sk-ant-...
 OPENAI_API_KEY=sk-...
 PERPLEXITY_API_KEY=pplx-...
+# Claude model names — must match VALID_CLAUDE_MODELS in backend/app/ai/config.py
+AI_CLAUDE_MODEL=claude-sonnet-4-6-20250929
+AI_FALLBACK_MODEL=claude-haiku-4-5-20251001
 
 # =============================================================================
 # Exchange（Bybit Sandbox必須）

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,10 @@ jobs:
             echo "::warning::Possible float usage in financial calculations. Use Decimal instead (see docs/13_security_design.md)."
           fi
 
+      - name: Validate Anthropic Claude model names
+        working-directory: ${{ github.workspace }}
+        run: python scripts/validate_anthropic_model.py
+
   trivy-scan:
     name: Trivy Container & Filesystem Scan
     runs-on: ubuntu-latest

--- a/.github/workflows/env-separation-check.yml
+++ b/.github/workflows/env-separation-check.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - '.env.staging'
       - '.env.production'
+      - 'backend/.env.staging.example'
+      - 'backend/.env.production.example'
       - 'docker-compose*.yml'
       - 'scripts/check_env_separation.sh'
   push:
@@ -17,13 +19,17 @@ jobs:
       - uses: actions/checkout@v4
       - name: Verify env separation
         run: |
-          if [ -f .env.production.example ] && [ -f .env.staging.example ]; then
-            cp .env.production.example .env.production
-            cp .env.staging.example .env.staging
-            bash scripts/check_env_separation.sh
-          else
-            echo "::warning::.env.*.example が見つからない、検証スキップ"
+          if [ ! -f backend/.env.production.example ]; then
+            echo "::error::backend/.env.production.example が見つかりません"
+            exit 1
           fi
+          if [ ! -f backend/.env.staging.example ]; then
+            echo "::error::backend/.env.staging.example が見つかりません"
+            exit 1
+          fi
+          cp backend/.env.production.example .env.production
+          cp backend/.env.staging.example .env.staging
+          bash scripts/check_env_separation.sh
       - name: Shellcheck
         uses: ludeeus/action-shellcheck@master
         with:

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -143,7 +143,8 @@ REBALANCE_TOKEN_SECRET=CHANGE_ME_REBALANCE_TOKEN_SECRET
 ANTHROPIC_API_KEY=CHANGE_ME_ANTHROPIC_API_KEY
 
 # Claude モデル名（production は最新安定版を推奨）
-AI_CLAUDE_MODEL=claude-sonnet-4-6
+# 許可リスト: backend/app/ai/config.py の VALID_CLAUDE_MODELS 参照
+AI_CLAUDE_MODEL=claude-sonnet-4-6-20250929
 
 # -- OpenAI (GPT-4o) --
 # 取得先: https://platform.openai.com/
@@ -152,8 +153,8 @@ OPENAI_API_KEY=CHANGE_ME_OPENAI_API_KEY
 # GPT モデル名
 AI_OPENAI_MODEL=gpt-4o
 
-# フォールバックモデル（Claude 障害時）
-AI_FALLBACK_MODEL=claude-sonnet-4-6
+# フォールバックモデル（Claude 障害時。primary と異なるモデルを指定すること）
+AI_FALLBACK_MODEL=claude-haiku-4-5-20251001
 
 # -- Perplexity (ニュース/マクロ分析) --
 # 取得先: https://www.perplexity.ai/settings/api

--- a/backend/.env.staging.example
+++ b/backend/.env.staging.example
@@ -40,6 +40,9 @@ INTERNAL_API_TOKEN=CHANGE_ME_GENERATE_WITH_secrets
 ANTHROPIC_API_KEY=sk-ant-xxxxx
 OPENAI_API_KEY=sk-xxxxx
 PERPLEXITY_API_KEY=pplx-xxxxx
+# Claude model names — must match VALID_CLAUDE_MODELS in backend/app/ai/config.py
+AI_CLAUDE_MODEL=claude-sonnet-4-6-20250929
+AI_FALLBACK_MODEL=claude-haiku-4-5-20251001
 
 # ============================================================
 # Exchange（必須）

--- a/backend/.env.staging.example
+++ b/backend/.env.staging.example
@@ -41,6 +41,10 @@ ANTHROPIC_API_KEY=sk-ant-xxxxx
 OPENAI_API_KEY=sk-xxxxx
 PERPLEXITY_API_KEY=pplx-xxxxx
 
+# AI モデル名（非推奨モデルは check_env_separation.sh で CI ブロック）
+AI_CLAUDE_MODEL=claude-sonnet-4-6
+AI_FALLBACK_MODEL=claude-haiku-4-5-20251001
+
 # ============================================================
 # Exchange（必須）
 # ============================================================

--- a/backend/app/ai/config.py
+++ b/backend/app/ai/config.py
@@ -14,6 +14,30 @@ from typing import Optional
 
 from app.utils.config import get_env
 
+# ---------------------------------------------------------------------------
+# モデル名許可リスト（Single source of truth）
+# scripts/validate_anthropic_model.py と同期すること
+# ---------------------------------------------------------------------------
+VALID_CLAUDE_MODELS: list[str] = [
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6-20250929",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5-20251001",
+    "claude-haiku-4-5",
+]
+
+DEFAULT_CLAUDE_MODEL: str = "claude-sonnet-4-6-20250929"
+DEFAULT_FALLBACK_MODEL: str = "claude-haiku-4-5-20251001"
+
+# 非推奨モデル: 起動時検証でブロックされる
+DEPRECATED_CLAUDE_MODELS: list[str] = [
+    "claude-sonnet-4-20250514",
+    "claude-3-5-sonnet-20241022",
+    "claude-3-5-sonnet-latest",
+    "claude-3-opus-20240229",
+]
+
 
 @dataclass
 class AISettings:
@@ -67,6 +91,18 @@ def _get_env_bool(name: str, default: bool) -> bool:
     return raw.lower() in ("true", "1", "yes")
 
 
+def _validate_model_config() -> None:
+    """起動時検証: 非推奨モデルが設定されていれば ValueError を raise する。"""
+    current = get_env("AI_CLAUDE_MODEL", required=False) or DEFAULT_CLAUDE_MODEL
+    fallback = get_env("AI_FALLBACK_MODEL", required=False) or DEFAULT_FALLBACK_MODEL
+    for name, value in [("AI_CLAUDE_MODEL", current), ("AI_FALLBACK_MODEL", fallback)]:
+        if value in DEPRECATED_CLAUDE_MODELS:
+            raise ValueError(
+                f"Deprecated Claude model configured: {name}={value!r}. "
+                f"Use one of: {VALID_CLAUDE_MODELS}"
+            )
+
+
 def get_ai_settings() -> AISettings:
     """
     AISettings を構築して返す。
@@ -74,7 +110,7 @@ def get_ai_settings() -> AISettings:
     全キーはオプション（graceful degradation）:
       - ANTHROPIC_API_KEY（未設定時: None）
       - OPENAI_API_KEY（未設定時: None）
-      - AI_CLAUDE_MODEL（デフォルト: claude-sonnet-4-20250514）
+      - AI_CLAUDE_MODEL（デフォルト: claude-sonnet-4-6-20250929）
       - AI_OPENAI_MODEL（デフォルト: gpt-4o）
       - AI_MIN_CONFIDENCE_THRESHOLD（デフォルト: 40）
       - AI_CROSS_VALIDATION_ENABLED（デフォルト: True）
@@ -83,9 +119,9 @@ def get_ai_settings() -> AISettings:
     anthropic_api_key = get_env("ANTHROPIC_API_KEY", required=False)
     openai_api_key = get_env("OPENAI_API_KEY", required=False)
 
-    claude_model = get_env("AI_CLAUDE_MODEL", required=False) or "claude-sonnet-4-20250514"
+    claude_model = get_env("AI_CLAUDE_MODEL", required=False) or DEFAULT_CLAUDE_MODEL
     openai_model = get_env("AI_OPENAI_MODEL", required=False) or "gpt-4o"
-    ai_fallback_model = get_env("AI_FALLBACK_MODEL", required=False) or "claude-sonnet-4-20250514"
+    ai_fallback_model = get_env("AI_FALLBACK_MODEL", required=False) or DEFAULT_FALLBACK_MODEL
 
     min_confidence_threshold = _get_env_int(
         "AI_MIN_CONFIDENCE_THRESHOLD",

--- a/backend/app/ai/config.py
+++ b/backend/app/ai/config.py
@@ -14,6 +14,27 @@ from typing import Optional
 
 from app.utils.config import get_env
 
+# Valid Claude model names as of 2026-04-20
+# e.g. claude-sonnet-4-6-20250929
+VALID_CLAUDE_MODELS: list[str] = [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6-20250929",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5-20251001",
+    "claude-haiku-4-5",
+]
+DEFAULT_CLAUDE_MODEL: str = "claude-sonnet-4-6-20250929"
+DEFAULT_FALLBACK_MODEL: str = "claude-haiku-4-5-20251001"
+
+# Deprecated models that should trigger CI failure
+# claude-sonnet-4-20250514 was the cause of the 2026-04-18 production 502 incident
+DEPRECATED_CLAUDE_MODELS: list[str] = [
+    "claude-sonnet-4-20250514",
+    "claude-3-5-sonnet-20241022",
+    "claude-3-5-sonnet-latest",
+    "claude-3-opus-20240229",
+]
+
 
 @dataclass
 class AISettings:
@@ -67,6 +88,18 @@ def _get_env_bool(name: str, default: bool) -> bool:
     return raw.lower() in ("true", "1", "yes")
 
 
+def _validate_model_config() -> None:
+    """Raise at startup if a deprecated model is configured."""
+    current = get_env("AI_CLAUDE_MODEL", required=False) or DEFAULT_CLAUDE_MODEL
+    fallback = get_env("AI_FALLBACK_MODEL", required=False) or DEFAULT_FALLBACK_MODEL
+    for name, value in [("AI_CLAUDE_MODEL", current), ("AI_FALLBACK_MODEL", fallback)]:
+        if value in DEPRECATED_CLAUDE_MODELS:
+            raise ValueError(
+                f"Deprecated Claude model configured: {name}={value}. "
+                f"See backend/app/ai/config.py VALID_CLAUDE_MODELS."
+            )
+
+
 def get_ai_settings() -> AISettings:
     """
     AISettings を構築して返す。
@@ -74,7 +107,7 @@ def get_ai_settings() -> AISettings:
     全キーはオプション（graceful degradation）:
       - ANTHROPIC_API_KEY（未設定時: None）
       - OPENAI_API_KEY（未設定時: None）
-      - AI_CLAUDE_MODEL（デフォルト: claude-sonnet-4-20250514）
+      - AI_CLAUDE_MODEL（デフォルト: DEFAULT_CLAUDE_MODEL）
       - AI_OPENAI_MODEL（デフォルト: gpt-4o）
       - AI_MIN_CONFIDENCE_THRESHOLD（デフォルト: 40）
       - AI_CROSS_VALIDATION_ENABLED（デフォルト: True）
@@ -83,9 +116,9 @@ def get_ai_settings() -> AISettings:
     anthropic_api_key = get_env("ANTHROPIC_API_KEY", required=False)
     openai_api_key = get_env("OPENAI_API_KEY", required=False)
 
-    claude_model = get_env("AI_CLAUDE_MODEL", required=False) or "claude-sonnet-4-20250514"
+    claude_model = get_env("AI_CLAUDE_MODEL", required=False) or DEFAULT_CLAUDE_MODEL
     openai_model = get_env("AI_OPENAI_MODEL", required=False) or "gpt-4o"
-    ai_fallback_model = get_env("AI_FALLBACK_MODEL", required=False) or "claude-sonnet-4-20250514"
+    ai_fallback_model = get_env("AI_FALLBACK_MODEL", required=False) or DEFAULT_FALLBACK_MODEL
 
     min_confidence_threshold = _get_env_int(
         "AI_MIN_CONFIDENCE_THRESHOLD",

--- a/backend/app/ai/service.py
+++ b/backend/app/ai/service.py
@@ -21,7 +21,7 @@ from app.ai.judgment_log import CognitiveState
 from app.data_feeds.context import MarketContext
 from app.notion.schemas import NotionNewsItem
 
-from .config import AISettings, get_ai_settings
+from .config import DEFAULT_FALLBACK_MODEL, AISettings, get_ai_settings
 from .prompts import get_prompt_template
 from .schemas import (
     AIAnalysisResult,
@@ -391,7 +391,7 @@ class AIService:
                 )
 
         # Opus failed twice → fall back to Sonnet
-        fallback_model = getattr(settings, "ai_fallback_model", "claude-sonnet-4-20250514")
+        fallback_model = getattr(settings, "ai_fallback_model", DEFAULT_FALLBACK_MODEL)
         logger.warning(
             "Claude Opus failed after %d attempts; switching to fallback model=%s",
             _MAX_OPUS_RETRIES,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -247,6 +247,7 @@ def create_app() -> FastAPI:
 
     @app.get("/health", tags=["health"])
     def health_check() -> dict[str, Any]:
+        from app.ai.config import DEFAULT_CLAUDE_MODEL, DEFAULT_FALLBACK_MODEL
         from app.automation.ai_judgment_scheduler import get_scheduler_status
         from app.automation.scheduler_watchdog import compute_scheduler_health
 
@@ -268,6 +269,8 @@ def create_app() -> FastAPI:
             "next_judgment": scheduler.get("next_run"),
             "scheduler_last_error": scheduler.get("last_error"),
             "warnings": warnings,
+            "claude_model": os.getenv("AI_CLAUDE_MODEL") or DEFAULT_CLAUDE_MODEL,
+            "claude_fallback_model": os.getenv("AI_FALLBACK_MODEL") or DEFAULT_FALLBACK_MODEL,
         }
 
     # --- Database initialization (Phase12) ---

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -270,6 +270,15 @@ def create_app() -> FastAPI:
             "warnings": warnings,
         }
 
+    # --- AI model config validation (fail-fast: must be first startup event) ---
+    @app.on_event("startup")
+    async def startup_validate_model_config() -> None:
+        """Fail-fast: reject deprecated Claude model names before any task starts."""
+        from app.ai.config import _validate_model_config  # noqa: PLC0415
+
+        _validate_model_config()
+        logger.info("AI model config validation passed")
+
     # --- Database initialization (Phase12) ---
     @app.on_event("startup")
     async def startup_database() -> None:

--- a/backend/tests/test_ai_config.py
+++ b/backend/tests/test_ai_config.py
@@ -135,7 +135,7 @@ class TestGetAISettings:
             importlib.reload(ai_config)
             settings = ai_config.get_ai_settings()
 
-        assert settings.claude_model == "claude-sonnet-4-20250514"
+        assert settings.claude_model == "claude-sonnet-4-6-20250929"
         assert settings.openai_model == "gpt-4o"
         assert settings.min_confidence_threshold == 40
         assert settings.cross_validation_enabled is True

--- a/backend/tests/test_ai_config_validation.py
+++ b/backend/tests/test_ai_config_validation.py
@@ -1,0 +1,68 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/test_ai_config_validation.py
+"""Tests for AI model config validation (startup guard against deprecated models)."""
+
+import os
+from unittest import mock
+
+import pytest
+
+from app.ai.config import (
+    DEFAULT_CLAUDE_MODEL,
+    DEFAULT_FALLBACK_MODEL,
+    DEPRECATED_CLAUDE_MODELS,
+    VALID_CLAUDE_MODELS,
+    _validate_model_config,
+)
+
+
+def test_default_model_is_not_deprecated() -> None:
+    assert DEFAULT_CLAUDE_MODEL not in DEPRECATED_CLAUDE_MODELS
+    assert DEFAULT_FALLBACK_MODEL not in DEPRECATED_CLAUDE_MODELS
+
+
+def test_default_model_is_in_valid_list() -> None:
+    assert DEFAULT_CLAUDE_MODEL in VALID_CLAUDE_MODELS
+    assert DEFAULT_FALLBACK_MODEL in VALID_CLAUDE_MODELS
+
+
+@mock.patch.dict(os.environ, {"AI_CLAUDE_MODEL": "claude-sonnet-4-20250514"})
+def test_deprecated_primary_model_raises_at_startup() -> None:
+    with pytest.raises(ValueError, match="Deprecated Claude model"):
+        _validate_model_config()
+
+
+@mock.patch.dict(os.environ, {"AI_FALLBACK_MODEL": "claude-3-5-sonnet-latest"})
+def test_deprecated_fallback_model_raises_at_startup() -> None:
+    with pytest.raises(ValueError, match="Deprecated Claude model"):
+        _validate_model_config()
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "AI_CLAUDE_MODEL": "claude-sonnet-4-6-20250929",
+        "AI_FALLBACK_MODEL": "claude-haiku-4-5-20251001",
+    },
+)
+def test_valid_models_pass_validation() -> None:
+    _validate_model_config()  # should not raise
+
+
+def test_unset_env_vars_use_defaults_and_pass() -> None:
+    env = {k: v for k, v in os.environ.items() if k not in ("AI_CLAUDE_MODEL", "AI_FALLBACK_MODEL")}
+    with mock.patch.dict(os.environ, env, clear=True):
+        _validate_model_config()  # defaults are valid, should not raise
+
+
+@mock.patch.dict(os.environ, {"AI_CLAUDE_MODEL": "claude-opus-4-7"})
+def test_opus_model_passes_validation() -> None:
+    _validate_model_config()  # should not raise
+
+
+@mock.patch.dict(os.environ, {"AI_CLAUDE_MODEL": "claude-unknown-99-99"})
+def test_unknown_model_is_not_in_deprecated_so_passes() -> None:
+    # Unknown models are NOT in DEPRECATED list, so they pass validation.
+    # The allowlist check is intentionally permissive to avoid blocking future models.
+    _validate_model_config()  # should not raise (deprecated-only check)

--- a/backend/tests/test_ai_config_validation.py
+++ b/backend/tests/test_ai_config_validation.py
@@ -1,0 +1,57 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/test_ai_config_validation.py
+"""Tests for AI model config validation (Layer 4 guard against deprecated models)."""
+
+import os
+from unittest import mock
+
+import pytest
+
+from app.ai.config import (
+    DEFAULT_CLAUDE_MODEL,
+    DEFAULT_FALLBACK_MODEL,
+    DEPRECATED_CLAUDE_MODELS,
+    VALID_CLAUDE_MODELS,
+    _validate_model_config,
+)
+
+
+def test_default_model_is_not_deprecated() -> None:
+    assert DEFAULT_CLAUDE_MODEL not in DEPRECATED_CLAUDE_MODELS
+    assert DEFAULT_FALLBACK_MODEL not in DEPRECATED_CLAUDE_MODELS
+
+
+def test_default_model_is_in_valid_list() -> None:
+    assert DEFAULT_CLAUDE_MODEL in VALID_CLAUDE_MODELS
+    assert DEFAULT_FALLBACK_MODEL in VALID_CLAUDE_MODELS
+
+
+@mock.patch.dict(os.environ, {"AI_CLAUDE_MODEL": "claude-sonnet-4-20250514"})
+def test_deprecated_primary_model_raises_at_startup() -> None:
+    with pytest.raises(ValueError, match="Deprecated Claude model"):
+        _validate_model_config()
+
+
+@mock.patch.dict(os.environ, {"AI_FALLBACK_MODEL": "claude-3-5-sonnet-latest"})
+def test_deprecated_fallback_model_raises_at_startup() -> None:
+    with pytest.raises(ValueError, match="Deprecated Claude model"):
+        _validate_model_config()
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "AI_CLAUDE_MODEL": "claude-sonnet-4-6-20250929",
+        "AI_FALLBACK_MODEL": "claude-haiku-4-5-20251001",
+    },
+)
+def test_valid_models_pass_validation() -> None:
+    _validate_model_config()  # should not raise
+
+
+@mock.patch.dict(os.environ, {}, clear=False)
+def test_unset_env_vars_use_defaults_and_pass() -> None:
+    env = {k: v for k, v in os.environ.items() if k not in ("AI_CLAUDE_MODEL", "AI_FALLBACK_MODEL")}
+    with mock.patch.dict(os.environ, env, clear=True):
+        _validate_model_config()  # defaults are valid, should not raise

--- a/backend/tests/test_ai_prefilter.py
+++ b/backend/tests/test_ai_prefilter.py
@@ -344,4 +344,4 @@ class TestOpusSonnetFallback:
             from app.ai.config import get_ai_settings
 
             settings = get_ai_settings()
-        assert settings.ai_fallback_model == "claude-sonnet-4-20250514"
+        assert settings.ai_fallback_model == "claude-haiku-4-5-20251001"

--- a/backend/tests/test_ai_prefilter.py
+++ b/backend/tests/test_ai_prefilter.py
@@ -178,7 +178,7 @@ class TestOpusSonnetFallback:
         self,
         *,
         opus_model: str = "claude-opus-4-5",
-        fallback_model: str = "claude-sonnet-4-20250514",
+        fallback_model: str = "claude-haiku-4-5-20251001",
     ) -> MagicMock:
         settings = MagicMock()
         settings.anthropic_api_key = "sk-test"
@@ -344,4 +344,4 @@ class TestOpusSonnetFallback:
             from app.ai.config import get_ai_settings
 
             settings = get_ai_settings()
-        assert settings.ai_fallback_model == "claude-sonnet-4-20250514"
+        assert settings.ai_fallback_model == "claude-haiku-4-5-20251001"

--- a/docs/43_env_model_update_procedure.md
+++ b/docs/43_env_model_update_procedure.md
@@ -1,0 +1,170 @@
+# docs/43 — Hetzner 実 .env モデル名更新手順
+
+## 対象
+
+Anthropic Claude モデル名（`AI_CLAUDE_MODEL` / `AI_FALLBACK_MODEL`）を更新する際に
+Hetzner VPS 上の実ファイルへ反映する手順。
+
+`.env.production.example` / `.env.staging.example` をリポジトリで更新した後、
+本手順に従って Hetzner 上の実ファイルに手動反映する。
+
+---
+
+## 前提
+
+- Hetzner SSH: `ssh -i ~/.ssh/hetzner_staging ultra@77.42.46.155`
+- 作業ディレクトリ: `/opt/ultra-autotrade`
+- 許可モデルリスト: `backend/app/ai/config.py` の `VALID_CLAUDE_MODELS`
+- CI スクリプト: `scripts/validate_anthropic_model.py` (root `.env.*.example` を検証)
+
+## ⚠️ 禁止事項
+
+- `sed -i` などで `.env.staging-new` と `.env.production` を同時一括置換しない
+  （2026-04-18 インシデント: 両ファイルが完全一致し環境分離が崩壊）
+- ファイルを nano 以外で直接編集する場合も必ず片方ずつ実施
+
+---
+
+## 手順
+
+### STEP 0: 事前確認
+
+```bash
+# Hetzner SSH
+ssh -i ~/.ssh/hetzner_staging ultra@77.42.46.155
+cd /opt/ultra-autotrade
+
+# 現在の稼働モデル確認（staging）
+curl -s http://localhost:8001/health | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('claude_model'), d.get('claude_fallback_model'))"
+
+# 現在の稼働モデル確認（production）
+curl -s http://localhost:8000/health | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('claude_model'), d.get('claude_fallback_model'))"
+
+# .env 内の現在値確認
+grep "AI_CLAUDE_MODEL\|AI_FALLBACK_MODEL" .env.staging-new
+grep "AI_CLAUDE_MODEL\|AI_FALLBACK_MODEL" .env.production
+```
+
+### STEP 1: バックアップ取得（必須）
+
+```bash
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+
+# staging バックアップ
+cp .env.staging-new ".env.staging-new.bak.${TIMESTAMP}"
+echo "Backup: .env.staging-new.bak.${TIMESTAMP}"
+
+# production バックアップ
+cp .env.production ".env.production.bak.${TIMESTAMP}"
+echo "Backup: .env.production.bak.${TIMESTAMP}"
+```
+
+### STEP 2: Shadow Staging の更新（先行反映）
+
+```bash
+# nano で staging のみ編集（production は触らない）
+nano .env.staging-new
+```
+
+変更箇所:
+```
+AI_CLAUDE_MODEL=claude-sonnet-4-6-20250929
+AI_FALLBACK_MODEL=claude-haiku-4-5-20251001
+```
+
+```bash
+# staging backend のみ再起動
+docker compose -f docker-compose.staging.yml --env-file .env.staging-new \
+  up -d --no-deps --force-recreate backend
+
+# 起動確認
+sleep 10
+curl -s http://localhost:8001/health | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); print('claude_model:', d.get('claude_model')); print('fallback:', d.get('claude_fallback_model')); print('scheduler_healthy:', d.get('scheduler_healthy'))"
+```
+
+### STEP 3: 30分観察
+
+```bash
+# scheduler_healthy と last_judgment を確認
+watch -n 60 "curl -s http://localhost:8001/health | python3 -c \"import sys,json; d=json.load(sys.stdin); print('scheduler:', d.get('scheduler_healthy'), '| last:', d.get('last_judgment','none')[:19] if d.get('last_judgment') else 'none')\""
+```
+
+確認項目:
+- `scheduler_healthy: true`
+- `last_judgment` が現在時刻付近（過去30分以内）に更新されていること
+- エラーログなし: `docker logs ultra-autotrade-project-backend-staging-1 2>&1 | grep -i error | tail -20`
+
+### STEP 4: claude.ai に staging 観察結果を報告し GO 合図を受ける
+
+```json
+// 報告用: curl -s http://localhost:8001/health | jq '{claude_model, claude_fallback_model, scheduler_healthy, last_judgment}'
+```
+
+### STEP 5: Production の更新（GO 合図後）
+
+```bash
+# production のみ編集（staging は触らない）
+nano .env.production
+```
+
+変更箇所:
+```
+AI_CLAUDE_MODEL=claude-sonnet-4-6-20250929
+AI_FALLBACK_MODEL=claude-haiku-4-5-20251001
+```
+
+```bash
+# production backend のみ再起動（フロント・DB に影響なし）
+docker compose -f docker-compose.production.yml --env-file .env.production \
+  up -d --no-deps --force-recreate backend
+
+# 起動確認
+sleep 15
+curl -s http://localhost:8000/health | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); print('claude_model:', d.get('claude_model')); print('fallback:', d.get('claude_fallback_model')); print('scheduler_healthy:', d.get('scheduler_healthy'))"
+
+# Cloudflare Tunnel 経由でも確認
+curl -s https://api.ultra-auto-trade.com/health | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); print('claude_model:', d.get('claude_model'))"
+```
+
+### STEP 6: 2時間監視
+
+```bash
+# エラー監視
+docker logs -f ultra-autotrade-project-backend-1 2>&1 | grep -E "ERROR|DEPRECATED|ValueError"
+
+# AI 判定成功確認（次回スケジュール実行後）
+curl -s http://localhost:8000/health | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); print(json.dumps({'scheduler_healthy': d.get('scheduler_healthy'), 'last_judgment': d.get('last_judgment')}, indent=2))"
+```
+
+---
+
+## ロールバック手順
+
+```bash
+TIMESTAMP=<バックアップ時刻>  # 例: 20260420_143000
+
+# staging ロールバック
+cp ".env.staging-new.bak.${TIMESTAMP}" .env.staging-new
+docker compose -f docker-compose.staging.yml --env-file .env.staging-new \
+  up -d --no-deps --force-recreate backend
+
+# production ロールバック（緊急時）
+cp ".env.production.bak.${TIMESTAMP}" .env.production
+docker compose -f docker-compose.production.yml --env-file .env.production \
+  up -d --no-deps --force-recreate backend
+```
+
+詳細: `docs/15_rollback_procedures.md` 参照
+
+---
+
+## 参照
+
+- 許可モデルリスト: `backend/app/ai/config.py` → `VALID_CLAUDE_MODELS`
+- CI 検証スクリプト: `scripts/validate_anthropic_model.py`
+- 環境分離ガイド: `docs/42_environment_separation_design.md`
+- 環境ファイル更新ルール: `CLAUDE.md` §「環境ファイル更新ルール」

--- a/docs/integration/backend_deps.md
+++ b/docs/integration/backend_deps.md
@@ -7,6 +7,16 @@
 
 ## backend/app/main.py
 
+### 変更 #3: /health エンドポイントに AI モデル設定を追加 (PR #95 / 2026-04-20)
+- **コミット範囲**: `408d3ad` (feature/remove-claude-model-hardcodes)
+- **変更内容**:
+  - `/health` レスポンスに `claude_model` / `claude_fallback_model` フィールド追加
+  - `app.ai.config` から `DEFAULT_CLAUDE_MODEL` / `DEFAULT_FALLBACK_MODEL` をインポート
+  - `AI_CLAUDE_MODEL` / `AI_FALLBACK_MODEL` 環境変数の実効値を確認できるようにする
+- **理由**: AIモデル名のハードコード除去 (PR #95) の一環。デプロイ後に稼働中のモデル設定を `/health` で検証できるようにする。
+- **影響範囲**: `/health` エンドポイントのレスポンスフィールド追加のみ。既存フィールド・ロジックへの影響なし。
+- **承認**: feature/remove-claude-model-hardcodes → dev の通常フロー経由（PR #95）
+
 ### 変更 #2: F-17a カスタムリミッター startup 通知 (PR #92 / 2026-04-19)
 - **コミット範囲**: `52043f6` (dev ブランチ, feature/risk-limiter-env-toggle マージ)
 - **変更内容**:

--- a/scripts/check_env_separation.sh
+++ b/scripts/check_env_separation.sh
@@ -183,6 +183,48 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# AI モデル名検証
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- AI モデル名チェック ---"
+
+_DEPRECATED_AI_MODELS=(
+  "claude-sonnet-4-20250514"
+  "claude-3-5-sonnet-20241022"
+  "claude-3-5-sonnet-latest"
+  "claude-3-opus-20240229"
+)
+
+_validate_ai_model_names() {
+  local env_file="$1"
+  local env_label="$2"
+  local ok=0
+
+  for pattern in "${_DEPRECATED_AI_MODELS[@]}"; do
+    if grep -qE "^(AI_CLAUDE_MODEL|AI_FALLBACK_MODEL)=.*${pattern}" "${env_file}"; then
+      VIOLATIONS+=("非推奨 Claude モデルが ${env_label} に設定されています: ${pattern}")
+      echo "  ❌ 非推奨モデル検出 [${env_label}]: ${pattern}"
+      ok=1
+    fi
+  done
+
+  local claude_model
+  claude_model="$(get_value "${env_file}" "AI_CLAUDE_MODEL")"
+  if [[ -z "${claude_model}" ]]; then
+    VIOLATIONS+=("AI_CLAUDE_MODEL が ${env_label} に未設定です")
+    echo "  ❌ AI_CLAUDE_MODEL 未設定 [${env_label}]"
+    ok=1
+  else
+    echo "  ✅ AI_CLAUDE_MODEL [${env_label}]: ${claude_model}"
+  fi
+
+  return "${ok}"
+}
+
+_validate_ai_model_names "${PRODUCTION_FILE}" "production"
+_validate_ai_model_names "${STAGING_FILE}" "staging"
+
+# ---------------------------------------------------------------------------
 # 結果サマリ
 # ---------------------------------------------------------------------------
 echo ""

--- a/scripts/deploy_staging.sh
+++ b/scripts/deploy_staging.sh
@@ -32,7 +32,7 @@ done
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 COMPOSE_FILE="docker-compose.staging.yml"
-ENV_FILE=".env.staging"
+ENV_FILE=".env.staging-new"
 FRONTEND_CONTAINER="ultra-autotrade-frontend-staging-new"
 BACKEND_CONTAINER="ultra-autotrade-backend-staging-new"
 POSTGRES_CONTAINER="ultra-autotrade-postgres-staging-new"

--- a/scripts/validate_anthropic_model.py
+++ b/scripts/validate_anthropic_model.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# scripts/validate_anthropic_model.py
+#
+# CI検証スクリプト: Anthropic Claude モデル名の整合性チェック
+#
+# 検証内容:
+#   (a) .env.*.example の AI_CLAUDE_MODEL / AI_FALLBACK_MODEL が許可リストに含まれるか
+#   (b) backend/app/**/*.py に非推奨モデル名がハードコードされていないか
+#       (backend/app/ai/config.py は許可: 定数定義が必要なため)
+#
+# 許可リストは backend/app/ai/config.py の VALID_CLAUDE_MODELS / DEPRECATED_CLAUDE_MODELS と同期。
+# 実行: python scripts/validate_anthropic_model.py
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Single source of truth: backend/app/ai/config.py と同期すること
+# ---------------------------------------------------------------------------
+VALID_CLAUDE_MODELS: list[str] = [
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6-20250929",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5-20251001",
+    "claude-haiku-4-5",
+]
+
+DEPRECATED_CLAUDE_MODELS: list[str] = [
+    "claude-sonnet-4-20250514",
+    "claude-3-5-sonnet-20241022",
+    "claude-3-5-sonnet-latest",
+    "claude-3-opus-20240229",
+]
+
+_MODEL_VAR_RE = re.compile(r"^(AI_CLAUDE_MODEL|AI_FALLBACK_MODEL)=(.+)")
+# Matches string literals like "claude-xxx" or 'claude-xxx'
+_HARDCODE_RE = re.compile(r"""['"](claude-[a-z0-9.-]+)['"]""")
+
+# config.py is the canonical definition file; skip it for hardcode check
+_ALLOWLISTED_FILES = {"config.py"}
+
+
+def check_env_examples(root: Path) -> list[str]:
+    """Check .env.*.example files for deprecated model values."""
+    errors: list[str] = []
+    for env_file in sorted(root.glob(".env.*.example")):
+        for line in env_file.read_text().splitlines():
+            m = _MODEL_VAR_RE.match(line.strip())
+            if not m:
+                continue
+            var_name = m.group(1)
+            value = m.group(2).strip("'\"").strip()
+            if value.startswith("<") or value.startswith("#"):
+                continue  # placeholder, skip
+            if value in DEPRECATED_CLAUDE_MODELS:
+                errors.append(
+                    f"  ❌ {env_file.name}: {var_name}={value!r} は非推奨モデルです"
+                )
+            elif value not in VALID_CLAUDE_MODELS:
+                errors.append(
+                    f"  ⚠️  {env_file.name}: {var_name}={value!r} が許可リストにありません"
+                )
+    return errors
+
+
+def check_hardcoded_deprecated(root: Path) -> list[str]:
+    """Scan backend/app/**/*.py for hardcoded deprecated model strings."""
+    errors: list[str] = []
+    backend_app = root / "backend" / "app"
+    if not backend_app.exists():
+        return errors
+
+    for py_file in sorted(backend_app.rglob("*.py")):
+        if "__pycache__" in str(py_file):
+            continue
+        if py_file.name in _ALLOWLISTED_FILES:
+            continue
+        for lineno, line in enumerate(py_file.read_text().splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            for m in _HARDCODE_RE.finditer(line):
+                model_name = m.group(1)
+                if model_name in DEPRECATED_CLAUDE_MODELS:
+                    rel = py_file.relative_to(root)
+                    errors.append(
+                        f"  ❌ {rel}:{lineno}: 非推奨モデルがハードコード: {model_name!r}"
+                    )
+    return errors
+
+
+def main() -> int:
+    root = Path(__file__).parent.parent
+
+    print("=== Anthropic Claude モデル名検証 ===\n")
+
+    env_errors = check_env_examples(root)
+    hardcode_errors = check_hardcoded_deprecated(root)
+
+    all_errors = env_errors + hardcode_errors
+
+    if env_errors:
+        print("【.env.*.example チェック】")
+        for e in env_errors:
+            print(e)
+        print()
+    else:
+        print("✅ .env.*.example チェック: 問題なし")
+
+    if hardcode_errors:
+        print("\n【ハードコード非推奨モデル チェック】")
+        for e in hardcode_errors:
+            print(e)
+        print()
+    else:
+        print("✅ ハードコード非推奨モデル チェック: 問題なし")
+
+    if all_errors:
+        print(f"\n❌ 検証失敗: {len(all_errors)} 件のエラー")
+        print(f"   有効なモデル名: {VALID_CLAUDE_MODELS}")
+        return 1
+
+    print("\n✅ 全チェック通過")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 変更概要

Anthropic Claude モデル名のバリデーション実装と `.env.*.example` のモデル名統一を main に反映。

## 変更内容

### feat(ai): 起動時バリデーション
- `backend/app/ai/config.py`: `VALID_CLAUDE_MODELS` / `DEPRECATED_CLAUDE_MODELS` / `_validate_model_config()`
- `backend/app/main.py`: startup イベントで fail-fast（非推奨モデルなら ValueError）
- DEFAULT: `claude-sonnet-4-20250514` → `claude-sonnet-4-6-20250929` / `claude-haiku-4-5-20251001`

### feat(ci): CI モデル名検証
- `scripts/validate_anthropic_model.py`: `.env.*.example` 許可リストチェック + py ハードコード検出
- `.github/workflows/ci.yml`: security-check ジョブに validate ステップ追加

### fix(env): backend/.env.production.example モデル名修正
- `AI_CLAUDE_MODEL`: `claude-sonnet-4-6` → `claude-sonnet-4-6-20250929`
- `AI_FALLBACK_MODEL`: `claude-sonnet-4-6` → `claude-haiku-4-5-20251001`

### docs: Hetzner 実ファイル更新手順書
- `docs/43_env_model_update_procedure.md` 追加

## verify.sh 結果（feature ブランチ時点）

```
✅ ruff check / format / mypy / pytest (2497 passed, 84.65%) / tsc / build — All passed
```

## Asana

- タスク1: GID 1214131013584528
- タスク3: GID 1214115987735000

## デプロイ後の手順

main マージ後、`docs/43_env_model_update_procedure.md` に従って Hetzner の実ファイルを更新。