### PR TITLE
[P0][山本影響] AI判定 Aaveデータ + cognitive_state 注入 (Asana 1214279097935851)

### DIFF
--- a/backend/app/automation/aave_data_fetcher.py
+++ b/backend/app/automation/aave_data_fetcher.py
@@ -1,0 +1,119 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""Aave マーケットデータを fail-open で取得する同期ヘルパー。
+
+ai_judgment_scheduler.run_ai_judgment_job (sync, executor 上で呼ばれる)
+から利用される。個別フィールドの取得失敗は None を返し、scheduler 全体は
+継続させる (落とさない)。
+
+設計判断:
+- Web3AaveClient.get_health_factor は同期 → 直接呼ぶ
+- Aave Liquidity API (`UtilizationMonitor` と同じ HTTP エンドポイント) は async →
+  asyncio.new_event_loop で囲む。executor スレッド上には running loop が
+  存在しないためこのパターンが安全
+- Decimal("inf") (借入なし) は health_factor=None として返す。
+  「借入なしで HF 無限大」は LLM プロンプトに有用情報を与えないため
+"""
+
+import asyncio
+import logging
+from decimal import Decimal
+from typing import Optional, TypedDict
+
+import httpx
+
+from app.aave.client import AaveClientError, get_default_aave_client
+
+logger = logging.getLogger(__name__)
+
+
+_AAVE_LIQUIDITY_API = "https://aave-api-v2.aave.com"
+
+
+class AaveMarketData(TypedDict):
+    utilization_rate: Optional[Decimal]
+    supply_apy: Optional[Decimal]
+    borrow_apy: Optional[Decimal]
+    health_factor: Optional[Decimal]
+
+
+def _empty_result() -> AaveMarketData:
+    return {
+        "utilization_rate": None,
+        "supply_apy": None,
+        "borrow_apy": None,
+        "health_factor": None,
+    }
+
+
+def _fetch_health_factor() -> Optional[Decimal]:
+    """Aave V3 Pool から Health Factor を同期取得。
+
+    Web3AaveClient はコンストラクタ時の wallet_private_key (AAVE_WALLET_PRIVATE_KEY)
+    から導出した self.account.address をデフォルトで読む。production は単一ウォレット
+    運用なので追加の wallet 引数は不要。
+
+    取得失敗 / Decimal("inf") (借入なし) の場合は None を返す。
+    """
+    try:
+        client = get_default_aave_client()
+        hf = client.get_health_factor()
+        if hf is None or hf == Decimal("inf"):
+            return None
+        return hf
+    except AaveClientError as exc:
+        logger.warning("aave_health_factor_fetch_failed: %s", exc)
+        return None
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("aave_health_factor_fetch_unexpected_error: %s", exc)
+        return None
+
+
+async def _fetch_utilization_async(asset_symbol: str) -> dict[str, Decimal]:
+    """Aave Liquidity API を 1 回叩く (httpx クライアントは context で close)。"""
+    async with httpx.AsyncClient(base_url=_AAVE_LIQUIDITY_API, timeout=10.0) as client:
+        response = await client.get(f"/data/liquidity/v2?poolId={asset_symbol}")
+        response.raise_for_status()
+        data = response.json()
+        return {
+            "utilization_rate": Decimal(str(data["utilizationRate"])),
+            "supply_apy": Decimal(str(data["supplyAPY"])),
+            "borrow_apy": Decimal(str(data["borrowAPY"])),
+        }
+
+
+def _fetch_utilization_sync(asset_symbol: str) -> dict[str, Optional[Decimal]]:
+    """async fetch を sync コンテキストから呼ぶ (executor スレッド前提)。"""
+    try:
+        loop = asyncio.new_event_loop()
+        try:
+            result = loop.run_until_complete(_fetch_utilization_async(asset_symbol))
+            return dict(result)
+        finally:
+            loop.close()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("aave_utilization_fetch_failed: %s", exc)
+        return {"utilization_rate": None, "supply_apy": None, "borrow_apy": None}
+
+
+def fetch_aave_market_data_safe(asset_symbol: str = "USDC") -> AaveMarketData:
+    """fail-open で Aave マーケットデータを取得する。
+
+    個別失敗 → そのフィールドのみ None。全失敗 → 全 None dict。
+    例外を呼び出し側に投げないことで scheduler の継続性を担保する。
+
+    Returns:
+        AaveMarketData (utilization_rate / supply_apy / borrow_apy / health_factor)
+    """
+    result = _empty_result()
+    result["health_factor"] = _fetch_health_factor()
+
+    util = _fetch_utilization_sync(asset_symbol)
+    if util.get("utilization_rate") is not None:
+        result["utilization_rate"] = util["utilization_rate"]
+    if util.get("supply_apy") is not None:
+        result["supply_apy"] = util["supply_apy"]
+    if util.get("borrow_apy") is not None:
+        result["borrow_apy"] = util["borrow_apy"]
+
+    return result

--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -20,10 +20,12 @@ from typing import Any, Callable, Optional
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.ai.judgment_log import get_judgment_logger
 from app.ai.models import AIDecision
 from app.ai.schemas import CrossValidationResult, RAGContext, TradeAction
 from app.ai.service import AIService
 from app.auth.models import InvestmentTier, User, normalize_tier
+from app.automation.aave_data_fetcher import fetch_aave_market_data_safe
 from app.data_feeds.context import build_market_context
 from app.database import SessionLocal
 from app.knowledge.schemas import KnowledgeSearchRequest
@@ -251,11 +253,21 @@ def run_ai_judgment_job(db: Optional[Session] = None) -> dict[str, Any]:
             logger.warning("RAG context retrieval failed, using empty context: %s", exc)
             rag_ctx = RAGContext(chunks=[], query=_DEFAULT_QUERY, source_count=0)
 
-        # Market context（ニュース・地政学リスク・マクロ）をキャッシュから取得
+        # Market context（ニュース・地政学リスク・マクロ + Aave + cognitive_state）
+        # を組み立てる。Aave 取得は fail-open ヘルパーで、個別失敗は None フォールバック。
+        # cognitive_state は HOLD 連続抑制のため LLM プロンプトに渡す。
         context_degraded = False
         market_ctx: Any
         try:
-            market_ctx = build_market_context()
+            aave_data = fetch_aave_market_data_safe()
+            cognitive_state = get_judgment_logger().get_cognitive_state()
+            market_ctx = build_market_context(
+                aave_utilization_rate=aave_data["utilization_rate"],
+                aave_supply_apy=aave_data["supply_apy"],
+                aave_borrow_apy=aave_data["borrow_apy"],
+                health_factor=aave_data["health_factor"],
+                cognitive_state=cognitive_state,
+            )
         except Exception as exc:
             context_degraded = True
             logger.warning("build_market_context() failed, using degraded context: %s", exc)

--- a/backend/app/automation/workflow.py
+++ b/backend/app/automation/workflow.py
@@ -760,12 +760,11 @@ def _process_single_item(
 
             from app.billing.dynamic_fee import calculate_fee_by_market  # noqa: PLC0415
 
-            # TODO(P0 タスク 1214279097935851): current_apy を MarketContext から正しく取得する。
-            # 現状 getattr(ctx, "current_apy", None) は MarketContext に該当属性がないため常に
-            # None を返し、Decimal("4") (4%) フォールバックされる。Aave クライアント連携時に修正予定。
-            _apy_raw = getattr(ctx, "current_apy", None) if ctx else None
+            # MarketContext.aave_supply_apy (fail-open ヘルパー経由で注入) を読む。
+            # Aave 取得失敗時は None → Decimal("4") (4%) フォールバック。
+            _apy_raw = getattr(ctx, "aave_supply_apy", None) if ctx else None
             if _apy_raw is None and isinstance(ctx, dict):
-                _apy_raw = ctx.get("current_apy")
+                _apy_raw = ctx.get("aave_supply_apy")
             current_apy = Decimal(str(_apy_raw)) if _apy_raw is not None else Decimal("4")
 
             # 30日保有での予想利益 = trade_amount × (APY/100) × (30/365)

--- a/backend/tests/test_aave_data_fetcher.py
+++ b/backend/tests/test_aave_data_fetcher.py
@@ -1,0 +1,93 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""Aave マーケットデータ fail-open ヘルパーの単体テスト。"""
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from app.aave.client import AaveClientError
+from app.automation.aave_data_fetcher import fetch_aave_market_data_safe
+
+
+def test_aave_data_safe_returns_none_dict_on_full_failure():
+    """AaveClient + Liquidity API 両方が失敗した場合、全 None dict を返すこと。"""
+    with (
+        patch(
+            "app.automation.aave_data_fetcher.get_default_aave_client",
+            side_effect=AaveClientError("rpc down"),
+        ),
+        patch(
+            "app.automation.aave_data_fetcher._fetch_utilization_async",
+            side_effect=Exception("net down"),
+        ),
+    ):
+        result = fetch_aave_market_data_safe()
+
+    assert result == {
+        "utilization_rate": None,
+        "supply_apy": None,
+        "borrow_apy": None,
+        "health_factor": None,
+    }
+
+
+def test_aave_data_safe_partial_success_health_factor_only():
+    """HF 取得成功 + Utilization 失敗時、HF のみ値を持つこと。"""
+    mock_client = MagicMock()
+    mock_client.get_health_factor.return_value = Decimal("1.85")
+
+    with (
+        patch("app.automation.aave_data_fetcher.get_default_aave_client", return_value=mock_client),
+        patch(
+            "app.automation.aave_data_fetcher._fetch_utilization_async",
+            side_effect=Exception("aave api down"),
+        ),
+    ):
+        result = fetch_aave_market_data_safe()
+
+    assert result["health_factor"] == Decimal("1.85")
+    assert result["utilization_rate"] is None
+    assert result["supply_apy"] is None
+    assert result["borrow_apy"] is None
+
+
+def test_aave_data_safe_inf_health_factor_returns_none():
+    """HF=inf (借入なし) の場合、health_factor は None になること。"""
+    mock_client = MagicMock()
+    mock_client.get_health_factor.return_value = Decimal("inf")
+
+    async def _ok_util(_symbol: str) -> dict:
+        return {
+            "utilization_rate": Decimal("0.85"),
+            "supply_apy": Decimal("0.04"),
+            "borrow_apy": Decimal("0.06"),
+        }
+
+    with (
+        patch("app.automation.aave_data_fetcher.get_default_aave_client", return_value=mock_client),
+        patch("app.automation.aave_data_fetcher._fetch_utilization_async", side_effect=_ok_util),
+    ):
+        result = fetch_aave_market_data_safe()
+
+    assert result["health_factor"] is None
+    assert result["utilization_rate"] == Decimal("0.85")
+    assert result["supply_apy"] == Decimal("0.04")
+    assert result["borrow_apy"] == Decimal("0.06")
+
+
+def test_aave_data_safe_calls_get_health_factor_no_args():
+    """get_health_factor は no-args で呼ばれること (Web3AaveClient は self.account.address を使う)。"""
+    mock_client = MagicMock()
+    mock_client.get_health_factor.return_value = Decimal("2.5")
+
+    with (
+        patch("app.automation.aave_data_fetcher.get_default_aave_client", return_value=mock_client),
+        patch(
+            "app.automation.aave_data_fetcher._fetch_utilization_async",
+            side_effect=Exception("skip"),
+        ),
+    ):
+        result = fetch_aave_market_data_safe()
+
+    mock_client.get_health_factor.assert_called_once_with()
+    assert result["health_factor"] == Decimal("2.5")

--- a/backend/tests/test_ai_judgment_scheduler.py
+++ b/backend/tests/test_ai_judgment_scheduler.py
@@ -768,3 +768,118 @@ def test_create_proposals_uses_normalized_tier(db_session):
     assert call_kwargs["tier"] == InvestmentTier.LOWER.value, (
         f"GENERAL は LOWER に正規化されるべきだが {call_kwargs['tier']!r} が渡された"
     )
+
+
+# ---------------------------------------------------------------------------
+# P0 Aave 注入 + cognitive_state 連携 (Asana 1214279097935851)
+# ---------------------------------------------------------------------------
+
+
+def test_run_ai_judgment_job_passes_aave_data(db_session):
+    """fetch_aave_market_data_safe の戻り値が build_market_context に kwargs として渡ること。"""
+    fake_aave = {
+        "utilization_rate": Decimal("0.85"),
+        "supply_apy": Decimal("4.2"),
+        "borrow_apy": Decimal("5.8"),
+        "health_factor": Decimal("2.1"),
+    }
+    mock_result = _make_cross_validation_result(TradeAction.HOLD)
+
+    with (
+        patch("app.automation.ai_judgment_scheduler.AIService") as MockAIService,
+        patch("app.automation.ai_judgment_scheduler.KnowledgeService") as MockKnowledgeService,
+        patch(
+            "app.automation.ai_judgment_scheduler.fetch_aave_market_data_safe",
+            return_value=fake_aave,
+        ),
+        patch("app.automation.ai_judgment_scheduler.build_market_context") as mock_build,
+    ):
+        MockAIService.return_value.judge_with_rag.return_value = mock_result
+        MockKnowledgeService.return_value.search.return_value = []
+
+        run_ai_judgment_job(db=db_session)
+
+    call_kwargs = mock_build.call_args.kwargs
+    assert call_kwargs["aave_utilization_rate"] == Decimal("0.85")
+    assert call_kwargs["aave_supply_apy"] == Decimal("4.2")
+    assert call_kwargs["aave_borrow_apy"] == Decimal("5.8")
+    assert call_kwargs["health_factor"] == Decimal("2.1")
+
+
+def test_run_ai_judgment_job_aave_failure_falls_back_to_none(db_session):
+    """Aave 取得失敗時、全フィールド None で MarketContext が構築され job が継続すること。"""
+    fake_aave = {
+        "utilization_rate": None,
+        "supply_apy": None,
+        "borrow_apy": None,
+        "health_factor": None,
+    }
+    mock_result = _make_cross_validation_result(TradeAction.HOLD)
+
+    with (
+        patch("app.automation.ai_judgment_scheduler.AIService") as MockAIService,
+        patch("app.automation.ai_judgment_scheduler.KnowledgeService") as MockKnowledgeService,
+        patch(
+            "app.automation.ai_judgment_scheduler.fetch_aave_market_data_safe",
+            return_value=fake_aave,
+        ),
+        patch("app.automation.ai_judgment_scheduler.build_market_context") as mock_build,
+    ):
+        MockAIService.return_value.judge_with_rag.return_value = mock_result
+        MockKnowledgeService.return_value.search.return_value = []
+
+        result = run_ai_judgment_job(db=db_session)
+
+    # Job は完走すること (HOLD path 後方互換)
+    assert result["action"] == "HOLD"
+    assert result["decision_id"] is not None
+
+    # 全フィールド None でも build_market_context は呼ばれる
+    call_kwargs = mock_build.call_args.kwargs
+    assert call_kwargs["aave_utilization_rate"] is None
+    assert call_kwargs["aave_supply_apy"] is None
+    assert call_kwargs["aave_borrow_apy"] is None
+    assert call_kwargs["health_factor"] is None
+
+
+def test_run_ai_judgment_job_passes_cognitive_state(db_session):
+    """get_judgment_logger().get_cognitive_state() の戻り値が build_market_context に渡ること。"""
+    from app.ai.judgment_log import CognitiveState  # noqa: PLC0415
+
+    fake_state = CognitiveState(
+        recent_actions=["HOLD", "HOLD", "HOLD"],
+        recent_confidences=[55, 58, 60],
+        last_action="HOLD",
+        last_confidence=60,
+        last_reason="待機継続",
+        consecutive_holds=3,
+        total_judgments=10,
+    )
+    mock_result = _make_cross_validation_result(TradeAction.HOLD)
+
+    with (
+        patch("app.automation.ai_judgment_scheduler.AIService") as MockAIService,
+        patch("app.automation.ai_judgment_scheduler.KnowledgeService") as MockKnowledgeService,
+        patch(
+            "app.automation.ai_judgment_scheduler.fetch_aave_market_data_safe",
+            return_value={
+                "utilization_rate": None,
+                "supply_apy": None,
+                "borrow_apy": None,
+                "health_factor": None,
+            },
+        ),
+        patch("app.automation.ai_judgment_scheduler.get_judgment_logger") as mock_logger_factory,
+        patch("app.automation.ai_judgment_scheduler.build_market_context") as mock_build,
+    ):
+        MockAIService.return_value.judge_with_rag.return_value = mock_result
+        MockKnowledgeService.return_value.search.return_value = []
+        mock_logger_factory.return_value.get_cognitive_state.return_value = fake_state
+
+        run_ai_judgment_job(db=db_session)
+
+    call_kwargs = mock_build.call_args.kwargs
+    passed_state = call_kwargs["cognitive_state"]
+    assert passed_state is fake_state
+    assert passed_state.consecutive_holds == 3
+    assert passed_state.total_judgments == 10

--- a/backend/tests/test_workflow_integration.py
+++ b/backend/tests/test_workflow_integration.py
@@ -761,11 +761,11 @@ class TestWorkflowTierNormalization:
         # db.get は呼ばれない (user_id が None なので user 取得スキップ)
         db.get.assert_not_called()
 
-    def test_dynamic_fee_apy_fallback_documented(self):
-        """current_apy 取得バグの回帰テスト: MarketContext に current_apy 属性が無い → Decimal("4") フォールバック。
+    def test_dynamic_fee_apy_fallback_when_aave_supply_apy_none(self):
+        """MarketContext.aave_supply_apy が None の場合 Decimal("4") フォールバックを使うこと。
 
-        TODO(P0 タスク 1214279097935851): MarketContext に Aave データを注入後は
-        current_apy が実値で渡されるよう修正される。本テストはその修正時に更新する。
+        Aave 取得失敗 / 未注入時の安全側挙動。本テストは workflow が
+        MarketContext を実際に build した時 (Aave 未注入パス) の挙動を検証する。
         """
         from unittest.mock import MagicMock, patch
 
@@ -794,8 +794,52 @@ class TestWorkflowTierNormalization:
 
         assert mock_fee.called
         call_kwargs = mock_fee.call_args.kwargs
-        # MarketContext に current_apy 属性が無いため、4% フォールバック値が使われる
-        assert call_kwargs["current_apy"] == Decimal("4"), (
-            "MarketContext に current_apy が注入されるよう修正されたら本テストを更新する "
-            "(P0 タスク 1214279097935851)"
+        # MarketContext.aave_supply_apy が None のため、4% フォールバック値が使われる
+        assert call_kwargs["current_apy"] == Decimal("4")
+
+    def test_workflow_uses_aave_supply_apy_not_current_apy(self):
+        """MarketContext.aave_supply_apy が設定されている場合、その値が dynamic_fee に渡ること。
+
+        P0 (Asana 1214279097935851): workflow.py の current_apy バグ修正の回帰テスト。
+        旧実装は getattr(ctx, "current_apy", None) を読んでいたため常に None →
+        Decimal("4") フォールバックされていた。MarketContext には current_apy 属性は無く、
+        正しくは aave_supply_apy を読むべき。
+        """
+        from unittest.mock import MagicMock, patch
+
+        from app.data_feeds.context import MarketContext
+
+        db = MagicMock()
+        ks = MagicMock()
+        ai = MagicMock()
+        ex = MagicMock()
+
+        item = _make_knowledge_item()
+        ks.get_pending.return_value = [item]
+        ks.search.return_value = []
+        ai.judge_with_rag.return_value = _make_cross_validation(TradeAction.BUY, 85)
+
+        # Aave データを注入した MarketContext を返すように build_market_context をモック
+        injected_ctx = MarketContext(aave_supply_apy=Decimal("6.5"))
+
+        with (
+            patch("app.automation.workflow.build_market_context", return_value=injected_ctx),
+            patch("app.billing.dynamic_fee.calculate_fee_by_market") as mock_fee,
+        ):
+            mock_fee.return_value.should_trade = True
+            mock_fee.return_value.fee_rate = Decimal("0.10")
+            mock_fee.return_value.fee_amount = Decimal("3.00")
+
+            process_pending_knowledge(
+                db,
+                knowledge_service=ks,
+                ai_service=ai,
+                exchange_service=ex,
+                execution_policy="require_approval",
+            )
+
+        assert mock_fee.called
+        call_kwargs = mock_fee.call_args.kwargs
+        assert call_kwargs["current_apy"] == Decimal("6.5"), (
+            f"aave_supply_apy=6.5 が current_apy として渡るべきだが {call_kwargs['current_apy']!r}"
         )


### PR DESCRIPTION
## Summary

Asana #1214279097935851 (山本影響P0 Phase2根本策)。

`build_market_context()` を引数ゼロで呼んでいたため、AI が Aave 状態と過去判定履歴
ブラインドで判定し HOLD バイアスが固定化していた問題を解消。あわせて
`workflow.py` の `current_apy` バグ (常に Decimal("4") フォールバック) も修正。

### 何を直したか

| 箇所 | Before | After |
|---|---|---|
| `ai_judgment_scheduler.py:258` | `build_market_context()` (kwargs ゼロ) | Aave 4 フィールド + cognitive_state を kwargs で注入 |
| `workflow.py:766` | `getattr(ctx, "current_apy", None)` (常に None) | `getattr(ctx, "aave_supply_apy", None)` |
| `aave_data_fetcher.py` | (なし) | fail-open 同期ヘルパー新規 |

### 変更ファイル (6 件 / +397 / -15)

- `backend/app/automation/aave_data_fetcher.py` (新規)
- `backend/app/automation/ai_judgment_scheduler.py`
- `backend/app/automation/workflow.py`
- `backend/tests/test_aave_data_fetcher.py` (新規 4 件)
- `backend/tests/test_ai_judgment_scheduler.py` (+3 件)
- `backend/tests/test_workflow_integration.py` (+1 件 / 1 件 趣旨更新)

### 設計判断

- **fail-open**: Aave クライアント / Liquidity API の失敗は scheduler を落とさず WARNING ログ + None フォールバック
- **後方互換**: HOLD path の degraded dict ハンドラは維持。MarketContext の例外発生時の挙動は変えない
- **シグネチャ非変更**: `build_market_context(**overrides)` は既に kwargs 受け口あり。差分は呼び出し側のみ
- **二重防御**: Aave 取得失敗で AI が Aave 情報なしで BUY を出すリスクは、workflow 側の `MonitoringService` が HF<1.6 で HARD_STOP するため許容
- **AAVE_WALLET_ADDRESS 不使用**: `Web3AaveClient` は秘密鍵から導出した `account.address` をデフォルト使用するため追加引数不要 (production は単一ウォレット運用)
- **F-6 連動**: `current_apy` バグの TODO コメント (本タスク GID 参照) を削除

### DoD ゲート

- [x] `./scripts/verify.sh` 全パス (ruff / format / mypy / pytest cov 80%+ / tsc / build) ※355s
- [x] 単体テスト 62 件全通過 (aave_data_fetcher 4 / scheduler 31 / workflow_integration 27)
- [x] HOLD path 後方互換テスト pass
- [x] WARNING ログ出力箇所確認

## Test plan

### Local

- [x] `cd backend && python -m pytest tests/test_aave_data_fetcher.py tests/test_ai_judgment_scheduler.py tests/test_workflow_integration.py -v` → 62 passed
- [x] `./scripts/verify.sh` → All checks passed (355s)

### Staging (本 PR merge 後)

- [ ] staging deploy (`scripts/deploy_staging.sh`)
- [ ] `/health` で `scheduler_healthy: true` 確認
- [ ] backend ログから Aave 取得成功確認: `docker logs ... | grep -E "aave_(health_factor|utilization)_fetch"`
- [ ] AI 判定 raw_response に `[Aave Market]` / `[Health Factor]` が含まれること
- [ ] 24h 観察: ai_decisions に BUY または SELL が 1 件以上出現するか

```sql
-- staging DB 観察用クエリ
SELECT
  created_at,
  action,
  confidence,
  primary_action,
  secondary_action,
  agreed
FROM ai_decisions
WHERE created_at >= NOW() - INTERVAL '24 hours'
ORDER BY created_at DESC;
```

### Production (別タスクで)

- [ ] 山本さん不在時間帯 (深夜 0:00-6:00 JST) に `scripts/deploy_production.sh`
- [ ] デプロイ後 1h 監視 (Slack #ultra-auto-project)

## スコープ外 (別タスク化)

- 本番デプロイは本 PR merge 後、別タスクで実施 (山本さん不在時間帯)
- F-10 (フロントエンド リスクモードUI) と並行進行のため frontend は触っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)