### PR TITLE
chore(i18n): update landing copy from Polygon/Arbitrum to Base

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -61,12 +61,12 @@ const faqItems = [
   {
     question: '対応ウォレットは何ですか？',
     answer:
-      'MetaMask、WalletConnect対応ウォレットに対応予定です。Arbitrum Oneネットワークへの接続が必要です。',
+      'MetaMask、WalletConnect対応ウォレットに対応予定です。Base Sepoliaネットワークへの接続が必要です（テストネット）。',
   },
   {
     question: 'どのチェーン・プロトコルに対応していますか？',
     answer:
-      'Arbitrum One上のAave V3に対応しています。今後、他のチェーンやプロトコルへの対応も検討しています。',
+      'Base Sepolia上のAave V3に対応しています（テストネット）。今後、Base Mainnetや他のチェーンへの対応も検討しています。',
   },
 ]
 
@@ -133,7 +133,7 @@ export default function LandingPage() {
             対応プロトコル・チェーン
           </h2>
           <div className="flex flex-wrap justify-center gap-4">
-            {['Aave V3', 'Arbitrum One'].map((label) => (
+            {['Aave V3', 'Base Sepolia'].map((label) => (
               <span
                 key={label}
                 className="inline-flex items-center rounded-full border border-blue-500/40 bg-blue-500/10 px-5 py-2 text-sm font-medium text-blue-300"

--- a/frontend/e2e/helpers/wallet-mock.ts
+++ b/frontend/e2e/helpers/wallet-mock.ts
@@ -14,7 +14,7 @@ export const MOCK_ADDRESS_SHORT =
 export type WalletMockOptions = {
   /**
    * EIP-155 chain ID the mock reports.
-   * Default: 42161 (Arbitrum One)
+   * Default: 84532 (Base Sepolia)
    */
   chainId?: number
   /**
@@ -44,7 +44,7 @@ export async function mockEthereum(
   page: Page,
   options: WalletMockOptions = {}
 ): Promise<void> {
-  const chainId = options.chainId ?? 42161
+  const chainId = options.chainId ?? 84532
   const rejectConnect = options.rejectConnect ?? false
   const chainIdHex = '0x' + chainId.toString(16)
 

--- a/frontend/lib/wallet/config.ts
+++ b/frontend/lib/wallet/config.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
 import { createConfig, http } from 'wagmi'
-import { arbitrum, arbitrumSepolia, base, baseSepolia, mainnet, optimism } from 'wagmi/chains'
+import { arbitrum, base, baseSepolia, mainnet, optimism } from 'wagmi/chains'
 import { injected } from 'wagmi/connectors'
 
 export const projectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || ''
@@ -9,7 +9,7 @@ export const projectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || ''
 // Default chain is Base Sepolia (testnet). Override via NEXT_PUBLIC_DEFAULT_CHAIN_ID.
 const defaultChainId = parseInt(process.env.NEXT_PUBLIC_DEFAULT_CHAIN_ID || '84532') // Base Sepolia
 
-const allChains = [baseSepolia, arbitrumSepolia, base, arbitrum, optimism, mainnet] as const
+const allChains = [baseSepolia, base, arbitrum, optimism, mainnet] as const
 
 // Put the default chain first so wagmi treats it as primary
 const sortedChains = [
@@ -21,7 +21,6 @@ export const wagmiConfig = createConfig({
   chains: sortedChains,
   transports: {
     [baseSepolia.id]: http(),
-    [arbitrumSepolia.id]: http(),
     [base.id]: http(),
     [arbitrum.id]: http(),
     [optimism.id]: http(),

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -219,7 +219,7 @@
     "featureSafe": "Safe Design",
     "featureSafeDesc": "Health Factor monitoring + Emergency Stop",
     "featureAave": "Aave V3",
-    "featureAaveDesc": "Auto trading on Polygon/Arbitrum"
+    "featureAaveDesc": "Auto trading on Base"
   },
   "Connect": {
     "title": "Connect Wallet",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -219,7 +219,7 @@
     "featureSafe": "安全設計",
     "featureSafeDesc": "ヘルスファクター監視 + 緊急停止",
     "featureAave": "Aave V3",
-    "featureAaveDesc": "Polygon/Arbitrum で自動運用"
+    "featureAaveDesc": "Base で自動運用"
   },
   "Connect": {
     "title": "ウォレットを接続",


### PR DESCRIPTION
## Summary

Follow-up to #108 (Arbitrum Sepolia removal). Aligns all user-facing copy and E2E defaults to Base L2 strategy.

- `messages/ja.json` + `messages/en.json`: `featureAaveDesc` Polygon/Arbitrum → Base
- `app/page.tsx`: FAQ text + protocol badge Arbitrum One → Base Sepolia
- `lib/wallet/config.ts`: remove `arbitrumSepolia` from wagmi `allChains` + transports
- `e2e/helpers/wallet-mock.ts`: default `chainId` 42161 → 84532 (Base Sepolia)

**No logic changes. Marketing copy + wagmi chain config only.**

## Test plan

- [x] `scripts/verify.sh` — all 7 gates pass (ruff/mypy/pytest/tsc/build)
- [x] `tsc --noEmit` — 0 type errors (arbitrumSepolia import removed cleanly)
- [x] `npm run build` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)