### PR TITLE
[P3] 凍結ファイルガード仕組み整備 (Asana 1214272305616630)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,14 @@
 repos:
+  - repo: local
+    hooks:
+      - id: frozen-files-guard
+        name: Frozen Files Guard
+        language: script
+        entry: scripts/check_frozen_files.sh
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+
   - repo: https://github.com/awslabs/automated-security-helper
     rev: v3.2.3
     hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1723,6 +1723,51 @@ Slack アラート受信
 
 ---
 
+## 凍結ファイルガード運用ルール（2026-04-26追加）
+
+> 背景: F-9 PR #128 lint fail、凍結ファイルの誤編集破損が複数回発生。機械的に防ぐ仕組みを導入。
+
+### 凍結ファイルとは
+変更するとシステム全体または本番環境に重大な影響を与えるファイル。一覧は `docs/integration/backend_deps.md` の「凍結ファイル登録表」参照。
+
+現在の凍結ファイル（抜粋）:
+- `backend/app/main.py` — FastAPI アプリ本体（router 登録・startup）
+- `backend/app/database.py` — ORM セッション管理
+- `backend/app/shared/` — 全モジュール共通定数・型
+- `backend/conftest.py` — pytest グローバルフィクスチャ
+- `backend/requirements.txt` — Python 依存バージョン master
+- `backend/alembic/versions/*.py` — DB マイグレーション履歴（**変更絶対禁止**）
+- `.github/workflows/path-check.yml` — CI 凍結ファイルガード本体
+- `pyproject.toml` — ruff/mypy/pytest 設定
+
+### 凍結ファイルを変更する手順
+1. `docs/integration/backend_deps.md` の凍結ファイル登録表で解凍条件を確認
+2. 同ファイルに「変更 #N」エントリを記載（テンプレートは同ファイル内参照）
+3. feature ブランチで変更を実装
+4. `git commit` — pre-commit フック (`scripts/check_frozen_files.sh`) が検証
+   - `docs/integration/backend_deps.md` が staged に含まれていれば ⚠️ WARN（続行可）
+   - 含まれていなければ ❌ FAIL（コミット中断）
+5. PR 作成 → `.github/workflows/path-check.yml` が CI でも検証
+
+### やってはいけないこと
+- `alembic/versions/*.py` は一切編集禁止（ロールバックは新規マイグレーション作成）
+- CI を `--no-verify` でスキップして凍結ファイルを変更すること
+- `pyproject.toml` の coverage 閾値を緩和方向に変更すること（Opus 承認なしでは禁止）
+
+### ローカル pre-commit 設定（初回のみ）
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+### 手動チェック（コミット前確認）
+```bash
+./scripts/check_frozen_files.sh        # staged ファイルを検査
+./scripts/check_frozen_files.sh --all  # HEAD との全差分を検査
+```
+
+---
+
 ## 標準チェックリスト（全実装で必ず確認）
 
 すべてのコード変更（機能追加・バグ修正・リファクタ問わず）で、実装完了前に以下を確認すること。

--- a/docs/integration/backend_deps.md
+++ b/docs/integration/backend_deps.md
@@ -5,7 +5,52 @@
 
 ---
 
-## backend/app/main.py
+## 凍結ファイル登録表
+
+CI チェック (`.github/workflows/path-check.yml`) および pre-commit フック (`scripts/check_frozen_files.sh`) が参照する凍結ファイルの公式リスト。
+新規ファイルを凍結する場合はこの表と `path-check.yml` の `FROZEN_PATTERNS` を同時に更新すること。
+
+| # | パス | 凍結理由 | 解凍条件 |
+|---|------|---------|---------|
+| 1 | `backend/app/main.py` | FastAPI router 登録・startup イベント・health エンドポイントの中核。意図しない変更でスケジューラー・CORS・依存注入が壊れる（2026-04-02 インシデント参照） | アーキテクチャ変更 PR + Opus レビュー + backend_deps.md 申請 |
+| 2 | `backend/app/database.py` | ORM セッション管理・トランザクション制御の中核。変更するとデータ不整合やデッドロックのリスクがある | DB 移行計画 PR + Opus レビュー + backend_deps.md 申請 |
+| 3 | `backend/app/shared/` | 全モジュール共通の定数・型・ユーティリティ。1 ファイル変更が全モジュールに波及する | 変更範囲を tests/ でカバーした上で backend_deps.md 申請 |
+| 4 | `backend/conftest.py` | pytest グローバルフィクスチャ。変更すると全テストの前提が崩れ、カバレッジゲートを突破するバグが混入する（2026-04-25 F-9 lint fail インシデント参照） | テストアーキテクチャ変更 PR + backend_deps.md 申請 |
+| 5 | `backend/requirements.txt` | Python 依存バージョンの master。不用意な変更で CVE が混入する。pip-compile 管理外のため手動編集がデグレを起こしやすい（CVE-2026-24049 インシデント参照） | セキュリティパッチ or 機能追加 PR + backend_deps.md 申請 |
+| 6 | `backend/alembic/versions/*.py` | DB マイグレーション履歴。一度 main にマージされたバージョンを編集すると本番 DB の alembic_version と矛盾して復旧不能になる | 変更禁止（ロールバックは新規マイグレーション作成） |
+| 7 | `frontend/package-lock.json` | npm 依存ロック。CLAUDE.md で `npm install --legacy-peer-deps` に統一済み。手動編集すると Docker ビルド・CI が壊れる | `npm install --legacy-peer-deps` 実行後の自動更新のみ |
+| 8 | `.github/workflows/path-check.yml` | 凍結ファイルガードの CI 本体。変更するとガードが無効化される恐れがある | ガード強化または機能拡張の場合は Opus レビュー必須 |
+| 9 | `.github/workflows/env-separation-check.yml` | env 分離チェック CI（2026-04-18 インシデントの根本対策）。変更するとステージング/本番の誤混入を見落とす | セキュリティ観点のレビュー + Opus 承認必須 |
+| 10 | `pyproject.toml` | ruff/mypy/pytest/coverage 設定。緩和方向の変更（coverage 閾値低下など）は全員への品質影響があるため原則禁止 | 品質向上目的のみ許可。緩和は Opus レビュー必須 |
+
+### 凍結ファイル変更フロー
+
+```
+1. この表で凍結理由・解凍条件を確認
+2. backend_deps.md に「変更 #N」エントリを追加（後述フォーマット参照）
+3. feature ブランチで変更を実装
+4. PR 作成 → path-check CI が自動検証（backend_deps.md 更新済みなら WARN 扱い）
+5. Opus レビュー（解凍条件に「Opus レビュー」が含まれる場合）
+6. main マージ
+```
+
+### 変更申請エントリ フォーマット（テンプレート）
+
+```markdown
+### 変更 #N: <変更タイトル> (PR #xxx / YYYY-MM-DD)
+- **コミット範囲**: `<sha>` (<ブランチ名>)
+- **変更内容**:
+  - <箇条書き>
+- **理由**: <凍結条件のどれに該当するか>
+- **影響範囲**: <変更が波及するモジュール・テスト>
+- **承認**: <レビュアー名 or PR番号>
+```
+
+---
+
+## 変更ログ
+
+### backend/app/main.py
 
 ### 変更 #3: /health エンドポイントに AI モデル設定を追加 (PR #95 / 2026-04-20)
 - **コミット範囲**: `408d3ad` (feature/remove-claude-model-hardcodes)
@@ -117,11 +162,11 @@
 
 変更なし（現時点）
 
-## backend/conftest.py
+### backend/conftest.py
 
 変更なし（現時点）
 
-## backend/requirements.txt
+### backend/requirements.txt
 
 ### 変更 #2: PyJWT[crypto] extra 追加（Privy ID Token 検証対応）(PR #155 / 2026-04-27)
 - **コミット範囲**: `c88dfd2` – `41f77d7` (feature/privy-did-storage)
@@ -140,6 +185,6 @@
 - **影響範囲**: ビルドツールのみ。アプリケーションロジックへの影響なし。
 - **承認**: dev → staging → main の通常フロー経由
 
-## backend/app/shared/
+### backend/app/shared/
 
 変更なし（現時点）

--- a/scripts/check_frozen_files.sh
+++ b/scripts/check_frozen_files.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# check_frozen_files.sh
+# pre-commit フックまたは手動実行で凍結ファイルの変更を検出する。
+# CI (.github/workflows/path-check.yml) と同じ FROZEN_PATTERNS を使用。
+#
+# Usage:
+#   ./scripts/check_frozen_files.sh          # staged ファイルを検査
+#   ./scripts/check_frozen_files.sh --all    # HEAD と比較して全変更を検査
+
+set -euo pipefail
+
+FROZEN_PATTERNS=(
+  "backend/app/shared/"
+  "backend/app/main.py"
+  "backend/app/database.py"
+  "backend/conftest.py"
+  "backend/requirements.txt"
+  "backend/alembic/versions/"
+  ".github/workflows/path-check.yml"
+  ".github/workflows/env-separation-check.yml"
+  "pyproject.toml"
+)
+
+# staged ファイル or 全変更ファイルを取得
+if [ "${1:-}" = "--all" ]; then
+  CHANGED=$(git diff --name-only HEAD 2>/dev/null || true)
+else
+  CHANGED=$(git diff --cached --name-only 2>/dev/null || true)
+fi
+
+if [ -z "$CHANGED" ]; then
+  exit 0
+fi
+
+# docs/integration/backend_deps.md が変更に含まれていれば「申請済み」とみなす
+HAS_BACKEND_DEPS_UPDATE=0
+if echo "$CHANGED" | grep -q '^docs/integration/backend_deps\.md$'; then
+  HAS_BACKEND_DEPS_UPDATE=1
+fi
+
+VIOLATIONS=""
+WARNINGS=""
+
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+
+  for pattern in "${FROZEN_PATTERNS[@]}"; do
+    if echo "$file" | grep -q "^$pattern"; then
+      if [ "$HAS_BACKEND_DEPS_UPDATE" -eq "1" ]; then
+        WARNINGS="${WARNINGS}  ⚠️  凍結ファイル変更（申請済み）: ${file}\n"
+      else
+        VIOLATIONS="${VIOLATIONS}  ❌ 凍結ファイル変更（未申請）: ${file}\n"
+      fi
+      break
+    fi
+  done
+done <<< "$CHANGED"
+
+if [ -n "$WARNINGS" ]; then
+  echo ""
+  echo "🛡️  凍結ファイルガード — 警告"
+  echo "──────────────────────────────────────────────"
+  echo -e "$WARNINGS"
+  echo "  docs/integration/backend_deps.md に申請済みのため続行します。"
+fi
+
+if [ -n "$VIOLATIONS" ]; then
+  echo ""
+  echo "🛡️  凍結ファイルガード — 違反"
+  echo "──────────────────────────────────────────────"
+  echo -e "$VIOLATIONS"
+  echo "  解決方法:"
+  echo "    1. docs/integration/backend_deps.md の凍結ファイル登録表で解凍条件を確認"
+  echo "    2. 同ファイルに「変更 #N」エントリを追加して git add"
+  echo "    3. 再度 git commit を実行"
+  echo ""
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- `docs/integration/backend_deps.md` に凍結ファイル登録表（10件）とテンプレートを追加
- `scripts/check_frozen_files.sh` を新規作成（pre-commit + `--all` モード対応）
- `.pre-commit-config.yaml` に `frozen-files-guard` フックを追加
- `CLAUDE.md` に凍結ファイルガード運用ルールセクションを追加

## 背景

2026-04-25教訓: F-9 PR #128 lint fail、凍結ファイルの誤編集破損が複数回発生。
機械的に防ぐ仕組みが存在しなかった。

## 変更内容

### 凍結ファイル登録表 (docs/integration/backend_deps.md)
| # | 対象 | 凍結理由 |
|---|------|---------|
| 1 | `backend/app/main.py` | FastAPI 本体 |
| 2 | `backend/app/database.py` | ORM セッション管理 |
| 3 | `backend/app/shared/` | 全モジュール共通定数 |
| 4 | `backend/conftest.py` | pytest グローバルフィクスチャ |
| 5 | `backend/requirements.txt` | Python 依存 master |
| 6 | `backend/alembic/versions/*.py` | DB マイグレーション履歴（変更絶対禁止） |
| 7 | `frontend/package-lock.json` | npm 依存ロック |
| 8 | `.github/workflows/path-check.yml` | CI ガード本体 |
| 9 | `.github/workflows/env-separation-check.yml` | env 分離チェック |
| 10 | `pyproject.toml` | ruff/mypy/pytest 設定 |

### scripts/check_frozen_files.sh
- staged ファイルを走査して凍結ファイルを検出
- `docs/integration/backend_deps.md` が staged に含まれていれば ⚠️ WARN（続行可）
- 含まれていなければ ❌ FAIL（コミット中断）
- `--all` オプションで HEAD との全差分を検査可能

### .pre-commit-config.yaml
- `frozen-files-guard` フックを `ash-simple-scan` の前に追加

## Test plan
- [x] `./scripts/check_frozen_files.sh` — 未変更時 exit 0
- [x] frozen file のみ staged → ❌ FAIL + 手順表示
- [x] frozen file + backend_deps.md staged → ⚠️ WARN + exit 0
- [x] docs/* のみ変更では CI path-check が通ること（既存挙動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)