### PR TITLE
[P2][再発防止] docker-compose env_file 明示 + --env-file 強制 (Asana 1214279916545155)

### DIFF
--- a/.github/workflows/compose-env-check.yml
+++ b/.github/workflows/compose-env-check.yml
@@ -1,0 +1,114 @@
+name: Compose env_file Sanity Check
+
+on:
+  pull_request:
+    paths:
+      - 'docker-compose*.yml'
+      - 'scripts/deploy_*.sh'
+      - '.github/workflows/compose-env-check.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'docker-compose*.yml'
+      - 'scripts/deploy_*.sh'
+
+jobs:
+  compose-env-check:
+    name: Compose env_file check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check staging backend has no DATABASE_URL in environment block
+        run: |
+          echo "=== Checking docker-compose.staging.yml ==="
+          # staging backend の environment: に DATABASE_URL が含まれていないこと
+          # (含まれると --env-file 省略時に空PWで上書きされる 2026-04-26 Lane1インシデント)
+          if python3 - <<'PYEOF'
+          import yaml, sys
+          with open("docker-compose.staging.yml") as f:
+              d = yaml.safe_load(f)
+          backend_env = d.get("services", {}).get("backend", {}).get("environment", {}) or {}
+          if isinstance(backend_env, list):
+              keys = [e.split("=")[0] for e in backend_env]
+          else:
+              keys = list(backend_env.keys())
+          if "DATABASE_URL" in keys:
+              print("❌ FAIL: staging backend environment: に DATABASE_URL が含まれています")
+              print("   --env-file 省略時に空パスワードで env_file 値を上書きします")
+              print("   DATABASE_URL は .env.staging-new に直接記述し environment: から削除してください")
+              sys.exit(1)
+          print("✅ staging backend environment: に DATABASE_URL なし (正常)")
+          PYEOF
+          then
+            echo "Check passed"
+          else
+            exit 1
+          fi
+
+      - name: Check production backend has no DATABASE_URL in environment block
+        run: |
+          echo "=== Checking docker-compose.production.yml ==="
+          python3 - <<'PYEOF'
+          import yaml, sys
+          with open("docker-compose.production.yml") as f:
+              d = yaml.safe_load(f)
+          backend_env = d.get("services", {}).get("backend", {}).get("environment", {}) or {}
+          if isinstance(backend_env, list):
+              keys = [e.split("=")[0] for e in backend_env]
+          else:
+              keys = list(backend_env.keys())
+          if "DATABASE_URL" in keys:
+              print("❌ FAIL: production backend environment: に DATABASE_URL が含まれています")
+              sys.exit(1)
+          print("✅ production backend environment: に DATABASE_URL なし (正常)")
+          PYEOF
+
+      - name: Check backend services have env_file declared
+        run: |
+          python3 - <<'PYEOF'
+          import yaml, sys
+          errors = []
+          for fname, envf in [
+              ("docker-compose.staging.yml",    ".env.staging-new"),
+              ("docker-compose.production.yml", ".env.production"),
+          ]:
+              with open(fname) as f:
+                  d = yaml.safe_load(f)
+              backend = d.get("services", {}).get("backend", {})
+              env_files = backend.get("env_file", [])
+              if isinstance(env_files, str):
+                  env_files = [env_files]
+              if not any(envf in str(ef) for ef in env_files):
+                  errors.append(f"❌ {fname}: backend に env_file: {envf} がありません")
+          if errors:
+              for e in errors:
+                  print(e)
+              sys.exit(1)
+          print("✅ 両 compose ファイルの backend に env_file 宣言あり")
+          PYEOF
+
+      - name: Check deploy scripts pass --env-file to up/build commands
+        run: |
+          echo "=== Checking deploy scripts ==="
+          FAIL=0
+          for script in scripts/deploy_staging.sh scripts/deploy_production.sh; do
+            # up -d コマンドが --env-file を伴っているか確認
+            UP_WITHOUT_ENVFILE=$(grep -nE '^\s+\$\{DC\}.*up -d' "${script}" | grep -v '\-\-env-file' || true)
+            BUILD_WITHOUT_ENVFILE=$(grep -nE '^\s+\$\{DC\}.*build' "${script}" | grep -v '\-\-env-file' || true)
+            if [[ -n "${UP_WITHOUT_ENVFILE}" ]]; then
+              echo "❌ ${script}: --env-file なし up -d コマンド:"
+              echo "${UP_WITHOUT_ENVFILE}"
+              FAIL=1
+            fi
+            if [[ -n "${BUILD_WITHOUT_ENVFILE}" ]]; then
+              echo "❌ ${script}: --env-file なし build コマンド:"
+              echo "${BUILD_WITHOUT_ENVFILE}"
+              FAIL=1
+            fi
+          done
+          if [[ "${FAIL}" -eq 0 ]]; then
+            echo "✅ 全 up/build コマンドに --env-file あり"
+          else
+            exit 1
+          fi

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -80,6 +80,8 @@ services:
   postgres:
     image: pgvector/pgvector:pg16
     container_name: ultra-autotrade-postgres-production
+    env_file:
+      - .env.production
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-ultra}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -82,6 +82,8 @@ services:
   postgres:
     image: pgvector/pgvector:pg16
     container_name: ultra-autotrade-postgres-staging-new
+    env_file:
+      - .env.staging-new
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-ultra}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -121,7 +123,9 @@ services:
     env_file:
       - .env.staging-new
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-ultra}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ultra_autotrade_staging}
+      # DATABASE_URL は .env.staging-new に直接記述すること。
+      # compose ${} 展開に依存すると --env-file 省略時に空パスワードで env_file 値を上書きする。
+      # (2026-04-26 Lane1インシデント: --env-file なし起動で DATABASE_URL 空PW上書きが発生)
       # Shadow Mode: 実トレード禁止 (Staging専用)
       REBALANCE_SHADOW_MODE: "true"
       AI_SHADOW_MODE: "true"

--- a/docs/19_operations_runbook.md
+++ b/docs/19_operations_runbook.md
@@ -491,3 +491,69 @@ Grafana などの可観測性ツールでは、Web ダッシュボードと同�
 
 > 注意: Grafana 側の表示は **既存 API の JSON を読み取る構成**とし、  
 > メトリクス定義の追加/変更は行わない（要件変更チャット案件）。
+
+---
+
+## 9. コンテナ再作成時の --env-file 明示ルール（2026-04-26 追加）
+
+### 背景（2026-04-26 Lane1インシデント）
+
+`docker compose up -d backend` を `--env-file` なしで実行したとき、
+`docker-compose.staging.yml` の `backend.environment.DATABASE_URL` に
+`${POSTGRES_PASSWORD}` が展開されず空パスワードになり、
+`env_file:` の正しい DATABASE_URL を上書きする問題が発生。
+30分以上バックエンドが DB 接続不能になりスケジューラーが停止した。
+
+### ルール
+
+#### 1. コンテナ再作成は必ず deploy スクリプト経由で行う
+
+```bash
+# Staging
+./scripts/deploy_staging.sh [--backend-only | --frontend-only | --no-build]
+
+# Production
+./scripts/deploy_production.sh [--backend-only | --frontend-only | --no-build]
+```
+
+#### 2. 手動で docker compose を実行するときは必ず --env-file を渡す
+
+```bash
+# Staging (必須)
+docker compose -f docker-compose.staging.yml -p ultra-autotrade-staging \
+  --env-file .env.staging-new \
+  up -d --no-deps --force-recreate backend
+
+# Production (必須)
+docker compose -f docker-compose.production.yml -p ultra-autotrade-project \
+  --env-file .env.production \
+  up -d --no-deps --force-recreate backend
+```
+
+**`--env-file` 省略は禁止。** `docker compose up -d` だけでは環境変数が展開されない。
+
+#### 3. デプロイ後に DATABASE_URL PW md5 を確認する
+
+```bash
+# staging
+docker exec ultra-autotrade-backend-staging-new env | grep "^DATABASE_URL=" \
+  | grep -oP '(?<=://[^:]+:)[^@]+' | tr -d '\n' | md5sum
+
+# 期待値: .env.staging-new の POSTGRES_PASSWORD と一致する md5
+grep "^POSTGRES_PASSWORD=" .env.staging-new | cut -d= -f2 | tr -d '\n' | md5sum
+```
+
+#### 4. CI ガード（自動）
+
+`docker-compose*.yml` または `scripts/deploy_*.sh` を変更する PR は
+`.github/workflows/compose-env-check.yml` が自動実行され:
+- staging/production backend の `environment:` に `DATABASE_URL` がないこと
+- 全 `up -d` / `build` コマンドに `--env-file` があること
+を検証する。**CI が赤い PR は merge 禁止。**
+
+#### 5. compose ファイルの設計原則
+
+- **DATABASE_URL は `env_file:` に記述し `environment:` には書かない**  
+  （`environment:` が `env_file:` を上書きするため、`${PW}` が空になるリスク）
+- postgres / backend の両サービスに `env_file:` を明示することで、  
+  `--env-file` フラグなしでも最低限の動作を保証する

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -84,6 +84,33 @@ resolve_dc() {
   fi
 }
 
+# env_file 適用検証: backend ランタイムの DATABASE_URL PW が env_file の値と一致するか確認
+verify_env_file_applied() {
+  local container="${BACKEND_CONTAINER}"
+  local env_file="${ENV_FILE}"
+  log "=== env_file 適用検証 ==="
+  local expected_pw
+  expected_pw=$(grep "^POSTGRES_PASSWORD=" "${env_file}" | cut -d= -f2- | tr -d '\n')
+  if [[ -z "${expected_pw}" ]]; then
+    expected_pw=$(grep "^DATABASE_URL=" "${env_file}" | grep -oP '(?<=://[^:]+:)[^@]+' | head -1)
+  fi
+  local expected_md5
+  expected_md5=$(echo -n "${expected_pw}" | md5sum | awk '{print $1}')
+
+  local runtime_md5
+  runtime_md5=$(docker exec "${container}" env 2>/dev/null | grep "^DATABASE_URL=" | grep -oP '(?<=://[^:]+:)[^@]+' | tr -d '\n' | md5sum | awk '{print $1}')
+
+  if [[ "${expected_md5}" == "${runtime_md5}" ]]; then
+    log "✅ DATABASE_URL PW md5 一致: ${runtime_md5}"
+  else
+    err "❌ DATABASE_URL PW md5 不一致!"
+    err "   expected (from ${env_file}): ${expected_md5}"
+    err "   runtime  (container env):   ${runtime_md5}"
+    err "   --env-file が正しく渡されていない可能性があります"
+    return 1
+  fi
+}
+
 # ヘルスチェック待ちループ
 wait_healthy() {
   local url="$1"
@@ -254,6 +281,7 @@ elif "${BACKEND_ONLY}"; then
   ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" up -d backend
 
   wait_healthy "http://localhost:8000/health" "backend" || on_failure
+  verify_env_file_applied || on_failure
 
 else
   # ─── フルデプロイ ──────────────────────────────
@@ -294,6 +322,7 @@ else
 
   wait_healthy "http://localhost:8000/health" "backend"  || on_failure
   wait_healthy "http://localhost:3000"         "frontend" || on_failure
+  verify_env_file_applied || on_failure
 fi
 
 # ───────────────────────────────────────────────

--- a/scripts/deploy_staging.sh
+++ b/scripts/deploy_staging.sh
@@ -89,6 +89,33 @@ resolve_dc() {
   fi
 }
 
+# env_file 適用検証: backend ランタイムの DATABASE_URL PW が env_file の値と一致するか確認
+verify_env_file_applied() {
+  local container="${BACKEND_CONTAINER}"
+  local env_file="${ENV_FILE}"
+  log "=== env_file 適用検証 ==="
+  local expected_pw
+  expected_pw=$(grep "^POSTGRES_PASSWORD=" "${env_file}" | cut -d= -f2- | tr -d '\n')
+  if [[ -z "${expected_pw}" ]]; then
+    expected_pw=$(grep "^DATABASE_URL=" "${env_file}" | grep -oP '(?<=://[^:]+:)[^@]+' | head -1)
+  fi
+  local expected_md5
+  expected_md5=$(echo -n "${expected_pw}" | md5sum | awk '{print $1}')
+
+  local runtime_md5
+  runtime_md5=$(docker exec "${container}" env 2>/dev/null | grep "^DATABASE_URL=" | grep -oP '(?<=://[^:]+:)[^@]+' | tr -d '\n' | md5sum | awk '{print $1}')
+
+  if [[ "${expected_md5}" == "${runtime_md5}" ]]; then
+    log "✅ DATABASE_URL PW md5 一致: ${runtime_md5}"
+  else
+    err "❌ DATABASE_URL PW md5 不一致!"
+    err "   expected (from ${env_file}): ${expected_md5}"
+    err "   runtime  (container env):   ${runtime_md5}"
+    err "   --env-file が正しく渡されていない可能性があります"
+    return 1
+  fi
+}
+
 # ヘルスチェック待ちループ
 wait_healthy() {
   local url="$1"
@@ -212,6 +239,7 @@ elif "${BACKEND_ONLY}"; then
   ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" up -d backend
 
   wait_healthy "http://localhost:8001/health" "backend(staging)" || on_failure
+  verify_env_file_applied || on_failure
 
 else
   log "フルデプロイ開始（Staging環境）"
@@ -245,6 +273,7 @@ else
 
   wait_healthy "http://localhost:8001/health" "backend(staging)"  || on_failure
   wait_healthy "http://localhost:3001"         "frontend(staging)" || on_failure
+  verify_env_file_applied || on_failure
 fi
 
 # ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `docker-compose.staging.yml`: backend `environment:` から `DATABASE_URL` を削除（**根本原因修正**）
- `docker-compose.staging.yml` / `docker-compose.production.yml`: postgres に `env_file:` 明示追加
- `scripts/deploy_staging.sh` / `deploy_production.sh`: デプロイ後 DATABASE_URL PW md5 verify 関数追加
- `.github/workflows/compose-env-check.yml`: compose config 安全チェック CI 追加
- `docs/19_operations_runbook.md`: §9 コンテナ再作成の `--env-file` 明示ルール追記

## 根本原因（2026-04-26 Lane1インシデント）

```yaml
# docker-compose.staging.yml (修正前)
backend:
  env_file:
    - .env.staging-new       # ← DATABASE_URL=...正しいPW... が入っている
  environment:
    DATABASE_URL: postgresql://${POSTGRES_USER:-ultra}:${POSTGRES_PASSWORD}@...
    #                                                   ^^^^^^^^^^^^^^^^^^^
    #                    --env-file なしだと空になり、env_file の値を上書きする！
```

`--env-file` を渡さずに `docker compose up -d backend` を実行すると、
`environment:` の `${POSTGRES_PASSWORD}` が空展開され、
`env_file:` の正しい DATABASE_URL を**上書き**してしまう。

```yaml
# docker-compose.staging.yml (修正後)
backend:
  env_file:
    - .env.staging-new       # DATABASE_URL はここから取得
  environment:
    # DATABASE_URL は削除 (compose ${} 展開に依存しない)
    REBALANCE_SHADOW_MODE: "true"
    AI_SHADOW_MODE: "true"
```

## 追加した防御層

| 層 | 内容 |
|----|------|
| compose 設計 | DATABASE_URL を `environment:` から削除、`env_file:` に一本化 |
| postgres `env_file:` | `--env-file` 省略時でも最低限の POSTGRES_PASSWORD を保持 |
| deploy スクリプト | `verify_env_file_applied()` が PW md5 を比較、不一致で即失敗 |
| CI | `compose-env-check.yml` が `DATABASE_URL` の誤追加・`--env-file` 抜けを自動検出 |
| Runbook | 手動操作時の `--env-file` 明示ルールを文書化 |

## Test plan

- [ ] CI `compose-env-check.yml` が green
- [ ] `docker compose -f docker-compose.staging.yml config` で staging backend に `DATABASE_URL` が env_file 経由で正しく解決される
- [ ] staging で `deploy_staging.sh --backend-only` → `verify_env_file_applied` が pass
- [ ] production 適用は別タスク（山本さん不在時間帯に実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)