### PR TITLE
F-4: FeeConfig v10_default seed data 投入 (#1214120401381545)

### DIFF
--- a/backend/alembic/sql/046_fee_v10_check_constraint_alignment.sql
+++ b/backend/alembic/sql/046_fee_v10_check_constraint_alignment.sql
@@ -1,0 +1,68 @@
+-- =============================================================================
+-- 046_fee_v10_check_constraint_alignment.sql
+-- fee_transactions.risk_mode CHECK 制約を F-3 RiskMode 内部値に揃える
+-- 関連: docs/45 §1.3, docs/47, Asana F-4 (1214120401381545)
+-- 作成日: 2026-04-25
+--
+-- 背景:
+--   - F-1 (045) 時点では risk_mode CHECK = ('LOW','MIDDLE','HIGH')
+--   - F-3 で RiskMode enum を導入: ('conservative','balanced','aggressive')
+--   - Aave MDD / Optimizer / Risk Profile が小文字内部値を直参照
+--   - F-5 fee_calculator が CHECK 違反を起こさないよう、本マイグレーションで揃える
+--
+-- なお tier CHECK = ('LOWER','MIDDLE','UPPER') は F-2 InvestmentTier と既に整合済み
+-- (大文字、3 値)。fee_transactions は新規テーブル = GENERAL レコード混入の心配なし。
+--
+-- 適用先:
+--   - staging-new: F-4 で実行 (試験)
+--   - production:  F-16 で実行 (本番リリース時、045 適用後)
+--
+-- 等価な Alembic migration: backend/alembic/versions/e5f6a7b8c9d0_check_constraint_alignment.py
+-- どちらか一方のみ適用すること。
+-- =============================================================================
+
+BEGIN;
+
+-- 旧 CHECK ('LOW','MIDDLE','HIGH') を削除
+ALTER TABLE fee_transactions
+  DROP CONSTRAINT IF EXISTS chk_fee_tx_risk_mode;
+
+-- 新 CHECK: F-3 RiskMode 内部値に揃える
+ALTER TABLE fee_transactions
+  ADD CONSTRAINT chk_fee_tx_risk_mode
+  CHECK (risk_mode IN ('conservative', 'balanced', 'aggressive'));
+
+COMMENT ON COLUMN fee_transactions.risk_mode IS
+  'v10 リスクモード (conservative / balanced / aggressive) — F-3 RiskMode enum 内部値';
+
+COMMIT;
+
+-- =============================================================================
+-- 検証クエリ (適用後の確認用)
+-- =============================================================================
+-- \d fee_transactions
+-- 期待: chk_fee_tx_risk_mode CHECK (risk_mode::text = ANY (ARRAY['conservative'::char...
+--
+-- 動作確認 (rollback で残さない):
+-- BEGIN;
+--   INSERT INTO fee_transactions (
+--     user_id, calculation_month, tier, risk_mode, deposit_amount_jpy
+--   ) VALUES (1, '2026-05-01', 'LOWER', 'conservative', 0);
+--   -- 成功すること
+-- ROLLBACK;
+-- BEGIN;
+--   INSERT INTO fee_transactions (
+--     user_id, calculation_month, tier, risk_mode, deposit_amount_jpy
+--   ) VALUES (1, '2026-05-01', 'LOWER', 'LOW', 0);
+--   -- chk_fee_tx_risk_mode 違反で失敗すること
+-- ROLLBACK;
+--
+-- =============================================================================
+-- ロールバック手順 (緊急時のみ)
+-- =============================================================================
+-- BEGIN;
+-- ALTER TABLE fee_transactions DROP CONSTRAINT IF EXISTS chk_fee_tx_risk_mode;
+-- ALTER TABLE fee_transactions
+--   ADD CONSTRAINT chk_fee_tx_risk_mode
+--   CHECK (risk_mode IN ('LOW', 'MIDDLE', 'HIGH'));
+-- COMMIT;

--- a/backend/alembic/versions/e5f6a7b8c9d0_check_constraint_alignment.py
+++ b/backend/alembic/versions/e5f6a7b8c9d0_check_constraint_alignment.py
@@ -1,0 +1,43 @@
+"""fee_v10_check_constraint_alignment
+
+Update fee_transactions.risk_mode CHECK constraint from v10-spec values
+('LOW','MIDDLE','HIGH') to F-3 RiskMode internal values
+('conservative','balanced','aggressive').
+
+Equivalent raw SQL: backend/alembic/sql/046_fee_v10_check_constraint_alignment.sql
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-04-25 16:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e5f6a7b8c9d0"
+down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Replace risk_mode CHECK with F-3 internal values."""
+    op.drop_constraint("chk_fee_tx_risk_mode", "fee_transactions", type_="check")
+    op.create_check_constraint(
+        "chk_fee_tx_risk_mode",
+        "fee_transactions",
+        "risk_mode IN ('conservative', 'balanced', 'aggressive')",
+    )
+
+
+def downgrade() -> None:
+    """Restore v10-spec values CHECK ('LOW','MIDDLE','HIGH')."""
+    op.drop_constraint("chk_fee_tx_risk_mode", "fee_transactions", type_="check")
+    op.create_check_constraint(
+        "chk_fee_tx_risk_mode",
+        "fee_transactions",
+        "risk_mode IN ('LOW', 'MIDDLE', 'HIGH')",
+    )

--- a/backend/app/billing/v10_models.py
+++ b/backend/app/billing/v10_models.py
@@ -27,10 +27,10 @@ from __future__ import annotations
 
 from datetime import date, datetime, timezone
 from decimal import Decimal
-from enum import Enum
 from typing import Any, Optional
 
 from sqlalchemy import (
+    JSON,
     BigInteger,
     Boolean,
     CheckConstraint,
@@ -48,6 +48,10 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
+#: PostgreSQL では JSONB、それ以外 (SQLite テスト等) では JSON を使う型 alias。
+#: 本番は PG なので JSONB の挙動 (バイナリ格納・GIN index 可能) は維持される。
+_JSONB_OR_JSON = JSONB().with_variant(JSON(), "sqlite")
+
 
 class V10Base(DeclarativeBase):
     """v10 専用 Declarative Base (旧 billing/models.py との衝突回避用).
@@ -62,17 +66,9 @@ class V10Base(DeclarativeBase):
 #: 後方互換のため alias として残置 (F-13 で v9 物理削除時に消去)。
 from app.auth.models import InvestmentTier as FeeTier  # noqa: E402, F401
 
-
-class FeeRiskMode(str, Enum):
-    """v10 リスクモード (F-3 で正式モジュールへ移管予定).
-
-    既存 ``users.risk_mode`` の値 (conservative/balanced/aggressive) とは別空間。
-    F-3 でマッピング辞書を導入する。
-    """
-
-    LOW = "LOW"
-    MIDDLE = "MIDDLE"
-    HIGH = "HIGH"
+#: F-3 で ``app.auth.models.RiskMode`` (conservative/balanced/aggressive) に統合済み。
+#: 後方互換のため alias として残置 (F-13 で v9 物理削除時に消去)。
+from app.auth.models import RiskMode as FeeRiskMode  # noqa: E402, F401
 
 
 class FeeConfigV10(V10Base):
@@ -84,12 +80,16 @@ class FeeConfigV10(V10Base):
 
     __tablename__ = "fee_configs"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer(), "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    )
     config_name: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
-    tier_thresholds_jpy: Mapped[list[int]] = mapped_column(JSONB, nullable=False)
-    tier_fee_rates: Mapped[list[float]] = mapped_column(JSONB, nullable=False)
-    tier_monthly_yield_caps: Mapped[list[float]] = mapped_column(JSONB, nullable=False)
-    subscription_rates: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    tier_thresholds_jpy: Mapped[list[int]] = mapped_column(_JSONB_OR_JSON, nullable=False)
+    tier_fee_rates: Mapped[list[float]] = mapped_column(_JSONB_OR_JSON, nullable=False)
+    tier_monthly_yield_caps: Mapped[list[float]] = mapped_column(_JSONB_OR_JSON, nullable=False)
+    subscription_rates: Mapped[dict[str, Any]] = mapped_column(_JSONB_OR_JSON, nullable=False)
     expense_markup_enabled: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("FALSE")
     )
@@ -136,7 +136,11 @@ class FeeTransaction(V10Base):
 
     __tablename__ = "fee_transactions"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer(), "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    )
     user_id: Mapped[int] = mapped_column(
         Integer,
         ForeignKey("users.id", ondelete="CASCADE"),
@@ -201,7 +205,10 @@ class FeeTransaction(V10Base):
             name="chk_fee_tx_tier",
         ),
         CheckConstraint(
-            "risk_mode IN ('LOW', 'MIDDLE', 'HIGH')",
+            # F-4 (046 マイグレーション): F-3 RiskMode 内部値に揃える。
+            # Aave MDD / Optimizer / Risk Profile が conservative/balanced/aggressive を
+            # 直参照しているため、fee_transactions も同じ値を使う。
+            "risk_mode IN ('conservative', 'balanced', 'aggressive')",
             name="chk_fee_tx_risk_mode",
         ),
         UniqueConstraint("user_id", "calculation_month", name="uq_fee_tx_user_month"),

--- a/backend/scripts/seed_fee_config_v10.py
+++ b/backend/scripts/seed_fee_config_v10.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""v10_default seed data 投入スクリプト (F-4)。
+
+使い方 (staging-new):
+    docker exec ultra-autotrade-backend-staging-new \\
+      python /app/backend/scripts/seed_fee_config_v10.py
+
+使い方 (本番):
+    docs/48_fee_config_seed_runbook.md の 3 段プロンプト手順に従う。
+    F-16 で実施する。
+
+オプション:
+    --dry-run : DB へ書き込まず、投入予定データだけ表示する
+
+冪等性:
+    config_name='v10_default' が is_active=True で既に存在する場合は何もしない (skip)。
+    値変更時の更新手順は docs/48 §4 を参照。
+
+設計:
+    - F-3 の RISK_MODE_SUBSCRIPTION_RATES を直参照することで、spec 値が変わっても
+      auth/models.py 1 箇所変更で seed 出力も自動追従する。
+    - subscription_rates JSONB のキーは F-3 内部値 (conservative/balanced/aggressive)
+      で固定。F-5 / F-6 / F-7 で同じキーを参照する前提。
+    - tier_thresholds_jpy / tier_fee_rates / tier_monthly_yield_caps は v10 spec §1
+      の固定値 (ここ以外には保存場所がないため inline 定義)。
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+# backend/ をパスに追加 (seed_test_data.py と同じパターン)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sqlalchemy import select  # noqa: E402
+from sqlalchemy.orm import Session  # noqa: E402
+
+from app.auth.models import RISK_MODE_SUBSCRIPTION_RATES, RiskMode  # noqa: E402
+from app.billing.v10_models import FeeConfigV10  # noqa: E402
+from app.database import SessionLocal  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+#: JST タイムゾーン (effective_from 用)。
+JST = timezone(timedelta(hours=9))
+
+#: v10 default 設定のレコード名。冪等性チェックのキー。
+V10_DEFAULT_CONFIG_NAME = "v10_default"
+
+#: v10 default が有効になる時刻 (JST 2026-05-01 00:00:00)。
+#: 過去日付に設定することで投入直後から有効になる。
+V10_DEFAULT_EFFECTIVE_FROM = datetime(2026, 5, 1, 0, 0, 0, tzinfo=JST)
+
+
+def build_v10_default_config() -> dict[str, object]:
+    """v10 spec §1 の値を組み立てる。
+
+    F-3 ``RISK_MODE_SUBSCRIPTION_RATES`` を直参照して整合保証。
+    値が将来変わっても auth/models.py 1 箇所修正で本関数の出力も追従する。
+
+    Returns:
+        FeeConfigV10 コンストラクタに渡せる dict。
+    """
+    return {
+        "config_name": V10_DEFAULT_CONFIG_NAME,
+        "tier_thresholds_jpy": [1_000_000, 10_000_000],
+        "tier_fee_rates": [0.30, 0.25, 0.20],
+        "tier_monthly_yield_caps": [0.018, 0.023, 0.030],
+        "subscription_rates": {
+            mode.value: float(RISK_MODE_SUBSCRIPTION_RATES[mode]) for mode in RiskMode
+        },
+        # → {"conservative": 0.0, "balanced": 0.003, "aggressive": 0.01}
+        "expense_markup_enabled": False,
+        "expense_markup_rate": Decimal("0"),
+        "affiliate_rate": Decimal("0.30"),
+        "is_active": True,
+        "effective_from": V10_DEFAULT_EFFECTIVE_FROM,
+    }
+
+
+def seed(db: Session, *, dry_run: bool = False) -> bool:
+    """v10_default を投入する。冪等。
+
+    Args:
+        db: SQLAlchemy セッション。
+        dry_run: True の場合 DB へ書き込まず、投入予定データを表示する。
+
+    Returns:
+        True  = 新規 INSERT を実行 (または dry_run で実行予定だった)
+        False = 既存 active があったため skip
+    """
+    config_data = build_v10_default_config()
+
+    # 既存の v10_default (active / inactive 問わず) があれば skip。
+    # config_name に UNIQUE 制約があり、状態を問わず重複作成は失敗するため。
+    # 値変更時は docs/48 §4 の手順 (新 config_name で投入後にスイッチ) を使う。
+    stmt = select(FeeConfigV10).where(FeeConfigV10.config_name == V10_DEFAULT_CONFIG_NAME)
+    existing = db.execute(stmt).scalar_one_or_none()
+
+    if existing is not None:
+        state = "active" if existing.is_active else "inactive"
+        msg = f"[SKIP] {V10_DEFAULT_CONFIG_NAME} (id={existing.id}, {state}) already exists"
+        logger.info(msg)
+        print(msg)
+        return False
+
+    if dry_run:
+        msg = f"[DRY-RUN] Would insert: {config_data}"
+        logger.info(msg)
+        print(msg)
+        return True
+
+    new_config = FeeConfigV10(**config_data)
+    db.add(new_config)
+    db.commit()
+    db.refresh(new_config)
+
+    msg = f"[OK] Inserted {V10_DEFAULT_CONFIG_NAME} (id={new_config.id})"
+    logger.info(msg)
+    print(msg)
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Seed v10_default FeeConfig")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be inserted without writing to DB",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    with SessionLocal() as db:
+        seed(db, dry_run=args.dry_run)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_seed_fee_config_v10.py
+++ b/backend/tests/test_seed_fee_config_v10.py
@@ -1,0 +1,223 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/test_seed_fee_config_v10.py
+"""F-4: backend/scripts/seed_fee_config_v10.py のテスト。
+
+関連:
+- backend/scripts/seed_fee_config_v10.py
+- backend/app/billing/v10_models.py (FeeConfigV10 / V10Base)
+- backend/app/auth/models.py (RISK_MODE_SUBSCRIPTION_RATES)
+- docs/48_fee_config_seed_runbook.md
+
+設計メモ:
+- v10_models.py は専用 V10Base (別 metadata) を使うため、
+  fixture で V10Base.metadata.create_all() を別途呼ぶ必要がある。
+- SQLite は JSONB を JSON テキストとして保存する (テスト用途では透過的)。
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from collections.abc import Generator
+from datetime import timezone
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+# scripts/ をパスに追加 (本番と同じ sys.path 操作)
+_BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-seed-fee-config")
+
+from app.billing.v10_models import FeeConfigV10  # noqa: E402
+from scripts.seed_fee_config_v10 import (  # noqa: E402
+    V10_DEFAULT_CONFIG_NAME,
+    build_v10_default_config,
+    seed,
+)
+
+# ---------------------------------------------------------------------------
+# Pure unit tests on build_v10_default_config (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildV10DefaultConfig:
+    """v10 spec §1 の値が正しく組み立てられることを保証する。"""
+
+    def test_config_name(self) -> None:
+        config = build_v10_default_config()
+        assert config["config_name"] == "v10_default"
+
+    def test_subscription_rates_use_internal_values(self) -> None:
+        """F-3 内部値 (conservative/balanced/aggressive) を キーとして使う。"""
+        config = build_v10_default_config()
+        rates = config["subscription_rates"]
+        assert isinstance(rates, dict)
+        assert "conservative" in rates
+        assert "balanced" in rates
+        assert "aggressive" in rates
+        assert set(rates.keys()) == {"conservative", "balanced", "aggressive"}
+
+    def test_subscription_rate_values_match_f3_spec(self) -> None:
+        config = build_v10_default_config()
+        rates = config["subscription_rates"]
+        assert rates["conservative"] == 0.0
+        assert rates["balanced"] == 0.003
+        assert rates["aggressive"] == 0.01  # Decimal("0.010") → float(0.01)
+
+    def test_tier_thresholds_match_v10_spec(self) -> None:
+        config = build_v10_default_config()
+        assert config["tier_thresholds_jpy"] == [1_000_000, 10_000_000]
+
+    def test_tier_fee_rates_match_v10_spec(self) -> None:
+        config = build_v10_default_config()
+        assert config["tier_fee_rates"] == [0.30, 0.25, 0.20]
+
+    def test_tier_monthly_yield_caps_match_v10_spec(self) -> None:
+        config = build_v10_default_config()
+        assert config["tier_monthly_yield_caps"] == [0.018, 0.023, 0.030]
+
+    def test_affiliate_rate_is_decimal(self) -> None:
+        config = build_v10_default_config()
+        assert config["affiliate_rate"] == Decimal("0.30")
+        assert isinstance(config["affiliate_rate"], Decimal)
+
+    def test_expense_markup_disabled_by_default(self) -> None:
+        config = build_v10_default_config()
+        assert config["expense_markup_enabled"] is False
+        assert config["expense_markup_rate"] == Decimal("0")
+
+    def test_is_active_default_true(self) -> None:
+        config = build_v10_default_config()
+        assert config["is_active"] is True
+
+    def test_effective_from_is_jst_aware(self) -> None:
+        """effective_from は JST タイムゾーン aware である。"""
+        config = build_v10_default_config()
+        eff = config["effective_from"]
+        assert eff.tzinfo is not None
+        # JST は UTC+9
+        assert (
+            eff.utcoffset()
+            == timezone.utc.utcoffset(eff) + (eff.utcoffset() - timezone.utc.utcoffset(eff))
+            or eff.utcoffset().total_seconds() == 9 * 3600
+        )
+
+
+# ---------------------------------------------------------------------------
+# DB integration tests on seed() (sync SessionLocal pattern)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def v10_db() -> Generator[Session, None, None]:
+    """fee_configs テーブルだけ持つ SQLite テスト DB を作る。
+
+    fee_transactions は users テーブル (別 Base) への FK を持つため
+    V10Base.metadata.create_all は失敗する。seed テスト (fee_configs のみ操作)
+    のスコープでは fee_configs テーブル単体で十分。
+    """
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    FeeConfigV10.__table__.create(bind=engine)  # type: ignore[attr-defined]
+    SessionFactory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = SessionFactory()
+    try:
+        yield db
+    finally:
+        db.close()
+        FeeConfigV10.__table__.drop(bind=engine)  # type: ignore[attr-defined]
+        engine.dispose()
+        os.unlink(path)
+
+
+class TestSeedIdempotency:
+    """同じスクリプトを何度実行しても安全 (冪等)。"""
+
+    def test_seed_inserts_when_no_active(self, v10_db: Session) -> None:
+        result = seed(v10_db)
+        assert result is True
+
+        rows = v10_db.query(FeeConfigV10).all()
+        assert len(rows) == 1
+        assert rows[0].config_name == V10_DEFAULT_CONFIG_NAME
+        assert rows[0].is_active is True
+
+    def test_seed_skips_when_active_exists(self, v10_db: Session) -> None:
+        # 1 回目: 投入
+        first = seed(v10_db)
+        assert first is True
+
+        # 2 回目: skip
+        second = seed(v10_db)
+        assert second is False
+
+        # レコードは 1 行のまま
+        assert v10_db.query(FeeConfigV10).count() == 1
+
+    def test_seed_skips_when_inactive_exists(self, v10_db: Session) -> None:
+        """v10_default が inactive として存在する場合も skip する。
+
+        config_name に UNIQUE 制約があり、状態を問わず重複作成は失敗する。
+        値変更時は docs/48 §4 の手順 (新 config_name で投入してスイッチ) を使う。
+        """
+        config_data = build_v10_default_config()
+        config_data["is_active"] = False
+        old = FeeConfigV10(**config_data)
+        v10_db.add(old)
+        v10_db.commit()
+
+        # inactive でも skip → 1 行のまま
+        result = seed(v10_db)
+        assert result is False
+        assert v10_db.query(FeeConfigV10).count() == 1
+
+
+class TestSeedDryRun:
+    """--dry-run はDB に書き込まない。"""
+
+    def test_dry_run_does_not_insert(self, v10_db: Session) -> None:
+        result = seed(v10_db, dry_run=True)
+        assert result is True  # 実行予定の意
+
+        # DB は空のまま
+        assert v10_db.query(FeeConfigV10).count() == 0
+
+    def test_dry_run_with_existing_active_skips(self, v10_db: Session) -> None:
+        # 既存 active 投入
+        seed(v10_db)
+        # dry-run でも skip
+        result = seed(v10_db, dry_run=True)
+        assert result is False
+        assert v10_db.query(FeeConfigV10).count() == 1
+
+
+class TestSeededRowMatchesSpec:
+    """投入後のレコードが v10 spec 値を保持することを保証する。"""
+
+    def test_seeded_row_subscription_rates(self, v10_db: Session) -> None:
+        seed(v10_db)
+        row = v10_db.query(FeeConfigV10).one()
+        assert row.subscription_rates == {
+            "conservative": 0.0,
+            "balanced": 0.003,
+            "aggressive": 0.01,
+        }
+
+    def test_seeded_row_tier_thresholds(self, v10_db: Session) -> None:
+        seed(v10_db)
+        row = v10_db.query(FeeConfigV10).one()
+        assert row.tier_thresholds_jpy == [1_000_000, 10_000_000]
+
+    def test_seeded_row_affiliate_rate(self, v10_db: Session) -> None:
+        seed(v10_db)
+        row = v10_db.query(FeeConfigV10).one()
+        # SQLite では NUMERIC が文字列として返ることがあるため Decimal 比較
+        assert Decimal(str(row.affiliate_rate)) == Decimal("0.30")

--- a/docs/48_fee_config_seed_runbook.md
+++ b/docs/48_fee_config_seed_runbook.md
@@ -1,0 +1,214 @@
+# FeeConfig v10_default 本番投入 Runbook (F-4)
+
+> 最終更新: 2026-04-25
+> 関連: `docs/45_fee_model_v10_migration_plan.md` §3 / §4 F-4 行
+> Asana: F-4 (1214120401381545)
+> 実行タイミング: **F-16 本番リリース時** (本ドキュメントは設計のみ。F-4 では実行しない)
+> セット: F-1 (045 DDL) → F-4 (046 CHECK + seed) → F-16 (本番適用)
+
+---
+
+## 0. 前提
+
+- F-1 マイグレーション (`045_fee_v10_tables.sql`) **本番適用済み**
+- F-4 マイグレーション (`046_fee_v10_check_constraint_alignment.sql`) **本番適用済み**
+- F-15 山本さんレビュー完了
+- 山本さんへの事前周知完了 (24h 前 DM)
+
+### staging-new 試験結果 (2026-04-25)
+
+| 項目 | 結果 |
+|------|------|
+| 046 SQL 適用 | ✅ `chk_fee_tx_risk_mode` を ('conservative','balanced','aggressive') に更新 |
+| seed 相当 INSERT 投入 | ✅ `fee_configs` に v10_default レコード 1 行 |
+| CHECK 動作確認 (positive) | ✅ `risk_mode='conservative'` で INSERT 成功 |
+| CHECK 動作確認 (negative) | ✅ `risk_mode='LOW'` で chk_fee_tx_risk_mode 違反 |
+
+---
+
+## 1. 事前バックアップ
+
+```bash
+# fee_configs / fee_transactions の現状を保存
+docker exec ultra-autotrade-postgres-production pg_dump \
+  -U ultra -d ultra_autotrade \
+  -t fee_configs -t fee_transactions \
+  > /tmp/fee_v10_backup_$(date +%Y%m%d).sql
+```
+
+---
+
+## 2. 投入実行 (3 段プロンプト方式、claude.ai 事前承認必須)
+
+### Phase A: 事前確認 (read-only, 5 分)
+
+```bash
+# A1. fee_configs の現状 (空であること)
+docker exec ultra-autotrade-postgres-production psql -U ultra -d ultra_autotrade -c "
+SELECT COUNT(*) FROM fee_configs;
+SELECT COUNT(*) FROM fee_configs WHERE config_name='v10_default';
+"
+# 期待: count=0 / 0 (F-16 でも未投入)
+
+# A2. CHECK 制約が 046 適用済みであることを確認
+docker exec ultra-autotrade-postgres-production psql -U ultra -d ultra_autotrade -c "
+\d fee_transactions
+" | grep chk_fee_tx_risk_mode
+# 期待: CHECK (risk_mode IN ('conservative','balanced','aggressive'))
+
+# A3. backend health check
+curl -sf https://api.ultra-auto-trade.com/health | python3 -m json.tool
+# 期待: status=ok, scheduler=true
+
+# A4. F-3 の RISK_MODE_SUBSCRIPTION_RATES が本番コードに反映済みか
+docker exec ultra-autotrade-backend-production grep -A3 "RISK_MODE_SUBSCRIPTION_RATES" \
+  /app/backend/app/auth/models.py
+# 期待: CONSERVATIVE: Decimal("0"), BALANCED: Decimal("0.003"), AGGRESSIVE: Decimal("0.010")
+```
+
+### Phase B: プラン提示 → claude.ai 承認
+
+| 項目 | 値 |
+|------|-----|
+| 実行コマンド | `python /app/backend/scripts/seed_fee_config_v10.py` |
+| 期待される変更 | `fee_configs` に 1 行 INSERT (`config_name=v10_default`, `is_active=true`) |
+| 想定実行時間 | < 5 秒 |
+| ロールバック条件 | INSERT 後の検証クエリで subscription_rates が想定値と異なる場合 |
+| 想定停止時間 | ゼロ (バックエンドは無停止) |
+
+### Phase C: 実行 (5 分)
+
+```bash
+# C1. dry-run でデータ確認
+docker exec -w /app/backend ultra-autotrade-backend-production \
+  python scripts/seed_fee_config_v10.py --dry-run
+# 期待: [DRY-RUN] Would insert: {...} (実 INSERT なし)
+
+# C2. 実投入
+docker exec -w /app/backend ultra-autotrade-backend-production \
+  python scripts/seed_fee_config_v10.py
+# 期待: [OK] Inserted v10_default (id=1)
+
+# C3. 冪等性確認 (もう一度実行 → skip)
+docker exec -w /app/backend ultra-autotrade-backend-production \
+  python scripts/seed_fee_config_v10.py
+# 期待: [SKIP] v10_default (id=1, active) already exists
+```
+
+---
+
+## 3. 検証
+
+```sql
+-- レコード確認
+SELECT
+  id,
+  config_name,
+  is_active,
+  subscription_rates,
+  tier_thresholds_jpy,
+  tier_fee_rates,
+  tier_monthly_yield_caps,
+  affiliate_rate,
+  effective_from
+FROM fee_configs;
+```
+
+**期待値**:
+| カラム | 期待値 |
+|--------|--------|
+| id | 1 |
+| config_name | `v10_default` |
+| is_active | `t` (true) |
+| subscription_rates | `{"conservative": 0.0, "balanced": 0.003, "aggressive": 0.01}` |
+| tier_thresholds_jpy | `[1000000, 10000000]` |
+| tier_fee_rates | `[0.30, 0.25, 0.20]` |
+| tier_monthly_yield_caps | `[0.018, 0.023, 0.030]` |
+| affiliate_rate | `0.30` |
+| effective_from | `2026-04-30 15:00:00+00` (= 2026-05-01 00:00 JST) |
+
+```bash
+# CHECK 制約動作確認 (positive)
+docker exec ultra-autotrade-postgres-production psql -U ultra -d ultra_autotrade -c "
+BEGIN;
+INSERT INTO fee_transactions (user_id, calculation_month, tier, risk_mode, deposit_amount_jpy)
+VALUES (1, '2026-05-01', 'LOWER', 'conservative', 0);
+ROLLBACK;
+"
+# 期待: INSERT 0 1 → ROLLBACK (成功)
+```
+
+---
+
+## 4. 値変更時の更新手順 (将来運用)
+
+`subscription_rates` 等の値を変更する場合:
+
+1. `backend/app/auth/models.py` の `RISK_MODE_SUBSCRIPTION_RATES` 等を更新 (PR レビュー必須)
+2. `backend/scripts/seed_fee_config_v10.py` の `V10_DEFAULT_CONFIG_NAME` を新名 (`v10_default_v2` 等) に変更 (PR レビュー必須)
+3. デプロイ後、新 seed 実行で新 config を INSERT
+4. 動作確認
+5. 旧 config を `is_active=false` に手動 UPDATE
+6. 新 config を `is_active=true` に手動 UPDATE
+7. `idx_fee_configs_active_effective` index により AI スケジューラーは即座に新 config を参照する
+
+```sql
+-- 切替例
+UPDATE fee_configs SET is_active = false WHERE config_name = 'v10_default';
+UPDATE fee_configs SET is_active = true WHERE config_name = 'v10_default_v2';
+```
+
+---
+
+## 5. ロールバック手順
+
+### Phase C 直後に問題発覚した場合
+
+```sql
+BEGIN;
+DELETE FROM fee_configs WHERE config_name = 'v10_default';
+COMMIT;
+```
+
+### バックアップから完全復元 (24h 以内)
+
+```bash
+docker exec ultra-autotrade-postgres-production psql -U ultra -d ultra_autotrade <<EOF
+TRUNCATE fee_configs CASCADE;
+\i /tmp/fee_v10_backup_YYYYMMDD.sql
+EOF
+```
+
+---
+
+## 6. ロールアウト後監視
+
+| チェック項目 | 方法 | 頻度 |
+|--------------|------|------|
+| `fee_configs` レコード数 | `SELECT COUNT(*) FROM fee_configs;` | 直後 |
+| AI スケジューラーが v10_default を参照 | `docker logs --tail=100 ultra-autotrade-backend-production \| grep -i 'fee_config\|v10_default'` | 1h 後 |
+| CHECK 違反エラー | `docker logs ... \| grep 'chk_fee_tx_'` | 24h 監視 |
+| 山本さん配下異常報告 | Slack `#ultra-auto-project` | 24h 監視 |
+
+---
+
+## 7. 設計判断 (F-4 で確定したこと)
+
+| 項目 | 採用案 | 理由 |
+|------|--------|------|
+| risk_mode CHECK 制約 | F-3 内部値に揃える (`'conservative','balanced','aggressive'`) | Aave MDD / Optimizer / Risk Profile が小文字内部値を直参照中。fee_calculator (F-5) で大文字変換層を入れずに済む |
+| tier CHECK 制約 | F-2 値のまま (`'LOWER','MIDDLE','UPPER'`) | F-2 InvestmentTier と既に整合済み (大文字 3 値)。fee_transactions は新規テーブルのため GENERAL 混入リスクなし |
+| seed の冪等性 | `config_name` 一致なら **状態問わず skip** | UNIQUE 制約により重複作成不可。値変更は §4 の新名スイッチ手順で対応 |
+| `subscription_rates` JSON キー | F-3 内部値 (lowercase) で固定 | F-5/F-6/F-7 で同じキーを参照する前提 |
+| seed script の値ソース | F-3 `RISK_MODE_SUBSCRIPTION_RATES` を **直参照** | spec 値変更時に auth/models.py 1 箇所修正で seed 出力も自動追従 |
+| v10_models.py の SQLite 互換 | `JSONB().with_variant(JSON(), "sqlite")` + `BigInteger().with_variant(Integer(), "sqlite")` | 本番は PG (JSONB/BIGINT 維持)、テストは SQLite で動作 |
+
+---
+
+## 8. 引き継ぎ
+
+| タスク | 引き継ぎ事項 |
+|--------|--------------|
+| F-5 (fee_calculator) | `subscription_rates` JSONB を読むときは F-3 内部値キー (`conservative` 等) を使う |
+| F-13 (v9 物理削除) | `seed_fee_config_v10.py` はそのまま残置 (fee_configs 自体は v10 で生き続ける) |
+| F-16 (本番リリース) | 本ドキュメント §1〜3 の手順を実行 |


### PR DESCRIPTION
## Summary

v10 spec §1 の値を \`fee_configs\` テーブルに投入する seed script を作成し、staging-new で動作確認。F-1 の \`risk_mode\` CHECK 制約を F-3 内部値に揃える 046 マイグレーションも同梱。本番投入は F-16 で実施。

\`docs/45_fee_model_v10_migration_plan.md\` §3 / §4 F-4 行 (PR #121) の方針に従う。

## 設計判断 (実装前に確定)

### CHECK 制約調整: **採用**

F-1 045 SQL の \`risk_mode\` CHECK = \`('LOW','MIDDLE','HIGH')\` と F-3 の \`RiskMode\` 内部値 \`('conservative','balanced','aggressive')\` が **不整合** だった。

Aave MDD / Optimizer / Risk Profile が小文字内部値を直参照しているため、CHECK 側を F-3 に揃える方針 (046 マイグレーション) を採用。これで F-5 fee_calculator が大文字変換層を持たずに済む。

| 制約 | F-1 | F-4 (採用) | 整合先 |
|------|-----|------------|--------|
| risk_mode | ('LOW','MIDDLE','HIGH') | **('conservative','balanced','aggressive')** | F-3 RiskMode 内部値 |
| tier | ('LOWER','MIDDLE','UPPER') | 変更なし | F-2 InvestmentTier (既に整合) |

## 主な変更

### 1. CHECK 制約調整 (046)

- \`backend/alembic/sql/046_fee_v10_check_constraint_alignment.sql\` (Hetzner 手動適用用)
- \`backend/alembic/versions/e5f6a7b8c9d0_check_constraint_alignment.py\` (Alembic 等価)

### 2. v10_models.py 整備

- \`FeeTransaction.__table_args__\` の \`CheckConstraint\` も同値に更新
- \`FeeRiskMode\` を独自 enum 廃止 → \`app.auth.models.RiskMode\` の alias に置換 (F-13 で削除)
- \`JSONB → JSONB().with_variant(JSON(), \"sqlite\")\` に変更 (テスト互換)
- \`BigInteger PK → BigInteger().with_variant(Integer(), \"sqlite\")\` に変更 (autoincrement テスト互換)
- 本番 PG では JSONB / BIGINT そのまま、SQLite テストでは JSON / INTEGER で動作

### 3. seed script (\`backend/scripts/seed_fee_config_v10.py\`)

- F-3 の \`RISK_MODE_SUBSCRIPTION_RATES\` を **直参照** → 値変更時の自動追従
- subscription_rates JSONB キーは F-3 内部値 (\`conservative\` / \`balanced\` / \`aggressive\`)
- \`tier_thresholds_jpy\` / \`tier_fee_rates\` / \`tier_monthly_yield_caps\` は v10 spec inline
- 冪等性: \`config_name='v10_default'\` が active/inactive 問わず存在すれば skip
- \`--dry-run\` 対応
- sync \`SessionLocal\` pattern (既存 \`seed_test_data.py\` と同じ)

### 4. テスト (18 件 4 クラス)

- \`TestBuildV10DefaultConfig\` (10 件): spec 値の組み立て
- \`TestSeedIdempotency\` (3 件): 冪等性 + UNIQUE 制約挙動
- \`TestSeedDryRun\` (2 件): \`--dry-run\` の no-write 確認
- \`TestSeededRowMatchesSpec\` (3 件): DB 投入後のレコード検証

### 5. staging-new 試験結果

| 検証 | 結果 |
|------|------|
| 046 SQL 適用 | ✅ \`chk_fee_tx_risk_mode\` を ('conservative','balanced','aggressive') に更新確認 |
| seed 相当 INSERT 投入 | ✅ subscription_rates 構造 = seed と完全一致 |
| CHECK positive | ✅ \`risk_mode='conservative'\` で INSERT 成功 |
| CHECK negative | ✅ \`risk_mode='LOW'\` で chk_fee_tx_risk_mode 違反 |

注: staging container は F-3 未デプロイのため Python script 直接実行は \`ImportError\`。SQL 直接投入で v10_default のデータ形式を検証 (本番では F-3 デプロイ済みのため Python script が使える)。

### 6. docs/48_fee_config_seed_runbook.md

- F-16 用 3 段プロンプト (Phase A 事前確認 / B プラン提示 / C 実行)
- 値変更時の更新手順 (新 \`config_name\` でスイッチ)
- ロールバック / 24h 監視項目

## 検証

\`\`\`
verify.sh 全 7 ゲート pass (301s)
- test_seed_fee_config_v10.py: 18 passed (新規)
- 既存無回帰: test_billing (42), test_risk_mode (24), test_tier_service (30)
- staging-new DB: 046 適用 + INSERT 試験完了
\`\`\`

## 山本さん本番テストへの影響: **ゼロ**

- 本番 DB は read-only / 一切 INSERT/UPDATE なし
- staging-new でのみ 046 適用 + 試験 INSERT
- 本番投入は F-16 で実施 (docs/48 の 3 段プロンプト runbook に従う)

## Test plan

- [x] verify.sh 全 7 ゲート pass
- [x] staging-new で 046 SQL 適用 + CHECK 動作確認
- [x] staging-new で v10_default データ形式の SQL 直接投入成功
- [x] 冪等性テスト (active/inactive 両方で skip)
- [ ] F-3 PR #124 マージ → staging deploy → seed script を Python で再実行 (本番投入の前段確認)
- [ ] F-5 で \`subscription_rates\` JSONB を読む際に F-3 内部値キーを使う
- [ ] F-16 で \`docs/48\` §2 の 3 段プロンプトを実行

## Asana

- F-4: https://app.asana.com/0/1213741124336104/1214120401381545
- F-3: https://app.asana.com/0/1213741124336104/1214120401362419 (PR #124)
- F-2: https://app.asana.com/0/1213741124336104/1214120248237710 (PR #123)
- F-1: https://app.asana.com/0/1213741124336104/1214120248239215 (PR #122)
- F-0: https://app.asana.com/0/1213741124336104/1214120338928565 (PR #121)

🤖 Generated with [Claude Code](https://claude.com/claude-code)