### PR TITLE
feat(auth): privy_did 保存ロジック追加 (/auth/wallet/connect)

### DIFF
--- a/backend/alembic/versions/f6a7b8c9d0e1_add_privy_did_to_users.py
+++ b/backend/alembic/versions/f6a7b8c9d0e1_add_privy_did_to_users.py
@@ -1,0 +1,41 @@
+"""add_privy_did_to_users
+
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-04-27 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f6a7b8c9d0e1"
+down_revision: Union[str, Sequence[str], None] = "e5f6a7b8c9d0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add privy_did column to users table."""
+    op.add_column(
+        "users",
+        sa.Column("privy_did", sa.String(length=255), nullable=True),
+    )
+    # NULL は unique 制約から除外されるため既存ユーザー (all NULL) との衝突なし
+    op.create_index(
+        "ix_users_privy_did",
+        "users",
+        ["privy_did"],
+        unique=True,
+        postgresql_where=sa.text("privy_did IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Remove privy_did column from users table."""
+    op.drop_index("ix_users_privy_did", table_name="users")
+    op.drop_column("users", "privy_did")

--- a/backend/app/auth/models.py
+++ b/backend/app/auth/models.py
@@ -10,6 +10,9 @@ ALTER TABLE users ADD COLUMN tier VARCHAR(20) NOT NULL DEFAULT 'LOWER';
 ALTER TABLE users ADD COLUMN last_judgment_at TIMESTAMP WITH TIME ZONE NULL;
 -- 注: F-2 で DEFAULT を 'GENERAL' から 'LOWER' に変更。本番 DB の DEFAULT 切替は
 -- F-16 マイグレーションで実施 (docs/46_users_tier_migration_plan.md 参照)。
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS privy_did VARCHAR(255) NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS ix_users_privy_did ON users (privy_did) WHERE privy_did IS NOT NULL;
 """
 
 import logging
@@ -229,6 +232,9 @@ class User(Base):
     )
     wallet_address: Mapped[Optional[str]] = mapped_column(
         String(42), unique=True, nullable=True, index=True, default=None
+    )
+    privy_did: Mapped[Optional[str]] = mapped_column(
+        String(255), unique=True, nullable=True, index=True, default=None
     )
     invited_by: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("users.id"), nullable=True, default=None

--- a/backend/app/auth/privy_verifier.py
+++ b/backend/app/auth/privy_verifier.py
@@ -1,0 +1,254 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/auth/privy_verifier.py
+"""Privy ID Token (Auth Token) verifier.
+
+Codex Review P1 (PR #155 / Asana 1214284566521324) 対応。
+クライアントから送られてくる Privy DID を素直に保存していたため、
+任意の文字列を privy_did として送り込むと別ユーザーの DID を所有しているかのように
+登録できた。本モジュールでサーバー側で Privy ID Token を検証し、JWT の sub claim
+(= 認証済み DID) と request.privy_did の一致確認を強制する。
+
+Privy 公式仕様 (https://docs.privy.io/authentication/user-authentication/access-tokens):
+- 署名アルゴリズム: ES256 (ECDSA P-256)
+- iss claim: "privy.io"
+- aud claim: Privy App ID
+- sub claim: User's Privy DID (例: did:privy:xxxxxxxx)
+
+公開鍵の入手方法 (本実装の優先順):
+1. PRIVY_VERIFICATION_KEY 環境変数 (PEM 形式の P-256 公開鍵) — Privy Dashboard
+   からコピーする静的キー。HTTP 通信不要・高速・JWKS API 仕様変更の影響なし。
+   公式が「重複したリクエストを避けるため Dashboard からキーをコピーする」
+   と明示している推奨方式。
+2. PRIVY_JWKS_URL (省略時 ``https://auth.privy.io/api/v1/apps/{app_id}/keys``) からの
+   動的取得 (1 時間 TTL の in-memory キャッシュ)。鍵ローテーション時にメンテフリーに
+   なるが、JWKS endpoint URL は公式ドキュメントに明示されていないため
+   フォールバック扱い。
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Optional
+
+import httpx
+import jwt as pyjwt
+from fastapi import HTTPException, status
+from jwt import (
+    ExpiredSignatureError,
+    InvalidAudienceError,
+    InvalidIssuerError,
+    InvalidSignatureError,
+    InvalidTokenError,
+)
+from jwt.algorithms import ECAlgorithm
+
+logger = logging.getLogger(__name__)
+
+PRIVY_ISSUER = "privy.io"
+PRIVY_ALGORITHM = "ES256"
+DEFAULT_JWKS_URL_TEMPLATE = "https://auth.privy.io/api/v1/apps/{app_id}/keys"
+JWKS_CACHE_TTL_SECONDS = 3600  # 1 hour
+
+
+class PrivyVerifier:
+    """Privy ID Token (JWT) を検証する。"""
+
+    def __init__(
+        self,
+        app_id: str,
+        verification_key: Optional[str] = None,
+        jwks_url: Optional[str] = None,
+        http_client: Optional[httpx.Client] = None,
+        clock_skew_seconds: int = 30,
+    ) -> None:
+        if not app_id:
+            raise ValueError("PrivyVerifier requires non-empty app_id")
+        self.app_id = app_id
+        self.verification_key = verification_key
+        self.jwks_url = jwks_url or DEFAULT_JWKS_URL_TEMPLATE.format(app_id=app_id)
+        self._http_client = http_client
+        self.clock_skew_seconds = clock_skew_seconds
+        self._jwks_cache_keys: dict[str, str] = {}
+        self._jwks_cache_fetched_at: float = 0.0
+        self._jwks_lock = threading.Lock()
+
+    def verify_id_token(self, token: str) -> str:
+        """ID Token を検証して sub claim (Privy DID) を返す。
+
+        失敗時は HTTPException(401) を raise する。JWKS 取得失敗のような
+        外部依存系エラーは 503 で返す (クライアント原因と区別するため)。
+        """
+        if not token:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Empty Privy ID token",
+            )
+        public_key = self._resolve_public_key(token)
+        try:
+            payload = pyjwt.decode(
+                token,
+                public_key,
+                algorithms=[PRIVY_ALGORITHM],
+                audience=self.app_id,
+                issuer=PRIVY_ISSUER,
+                leeway=self.clock_skew_seconds,
+                options={"require": ["exp", "iat", "iss", "aud", "sub"]},
+            )
+        except ExpiredSignatureError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Privy ID token expired",
+            ) from exc
+        except (InvalidSignatureError, InvalidAudienceError, InvalidIssuerError) as exc:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid Privy ID token",
+            ) from exc
+        except InvalidTokenError as exc:
+            # 期限・aud・iss 以外の構造的エラー (missing claim 等)
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid Privy ID token",
+            ) from exc
+
+        sub = payload.get("sub")
+        if not isinstance(sub, str) or not sub:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid Privy ID token (missing sub)",
+            )
+        return sub
+
+    # ── 公開鍵解決 ───────────────────────────────────────────
+
+    def _resolve_public_key(self, token: str) -> str:
+        if self.verification_key:
+            return self.verification_key
+        return self._get_jwks_key(token)
+
+    def _get_jwks_key(self, token: str) -> str:
+        try:
+            unverified_header = pyjwt.get_unverified_header(token)
+        except InvalidTokenError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid Privy ID token (header)",
+            ) from exc
+        kid = unverified_header.get("kid")
+        if not isinstance(kid, str) or not kid:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid Privy ID token (no kid)",
+            )
+
+        with self._jwks_lock:
+            now = time.time()
+            cache_age = now - self._jwks_cache_fetched_at
+            if not self._jwks_cache_keys or cache_age >= JWKS_CACHE_TTL_SECONDS:
+                self._jwks_cache_keys = self._fetch_jwks()
+                self._jwks_cache_fetched_at = now
+            elif kid not in self._jwks_cache_keys:
+                # キャッシュ TTL 内でも未知の kid なら強制再取得 (key rotation)
+                self._jwks_cache_keys = self._fetch_jwks()
+                self._jwks_cache_fetched_at = now
+
+            pem = self._jwks_cache_keys.get(kid)
+
+        if pem is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=f"Privy JWKS does not contain kid={kid}",
+            )
+        return pem
+
+    def _fetch_jwks(self) -> dict[str, str]:
+        owns_client = self._http_client is None
+        client = self._http_client or httpx.Client(timeout=10.0)
+        try:
+            try:
+                resp = client.get(self.jwks_url)
+                resp.raise_for_status()
+                data = resp.json()
+            except httpx.HTTPError as exc:
+                logger.error("Failed to fetch Privy JWKS from %s: %s", self.jwks_url, exc)
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail="Privy JWKS unavailable",
+                ) from exc
+        finally:
+            if owns_client:
+                client.close()
+
+        keys = data.get("keys") if isinstance(data, dict) else None
+        if not isinstance(keys, list) or not keys:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Privy JWKS response invalid",
+            )
+        keys_pem: dict[str, str] = {}
+        from cryptography.hazmat.primitives import serialization  # noqa: PLC0415
+
+        for jwk in keys:
+            if not isinstance(jwk, dict):
+                continue
+            kid = jwk.get("kid")
+            if not isinstance(kid, str) or not kid:
+                continue
+            try:
+                public_key = ECAlgorithm.from_jwk(jwk)
+                pem_bytes = public_key.public_bytes(  # type: ignore[union-attr]
+                    encoding=serialization.Encoding.PEM,
+                    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+                )
+            except (InvalidTokenError, ValueError, TypeError) as exc:
+                logger.warning("Skipping invalid Privy JWK kid=%s: %s", kid, exc)
+                continue
+            keys_pem[kid] = pem_bytes.decode("ascii")
+        if not keys_pem:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Privy JWKS response had no usable keys",
+            )
+        return keys_pem
+
+
+# ── ファクトリ + シングルトン ─────────────────────────────────────
+
+_default_verifier: Optional[PrivyVerifier] = None
+_default_verifier_lock = threading.Lock()
+
+
+def get_privy_verifier() -> Optional[PrivyVerifier]:
+    """環境変数から PrivyVerifier を組み立てる (lazy singleton)。
+
+    PRIVY_APP_ID 未設定なら ``None`` を返し、router 側で
+    「Privy 検証 OFF (後方互換モード)」として扱う。
+    """
+    global _default_verifier
+    if _default_verifier is not None:
+        return _default_verifier
+    with _default_verifier_lock:
+        if _default_verifier is not None:
+            return _default_verifier
+        app_id = os.getenv("PRIVY_APP_ID")
+        if not app_id:
+            return None
+        verification_key = os.getenv("PRIVY_VERIFICATION_KEY") or None
+        jwks_url = os.getenv("PRIVY_JWKS_URL") or None
+        _default_verifier = PrivyVerifier(
+            app_id=app_id,
+            verification_key=verification_key,
+            jwks_url=jwks_url,
+        )
+        return _default_verifier
+
+
+def reset_privy_verifier() -> None:
+    """テスト用: グローバルシングルトンをクリア。"""
+    global _default_verifier
+    with _default_verifier_lock:
+        _default_verifier = None

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -34,6 +34,7 @@ from .models import (
     User,
     UserRole,
 )
+from .privy_verifier import get_privy_verifier
 from .schemas import (
     LoginRequest,
     PasswordChangeRequest,
@@ -429,22 +430,57 @@ def wallet_connect(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+    # ── Privy ID Token 検証 (Codex Review P1 対応) ──
+    # 後方互換のため、PRIVY_APP_ID 未設定時 (= verifier=None) は privy_did/id_token を
+    # 検証せずに drop する。本番環境では PRIVY_APP_ID + 公開鍵を必ず設定すること。
+    verifier = get_privy_verifier()
+    privy_did_to_store: str | None = None
+    if request.privy_id_token:
+        if verifier is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Privy verification not configured on server",
+            )
+        verified_did = verifier.verify_id_token(request.privy_id_token)
+        if request.privy_did and request.privy_did != verified_did:
+            logger.warning(
+                "Privy DID mismatch: request.privy_did=%s..., id_token.sub=%s...",
+                request.privy_did[:20],
+                verified_did[:20],
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Privy DID does not match ID token sub",
+            )
+        privy_did_to_store = verified_did
+    elif request.privy_did:
+        if verifier is not None:
+            # Privy 検証 ON 環境では未検証 DID を受け付けない
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="privy_did requires privy_id_token for verification",
+            )
+        # 移行期 (PRIVY_APP_ID 未設定) のみ警告ログ + DID を drop
+        logger.warning(
+            "Received privy_did but PRIVY_APP_ID not configured; dropping unverified DID"
+        )
+
     # ウォレットアドレスでユーザー検索
     existing_user = AuthService.get_user_by_wallet(db, request.wallet_address)
     is_new_user = existing_user is None
 
     if is_new_user:
         user = AuthService.create_wallet_user(
-            db, request.wallet_address, privy_did=request.privy_did
+            db, request.wallet_address, privy_did=privy_did_to_store
         )
     else:
         if existing_user is None:
             raise RuntimeError("existing_user is None after wallet lookup")
         user = existing_user
-        # 既存ユーザーに privy_did が未保存かつリクエストに含まれる場合は後追い保存
-        if request.privy_did and not user.privy_did:
+        # 既存ユーザーに privy_did が未保存かつ検証済み DID が手元にあれば後追い保存
+        if privy_did_to_store and not user.privy_did:
             try:
-                AuthService.update_privy_did(db, user, request.privy_did)
+                AuthService.update_privy_did(db, user, privy_did_to_store)
             except Exception:
                 db.rollback()
                 logger.warning(

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -435,12 +435,17 @@ def wallet_connect(
     # 検証せずに drop する。本番環境では PRIVY_APP_ID + 公開鍵を必ず設定すること。
     verifier = get_privy_verifier()
     privy_did_to_store: str | None = None
-    if request.privy_id_token:
-        if verifier is None:
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Privy verification not configured on server",
+    if verifier is None:
+        # 後方互換モード: PRIVY_APP_ID 未設定時は Privy フィールドを silent drop して通常認証へ継続
+        if request.privy_id_token or request.privy_did:
+            logger.warning(
+                "Privy verification disabled (PRIVY_APP_ID not set), "
+                "dropping privy_id_token=%s and privy_did=%s",
+                "<present>" if request.privy_id_token else None,
+                "<present>" if request.privy_did else None,
             )
+    elif request.privy_id_token:
+        # 検証モード (PRIVY_APP_ID 設定済み): id_token を検証して DID を取得
         verified_did = verifier.verify_id_token(request.privy_id_token)
         if request.privy_did and request.privy_did != verified_did:
             logger.warning(
@@ -454,15 +459,10 @@ def wallet_connect(
             )
         privy_did_to_store = verified_did
     elif request.privy_did:
-        if verifier is not None:
-            # Privy 検証 ON 環境では未検証 DID を受け付けない
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="privy_did requires privy_id_token for verification",
-            )
-        # 移行期 (PRIVY_APP_ID 未設定) のみ警告ログ + DID を drop
-        logger.warning(
-            "Received privy_did but PRIVY_APP_ID not configured; dropping unverified DID"
+        # Privy 検証 ON 環境では未検証 DID を受け付けない
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="privy_did requires privy_id_token for verification",
         )
 
     # ウォレットアドレスでユーザー検索

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -446,6 +446,7 @@ def wallet_connect(
             try:
                 AuthService.update_privy_did(db, user, request.privy_did)
             except Exception:
+                db.rollback()
                 logger.warning(
                     "privy_did update failed (conflict?): wallet=%s...", request.wallet_address[:10]
                 )

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -434,11 +434,21 @@ def wallet_connect(
     is_new_user = existing_user is None
 
     if is_new_user:
-        user = AuthService.create_wallet_user(db, request.wallet_address)
+        user = AuthService.create_wallet_user(
+            db, request.wallet_address, privy_did=request.privy_did
+        )
     else:
         if existing_user is None:
             raise RuntimeError("existing_user is None after wallet lookup")
         user = existing_user
+        # 既存ユーザーに privy_did が未保存かつリクエストに含まれる場合は後追い保存
+        if request.privy_did and not user.privy_did:
+            try:
+                AuthService.update_privy_did(db, user, request.privy_did)
+            except Exception:
+                logger.warning(
+                    "privy_did update failed (conflict?): wallet=%s...", request.wallet_address[:10]
+                )
 
     token, expires_in = AuthService.create_access_token(
         user_id=user.id,

--- a/backend/app/auth/schemas.py
+++ b/backend/app/auth/schemas.py
@@ -194,6 +194,7 @@ class WalletConnectRequest(BaseModel):
     )
     message: str = Field(..., description="Signed message (must contain timestamp)")
     signature: str = Field(..., description="ECDSA signature (0x...)")
+    privy_did: Optional[str] = Field(None, max_length=255, description="Privy DID (did:privy:...)")
 
 
 class WalletConnectResponse(BaseModel):

--- a/backend/app/auth/schemas.py
+++ b/backend/app/auth/schemas.py
@@ -195,6 +195,13 @@ class WalletConnectRequest(BaseModel):
     message: str = Field(..., description="Signed message (must contain timestamp)")
     signature: str = Field(..., description="ECDSA signature (0x...)")
     privy_did: Optional[str] = Field(None, max_length=255, description="Privy DID (did:privy:...)")
+    # Privy ID Token (JWT) — 提供された場合はサーバー側で署名検証し、
+    # sub claim と privy_did の一致を強制する (Codex Review P1 対応)。
+    privy_id_token: Optional[str] = Field(
+        None,
+        max_length=4096,
+        description="Privy ID token (JWT). 提供時はサーバーで検証し sub == privy_did を確認する。",
+    )
 
 
 class WalletConnectResponse(BaseModel):

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -360,7 +360,9 @@ class AuthService:
             return False
 
     @classmethod
-    def create_wallet_user(cls, db: Session, wallet_address: str) -> User:
+    def create_wallet_user(
+        cls, db: Session, wallet_address: str, privy_did: Optional[str] = None
+    ) -> User:
         """
         ウォレットアドレスからユーザーを自動作成する。
 
@@ -368,6 +370,7 @@ class AuthService:
         - risk_mode = conservative
         - terms_accepted_at = None
         - email / username は wallet_ プレフィックス + アドレス先頭8文字（衝突時はランダム4桁追加）
+        - privy_did: Privy固有のDID（任意、後追い更新も可能）
         """
         base_slug = wallet_address[2:10].lower()
         base_email = f"wallet_{base_slug}@wallet.local"
@@ -396,6 +399,7 @@ class AuthService:
             risk_mode="conservative",
             terms_accepted_at=None,
             wallet_address=wallet_address.lower(),
+            privy_did=privy_did,
         )
         db.add(user)
         db.commit()
@@ -403,3 +407,15 @@ class AuthService:
 
         logger.info("Created wallet user: %s (wallet=%s...)", user.email, wallet_address[:10])
         return user
+
+    @classmethod
+    def update_privy_did(cls, db: Session, user: User, privy_did: str) -> None:
+        """既存ユーザーの privy_did を後追い保存する。
+
+        既に同じ privy_did が設定されている場合はスキップ。
+        別ユーザーが同じ privy_did を持つ場合は IntegrityError が発生するため呼び出し元でハンドリングする。
+        """
+        if user.privy_did == privy_did:
+            return
+        user.privy_did = privy_did
+        db.commit()

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -18,7 +18,9 @@ from typing import Any, Optional
 import bcrypt
 import jwt as pyjwt
 from eth_account.messages import encode_defunct
+from fastapi import HTTPException, status
 from jwt import InvalidTokenError as JWTError
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from web3 import Web3
 
@@ -402,7 +404,22 @@ class AuthService:
             privy_did=privy_did,
         )
         db.add(user)
-        db.commit()
+        try:
+            db.commit()
+        except IntegrityError as exc:
+            # privy_did UNIQUE 違反 (= 別ユーザーが同じ DID を保持) や
+            # wallet_address 競合 (並行リクエスト) を 409 Conflict で返す。
+            db.rollback()
+            logger.warning(
+                "Wallet user creation conflict (wallet=%s..., privy_did=%s): %s",
+                wallet_address[:10],
+                (privy_did[:20] + "...") if privy_did else None,
+                exc.orig if hasattr(exc, "orig") else exc,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="DID already in use",
+            ) from exc
         db.refresh(user)
 
         logger.info("Created wallet user: %s (wallet=%s...)", user.email, wallet_address[:10])

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,7 +16,7 @@ python-dotenv>=1.0.0
 # Authentication & Database (Phase 12)
 sqlalchemy>=2.0.0
 bcrypt>=4.1.0
-PyJWT>=2.9.0
+PyJWT[crypto]>=2.9.0    # [crypto] extra で cryptography (RS256/ES256 等) を有効化 — Privy ID Token 検証に必要
 pydantic[email]>=2.0.0
 
 # PostgreSQL + pgvector (PoC Pivot)

--- a/backend/tests/auth/test_wallet_connect.py
+++ b/backend/tests/auth/test_wallet_connect.py
@@ -505,3 +505,65 @@ class TestWalletConnect:
         data = response.json()
         assert "access_token" in data
         assert data["is_new_user"] is True
+
+    # ── 後方互換リグレッション修正 (Codex Review P1, GID 1214284845161706) ────
+
+    def test_unconfigured_privy_with_id_token_returns_200(
+        self,
+        client: TestClient,
+        privy_unset_env: None,  # noqa: ARG002
+    ):
+        """PRIVY_APP_ID 未設定 + privy_id_token あり → 200 (silent drop, 後方互換)。"""
+        payload = self._make_valid_request()
+        payload["privy_id_token"] = "ey.fake.token"
+
+        response = client.post("/auth/wallet/connect", json=payload)
+        assert response.status_code == 200
+        assert "access_token" in response.json()
+
+    def test_unconfigured_privy_with_did_only_returns_200(
+        self,
+        client: TestClient,
+        privy_unset_env: None,  # noqa: ARG002
+    ):
+        """PRIVY_APP_ID 未設定 + privy_did あり (id_token なし) → 200 (silent drop, 後方互換)。"""
+        payload = self._make_valid_request()
+        payload["privy_did"] = "did:privy:test-compat"
+
+        response = client.post("/auth/wallet/connect", json=payload)
+        assert response.status_code == 200
+        assert "access_token" in response.json()
+
+    def test_unconfigured_privy_with_both_fields_returns_200(
+        self,
+        client: TestClient,
+        privy_unset_env: None,  # noqa: ARG002
+    ):
+        """PRIVY_APP_ID 未設定 + privy_id_token + privy_did 両方あり → 200 (両方 drop)。"""
+        payload = self._make_valid_request()
+        payload["privy_id_token"] = "ey.fake.token"
+        payload["privy_did"] = "did:privy:test-compat-both"
+
+        response = client.post("/auth/wallet/connect", json=payload)
+        assert response.status_code == 200
+        assert "access_token" in response.json()
+
+    def test_unconfigured_privy_emits_warning_log(
+        self,
+        client: TestClient,
+        privy_unset_env: None,  # noqa: ARG002
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """PRIVY_APP_ID 未設定 + privy_id_token あり → WARN ログ出力 (機密情報を含まない)。"""
+        import logging
+
+        payload = self._make_valid_request()
+        payload["privy_id_token"] = "ey.fake.token"
+
+        with caplog.at_level(logging.WARNING):
+            response = client.post("/auth/wallet/connect", json=payload)
+
+        assert response.status_code == 200
+        assert any("Privy verification disabled" in r.message for r in caplog.records)
+        # 機密情報 (id_token の中身) がログに含まれないことを確認
+        assert not any("ey.fake.token" in r.message for r in caplog.records)

--- a/backend/tests/auth/test_wallet_connect.py
+++ b/backend/tests/auth/test_wallet_connect.py
@@ -8,13 +8,19 @@ WalletConnect 認証のテスト。
 - 無効な署名で 401 が返ること
 - 既存 wallet ユーザーには既存 JWT が返ること
 - 新規ユーザーは needs_terms_acceptance = True
+- Privy ID Token (JWT) 検証 (Codex Review P1 対応, Asana 1214284566521324)
+- 重複 privy_did 登録時の 409 Conflict (Codex Review P2 対応)
 """
 
 import os
 import tempfile
-from typing import Generator
+import time
+from typing import Generator, Tuple
 
+import jwt as pyjwt
 import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
 from eth_account import Account
 from eth_account.messages import encode_defunct
 from fastapi.testclient import TestClient
@@ -28,6 +34,7 @@ os.environ["JWT_ACCESS_TOKEN_EXPIRE_MINUTES"] = "30"
 os.environ["INITIAL_ADMIN_EMAIL"] = "admin@example.com"
 
 from app.auth.models import User
+from app.auth.privy_verifier import reset_privy_verifier
 from app.database import Base, get_db
 from app.main import create_app
 
@@ -36,12 +43,100 @@ TEST_PRIVATE_KEY = "0x4c0883a69102937d6231471b5dbb6e538eba2ef158d8b8b75f21c8f4d9
 TEST_ACCOUNT = Account.from_key(TEST_PRIVATE_KEY)
 TEST_WALLET_ADDRESS = TEST_ACCOUNT.address
 
+# 第二のウォレット (重複 privy_did テスト用)
+TEST_PRIVATE_KEY_2 = "0x1111111111111111111111111111111111111111111111111111111111111111"
+TEST_ACCOUNT_2 = Account.from_key(TEST_PRIVATE_KEY_2)
+TEST_WALLET_ADDRESS_2 = TEST_ACCOUNT_2.address
+
+PRIVY_TEST_APP_ID = "test-app-id-for-pytest"
+
 
 def _sign_message(message: str, private_key: str) -> str:
     """テスト用署名を生成する。"""
     encoded = encode_defunct(text=message)
     signed = Account.sign_message(encoded, private_key=private_key)
     return signed.signature.hex()
+
+
+def _generate_es256_keypair() -> Tuple[bytes, bytes]:
+    """ES256 (P-256) keypair を PEM 形式で生成する。"""
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def _make_id_token(
+    private_pem: bytes,
+    *,
+    sub: str,
+    app_id: str = PRIVY_TEST_APP_ID,
+    iss: str = "privy.io",
+    exp_offset: int = 3600,
+    iat_offset: int = 0,
+) -> str:
+    """Privy ID Token を生成する。"""
+    now = int(time.time())
+    payload = {
+        "iss": iss,
+        "aud": app_id,
+        "sub": sub,
+        "iat": now + iat_offset,
+        "exp": now + exp_offset,
+    }
+    return pyjwt.encode(payload, private_pem, algorithm="ES256")
+
+
+@pytest.fixture()
+def privy_keypair() -> Tuple[bytes, bytes]:
+    """ES256 keypair を生成する fixture。"""
+    return _generate_es256_keypair()
+
+
+@pytest.fixture()
+def privy_env(privy_keypair: Tuple[bytes, bytes]) -> Generator[None, None, None]:
+    """PRIVY_APP_ID / PRIVY_VERIFICATION_KEY を設定し、PrivyVerifier シングルトンをリセット。"""
+    _, public_pem = privy_keypair
+    prev_app_id = os.environ.get("PRIVY_APP_ID")
+    prev_key = os.environ.get("PRIVY_VERIFICATION_KEY")
+    os.environ["PRIVY_APP_ID"] = PRIVY_TEST_APP_ID
+    os.environ["PRIVY_VERIFICATION_KEY"] = public_pem.decode("ascii")
+    reset_privy_verifier()
+    try:
+        yield
+    finally:
+        if prev_app_id is None:
+            os.environ.pop("PRIVY_APP_ID", None)
+        else:
+            os.environ["PRIVY_APP_ID"] = prev_app_id
+        if prev_key is None:
+            os.environ.pop("PRIVY_VERIFICATION_KEY", None)
+        else:
+            os.environ["PRIVY_VERIFICATION_KEY"] = prev_key
+        reset_privy_verifier()
+
+
+@pytest.fixture()
+def privy_unset_env() -> Generator[None, None, None]:
+    """PRIVY_APP_ID 未設定環境を保証する fixture (後方互換テスト用)。"""
+    prev_app_id = os.environ.pop("PRIVY_APP_ID", None)
+    prev_key = os.environ.pop("PRIVY_VERIFICATION_KEY", None)
+    reset_privy_verifier()
+    try:
+        yield
+    finally:
+        if prev_app_id is not None:
+            os.environ["PRIVY_APP_ID"] = prev_app_id
+        if prev_key is not None:
+            os.environ["PRIVY_VERIFICATION_KEY"] = prev_key
+        reset_privy_verifier()
 
 
 @pytest.fixture()
@@ -86,6 +181,16 @@ class TestWalletConnect:
         signature = _sign_message(message, TEST_PRIVATE_KEY)
         return {
             "wallet_address": TEST_WALLET_ADDRESS,
+            "message": message,
+            "signature": signature,
+        }
+
+    def _make_valid_request_2(self) -> dict:
+        """第二ウォレットの有効リクエスト (重複 DID テスト用)。"""
+        message = "Ultra AutoTrade: test at 2026-03-24T00:00:00Z (#2)"
+        signature = _sign_message(message, TEST_PRIVATE_KEY_2)
+        return {
+            "wallet_address": TEST_WALLET_ADDRESS_2,
             "message": message,
             "signature": signature,
         }
@@ -193,14 +298,27 @@ class TestWalletConnect:
         assert "expires_in" in data
         assert data["expires_in"] > 0
 
-    def test_wallet_connect_new_user_with_privy_did_saves_did(self, client: TestClient, test_db):
-        """新規ユーザー作成時に privy_did が DB に保存されること。"""
+    # ── Privy ID Token 検証 (Codex Review P1) ─────────────────────────
+
+    def test_wallet_connect_valid_id_token_with_matching_did_saves_did(
+        self,
+        client: TestClient,
+        test_db,
+        privy_keypair: Tuple[bytes, bytes],
+        privy_env: None,  # noqa: ARG002
+    ):
+        """有効 privy_id_token + 一致 privy_did → 200 で DB 保存 (新仕様)。"""
         _, engine = test_db
+        private_pem, _ = privy_keypair
+        did = "did:privy:test123abc"
+        token = _make_id_token(private_pem, sub=did)
+
         payload = self._make_valid_request()
-        payload["privy_did"] = "did:privy:test123abc"
+        payload["privy_did"] = did
+        payload["privy_id_token"] = token
 
         response = client.post("/auth/wallet/connect", json=payload)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json()
         assert response.json()["is_new_user"] is True
 
         Session = sessionmaker(bind=engine)
@@ -211,21 +329,119 @@ class TestWalletConnect:
                 .first()
             )
             assert user is not None
-            assert user.privy_did == "did:privy:test123abc"
+            assert user.privy_did == did
 
-    def test_wallet_connect_existing_user_privy_did_backfilled(self, client: TestClient, test_db):
-        """既存ユーザーに privy_did が未設定の場合、後追い保存されること。"""
-        _, engine = test_db
-        # 1回目: privy_did なしで登録
+    def test_wallet_connect_valid_id_token_did_mismatch_returns_401(
+        self,
+        client: TestClient,
+        privy_keypair: Tuple[bytes, bytes],
+        privy_env: None,  # noqa: ARG002
+    ):
+        """有効 privy_id_token + 不一致 privy_did → 401 (DID 偽装試行を拒否)。"""
+        private_pem, _ = privy_keypair
+        token = _make_id_token(private_pem, sub="did:privy:authentic-user")
+
         payload = self._make_valid_request()
-        first_response = client.post("/auth/wallet/connect", json=payload)
-        assert first_response.status_code == 200
+        payload["privy_did"] = "did:privy:attacker-impersonation"
+        payload["privy_id_token"] = token
 
-        # 2回目: privy_did 付きで再接続
-        payload["privy_did"] = "did:privy:backfill456"
-        second_response = client.post("/auth/wallet/connect", json=payload)
-        assert second_response.status_code == 200
-        assert second_response.json()["is_new_user"] is False
+        response = client.post("/auth/wallet/connect", json=payload)
+        assert response.status_code == 401
+        assert "match" in response.json()["detail"].lower()
+
+    def test_wallet_connect_unverified_did_returns_400_when_privy_enabled(
+        self,
+        client: TestClient,
+        privy_env: None,  # noqa: ARG002
+    ):
+        """privy_id_token なし + privy_did あり (PRIVY 設定済み) → 400 (未検証 DID 拒否)。"""
+        payload = self._make_valid_request()
+        payload["privy_did"] = "did:privy:unverified123"
+
+        response = client.post("/auth/wallet/connect", json=payload)
+        assert response.status_code == 400
+        assert "id_token" in response.json()["detail"].lower()
+
+    def test_wallet_connect_expired_id_token_returns_401(
+        self,
+        client: TestClient,
+        privy_keypair: Tuple[bytes, bytes],
+        privy_env: None,  # noqa: ARG002
+    ):
+        """期限切れ privy_id_token → 401。"""
+        private_pem, _ = privy_keypair
+        # iat=2h前, exp=1h前 → 既に期限切れ
+        expired_token = _make_id_token(
+            private_pem, sub="did:privy:expired", iat_offset=-7200, exp_offset=-3600
+        )
+
+        payload = self._make_valid_request()
+        payload["privy_id_token"] = expired_token
+
+        response = client.post("/auth/wallet/connect", json=payload)
+        assert response.status_code == 401
+
+    def test_wallet_connect_invalid_signature_id_token_returns_401(
+        self,
+        client: TestClient,
+        privy_env: None,  # noqa: ARG002
+    ):
+        """別の鍵で署名された privy_id_token → 401。"""
+        # 設定に登録されていない別 keypair で署名
+        attacker_private_pem, _ = _generate_es256_keypair()
+        forged_token = _make_id_token(attacker_private_pem, sub="did:privy:forged")
+
+        payload = self._make_valid_request()
+        payload["privy_id_token"] = forged_token
+
+        response = client.post("/auth/wallet/connect", json=payload)
+        assert response.status_code == 401
+
+    def test_wallet_connect_duplicate_privy_did_returns_409(
+        self,
+        client: TestClient,
+        privy_keypair: Tuple[bytes, bytes],
+        privy_env: None,  # noqa: ARG002
+    ):
+        """同じ privy_did で別ウォレットの新規ユーザー作成 → 409 Conflict (Codex Review P2)。"""
+        private_pem, _ = privy_keypair
+        did = "did:privy:duplicate"
+        token = _make_id_token(private_pem, sub=did)
+
+        # 1回目: ウォレット A で登録 (DID 保存)
+        first = self._make_valid_request()
+        first["privy_did"] = did
+        first["privy_id_token"] = token
+        resp1 = client.post("/auth/wallet/connect", json=first)
+        assert resp1.status_code == 200
+
+        # 2回目: 別ウォレット B で同じ DID を使って登録 → 409
+        second = self._make_valid_request_2()
+        second["privy_did"] = did
+        second["privy_id_token"] = token  # 同じ DID なので token も同じで OK
+        resp2 = client.post("/auth/wallet/connect", json=second)
+        assert resp2.status_code == 409
+        assert "did" in resp2.json()["detail"].lower()
+
+    def test_wallet_connect_id_token_only_uses_sub_as_did(
+        self,
+        client: TestClient,
+        test_db,
+        privy_keypair: Tuple[bytes, bytes],
+        privy_env: None,  # noqa: ARG002
+    ):
+        """privy_id_token のみ (privy_did なし) → 200 で sub を DID として使用。"""
+        _, engine = test_db
+        private_pem, _ = privy_keypair
+        did = "did:privy:from-sub-only"
+        token = _make_id_token(private_pem, sub=did)
+
+        payload = self._make_valid_request()
+        # privy_did は送らない
+        payload["privy_id_token"] = token
+
+        response = client.post("/auth/wallet/connect", json=payload)
+        assert response.status_code == 200, response.json()
 
         Session = sessionmaker(bind=engine)
         with Session() as session:
@@ -235,13 +451,54 @@ class TestWalletConnect:
                 .first()
             )
             assert user is not None
-            assert user.privy_did == "did:privy:backfill456"
+            assert user.privy_did == did
 
-    def test_wallet_connect_without_privy_did_still_works(self, client: TestClient):
-        """privy_did なしのリクエストが従来通り動作すること（後方互換）。"""
+    def test_wallet_connect_existing_user_id_token_backfill(
+        self,
+        client: TestClient,
+        test_db,
+        privy_keypair: Tuple[bytes, bytes],
+        privy_env: None,  # noqa: ARG002
+    ):
+        """既存ユーザーに privy_did 未設定なら、有効な ID Token で後追い保存。"""
+        _, engine = test_db
+
+        # 1回目: privy 関連なしで作成
+        first = self._make_valid_request()
+        resp1 = client.post("/auth/wallet/connect", json=first)
+        assert resp1.status_code == 200
+
+        # 2回目: 有効 ID Token + 一致 DID で再接続
+        private_pem, _ = privy_keypair
+        did = "did:privy:backfill456"
+        token = _make_id_token(private_pem, sub=did)
+        second = self._make_valid_request()
+        second["privy_did"] = did
+        second["privy_id_token"] = token
+        resp2 = client.post("/auth/wallet/connect", json=second)
+        assert resp2.status_code == 200
+        assert resp2.json()["is_new_user"] is False
+
+        Session = sessionmaker(bind=engine)
+        with Session() as session:
+            user = (
+                session.query(User)
+                .filter(User.wallet_address == TEST_WALLET_ADDRESS.lower())
+                .first()
+            )
+            assert user is not None
+            assert user.privy_did == did
+
+    def test_wallet_connect_without_privy_did_still_works(
+        self,
+        client: TestClient,
+        privy_unset_env: None,  # noqa: ARG002
+    ):
+        """privy_did/privy_id_token なしのリクエストは従来通り動作する (後方互換)。"""
         payload = self._make_valid_request()
-        # privy_did を明示的に含めない
+        # privy_did / privy_id_token を明示的に含めない
         assert "privy_did" not in payload
+        assert "privy_id_token" not in payload
 
         response = client.post("/auth/wallet/connect", json=payload)
         assert response.status_code == 200

--- a/backend/tests/auth/test_wallet_connect.py
+++ b/backend/tests/auth/test_wallet_connect.py
@@ -27,6 +27,7 @@ os.environ["JWT_ALGORITHM"] = "HS256"
 os.environ["JWT_ACCESS_TOKEN_EXPIRE_MINUTES"] = "30"
 os.environ["INITIAL_ADMIN_EMAIL"] = "admin@example.com"
 
+from app.auth.models import User
 from app.database import Base, get_db
 from app.main import create_app
 
@@ -191,3 +192,59 @@ class TestWalletConnect:
         data = response.json()
         assert "expires_in" in data
         assert data["expires_in"] > 0
+
+    def test_wallet_connect_new_user_with_privy_did_saves_did(self, client: TestClient, test_db):
+        """新規ユーザー作成時に privy_did が DB に保存されること。"""
+        _, engine = test_db
+        payload = self._make_valid_request()
+        payload["privy_did"] = "did:privy:test123abc"
+
+        response = client.post("/auth/wallet/connect", json=payload)
+        assert response.status_code == 200
+        assert response.json()["is_new_user"] is True
+
+        Session = sessionmaker(bind=engine)
+        with Session() as session:
+            user = (
+                session.query(User)
+                .filter(User.wallet_address == TEST_WALLET_ADDRESS.lower())
+                .first()
+            )
+            assert user is not None
+            assert user.privy_did == "did:privy:test123abc"
+
+    def test_wallet_connect_existing_user_privy_did_backfilled(self, client: TestClient, test_db):
+        """既存ユーザーに privy_did が未設定の場合、後追い保存されること。"""
+        _, engine = test_db
+        # 1回目: privy_did なしで登録
+        payload = self._make_valid_request()
+        first_response = client.post("/auth/wallet/connect", json=payload)
+        assert first_response.status_code == 200
+
+        # 2回目: privy_did 付きで再接続
+        payload["privy_did"] = "did:privy:backfill456"
+        second_response = client.post("/auth/wallet/connect", json=payload)
+        assert second_response.status_code == 200
+        assert second_response.json()["is_new_user"] is False
+
+        Session = sessionmaker(bind=engine)
+        with Session() as session:
+            user = (
+                session.query(User)
+                .filter(User.wallet_address == TEST_WALLET_ADDRESS.lower())
+                .first()
+            )
+            assert user is not None
+            assert user.privy_did == "did:privy:backfill456"
+
+    def test_wallet_connect_without_privy_did_still_works(self, client: TestClient):
+        """privy_did なしのリクエストが従来通り動作すること（後方互換）。"""
+        payload = self._make_valid_request()
+        # privy_did を明示的に含めない
+        assert "privy_did" not in payload
+
+        response = client.post("/auth/wallet/connect", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert "access_token" in data
+        assert data["is_new_user"] is True

--- a/docs/integration/backend_deps.md
+++ b/docs/integration/backend_deps.md
@@ -64,6 +64,16 @@
 
 ## backend/requirements.txt
 
+### 変更 #2: PyJWT[crypto] extra 追加（Privy ID Token 検証対応）(PR #155 / 2026-04-27)
+- **コミット範囲**: `c88dfd2` – `41f77d7` (feature/privy-did-storage)
+- **変更内容**: `PyJWT>=2.9.0` → `PyJWT[crypto]>=2.9.0`
+- **理由**: Privy ID Token 検証 (PR #155) に RS256/ES256 アルゴリズムサポートが必要。
+  `PyJWT` 単体では非対称鍵アルゴリズムを扱えず、`cryptography` ライブラリが必要。
+  `[crypto]` extra を追加することで `cryptography` が自動的にインストールされる。
+- **影響範囲**: `cryptography` ライブラリの追加のみ。既存認証ロジックへの影響なし。
+  `pyjwt` は既存コードでも使用しており、API 互換変更（追加のみ）。
+- **承認**: feature/privy-did-storage → main の通常フロー経由（PR #155）
+
 ### 変更 #1: wheel バージョン固定（CVE-2026-24049）
 - **コミット**: `fd2b6a6` (dev ブランチ)
 - **変更内容**: `wheel>=0.46.2` を追加


### PR DESCRIPTION
## Summary

- `users` テーブルに `privy_did` カラム追加（nullable / unique / indexed）
- `POST /auth/wallet/connect` が `privy_did` を受け取り DB 保存するよう拡張
- 新規ユーザー: INSERT 時に同時保存
- 既存ユーザー: `privy_did` 未設定かつリクエストに含まれる場合は後追い UPDATE
- `privy_did` が省略されても従来通り動作（後方互換）

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `backend/app/auth/models.py` | `User` に `privy_did` カラム追加 + ALTER TABLE コメント |
| `backend/app/auth/schemas.py` | `WalletConnectRequest` に `privy_did: Optional[str] = None` |
| `backend/app/auth/service.py` | `create_wallet_user()` に `privy_did` 引数追加、`update_privy_did()` 追加 |
| `backend/app/auth/router.py` | `/auth/wallet/connect` で `privy_did` 保存ロジック呼び出し |
| `backend/alembic/versions/f6a7b8c9d0e1_...py` | alembic マイグレーション新規作成（partial unique index） |
| `backend/tests/auth/test_wallet_connect.py` | privy_did テスト3件追加 |

## DoD チェック

- [x] User モデルに privy_did カラム追加
- [x] alembic migration 作成
- [x] /auth/wallet/connect エンドポイント privy_did 受け取り対応
- [x] pytest 通過（85% coverage）+ 新規テスト3件
- [x] verify.sh Gate 1-5 通過（ruff / format / mypy / pytest / security）
- [ ] Gate 4 (E2E) — frontend 統合タスクが必要なため別タスク化（本 PR は backend 2層のみ）
- [ ] staging での alembic upgrade head 確認（マージ後に実施）

## 注意事項

**frontend 統合タスクが必要。** 本 PR は backend + DB の 2 層のみ対応。
フロントエンドから `privy_did` を送信する実装は別タスクで対応すること（Asana #1214148335864583 参照）。

既存テスター（id=11, 13, 14）への影響なし。`privy_did` は nullable のため既存全ユーザーは NULL のまま。

🤖 Generated with [Claude Code](https://claude.com/claude-code)