### PR TITLE
refactor(frontend): remove Arbitrum Sepolia residue, unify to Base Sepolia only

### DIFF
--- a/frontend/app/(user)/connect/page.tsx
+++ b/frontend/app/(user)/connect/page.tsx
@@ -17,12 +17,10 @@ type UserMode = 'managed' | 'active' | 'pro'
 
 const USER_MODE_STORAGE_KEY = 'ultra_user_mode'
 
-// Arbitrum One (mainnet), Arbitrum Sepolia (testnet), Base Sepolia (testnet)
-const SUPPORTED_CHAIN_IDS = [42161, 421614, 84532]
+// Base Sepolia (testnet only)
+const SUPPORTED_CHAIN_IDS = [84532]
 
 const CHAIN_DISPLAY_NAMES: Record<number, string> = {
-  42161: 'Arbitrum One',
-  421614: 'Arbitrum Sepolia',
   84532: 'Base Sepolia',
 }
 
@@ -230,47 +228,6 @@ export default function ConnectPage() {
                       onClick={() => wallet?.switchChain(84532)}
                     >
                       Base Sepolia (テスト用) に切り替える
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="w-full border-yellow-600 text-yellow-400 hover:bg-yellow-950/40"
-                      onClick={() => wallet?.switchChain(421614)}
-                    >
-                      Arbitrum Sepolia (テスト用) に切り替える
-                    </Button>
-                    <p className="text-xs text-zinc-500 font-semibold uppercase tracking-wide pt-1">メインネット</p>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="w-full border-zinc-600 text-zinc-400 hover:bg-zinc-800/40"
-                      onClick={() => wallet?.switchChain(8453)}
-                    >
-                      Base に切り替える
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="w-full border-zinc-600 text-zinc-400 hover:bg-zinc-800/40"
-                      onClick={() => wallet?.switchChain(42161)}
-                    >
-                      Arbitrum One に切り替える
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="w-full border-zinc-600 text-zinc-400 hover:bg-zinc-800/40"
-                      onClick={() => wallet?.switchChain(10)}
-                    >
-                      Optimism に切り替える
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="w-full border-zinc-600 text-zinc-400 hover:bg-zinc-800/40"
-                      onClick={() => wallet?.switchChain(1)}
-                    >
-                      Ethereum に切り替える
                     </Button>
                   </div>
                 )}

--- a/frontend/app/(user)/history/_components/TransactionList.tsx
+++ b/frontend/app/(user)/history/_components/TransactionList.tsx
@@ -28,7 +28,7 @@ export interface Transaction {
   amountUSD: number
   status: TransactionStatus
   txHash: string
-  chain: 'arbitrum' | 'arbitrum-sepolia' | 'base' | 'base-sepolia' | 'ethereum'
+  chain: 'arbitrum' | 'base' | 'base-sepolia' | 'ethereum'
   timestamp: string
 }
 

--- a/frontend/app/(user)/settings/_components/WalletInfoCard.tsx
+++ b/frontend/app/(user)/settings/_components/WalletInfoCard.tsx
@@ -31,7 +31,6 @@ function getNetworkName(chainId: number | null): string {
   const names: Record<number, string> = {
     1: 'Ethereum',
     42161: 'Arbitrum One',
-    421614: 'Arbitrum Sepolia',
     84532: 'Base Sepolia',
     137: 'Polygon',
     80001: 'Polygon Mumbai',
@@ -45,7 +44,6 @@ function getNetworkBadgeClass(chainId: number | null): string {
   const colorMap: Record<number, string> = {
     1: 'bg-blue-900/40 text-blue-300 border-blue-700',
     42161: 'bg-sky-900/40 text-sky-300 border-sky-700',
-    421614: 'bg-sky-900/40 text-sky-300 border-sky-700',
     84532: 'bg-indigo-900/40 text-indigo-300 border-indigo-700',
     137: 'bg-purple-900/40 text-purple-300 border-purple-700',
   }

--- a/frontend/app/user/approve/_components/TransactionStatus.tsx
+++ b/frontend/app/user/approve/_components/TransactionStatus.tsx
@@ -12,10 +12,10 @@ export interface TransactionStatusProps {
 }
 
 function getTxUrl(hash: string, chain?: string): string {
-  if (chain === 'arbitrum-sepolia') return `https://sepolia.arbiscan.io/tx/${hash}`
   if (chain === 'base-sepolia') return `https://sepolia.basescan.org/tx/${hash}`
   if (chain === 'base') return `https://basescan.org/tx/${hash}`
-  return `https://arbiscan.io/tx/${hash}`
+  if (chain === 'arbitrum') return `https://arbiscan.io/tx/${hash}`
+  return `https://sepolia.basescan.org/tx/${hash}`
 }
 
 function TxLink({ hash, chain }: { hash: string; chain?: string }) {

--- a/frontend/app/user/approve/page.tsx
+++ b/frontend/app/user/approve/page.tsx
@@ -55,10 +55,9 @@ const TOKEN_DECIMALS: Record<string, number> = {
 const SUPPORTED_TOKENS = new Set<string>(['USDC', 'USDT', 'WBTC', 'WETH', 'DAI'])
 
 function chainIdToName(chainId: number | undefined): string {
-  if (chainId === 42161) return 'arbitrum'
-  if (chainId === 421614) return 'arbitrum-sepolia'
   if (chainId === 84532) return 'base-sepolia'
-  return 'arbitrum-sepolia'
+  if (chainId === 42161) return 'arbitrum'
+  return 'base-sepolia'
 }
 
 function mapToProposal(item: ProposalAPIResponse): Proposal {

--- a/frontend/app/user/history/page.tsx
+++ b/frontend/app/user/history/page.tsx
@@ -77,11 +77,10 @@ const aaveOperationConfig: Record<AaveOperation, { label: string; className: str
 }
 
 function getExplorerUrl(txHash: string, chain: string): string {
-  if (chain === 'arbitrum') return `https://arbiscan.io/tx/${txHash}`
-  if (chain === 'arbitrum-sepolia') return `https://sepolia.arbiscan.io/tx/${txHash}`
   if (chain === 'base-sepolia') return `https://sepolia.basescan.org/tx/${txHash}`
   if (chain === 'base') return `https://basescan.org/tx/${txHash}`
-  return `https://arbiscan.io/tx/${txHash}`
+  if (chain === 'arbitrum') return `https://arbiscan.io/tx/${txHash}`
+  return `https://sepolia.basescan.org/tx/${txHash}`
 }
 
 function AaveHistoryTab() {

--- a/frontend/app/user/wallet/WalletContent.tsx
+++ b/frontend/app/user/wallet/WalletContent.tsx
@@ -14,7 +14,7 @@ export function WalletContent() {
   const { address, isConnected, chain } = useAccount()
   const { data: balance } = useBalance({ address })
   const { disconnect } = useDisconnect()
-  const ALLOWED_CHAIN_IDS = [42161, 421614, 84532]
+  const ALLOWED_CHAIN_IDS = [84532]
   const isCorrectChain = chain?.id != null && ALLOWED_CHAIN_IDS.includes(chain.id)
 
   if (!isConnected) {

--- a/frontend/components/layout/UserHeader.tsx
+++ b/frontend/components/layout/UserHeader.tsx
@@ -7,17 +7,13 @@ import { useWallet } from '@/hooks/useWallet'
 import { WalletAddressMask } from '@/components/shared'
 import { useTranslations } from 'next-intl'
 const CHAIN_INFO: Record<number, { name: string; colorClass: string }> = {
-  42161: {
-    name: 'Arbitrum One',
-    colorClass: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
-  },
-  421614: {
-    name: 'Arbitrum Sepolia',
-    colorClass: 'bg-yellow-500/10 text-yellow-500 border-yellow-500/30',
-  },
   84532: {
     name: 'Base Sepolia',
     colorClass: 'bg-yellow-500/10 text-yellow-500 border-yellow-500/30',
+  },
+  8453: {
+    name: 'Base',
+    colorClass: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
   },
 }
 

--- a/frontend/components/shared/TxHashLink.tsx
+++ b/frontend/components/shared/TxHashLink.tsx
@@ -6,13 +6,12 @@ import { ExternalLink } from 'lucide-react'
 
 export interface TxHashLinkProps {
   hash: string
-  chain?: 'arbitrum' | 'arbitrum-sepolia' | 'base' | 'base-sepolia' | 'ethereum'
+  chain?: 'arbitrum' | 'base' | 'base-sepolia' | 'ethereum'
   truncate?: boolean
 }
 
 const explorerBaseUrl: Record<string, string> = {
   arbitrum: 'https://arbiscan.io/tx',
-  'arbitrum-sepolia': 'https://sepolia.arbiscan.io/tx',
   base: 'https://basescan.org/tx',
   'base-sepolia': 'https://sepolia.basescan.org/tx',
   ethereum: 'https://etherscan.io/tx',
@@ -23,8 +22,8 @@ function truncateHash(hash: string): string {
   return `${hash.slice(0, 6)}...${hash.slice(-4)}`
 }
 
-export function TxHashLink({ hash, chain = 'arbitrum', truncate = true }: TxHashLinkProps) {
-  const url = `${explorerBaseUrl[chain] ?? explorerBaseUrl['arbitrum']}/${hash}`
+export function TxHashLink({ hash, chain = 'base-sepolia', truncate = true }: TxHashLinkProps) {
+  const url = `${explorerBaseUrl[chain] ?? explorerBaseUrl['base-sepolia']}/${hash}`
   const display = truncate ? truncateHash(hash) : hash
 
   return (

--- a/frontend/components/user/UserHeader.tsx
+++ b/frontend/components/user/UserHeader.tsx
@@ -107,9 +107,7 @@ export function UserHeader() {
                   variant="outline"
                   className={cn(
                     'text-xs hidden sm:flex',
-                    chain?.id === 42161
-                      ? 'border-green-500/50 text-green-400'
-                      : [421614, 84532, 11155111].includes(chain?.id ?? 0)
+                    chain?.id === 84532
                       ? 'border-yellow-500/50 text-yellow-400'
                       : 'border-red-500/50 text-red-400'
                   )}

--- a/frontend/e2e/new-features.spec.ts
+++ b/frontend/e2e/new-features.spec.ts
@@ -180,26 +180,16 @@ test.describe('メインネットチェーン選択 — /connect', () => {
 
   test('未接続時はネットワーク選択UIが表示されない', async ({ page }) => {
     await page.goto('/connect');
-    // isConnected が false → NetworkCheck Card, Mainnet buttons は非表示
-    const baseBtn = page.getByRole('button', { name: /Base に切り替える/ });
-    const arbitrumBtn = page.getByRole('button', { name: /Arbitrum One に切り替える/ });
-    const optimismBtn = page.getByRole('button', { name: /Optimism に切り替える/ });
-    const ethereumBtn = page.getByRole('button', { name: /Ethereum に切り替える/ });
-
-    await expect(baseBtn).not.toBeVisible();
-    await expect(arbitrumBtn).not.toBeVisible();
-    await expect(optimismBtn).not.toBeVisible();
-    await expect(ethereumBtn).not.toBeVisible();
+    // isConnected が false → NetworkCheck Card は非表示
+    const baseSepoliaBtn = page.getByRole('button', { name: /Base Sepolia \(テスト用\)/ });
+    await expect(baseSepoliaBtn).not.toBeVisible();
   });
 
   test('未接続時はテストネットの切り替えボタンが表示されない', async ({ page }) => {
     await page.goto('/connect');
     // isConnected が false → テストネットボタンも非表示
     const baseSepoliaBtn = page.getByRole('button', { name: /Base Sepolia/ });
-    const arbitrumSepoliaBtn = page.getByRole('button', { name: /Arbitrum Sepolia/ });
-
     await expect(baseSepoliaBtn).not.toBeVisible();
-    await expect(arbitrumSepoliaBtn).not.toBeVisible();
   });
 
   test('ステップインジケーターに3ステップが全て表示される', async ({ page }) => {

--- a/frontend/e2e/wallet-connect.spec.ts
+++ b/frontend/e2e/wallet-connect.spec.ts
@@ -5,15 +5,14 @@
  * Covers:
  *  1. Landing page – CTA button visibility and navigation
  *  2. /connect    – Step indicator and initial UI
- *  3. Wallet mock – Successful connection (address badge, network card)
- *  4. Wallet mock – Wrong network → Arbitrum switch prompt
- *  5. Wallet mock – switchToArbitrum() → network check resolves
- *  6. Wallet mock – Arbitrum Sepolia (421614) accepted as correct network
- *  7. Wallet mock – Connection rejection → UI unchanged
- *  8. /connect    – Minimum balance warning (always shown: current impl uses
+ *  3. Wallet mock – Successful connection on Base Sepolia (address badge, network card)
+ *  4. Wallet mock – Wrong network → Base Sepolia switch prompt
+ *  5. Wallet mock – switchToBaseSepolia() → network check resolves
+ *  6. Wallet mock – Connection rejection → UI unchanged
+ *  7. /connect    – Minimum balance warning (always shown: current impl uses
  *                   hardcoded BigInt(0) for totalCollateralBase)
- *  9. /connect    – Terms/start-button absent when balance check fails
- * 10. Mobile (375 px) – Landing CTA and connect page are functional
+ *  8. /connect    – Terms/start-button present when network check passes
+ *  9. Mobile (375 px) – Landing CTA and connect page are functional
  */
 
 import { test, expect } from '@playwright/test'
@@ -98,13 +97,13 @@ test.describe('[Connect] 初期状態', () => {
 })
 
 // ──────────────────────────────────────────────────────────────────────────────
-// 3. ウォレット接続モック – 成功（Arbitrum One）
+// 3. ウォレット接続モック – 成功（Base Sepolia）
 // ──────────────────────────────────────────────────────────────────────────────
 
-test.describe('[Connect/Mock] 接続成功 – Arbitrum One (42161)', () => {
+test.describe('[Connect/Mock] 接続成功 – Base Sepolia (84532)', () => {
   test.beforeEach(async ({ page }) => {
     // Inject mock BEFORE goto so wagmi sees it on mount
-    await mockEthereum(page, { chainId: 42161 })
+    await mockEthereum(page, { chainId: 84532 })
     await page.goto('/connect')
     await clearWagmiStorage(page)
     // Reload so wagmi re-initialises with cleared storage
@@ -121,9 +120,9 @@ test.describe('[Connect/Mock] 接続成功 – Arbitrum One (42161)', () => {
     await expect(page.getByText('ネットワーク確認').nth(1)).toBeVisible({ timeout: 5_000 })
   })
 
-  test('Arbitrum One では「接続済み」チェックマークが表示される', async ({ page }) => {
+  test('Base Sepolia では「接続済み」チェックマークが表示される', async ({ page }) => {
     await clickConnectAndWait(page)
-    await expect(page.getByText('Arbitrum One に接続済み')).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText('Base Sepolia に接続済み')).toBeVisible({ timeout: 5_000 })
   })
 
   test('接続後に「ウォレットを接続する」ボタンが非表示になる', async ({ page }) => {
@@ -135,10 +134,10 @@ test.describe('[Connect/Mock] 接続成功 – Arbitrum One (42161)', () => {
 })
 
 // ──────────────────────────────────────────────────────────────────────────────
-// 4. 非Arbitrumネットワーク → 切替プロンプト
+// 4. 非対応ネットワーク → 切替プロンプト
 // ──────────────────────────────────────────────────────────────────────────────
 
-test.describe('[Connect/Mock] 非Arbitrumネットワーク – 切替プロンプト', () => {
+test.describe('[Connect/Mock] 非対応ネットワーク – 切替プロンプト', () => {
   test.beforeEach(async ({ page }) => {
     await mockEthereum(page, { chainId: 1 }) // Ethereum mainnet
     await page.goto('/connect')
@@ -146,26 +145,26 @@ test.describe('[Connect/Mock] 非Arbitrumネットワーク – 切替プロン�
     await page.reload()
   })
 
-  test('非Arbitrum接続時に切替案内メッセージが表示される', async ({ page }) => {
+  test('非対応ネットワーク接続時に切替案内メッセージが表示される', async ({ page }) => {
     await clickConnectAndWait(page)
     await expect(
       page.getByText('Base Sepoliaに切り替えてください')
     ).toBeVisible({ timeout: 5_000 })
   })
 
-  test('「Arbitrum One に切り替える」ボタンが表示される', async ({ page }) => {
+  test('「Base Sepolia (テスト用) に切り替える」ボタンが表示される', async ({ page }) => {
     await clickConnectAndWait(page)
     await expect(
-      page.getByRole('button', { name: 'Arbitrum One に切り替える' })
+      page.getByRole('button', { name: 'Base Sepolia (テスト用) に切り替える' })
     ).toBeVisible({ timeout: 5_000 })
   })
 })
 
 // ──────────────────────────────────────────────────────────────────────────────
-// 5. switchToArbitrum() – ネットワーク切替後にUIが更新される
+// 5. switchToBaseSepolia() – ネットワーク切替後にUIが更新される
 // ──────────────────────────────────────────────────────────────────────────────
 
-test.describe('[Connect/Mock] switchToArbitrum – UI更新', () => {
+test.describe('[Connect/Mock] switchToBaseSepolia – UI更新', () => {
   test('切替ボタンをクリックするとネットワーク確認OKになる', async ({ page }) => {
     await mockEthereum(page, { chainId: 1 })
     await page.goto('/connect')
@@ -173,12 +172,12 @@ test.describe('[Connect/Mock] switchToArbitrum – UI更新', () => {
     await page.reload()
 
     await clickConnectAndWait(page)
-    const switchBtn = page.getByRole('button', { name: 'Arbitrum One に切り替える' })
+    const switchBtn = page.getByRole('button', { name: 'Base Sepolia (テスト用) に切り替える' })
     await expect(switchBtn).toBeVisible({ timeout: 5_000 })
     await switchBtn.click()
 
-    // Mock emits 'chainChanged' → wagmi updates chainId to 42161 → re-render
-    await expect(page.getByText('Arbitrum One に接続済み')).toBeVisible({
+    // Mock emits 'chainChanged' → wagmi updates chainId to 84532 → re-render
+    await expect(page.getByText('Base Sepolia に接続済み')).toBeVisible({
       timeout: 8_000,
     })
     await expect(switchBtn).not.toBeVisible()
@@ -186,27 +185,7 @@ test.describe('[Connect/Mock] switchToArbitrum – UI更新', () => {
 })
 
 // ──────────────────────────────────────────────────────────────────────────────
-// 6. Arbitrum Sepolia (421614) でも正常ネットワークと認識される
-// ──────────────────────────────────────────────────────────────────────────────
-
-test.describe('[Connect/Mock] Arbitrum Sepolia (421614)', () => {
-  test('Arbitrum Sepolia でもネットワーク確認OKになる', async ({ page }) => {
-    await mockEthereum(page, { chainId: 421614 })
-    await page.goto('/connect')
-    await clearWagmiStorage(page)
-    await page.reload()
-
-    await clickConnectAndWait(page)
-    // Arbitrum Sepolia (421614) は SUPPORTED_CHAIN_IDS に含まれるため isCorrectNetwork=true
-    // getNetworkDisplayName(421614) → 'Arbitrum Sepolia' → 'Arbitrum Sepolia に接続済み'
-    await expect(page.getByText('Arbitrum Sepolia に接続済み')).toBeVisible({
-      timeout: 5_000,
-    })
-  })
-})
-
-// ──────────────────────────────────────────────────────────────────────────────
-// 7. 接続拒否
+// 6. 接続拒否
 // ──────────────────────────────────────────────────────────────────────────────
 
 test.describe('[Connect/Mock] 接続拒否', () => {
@@ -231,7 +210,7 @@ test.describe('[Connect/Mock] 接続拒否', () => {
 })
 
 // ──────────────────────────────────────────────────────────────────────────────
-// 8. 最低残高チェック
+// 7. 最低残高チェック
 // ──────────────────────────────────────────────────────────────────────────────
 
 test.describe('[Connect/Mock] 最低残高チェック', () => {
@@ -246,13 +225,13 @@ test.describe('[Connect/Mock] 最低残高チェック', () => {
    */
 
   test.beforeEach(async ({ page }) => {
-    await mockEthereum(page, { chainId: 42161 })
+    await mockEthereum(page, { chainId: 84532 })
     await page.goto('/connect')
     await clearWagmiStorage(page)
     await page.reload()
     await clickConnectAndWait(page)
     // Wait for network OK before balance check card appears
-    await expect(page.getByText('Arbitrum One に接続済み')).toBeVisible({
+    await expect(page.getByText('Base Sepolia に接続済み')).toBeVisible({
       timeout: 5_000,
     })
   })
@@ -278,7 +257,7 @@ test.describe('[Connect/Mock] 最低残高チェック', () => {
 })
 
 // ──────────────────────────────────────────────────────────────────────────────
-// 9. 規約同意セクション・開始ボタン（現実装での非表示確認）
+// 8. 規約同意セクション・開始ボタン（現実装での表示確認）
 // ──────────────────────────────────────────────────────────────────────────────
 
 test.describe('[Connect] 規約同意セクション', () => {
@@ -286,17 +265,17 @@ test.describe('[Connect] 規約同意セクション', () => {
    * allChecksPass = isConnected && isCorrectNetwork
    *
    * NOTE: 残高チェックは allChecksPass に含まれない（実装変更済み）。
-   * Arbitrum One (42161) で接続すると isCorrectNetwork=true → allChecksPass=true
+   * Base Sepolia (84532) で接続すると isCorrectNetwork=true → allChecksPass=true
    * → 規約同意カードと「運用を開始する」ボタンが表示される。
    */
 
   test.beforeEach(async ({ page }) => {
-    await mockEthereum(page, { chainId: 42161 })
+    await mockEthereum(page, { chainId: 84532 })
     await page.goto('/connect')
     await clearWagmiStorage(page)
     await page.reload()
     await clickConnectAndWait(page)
-    await expect(page.getByText('Arbitrum One に接続済み')).toBeVisible({
+    await expect(page.getByText('Base Sepolia に接続済み')).toBeVisible({
       timeout: 5_000,
     })
   })
@@ -324,7 +303,7 @@ test.describe('[Connect] 規約同意セクション', () => {
 })
 
 // ──────────────────────────────────────────────────────────────────────────────
-// 10. モバイルビューポート (375 px)
+// 9. モバイルビューポート (375 px)
 // ──────────────────────────────────────────────────────────────────────────────
 
 test.describe('[Mobile 375px] 基本フロー', () => {
@@ -346,19 +325,19 @@ test.describe('[Mobile 375px] 基本フロー', () => {
   })
 
   test('モバイルでウォレット接続→アドレスバッジが表示される', async ({ page }) => {
-    await mockEthereum(page, { chainId: 42161 })
+    await mockEthereum(page, { chainId: 84532 })
     await page.goto('/connect')
     await clearWagmiStorage(page)
     await page.reload()
 
     await clickConnectAndWait(page)
     await expect(page.getByText(MOCK_ADDRESS_SHORT)).toBeVisible()
-    await expect(page.getByText('Arbitrum One に接続済み')).toBeVisible({
+    await expect(page.getByText('Base Sepolia に接続済み')).toBeVisible({
       timeout: 5_000,
     })
   })
 
-  test('モバイルで非Arbitrum接続時に切替プロンプトが表示される', async ({
+  test('モバイルで非対応ネットワーク接続時に切替プロンプトが表示される', async ({
     page,
   }) => {
     await mockEthereum(page, { chainId: 1 })
@@ -372,20 +351,20 @@ test.describe('[Mobile 375px] 基本フロー', () => {
       page.getByText('Base Sepoliaに切り替えてください')
     ).toBeVisible({ timeout: 5_000 })
     await expect(
-      page.getByRole('button', { name: 'Arbitrum One に切り替える' })
+      page.getByRole('button', { name: 'Base Sepolia (テスト用) に切り替える' })
     ).toBeVisible()
   })
 })
 
 // ──────────────────────────────────────────────────────────────────────────────
-// 11. 運用モード選択UI (allChecksPass 時のみ表示)
+// 10. 運用モード選択UI (allChecksPass 時のみ表示)
 // ──────────────────────────────────────────────────────────────────────────────
 
 test.describe('[Connect] 運用モード選択UI', () => {
   /**
    * NOTE: allChecksPass = isConnected && isCorrectNetwork
    * The mode selector is rendered only when allChecksPass is true.
-   * These tests use Arbitrum One (42161) mock so the network check passes.
+   * These tests use Base Sepolia (84532) mock so the network check passes.
    *
    * Because balanceCheck is always isBelowMinimum=true (mock data), the
    * balance card shows a warning, but allChecksPass is NOT gated on balance —
@@ -402,12 +381,12 @@ test.describe('[Connect] 運用モード選択UI', () => {
     await page.addInitScript(() => {
       localStorage.removeItem('ultra_user_mode')
     })
-    await mockEthereum(page, { chainId: 42161 })
+    await mockEthereum(page, { chainId: 84532 })
     await page.goto('/connect')
     await clearWagmiStorage(page)
     await page.reload()
     await clickConnectAndWait(page)
-    await expect(page.getByText('Arbitrum One に接続済み')).toBeVisible({
+    await expect(page.getByText('Base Sepolia に接続済み')).toBeVisible({
       timeout: 5_000,
     })
   })

--- a/frontend/hooks/useWallet.ts
+++ b/frontend/hooks/useWallet.ts
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useAccount, useConnect, useDisconnect } from 'wagmi'
 import { injected } from 'wagmi/connectors'
 import { ethers } from 'ethers'
-import { ARBITRUM_CHAIN_IDS } from '@/lib/web3/config'
+import { SUPPORTED_CHAIN_IDS } from '@/lib/web3/config'
 
 type EthereumProvider = ethers.Eip1193Provider & {
   request: (args: { method: string; params?: unknown[] }) => Promise<unknown>
@@ -25,7 +25,7 @@ export function useWallet() {
   const [provider, setProvider] = useState<ethers.BrowserProvider | null>(null)
   const [signer, setSigner] = useState<ethers.Signer | null>(null)
 
-  const isCorrectChain = chainId != null && ARBITRUM_CHAIN_IDS.includes(chainId)
+  const isCorrectChain = chainId != null && SUPPORTED_CHAIN_IDS.includes(chainId)
 
   // window.ethereum が利用可能なときに BrowserProvider を生成
   useEffect(() => {
@@ -48,48 +48,6 @@ export function useWallet() {
     setProvider(null)
     setSigner(null)
   }, [disconnect])
-
-  const switchToArbitrum = useCallback(async () => {
-    if (typeof window === 'undefined' || !window.ethereum) return
-    try {
-      await window.ethereum.request({
-        method: 'wallet_switchEthereumChain',
-        params: [{ chainId: '0xa4b1' }], // Arbitrum One = 42161
-      })
-    } catch {
-      await window.ethereum.request({
-        method: 'wallet_addEthereumChain',
-        params: [{
-          chainId: '0xa4b1',
-          chainName: 'Arbitrum One',
-          rpcUrls: ['https://arb1.arbitrum.io/rpc'],
-          nativeCurrency: { name: 'ETH', symbol: 'ETH', decimals: 18 },
-          blockExplorerUrls: ['https://arbiscan.io'],
-        }],
-      })
-    }
-  }, [])
-
-  const switchToArbitrumSepolia = useCallback(async () => {
-    if (typeof window === 'undefined' || !window.ethereum) return
-    try {
-      await window.ethereum.request({
-        method: 'wallet_switchEthereumChain',
-        params: [{ chainId: '0x66eee' }], // Arbitrum Sepolia = 421614
-      })
-    } catch {
-      await window.ethereum.request({
-        method: 'wallet_addEthereumChain',
-        params: [{
-          chainId: '0x66eee',
-          chainName: 'Arbitrum Sepolia',
-          rpcUrls: ['https://sepolia-rollup.arbitrum.io/rpc'],
-          nativeCurrency: { name: 'ETH', symbol: 'ETH', decimals: 18 },
-          blockExplorerUrls: ['https://sepolia.arbiscan.io'],
-        }],
-      })
-    }
-  }, [])
 
   const switchToBaseSepolia = useCallback(async () => {
     if (typeof window === 'undefined' || !window.ethereum) return
@@ -169,8 +127,6 @@ export function useWallet() {
     isCorrectChain,
     connect: connectWallet,
     disconnect: disconnectWallet,
-    switchToArbitrum,
-    switchToArbitrumSepolia,
     switchToBaseSepolia,
     switchToBase,
     switchToOptimism,

--- a/frontend/lib/web3/config.ts
+++ b/frontend/lib/web3/config.ts
@@ -52,11 +52,6 @@ export const SUPPORTED_CHAINS = {
     name: 'Arbitrum One',
     rpc: process.env.NEXT_PUBLIC_ARBITRUM_ONE_RPC || 'https://arb1.arbitrum.io/rpc',
   },
-  'arbitrum-sepolia': {
-    id: 421614,
-    name: 'Arbitrum Sepolia',
-    rpc: process.env.NEXT_PUBLIC_ARBITRUM_SEPOLIA_RPC || 'https://sepolia-rollup.arbitrum.io/rpc',
-  },
   'base-sepolia': {
     id: 84532,
     name: 'Base Sepolia',
@@ -88,14 +83,13 @@ export const DEFAULT_CHAIN: SupportedChainKey =
 
 export const MINIMUM_USD_BALANCE = 3000
 
-// Supported chain IDs (testnet + mainnet)
-export const ARBITRUM_CHAIN_IDS = [42161, 421614, 84532, 8453, 10, 1]
+// Supported chain IDs (Base Sepolia testnet only)
+export const SUPPORTED_CHAIN_IDS = [84532]
 
 export function getChainKey(chainId: number): SupportedChainKey | null {
-  if (chainId === 42161) return 'arbitrum'
-  if (chainId === 421614) return 'arbitrum-sepolia'
   if (chainId === 84532) return 'base-sepolia'
   if (chainId === 8453) return 'base'
+  if (chainId === 42161) return 'arbitrum'
   if (chainId === 10) return 'optimism'
   if (chainId === 1) return 'mainnet'
   return null

--- a/frontend/types/web3.ts
+++ b/frontend/types/web3.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 Ultra AutoTrade. All rights reserved.
 
-export type SupportedChain = 'arbitrum' | 'arbitrum-sepolia' | 'base-sepolia'
+export type SupportedChain = 'arbitrum' | 'base-sepolia'
 export type SupportedToken = 'USDC' | 'USDT' | 'WETH' | 'WBTC' | 'DAI'
 export type TransactionStatus = 'idle' | 'pending' | 'confirming' | 'success' | 'failed'
 export type InterestRateMode = 1 | 2  // 1=stable, 2=variable


### PR DESCRIPTION
## Summary

- `SUPPORTED_CHAIN_IDS` unified to `[84532]` (was `[42161, 421614, 84532]`); export renamed from `ARBITRUM_CHAIN_IDS`
- Connect page: Arbitrum Sepolia switch button removed; mainnet chain buttons removed (Base Sepolia is the sole testnet)
- `useWallet`: `switchToArbitrum` + `switchToArbitrumSepolia` functions removed; `isCorrectChain` now references renamed export
- All chain-related display maps, type unions, and explorer URL branches purged of `421614` / `'arbitrum-sepolia'`
- E2E tests updated: mock chain 42161 → 84532; Arbitrum Sepolia test case removed; descriptions corrected
- `AAVE_V3_ADDRESSES` / `TOKEN_ADDRESSES` retain `arbitrum-sepolia` entries as read-only historical reference data (not removed)

**15 files changed, 66 insertions, 201 deletions**

## Test plan

- [x] Gate 1–2: `ruff check` + `ruff format --check` — 0 errors
- [x] Gate 3: `mypy app/` — 0 type errors
- [x] Gate 4: `pytest` — all pass, coverage ≥ 80%
- [x] Gate 5: `ruff check --select S` — no new security warnings
- [x] Gate 6: `tsc --noEmit` — 0 type errors
- [x] Gate 7: `npm run build` — success (309 s)
- [ ] Gate E2E: Playwright wallet-connect.spec.ts (run against staging after deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)