### PR TITLE
F-2: InvestmentTier 3層化 + users.tier マイグレーションプラン (#1214120248237710)

### DIFF
--- a/backend/app/auth/models.py
+++ b/backend/app/auth/models.py
@@ -6,8 +6,10 @@
 
 docs/13_security_design.md に準拠したセキュリティ要件を満たす。
 
-ALTER TABLE users ADD COLUMN tier VARCHAR(20) NOT NULL DEFAULT 'GENERAL';
+ALTER TABLE users ADD COLUMN tier VARCHAR(20) NOT NULL DEFAULT 'LOWER';
 ALTER TABLE users ADD COLUMN last_judgment_at TIMESTAMP WITH TIME ZONE NULL;
+-- 注: F-2 で DEFAULT を 'GENERAL' から 'LOWER' に変更。本番 DB の DEFAULT 切替は
+-- F-16 マイグレーションで実施 (docs/46_users_tier_migration_plan.md 参照)。
 """
 
 from datetime import datetime, timezone
@@ -31,10 +33,41 @@ class UserRole(str, Enum):
 
 
 class InvestmentTier(str, Enum):
-    """投資ティア（二層手数料モデル）。"""
+    """投資ティア。
 
-    GENERAL = "GENERAL"  # 〜300万円（〜$20,000）
-    UPPER = "UPPER"  # 300万円〜（$20,000〜）
+    v10 (F-2 2026-04-25 〜): LOWER / MIDDLE / UPPER の 3 層
+      - LOWER:  〜1,000,000 円
+      - MIDDLE: 1,000,001 〜 10,000,000 円
+      - UPPER:  10,000,001 円 〜
+
+    GENERAL は v9 過渡期互換値 (DEPRECATED)。F-16 で users.tier の
+    全 GENERAL レコードを LOWER/MIDDLE/UPPER に再判定後、F-13 で本 enum から削除。
+    """
+
+    LOWER = "LOWER"
+    MIDDLE = "MIDDLE"
+    UPPER = "UPPER"
+    GENERAL = "GENERAL"  # DEPRECATED (v9). 削除は F-13 (F-16 マイグレーション完了後)
+
+
+#: v9 GENERAL → v10 デフォルト変換マップ (read-time fallback)。
+#: F-16 マイグレーションで DB から GENERAL が消失した時点で参照箇所も削除可能。
+LEGACY_TIER_MAP: dict[str, "InvestmentTier"] = {
+    "GENERAL": InvestmentTier.LOWER,
+}
+
+#: tier 値 → 日本語ラベル。フロント表示および通知文言で使用。
+TIER_JP_LABELS: dict[InvestmentTier, str] = {
+    InvestmentTier.LOWER: "一般",
+    InvestmentTier.MIDDLE: "ミドル",
+    InvestmentTier.UPPER: "アッパー",
+    InvestmentTier.GENERAL: "一般",  # GENERAL は LOWER と同じラベル (過渡期)
+}
+
+
+#: v10 tier 判定の境界値 (JPY)。
+TIER_BOUNDARY_LOWER_JPY = 1_000_000  # LOWER / MIDDLE 境界
+TIER_BOUNDARY_UPPER_JPY = 10_000_000  # MIDDLE / UPPER 境界
 
 
 class User(Base):
@@ -99,7 +132,7 @@ class User(Base):
         Integer, ForeignKey("users.id"), nullable=True, default=None
     )
     tier: Mapped[str] = mapped_column(
-        String(20), nullable=False, default=InvestmentTier.GENERAL.value
+        String(20), nullable=False, default=InvestmentTier.LOWER.value
     )
     last_judgment_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True, default=None

--- a/backend/app/auth/schemas.py
+++ b/backend/app/auth/schemas.py
@@ -21,11 +21,9 @@ class UserRole(str, Enum):
     VIEWER = "viewer"
 
 
-class InvestmentTier(str, Enum):
-    """投資ティア（二層手数料モデル）。"""
-
-    GENERAL = "GENERAL"
-    UPPER = "UPPER"
+# InvestmentTier は app.auth.models で定義 (v10 3 層 + GENERAL 過渡期互換)。
+# F-2 までは本ファイルでも重複定義していたが、単一情報源 (auth/models.py) に統合した。
+from app.auth.models import InvestmentTier as InvestmentTier  # noqa: E402, F401
 
 
 class RegisterRequest(BaseModel):
@@ -84,7 +82,7 @@ class UserResponse(BaseModel):
     terms_version: Optional[str] = None
     risk_mode: Optional[str] = "conservative"
     invited_by: Optional[int] = None
-    tier: InvestmentTier = InvestmentTier.GENERAL
+    tier: InvestmentTier = InvestmentTier.LOWER
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -3,8 +3,10 @@
 """AI判定定期スケジューラー。
 
 ティア別間隔で AI 判定を実行し、結果を ai_decisions に保存する。
-- UPPER ティア: AI_JUDGMENT_INTERVAL_HOURS_UPPER（デフォルト 4 時間）
-- GENERAL ティア: AI_JUDGMENT_INTERVAL_HOURS_GENERAL（デフォルト 8 時間）
+- UPPER ティア:  AI_JUDGMENT_INTERVAL_HOURS_UPPER (デフォルト 4 時間)
+- MIDDLE ティア: AI_JUDGMENT_INTERVAL_HOURS_MIDDLE (デフォルト 6 時間)
+- LOWER ティア:  AI_JUDGMENT_INTERVAL_HOURS_LOWER (デフォルト 8 時間)
+- GENERAL ティア: AI_JUDGMENT_INTERVAL_HOURS_GENERAL (デフォルト 8 時間、v9 互換)
 BUY/SELL 判定時はティア間隔を満たすアクティブユーザーに Proposal を作成する。
 """
 
@@ -30,7 +32,9 @@ from app.proposals.models import Proposal
 
 # ティア別デフォルト判定間隔（時間）
 _DEFAULT_INTERVAL_UPPER = 4
-_DEFAULT_INTERVAL_GENERAL = 8
+_DEFAULT_INTERVAL_MIDDLE = 6
+_DEFAULT_INTERVAL_LOWER = 8
+_DEFAULT_INTERVAL_GENERAL = 8  # v9 互換 (LOWER と同値)
 
 logger = logging.getLogger(__name__)
 
@@ -99,11 +103,18 @@ def _get_tier_interval_hours(tier: str) -> int:
     """ティアに応じた AI 判定間隔（時間）を返す。
 
     環境変数で上書き可能:
-    - AI_JUDGMENT_INTERVAL_HOURS_UPPER（デフォルト 4）
-    - AI_JUDGMENT_INTERVAL_HOURS_GENERAL（デフォルト 8）
+    - AI_JUDGMENT_INTERVAL_HOURS_UPPER (デフォルト 4)
+    - AI_JUDGMENT_INTERVAL_HOURS_MIDDLE (デフォルト 6)
+    - AI_JUDGMENT_INTERVAL_HOURS_LOWER (デフォルト 8)
+    - AI_JUDGMENT_INTERVAL_HOURS_GENERAL (デフォルト 8、v9 互換)
     """
     if tier == InvestmentTier.UPPER.value:
         return int(os.getenv("AI_JUDGMENT_INTERVAL_HOURS_UPPER", str(_DEFAULT_INTERVAL_UPPER)))
+    if tier == InvestmentTier.MIDDLE.value:
+        return int(os.getenv("AI_JUDGMENT_INTERVAL_HOURS_MIDDLE", str(_DEFAULT_INTERVAL_MIDDLE)))
+    if tier == InvestmentTier.LOWER.value:
+        return int(os.getenv("AI_JUDGMENT_INTERVAL_HOURS_LOWER", str(_DEFAULT_INTERVAL_LOWER)))
+    # GENERAL (v9 互換) または未知の値 → GENERAL のデフォルト (= LOWER と同値)
     return int(os.getenv("AI_JUDGMENT_INTERVAL_HOURS_GENERAL", str(_DEFAULT_INTERVAL_GENERAL)))
 
 

--- a/backend/app/billing/dynamic_fee.py
+++ b/backend/app/billing/dynamic_fee.py
@@ -23,10 +23,13 @@ from enum import Enum
 
 logger = logging.getLogger(__name__)
 
-# ティア別手数料率レンジ（旧ENBベース — 後方互換）
+# ティア別手数料率レンジ (ENB ベース、後方互換)
+# v10 (F-2 2026-04-25): LOWER/MIDDLE 追加。GENERAL は LOWER alias (F-13 で削除)。
 _TIER_FEE_RANGES: dict[str, tuple[Decimal, Decimal]] = {
-    "GENERAL": (Decimal("0.03"), Decimal("0.10")),
+    "LOWER": (Decimal("0.03"), Decimal("0.10")),
+    "MIDDLE": (Decimal("0.08"), Decimal("0.18")),
     "UPPER": (Decimal("0.15"), Decimal("0.25")),
+    "GENERAL": (Decimal("0.03"), Decimal("0.10")),  # DEPRECATED: LOWER alias
 }
 
 _ZERO = Decimal("0")
@@ -46,19 +49,29 @@ class MarketCondition(str, Enum):
 
 
 # FEE_MATRIX: (tier, market_condition) → (min_rate, max_rate)
+# v10 (F-2): LOWER/MIDDLE/UPPER の 3 層 + GENERAL 互換。
 _MARKET_FEE_MATRIX: dict[tuple[str, MarketCondition], tuple[Decimal, Decimal]] = {
-    ("GENERAL", MarketCondition.BEAR): (Decimal("0.03"), Decimal("0.05")),
-    ("GENERAL", MarketCondition.STABLE): (Decimal("0.06"), Decimal("0.10")),
-    ("GENERAL", MarketCondition.BULL): (Decimal("0.08"), Decimal("0.15")),
+    ("LOWER", MarketCondition.BEAR): (Decimal("0.03"), Decimal("0.05")),
+    ("LOWER", MarketCondition.STABLE): (Decimal("0.06"), Decimal("0.10")),
+    ("LOWER", MarketCondition.BULL): (Decimal("0.08"), Decimal("0.15")),
+    ("MIDDLE", MarketCondition.BEAR): (Decimal("0.06"), Decimal("0.10")),
+    ("MIDDLE", MarketCondition.STABLE): (Decimal("0.10"), Decimal("0.15")),
+    ("MIDDLE", MarketCondition.BULL): (Decimal("0.12"), Decimal("0.18")),
     ("UPPER", MarketCondition.BEAR): (Decimal("0.10"), Decimal("0.15")),
     ("UPPER", MarketCondition.STABLE): (Decimal("0.15"), Decimal("0.22")),
     ("UPPER", MarketCondition.BULL): (Decimal("0.20"), Decimal("0.25")),
+    # v9 互換 (DEPRECATED, F-13 で削除) — LOWER と同値
+    ("GENERAL", MarketCondition.BEAR): (Decimal("0.03"), Decimal("0.05")),
+    ("GENERAL", MarketCondition.STABLE): (Decimal("0.06"), Decimal("0.10")),
+    ("GENERAL", MarketCondition.BULL): (Decimal("0.08"), Decimal("0.15")),
 }
 
-# キャップ: 一般層15%, アッパー層25%
+# キャップ: LOWER 15% / MIDDLE 18% / UPPER 25% (GENERAL は LOWER 互換)
 _MARKET_FEE_CAPS: dict[str, Decimal] = {
-    "GENERAL": Decimal("0.15"),
+    "LOWER": Decimal("0.15"),
+    "MIDDLE": Decimal("0.18"),
     "UPPER": Decimal("0.25"),
+    "GENERAL": Decimal("0.15"),  # DEPRECATED: LOWER alias
 }
 
 # デフォルト固定経費 ($0.27/トレード = ガス代 + API費用)

--- a/backend/app/billing/v10_models.py
+++ b/backend/app/billing/v10_models.py
@@ -58,12 +58,9 @@ class V10Base(DeclarativeBase):
     metadata = MetaData()
 
 
-class FeeTier(str, Enum):
-    """v10 投資ティア (F-2 で正式モジュールへ移管予定)."""
-
-    LOWER = "LOWER"
-    MIDDLE = "MIDDLE"
-    UPPER = "UPPER"
+#: F-2 で `app.auth.models.InvestmentTier` に統合済み。
+#: 後方互換のため alias として残置 (F-13 で v9 物理削除時に消去)。
+from app.auth.models import InvestmentTier as FeeTier  # noqa: E402, F401
 
 
 class FeeRiskMode(str, Enum):

--- a/backend/app/users/fee_service.py
+++ b/backend/app/users/fee_service.py
@@ -2,14 +2,14 @@
 # Unauthorized copying or distribution is strictly prohibited.
 # backend/app/users/fee_service.py
 """
-tier別手数料率サービス。
+tier 別手数料率サービス。
 
-二層戦略:
-  GENERAL: 手数料率 3〜10%（〜$20,000）
-  UPPER:   手数料率 15〜25%（$20,000〜）
+v10 三層戦略 (F-2 2026-04-25 〜):
+  LOWER:  手数料率 3〜10% (〜100 万円)
+  MIDDLE: 手数料率 8〜18% (100 万〜1000 万円)
+  UPPER:  手数料率 15〜25% (1000 万円〜)
 
-B-1 で AI Optimizer ENB ベースの動的計算が追加される予定。
-C-3 では各ティアの手数料率レンジのみを返す。
+GENERAL は v9 過渡期互換 (LOWER と同一レンジ)。F-13 で削除予定。
 """
 
 from typing_extensions import TypedDict
@@ -27,25 +27,40 @@ class FeeRateRange(TypedDict):
     description: str
 
 
+_LOWER = FeeRateRange(
+    tier="LOWER",
+    label="一般",
+    min_rate="0.03",
+    max_rate="0.10",
+    min_rate_pct="3",
+    max_rate_pct="10",
+    description="デポジット 100 万円以下のティア",
+)
+_MIDDLE = FeeRateRange(
+    tier="MIDDLE",
+    label="ミドル",
+    min_rate="0.08",
+    max_rate="0.18",
+    min_rate_pct="8",
+    max_rate_pct="18",
+    description="デポジット 100 万〜1000 万円のティア",
+)
+_UPPER = FeeRateRange(
+    tier="UPPER",
+    label="アッパー",
+    min_rate="0.15",
+    max_rate="0.25",
+    min_rate_pct="15",
+    max_rate_pct="25",
+    description="デポジット 1000 万円以上のティア",
+)
+
 _FEE_SCHEDULE: dict[str, FeeRateRange] = {
-    "GENERAL": FeeRateRange(
-        tier="GENERAL",
-        label="一般",
-        min_rate="0.03",
-        max_rate="0.10",
-        min_rate_pct="3",
-        max_rate_pct="10",
-        description="運用資産 $20,000 未満のティア",
-    ),
-    "UPPER": FeeRateRange(
-        tier="UPPER",
-        label="アッパー",
-        min_rate="0.15",
-        max_rate="0.25",
-        min_rate_pct="15",
-        max_rate_pct="25",
-        description="運用資産 $20,000 以上のティア",
-    ),
+    "LOWER": _LOWER,
+    "MIDDLE": _MIDDLE,
+    "UPPER": _UPPER,
+    # v9 互換 (DEPRECATED, F-13 で削除)
+    "GENERAL": _LOWER,
 }
 
 
@@ -54,7 +69,7 @@ def get_fee_rate_range(tier: str) -> FeeRateRange:
     ティア文字列から手数料率レンジを返す。
 
     Args:
-        tier: "GENERAL" または "UPPER"
+        tier: "LOWER" / "MIDDLE" / "UPPER" (または v9 互換 "GENERAL")
 
     Returns:
         FeeRateRange dict
@@ -63,12 +78,14 @@ def get_fee_rate_range(tier: str) -> FeeRateRange:
         ValueError: 不明なティアを指定した場合
     """
     if tier not in _FEE_SCHEDULE:
-        raise ValueError(f"Unknown tier: {tier!r}. Must be one of {list(_FEE_SCHEDULE)}")
+        raise ValueError(f"Unknown tier: {tier!r}. Must be one of {sorted(_FEE_SCHEDULE)}")
     return _FEE_SCHEDULE[tier]
 
 
 def get_full_fee_schedule() -> list[FeeRateRange]:
     """
-    全ティアの手数料率レンジ一覧を返す（GENERAL → UPPER の順）。
+    全ティアの手数料率レンジ一覧を返す (LOWER → MIDDLE → UPPER の順)。
+
+    v9 互換の GENERAL は内部 alias のため返却しない。
     """
-    return [_FEE_SCHEDULE["GENERAL"], _FEE_SCHEDULE["UPPER"]]
+    return [_LOWER, _MIDDLE, _UPPER]

--- a/backend/app/users/tier_service.py
+++ b/backend/app/users/tier_service.py
@@ -4,12 +4,17 @@
 """
 投資ティア判定サービス。
 
-二層戦略:
-  GENERAL: total_allocated_usd < TIER_THRESHOLD_USD
+v10 三層戦略 (F-2 2026-04-25 〜):
+  LOWER:  deposit_jpy <= 1,000,000
+  MIDDLE: 1,000,001 <= deposit_jpy <= 10,000,000
+  UPPER:  deposit_jpy >= 10,000,001
+
+v9 二層戦略 (パートナー配下の active 割り振り合計 USD):
+  GENERAL: total_allocated_usd < TIER_THRESHOLD_USD (≒ $20,000)
   UPPER:   total_allocated_usd >= TIER_THRESHOLD_USD
 
-デフォルト閾値: $20,000（≒ 300万円 @ 150円/$）
-環境変数 TIER_THRESHOLD_USD で上書き可能。
+  v9 経路 (refresh_partner_tier) は本タスクでも残置するが、戻り値は v10 LOWER/UPPER
+  に揃えた (GENERAL は廃止予定の互換値)。F-13 で完全廃止予定。
 """
 
 import logging
@@ -19,7 +24,12 @@ from decimal import Decimal
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from app.auth.models import InvestmentTier, User
+from app.auth.models import (
+    TIER_BOUNDARY_LOWER_JPY,
+    TIER_BOUNDARY_UPPER_JPY,
+    InvestmentTier,
+    User,
+)
 from app.partner.allocation_models import FundAllocation
 
 logger = logging.getLogger(__name__)
@@ -39,18 +49,45 @@ def _get_threshold() -> Decimal:
 
 def determine_tier(total_allocated_usd: Decimal) -> str:
     """
-    割り振り合計額からティアを判定する。
+    v9 互換: 割り振り合計額 (USD) からティアを判定する。
+
+    F-2 までは ``"GENERAL" / "UPPER"`` を返していたが、v10 移行に伴い
+    GENERAL → ``InvestmentTier.LOWER.value`` に置換した。F-16 マイグレーションで
+    既存 6 ユーザーの ``users.tier`` GENERAL レコードが LOWER/MIDDLE/UPPER に
+    再判定される。
 
     Args:
         total_allocated_usd: パートナー配下の active 割り振り合計額（USD, Decimal）
 
     Returns:
-        "GENERAL" または "UPPER"
+        "LOWER" または "UPPER"
     """
     threshold = _get_threshold()
     if total_allocated_usd >= threshold:
         return InvestmentTier.UPPER.value
-    return InvestmentTier.GENERAL.value
+    return InvestmentTier.LOWER.value
+
+
+def determine_tier_jpy(deposit_jpy: Decimal) -> InvestmentTier:
+    """
+    v10: ユーザーのデポジット額 (JPY) からティアを判定する。
+
+    境界:
+      LOWER:  deposit_jpy <= 1,000,000
+      MIDDLE: 1,000,001 <= deposit_jpy <= 10,000,000
+      UPPER:  deposit_jpy >= 10,000,001
+
+    Args:
+        deposit_jpy: ユーザーのデポジット額（JPY, Decimal）
+
+    Returns:
+        InvestmentTier (LOWER / MIDDLE / UPPER)
+    """
+    if deposit_jpy <= Decimal(TIER_BOUNDARY_LOWER_JPY):
+        return InvestmentTier.LOWER
+    if deposit_jpy <= Decimal(TIER_BOUNDARY_UPPER_JPY):
+        return InvestmentTier.MIDDLE
+    return InvestmentTier.UPPER
 
 
 def refresh_partner_tier(db: Session, partner_id: int) -> str:

--- a/backend/tests/test_fee_service.py
+++ b/backend/tests/test_fee_service.py
@@ -25,14 +25,23 @@ from app.users.fee_service import (  # noqa: E402
 
 
 class TestGetFeeRateRange:
-    def test_general_tier(self) -> None:
-        result = get_fee_rate_range("GENERAL")
-        assert result["tier"] == "GENERAL"
+    def test_lower_tier(self) -> None:
+        result = get_fee_rate_range("LOWER")
+        assert result["tier"] == "LOWER"
         assert result["label"] == "一般"
         assert result["min_rate"] == "0.03"
         assert result["max_rate"] == "0.10"
         assert result["min_rate_pct"] == "3"
         assert result["max_rate_pct"] == "10"
+
+    def test_middle_tier(self) -> None:
+        result = get_fee_rate_range("MIDDLE")
+        assert result["tier"] == "MIDDLE"
+        assert result["label"] == "ミドル"
+        assert result["min_rate"] == "0.08"
+        assert result["max_rate"] == "0.18"
+        assert result["min_rate_pct"] == "8"
+        assert result["max_rate_pct"] == "18"
 
     def test_upper_tier(self) -> None:
         result = get_fee_rate_range("UPPER")
@@ -43,22 +52,30 @@ class TestGetFeeRateRange:
         assert result["min_rate_pct"] == "15"
         assert result["max_rate_pct"] == "25"
 
+    def test_general_legacy_tier_returns_lower(self) -> None:
+        # GENERAL は v9 互換 alias → LOWER と同じ内容を返す
+        result = get_fee_rate_range("GENERAL")
+        assert result["tier"] == "LOWER"
+        assert result["min_rate"] == "0.03"
+        assert result["max_rate"] == "0.10"
+
     def test_unknown_tier_raises(self) -> None:
         with pytest.raises(ValueError, match="Unknown tier"):
             get_fee_rate_range("PLATINUM")
 
 
 class TestGetFullFeeSchedule:
-    def test_returns_both_tiers(self) -> None:
+    def test_returns_three_tiers(self) -> None:
         schedule = get_full_fee_schedule()
-        assert len(schedule) == 2
+        assert len(schedule) == 3
         tiers = [item["tier"] for item in schedule]
-        assert tiers == ["GENERAL", "UPPER"]
+        assert tiers == ["LOWER", "MIDDLE", "UPPER"]
 
-    def test_general_before_upper(self) -> None:
+    def test_order_lower_middle_upper(self) -> None:
         schedule = get_full_fee_schedule()
-        assert schedule[0]["tier"] == "GENERAL"
-        assert schedule[1]["tier"] == "UPPER"
+        assert schedule[0]["tier"] == "LOWER"
+        assert schedule[1]["tier"] == "MIDDLE"
+        assert schedule[2]["tier"] == "UPPER"
 
 
 # ---- API endpoint tests ----
@@ -120,17 +137,20 @@ class TestFeeScheduleEndpoint:
         data = r.json()
         assert "schedule" in data
         assert "note" in data
-        assert len(data["schedule"]) == 2
+        assert len(data["schedule"]) == 3
         tiers = [s["tier"] for s in data["schedule"]]
-        assert "GENERAL" in tiers
+        assert "LOWER" in tiers
+        assert "MIDDLE" in tiers
         assert "UPPER" in tiers
 
     def test_schedule_rate_values(self, client: TestClient) -> None:
         token = _register_and_login(client)
         r = client.get("/users/fee-schedule", headers={"Authorization": f"Bearer {token}"})
         schedule = {s["tier"]: s for s in r.json()["schedule"]}
-        assert schedule["GENERAL"]["min_rate"] == "0.03"
-        assert schedule["GENERAL"]["max_rate"] == "0.10"
+        assert schedule["LOWER"]["min_rate"] == "0.03"
+        assert schedule["LOWER"]["max_rate"] == "0.10"
+        assert schedule["MIDDLE"]["min_rate"] == "0.08"
+        assert schedule["MIDDLE"]["max_rate"] == "0.18"
         assert schedule["UPPER"]["min_rate"] == "0.15"
         assert schedule["UPPER"]["max_rate"] == "0.25"
 
@@ -153,7 +173,7 @@ class TestUserFeeInfoEndpoint:
         assert r.status_code == 200
         data = r.json()
         assert data["user_id"] == user_id
-        assert data["tier"] in ("GENERAL", "UPPER")
+        assert data["tier"] in ("LOWER", "MIDDLE", "UPPER", "GENERAL")
         assert "fee_rate_range" in data
         assert "min_rate" in data["fee_rate_range"]
         assert "max_rate" in data["fee_rate_range"]
@@ -166,7 +186,7 @@ class TestUserFeeInfoEndpoint:
         )
         assert r.status_code == 404
 
-    def test_default_tier_is_general(self, client: TestClient) -> None:
+    def test_default_tier_is_lower(self, client: TestClient) -> None:
         token = _register_and_login(client)
         me = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
         user_id = me.json()["id"]
@@ -175,6 +195,6 @@ class TestUserFeeInfoEndpoint:
             f"/users/{user_id}/fee-info",
             headers={"Authorization": f"Bearer {token}"},
         )
-        # 新規ユーザーはデフォルトで GENERAL
-        assert r.json()["tier"] == "GENERAL"
-        assert r.json()["fee_rate_range"]["tier"] == "GENERAL"
+        # F-2 (2026-04-25): 新規ユーザーはデフォルトで LOWER (旧 GENERAL)
+        assert r.json()["tier"] == "LOWER"
+        assert r.json()["fee_rate_range"]["tier"] == "LOWER"

--- a/backend/tests/test_tier_service.py
+++ b/backend/tests/test_tier_service.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-tier-service")
 
-from app.auth.models import InvestmentTier, User, UserRole
+from app.auth.models import TIER_JP_LABELS, InvestmentTier, User, UserRole
 from app.auth.router import router as auth_router
 from app.auth.schemas import UserCreateRequest
 from app.auth.service import AuthService
@@ -22,7 +22,7 @@ from app.database import Base, get_db
 from app.partner.allocation_schemas import AllocationCreateRequest, AllocationUpdateRequest
 from app.partner.allocation_service import create_allocation, delete_allocation, update_allocation
 from app.users.router import router as users_router
-from app.users.tier_service import determine_tier, refresh_partner_tier
+from app.users.tier_service import determine_tier, determine_tier_jpy, refresh_partner_tier
 
 SessionFactory = sessionmaker[Session]
 
@@ -44,10 +44,13 @@ def test_db() -> Generator[tuple[SessionFactory, object], None, None]:
 
 
 class TestDetermineTier:
-    """determine_tier の境界値テスト。デフォルト閾値 $20,000。"""
+    """determine_tier の境界値テスト。デフォルト閾値 $20,000。
+
+    F-2 (2026-04-25): 戻り値を v9 GENERAL から v10 LOWER に変更。
+    """
 
     def test_below_threshold(self) -> None:
-        assert determine_tier(Decimal("19999.99")) == InvestmentTier.GENERAL.value
+        assert determine_tier(Decimal("19999.99")) == InvestmentTier.LOWER.value
 
     def test_at_threshold(self) -> None:
         assert determine_tier(Decimal("20000.00")) == InvestmentTier.UPPER.value
@@ -56,11 +59,11 @@ class TestDetermineTier:
         assert determine_tier(Decimal("20000.01")) == InvestmentTier.UPPER.value
 
     def test_zero(self) -> None:
-        assert determine_tier(Decimal("0")) == InvestmentTier.GENERAL.value
+        assert determine_tier(Decimal("0")) == InvestmentTier.LOWER.value
 
     def test_custom_threshold_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("TIER_THRESHOLD_USD", "10000")
-        assert determine_tier(Decimal("9999")) == InvestmentTier.GENERAL.value
+        assert determine_tier(Decimal("9999")) == InvestmentTier.LOWER.value
         assert determine_tier(Decimal("10000")) == InvestmentTier.UPPER.value
 
     def test_invalid_threshold_env_falls_back_to_default(
@@ -68,7 +71,7 @@ class TestDetermineTier:
     ) -> None:
         monkeypatch.setenv("TIER_THRESHOLD_USD", "not-a-number")
         # フォールバック → デフォルト $20,000
-        assert determine_tier(Decimal("19999")) == InvestmentTier.GENERAL.value
+        assert determine_tier(Decimal("19999")) == InvestmentTier.LOWER.value
         assert determine_tier(Decimal("20000")) == InvestmentTier.UPPER.value
 
 
@@ -93,9 +96,9 @@ class TestRefreshPartnerTier:
         with factory() as db:
             partner = _make_partner(db)
             tier = refresh_partner_tier(db, partner.id)
-            assert tier == InvestmentTier.GENERAL.value
+            assert tier == InvestmentTier.LOWER.value
             db.refresh(partner)
-            assert partner.tier == InvestmentTier.GENERAL.value
+            assert partner.tier == InvestmentTier.LOWER.value
 
     def test_below_threshold_gives_general(self, test_db: tuple) -> None:
         factory, _ = test_db
@@ -106,7 +109,7 @@ class TestRefreshPartnerTier:
             )
             create_allocation(db, partner.id, req)
             db.refresh(partner)
-            assert partner.tier == InvestmentTier.GENERAL.value
+            assert partner.tier == InvestmentTier.LOWER.value
 
     def test_at_threshold_gives_upper(self, test_db: tuple) -> None:
         factory, _ = test_db
@@ -128,7 +131,7 @@ class TestRefreshPartnerTier:
             )
             alloc = create_allocation(db, partner.id, req)
             db.refresh(partner)
-            assert partner.tier == InvestmentTier.GENERAL.value
+            assert partner.tier == InvestmentTier.LOWER.value
 
             # 金額を増やして UPPER に
             update_req = AllocationUpdateRequest(allocated_amount_usd=Decimal("25000"))
@@ -149,7 +152,7 @@ class TestRefreshPartnerTier:
 
             delete_allocation(db, alloc.id, partner.id)
             db.refresh(partner)
-            assert partner.tier == InvestmentTier.GENERAL.value
+            assert partner.tier == InvestmentTier.LOWER.value
 
     def test_withdrawn_allocation_excluded_from_tier(self, test_db: tuple) -> None:
         """status=withdrawn の割り振りはティア計算に含まれない。"""
@@ -166,7 +169,7 @@ class TestRefreshPartnerTier:
             update_req = AllocationUpdateRequest(status="withdrawn")
             update_allocation(db, alloc.id, partner.id, update_req)
             db.refresh(partner)
-            assert partner.tier == InvestmentTier.GENERAL.value
+            assert partner.tier == InvestmentTier.LOWER.value
 
 
 # ---------------------------------------------------------------------------
@@ -207,7 +210,7 @@ class TestTierAPI:
                 headers={"Authorization": f"Bearer {token}"},
             )
             assert r.status_code == 200
-            assert r.json()["tier"] == InvestmentTier.GENERAL.value
+            assert r.json()["tier"] == InvestmentTier.LOWER.value
 
     def test_viewer_cannot_access_tier(self, test_db: tuple) -> None:
         factory, _ = test_db
@@ -266,3 +269,70 @@ class TestTierAPI:
                 headers={"Authorization": f"Bearer {token}"},
             )
             assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# determine_tier_jpy ユニットテスト (v10 3 層、JPY 境界)
+# ---------------------------------------------------------------------------
+
+
+class TestDetermineTierJpy:
+    """v10 三層判定の境界値テスト。
+
+    境界:
+      LOWER:  deposit_jpy <= 1,000,000
+      MIDDLE: 1,000,001 <= deposit_jpy <= 10,000,000
+      UPPER:  deposit_jpy >= 10,000,001
+    """
+
+    def test_zero(self) -> None:
+        assert determine_tier_jpy(Decimal("0")) == InvestmentTier.LOWER
+
+    def test_just_below_lower_boundary(self) -> None:
+        assert determine_tier_jpy(Decimal("999999")) == InvestmentTier.LOWER
+
+    def test_at_lower_boundary(self) -> None:
+        # 100 万円ジャストは LOWER に含む
+        assert determine_tier_jpy(Decimal("1000000")) == InvestmentTier.LOWER
+
+    def test_just_above_lower_boundary(self) -> None:
+        # 100 万円 +1 円から MIDDLE
+        assert determine_tier_jpy(Decimal("1000001")) == InvestmentTier.MIDDLE
+
+    def test_mid_middle_range(self) -> None:
+        assert determine_tier_jpy(Decimal("5000000")) == InvestmentTier.MIDDLE
+
+    def test_just_below_upper_boundary(self) -> None:
+        assert determine_tier_jpy(Decimal("9999999")) == InvestmentTier.MIDDLE
+
+    def test_at_upper_boundary(self) -> None:
+        # 1000 万円ジャストは MIDDLE に含む
+        assert determine_tier_jpy(Decimal("10000000")) == InvestmentTier.MIDDLE
+
+    def test_just_above_upper_boundary(self) -> None:
+        # 1000 万円 +1 円から UPPER
+        assert determine_tier_jpy(Decimal("10000001")) == InvestmentTier.UPPER
+
+    def test_far_above_upper(self) -> None:
+        assert determine_tier_jpy(Decimal("100000000")) == InvestmentTier.UPPER
+
+
+class TestTierJpLabels:
+    """日本語ラベル辞書テスト。"""
+
+    def test_lower_label(self) -> None:
+        assert TIER_JP_LABELS[InvestmentTier.LOWER] == "一般"
+
+    def test_middle_label(self) -> None:
+        assert TIER_JP_LABELS[InvestmentTier.MIDDLE] == "ミドル"
+
+    def test_upper_label(self) -> None:
+        assert TIER_JP_LABELS[InvestmentTier.UPPER] == "アッパー"
+
+    def test_general_legacy_label(self) -> None:
+        # GENERAL (v9 互換) は LOWER と同じラベル
+        assert TIER_JP_LABELS[InvestmentTier.GENERAL] == "一般"
+
+    def test_all_enum_values_have_labels(self) -> None:
+        for tier in InvestmentTier:
+            assert tier in TIER_JP_LABELS, f"Missing JP label for {tier}"

--- a/docs/46_users_tier_migration_plan.md
+++ b/docs/46_users_tier_migration_plan.md
@@ -1,0 +1,228 @@
+# users.tier マイグレーションプラン (F-2)
+
+> 最終更新: 2026-04-25
+> 関連: `docs/45_fee_model_v10_migration_plan.md` §2.2 / §4 F-2 行
+> Asana: F-2 (1214120248237710)
+> 実行タイミング: **F-16 本番リリース時** (本ドキュメントは設計のみ。F-2 では実行しない)
+
+---
+
+## 0. 前提
+
+### 本番 DB 現状 (2026-04-25 read-only 調査)
+
+| 項目 | 値 |
+|------|-----|
+| `users.tier` 値分布 | GENERAL × 6 (UPPER 0) |
+| `users.tier` 列型 | `VARCHAR(20)`, `NOT NULL`, `DEFAULT 'GENERAL'` |
+| 関連テーブル | `fund_allocations` (partner_id / tester_user_id / allocated_amount_usd / status) |
+
+### 既存 6 ユーザー snapshot
+
+| id | username | role | tier (現状) | active 割り振り USD |
+|----|----------|------|-------------|---------------------|
+| 1  | hkobayashi   | admin   | GENERAL | 0 |
+| 7  | admin-hk     | admin   | GENERAL | 0 |
+| 8  | partner-test | editor  | GENERAL | 0 |
+| 11 | yamamoto     | partner | GENERAL | 0 |
+| 13 | 小林テスト   | viewer  | GENERAL | 1100.00 |
+| 14 | 小林テステス | viewer  | GENERAL | 0 |
+
+### v10 要件 (F-2 enum)
+
+| tier | 境界 (JPY) | 用途 |
+|------|------------|------|
+| LOWER  | 〜 1,000,000 | デフォルト (デポジット 100 万円以下) |
+| MIDDLE | 1,000,001 〜 10,000,000 | デポジット 100 万 〜 1000 万円 |
+| UPPER  | 10,000,001 〜 | デポジット 1000 万円〜 |
+
+マイグレーション方針: 手動 `ALTER` + `UPDATE` (Alembic 自動マイグレーションは未使用。`docs/ops/02_db_tables.md` 準拠)。
+
+---
+
+## 1. 既存 6 ユーザーの再判定方針
+
+### 1.1 デポジット額算出
+
+ユーザーごとの算出ソース:
+- `viewer` (テスター): `fund_allocations.allocated_amount_usd × USDJPY` の合計 (status='active')
+- `admin` / `partner` / `editor`: 個人デポジット情報を v10 で別途設計 (現状 0 として扱う)
+
+### 1.2 判定アルゴリズム
+
+```python
+deposit_jpy = sum(allocated_amount_usd for fa in active_allocations if fa.tester_user_id = u.id) * USDJPY
+
+if deposit_jpy <= 1_000_000:
+    tier = "LOWER"
+elif deposit_jpy <= 10_000_000:
+    tier = "MIDDLE"
+else:
+    tier = "UPPER"
+```
+
+### 1.3 USDJPY レート
+
+- 切替時点 (F-16 実行直前) の Bybit ティッカー or 中央値レートをスナップショットして固定
+- 本ドキュメント上の試算は **USDJPY=150** を仮置き (F-16 実行時に最新値で再計算する)
+- F-16 実行後の `fee_transactions` 計算では同じレートを参照する設計 (F-5 で詳細実装)
+
+### 1.4 試算結果 (USDJPY=150 固定、2026-04-25 snapshot)
+
+| id | username | alloc USD | deposit JPY | 判定 tier |
+|----|----------|-----------|-------------|-----------|
+| 1  | hkobayashi   | 0       | 0       | LOWER |
+| 7  | admin-hk     | 0       | 0       | LOWER |
+| 8  | partner-test | 0       | 0       | LOWER |
+| 11 | yamamoto     | 0       | 0       | LOWER |
+| 13 | 小林テスト   | 1100.00 | 165,000 | LOWER |
+| 14 | 小林テステス | 0       | 0       | LOWER |
+
+**結論**: 6 ユーザー全員 LOWER に収束。MIDDLE/UPPER 該当者はゼロ。
+
+---
+
+## 2. マイグレーション SQL (F-16 本番適用予定、本タスクでは実行しない)
+
+### 2.1 事前チェック
+
+```bash
+# tier 値分布の最終確認
+docker exec ultra-autotrade-postgres-production psql -U ultra -d ultra_autotrade -c "
+SELECT tier, COUNT(*) FROM users GROUP BY tier ORDER BY tier;
+"
+
+# fund_allocations の active 件数確認
+docker exec ultra-autotrade-postgres-production psql -U ultra -d ultra_autotrade -c "
+SELECT tester_user_id, SUM(allocated_amount_usd) AS usd
+FROM fund_allocations
+WHERE status='active'
+GROUP BY tester_user_id;
+"
+```
+
+### 2.2 バックアップ
+
+```bash
+docker exec ultra-autotrade-postgres-production pg_dump -U ultra -d ultra_autotrade \
+  -t users -t fund_allocations \
+  > /tmp/users_fund_alloc_backup_$(date +%Y%m%d).sql
+```
+
+### 2.3 マイグレーション本体
+
+```sql
+BEGIN;
+
+-- 1. column DEFAULT 切替 (新規ユーザー作成時の初期値)
+ALTER TABLE users ALTER COLUMN tier SET DEFAULT 'LOWER';
+
+-- 2. 既存値変換 (デポジット額ベース、USDJPY は実行時に決定)
+--    下記の :usdjpy パラメータは実行時に SET で渡す
+\set usdjpy 150
+
+WITH user_deposits AS (
+  SELECT u.id,
+         COALESCE(SUM(fa.allocated_amount_usd) * :usdjpy, 0) AS deposit_jpy
+  FROM users u
+  LEFT JOIN fund_allocations fa
+    ON fa.tester_user_id = u.id AND fa.status = 'active'
+  GROUP BY u.id
+)
+UPDATE users u
+SET tier = CASE
+  WHEN ud.deposit_jpy <= 1000000  THEN 'LOWER'
+  WHEN ud.deposit_jpy <= 10000000 THEN 'MIDDLE'
+  ELSE 'UPPER'
+END
+FROM user_deposits ud
+WHERE u.id = ud.id
+  AND u.tier = 'GENERAL';  -- v10 値 (LOWER/MIDDLE/UPPER) は再判定対象外
+
+-- 3. 検証
+SELECT tier, COUNT(*) FROM users GROUP BY tier ORDER BY tier;
+-- 期待: LOWER:6 (現状 snapshot 通り)
+
+COMMIT;
+```
+
+### 2.4 適用後の追加検証
+
+```bash
+# Pydantic で読めることを確認 (バックエンド再起動後)
+curl -sf https://api.ultra-auto-trade.com/health | python3 -m json.tool
+
+# 各ユーザーの tier 表示
+docker exec ultra-autotrade-postgres-production psql -U ultra -d ultra_autotrade -c "
+SELECT id, username, role, tier FROM users ORDER BY id;
+"
+```
+
+---
+
+## 3. ロールバック手順
+
+### 3.1 SQL レベル (F-16 当日のみ実行可)
+
+```sql
+BEGIN;
+
+-- バックアップ復元 (\copy or pg_restore)
+TRUNCATE users CASCADE;
+\copy users FROM '/tmp/users_backup_<date>.csv' CSV HEADER
+
+-- column DEFAULT を v9 値に戻す
+ALTER TABLE users ALTER COLUMN tier SET DEFAULT 'GENERAL';
+
+COMMIT;
+```
+
+### 3.2 アプリケーションレベル
+
+- F-2 PR を revert (gh pr revert) → main 再デプロイ
+- enum に GENERAL がそのまま残っているため、過渡期互換は維持
+
+---
+
+## 4. 実行タイミング (F-16)
+
+1. F-15 山本さんレビュー完了
+2. **山本さんへの事前周知 (24h 前 DM)**:
+    - 「次回バックエンド更新時に手数料モデルが v10 に切り替わり、ティアが LOWER (一般) として表示されます」
+    - 「金額・操作には影響なし」
+3. F-16 本番リリース時に本 SQL 実行
+4. backend 再起動
+5. 各ユーザーのダッシュボードで tier 表示が「一般」(LOWER) になっていることを確認
+
+---
+
+## 5. ロールアウト後監視
+
+| チェック項目 | 方法 | 頻度 |
+|--------------|------|------|
+| tier 値分布 | `SELECT tier, COUNT(*) FROM users GROUP BY tier;` | 直後 + 24h 後 |
+| API `/users/{id}/tier` | curl 6 回 (全ユーザー) | 直後 |
+| 山本さん配下異常報告 | Slack `#ultra-auto-project` | 24h 監視 |
+| Pydantic バリデーションエラー | `docker logs ... \| grep -i 'validationerror\|invalidvalue'` | 直後 + 6h |
+
+---
+
+## 6. 設計判断 (F-2 で確定したこと)
+
+| 項目 | 採用案 | 理由 |
+|------|--------|------|
+| enum 拡張方針 | **Option A**: GENERAL を deprecated として残し、LOWER/MIDDLE/UPPER 追加 | 本番 6 ユーザーが現在 GENERAL を保持しており、Pydantic バリデーション失敗を防ぐため |
+| tier 単位 | JPY (`determine_tier_jpy`) | v10 spec が JPY 境界を採用 |
+| 旧 USD パス (`determine_tier`) | 戻り値を GENERAL → LOWER に変更 | v10 vocabulary 統一 |
+| 日本語ラベル | `TIER_JP_LABELS` 辞書を auth/models.py に集約 | 単一情報源、フロントは API 経由で取得 |
+| `users.tier` DEFAULT | F-2 でコード側 `'LOWER'`、DB 側は F-16 で `ALTER DEFAULT` | コード側は単独デプロイで OK、DB DEFAULT 切替は本番 SQL 必須 |
+
+---
+
+## 7. F-3 / F-13 / F-16 への引き継ぎ
+
+| タスク | 引き継ぎ事項 |
+|--------|--------------|
+| F-3 (RiskMode enum) | 本ドキュメントの設計を踏襲 (deprecated 残置 → F-13 削除) |
+| F-13 (v9 物理削除) | `InvestmentTier.GENERAL` 削除 + `TIER_JP_LABELS` から GENERAL エントリ削除 + `dynamic_fee.py` / `fee_service.py` の GENERAL 互換マップ削除 |
+| F-16 (本番リリース) | 本ドキュメント §2 SQL を実行 |

--- a/frontend/app/(partner)/partner/dashboard/_components/AllocationTable.tsx
+++ b/frontend/app/(partner)/partner/dashboard/_components/AllocationTable.tsx
@@ -23,7 +23,7 @@ import { getStoredToken } from '@/lib/auth'
 interface Props {
   /** tester_name → TesterPerformance from /api/partner/performance */
   performanceMap?: Record<string, TesterPerformance>
-  /** user_id → tier ("GENERAL" | "UPPER") */
+  /** user_id → tier ("LOWER" | "MIDDLE" | "UPPER", v9 互換: "GENERAL") */
   tierMap?: Record<number, string>
   /** Called after any CRUD so parent (page.tsx) can re-fetch allocations + performance */
   onRefresh?: () => void


### PR DESCRIPTION
## Summary

`InvestmentTier` を v9 二層 (GENERAL/UPPER) から v10 三層 (LOWER/MIDDLE/UPPER) に拡張し、tier 判定ロジックと fee マトリクスを更新。本番 6 ユーザー (全員 GENERAL) の値変換は F-16 で実施 (本タスクで実行しない)。

`docs/45_fee_model_v10_migration_plan.md` §4 F-2 行 (PR #121) の方針に従う。

## 戦略選択 (Option A 採用)

本番 \`users.tier='GENERAL'\` × 6 が現存するため、enum から GENERAL を即削除すると Pydantic バリデーション失敗が起きる。F-2 では LOWER/MIDDLE 追加 + GENERAL 残置 (deprecated) で対応。F-13 で物理削除。

> 詳細は \`docs/46_users_tier_migration_plan.md\` §6「設計判断」参照

## 主な変更

### 1. enum 一元化 (\`backend/app/auth/models.py\`)

- \`InvestmentTier\` に \`LOWER\` / \`MIDDLE\` 追加、\`GENERAL\` を deprecated として残置
- \`TIER_JP_LABELS\` (日本語ラベル辞書) / \`TIER_BOUNDARY_*_JPY\` (境界定数) 追加
- \`LEGACY_TIER_MAP {"GENERAL": LOWER}\` 追加 (read-time fallback)
- \`auth/schemas.py\` の重複定義を削除し、\`auth/models\` から re-export
- \`billing/v10_models.py\` の \`FeeTier\` を \`auth/models.InvestmentTier\` の alias に置換 (F-1 PR #122 への影響なし)

### 2. tier 判定ロジック (\`backend/app/users/tier_service.py\`)

- \`determine_tier_jpy(deposit_jpy)\` を新規追加 (v10 境界 100 万 / 1000 万 JPY)
- \`determine_tier(usd)\` は v9 互換維持、戻り値 GENERAL → LOWER に変更

### 3. fee 計算側の MIDDLE 対応

- \`users/fee_service.py\` に MIDDLE 行追加 (8〜18%)、GENERAL は LOWER alias
- \`billing/dynamic_fee.py\` の \`_TIER_FEE_RANGES\` / \`_MARKET_FEE_MATRIX\` / \`_MARKET_FEE_CAPS\` 全てに MIDDLE 行追加 (GENERAL も互換維持)

### 4. ai_judgment_scheduler.py

- \`_DEFAULT_INTERVAL_MIDDLE = 6h\`、\`_DEFAULT_INTERVAL_LOWER = 8h\` 追加
- \`_get_tier_interval_hours\` に MIDDLE / LOWER 分岐追加。GENERAL は引き続き 8h (v9 互換)

### 5. テスト追加

- \`test_tier_service.py\`: \`TestDetermineTierJpy\` (境界値 9 ケース) + \`TestTierJpLabels\` (5 ケース)
- \`test_fee_service.py\`: MIDDLE tier テスト + GENERAL legacy alias テスト

### 6. マイグレーションプラン (\`docs/46_users_tier_migration_plan.md\`)

- 本番 6 ユーザー snapshot (全員 alloc≦\$1100 → 全員 LOWER に収束)
- F-16 用 SQL (CTE で deposit_jpy 算出 → CASE で tier 再判定)
- USDJPY=150 仮置き、F-16 実行時に最新値で再計算する旨明記
- ロールバック手順

### 7. frontend

- AllocationTable.tsx の JSDoc 型表記を v10 vocabulary に更新 (動作変更なし、F-10 / F-11 で UI 本格更新)

## 検証

\`\`\`
verify.sh 全 7 ゲート pass (312s)
- test_tier_service.py: 30 passed (新規 14 件追加)
- test_fee_service.py:  14 passed (MIDDLE / GENERAL legacy 含む)
- test_ai_judgment_scheduler.py: 27 passed (GENERAL 8h 維持確認)
- test_billing_*:       42 passed (FeeTier alias 後も無回帰)
- test_dynamic_fee:     47 passed
\`\`\`

## 山本さん本番テストへの影響: **ゼロ**

- 本番 DB は read-only SELECT のみ (6 ユーザー snapshot 取得用)
- \`ALTER TABLE\` / \`UPDATE\` 一切なし (F-16 で実施)
- backend は \`GENERAL\` 値を引き続き受け入れるため、本 PR をデプロイしても 6 ユーザーはそのまま動作 (Pydantic / SQLAlchemy 両方で GENERAL が valid enum)
- 既存 \`/api/billing/*\` / \`/auth/me\` / \`/users/{id}/tier\` 等のエンドポイントは無回帰

## Test plan

- [x] verify.sh 全 7 ゲート pass
- [x] 既存 GENERAL/UPPER tests 引き続き pass
- [x] 新規 LOWER/MIDDLE 境界値テスト pass
- [x] 本番 read-only snapshot 確認 (GENERAL × 6 で変化なし)
- [ ] F-3 (RiskMode enum) で同設計パターンを踏襲
- [ ] F-13 で \`InvestmentTier.GENERAL\` 削除 + 関連互換コード一掃
- [ ] F-16 で \`docs/46_users_tier_migration_plan.md\` §2 SQL を本番適用

## Asana

- F-2: https://app.asana.com/0/1213741124336104/1214120248237710
- F-1: https://app.asana.com/0/1213741124336104/1214120248239215 (PR #122)
- F-0: https://app.asana.com/0/1213741124336104/1214120338928565 (PR #121)

🤖 Generated with [Claude Code](https://claude.com/claude-code)