### PR TITLE
fix(infra): postgres healthcheck -d フラグ追加（FATAL database does not exist 抑制）

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -92,7 +92,7 @@ services:
     networks:
       - production-net
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-ultra}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-ultra} -d ${POSTGRES_DB:-ultra_autotrade}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -94,7 +94,7 @@ services:
     networks:
       - staging-net
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-ultra}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-ultra} -d ${POSTGRES_DB:-ultra_autotrade_staging}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/deploy_plan/2026-04-26_F-6_deploy.md
+++ b/docs/deploy_plan/2026-04-26_F-6_deploy.md
@@ -1,0 +1,153 @@
+# F-6 本番デプロイ計画書 (2026-04-26)
+
+## 対象
+
+- Asana: 1214120371503067
+- PR: #130 (mergedAt: 2026-04-26T00:27:15Z)
+- 主要 commit: 999c483 (feat(fees): F-6 AI判断ロジック統合)
+- main マージ commit: 2b76a97
+
+## 変更内容サマリ
+
+- `backend/app/auth/models.py`: `normalize_tier()` 関数追加（GENERAL → LOWER フォールバック）
+- `backend/app/automation/ai_judgment_scheduler.py`: tier 正規化呼び出し追加
+- `backend/app/automation/workflow.py`: GENERAL ハードコード除去・tier 正規化経由に変更
+- `backend/app/api/automation_dashboard.py`: minor fix
+- `backend/app/knowledge/router.py`: minor fix
+- 新規テスト: `test_normalize_tier.py` (92行), `test_ai_judgment_scheduler.py` (45行), `test_workflow_integration.py` (134行)
+
+## デプロイ前スナップショット (2026-04-26 09:35 JST 取得)
+
+| 項目 | 値 |
+|------|-----|
+| Hetzner working tree HEAD | 2b76a97 (origin/main と同一、F-6 含む) |
+| 本番 backend コンテナ作成日時 | 2026-04-24T05:45:44Z (F-6 前のビルド) |
+| 本番 backend イメージ SHA | sha256:b55ea64ccbeb9041837193f0e5bc3f51c9834091f3cfef0c5ec923261ed1c16e |
+| users.tier 分布 | GENERAL = 6 件 |
+| proposals 総件数 | 0 件 |
+| ai_decisions 24h | HOLD = 6 件、avg confidence = 22.8 |
+| health endpoint | ok (scheduler_healthy: true, last_judgment: 2026-04-25T20:49:24Z) |
+| .env.production md5 | ab8b4284ff9a42f23df7f4ca80eabf2c |
+| 既知エラー (24h) | OpenAI 429 (quota超過) のみ、F-6 由来なし |
+
+## 推奨デプロイ時間帯
+
+**JST 23:00〜翌07:00**（山本さん不在時間帯）
+
+## デプロイ手順
+
+```bash
+ssh -i ~/.ssh/hetzner_staging ultra@77.42.46.155
+cd /opt/ultra-autotrade
+
+# Step 1: git 状態確認 (working tree は既に 2b76a97 のはずだが念のため)
+git status
+git log --oneline -3
+# → 2b76a97 が HEAD であることを確認
+
+# Step 2: .env.production バックアップ (本デプロイでは .env 変更なし、念のため)
+cp .env.production .env.production.backup.$(date +%Y%m%d_%H%M%S)
+
+# Step 3: backend-production 再起動 (rebuild 不要: working tree に最新コードあり)
+docker compose -p ultra-autotrade-project -f docker-compose.production.yml up -d --no-deps backend
+
+# Step 4: 起動確認 (15秒待機)
+sleep 15
+docker compose -p ultra-autotrade-project -f docker-compose.production.yml ps backend
+
+# Step 5: health check
+curl -sf https://api.ultra-auto-trade.com/health | python3 -m json.tool
+# 期待: status=ok, scheduler_healthy=true, scheduler_last_error=null
+
+# Step 6: エラーログ確認
+docker logs --tail=100 ultra-autotrade-backend-production 2>&1 | grep -iE "error|exception|fatal" | grep -v "OpenAI API"
+# 期待: 新規エラーなし (OpenAI 429 は既知、無視)
+
+# Step 7: tier_normalize_fallback ログ確認
+docker logs --tail=200 ultra-autotrade-backend-production 2>&1 | grep -i "tier_normalize_fallback"
+# 期待: LEGACY_TIER_MAP 経由 (GENERAL → LOWER) のみ、または出力なし
+
+# Step 8: proposals 件数確認 (変化なし = 0 件が期待)
+docker compose -p ultra-autotrade-project -f docker-compose.production.yml exec postgres psql -U ultra -d ultra_autotrade -c "SELECT COUNT(*) FROM proposals;"
+```
+
+## ロールバックトリガー
+
+- health endpoint が non-2xx を 10 秒以上継続
+- `ultra-autotrade-backend-production` が Crash/Restart Loop
+- `tier_normalize_fallback` ログに LEGACY_TIER_MAP 想定外の値（INVALID 等）
+- 新規例外スタックトレース（OpenAI 429 以外）
+- proposals 件数が 0 件から増加（意図しないデータ変更）
+
+## ロールバック手順
+
+```bash
+# コンテナが起動しない場合: 旧イメージで再起動
+docker run -d --name ultra-autotrade-backend-production-rollback \
+  sha256:b55ea64ccbeb9041837193f0e5bc3f51c9834091f3cfef0c5ec923261ed1c16e ...
+
+# または git revert でコードを戻す
+cd /opt/ultra-autotrade
+git revert --no-edit 2b76a97
+git push origin main
+docker compose -p ultra-autotrade-project -f docker-compose.production.yml up -d --no-deps backend
+```
+
+## 注意事項
+
+- Hetzner working tree は既に 2b76a97 (F-6 含む main HEAD)。`git pull` 不要。
+- `.env.production` 変更なし。フロントエンドリビルド不要。
+- ai_judgment_scheduler は backend 内蔵（別コンテナなし）。backend 再起動で自動再開。
+- DB スキーマ変更なし。ALTER TABLE 不要。
+- `docker compose up -d --no-deps backend` のみで完了（rebuild なし）。
+
+---
+
+## 実績 (2026-04-26 11:23〜11:35 JST)
+
+### デプロイ実績
+
+| 項目 | 値 |
+|------|-----|
+| デプロイ開始時刻 (JST) | 11:24:25 |
+| backend-production 再起動所要 | 約 60秒 (--build 含む) |
+| health check | pass (status: ok) |
+| scheduler_healthy | true |
+| F-6 commit 反映確認 | 999c483 (2b76a97 → c5b5915 へ git pull 完了) |
+| ロールバック発動 | なし |
+
+### .env.production 更新
+
+| 項目 | 値 |
+|------|-----|
+| 追加前 md5 | ab8b4284ff9a42f23df7f4ca80eabf2c |
+| 追加後 md5 | bb87fb556916a96d62bdf04dec7b84c2 |
+| 追加内容 | `PHASE1_EXCEPTION_EXPIRES_ON=2026-09-30` (PR #133 依存) |
+
+### tier_normalize_fallback ログ
+
+- 出現件数: 0件
+- 内訳: DB上の users.tier が GENERAL のユーザーに対して scheduler 実行中は GENERAL が
+  渡らなかった（scheduler 実行 1回、HOLD判定）
+- 想定外の値: なし
+
+### DB状態 (デプロイ後)
+
+| 項目 | 値 |
+|------|-----|
+| ai_decisions 直近10分 | HOLD = 2件 |
+| proposals | 0件 (デプロイ前と同じ) |
+
+### Gate 4 E2E
+
+| 項目 | 値 |
+|------|-----|
+| 実行件数 | 38 passed, 8 skipped |
+| pass率 | 100% (skipは partner login テスト、cred不要) |
+| 失敗 | なし |
+
+### 山本影響実績
+
+- proposals 0件継続: 確認
+- tier正規化: LOWER同値、数値変化なし（想定通り）
+- 既知エラー: OpenAI 429 (quota超過) のみ継続、F-6 由来の新規エラーなし


### PR DESCRIPTION
## Summary

- `docker-compose.production.yml` と `docker-compose.staging.yml` の postgres healthcheck を修正
- `pg_isready -U ultra` → `pg_isready -U ultra -d ultra_autotrade` / `ultra_autotrade_staging`

## 根本原因

`pg_isready` に `-d` フラグを指定しないと、PostgreSQL は接続先DBとして **ユーザー名** (`ultra`) を使用する。
DB `ultra` は存在しないため、10秒ごとに以下の FATAL が記録されていた（2026-04-26, 2138+件/6時間）:

```
FATAL:  database "ultra" does not exist
```

コンテナの healthcheck 自体は exit=0 を返すため `Status=healthy` のままで、エラーは見落とされやすい。

## 影響

- 本番 postgres ログに 10 秒/件のノイズ → Loki 肥大化
- ログ監視で真のエラーが埋もれるリスク

## 修正内容

```yaml
# Before
test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-ultra}"]

# After (production)
test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-ultra} -d ${POSTGRES_DB:-ultra_autotrade}"]

# After (staging)
test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-ultra} -d ${POSTGRES_DB:-ultra_autotrade_staging}"]
```

## Hetzner 適用手順（マージ後）

```bash
cd /opt/ultra-autotrade
git pull origin main
# postgres の healthcheck のみ更新（再作成不要）
docker compose -p ultra-autotrade-project -f docker-compose.production.yml up -d --no-deps --force-recreate postgres
```

> 注意: `--force-recreate` で postgres コンテナを再作成するが、ボリューム(`postgres-data`)は保持される。
> backend は postgres 再起動中に接続リトライするため通常は自動復旧する。

## Test plan

- [ ] Hetzner で `git pull` + `docker compose up -d --no-deps --force-recreate postgres`
- [ ] `docker logs ultra-autotrade-postgres-production 2>&1 | grep "FATAL" | tail -5` → 0件
- [ ] `docker compose ps` で postgres が `(healthy)` であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)