### PR TITLE
feat(scripts): check_env_separation.sh Phase 1 例外ロジック実装

### DIFF
--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -32,6 +32,10 @@
 # 環境種別（必須・固定値）
 APP_ENV=production
 
+# Phase 1 例外設定: この日付までは check_env_separation.sh が APP_ENV 等の staging 値を WARN に格下げ
+# Phase 2 移行後に削除するか日付を更新すること
+PHASE1_EXCEPTION_EXPIRES_ON=2026-09-30
+
 # ログレベル（production は INFO 推奨）
 LOG_LEVEL=INFO
 

--- a/scripts/check_env_separation.sh
+++ b/scripts/check_env_separation.sh
@@ -21,8 +21,9 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-STAGING_FILE="${PROJECT_ROOT}/.env.staging"
-PRODUCTION_FILE="${PROJECT_ROOT}/.env.production"
+# テスト時のファイルパスオーバーライド (scripts/tests/test_check_env_separation.sh が使用)
+STAGING_FILE="${STAGING_ENV_FILE:-${PROJECT_ROOT}/.env.staging}"
+PRODUCTION_FILE="${PRODUCTION_ENV_FILE:-${PROJECT_ROOT}/.env.production}"
 
 # 両ファイルが揃っていない場合は検証できないのでスキップ（CI で片側のみ存在する場合に配慮）
 if [[ ! -f "${STAGING_FILE}" ]] || [[ ! -f "${PRODUCTION_FILE}" ]]; then
@@ -33,6 +34,38 @@ if [[ ! -f "${STAGING_FILE}" ]] || [[ ! -f "${PRODUCTION_FILE}" ]]; then
 fi
 
 echo "=== 環境分離チェック: .env.staging vs .env.production ==="
+
+# ---------------------------------------------------------------------------
+# Phase 1 例外設定
+# Phase 1 期間中は以下の変数が意図的に staging 値のまま .env.production に存在する。
+# PHASE1_EXCEPTION_EXPIRES_ON を .env.production から読み取り、期限内なら WARN に格下げ。
+# ---------------------------------------------------------------------------
+PHASE1_EXCEPTION_VARS=(
+  "APP_ENV"
+  "BYBIT_SANDBOX"
+  "AAVE_NETWORK"
+  "AAVE_RPC_URL"
+  "EXCHANGE_CLIENT_TYPE"
+  "AAVE_POOL_ADDRESS"
+)
+
+PHASE1_EXPIRES="$(grep -E '^PHASE1_EXCEPTION_EXPIRES_ON=' "${PRODUCTION_FILE}" | head -n 1 | cut -d= -f2)"
+if [[ -z "${PHASE1_EXPIRES}" ]]; then
+  echo "❌ ERROR: PHASE1_EXCEPTION_EXPIRES_ON が .env.production に設定されていません。"
+  echo "   例: PHASE1_EXCEPTION_EXPIRES_ON=2026-09-30"
+  echo "   Phase 1 例外ロジックを正しく動作させるために必須です。"
+  exit 1
+fi
+
+# テスト時の日付オーバーライド (ENV_SEPARATION_TEST_DATE=YYYY-MM-DD で差し替え可能)
+TODAY="${ENV_SEPARATION_TEST_DATE:-$(date +%Y-%m-%d)}"
+if [[ "${TODAY}" > "${PHASE1_EXPIRES}" ]]; then
+  PHASE1_ACTIVE=false
+  echo "ℹ️  Phase 1 例外期間が終了しています (PHASE1_EXCEPTION_EXPIRES_ON=${PHASE1_EXPIRES}, TODAY=${TODAY})"
+else
+  PHASE1_ACTIVE=true
+  echo "ℹ️  Phase 1 例外モード有効 (PHASE1_EXCEPTION_EXPIRES_ON=${PHASE1_EXPIRES}, TODAY=${TODAY})"
+fi
 
 # ---------------------------------------------------------------------------
 # ヘルパー関数
@@ -70,10 +103,32 @@ display_value() {
   fi
 }
 
+# Phase 1 例外変数か判定
+is_phase1_exception_var() {
+  local key="$1"
+  local v
+  for v in "${PHASE1_EXCEPTION_VARS[@]}"; do
+    [[ "${v}" == "${key}" ]] && return 0
+  done
+  return 1
+}
+
+# 違反追加: Phase 1 例外中かつ対象変数ならWARNに格下げ、それ以外はVIOLATIONS
+_add_violation_or_warn() {
+  local key="$1"
+  local message="$2"
+  if [[ "${PHASE1_ACTIVE}" == "true" ]] && is_phase1_exception_var "${key}"; then
+    WARNINGS+=("[Phase1例外 until ${PHASE1_EXPIRES}] ${message}")
+  else
+    VIOLATIONS+=("${message}")
+  fi
+}
+
 # ---------------------------------------------------------------------------
 # 違反収集
 # ---------------------------------------------------------------------------
 VIOLATIONS=()
+WARNINGS=()
 
 # ---------------------------------------------------------------------------
 # 必須差分キー: 以下のいずれか1個でも同値なら違反
@@ -101,8 +156,12 @@ for key in "${REQUIRED_DIFF_KEYS[@]}"; do
   fi
 
   if [[ "${staging_val}" == "${production_val}" ]]; then
-    VIOLATIONS+=("必須差分キー ${key} が同値: staging=$(display_value "${key}" "${staging_val}") / production=$(display_value "${key}" "${production_val}")")
-    echo "  ❌ ${key}: staging=$(display_value "${key}" "${staging_val}") == production=$(display_value "${key}" "${production_val}")"
+    _add_violation_or_warn "${key}" "必須差分キー ${key} が同値: staging=$(display_value "${key}" "${staging_val}") / production=$(display_value "${key}" "${production_val}")"
+    if [[ "${PHASE1_ACTIVE}" == "true" ]] && is_phase1_exception_var "${key}"; then
+      echo "  ⚠️  ${key}: staging==production (Phase1例外: WARN)"
+    else
+      echo "  ❌ ${key}: staging=$(display_value "${key}" "${staging_val}") == production=$(display_value "${key}" "${production_val}")"
+    fi
   else
     echo "  ✅ ${key}: 差分あり"
   fi
@@ -149,22 +208,34 @@ echo ""
 echo "--- 禁止パターンチェック (.env.production) ---"
 
 if grep -qE '^APP_ENV=staging[[:space:]]*$' "${PRODUCTION_FILE}"; then
-  VIOLATIONS+=(".env.production に APP_ENV=staging が含まれています")
-  echo "  ❌ APP_ENV=staging を検出"
+  _add_violation_or_warn "APP_ENV" ".env.production に APP_ENV=staging が含まれています"
+  if [[ "${PHASE1_ACTIVE}" == "true" ]] && is_phase1_exception_var "APP_ENV"; then
+    echo "  ⚠️  APP_ENV=staging を検出 (Phase1例外: WARN)"
+  else
+    echo "  ❌ APP_ENV=staging を検出"
+  fi
 else
   echo "  ✅ APP_ENV=staging なし"
 fi
 
 if grep -qE '^BYBIT_SANDBOX=true[[:space:]]*$' "${PRODUCTION_FILE}"; then
-  VIOLATIONS+=(".env.production に BYBIT_SANDBOX=true が含まれています (本番は false 必須)")
-  echo "  ❌ BYBIT_SANDBOX=true を検出"
+  _add_violation_or_warn "BYBIT_SANDBOX" ".env.production に BYBIT_SANDBOX=true が含まれています (本番は false 必須)"
+  if [[ "${PHASE1_ACTIVE}" == "true" ]] && is_phase1_exception_var "BYBIT_SANDBOX"; then
+    echo "  ⚠️  BYBIT_SANDBOX=true を検出 (Phase1例外: WARN)"
+  else
+    echo "  ❌ BYBIT_SANDBOX=true を検出"
+  fi
 else
   echo "  ✅ BYBIT_SANDBOX=true なし"
 fi
 
 if grep -qiE '^AAVE_NETWORK=.*sepolia.*' "${PRODUCTION_FILE}"; then
-  VIOLATIONS+=(".env.production に AAVE_NETWORK の sepolia 指定が含まれています (本番は mainnet 必須)")
-  echo "  ❌ AAVE_NETWORK=*sepolia* を検出"
+  _add_violation_or_warn "AAVE_NETWORK" ".env.production に AAVE_NETWORK の sepolia 指定が含まれています (本番は mainnet 必須)"
+  if [[ "${PHASE1_ACTIVE}" == "true" ]] && is_phase1_exception_var "AAVE_NETWORK"; then
+    echo "  ⚠️  AAVE_NETWORK=*sepolia* を検出 (Phase1例外: WARN)"
+  else
+    echo "  ❌ AAVE_NETWORK=*sepolia* を検出"
+  fi
 else
   echo "  ✅ AAVE_NETWORK に sepolia 含まず"
 fi
@@ -229,6 +300,14 @@ _validate_ai_model_names "${STAGING_FILE}" "staging"
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== 結果 ==="
+
+if [[ "${#WARNINGS[@]}" -gt 0 ]]; then
+  echo "⚠️  Phase 1 例外 WARN: ${#WARNINGS[@]} 件 (exit 0)"
+  for w in "${WARNINGS[@]}"; do
+    echo "   - ${w}"
+  done
+fi
+
 if [[ "${#VIOLATIONS[@]}" -eq 0 ]]; then
   echo "✅ 環境分離チェック: 全項目通過"
   exit 0

--- a/scripts/tests/test_check_env_separation.sh
+++ b/scripts/tests/test_check_env_separation.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# test_check_env_separation.sh
+#
+# check_env_separation.sh の Phase 1 例外ロジックのテスト
+#
+# 実行:
+#   bash scripts/tests/test_check_env_separation.sh
+#
+# 終了コード:
+#   0: 全テスト通過
+#   1: 1件以上失敗
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_SCRIPT="${SCRIPT_DIR}/../check_env_separation.sh"
+TMPDIR_TEST="$(mktemp -d)"
+
+PASS=0
+FAIL=0
+
+trap 'rm -rf "${TMPDIR_TEST}"' EXIT
+
+_pass() { echo "  ✅ PASS: $1"; PASS=$(( PASS + 1 )); }
+_fail() { echo "  ❌ FAIL: $1"; FAIL=$(( FAIL + 1 )); }
+
+# mock env ファイルを生成するヘルパー
+# 引数: ファイルパス, キー=値 のペア (残りすべて)
+make_env() {
+  local file="$1"; shift
+  : > "${file}"
+  for kv in "$@"; do
+    echo "${kv}" >> "${file}"
+  done
+}
+
+# スクリプトを実行して exit code と stdout を取得
+run_check() {
+  local staging="$1"
+  local production="$2"
+  local test_date="${3:-2026-04-26}"
+  STAGING_ENV_FILE="${staging}" \
+  PRODUCTION_ENV_FILE="${production}" \
+  ENV_SEPARATION_TEST_DATE="${test_date}" \
+  bash "${CHECK_SCRIPT}" 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# 共通変数 (テスト全体で使用)
+# ---------------------------------------------------------------------------
+COMMON_AI_MODEL="AI_CLAUDE_MODEL=claude-sonnet-4-6"
+COMMON_STAGING_ONLY=(
+  "POSTGRES_DB=ultra_staging"
+  "DATABASE_URL=postgresql://ultra:pw@postgres:5432/ultra_staging"
+  "CORS_ORIGINS=https://staging.example.com"
+  "NEXT_PUBLIC_API_URL=https://staging.example.com"
+)
+COMMON_PROD_ONLY=(
+  "POSTGRES_DB=ultra_production"
+  "DATABASE_URL=postgresql://ultra:pw@postgres:5432/ultra_production"
+  "CORS_ORIGINS=https://app.example.com"
+  "NEXT_PUBLIC_API_URL=https://app.example.com"
+)
+PHASE1_VARS_STAGING=(
+  "APP_ENV=staging"
+  "BYBIT_SANDBOX=true"
+  "AAVE_NETWORK=base_sepolia"
+)
+# ---------------------------------------------------------------------------
+
+echo "=== check_env_separation.sh テスト ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# Case 1: Phase 1 期間内 + 例外変数差分 → exit 0 + WARN
+# ---------------------------------------------------------------------------
+echo "--- Case 1: Phase1期間内 + 例外変数差分 → exit 0 + WARN ---"
+{
+  staging="${TMPDIR_TEST}/c1_staging.env"
+  production="${TMPDIR_TEST}/c1_prod.env"
+
+  make_env "${staging}" \
+    "${PHASE1_VARS_STAGING[@]}" \
+    "${COMMON_STAGING_ONLY[@]}" \
+    "${COMMON_AI_MODEL}" \
+    "PHASE1_EXCEPTION_EXPIRES_ON=2026-09-30"
+
+  make_env "${production}" \
+    "${PHASE1_VARS_STAGING[@]}" \
+    "${COMMON_PROD_ONLY[@]}" \
+    "${COMMON_AI_MODEL}" \
+    "PHASE1_EXCEPTION_EXPIRES_ON=2026-09-30"
+
+  output="$(run_check "${staging}" "${production}" "2026-04-26")"
+  exit_code=$?
+
+  if [[ "${exit_code}" -eq 0 ]]; then
+    _pass "exit 0"
+  else
+    _fail "exit 0 が期待値、実際: ${exit_code}"
+    echo "    output: ${output}"
+  fi
+
+  if echo "${output}" | grep -q "Phase1例外"; then
+    _pass "WARN メッセージ出力"
+  else
+    _fail "WARN メッセージが出力されない"
+    echo "    output: ${output}"
+  fi
+}
+echo ""
+
+# ---------------------------------------------------------------------------
+# Case 2: Phase 1 期間外 + 例外変数差分 → exit 1
+# ---------------------------------------------------------------------------
+echo "--- Case 2: Phase1期間外 + 例外変数差分 → exit 1 ---"
+{
+  staging="${TMPDIR_TEST}/c2_staging.env"
+  production="${TMPDIR_TEST}/c2_prod.env"
+
+  make_env "${staging}" \
+    "${PHASE1_VARS_STAGING[@]}" \
+    "${COMMON_STAGING_ONLY[@]}" \
+    "${COMMON_AI_MODEL}" \
+    "PHASE1_EXCEPTION_EXPIRES_ON=2025-12-31"
+
+  make_env "${production}" \
+    "${PHASE1_VARS_STAGING[@]}" \
+    "${COMMON_PROD_ONLY[@]}" \
+    "${COMMON_AI_MODEL}" \
+    "PHASE1_EXCEPTION_EXPIRES_ON=2025-12-31"
+
+  output="$(run_check "${staging}" "${production}" "2026-04-26")"
+  exit_code=$?
+
+  if [[ "${exit_code}" -eq 1 ]]; then
+    _pass "exit 1"
+  else
+    _fail "exit 1 が期待値、実際: ${exit_code}"
+    echo "    output: ${output}"
+  fi
+
+  if echo "${output}" | grep -q "Phase 1 例外期間が終了"; then
+    _pass "期間終了メッセージ出力"
+  else
+    _fail "期間終了メッセージが出力されない"
+    echo "    output: ${output}"
+  fi
+}
+echo ""
+
+# ---------------------------------------------------------------------------
+# Case 3: 例外外変数 (DATABASE_URL) が同値 → 常に exit 1
+# ---------------------------------------------------------------------------
+echo "--- Case 3: 例外外変数が同値 → 常に exit 1 ---"
+{
+  staging="${TMPDIR_TEST}/c3_staging.env"
+  production="${TMPDIR_TEST}/c3_prod.env"
+
+  # POSTGRES_DB / DATABASE_URL が同値 = 必須差分キー違反 (Phase1例外対象外)
+  make_env "${staging}" \
+    "${PHASE1_VARS_STAGING[@]}" \
+    "POSTGRES_DB=ultra_same" \
+    "DATABASE_URL=postgresql://ultra:pw@postgres:5432/ultra_same" \
+    "CORS_ORIGINS=https://staging.example.com" \
+    "NEXT_PUBLIC_API_URL=https://staging.example.com" \
+    "${COMMON_AI_MODEL}" \
+    "PHASE1_EXCEPTION_EXPIRES_ON=2026-09-30"
+
+  make_env "${production}" \
+    "${PHASE1_VARS_STAGING[@]}" \
+    "POSTGRES_DB=ultra_same" \
+    "DATABASE_URL=postgresql://ultra:pw@postgres:5432/ultra_same" \
+    "CORS_ORIGINS=https://app.example.com" \
+    "NEXT_PUBLIC_API_URL=https://app.example.com" \
+    "${COMMON_AI_MODEL}" \
+    "PHASE1_EXCEPTION_EXPIRES_ON=2026-09-30"
+
+  output="$(run_check "${staging}" "${production}" "2026-04-26")"
+  exit_code=$?
+
+  if [[ "${exit_code}" -eq 1 ]]; then
+    _pass "Phase1期間内でも例外外変数違反 → exit 1"
+  else
+    _fail "exit 1 が期待値、実際: ${exit_code}"
+    echo "    output: ${output}"
+  fi
+
+  if echo "${output}" | grep -qE "POSTGRES_DB|DATABASE_URL"; then
+    _pass "違反キー (DATABASE_URL/POSTGRES_DB) がエラーに出力"
+  else
+    _fail "違反キーがエラー出力されない"
+    echo "    output: ${output}"
+  fi
+}
+echo ""
+
+# ---------------------------------------------------------------------------
+# Case 4: PHASE1_EXCEPTION_EXPIRES_ON 未設定 → exit 1
+# ---------------------------------------------------------------------------
+echo "--- Case 4: PHASE1_EXCEPTION_EXPIRES_ON未設定 → exit 1 ---"
+{
+  staging="${TMPDIR_TEST}/c4_staging.env"
+  production="${TMPDIR_TEST}/c4_prod.env"
+
+  make_env "${staging}" \
+    "APP_ENV=staging" \
+    "${COMMON_STAGING_ONLY[@]}" \
+    "${COMMON_AI_MODEL}"
+
+  make_env "${production}" \
+    "APP_ENV=production" \
+    "${COMMON_PROD_ONLY[@]}" \
+    "${COMMON_AI_MODEL}"
+  # PHASE1_EXCEPTION_EXPIRES_ON は意図的に設定しない
+
+  output="$(run_check "${staging}" "${production}" "2026-04-26")"
+  exit_code=$?
+
+  if [[ "${exit_code}" -eq 1 ]]; then
+    _pass "exit 1"
+  else
+    _fail "exit 1 が期待値、実際: ${exit_code}"
+    echo "    output: ${output}"
+  fi
+
+  if echo "${output}" | grep -q "PHASE1_EXCEPTION_EXPIRES_ON"; then
+    _pass "設定要求メッセージ出力"
+  else
+    _fail "設定要求メッセージが出力されない"
+    echo "    output: ${output}"
+  fi
+}
+echo ""
+
+# ---------------------------------------------------------------------------
+# Case 5: 全項目通過 (Phase1例外WARNのみ) → exit 0
+# ---------------------------------------------------------------------------
+echo "--- Case 5: 全項目通過 (Phase1例外WARNのみ) → exit 0 ---"
+{
+  staging="${TMPDIR_TEST}/c5_staging.env"
+  production="${TMPDIR_TEST}/c5_prod.env"
+
+  make_env "${staging}" \
+    "${PHASE1_VARS_STAGING[@]}" \
+    "${COMMON_STAGING_ONLY[@]}" \
+    "${COMMON_AI_MODEL}" \
+    "PHASE1_EXCEPTION_EXPIRES_ON=2026-09-30"
+
+  make_env "${production}" \
+    "${PHASE1_VARS_STAGING[@]}" \
+    "${COMMON_PROD_ONLY[@]}" \
+    "${COMMON_AI_MODEL}" \
+    "PHASE1_EXCEPTION_EXPIRES_ON=2026-09-30"
+
+  output="$(run_check "${staging}" "${production}" "2026-06-01")"
+  exit_code=$?
+
+  if [[ "${exit_code}" -eq 0 ]]; then
+    _pass "exit 0"
+  else
+    _fail "exit 0 が期待値、実際: ${exit_code}"
+    echo "    output: ${output}"
+  fi
+
+  if echo "${output}" | grep -q "全項目通過"; then
+    _pass "全項目通過メッセージ出力"
+  else
+    _fail "全項目通過メッセージが出力されない"
+    echo "    output: ${output}"
+  fi
+}
+echo ""
+
+# ---------------------------------------------------------------------------
+# 結果
+# ---------------------------------------------------------------------------
+echo "=== テスト結果 ==="
+echo "  通過: ${PASS} / 失敗: ${FAIL}"
+if [[ "${FAIL}" -eq 0 ]]; then
+  echo "✅ 全テスト通過"
+  exit 0
+else
+  echo "❌ ${FAIL} 件のテスト失敗"
+  exit 1
+fi


### PR DESCRIPTION
## Asana
- 1214121023479550

## 背景
PR #91 (env-separation) で実装漏れ。Phase 1 中は APP_ENV/BYBIT_SANDBOX/AAVE_NETWORK 等が意図的に staging 値で `.env.production` に存在するため、check_env_separation.sh が誤検出して FAIL する問題を解消。

## 変更内容

### scripts/check_env_separation.sh
- `PHASE1_EXCEPTION_VARS` リスト追加 (APP_ENV / BYBIT_SANDBOX / AAVE_NETWORK / AAVE_RPC_URL / EXCHANGE_CLIENT_TYPE / AAVE_POOL_ADDRESS)
- `PHASE1_EXCEPTION_EXPIRES_ON` を `.env.production` から読み取り → 未設定なら exit 1
- `ENV_SEPARATION_TEST_DATE` / `STAGING_ENV_FILE` / `PRODUCTION_ENV_FILE` 環境変数オーバーライド対応 (テスト用)
- Phase 1 期間内: 例外変数の差分を WARN に格下げ (exit 0)
- Phase 1 期間外: 例外変数の差分も FAIL (exit 1)
- 例外外変数の違反: 常に FAIL (既存動作維持)

### scripts/tests/test_check_env_separation.sh (新規)
5 ケース × 2 アサーション = 10 アサーション、全 pass

| ケース | 内容 | 期待 |
|--------|------|------|
| Case 1 | Phase1 期間内 + 例外変数差分 | exit 0 + WARN |
| Case 2 | Phase1 期間外 + 例外変数差分 | exit 1 |
| Case 3 | 例外外変数 (DATABASE_URL) が同値 | 常に exit 1 |
| Case 4 | PHASE1_EXCEPTION_EXPIRES_ON 未設定 | exit 1 |
| Case 5 | 全項目通過 (Phase1 WARN のみ) | exit 0 |

## 事前作業 (Hetzner .env.production)
マージ後、Hetzner 本番サーバーの `.env.production` に以下を追加が必要:
```
PHASE1_EXCEPTION_EXPIRES_ON=2026-09-30
```

## テスト
```
bash scripts/tests/test_check_env_separation.sh  # 10/10 pass
shellcheck scripts/check_env_separation.sh        # pass
shellcheck scripts/tests/test_check_env_separation.sh  # pass
```

## 影響
- `scripts/` 単独、本番動作に直接影響なし
- CI (`.github/workflows/env-separation-check.yml`) は .env.production が存在しない場合 exit 0 でスキップするため CI への影響なし

## 関連
- PR #91 env-separation (実装漏れ修正)