### PR TITLE
F-1: fee_configs + fee_transactions DDL (#1214120248239215)

### DIFF
--- a/backend/alembic/sql/045_fee_v10_tables.sql
+++ b/backend/alembic/sql/045_fee_v10_tables.sql
@@ -1,0 +1,134 @@
+-- =============================================================================
+-- 045_fee_v10_tables.sql
+-- Fee Model v10 (Option A: 既存billing完全置換) DDL
+-- 関連: docs/45_fee_model_v10_migration_plan.md / Asana F-1 (1214120248239215)
+-- 作成日: 2026-04-25
+--
+-- 適用先:
+--   - staging-new: F-1 で実行 (試験)
+--   - production:  F-16 で実行 (本番リリース時)
+--
+-- 前提条件:
+--   - fee_configs / fee_calculations / high_water_marks が **0 行** であること
+--   - 本番 DB は F-0 (PR #121) で 0 行確認済み (2026-04-25 時点)
+--   - staging-new は F-1 着手時に 0 行確認 (このコメント参照タイミングで再確認すること)
+--
+-- 等価な Alembic migration: backend/alembic/versions/d4e5f6a7b8c9_fee_v10_tables.py
+-- どちらか一方のみ適用すること (両方流すと 2 回目で失敗する)
+-- =============================================================================
+
+BEGIN;
+
+-- -----------------------------------------------------------------------------
+-- 1. 既存 v9 billing 3 テーブルの DROP (Option A)
+-- -----------------------------------------------------------------------------
+DROP TABLE IF EXISTS fee_calculations CASCADE;
+DROP TABLE IF EXISTS high_water_marks CASCADE;
+DROP TABLE IF EXISTS fee_configs CASCADE;
+
+-- -----------------------------------------------------------------------------
+-- 2. fee_configs (v10) CREATE
+-- -----------------------------------------------------------------------------
+CREATE TABLE fee_configs (
+  id BIGSERIAL PRIMARY KEY,
+  config_name VARCHAR(64) NOT NULL UNIQUE,
+  tier_thresholds_jpy JSONB NOT NULL,
+  tier_fee_rates JSONB NOT NULL,
+  tier_monthly_yield_caps JSONB NOT NULL,
+  subscription_rates JSONB NOT NULL,
+  expense_markup_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+  expense_markup_rate NUMERIC(6, 4) NOT NULL DEFAULT 0,
+  affiliate_rate NUMERIC(6, 4) NOT NULL DEFAULT 0.30,
+  is_active BOOLEAN NOT NULL DEFAULT FALSE,
+  effective_from TIMESTAMP WITH TIME ZONE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_fee_configs_active_effective
+  ON fee_configs (is_active, effective_from DESC);
+
+COMMENT ON TABLE fee_configs IS
+  'Fee model v10 設定 (リスクモード・tier・サブスク率等)';
+COMMENT ON COLUMN fee_configs.tier_thresholds_jpy IS
+  '一般/ミドル/アッパー境界 JPY 配列 (例: [1000000, 10000000])';
+COMMENT ON COLUMN fee_configs.tier_fee_rates IS
+  'tier 別手数料率配列 (例: [0.30, 0.25, 0.20])';
+COMMENT ON COLUMN fee_configs.tier_monthly_yield_caps IS
+  'tier 別月次利回り上限 (例: [0.018, 0.023, 0.030])';
+COMMENT ON COLUMN fee_configs.subscription_rates IS
+  'リスクモード別月額サブスク率 (例: {"low":0,"middle":0.003,"high":0.010})';
+
+-- -----------------------------------------------------------------------------
+-- 3. fee_transactions (v10) CREATE
+--   FK: users.id は INTEGER (auth/models.py:57 確認済み)
+-- -----------------------------------------------------------------------------
+CREATE TABLE fee_transactions (
+  id BIGSERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  calculation_month DATE NOT NULL,
+  tier VARCHAR(16) NOT NULL,
+  risk_mode VARCHAR(16) NOT NULL,
+  deposit_amount_jpy NUMERIC(18, 2) NOT NULL,
+  gross_profit_jpy NUMERIC(18, 2) NOT NULL DEFAULT 0,
+  expense_jpy NUMERIC(18, 2) NOT NULL DEFAULT 0,
+  net_profit_jpy NUMERIC(18, 2) NOT NULL DEFAULT 0,
+  fee_rate_applied NUMERIC(6, 4) NOT NULL DEFAULT 0,
+  fee_amount_jpy NUMERIC(18, 2) NOT NULL DEFAULT 0,
+  subscription_rate_applied NUMERIC(6, 4) NOT NULL DEFAULT 0,
+  subscription_amount_jpy NUMERIC(18, 2) NOT NULL DEFAULT 0,
+  subscription_protected BOOLEAN NOT NULL DEFAULT FALSE,
+  monthly_yield_cap_applied NUMERIC(6, 4) NOT NULL DEFAULT 0,
+  yield_excess_to_uata_jpy NUMERIC(18, 2) NOT NULL DEFAULT 0,
+  user_takehome_jpy NUMERIC(18, 2) NOT NULL DEFAULT 0,
+  affiliate_id INTEGER NULL REFERENCES users(id) ON DELETE SET NULL,
+  affiliate_amount_jpy NUMERIC(18, 2) NOT NULL DEFAULT 0,
+  calculated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  finalized_at TIMESTAMP WITH TIME ZONE NULL,
+
+  CONSTRAINT chk_fee_tx_tier CHECK (tier IN ('LOWER', 'MIDDLE', 'UPPER')),
+  CONSTRAINT chk_fee_tx_risk_mode CHECK (risk_mode IN ('LOW', 'MIDDLE', 'HIGH')),
+  CONSTRAINT uq_fee_tx_user_month UNIQUE (user_id, calculation_month)
+);
+
+CREATE INDEX idx_fee_tx_user_month
+  ON fee_transactions (user_id, calculation_month DESC);
+CREATE INDEX idx_fee_tx_finalized
+  ON fee_transactions (finalized_at)
+  WHERE finalized_at IS NULL;
+CREATE INDEX idx_fee_tx_affiliate
+  ON fee_transactions (affiliate_id)
+  WHERE affiliate_id IS NOT NULL;
+
+COMMENT ON TABLE fee_transactions IS
+  'Fee model v10 月次手数料計算結果 (1 ユーザー × 1 月で 1 行)';
+COMMENT ON COLUMN fee_transactions.tier IS
+  'v10 投資ティア (LOWER / MIDDLE / UPPER)';
+COMMENT ON COLUMN fee_transactions.risk_mode IS
+  'v10 リスクモード (LOW / MIDDLE / HIGH)';
+COMMENT ON COLUMN fee_transactions.subscription_protected IS
+  'サブスク控除によりユーザー手取りが負にならないよう保護されたか';
+
+COMMIT;
+
+-- =============================================================================
+-- 検証クエリ (適用後の確認用)
+-- =============================================================================
+-- SELECT table_name FROM information_schema.tables
+--   WHERE table_schema='public'
+--     AND table_name IN ('fee_configs','fee_transactions','fee_calculations','high_water_marks')
+--   ORDER BY table_name;
+-- 期待: fee_configs, fee_transactions のみ
+--
+-- \d fee_configs
+-- \d fee_transactions
+--
+-- =============================================================================
+-- ロールバック手順 (緊急時のみ)
+-- =============================================================================
+-- BEGIN;
+-- DROP TABLE IF EXISTS fee_transactions CASCADE;
+-- DROP TABLE IF EXISTS fee_configs CASCADE;
+-- -- v9 billing テーブルの再構築は backend/app/billing/models.py から
+-- -- alembic stamp <prev_revision> + alembic upgrade head で復元可能
+-- COMMIT;

--- a/backend/alembic/sql/README.md
+++ b/backend/alembic/sql/README.md
@@ -1,0 +1,74 @@
+# Manual DDL Scripts
+
+This directory holds raw SQL scripts intended for **manual execution** on
+staging-new and production via `psql -f`.
+
+## Why both Alembic *and* raw SQL?
+
+Per [`docs/ops/02_db_tables.md`](../../../docs/ops/02_db_tables.md), Ultra
+AutoTrade does **not** auto-run Alembic on production deployment. Schema
+changes are applied by hand on Hetzner using `ALTER TABLE` / `CREATE TABLE`
+statements before the new code is rolled out.
+
+To keep the repo consistent we still write each schema change as both:
+
+1. an Alembic revision (`backend/alembic/versions/<hash>_<name>.py`) — so
+   `alembic upgrade head` works in the local dev container and CI
+2. a hand-runnable SQL script (`backend/alembic/sql/<NNN>_<name>.sql`) — what
+   the operator actually pastes into `psql` on Hetzner
+
+Both files describe the **same DDL**. Run only one of them per environment.
+
+## Scripts
+
+| File | Alembic revision | Purpose |
+|------|------------------|---------|
+| `045_fee_v10_tables.sql` | `d4e5f6a7b8c9_fee_v10_tables.py` | Drop v9 billing tables (`fee_configs`, `fee_calculations`, `high_water_marks`) and create v10 (`fee_configs`, `fee_transactions`). See [Asana F-1](https://app.asana.com/0/1213741124336104/1214120248239215) and [`docs/45_fee_model_v10_migration_plan.md`](../../../docs/45_fee_model_v10_migration_plan.md). |
+
+## Execution order
+
+1. **staging-new** — applied during F-1 (this PR) for verification.
+2. **production** — applied during F-16 (release) only after F-2 through F-15
+   are merged and approved.
+
+## Pre-flight (always run before each environment)
+
+```bash
+docker exec ultra-autotrade-postgres-<env> psql -U ultra -d <db> -c "
+SELECT table_name, (SELECT COUNT(*) FROM information_schema.tables t2
+                    WHERE t2.table_name = t.table_name)
+FROM (VALUES ('fee_configs'),('fee_calculations'),('high_water_marks'),
+              ('fee_transactions')) AS t(table_name);
+"
+```
+
+The 045 DROP statements assume the v9 tables are **0 rows**. F-0 confirmed
+this for production on 2026-04-25; reconfirm immediately before applying.
+
+## Apply
+
+```bash
+# staging-new
+docker exec -i ultra-autotrade-postgres-staging-new \
+  psql -U ultra -d ultra_autotrade_staging \
+  < backend/alembic/sql/045_fee_v10_tables.sql
+
+# production (F-16 only)
+docker exec -i ultra-autotrade-postgres-production \
+  psql -U ultra -d ultra_autotrade \
+  < backend/alembic/sql/045_fee_v10_tables.sql
+```
+
+## Rollback
+
+Each SQL script ends with a commented-out rollback block. Uncomment and run
+only if the post-deploy verification fails. v9 billing data is **not**
+restorable (production was 0 rows at the cutover).
+
+## Why v10 models live in a separate Base
+
+`backend/app/billing/v10_models.py` uses its own `V10Base` because the v10
+table names (`fee_configs`, `fee_transactions`) collide with the still-present
+v9 classes in `backend/app/billing/models.py`. F-13 will delete the v9 module
+and merge the v10 classes into `app.billing.models` under the regular
+`app.database.Base`.

--- a/backend/alembic/versions/d4e5f6a7b8c9_fee_v10_tables.py
+++ b/backend/alembic/versions/d4e5f6a7b8c9_fee_v10_tables.py
@@ -1,0 +1,277 @@
+"""fee_v10_tables
+
+Drop v9 billing tables (fee_configs / fee_calculations / high_water_marks)
+and create v10 fee model tables (fee_configs / fee_transactions).
+
+Equivalent raw SQL: backend/alembic/sql/045_fee_v10_tables.sql
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-04-25 09:30:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d4e5f6a7b8c9"
+down_revision: Union[str, Sequence[str], None] = "c3d4e5f6a7b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Drop v9 billing tables, create v10 fee_configs / fee_transactions."""
+    op.drop_table("fee_calculations")
+    op.drop_table("high_water_marks")
+    op.drop_table("fee_configs")
+
+    op.create_table(
+        "fee_configs",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("config_name", sa.String(64), nullable=False, unique=True),
+        sa.Column("tier_thresholds_jpy", postgresql.JSONB(), nullable=False),
+        sa.Column("tier_fee_rates", postgresql.JSONB(), nullable=False),
+        sa.Column("tier_monthly_yield_caps", postgresql.JSONB(), nullable=False),
+        sa.Column("subscription_rates", postgresql.JSONB(), nullable=False),
+        sa.Column(
+            "expense_markup_enabled", sa.Boolean(), nullable=False, server_default=sa.false()
+        ),
+        sa.Column(
+            "expense_markup_rate",
+            sa.Numeric(6, 4),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "affiliate_rate",
+            sa.Numeric(6, 4),
+            nullable=False,
+            server_default=sa.text("0.30"),
+        ),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("effective_from", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+    )
+    op.create_index(
+        "idx_fee_configs_active_effective",
+        "fee_configs",
+        ["is_active", sa.text("effective_from DESC")],
+    )
+
+    op.create_table(
+        "fee_transactions",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("calculation_month", sa.Date(), nullable=False),
+        sa.Column("tier", sa.String(16), nullable=False),
+        sa.Column("risk_mode", sa.String(16), nullable=False),
+        sa.Column("deposit_amount_jpy", sa.Numeric(18, 2), nullable=False),
+        sa.Column(
+            "gross_profit_jpy", sa.Numeric(18, 2), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column("expense_jpy", sa.Numeric(18, 2), nullable=False, server_default=sa.text("0")),
+        sa.Column("net_profit_jpy", sa.Numeric(18, 2), nullable=False, server_default=sa.text("0")),
+        sa.Column(
+            "fee_rate_applied", sa.Numeric(6, 4), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column("fee_amount_jpy", sa.Numeric(18, 2), nullable=False, server_default=sa.text("0")),
+        sa.Column(
+            "subscription_rate_applied",
+            sa.Numeric(6, 4),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "subscription_amount_jpy",
+            sa.Numeric(18, 2),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "subscription_protected",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+        sa.Column(
+            "monthly_yield_cap_applied",
+            sa.Numeric(6, 4),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "yield_excess_to_uata_jpy",
+            sa.Numeric(18, 2),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "user_takehome_jpy",
+            sa.Numeric(18, 2),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "affiliate_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "affiliate_amount_jpy",
+            sa.Numeric(18, 2),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "calculated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column("finalized_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint("tier IN ('LOWER', 'MIDDLE', 'UPPER')", name="chk_fee_tx_tier"),
+        sa.CheckConstraint("risk_mode IN ('LOW', 'MIDDLE', 'HIGH')", name="chk_fee_tx_risk_mode"),
+        sa.UniqueConstraint("user_id", "calculation_month", name="uq_fee_tx_user_month"),
+    )
+    op.create_index(
+        "idx_fee_tx_user_month",
+        "fee_transactions",
+        ["user_id", sa.text("calculation_month DESC")],
+    )
+    op.create_index(
+        "idx_fee_tx_finalized",
+        "fee_transactions",
+        ["finalized_at"],
+        postgresql_where=sa.text("finalized_at IS NULL"),
+    )
+    op.create_index(
+        "idx_fee_tx_affiliate",
+        "fee_transactions",
+        ["affiliate_id"],
+        postgresql_where=sa.text("affiliate_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Restore v9 billing tables and drop v10 tables.
+
+    Note: v9 schema is reconstructed from backend/app/billing/models.py.
+    Existing data (if any) is NOT restored.
+    """
+    op.drop_index("idx_fee_tx_affiliate", table_name="fee_transactions")
+    op.drop_index("idx_fee_tx_finalized", table_name="fee_transactions")
+    op.drop_index("idx_fee_tx_user_month", table_name="fee_transactions")
+    op.drop_table("fee_transactions")
+
+    op.drop_index("idx_fee_configs_active_effective", table_name="fee_configs")
+    op.drop_table("fee_configs")
+
+    op.create_table(
+        "fee_configs",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "management_fee_rate",
+            sa.Numeric(10, 6),
+            nullable=False,
+            server_default=sa.text("0.005"),
+        ),
+        sa.Column(
+            "performance_fee_rate",
+            sa.Numeric(10, 6),
+            nullable=False,
+            server_default=sa.text("0.10"),
+        ),
+        sa.Column(
+            "high_water_mark_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+        sa.Column(
+            "minimum_aum",
+            sa.Numeric(18, 6),
+            nullable=False,
+            server_default=sa.text("3000"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+    )
+
+    op.create_table(
+        "high_water_marks",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column("hwm_value", sa.Numeric(18, 6), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+    )
+    op.create_index("ix_high_water_marks_user_id", "high_water_marks", ["user_id"])
+
+    op.create_table(
+        "fee_calculations",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("calculation_date", sa.Date(), nullable=False),
+        sa.Column("period_type", sa.String(10), nullable=False),
+        sa.Column("aum_snapshot", sa.Numeric(18, 6), nullable=False),
+        sa.Column("management_fee", sa.Numeric(18, 6), nullable=False),
+        sa.Column("performance_fee", sa.Numeric(18, 6), nullable=False),
+        sa.Column("total_fee", sa.Numeric(18, 6), nullable=False),
+        sa.Column("profit_since_hwm", sa.Numeric(18, 6), nullable=False),
+        sa.Column("high_water_mark", sa.Numeric(18, 6), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+    )
+    op.create_index("ix_fee_calculations_user_id", "fee_calculations", ["user_id"])

--- a/backend/app/billing/v10_models.py
+++ b/backend/app/billing/v10_models.py
@@ -1,0 +1,233 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/billing/v10_models.py
+"""
+Fee Model v10 SQLAlchemy ORM 定義 (Option A: 既存 billing/models.py を完全置換予定)。
+
+テーブル:
+- fee_configs      : v10 設定 (リスクモード × tier の手数料率マトリクス)
+- fee_transactions : 月次手数料計算結果
+
+設計方針:
+- 既存 ``app.billing.models.FeeConfig`` 等は **F-1 では削除しない** (F-13 で物理削除)
+- ただし両者は同じ ``__tablename__`` を保持するため、同じ ``Base.metadata`` に登録すると
+  SQLAlchemy 起動時に "Table is already defined" エラーが発生する
+- そのため本モジュールは **専用の ``V10Base``** を使い、既存 ``app.database.Base`` とは
+  メタデータを分離する
+- DDL は ``backend/alembic/versions/d4e5f6a7b8c9_fee_v10_tables.py`` および
+  ``backend/alembic/sql/045_fee_v10_tables.sql`` が真実の源 (本モデル定義はクエリ用)
+- F-13 で旧モデル削除後、本モジュールを ``app.billing.models`` にマージし
+  ``V10Base`` を削除して通常の ``Base`` に統合する
+
+Tier / RiskMode の Python Enum は本モジュール内で暫定定義する。F-2 (InvestmentTier
+3 層化) / F-3 (RiskMode enum) で正式モジュール化する際に import を差し替える。
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from enum import Enum
+from typing import Any, Optional
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    CheckConstraint,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    MetaData,
+    Numeric,
+    String,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class V10Base(DeclarativeBase):
+    """v10 専用 Declarative Base (旧 billing/models.py との衝突回避用).
+
+    F-13 で旧モデル削除後、本クラスを廃止し ``app.database.Base`` に統合する。
+    """
+
+    metadata = MetaData()
+
+
+class FeeTier(str, Enum):
+    """v10 投資ティア (F-2 で正式モジュールへ移管予定)."""
+
+    LOWER = "LOWER"
+    MIDDLE = "MIDDLE"
+    UPPER = "UPPER"
+
+
+class FeeRiskMode(str, Enum):
+    """v10 リスクモード (F-3 で正式モジュールへ移管予定).
+
+    既存 ``users.risk_mode`` の値 (conservative/balanced/aggressive) とは別空間。
+    F-3 でマッピング辞書を導入する。
+    """
+
+    LOW = "LOW"
+    MIDDLE = "MIDDLE"
+    HIGH = "HIGH"
+
+
+class FeeConfigV10(V10Base):
+    """v10 手数料設定。
+
+    1 レコード = 1 つの設定スナップショット。``is_active=True`` かつ最新の
+    ``effective_from`` を持つレコードが現行設定。
+    """
+
+    __tablename__ = "fee_configs"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    config_name: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    tier_thresholds_jpy: Mapped[list[int]] = mapped_column(JSONB, nullable=False)
+    tier_fee_rates: Mapped[list[float]] = mapped_column(JSONB, nullable=False)
+    tier_monthly_yield_caps: Mapped[list[float]] = mapped_column(JSONB, nullable=False)
+    subscription_rates: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    expense_markup_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("FALSE")
+    )
+    expense_markup_rate: Mapped[Decimal] = mapped_column(
+        Numeric(6, 4), nullable=False, server_default=text("0")
+    )
+    affiliate_rate: Mapped[Decimal] = mapped_column(
+        Numeric(6, 4), nullable=False, server_default=text("0.30")
+    )
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("FALSE"))
+    effective_from: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=text("NOW()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        server_default=text("NOW()"),
+    )
+
+    __table_args__ = (
+        Index(
+            "idx_fee_configs_active_effective",
+            "is_active",
+            text("effective_from DESC"),
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return f"<FeeConfigV10(id={self.id}, name={self.config_name!r}, active={self.is_active})>"
+
+
+class FeeTransaction(V10Base):
+    """v10 月次手数料計算結果。
+
+    1 ユーザー × 1 ヶ月 (calculation_month は月初日) で 1 レコード。
+    ``finalized_at`` が NULL の間は再計算で上書き可能、NOT NULL になった後は確定。
+    """
+
+    __tablename__ = "fee_transactions"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    calculation_month: Mapped[date] = mapped_column(Date, nullable=False)
+    tier: Mapped[str] = mapped_column(String(16), nullable=False)
+    risk_mode: Mapped[str] = mapped_column(String(16), nullable=False)
+    deposit_amount_jpy: Mapped[Decimal] = mapped_column(Numeric(18, 2), nullable=False)
+    gross_profit_jpy: Mapped[Decimal] = mapped_column(
+        Numeric(18, 2), nullable=False, server_default=text("0")
+    )
+    expense_jpy: Mapped[Decimal] = mapped_column(
+        Numeric(18, 2), nullable=False, server_default=text("0")
+    )
+    net_profit_jpy: Mapped[Decimal] = mapped_column(
+        Numeric(18, 2), nullable=False, server_default=text("0")
+    )
+    fee_rate_applied: Mapped[Decimal] = mapped_column(
+        Numeric(6, 4), nullable=False, server_default=text("0")
+    )
+    fee_amount_jpy: Mapped[Decimal] = mapped_column(
+        Numeric(18, 2), nullable=False, server_default=text("0")
+    )
+    subscription_rate_applied: Mapped[Decimal] = mapped_column(
+        Numeric(6, 4), nullable=False, server_default=text("0")
+    )
+    subscription_amount_jpy: Mapped[Decimal] = mapped_column(
+        Numeric(18, 2), nullable=False, server_default=text("0")
+    )
+    subscription_protected: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("FALSE")
+    )
+    monthly_yield_cap_applied: Mapped[Decimal] = mapped_column(
+        Numeric(6, 4), nullable=False, server_default=text("0")
+    )
+    yield_excess_to_uata_jpy: Mapped[Decimal] = mapped_column(
+        Numeric(18, 2), nullable=False, server_default=text("0")
+    )
+    user_takehome_jpy: Mapped[Decimal] = mapped_column(
+        Numeric(18, 2), nullable=False, server_default=text("0")
+    )
+    affiliate_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    affiliate_amount_jpy: Mapped[Decimal] = mapped_column(
+        Numeric(18, 2), nullable=False, server_default=text("0")
+    )
+    calculated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=text("NOW()"),
+    )
+    finalized_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        CheckConstraint(
+            "tier IN ('LOWER', 'MIDDLE', 'UPPER')",
+            name="chk_fee_tx_tier",
+        ),
+        CheckConstraint(
+            "risk_mode IN ('LOW', 'MIDDLE', 'HIGH')",
+            name="chk_fee_tx_risk_mode",
+        ),
+        UniqueConstraint("user_id", "calculation_month", name="uq_fee_tx_user_month"),
+        Index(
+            "idx_fee_tx_user_month",
+            "user_id",
+            text("calculation_month DESC"),
+        ),
+        Index(
+            "idx_fee_tx_finalized",
+            "finalized_at",
+            postgresql_where=text("finalized_at IS NULL"),
+        ),
+        Index(
+            "idx_fee_tx_affiliate",
+            "affiliate_id",
+            postgresql_where=text("affiliate_id IS NOT NULL"),
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<FeeTransaction(id={self.id}, user_id={self.user_id}, "
+            f"month={self.calculation_month}, tier={self.tier}, "
+            f"risk_mode={self.risk_mode}, total={self.fee_amount_jpy})>"
+        )


### PR DESCRIPTION
## Summary

Fee Model v10 (Option A: 既存billing完全置換) の DDL とSQLAlchemy ORM を追加。staging-new DB で試験適用済み。本番DB は F-16 で適用予定。

`docs/45_fee_model_v10_migration_plan.md` §4 F-1 行 (PR #121) の方針に従う。

## 追加ファイル

| ファイル | 用途 |
|----------|------|
| `backend/alembic/sql/045_fee_v10_tables.sql` | Hetzner手動 \`psql -f\` 用の DDL |
| `backend/alembic/sql/README.md` | sql/ 配下の運用手順 |
| `backend/alembic/versions/d4e5f6a7b8c9_fee_v10_tables.py` | Alembic 等価 (CI/dev での \`alembic upgrade head\` 用) |
| `backend/app/billing/v10_models.py` | FeeConfigV10 + FeeTransaction (V10Base) |

## 設計判断

### 1. v10 モデルは別 \`V10Base\` を使用

既存 \`app.billing.models.FeeConfig\` が \`__tablename__ = \"fee_configs\"\` を持っており、新 \`FeeConfigV10\` が同じ table 名を **同じ Base.metadata** に登録するとSQLAlchemy 起動時に \"Table 'fee_configs' is already defined\" で失敗する。

旧モデルは F-13 で物理削除予定のため、F-1 では削除せず、新モデルのみ専用 \`V10Base\` (DeclarativeBase 別 metadata) に分離。F-13 で旧モデル削除後、通常の \`Base\` に統合する。

### 2. FK は INTEGER (元仕様の BIGINT を修正)

\`backend/app/auth/models.py:57\` で \`users.id: Mapped[int] = mapped_column(Integer, ...)\` のため、\`fee_transactions.user_id\` / \`affiliate_id\` も INTEGER に揃えた。

### 3. Tier / RiskMode は CHECK 制約で強制

DB 側: \`tier IN ('LOWER','MIDDLE','UPPER')\` / \`risk_mode IN ('LOW','MIDDLE','HIGH')\`。

既存 \`users.tier\` (現状 GENERAL) と \`users.risk_mode\` (現状 conservative) からの変換は F-2 / F-3 でマッピング辞書を導入予定。

## 検証

### staging-new DB 適用結果

\`\`\`sql
-- 適用前
fee_calculations, fee_configs, high_water_marks (3テーブル, 各0行)

-- 適用後
fee_configs       (v10 schema)
fee_transactions  (v10 schema)
-- fee_calculations / high_water_marks: 消失確認
\`\`\`

\`\\d fee_configs\` / \`\\d fee_transactions\` で構造を確認 (FK / CHECK 制約 / index 全て期待通り)。

### verify.sh (DoD)

\`\`\`
[1/7] ruff check         ✅
[2/7] ruff format        ✅
[3/7] mypy               ✅
[4/7] pytest (cov ≥ 80%) ✅
[5/7] ruff security      ✅
[6/7] tsc --noEmit       ✅
[7/7] npm run build      ✅
All checks passed (307s)
\`\`\`

## 山本さん本番テストへの影響

**ゼロ**。

- 本番DB (\`ultra_autotrade\`) には一切接続していない
- staging-new (\`ultra_autotrade_staging\`) のみで DDL 試験
- フロントエンド・バックエンドコード変更は新規ファイル追加のみ (既存コードに変更なし)
- 既存 \`/api/billing/*\` エンドポイントは引き続き動作 (本番DB で旧テーブル健在)

## Test plan

- [x] staging-new DB に DDL 適用、構造確認
- [x] verify.sh 全7ゲート pass
- [x] 既存 billing 系テスト (test_billing_service / test_billing_router / test_billing_qa_edge_cases) 引き続き pass (V10Base分離により無影響)
- [ ] F-2 / F-3 着手前に enum 値マッピング辞書設計
- [ ] F-13 で V10Base → 通常 Base に統合 + 旧 billing/models.py 削除
- [ ] F-16 本番リリース前に \`docs/22_production_release_checklist.md\` §8 に従い 045 SQL を本番適用

## Asana

- F-1: https://app.asana.com/0/1213741124336104/1214120248239215
- F-0 (親): https://app.asana.com/0/1213741124336104/1214120338928565

🤖 Generated with [Claude Code](https://claude.com/claude-code)