### PR TITLE
F-6: AI判断ロジック統合 (tier正規化 + GENERALハードコード除去)

### DIFF
--- a/backend/app/api/automation_dashboard.py
+++ b/backend/app/api/automation_dashboard.py
@@ -150,6 +150,7 @@ def run_workflow(
         monitoring_service=monitoring_service,
         dry_run=dry_run,
         execution_policy=current_user.execution_policy,
+        user_id=current_user.id,
     )
 
     sanitized_errors = [

--- a/backend/app/auth/models.py
+++ b/backend/app/auth/models.py
@@ -12,6 +12,7 @@ ALTER TABLE users ADD COLUMN last_judgment_at TIMESTAMP WITH TIME ZONE NULL;
 -- F-16 マイグレーションで実施 (docs/46_users_tier_migration_plan.md 参照)。
 """
 
+import logging
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
@@ -21,6 +22,8 @@ from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, Numeric, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
+
+logger = logging.getLogger(__name__)
 
 
 class UserRole(str, Enum):
@@ -133,6 +136,40 @@ def get_risk_mode_label(value: str | None) -> str:
     except ValueError:
         return RISK_MODE_JP_LABELS[RiskMode.CONSERVATIVE]
     return RISK_MODE_JP_LABELS[mode]
+
+
+def normalize_tier(raw_tier: str | None, *, user_id: int | None = None) -> InvestmentTier:
+    """``users.tier`` の DB 値 (str) を ``InvestmentTier`` enum に正規化する。
+
+    F-6 で導入。``workflow.py`` / ``ai_judgment_scheduler.py`` の trade-time フィー計算
+    経路で、``user.tier`` を ``calculate_fee_by_market`` に渡す前の正規化に使う。
+
+    優先順:
+      1. ``LEGACY_TIER_MAP`` のキー (現状: GENERAL → LOWER) → マップ値を返す
+         (deprecated 値を v10 系列に強制正規化するため、enum 解決より優先)
+      2. ``InvestmentTier`` の有効値 (LOWER/MIDDLE/UPPER) → そのまま enum で返す
+      3. それ以外 (None / 不明値) → WARNING ログ + ``InvestmentTier.LOWER`` フォールバック
+
+    フォールバック時に ``ValueError`` は raise しない (フィー計算は継続、HOLD 転換させない)。
+    F-13 で GENERAL を物理削除後も、本関数の不明値フォールバックパスで安全に吸収できる。
+    """
+    if raw_tier is not None:
+        mapped = LEGACY_TIER_MAP.get(raw_tier)
+        if mapped is not None:
+            return mapped
+        try:
+            return InvestmentTier(raw_tier)
+        except ValueError:
+            pass
+    logger.warning(
+        "tier_normalize_fallback",
+        extra={
+            "user_id": user_id,
+            "received_tier": raw_tier,
+            "fallback_to": InvestmentTier.LOWER.value,
+        },
+    )
+    return InvestmentTier.LOWER
 
 
 class User(Base):

--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -23,7 +23,7 @@ from sqlalchemy.orm import Session
 from app.ai.models import AIDecision
 from app.ai.schemas import CrossValidationResult, RAGContext, TradeAction
 from app.ai.service import AIService
-from app.auth.models import InvestmentTier, User
+from app.auth.models import InvestmentTier, User, normalize_tier
 from app.data_feeds.context import build_market_context
 from app.database import SessionLocal
 from app.knowledge.schemas import KnowledgeSearchRequest
@@ -185,7 +185,7 @@ def _create_proposals_for_users(
         )
         market_fee = calculate_fee_by_market(
             trade_amount_usd=_PROPOSAL_AMOUNT_USD,
-            tier=user.tier,
+            tier=normalize_tier(user.tier, user_id=user.id).value,
             current_apy=_default_apy,
             expected_profit_usd=_expected_profit,
             fixed_cost_usd=fixed_cost,

--- a/backend/app/automation/workflow.py
+++ b/backend/app/automation/workflow.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session
 from app.ai.judgment_log import JudgmentRecord, get_judgment_logger
 from app.ai.schemas import AIAnalysisResult, RAGContext, TradeAction
 from app.ai.service import AIService
+from app.auth.models import User, normalize_tier
 from app.automation.monitoring_service import MonitoringService
 from app.automation.schemas import ComponentType, WorkflowRunResult, WorkflowStepError
 from app.automation.shadow_mode_service import ShadowModeService
@@ -362,6 +363,7 @@ def process_pending_knowledge(
     trade_amount_usd: Decimal = Decimal("50"),
     dry_run: bool = False,
     execution_policy: str = "auto_execute",
+    user_id: Optional[int] = None,
 ) -> WorkflowRunResult:
     """Process pending knowledge items through the full pipeline.
 
@@ -556,6 +558,7 @@ def process_pending_knowledge(
                 shadow_mode_service=shadow_mode_service,
                 health_factor=hf,
                 execution_policy=effective_policy,
+                user_id=user_id,
             )
 
             if result.shadow_logged:
@@ -692,6 +695,7 @@ def _process_single_item(
     shadow_mode_service: Optional[ShadowModeService] = None,
     health_factor: Optional[Decimal] = None,
     execution_policy: str = "auto_execute",
+    user_id: Optional[int] = None,
 ) -> _SingleItemResult:
     """Process a single knowledge item through the full pipeline."""
     query = item.title or item.source_url or "analyze market conditions"
@@ -756,7 +760,9 @@ def _process_single_item(
 
             from app.billing.dynamic_fee import calculate_fee_by_market  # noqa: PLC0415
 
-            # APYを市場コンテキストから取得、なければデフォルト4%
+            # TODO(P0 タスク 1214279097935851): current_apy を MarketContext から正しく取得する。
+            # 現状 getattr(ctx, "current_apy", None) は MarketContext に該当属性がないため常に
+            # None を返し、Decimal("4") (4%) フォールバックされる。Aave クライアント連携時に修正予定。
             _apy_raw = getattr(ctx, "current_apy", None) if ctx else None
             if _apy_raw is None and isinstance(ctx, dict):
                 _apy_raw = ctx.get("current_apy")
@@ -768,9 +774,20 @@ def _process_single_item(
             )
             fixed_cost = Decimal(os.getenv("TRADE_FIXED_COST_USD", "0.27"))
 
+            # F-6: tier 正規化 (LEGACY_TIER_MAP 経由 + 不明値 LOWER フォールバック)。
+            # user_id 未指定 (legacy item-driven path) は raw_tier=None で LOWER フォールバック。
+            # 旧実装の tier="GENERAL" ハードコードは LEGACY_TIER_MAP で LOWER に正規化されるため
+            # 数値的な互換性は維持される (GENERAL と LOWER は dynamic_fee マトリクス上で同値)。
+            user_tier_raw: Optional[str] = None
+            if user_id is not None:
+                user = db.get(User, user_id)
+                if user is not None:
+                    user_tier_raw = user.tier
+            tier_value = normalize_tier(user_tier_raw, user_id=user_id).value
+
             market_fee = calculate_fee_by_market(
                 trade_amount_usd=trade_amount_usd,
-                tier="GENERAL",  # ユーザーtier不明の場合は保守的にGENERAL
+                tier=tier_value,
                 current_apy=current_apy,
                 expected_profit_usd=expected_profit,
                 fixed_cost_usd=fixed_cost,
@@ -796,6 +813,7 @@ def _process_single_item(
                 action=action,
                 reason=reason,
                 trade_amount_usd=trade_amount_usd,
+                user_id=user_id if user_id is not None else 0,
                 fee_rate=market_fee.fee_rate,
                 fee_amount=market_fee.fee_amount,
             )

--- a/backend/app/knowledge/router.py
+++ b/backend/app/knowledge/router.py
@@ -263,6 +263,7 @@ def workflow_trigger(
             ai_service=AIService(),
             exchange_service=get_exchange_service(),
             monitoring_service=None,
+            user_id=current_user.id,
         )
         logger.info(
             "Workflow triggered via API",

--- a/backend/tests/test_ai_judgment_scheduler.py
+++ b/backend/tests/test_ai_judgment_scheduler.py
@@ -723,3 +723,48 @@ def test_buy_updates_last_judgment_at(db_session):
 
     db_session.refresh(user)
     assert user.last_judgment_at is not None
+
+
+# ---------------------------------------------------------------------------
+# F-6: tier 正規化のテスト
+# ---------------------------------------------------------------------------
+
+
+def test_create_proposals_uses_normalized_tier(db_session):
+    """``user.tier`` が calculate_fee_by_market に渡される際 normalize_tier 経由になっていること。
+
+    GENERAL ユーザーは LEGACY_TIER_MAP で LOWER に正規化されるため、
+    呼び出し時の tier 引数は "LOWER" になる。
+    """
+    user = User(
+        email="legacy_general@example.com",
+        username="legacy_general",
+        hashed_password="x",
+        is_active=True,
+        execution_policy="require_approval",
+        tier=InvestmentTier.GENERAL.value,
+        last_judgment_at=None,
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    mock_result = _make_cross_validation_result(TradeAction.BUY)
+
+    with (
+        patch("app.automation.ai_judgment_scheduler.AIService") as MockAIService,
+        patch("app.automation.ai_judgment_scheduler.KnowledgeService") as MockKnowledgeService,
+        patch("app.billing.dynamic_fee.calculate_fee_by_market") as mock_fee,
+    ):
+        MockAIService.return_value.judge_with_rag.return_value = mock_result
+        MockKnowledgeService.return_value.search.return_value = []
+        mock_fee.return_value.should_trade = True
+        mock_fee.return_value.fee_rate = Decimal("0.05")
+        mock_fee.return_value.fee_amount = Decimal("5.00")
+
+        run_ai_judgment_job(db=db_session)
+
+    assert mock_fee.call_count == 1
+    call_kwargs = mock_fee.call_args.kwargs
+    assert call_kwargs["tier"] == InvestmentTier.LOWER.value, (
+        f"GENERAL は LOWER に正規化されるべきだが {call_kwargs['tier']!r} が渡された"
+    )

--- a/backend/tests/test_normalize_tier.py
+++ b/backend/tests/test_normalize_tier.py
@@ -1,0 +1,92 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_normalize_tier.py
+"""normalize_tier() ヘルパーのユニットテスト (F-6)。"""
+
+import logging
+import os
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-normalize-tier")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "admin@example.com")
+
+import pytest  # noqa: E402
+
+from app.auth.models import (  # noqa: E402
+    LEGACY_TIER_MAP,
+    InvestmentTier,
+    normalize_tier,
+)
+
+
+class TestNormalizeTierKnownValues:
+    """LOWER / MIDDLE / UPPER は enum でそのまま返る。"""
+
+    @pytest.mark.parametrize(
+        "raw_value,expected",
+        [
+            ("LOWER", InvestmentTier.LOWER),
+            ("MIDDLE", InvestmentTier.MIDDLE),
+            ("UPPER", InvestmentTier.UPPER),
+        ],
+    )
+    def test_normalize_tier_known_value(self, raw_value: str, expected: InvestmentTier) -> None:
+        assert normalize_tier(raw_value) == expected
+
+
+class TestNormalizeTierLegacy:
+    """LEGACY_TIER_MAP のキー (現状: GENERAL → LOWER) はマップ値を返す。"""
+
+    def test_normalize_tier_legacy_general_falls_back_to_lower(self) -> None:
+        assert "GENERAL" in LEGACY_TIER_MAP
+        assert normalize_tier("GENERAL") == InvestmentTier.LOWER
+
+    def test_normalize_tier_legacy_takes_priority_over_enum(self) -> None:
+        """GENERAL は InvestmentTier 有効値だが、LEGACY_TIER_MAP の正規化が優先される。
+
+        F-13 で GENERAL が enum から削除された後も、本テストの動作 (LOWER 返却) を維持する。
+        """
+        result = normalize_tier("GENERAL")
+        assert result is InvestmentTier.LOWER
+        assert result is not InvestmentTier.GENERAL
+
+
+class TestNormalizeTierFallback:
+    """不明値 / None は WARNING ログ + LOWER フォールバック (ValueError は raise しない)。"""
+
+    def test_normalize_tier_unknown_logs_warning_and_returns_lower(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.WARNING, logger="app.auth.models"):
+            result = normalize_tier("INVALID_TIER", user_id=42)
+        assert result == InvestmentTier.LOWER
+        assert any(
+            record.message == "tier_normalize_fallback" and record.levelno == logging.WARNING
+            for record in caplog.records
+        )
+        warning_record = next(r for r in caplog.records if r.message == "tier_normalize_fallback")
+        assert warning_record.user_id == 42
+        assert warning_record.received_tier == "INVALID_TIER"
+        assert warning_record.fallback_to == "LOWER"
+
+    def test_normalize_tier_none_returns_lower(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="app.auth.models"):
+            result = normalize_tier(None)
+        assert result == InvestmentTier.LOWER
+        warning_record = next(r for r in caplog.records if r.message == "tier_normalize_fallback")
+        assert warning_record.received_tier is None
+        assert warning_record.user_id is None
+
+    def test_normalize_tier_empty_string_falls_back_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """空文字も不明値扱い (LEGACY_TIER_MAP にも enum にも該当しない)。"""
+        with caplog.at_level(logging.WARNING, logger="app.auth.models"):
+            result = normalize_tier("", user_id=7)
+        assert result == InvestmentTier.LOWER
+        assert any(r.message == "tier_normalize_fallback" for r in caplog.records)
+
+    def test_normalize_tier_does_not_raise_on_unknown(self) -> None:
+        """フォールバック時に ValueError を raise しない (フィー計算継続のため)。"""
+        try:
+            normalize_tier("XYZ", user_id=1)
+        except ValueError as exc:  # pragma: no cover
+            pytest.fail(f"normalize_tier should not raise ValueError but got: {exc}")

--- a/backend/tests/test_workflow_integration.py
+++ b/backend/tests/test_workflow_integration.py
@@ -665,3 +665,137 @@ class TestLineNotificationsConnected:
             with patch("app.notifications.line_notifier.LINENotifyClient.send") as mock_send:
                 service.record_health_factor(Decimal("1.4"))
                 mock_send.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# F-6: workflow.py の tier 正規化テスト
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowTierNormalization:
+    """workflow.py:_process_single_item における tier 正規化と current_apy フォールバックの回帰。"""
+
+    def test_workflow_uses_user_tier_not_hardcoded_general(self):
+        """user_id 経由で user.tier を取得し、normalize_tier 経由で計算される (GENERAL ハードコード除去)。
+
+        旧実装は tier="GENERAL" を直接渡していたが、F-6 で user_id → user.tier → normalize_tier
+        の経路に変更。LEGACY_TIER_MAP により GENERAL は LOWER に正規化されるため
+        既存呼び出し (tier=GENERAL) と数値的に同値になる。
+        """
+        from unittest.mock import MagicMock, patch
+
+        from app.auth.models import InvestmentTier, User
+
+        db = MagicMock()
+        # db.get(User, user_id) が tier=UPPER のユーザーを返す
+        db.get.return_value = User(
+            id=42,
+            email="upper@example.com",
+            username="upper",
+            hashed_password="x",
+            tier=InvestmentTier.UPPER.value,
+        )
+
+        ks = MagicMock()
+        ai = MagicMock()
+        ex = MagicMock()
+
+        item = _make_knowledge_item()
+        ks.get_pending.return_value = [item]
+        ks.search.return_value = []
+        ai.judge_with_rag.return_value = _make_cross_validation(TradeAction.BUY, 85)
+
+        with patch("app.billing.dynamic_fee.calculate_fee_by_market") as mock_fee:
+            mock_fee.return_value.should_trade = True
+            mock_fee.return_value.fee_rate = Decimal("0.20")
+            mock_fee.return_value.fee_amount = Decimal("10.00")
+
+            process_pending_knowledge(
+                db,
+                knowledge_service=ks,
+                ai_service=ai,
+                exchange_service=ex,
+                execution_policy="require_approval",
+                user_id=42,
+            )
+
+        assert mock_fee.called
+        call_kwargs = mock_fee.call_args.kwargs
+        assert call_kwargs["tier"] == InvestmentTier.UPPER.value, (
+            f"user.tier=UPPER が渡されるべきだが {call_kwargs['tier']!r} だった"
+        )
+
+    def test_workflow_user_id_none_falls_back_to_lower(self):
+        """user_id=None (legacy / internal token path) は normalize_tier(None) → LOWER フォールバック。"""
+        from unittest.mock import MagicMock, patch
+
+        from app.auth.models import InvestmentTier
+
+        db = MagicMock()
+        ks = MagicMock()
+        ai = MagicMock()
+        ex = MagicMock()
+
+        item = _make_knowledge_item()
+        ks.get_pending.return_value = [item]
+        ks.search.return_value = []
+        ai.judge_with_rag.return_value = _make_cross_validation(TradeAction.BUY, 85)
+
+        with patch("app.billing.dynamic_fee.calculate_fee_by_market") as mock_fee:
+            mock_fee.return_value.should_trade = True
+            mock_fee.return_value.fee_rate = Decimal("0.05")
+            mock_fee.return_value.fee_amount = Decimal("2.00")
+
+            process_pending_knowledge(
+                db,
+                knowledge_service=ks,
+                ai_service=ai,
+                exchange_service=ex,
+                execution_policy="require_approval",
+                # user_id=None (デフォルト)
+            )
+
+        assert mock_fee.called
+        call_kwargs = mock_fee.call_args.kwargs
+        assert call_kwargs["tier"] == InvestmentTier.LOWER.value
+        # db.get は呼ばれない (user_id が None なので user 取得スキップ)
+        db.get.assert_not_called()
+
+    def test_dynamic_fee_apy_fallback_documented(self):
+        """current_apy 取得バグの回帰テスト: MarketContext に current_apy 属性が無い → Decimal("4") フォールバック。
+
+        TODO(P0 タスク 1214279097935851): MarketContext に Aave データを注入後は
+        current_apy が実値で渡されるよう修正される。本テストはその修正時に更新する。
+        """
+        from unittest.mock import MagicMock, patch
+
+        db = MagicMock()
+        ks = MagicMock()
+        ai = MagicMock()
+        ex = MagicMock()
+
+        item = _make_knowledge_item()
+        ks.get_pending.return_value = [item]
+        ks.search.return_value = []
+        ai.judge_with_rag.return_value = _make_cross_validation(TradeAction.BUY, 85)
+
+        with patch("app.billing.dynamic_fee.calculate_fee_by_market") as mock_fee:
+            mock_fee.return_value.should_trade = True
+            mock_fee.return_value.fee_rate = Decimal("0.05")
+            mock_fee.return_value.fee_amount = Decimal("1.00")
+
+            process_pending_knowledge(
+                db,
+                knowledge_service=ks,
+                ai_service=ai,
+                exchange_service=ex,
+                execution_policy="require_approval",
+            )
+
+        assert mock_fee.called
+        call_kwargs = mock_fee.call_args.kwargs
+        # MarketContext に current_apy 属性が無いため、4% フォールバック値が使われる
+        assert call_kwargs["current_apy"] == Decimal("4"), (
+            "MarketContext に current_apy が注入されるよう修正されたら本テストを更新する "
+            "(P0 タスク 1214279097935851)"
+        )

--- a/docs/45_fee_model_v10_migration_plan.md
+++ b/docs/45_fee_model_v10_migration_plan.md
@@ -176,7 +176,7 @@
 | 1214120401362419 | F-3 | RiskMode enum (v10) | **既存 risk_mode 列の enum 値はリネーム不可**。日本語ラベル辞書だけ新設。NULL 4人を 'conservative' で埋める | 2026-04-30 |
 | 1214120401381545 | F-4 | FeeConfig seed data | F-1 完了後。リスクモード × tier の手数料率マトリクス投入 | 2026-05-01 |
 | 1214120371502936 | F-5 | fee_calculator.py コア | 新規 `backend/app/fees/calculator.py`。dynamic_fee.py の `calculate_fee_by_market` をベースに統合 | 2026-05-04 |
-| 1214120371503067 | F-6 | AI判断ロジック統合 | workflow.py:757, ai_judgment_scheduler.py:154 の dynamic_fee import を v10 API に差し替え | 2026-05-05 |
+| 1214120371503067 | F-6 | AI判断ロジック統合 | workflow.py:757, ai_judgment_scheduler.py:154 の dynamic_fee import を v10 API に差し替え (注[1]参照) | 2026-05-05 |
 | 1214120401388139 | F-7 | 月末バッチ | 既存 `POST /api/billing/batch/daily` は **廃止**。v10 は月次。`scheduled_tasks.py` に新規ジョブ | 2026-05-06 |
 | 1214120371503131 | F-8 | fees.py API | `/api/billing/*` 4 endpoints と `/api/fees/*` 2 endpoints を `/api/fees/*` 1系統に統合 | 2026-05-07 |
 | 1214120371503003 | F-9 | 経費マークアップ | 固定経費 $0.27/トレード (現状 dynamic_fee デフォルト) を v10 で再評価 | 2026-05-08 |
@@ -187,6 +187,14 @@
 | 1214120353305989 | F-14 | Playwright E2E | F-1〜F-13 完了後。フィー画面 UI / API レグレッション | 2026-05-14 |
 | 1214120401388204 | F-15 | 山本さんレビュー | F-14 完了後。本番デプロイ前承認 | 2026-05-15 |
 | 1214120338926364 | F-16 | v10 本番リリース | F-15 完了後。Hetzner ALTER TABLE → コードデプロイ | 2026-05-18 |
+
+> **注[1]**: F-6 解釈A確定 (2026-04-26 claude.ai判断)。`docs/fee_model_v10_spec.md` §4 未作成のため、F-6 スコープは以下に限定:
+>
+> - `workflow.py` / `ai_judgment_scheduler.py` の tier 正規化 (`normalize_tier()` ヘルパー導入、`auth/models.py`)
+> - `workflow.py` の `tier="GENERAL"` ハードコード除去 (`user_id` 配線で `user.tier` 経由)
+> - `current_apy` バグの TODO 化 (修正は P0 タスク 1214279097935851 で MarketContext に Aave データ注入時に対応)
+>
+> 月次 `FeeCalculator` 統合は **F-7 担当**。Phase 1 中は trade-time の `should_trade` gate を `calculate_fee_by_market` で維持する。
 
 ---
 


### PR DESCRIPTION
## Asana

- F-6 (1214120371503067)
- 解釈A確定 (claude.ai 2026-04-26)

## 変更内容

- `normalize_tier()` ヘルパー追加 (`backend/app/auth/models.py`): LEGACY_TIER_MAP 経由 + 不明値 WARNING + LOWER fallback
- `ai_judgment_scheduler.py`: `user.tier` → `normalize_tier(user.tier, user_id=user.id).value`
- `workflow.py`: `tier="GENERAL"` ハードコード除去、`_process_single_item` に `user_id` 引数追加
- `process_pending_knowledge` に `user_id` 引数追加、`knowledge/router.py` / `api/automation_dashboard.py` 呼出元から配線
- `workflow.py:760` 周辺に `current_apy` 取得バグ TODO コメント追加 (修正は別 P0 タスク 1214279097935851)
- テスト追加: 新規 `test_normalize_tier.py` (7件) + 既存拡張 4件 (scheduler 1 / integration 3)
- `docs/45_fee_model_v10_migration_plan.md` §4 F-6行に脚注[1]追記

## スコープ外 (別タスク)

- v10 `FeeCalculator` 統合 → F-7 担当 (月次バッチ)
- `current_apy` 取得修正 → P0 タスク 1214279097935851 (MarketContext に Aave データ注入)
- メトリクスカウンター追加 → 別タスク (Prometheus integration)

## 山本影響

- **低**: proposals 0件継続中、tier 正規化は LEGACY_TIER_MAP 経由で `GENERAL → LOWER` 同値変換 (dynamic_fee マトリクス上で同値) → 数値的変化なし想定
- **本番デプロイは別タスク化**: 山本不在時間帯選定は claude.ai 判断

## テスト

- 新規 11件追加、全 pass
- `pytest 2645 passed, 9 skipped` / `coverage 85.23%` (Required ≥ 80%)
- 7-gate Gates 1-3 (ruff/format/mypy/pytest) + Gate 6/7 (tsc/build) 全 pass
- verify.sh 全体 319 秒で完了

## ロールバックプラン

1. `git revert <PR sha>` → main push → Hetzner で `deploy_production.sh --backend-only`
2. 旧 `calculate_fee_by_market` API は v10 と並列維持 (F-13まで残置) → 即時切戻し可能
3. DB 影響なし (`proposals.fee_rate/fee_amount` スキーマ変更なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)