### PR TITLE
fix(auth): improve error handling for DID backfill, JWKS, and concurrent inserts

### DIFF
--- a/backend/app/auth/privy_verifier.py
+++ b/backend/app/auth/privy_verifier.py
@@ -179,6 +179,13 @@ class PrivyVerifier:
                     status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                     detail="Privy JWKS unavailable",
                 ) from exc
+            except ValueError as exc:
+                # json.JSONDecodeError も含む。malformed JSON / 空ボディ等の上流不具合
+                logger.error("Privy JWKS response is not valid JSON (%s): %s", self.jwks_url, exc)
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail="Privy JWKS upstream returned invalid JSON",
+                ) from exc
         finally:
             if owns_client:
                 client.close()

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel
 from slowapi import Limiter
 from slowapi.util import get_remote_address
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.database import get_db
@@ -477,15 +478,46 @@ def wallet_connect(
         if existing_user is None:
             raise RuntimeError("existing_user is None after wallet lookup")
         user = existing_user
-        # 既存ユーザーに privy_did が未保存かつ検証済み DID が手元にあれば後追い保存
+        # 既存ユーザーに privy_did が未保存かつ検証済み DID が手元にあれば後追い保存。
+        # IntegrityError (= 別ユーザーが既に同じ DID を保持) は 409、
+        # それ以外の DB エラーは 500 で明示的に返す。silently 握り潰さない。
         if privy_did_to_store and not user.privy_did:
             try:
                 AuthService.update_privy_did(db, user, privy_did_to_store)
-            except Exception:
+            except IntegrityError as exc:
                 db.rollback()
-                logger.warning(
-                    "privy_did update failed (conflict?): wallet=%s...", request.wallet_address[:10]
+                constraint_name = AuthService._extract_constraint_name(exc)
+                if constraint_name and "privy_did" in constraint_name:
+                    logger.warning(
+                        "privy_did backfill conflict (DID already linked to another user): "
+                        "wallet=%s..., did=%s...",
+                        request.wallet_address[:10],
+                        privy_did_to_store[:20],
+                    )
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail="Privy DID already linked to another user",
+                    ) from exc
+                logger.exception(
+                    "privy_did backfill failed with unexpected IntegrityError "
+                    "(constraint=%s): wallet=%s...",
+                    constraint_name or "<unknown>",
+                    request.wallet_address[:10],
                 )
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="DID backfill failed",
+                ) from exc
+            except Exception as exc:
+                db.rollback()
+                logger.exception(
+                    "privy_did backfill failed: wallet=%s...",
+                    request.wallet_address[:10],
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="DID backfill failed",
+                ) from exc
 
     token, expires_in = AuthService.create_access_token(
         user_id=user.id,

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -407,23 +407,72 @@ class AuthService:
         try:
             db.commit()
         except IntegrityError as exc:
-            # privy_did UNIQUE 違反 (= 別ユーザーが同じ DID を保持) や
-            # wallet_address 競合 (並行リクエスト) を 409 Conflict で返す。
+            # IntegrityError の原因 (privy_did 衝突 / wallet_address 並行作成) を
+            # constraint 名で判別する。privy_did 衝突 → 409、wallet_address 衝突は
+            # 並行 first-login の可能性が高いので既存ユーザーを取得して返す。
             db.rollback()
+            constraint_name = cls._extract_constraint_name(exc)
             logger.warning(
-                "Wallet user creation conflict (wallet=%s..., privy_did=%s): %s",
+                "Wallet user creation IntegrityError (wallet=%s..., privy_did=%s, "
+                "constraint=%s): %s",
                 wallet_address[:10],
                 (privy_did[:20] + "...") if privy_did else None,
+                constraint_name or "<unknown>",
                 exc.orig if hasattr(exc, "orig") else exc,
             )
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="DID already in use",
-            ) from exc
+
+            if constraint_name and "privy_did" in constraint_name:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="DID already in use",
+                ) from exc
+
+            if constraint_name and "wallet_address" in constraint_name:
+                # 並行 first-login: 別リクエストが先に同じ wallet_address で作成済み。
+                # 既存ユーザーを取得して返すことで race を吸収する。
+                existing = cls.get_user_by_wallet(db, wallet_address)
+                if existing is not None:
+                    logger.info(
+                        "Resolved concurrent wallet creation race: wallet=%s..., user_id=%s",
+                        wallet_address[:10],
+                        existing.id,
+                    )
+                    return existing
+                # 取得できない場合は不整合 → 500
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Concurrent wallet insert race not resolvable",
+                ) from exc
+
+            # 想定外の constraint (email / username 等) は呼び出し元で再 raise。
+            logger.exception(
+                "Unexpected IntegrityError on wallet user creation (constraint=%s)",
+                constraint_name or "<unknown>",
+            )
+            raise
         db.refresh(user)
 
         logger.info("Created wallet user: %s (wallet=%s...)", user.email, wallet_address[:10])
         return user
+
+    @staticmethod
+    def _extract_constraint_name(exc: IntegrityError) -> str:
+        """IntegrityError から違反した constraint 名を抽出する。
+
+        PostgreSQL (psycopg2 / psycopg3) は ``exc.orig.diag.constraint_name`` で
+        constraint 名を提供する。SQLite 等の他ドライバーは diag を持たないため
+        フォールバックとして orig の文字列表現に含まれる constraint 名を文字列
+        マッチで判定する (本関数は呼び出し側で部分一致 ``in`` で使うことを前提)。
+        """
+        orig = getattr(exc, "orig", None)
+        if orig is None:
+            return ""
+        diag = getattr(orig, "diag", None)
+        if diag is not None:
+            constraint = getattr(diag, "constraint_name", None)
+            if isinstance(constraint, str) and constraint:
+                return constraint
+        return str(orig)
 
     @classmethod
     def update_privy_did(cls, db: Session, user: User, privy_did: str) -> None:

--- a/backend/tests/auth/test_wallet_connect.py
+++ b/backend/tests/auth/test_wallet_connect.py
@@ -567,3 +567,166 @@ class TestWalletConnect:
         assert any("Privy verification disabled" in r.message for r in caplog.records)
         # 機密情報 (id_token の中身) がログに含まれないことを確認
         assert not any("ey.fake.token" in r.message for r in caplog.records)
+
+
+# ── Codex Review 3rd round 指摘 (session 019dcc18) 対応テスト ─────────────────
+
+
+class TestErrorHandlingFixes:
+    """P2-1 / P2-2 / P2-3 のエラーハンドリング改善テスト。"""
+
+    # ── P2-1: 既存ユーザー DID backfill 時の IntegrityError → 409 ─────
+
+    def test_existing_user_backfill_did_conflict_returns_409(
+        self,
+        client: TestClient,
+        privy_keypair: Tuple[bytes, bytes],
+        privy_env: None,  # noqa: ARG002
+    ):
+        """既存ユーザーへの DID backfill 中、別ユーザーが既に同じ DID を保持 → 409。
+
+        シナリオ:
+          1. ウォレット B が DID X で登録 (DID X が users.privy_did に保存)
+          2. ウォレット A は DID なしで登録
+          3. ウォレット A が DID X 付きで再接続 → backfill で UNIQUE 違反 → 409
+        """
+        private_pem, _ = privy_keypair
+        did = "did:privy:already-linked-elsewhere"
+        token = _make_id_token(private_pem, sub=did)
+
+        # Step 1: ウォレット B を DID X で登録
+        payload_b = {
+            "wallet_address": TEST_WALLET_ADDRESS_2,
+            "message": "Ultra AutoTrade: backfill conflict #B",
+            "signature": _sign_message("Ultra AutoTrade: backfill conflict #B", TEST_PRIVATE_KEY_2),
+            "privy_did": did,
+            "privy_id_token": token,
+        }
+        resp_b = client.post("/auth/wallet/connect", json=payload_b)
+        assert resp_b.status_code == 200, resp_b.json()
+
+        # Step 2: ウォレット A を DID なしで登録
+        msg_a = "Ultra AutoTrade: backfill conflict #A"
+        payload_a_first = {
+            "wallet_address": TEST_WALLET_ADDRESS,
+            "message": msg_a,
+            "signature": _sign_message(msg_a, TEST_PRIVATE_KEY),
+        }
+        resp_a1 = client.post("/auth/wallet/connect", json=payload_a_first)
+        assert resp_a1.status_code == 200, resp_a1.json()
+        assert resp_a1.json()["is_new_user"] is True
+
+        # Step 3: ウォレット A が DID X 付きで再接続 → backfill 衝突 → 409
+        msg_a2 = "Ultra AutoTrade: backfill conflict #A2"
+        payload_a_second = {
+            "wallet_address": TEST_WALLET_ADDRESS,
+            "message": msg_a2,
+            "signature": _sign_message(msg_a2, TEST_PRIVATE_KEY),
+            "privy_did": did,
+            "privy_id_token": token,
+        }
+        resp_a2 = client.post("/auth/wallet/connect", json=payload_a_second)
+        assert resp_a2.status_code == 409, resp_a2.json()
+        assert "did" in resp_a2.json()["detail"].lower()
+
+    # ── P2-2: JWKS 解析失敗 → 503 ───────────────────────────────────
+
+    def test_fetch_jwks_malformed_json_returns_503(self):
+        """JWKS endpoint が malformed JSON を返すと 503 に変換される (500 漏れ防止)。"""
+        import httpx
+        from fastapi import HTTPException
+
+        from app.auth.privy_verifier import PrivyVerifier
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=b"not json {{{ broken")
+
+        transport = httpx.MockTransport(handler)
+        http_client = httpx.Client(transport=transport)
+        verifier = PrivyVerifier(
+            app_id="test-app",
+            jwks_url="https://privy.example/jwks",
+            http_client=http_client,
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            verifier._fetch_jwks()
+        assert exc_info.value.status_code == 503
+        assert "json" in str(exc_info.value.detail).lower()
+
+    def test_fetch_jwks_http_error_still_returns_503(self):
+        """既存の httpx.HTTPError 経路 (5xx 等) も 503 を維持していることの回帰テスト。"""
+        import httpx
+        from fastapi import HTTPException
+
+        from app.auth.privy_verifier import PrivyVerifier
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, content=b"upstream down")
+
+        transport = httpx.MockTransport(handler)
+        http_client = httpx.Client(transport=transport)
+        verifier = PrivyVerifier(
+            app_id="test-app",
+            jwks_url="https://privy.example/jwks",
+            http_client=http_client,
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            verifier._fetch_jwks()
+        assert exc_info.value.status_code == 503
+
+    # ── P2-3: wallet_address 並行衝突 → 既存ユーザー resolve ─────────
+
+    def test_create_wallet_user_resolves_concurrent_wallet_race(self, test_db):
+        """並行 first-login: 別 transaction が同じ wallet_address で先に user を
+        作成済みの状態で create_wallet_user() を呼ぶと、IntegrityError を吸収して
+        既存ユーザーを返す (409 で誤報告しない)。
+        """
+        from app.auth.service import AuthService
+
+        _, engine = test_db
+        SessionLocal = sessionmaker(bind=engine)
+
+        wallet = TEST_WALLET_ADDRESS.lower()
+
+        # Session A: 先に user を作成・コミット
+        with SessionLocal() as session_a:
+            first = AuthService.create_wallet_user(session_a, wallet)
+            session_a.commit()
+            first_id = first.id
+            first_email = first.email
+
+        # Session B: 同じ wallet で create_wallet_user() を再度呼ぶ。
+        # 内部で wallet_address UNIQUE 違反 (IntegrityError) を検知し、
+        # 既存ユーザーを取得して返すことで race を吸収する。
+        with SessionLocal() as session_b:
+            second = AuthService.create_wallet_user(session_b, wallet)
+            assert second.id == first_id
+            assert second.wallet_address == wallet
+            assert second.email == first_email
+
+    def test_create_wallet_user_privy_did_conflict_still_returns_409(self, test_db):
+        """privy_did UNIQUE 違反は引き続き 409 を返すこと (P2-3 リファクタの回帰防止)。"""
+        from fastapi import HTTPException
+
+        from app.auth.service import AuthService
+
+        _, engine = test_db
+        SessionLocal = sessionmaker(bind=engine)
+
+        did = "did:privy:taken-by-someone-else"
+        wallet1 = TEST_WALLET_ADDRESS.lower()
+        wallet2 = TEST_WALLET_ADDRESS_2.lower()
+
+        # Session 1: 既に DID を保持するユーザーを作成
+        with SessionLocal() as s1:
+            AuthService.create_wallet_user(s1, wallet1, privy_did=did)
+            s1.commit()
+
+        # Session 2: 別 wallet で同じ DID を使って作成 → 409
+        with SessionLocal() as s2:
+            with pytest.raises(HTTPException) as exc_info:
+                AuthService.create_wallet_user(s2, wallet2, privy_did=did)
+            assert exc_info.value.status_code == 409
+            assert "did" in str(exc_info.value.detail).lower()


### PR DESCRIPTION
## Summary

PR #155 (Privy DID 永続化) の Codex Review 3rd round (session `019dcc18-0fe9-78b3-a9f6-8cd780c57119`) で指摘された **P2 を 3 件まとめて修正**。すべて認証フローのエラーハンドリング改善で、機能追加はなし。

| # | ファイル | 行 | 問題 | 修正 |
|---|----------|----|------|------|
| P2-1 | `backend/app/auth/router.py` | :482-488 | 既存ユーザー DID backfill 中の例外を silently 握り潰し | `IntegrityError` を constraint 名で判定 → 409 / 500 を明示的に返す |
| P2-2 | `backend/app/auth/privy_verifier.py` | :173-176 | `resp.json()` の `ValueError`/`JSONDecodeError` 漏れ → 500 | 503 (`Privy JWKS upstream returned invalid JSON`) に変換 |
| P2-3 | `backend/app/auth/service.py` | :419-422 | `IntegrityError` を全て「DID 重複」として 409 を返却 | constraint 名で分岐: privy_did → 409 / wallet_address (並行 first-login) → 既存ユーザー resolve / その他 → 500 |

constraint 抽出は `AuthService._extract_constraint_name()` に集約。PostgreSQL では `orig.diag.constraint_name`、それ以外のドライバー (テストの SQLite 等) では `str(orig)` にフォールバックし、呼び出し側は `'privy_did' in constraint` などの部分一致で判定する。

## テスト追加 (5 ケース、`TestErrorHandlingFixes`)

- `test_existing_user_backfill_did_conflict_returns_409` — P2-1 (API 経由)
- `test_fetch_jwks_malformed_json_returns_503` — P2-2 (httpx.MockTransport)
- `test_fetch_jwks_http_error_still_returns_503` — P2-2 回帰
- `test_create_wallet_user_resolves_concurrent_wallet_race` — P2-3 (sequential 2 セッション)
- `test_create_wallet_user_privy_did_conflict_still_returns_409` — P2-3 回帰

## 検証

- `ruff check .` / `ruff format --check .` ✅
- `mypy app/ --config-file ../pyproject.toml` ✅ (3 source files)
- `pytest tests/ -q --no-cov` ✅ **2671 passed, 9 skipped** (305s)
- `pytest tests/auth/ -q` ✅ **25 passed** (20 既存 + 5 新規)

## Test plan

- [x] verify.sh Gate 1-4 (ruff / format / mypy / pytest) 通過
- [x] 新規 5 ケースが PASS
- [x] 既存 20 ケース (PR #155 リグレッション) が PASS
- [ ] Codex Review 再実行 (ユーザー手動 — 後続)

## 関連

- Codex session: `019dcc18-0fe9-78b3-a9f6-8cd780c57119`
- Asana: GID `1214284848105227`
- 元 PR: #155 (already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)