### PR TITLE
F-8a: v10 fees API endpoints (read-only中心) (#1214120371503131)

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""API v1 routers (Fee Model v10 〜)。"""

--- a/backend/app/api/v1/fees.py
+++ b/backend/app/api/v1/fees.py
@@ -1,0 +1,451 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/api/v1/fees.py
+"""F-8a: v10 fees API endpoints (read-only 中心 + simulate)。
+
+旧 ``/api/billing/*`` (billing/router.py) と ``/api/fees/calculate|schedule``
+(aave/fee_router.py) は **本タスクでは無変更**。F-8b で廃止 + フロント差し替え予定。
+
+新規 endpoints:
+- GET  /api/v1/fees/config              認証済み: 現行 active fee_config 取得
+- GET  /api/v1/fees/my-summary          自分のみ: 累計手数料サマリ
+- GET  /api/v1/fees/my-history          自分のみ: 月別履歴 (最新 N 件)
+- POST /api/v1/fees/simulate            認証済み: F-5 calculator 直呼び (DB 書込なし)
+- GET  /api/v1/fees/affiliate-earnings  自分のみ: アフィリエイト報酬履歴
+- GET  /api/v1/fees/all-users           admin: 全ユーザー手数料一覧
+- POST /api/v1/fees/finalize-month      admin: 501 (F-7 で本実装)
+- GET  /api/v1/fees/uata-income         admin: UATa 収入集計
+
+設計:
+- プロジェクトは sync (SessionLocal) のため、async ではなく sync handler を使用
+- Decimal は Pydantic で str に直列化 (フロントは ``Number(str).toFixed()`` で受ける、
+  CLAUDE.md "Decimal型 → Number() ラップ" メモリ準拠)
+- Pydantic レスポンスは Pydantic v2 の ``model_config = ConfigDict(from_attributes=True)``
+
+関連:
+- F-5 ``app.fees.calculator`` (純粋関数エンジン)
+- F-1 ``app.billing.v10_models`` (FeeConfigV10 / FeeTransaction)
+- F-3 ``app.auth.models`` (RiskMode / InvestmentTier)
+- docs/45_fee_model_v10_migration_plan.md §4 F-8 行
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.auth.dependencies import require_active_user, require_admin
+from app.auth.models import InvestmentTier, RiskMode, User
+from app.billing.v10_models import FeeConfigV10, FeeTransaction
+from app.database import get_db
+from app.fees import FeeCalculationInput, FeeCalculator
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/fees", tags=["fees-v10"])
+
+# ===== current month 起点 =====
+_FIRST_DAY_OF_MONTH = 1
+
+
+def _today_month_start() -> date:
+    today = date.today()
+    return today.replace(day=_FIRST_DAY_OF_MONTH)
+
+
+# ===========================================================================
+# Pydantic schemas
+# ===========================================================================
+
+
+class FeeConfigResponse(BaseModel):
+    """現行 active fee_config (v10_default 等)。"""
+
+    config_name: str
+    tier_thresholds_jpy: list[int]
+    tier_fee_rates: list[float]
+    tier_monthly_yield_caps: list[float]
+    subscription_rates: dict[str, float]
+    expense_markup_enabled: bool
+    expense_markup_rate: str  # Decimal → str
+    affiliate_rate: str
+    is_active: bool
+    effective_from: datetime
+
+
+class FeeSummaryResponse(BaseModel):
+    """ユーザー単位の累計サマリ。"""
+
+    user_id: int
+    total_fee_paid_jpy: str
+    total_subscription_paid_jpy: str
+    total_user_takehome_jpy: str
+    total_yield_excess_to_uata_jpy: str
+    months_count: int
+
+
+class FeeHistoryItemResponse(BaseModel):
+    """月次履歴の 1 行。"""
+
+    model_config = ConfigDict(from_attributes=False)
+
+    calculation_month: date
+    tier: str
+    risk_mode: str
+    deposit_jpy: str
+    net_profit_jpy: str
+    fee_amount_jpy: str
+    subscription_amount_jpy: str
+    user_takehome_jpy: str
+    finalized_at: datetime | None = None
+
+
+class AffiliateEarningItemResponse(BaseModel):
+    """アフィリエイト報酬の 1 行 (自分が affiliate_id として記録された月)。"""
+
+    calculation_month: date
+    invitee_user_id: int
+    invitee_subscription_amount_jpy: str
+    affiliate_amount_jpy: str
+    finalized_at: datetime | None = None
+
+
+class AllUsersFeeItemResponse(BaseModel):
+    """admin 用全ユーザー手数料一覧の 1 行。"""
+
+    user_id: int
+    calculation_month: date
+    tier: str
+    risk_mode: str
+    deposit_jpy: str
+    net_profit_jpy: str
+    fee_amount_jpy: str
+    subscription_amount_jpy: str
+    user_takehome_jpy: str
+    affiliate_id: int | None
+    affiliate_amount_jpy: str
+    finalized_at: datetime | None
+
+
+class SimulateRequest(BaseModel):
+    """v10 計算シミュレーション入力。DB 書込なし。"""
+
+    deposit_jpy: Decimal = Field(ge=0)
+    gross_profit_jpy: Decimal
+    expense_jpy: Decimal = Field(default=Decimal("0"), ge=0)
+    user_tier: InvestmentTier
+    user_risk_mode: RiskMode
+    is_first_month: bool = False
+    affiliate_id: int | None = None
+
+
+class SimulateResponse(BaseModel):
+    """``FeeCalculationResult`` の API 露出版 (Decimal → str)。"""
+
+    net_profit_jpy: str
+    fee_rate_applied: str
+    fee_amount_jpy: str
+    subscription_rate_applied: str
+    subscription_amount_jpy: str
+    subscription_protected: bool
+    monthly_yield_cap_applied: str
+    yield_excess_to_uata_jpy: str
+    user_takehome_jpy: str
+    affiliate_amount_jpy: str
+
+
+class UataIncomeResponse(BaseModel):
+    """admin 用 UATa 収入集計レスポンス。"""
+
+    month_from: date
+    month_to: date
+    subscription_total: str
+    fee_total: str
+    yield_excess_total: str
+    affiliate_payout_total: str
+    uata_income_total: str  # subscription + fee + yield_excess - affiliate
+
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+
+def _get_active_fee_config(db: Session = Depends(get_db)) -> FeeConfigV10:
+    """現行 active な FeeConfigV10 を返す。なければ 503。"""
+    stmt = (
+        select(FeeConfigV10)
+        .where(FeeConfigV10.is_active.is_(True))
+        .order_by(FeeConfigV10.effective_from.desc())
+        .limit(1)
+    )
+    config = db.execute(stmt).scalar_one_or_none()
+    if config is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Fee config not initialized. Run scripts/seed_fee_config_v10.py.",
+        )
+    return config
+
+
+def _decimal_str(value: Decimal | int | float | None) -> str:
+    """Decimal/None を str に直列化 (None → '0')。"""
+    if value is None:
+        return "0"
+    return str(value if isinstance(value, Decimal) else Decimal(str(value)))
+
+
+# ===========================================================================
+# Endpoints
+# ===========================================================================
+
+
+@router.get("/config", response_model=FeeConfigResponse, summary="現行 active fee_config 取得")
+def get_fee_config(
+    _user: User = Depends(require_active_user),
+    config: FeeConfigV10 = Depends(_get_active_fee_config),
+) -> FeeConfigResponse:
+    return FeeConfigResponse(
+        config_name=config.config_name,
+        tier_thresholds_jpy=list(config.tier_thresholds_jpy),
+        tier_fee_rates=[float(r) for r in config.tier_fee_rates],
+        tier_monthly_yield_caps=[float(c) for c in config.tier_monthly_yield_caps],
+        subscription_rates={k: float(v) for k, v in config.subscription_rates.items()},
+        expense_markup_enabled=config.expense_markup_enabled,
+        expense_markup_rate=_decimal_str(config.expense_markup_rate),
+        affiliate_rate=_decimal_str(config.affiliate_rate),
+        is_active=config.is_active,
+        effective_from=config.effective_from,
+    )
+
+
+@router.get(
+    "/my-summary",
+    response_model=FeeSummaryResponse,
+    summary="自分の累計手数料サマリ",
+)
+def get_my_fee_summary(
+    user: User = Depends(require_active_user),
+    db: Session = Depends(get_db),
+) -> FeeSummaryResponse:
+    stmt = select(
+        func.count(FeeTransaction.id).label("months_count"),
+        func.coalesce(func.sum(FeeTransaction.fee_amount_jpy), 0).label("total_fee"),
+        func.coalesce(func.sum(FeeTransaction.subscription_amount_jpy), 0).label("total_sub"),
+        func.coalesce(func.sum(FeeTransaction.user_takehome_jpy), 0).label("total_takehome"),
+        func.coalesce(func.sum(FeeTransaction.yield_excess_to_uata_jpy), 0).label("total_excess"),
+    ).where(FeeTransaction.user_id == user.id)
+    row = db.execute(stmt).one()
+    return FeeSummaryResponse(
+        user_id=user.id,
+        total_fee_paid_jpy=_decimal_str(row.total_fee),
+        total_subscription_paid_jpy=_decimal_str(row.total_sub),
+        total_user_takehome_jpy=_decimal_str(row.total_takehome),
+        total_yield_excess_to_uata_jpy=_decimal_str(row.total_excess),
+        months_count=int(row.months_count or 0),
+    )
+
+
+@router.get(
+    "/my-history",
+    response_model=list[FeeHistoryItemResponse],
+    summary="自分の月別履歴 (最新 N 件)",
+)
+def get_my_fee_history(
+    user: User = Depends(require_active_user),
+    db: Session = Depends(get_db),
+    limit: int = Query(default=24, ge=1, le=120),
+) -> list[FeeHistoryItemResponse]:
+    stmt = (
+        select(FeeTransaction)
+        .where(FeeTransaction.user_id == user.id)
+        .order_by(FeeTransaction.calculation_month.desc())
+        .limit(limit)
+    )
+    rows = db.execute(stmt).scalars().all()
+    return [
+        FeeHistoryItemResponse(
+            calculation_month=r.calculation_month,
+            tier=r.tier,
+            risk_mode=r.risk_mode,
+            deposit_jpy=_decimal_str(r.deposit_amount_jpy),
+            net_profit_jpy=_decimal_str(r.net_profit_jpy),
+            fee_amount_jpy=_decimal_str(r.fee_amount_jpy),
+            subscription_amount_jpy=_decimal_str(r.subscription_amount_jpy),
+            user_takehome_jpy=_decimal_str(r.user_takehome_jpy),
+            finalized_at=r.finalized_at,
+        )
+        for r in rows
+    ]
+
+
+@router.post(
+    "/simulate",
+    response_model=SimulateResponse,
+    summary="v10 計算シミュレーション (DB 書込なし)",
+)
+def simulate_fee(
+    payload: SimulateRequest,
+    user: User = Depends(require_active_user),
+    config: FeeConfigV10 = Depends(_get_active_fee_config),
+) -> SimulateResponse:
+    calculator = FeeCalculator(config)
+    result = calculator.calculate_monthly(
+        FeeCalculationInput(
+            user_id=user.id,
+            calculation_month=_today_month_start(),
+            deposit_jpy=payload.deposit_jpy,
+            gross_profit_jpy=payload.gross_profit_jpy,
+            expense_jpy=payload.expense_jpy,
+            user_tier=payload.user_tier,
+            user_risk_mode=payload.user_risk_mode,
+            affiliate_id=payload.affiliate_id,
+            is_first_month=payload.is_first_month,
+        )
+    )
+    return SimulateResponse(
+        net_profit_jpy=_decimal_str(result.net_profit_jpy),
+        fee_rate_applied=_decimal_str(result.fee_rate_applied),
+        fee_amount_jpy=_decimal_str(result.fee_amount_jpy),
+        subscription_rate_applied=_decimal_str(result.subscription_rate_applied),
+        subscription_amount_jpy=_decimal_str(result.subscription_amount_jpy),
+        subscription_protected=result.subscription_protected,
+        monthly_yield_cap_applied=_decimal_str(result.monthly_yield_cap_applied),
+        yield_excess_to_uata_jpy=_decimal_str(result.yield_excess_to_uata_jpy),
+        user_takehome_jpy=_decimal_str(result.user_takehome_jpy),
+        affiliate_amount_jpy=_decimal_str(result.affiliate_amount_jpy),
+    )
+
+
+@router.get(
+    "/affiliate-earnings",
+    response_model=list[AffiliateEarningItemResponse],
+    summary="自分が招待者として記録された月別 affiliate 報酬",
+)
+def get_my_affiliate_earnings(
+    user: User = Depends(require_active_user),
+    db: Session = Depends(get_db),
+    limit: int = Query(default=24, ge=1, le=120),
+) -> list[AffiliateEarningItemResponse]:
+    stmt = (
+        select(FeeTransaction)
+        .where(FeeTransaction.affiliate_id == user.id)
+        .order_by(FeeTransaction.calculation_month.desc())
+        .limit(limit)
+    )
+    rows = db.execute(stmt).scalars().all()
+    return [
+        AffiliateEarningItemResponse(
+            calculation_month=r.calculation_month,
+            invitee_user_id=r.user_id,
+            invitee_subscription_amount_jpy=_decimal_str(r.subscription_amount_jpy),
+            affiliate_amount_jpy=_decimal_str(r.affiliate_amount_jpy),
+            finalized_at=r.finalized_at,
+        )
+        for r in rows
+    ]
+
+
+@router.get(
+    "/all-users",
+    response_model=list[AllUsersFeeItemResponse],
+    summary="全ユーザー手数料一覧 (admin)",
+    dependencies=[Depends(require_admin)],
+)
+def list_all_users_fees(
+    db: Session = Depends(get_db),
+    month: date | None = Query(
+        default=None,
+        description="YYYY-MM-DD (月初日)。省略時は今月。",
+    ),
+) -> list[AllUsersFeeItemResponse]:
+    target_month = month or _today_month_start()
+    stmt = (
+        select(FeeTransaction)
+        .where(FeeTransaction.calculation_month == target_month)
+        .order_by(FeeTransaction.user_id)
+    )
+    rows = db.execute(stmt).scalars().all()
+    return [
+        AllUsersFeeItemResponse(
+            user_id=r.user_id,
+            calculation_month=r.calculation_month,
+            tier=r.tier,
+            risk_mode=r.risk_mode,
+            deposit_jpy=_decimal_str(r.deposit_amount_jpy),
+            net_profit_jpy=_decimal_str(r.net_profit_jpy),
+            fee_amount_jpy=_decimal_str(r.fee_amount_jpy),
+            subscription_amount_jpy=_decimal_str(r.subscription_amount_jpy),
+            user_takehome_jpy=_decimal_str(r.user_takehome_jpy),
+            affiliate_id=r.affiliate_id,
+            affiliate_amount_jpy=_decimal_str(r.affiliate_amount_jpy),
+            finalized_at=r.finalized_at,
+        )
+        for r in rows
+    ]
+
+
+@router.post(
+    "/finalize-month",
+    summary="月次 finalize (F-7 で本実装、現状スケルトン)",
+    dependencies=[Depends(require_admin)],
+)
+def finalize_month(month: date) -> dict[str, Any]:
+    """F-7 (1214120401388139) で本実装予定。本タスクでは 501 を返すスケルトン。"""
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail=(
+            "Not yet implemented. Will be implemented in F-7 "
+            "(Asana 1214120401388139). Requested month: "
+            f"{month.isoformat()}"
+        ),
+    )
+
+
+@router.get(
+    "/uata-income",
+    response_model=UataIncomeResponse,
+    summary="UATa 収入集計 (admin)",
+    dependencies=[Depends(require_admin)],
+)
+def get_uata_income(
+    db: Session = Depends(get_db),
+    month_from: date = Query(..., description="開始月初日 (inclusive)"),
+    month_to: date = Query(..., description="終了月初日 (inclusive)"),
+) -> UataIncomeResponse:
+    if month_from > month_to:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="month_from must be <= month_to",
+        )
+    stmt = select(
+        func.coalesce(func.sum(FeeTransaction.subscription_amount_jpy), 0).label("subscription"),
+        func.coalesce(func.sum(FeeTransaction.fee_amount_jpy), 0).label("fee"),
+        func.coalesce(func.sum(FeeTransaction.yield_excess_to_uata_jpy), 0).label("yield_excess"),
+        func.coalesce(func.sum(FeeTransaction.affiliate_amount_jpy), 0).label("affiliate"),
+    ).where(
+        FeeTransaction.calculation_month >= month_from,
+        FeeTransaction.calculation_month <= month_to,
+    )
+    row = db.execute(stmt).one()
+    sub_d = Decimal(str(row.subscription))
+    fee_d = Decimal(str(row.fee))
+    excess_d = Decimal(str(row.yield_excess))
+    aff_d = Decimal(str(row.affiliate))
+    uata = sub_d + fee_d + excess_d - aff_d
+    return UataIncomeResponse(
+        month_from=month_from,
+        month_to=month_to,
+        subscription_total=_decimal_str(sub_d),
+        fee_total=_decimal_str(fee_d),
+        yield_excess_total=_decimal_str(excess_d),
+        affiliate_payout_total=_decimal_str(aff_d),
+        uata_income_total=_decimal_str(uata),
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -40,6 +40,7 @@ from app.ai.feedback_router import router as ai_feedback_router
 from app.ai.router import router as ai_router
 from app.api.alias_router import router as alias_router
 from app.api.automation_dashboard import router as automation_dashboard_router
+from app.api.v1.fees import router as fees_v10_router
 from app.auth.router import router as auth_router
 from app.auth.service import AuthService
 from app.automation.automation_router import router as automation_router
@@ -228,6 +229,8 @@ def create_app() -> FastAPI:
     app.include_router(data_feeds_router)  # External data feeds (Phase 2)
     app.include_router(reports_router, prefix="/api/reports")  # Monthly reports
     app.include_router(billing_router)
+    # F-8a: Fee Model v10 API (/api/v1/fees/*)。既存 billing/fee_router は併存維持 (F-8b で廃止予定)。
+    app.include_router(fees_v10_router, prefix="/api/v1")
     app.include_router(ai_decisions_router)  # AI Decisions API
     app.include_router(ai_feedback_router)  # AI Feedback API (Layer 4)
     app.include_router(transactions_router)  # Transactions API

--- a/backend/tests/test_api_v1_fees.py
+++ b/backend/tests/test_api_v1_fees.py
@@ -1,0 +1,714 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/test_api_v1_fees.py
+"""F-8a: ``/api/v1/fees/*`` 8 endpoints のテスト。
+
+カバー範囲:
+- 認可: 401 (未認証) / 403 (権限不足) / 200 (正常)
+- 正常系: レスポンス構造、Decimal が文字列で返る
+- 空データ: my-summary は 0 / months_count=0、my-history は []
+- simulate: F-5 FeeCalculator と完全一致
+- admin endpoints: all-users, uata-income, finalize-month (501)
+
+DB は SQLite テスト DB (Base + V10Base 両方を create_all)。
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Generator
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ["JWT_SECRET_KEY"] = "test-secret-key-api-v1-fees"
+os.environ["JWT_ALGORITHM"] = "HS256"
+os.environ["JWT_ACCESS_TOKEN_EXPIRE_MINUTES"] = "30"
+os.environ["INITIAL_ADMIN_EMAIL"] = "fees_admin@example.com"
+
+from app.auth.models import InvestmentTier, RiskMode, User, UserRole  # noqa: E402
+from app.auth.schemas import UserCreateRequest  # noqa: E402
+from app.auth.service import AuthService  # noqa: E402
+from app.billing.v10_models import FeeConfigV10, FeeTransaction, V10Base  # noqa: E402
+from app.database import Base, get_db  # noqa: E402
+from app.fees import FeeCalculationInput, FeeCalculator  # noqa: E402
+from app.main import create_app  # noqa: E402
+from tests.helpers.fee_config_factory import make_v10_default_config  # noqa: E402
+
+_JST = timezone(timedelta(hours=9))
+
+# FeeTransaction の FK ('users.id') が別 metadata を参照しているため、
+# テスト用に users テーブル定義を V10Base.metadata に複製する (1 度だけ)。
+# 本番 PG では Alembic SQL で全テーブルが同一 schema に作成されるため不要。
+if "users" not in V10Base.metadata.tables:
+    User.__table__.to_metadata(V10Base.metadata)  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def test_db() -> Generator[tuple, None, None]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    # 旧 app.billing.models.FeeConfig が Base.metadata で fee_configs を作成済み。
+    # 同名で v10 版 (FeeConfigV10、別 metadata) を作るため、旧版を drop してから再作成する。
+    Base.metadata.tables["fee_configs"].drop(bind=engine)
+    if "fee_calculations" in Base.metadata.tables:
+        Base.metadata.tables["fee_calculations"].drop(bind=engine)
+    if "high_water_marks" in Base.metadata.tables:
+        Base.metadata.tables["high_water_marks"].drop(bind=engine)
+    FeeConfigV10.__table__.create(bind=engine)  # type: ignore[attr-defined]
+    FeeTransaction.__table__.create(bind=engine)  # type: ignore[attr-defined]
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    def override_get_db() -> Generator[Session, None, None]:
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    yield override_get_db, SessionLocal
+    FeeTransaction.__table__.drop(bind=engine)  # type: ignore[attr-defined]
+    FeeConfigV10.__table__.drop(bind=engine)  # type: ignore[attr-defined]
+    Base.metadata.drop_all(bind=engine)
+    os.unlink(path)
+
+
+@pytest.fixture()
+def client(test_db) -> TestClient:
+    override_get_db, _ = test_db
+    os.environ["INITIAL_ADMIN_EMAIL"] = "fees_admin@example.com"
+    app = create_app()
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app)
+
+
+def _seed_active_config(db: Session) -> FeeConfigV10:
+    """make_v10_default_config を DB に投入する。"""
+    cfg = make_v10_default_config()
+    db.add(cfg)
+    db.commit()
+    db.refresh(cfg)
+    return cfg
+
+
+def _register_admin(client: TestClient) -> str:
+    """初回 register で admin になる → access_token を返す。"""
+    client.post(
+        "/auth/register",
+        json={
+            "email": "fees_admin@example.com",
+            "username": "feesadmin",
+            "password": "adminpassword123",
+        },
+    )
+    r = client.post(
+        "/auth/login",
+        json={"email": "fees_admin@example.com", "password": "adminpassword123"},
+    )
+    return r.json()["access_token"]
+
+
+def _create_user(
+    SessionFactory,
+    *,
+    email: str,
+    username: str,
+    role: UserRole = UserRole.VIEWER,
+    password: str = "password123",
+) -> int:
+    """admin 経由で登録できないため、AuthService 直叩きでテスト用ユーザー作成。"""
+    with SessionFactory() as db:
+        req = UserCreateRequest(email=email, username=username, password=password, role=role)
+        user = AuthService.create_user(db, req)
+        return user.id
+
+
+def _login(client: TestClient, email: str, password: str = "password123") -> str:
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+def _add_fee_tx(
+    SessionFactory,
+    *,
+    user_id: int,
+    month: date,
+    fee_amount: Decimal = Decimal("1000"),
+    sub_amount: Decimal = Decimal("3000"),
+    takehome: Decimal = Decimal("23000"),
+    excess: Decimal = Decimal("0"),
+    affiliate_id: int | None = None,
+    affiliate_amount: Decimal = Decimal("0"),
+    finalized: bool = False,
+) -> None:
+    with SessionFactory() as db:
+        tx = FeeTransaction(
+            user_id=user_id,
+            calculation_month=month,
+            tier="MIDDLE",
+            risk_mode="balanced",
+            deposit_amount_jpy=Decimal("1000000"),
+            gross_profit_jpy=Decimal("100000"),
+            expense_jpy=Decimal("0"),
+            net_profit_jpy=Decimal("100000"),
+            fee_rate_applied=Decimal("0.25"),
+            fee_amount_jpy=fee_amount,
+            subscription_rate_applied=Decimal("0.003"),
+            subscription_amount_jpy=sub_amount,
+            subscription_protected=False,
+            monthly_yield_cap_applied=Decimal("0.023"),
+            yield_excess_to_uata_jpy=excess,
+            user_takehome_jpy=takehome,
+            affiliate_id=affiliate_id,
+            affiliate_amount_jpy=affiliate_amount,
+            finalized_at=datetime.now(timezone.utc) if finalized else None,
+        )
+        db.add(tx)
+        db.commit()
+
+
+# ===========================================================================
+# Authorization (401 / 403)
+# ===========================================================================
+
+
+class TestAuthorization:
+    """各 endpoint の認可境界テスト。"""
+
+    def test_config_unauthenticated_returns_401(self, client: TestClient) -> None:
+        r = client.get("/api/v1/fees/config")
+        assert r.status_code == 401
+
+    def test_my_summary_unauthenticated_returns_401(self, client: TestClient) -> None:
+        r = client.get("/api/v1/fees/my-summary")
+        assert r.status_code == 401
+
+    def test_my_history_unauthenticated_returns_401(self, client: TestClient) -> None:
+        r = client.get("/api/v1/fees/my-history")
+        assert r.status_code == 401
+
+    def test_simulate_unauthenticated_returns_401(self, client: TestClient) -> None:
+        r = client.post(
+            "/api/v1/fees/simulate",
+            json={
+                "deposit_jpy": "1000000",
+                "gross_profit_jpy": "10000",
+                "user_tier": "LOWER",
+                "user_risk_mode": "conservative",
+            },
+        )
+        assert r.status_code == 401
+
+    def test_affiliate_earnings_unauthenticated_returns_401(self, client: TestClient) -> None:
+        r = client.get("/api/v1/fees/affiliate-earnings")
+        assert r.status_code == 401
+
+    def test_all_users_requires_admin(self, client: TestClient, test_db) -> None:
+        _, SessionFactory = test_db
+        # 初回 register で admin が出来るが、もう 1 人 viewer を作る
+        _register_admin(client)
+        _create_user(SessionFactory, email="viewer@example.com", username="viewer1")
+        token = _login(client, "viewer@example.com")
+        r = client.get(
+            "/api/v1/fees/all-users",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 403
+
+    def test_uata_income_requires_admin(self, client: TestClient, test_db) -> None:
+        _, SessionFactory = test_db
+        _register_admin(client)
+        _create_user(SessionFactory, email="viewer@example.com", username="viewer1")
+        token = _login(client, "viewer@example.com")
+        r = client.get(
+            "/api/v1/fees/uata-income?month_from=2026-05-01&month_to=2026-05-01",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 403
+
+    def test_finalize_month_requires_admin(self, client: TestClient, test_db) -> None:
+        _, SessionFactory = test_db
+        _register_admin(client)
+        _create_user(SessionFactory, email="viewer@example.com", username="viewer1")
+        token = _login(client, "viewer@example.com")
+        r = client.post(
+            "/api/v1/fees/finalize-month?month=2026-05-01",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 403
+
+
+# ===========================================================================
+# /config endpoint
+# ===========================================================================
+
+
+class TestFeeConfigEndpoint:
+    def test_503_when_no_active_config(self, client: TestClient) -> None:
+        token = _register_admin(client)
+        r = client.get(
+            "/api/v1/fees/config",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 503
+
+    def test_200_returns_v10_default(self, client: TestClient, test_db) -> None:
+        _, SessionFactory = test_db
+        with SessionFactory() as db:
+            _seed_active_config(db)
+        token = _register_admin(client)
+        r = client.get(
+            "/api/v1/fees/config",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["config_name"] == "v10_default"
+        assert body["tier_thresholds_jpy"] == [1000000, 10000000]
+        assert body["tier_fee_rates"] == [0.30, 0.25, 0.20]
+        assert body["subscription_rates"]["conservative"] == 0.0
+        assert body["subscription_rates"]["balanced"] == 0.003
+        # Numeric(6,4) のため "0.3000" として返る
+        assert Decimal(body["affiliate_rate"]) == Decimal("0.30")
+        assert body["is_active"] is True
+
+
+# ===========================================================================
+# /my-summary endpoint
+# ===========================================================================
+
+
+class TestMySummaryEndpoint:
+    def test_returns_zeros_when_no_transactions(self, client: TestClient, test_db) -> None:
+        _, SessionFactory = test_db
+        with SessionFactory() as db:
+            _seed_active_config(db)
+        token = _register_admin(client)
+        r = client.get(
+            "/api/v1/fees/my-summary",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["months_count"] == 0
+        # SQLAlchemy SUM の coalesce 結果は SQLite で 0 を返すが、Numeric(18,2) 列の合計は
+        # PG では "0.00" になる。Decimal 比較で 0 一致を確認。
+        assert Decimal(body["total_fee_paid_jpy"]) == Decimal("0")
+        assert Decimal(body["total_subscription_paid_jpy"]) == Decimal("0")
+
+    def test_aggregates_only_own_transactions(self, client: TestClient, test_db) -> None:
+        _, SessionFactory = test_db
+        with SessionFactory() as db:
+            _seed_active_config(db)
+        # admin (user1) 登録 + viewer (user2) 作成
+        token = _register_admin(client)
+        with SessionFactory() as db:
+            admin_id = AuthService.get_user_by_email(db, "fees_admin@example.com").id
+        viewer_id = _create_user(SessionFactory, email="other@example.com", username="other1")
+
+        # admin に 2 ヶ月、other に 1 ヶ月
+        _add_fee_tx(
+            SessionFactory,
+            user_id=admin_id,
+            month=date(2026, 4, 1),
+            fee_amount=Decimal("1000"),
+            sub_amount=Decimal("3000"),
+        )
+        _add_fee_tx(
+            SessionFactory,
+            user_id=admin_id,
+            month=date(2026, 5, 1),
+            fee_amount=Decimal("2000"),
+            sub_amount=Decimal("3000"),
+        )
+        _add_fee_tx(
+            SessionFactory,
+            user_id=viewer_id,
+            month=date(2026, 4, 1),
+            fee_amount=Decimal("9999"),
+            sub_amount=Decimal("9999"),
+        )
+
+        r = client.get(
+            "/api/v1/fees/my-summary",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        body = r.json()
+        # admin の 2 ヶ月分のみ
+        assert body["months_count"] == 2
+        assert Decimal(body["total_fee_paid_jpy"]) == Decimal("3000")  # 1000 + 2000
+        assert Decimal(body["total_subscription_paid_jpy"]) == Decimal("6000")  # 3000 + 3000
+
+
+# ===========================================================================
+# /my-history endpoint
+# ===========================================================================
+
+
+class TestMyHistoryEndpoint:
+    def test_empty_returns_empty_list(self, client: TestClient, test_db) -> None:
+        _, SessionFactory = test_db
+        with SessionFactory() as db:
+            _seed_active_config(db)
+        token = _register_admin(client)
+        r = client.get(
+            "/api/v1/fees/my-history",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        assert r.json() == []
+
+    def test_returns_only_own_history_desc(self, client: TestClient, test_db) -> None:
+        _, SessionFactory = test_db
+        with SessionFactory() as db:
+            _seed_active_config(db)
+        token = _register_admin(client)
+        with SessionFactory() as db:
+            admin_id = AuthService.get_user_by_email(db, "fees_admin@example.com").id
+        other_id = _create_user(SessionFactory, email="other@example.com", username="other1")
+
+        _add_fee_tx(SessionFactory, user_id=admin_id, month=date(2026, 4, 1))
+        _add_fee_tx(SessionFactory, user_id=admin_id, month=date(2026, 5, 1))
+        _add_fee_tx(SessionFactory, user_id=other_id, month=date(2026, 5, 1))
+
+        r = client.get(
+            "/api/v1/fees/my-history",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        rows = r.json()
+        assert len(rows) == 2
+        # 降順
+        assert rows[0]["calculation_month"] == "2026-05-01"
+        assert rows[1]["calculation_month"] == "2026-04-01"
+
+    def test_limit_param_caps_results(self, client: TestClient, test_db) -> None:
+        _, SessionFactory = test_db
+        with SessionFactory() as db:
+            _seed_active_config(db)
+        token = _register_admin(client)
+        with SessionFactory() as db:
+            admin_id = AuthService.get_user_by_email(db, "fees_admin@example.com").id
+        for m in (1, 2, 3, 4, 5):
+            _add_fee_tx(SessionFactory, user_id=admin_id, month=date(2026, m, 1))
+
+        r = client.get(
+            "/api/v1/fees/my-history?limit=2",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        rows = r.json()
+        assert len(rows) == 2
+        assert rows[0]["calculation_month"] == "2026-05-01"
+
+
+# ===========================================================================
+# /simulate endpoint — must match FeeCalculator
+# ===========================================================================
+
+
+class TestSimulateMatchesCalculator:
+    def test_simulate_matches_calculator_lower_conservative(
+        self, client: TestClient, test_db
+    ) -> None:
+        _, SessionFactory = test_db
+        with SessionFactory() as db:
+            _seed_active_config(db)
+        token = _register_admin(client)
+        with SessionFactory() as db:
+            admin_id = AuthService.get_user_by_email(db, "fees_admin@example.com").id
+
+        payload = {
+            "deposit_jpy": "100000",
+            "gross_profit_jpy": "1000",
+            "expense_jpy": "100",
+            "user_tier": "LOWER",
+            "user_risk_mode": "conservative",
+            "is_first_month": False,
+        }
+        r = client.post(
+            "/api/v1/fees/simulate",
+            json=payload,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+
+        # F-5 を直接呼んで一致確認
+        config = make_v10_default_config()
+        calc = FeeCalculator(config)
+        expected = calc.calculate_monthly(
+            FeeCalculationInput(
+                user_id=admin_id,
+                calculation_month=date.today().replace(day=1),
+                deposit_jpy=Decimal("100000"),
+                gross_profit_jpy=Decimal("1000"),
+                expense_jpy=Decimal("100"),
+                user_tier=InvestmentTier.LOWER,
+                user_risk_mode=RiskMode.CONSERVATIVE,
+                is_first_month=False,
+            )
+        )
+        assert body["net_profit_jpy"] == str(expected.net_profit_jpy)
+        assert body["fee_amount_jpy"] == str(expected.fee_amount_jpy)
+        assert body["user_takehome_jpy"] == str(expected.user_takehome_jpy)
+        assert body["subscription_protected"] == expected.subscription_protected
+
+    def test_simulate_subscription_protection_branch(self, client: TestClient, test_db) -> None:
+        _, SessionFactory = test_db
+        with SessionFactory() as db:
+            _seed_active_config(db)
+        token = _register_admin(client)
+        # balanced + 1000 利益 (sub=3000 > 1000) → 保護発動
+        r = client.post(
+            "/api/v1/fees/simulate",
+            json={
+                "deposit_jpy": "1000000",
+                "gross_profit_jpy": "1000",
+                "user_tier": "MIDDLE",
+                "user_risk_mode": "balanced",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        body = r.json()
+        assert body["subscription_protected"] is True
+        assert body["subscription_amount_jpy"] == "0"
+        assert body["yield_excess_to_uata_jpy"] == "1000"
+        assert body["user_takehome_jpy"] == "0"
+
+    def test_simulate_first_month_zero_subscription(self, client: TestClient, test_db) -> None:
+        _, SessionFactory = test_db
+        with SessionFactory() as db:
+            _seed_active_config(db)
+        token = _register_admin(client)
+        r = client.post(
+            "/api/v1/fees/simulate",
+            json={
+                "deposit_jpy": "1000000",
+                "gross_profit_jpy": "10000",
+                "user_tier": "MIDDLE",
+                "user_risk_mode": "balanced",
+                "is_first_month": True,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        body = r.json()
+        assert body["subscription_rate_applied"] == "0"
+        assert body["subscription_amount_jpy"] == "0"
+
+    def test_simulate_503_when_no_active_config(self, client: TestClient) -> None:
+        token = _register_admin(client)
+        r = client.post(
+            "/api/v1/fees/simulate",
+            json={
+                "deposit_jpy": "100000",
+                "gross_profit_jpy": "1000",
+                "user_tier": "LOWER",
+                "user_risk_mode": "conservative",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 503
+
+
+# ===========================================================================
+# /affiliate-earnings endpoint
+# ===========================================================================
+
+
+class TestAffiliateEarningsEndpoint:
+    def test_empty_returns_empty_list(self, client: TestClient, test_db) -> None:
+        _, SessionFactory = test_db
+        with SessionFactory() as db:
+            _seed_active_config(db)
+        token = _register_admin(client)
+        r = client.get(
+            "/api/v1/fees/affiliate-earnings",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        assert r.json() == []
+
+    def test_returns_rows_where_self_is_affiliate(self, client: TestClient, test_db) -> None:
+        _, SessionFactory = test_db
+        with SessionFactory() as db:
+            _seed_active_config(db)
+        token = _register_admin(client)
+        with SessionFactory() as db:
+            admin_id = AuthService.get_user_by_email(db, "fees_admin@example.com").id
+        invitee_id = _create_user(SessionFactory, email="invitee@example.com", username="inv1")
+
+        # invitee の月次に admin が affiliate として記録されている
+        _add_fee_tx(
+            SessionFactory,
+            user_id=invitee_id,
+            month=date(2026, 5, 1),
+            sub_amount=Decimal("3000"),
+            affiliate_id=admin_id,
+            affiliate_amount=Decimal("900"),
+        )
+
+        r = client.get(
+            "/api/v1/fees/affiliate-earnings",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        rows = r.json()
+        assert len(rows) == 1
+        assert rows[0]["invitee_user_id"] == invitee_id
+        assert Decimal(rows[0]["affiliate_amount_jpy"]) == Decimal("900")
+        assert Decimal(rows[0]["invitee_subscription_amount_jpy"]) == Decimal("3000")
+
+
+# ===========================================================================
+# Admin: /all-users
+# ===========================================================================
+
+
+class TestAllUsersEndpoint:
+    def test_admin_gets_all_users_for_month(self, client: TestClient, test_db) -> None:
+        _, SessionFactory = test_db
+        with SessionFactory() as db:
+            _seed_active_config(db)
+        token = _register_admin(client)
+        with SessionFactory() as db:
+            admin_id = AuthService.get_user_by_email(db, "fees_admin@example.com").id
+        other_id = _create_user(SessionFactory, email="other@example.com", username="other1")
+
+        _add_fee_tx(SessionFactory, user_id=admin_id, month=date(2026, 5, 1))
+        _add_fee_tx(SessionFactory, user_id=other_id, month=date(2026, 5, 1))
+        _add_fee_tx(SessionFactory, user_id=admin_id, month=date(2026, 4, 1))
+
+        r = client.get(
+            "/api/v1/fees/all-users?month=2026-05-01",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        rows = r.json()
+        # 2026-05-01 の 2 件のみ (4 月分は含まれない)
+        assert len(rows) == 2
+        user_ids = {row["user_id"] for row in rows}
+        assert {admin_id, other_id} == user_ids
+
+    def test_admin_default_month_is_current(self, client: TestClient, test_db) -> None:
+        _, SessionFactory = test_db
+        with SessionFactory() as db:
+            _seed_active_config(db)
+        token = _register_admin(client)
+        with SessionFactory() as db:
+            admin_id = AuthService.get_user_by_email(db, "fees_admin@example.com").id
+        current_month = date.today().replace(day=1)
+        _add_fee_tx(SessionFactory, user_id=admin_id, month=current_month)
+
+        # month 引数省略
+        r = client.get(
+            "/api/v1/fees/all-users",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        rows = r.json()
+        assert len(rows) == 1
+
+
+# ===========================================================================
+# Admin: /finalize-month (501 stub)
+# ===========================================================================
+
+
+class TestFinalizeMonthStub:
+    def test_returns_501_with_f7_reference(self, client: TestClient) -> None:
+        token = _register_admin(client)
+        r = client.post(
+            "/api/v1/fees/finalize-month?month=2026-05-01",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 501
+        assert "F-7" in r.json()["detail"] or "1214120401388139" in r.json()["detail"]
+
+
+# ===========================================================================
+# Admin: /uata-income
+# ===========================================================================
+
+
+class TestUataIncomeEndpoint:
+    def test_empty_range_returns_zeros(self, client: TestClient) -> None:
+        token = _register_admin(client)
+        r = client.get(
+            "/api/v1/fees/uata-income?month_from=2026-05-01&month_to=2026-05-01",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert Decimal(body["subscription_total"]) == Decimal("0")
+        assert Decimal(body["fee_total"]) == Decimal("0")
+        assert Decimal(body["yield_excess_total"]) == Decimal("0")
+        assert Decimal(body["affiliate_payout_total"]) == Decimal("0")
+        assert Decimal(body["uata_income_total"]) == Decimal("0")
+
+    def test_aggregates_within_range(self, client: TestClient, test_db) -> None:
+        _, SessionFactory = test_db
+        token = _register_admin(client)
+        with SessionFactory() as db:
+            admin_id = AuthService.get_user_by_email(db, "fees_admin@example.com").id
+
+        # 4 月: sub 3000, fee 1000, excess 500, affiliate 900
+        _add_fee_tx(
+            SessionFactory,
+            user_id=admin_id,
+            month=date(2026, 4, 1),
+            fee_amount=Decimal("1000"),
+            sub_amount=Decimal("3000"),
+            excess=Decimal("500"),
+            affiliate_amount=Decimal("900"),
+        )
+        # 5 月: 範囲外 (month_to=4月)
+        _add_fee_tx(SessionFactory, user_id=admin_id, month=date(2026, 5, 1))
+
+        r = client.get(
+            "/api/v1/fees/uata-income?month_from=2026-04-01&month_to=2026-04-30",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        body = r.json()
+        assert Decimal(body["subscription_total"]) == Decimal("3000")
+        assert Decimal(body["fee_total"]) == Decimal("1000")
+        assert Decimal(body["yield_excess_total"]) == Decimal("500")
+        assert Decimal(body["affiliate_payout_total"]) == Decimal("900")
+        # uata_income = 3000 + 1000 + 500 - 900 = 3600
+        assert Decimal(body["uata_income_total"]) == Decimal("3600")
+
+    def test_invalid_range_returns_400(self, client: TestClient) -> None:
+        token = _register_admin(client)
+        r = client.get(
+            "/api/v1/fees/uata-income?month_from=2026-06-01&month_to=2026-05-01",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 400
+
+
+# ===========================================================================
+# Coexistence: 既存 /api/billing/* / /api/fees/* が無回帰
+# ===========================================================================
+
+
+class TestCoexistenceWithLegacyEndpoints:
+    """F-8a 投入後も既存 endpoint が登録されていることを 404 でないことで確認。"""
+
+    def test_legacy_billing_config_route_registered(self, client: TestClient) -> None:
+        # auth なしで叩いても 401 / 422 が返る (404 ではない = ルート存在)
+        r = client.get("/api/billing/config")
+        assert r.status_code != 404, "/api/billing/config route was removed!"
+
+    def test_legacy_fees_calculate_route_registered(self, client: TestClient) -> None:
+        r = client.get("/api/fees/calculate?aum_usd=1000")
+        assert r.status_code != 404, "/api/fees/calculate route was removed!"

--- a/docs/integration/backend_deps.md
+++ b/docs/integration/backend_deps.md
@@ -44,6 +44,16 @@
 
 ---
 
+
+### 変更 #4: F-8a v10 fees router 登録 (PR #127 / 2026-04-25)
+- **コミット範囲**: `d55a53c` (feature/f8a-fees-api-readonly)
+- **変更内容**:
+  - `from app.api.v1 import fees as fees_v10_router` を追加
+  - `app.include_router(fees_v10_router.router, prefix="/api/v1")` を `billing_router` の直後に追加
+- **理由**: F-8a (Asana 1214120371503131) — v10 fees API endpoints (/api/v1/fees/*) を FastAPI app に登録。既存 /api/billing/* と /api/fees/calculate|schedule は無変更で併存維持 (F-8b GID 1214288467406433 で廃止予定)。
+- **影響範囲**: 新規 router 追加のみ。既存 endpoint への影響なし。`TestCoexistenceWithLegacyEndpoints` (2件) で既存 endpoint の404でないことを保証。
+- **承認**: feature/f8a-fees-api-readonly → main の通常フロー経由（PR #127）
+
 ## backend/app/database.py
 
 変更なし（現時点）

--- a/docs/ops/01_api_endpoints.md
+++ b/docs/ops/01_api_endpoints.md
@@ -103,12 +103,32 @@
 | GET | `/api/transparency/risk-profile` | 🔑 | リスクプロファイル |
 | GET | `/api/transparency/risk-profile/{mode}` | 🔑 | モード別リスクプロファイル |
 
-## 手数料計算 `/api/fees`
+## 手数料計算 `/api/fees` (v9 旧、F-8b で廃止予定)
 
 | Method | Path | 認証 | 説明 |
 |--------|------|------|------|
-| GET | `/api/fees/calculate` | 🔑 | 手数料計算 |
-| GET | `/api/fees/schedule` | 🔑 | 手数料スケジュール |
+| GET | `/api/fees/calculate` | 🔑 | 手数料計算 (旧) |
+| GET | `/api/fees/schedule` | 🔑 | 手数料スケジュール (旧) |
+
+> **DEPRECATED**: F-8b (Asana 1214288467406433) で廃止予定。F-8a で `/api/v1/fees/*` (下記) に置換。
+> 本タスク (F-8a, PR #126 以降) では併存中。
+
+## 手数料 v10 `/api/v1/fees` (F-8a 新規)
+
+Fee Model v10 read-only 中心 + simulate。F-1〜F-5 (FeeConfigV10 / FeeTransaction / FeeCalculator) を消費する。
+
+| Method | Path | 認証 | 説明 |
+|--------|------|------|------|
+| GET  | `/api/v1/fees/config`              | 🔑 | 現行 active fee_config 取得 |
+| GET  | `/api/v1/fees/my-summary`          | 🔑 | 自分の累計手数料サマリ |
+| GET  | `/api/v1/fees/my-history`          | 🔑 | 自分の月別履歴 (最新 N 件、`?limit=N`) |
+| POST | `/api/v1/fees/simulate`            | 🔑 | v10 計算シミュレーション (DB 書込なし) |
+| GET  | `/api/v1/fees/affiliate-earnings` | 🔑 | 自分が招待者として記録された月別 affiliate 報酬 |
+| GET  | `/api/v1/fees/all-users`           | 👑 | 全ユーザー手数料一覧 (`?month=YYYY-MM-DD`) |
+| POST | `/api/v1/fees/finalize-month`      | 👑 | 月次 finalize (現状 501、F-7 で本実装) |
+| GET  | `/api/v1/fees/uata-income`         | 👑 | UATa 収入集計 (`?month_from&month_to`) |
+
+**Decimal 返却**: 金額系フィールドは Decimal を文字列で返す (例: `"3000"` `"0.30"`)。フロントは `Number(str).toFixed()` で扱う (CLAUDE.md "Decimal型 → Number() ラップ" メモリ準拠)。
 
 ---
 
@@ -218,7 +238,11 @@
 
 ---
 
-## Billing `/api/billing`
+## Billing `/api/billing` (v9 旧、F-8b で廃止予定)
+
+> **DEPRECATED**: F-8b (Asana 1214288467406433) で廃止予定。`/api/v1/fees/*` (上記) に置換。
+> 本タスク (F-8a) 時点では併存中。フロント差し替えも F-8b で対応。
+
 
 | Method | Path | 認証 | 説明 |
 |--------|------|------|------|


### PR DESCRIPTION
## Summary

\`backend/app/api/v1/fees.py\` を新規作成。v10 仕様の read-only API endpoints (8件) を追加。**既存 \`/api/billing/*\` と \`/api/fees/calculate|schedule\` は無変更で併存維持** (F-8b で廃止 + フロント差し替え予定)。

\`docs/45_fee_model_v10_migration_plan.md\` §4 F-8 行 (PR #121) の方針に従う。

## 新規 endpoints (8件)

| Method | Path | 認可 | 用途 |
|--------|------|------|------|
| GET  | /api/v1/fees/config              | 認証済み | 現行 active fee_config 取得 |
| GET  | /api/v1/fees/my-summary          | 自分のみ | 累計サマリ |
| GET  | /api/v1/fees/my-history          | 自分のみ | 月別履歴 (最新 N 件、\`?limit=N\`) |
| POST | /api/v1/fees/simulate            | 認証済み | F-5 calculator 直呼び (DB 書込なし) |
| GET  | /api/v1/fees/affiliate-earnings  | 自分のみ | アフィリエイト報酬履歴 |
| GET  | /api/v1/fees/all-users           | admin    | 全ユーザー手数料一覧 (\`?month=YYYY-MM-DD\`) |
| POST | /api/v1/fees/finalize-month      | admin    | **501 (F-7 で本実装、本タスクはスケルトン)** |
| GET  | /api/v1/fees/uata-income         | admin    | UATa 収入集計 (\`?month_from&month_to\`) |

## 主な変更

### 1. backend/app/api/v1/__init__.py + fees.py 新規 (361 行)

- sync (\`SessionLocal\`) パターン (タスク仕様の async ではなく既存プロジェクトに合わせる)
- Pydantic レスポンスは Decimal を str にシリアライズ (フロントは \`Number(str).toFixed()\`、CLAUDE.md メモリ準拠)
- \`_get_active_fee_config\` dependency: active な \`FeeConfigV10\` がなければ 503
- \`require_active_user\` / \`require_admin\` で認可制御

### 2. backend/app/main.py

- \`app.include_router(fees_v10_router, prefix=\"/api/v1\")\` を \`billing_router\` の直後に追加
- 既存 \`/api/billing/*\` / \`/api/fees/calculate|schedule\` は登録そのまま維持

### 3. backend/tests/test_api_v1_fees.py 新規 (29 ケース 9 クラス)

| クラス | ケース数 | 内容 |
|--------|---------|------|
| TestAuthorization | 8 | 401/403 境界 |
| TestFeeConfigEndpoint | 2 | 503 (config 未投入) / 200 |
| TestMySummaryEndpoint | 2 | 空データ 0、自分のみ集計 |
| TestMyHistoryEndpoint | 3 | 空配列、降順、limit cap |
| TestSimulateMatchesCalculator | 4 | F-5 と完全一致 / 保護分岐 / 初月 / 503 |
| TestAffiliateEarningsEndpoint | 2 | 空配列 / 自分が affiliate のレコード |
| TestAllUsersEndpoint | 2 | 月指定 / 当月デフォルト |
| TestFinalizeMonthStub | 1 | 501 + F-7 GID 参照 |
| TestUataIncomeEndpoint | 3 | 空 0、集計、month_from > to で 400 |
| TestCoexistenceWithLegacyEndpoints | 2 | /api/billing/config と /api/fees/calculate が 404 でないこと |

### 4. docs/ops/01_api_endpoints.md

- 旧 \`/api/fees/*\` / \`/api/billing/*\` セクションに **DEPRECATED + F-8b 廃止予定** の注記
- 新 \`/api/v1/fees/*\` セクションを 8 endpoints + Decimal 文字列返却ルール込みで追加

## 設計判断

- **sync パターン採用**: 既存プロジェクトが \`SessionLocal\` (sync) のため。タスク仕様の async は使わない
- **auth dep を最初に評価**: \`/config\` と \`/simulate\` で \`_user\` を最初に書き、503 (config 未投入) より先に 401 (未認証) が出るようにした
- **\`Annotated\` ではなく \`= Depends()\` 形式**: \`Annotated[Session, Depends(...)]\` が FastAPI で response field として誤認識されたため、既存 \`auth/router.py\` パターンに揃える
- **テスト fixture の FK 解決**: \`V10Base\` の FK が \`users\` (\`Base\`) を参照するため、\`User.__table__.to_metadata(V10Base.metadata)\` でテスト用にメタデータ共有
- **旧 \`fee_configs\` テーブル衝突回避**: \`Base.metadata.create_all\` 後に旧 \`fee_configs\` / \`fee_calculations\` / \`high_water_marks\` を drop してから \`FeeConfigV10\` / \`FeeTransaction\` を create

## 検証

\`\`\`
verify.sh 全 7 ゲート pass (317s)
- test_api_v1_fees.py:    29 passed (新規)
- test_billing_*:         42 passed (回帰なし)
- test_fee_calculator:    28 passed
- test_dynamic_fee:       47 passed
- test_seed_fee_config_v10: 18 passed
- test_risk_mode:         24 passed
- test_tier_service:      30 passed
- test_auth:              84 passed
\`\`\`

## 既存併存確認

- \`/api/billing/*\` 4 endpoints: 無変更で動作 (\`TestCoexistenceWithLegacyEndpoints\` で route 存在を保証)
- \`/api/fees/calculate|schedule\` (aave/fee_router.py): 無変更で動作
- フロントエンドからの既存呼び出し: 無影響

## 山本さん本番テストへの影響: **ゼロ**

- 新規 endpoint 追加のみ、既存 endpoint 完全併存
- フロントエンドからの呼び出し変更なし (F-8b で対応)
- DB INSERT/UPDATE/ALTER 一切なし (read-only SELECT + simulate のみ)
- \`workflow.py\` / \`ai_judgment_scheduler.py\` 無変更 (F-6 で対応)

## Test plan

- [x] verify.sh 全 7 ゲート pass
- [x] 29 ケース 9 クラスの単体テスト
- [x] 既存テスト無回帰 (test_billing 等)
- [x] 既存 endpoint coexistence 確認
- [ ] F-7 (\`POST /finalize-month\`) で 501 → 200 化
- [ ] F-8b (Asana 1214288467406433) で旧 \`/api/billing/*\` / \`/api/fees/calculate|schedule\` を物理削除 + フロント差し替え

## Asana

- F-8a (本タスク): https://app.asana.com/0/1213741124336104/1214120371503131
- **F-8b (廃止 + フロント差し替え)**: https://app.asana.com/0/1213741124336104/1214288467406433
- F-7 (finalize-month 本実装): https://app.asana.com/0/1213741124336104/1214120401388139
- F-5: https://app.asana.com/0/1213741124336104/1214120371502936 (PR #126)
- F-4: https://app.asana.com/0/1213741124336104/1214120401381545 (PR #125)
- F-3: https://app.asana.com/0/1213741124336104/1214120401362419 (PR #124)
- F-2: https://app.asana.com/0/1213741124336104/1214120248237710 (PR #123)
- F-1: https://app.asana.com/0/1213741124336104/1214120248239215 (PR #122)
- F-0: https://app.asana.com/0/1213741124336104/1214120338928565 (PR #121)

🤖 Generated with [Claude Code](https://claude.com/claude-code)