### PR TITLE
fix(scheduler): process_news_loop に X-Internal-Token ヘッダーを付与

### DIFF
--- a/backend/app/automation/scheduled_tasks.py
+++ b/backend/app/automation/scheduled_tasks.py
@@ -645,6 +645,7 @@ async def process_news_loop(
             async with httpx.AsyncClient() as client:
                 resp = await client.post(
                     url,
+                    params={"dry_run": "false"},
                     headers={"X-Internal-Token": token},
                     timeout=120.0,
                 )

--- a/backend/app/automation/scheduled_tasks.py
+++ b/backend/app/automation/scheduled_tasks.py
@@ -648,6 +648,7 @@ async def process_news_loop(
                     headers={"X-Internal-Token": token},
                     timeout=120.0,
                 )
+                resp.raise_for_status()  # 4xx/5xx を HTTPStatusError として伝播
 
             logger.info(
                 "process_news_loop: POST %s → %d",

--- a/backend/app/automation/scheduled_tasks.py
+++ b/backend/app/automation/scheduled_tasks.py
@@ -603,6 +603,73 @@ async def latency_monitor_loop(
             await asyncio.sleep(600)
 
 
+async def process_news_loop(
+    *,
+    interval_seconds: int = 300,
+    on_error: Optional[Callable[[Exception], None]] = None,
+) -> None:
+    """
+    POST /automation/process-news を定期実行するループ。
+
+    INTERNAL_API_TOKEN を X-Internal-Token ヘッダーに付与して内部 API を呼ぶ。
+    BACKEND_BASE_URL が未設定の場合は http://localhost:8000 を使用。
+
+    Args:
+        interval_seconds: 実行間隔（秒）。デフォルト 300 秒（5 分）
+        on_error: エラー発生時のコールバック
+
+    Note:
+        - INTERNAL_API_TOKEN が未設定の場合はスキップしてログ警告のみ
+        - このコルーチンは無限ループで動作する
+        - 停止は asyncio.CancelledError で行う
+        - エラー発生時もループは継続（fail-safe）
+    """
+    import os  # noqa: PLC0415
+
+    logger.info("Starting process_news_loop (interval: %ds)", interval_seconds)
+
+    while True:
+        try:
+            await asyncio.sleep(interval_seconds)
+
+            token = os.getenv("INTERNAL_API_TOKEN", "")
+            if not token:
+                logger.warning("process_news_loop: INTERNAL_API_TOKEN not set, skipping")
+                continue
+
+            base_url = os.getenv("BACKEND_BASE_URL", "http://localhost:8000")
+            url = f"{base_url}/automation/process-news"
+
+            import httpx  # noqa: PLC0415
+
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    url,
+                    headers={"X-Internal-Token": token},
+                    timeout=120.0,
+                )
+
+            logger.info(
+                "process_news_loop: POST %s → %d",
+                url,
+                resp.status_code,
+            )
+
+        except asyncio.CancelledError:
+            logger.info("process_news_loop cancelled - shutting down")
+            raise
+
+        except Exception as exc:
+            logger.error("process_news_loop error: %s", exc)
+            if on_error:
+                try:
+                    on_error(exc)
+                except Exception as callback_exc:
+                    logger.error("Error in on_error callback: %s", callback_exc)
+
+            await asyncio.sleep(60)
+
+
 async def price_change_monitor_loop(
     *,
     interval_seconds: int = 300,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -413,6 +413,11 @@ def create_app() -> FastAPI:
                 mmt_interval = int(os.getenv("MMT_UPDATE_INTERVAL", "1800")) // 60
                 asyncio.create_task(start_mmt_background_task(interval_minutes=mmt_interval))
                 logger.info("MMT data feed started (interval: %ds)", mmt_interval * 60)
+            from app.automation.scheduled_tasks import process_news_loop  # noqa: PLC0415
+
+            pn_interval = int(os.getenv("PROCESS_NEWS_INTERVAL_SECONDS", "300"))
+            asyncio.create_task(process_news_loop(interval_seconds=pn_interval))
+            logger.info("process_news_loop started (interval=%ds)", pn_interval)
         except BaseException as exc:
             logger.error("Failed to start data feed background tasks: %s", exc)
 

--- a/backend/tests/test_scheduled_tasks.py
+++ b/backend/tests/test_scheduled_tasks.py
@@ -13,6 +13,7 @@ from datetime import datetime, time
 from unittest.mock import AsyncMock, MagicMock, patch
 from zoneinfo import ZoneInfo
 
+import httpx
 import pytest
 
 from app.automation.scheduled_tasks import (
@@ -1658,3 +1659,107 @@ class TestProcessNewsLoop:
                 await process_news_loop(interval_seconds=1, on_error=on_error)
 
         assert 60 in sleep_calls
+
+    @pytest.mark.asyncio
+    async def test_process_news_loop_401_triggers_on_error(self) -> None:
+        """401 レスポンス → raise_for_status() で HTTPStatusError → on_error が呼ばれる。"""
+        from app.automation.scheduled_tasks import process_news_loop
+
+        sleep_calls: list[float] = []
+
+        async def mock_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+            if seconds == 60:
+                raise asyncio.CancelledError()
+
+        on_error_calls: list[Exception] = []
+
+        def on_error(exc: Exception) -> None:
+            on_error_calls.append(exc)
+
+        mock_class, mock_client = self._make_httpx_mock(status_code=401)
+        mock_resp = mock_client.post.return_value
+        mock_request = httpx.Request("POST", "http://localhost:8000/automation/process-news")
+        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "401 Unauthorized", request=mock_request, response=MagicMock()
+        )
+
+        with (
+            patch("app.automation.scheduled_tasks.asyncio.sleep", side_effect=mock_sleep),
+            patch.dict("os.environ", {"INTERNAL_API_TOKEN": "tok"}),
+            patch("httpx.AsyncClient", mock_class),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await process_news_loop(interval_seconds=1, on_error=on_error)
+
+        assert len(on_error_calls) == 1
+        assert isinstance(on_error_calls[0], httpx.HTTPStatusError)
+        assert 60 in sleep_calls
+
+    @pytest.mark.asyncio
+    async def test_process_news_loop_500_triggers_on_error(self) -> None:
+        """500 レスポンス → raise_for_status() で HTTPStatusError → on_error が呼ばれる。"""
+        from app.automation.scheduled_tasks import process_news_loop
+
+        sleep_calls: list[float] = []
+
+        async def mock_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+            if seconds == 60:
+                raise asyncio.CancelledError()
+
+        on_error_calls: list[Exception] = []
+
+        def on_error(exc: Exception) -> None:
+            on_error_calls.append(exc)
+
+        mock_class, mock_client = self._make_httpx_mock(status_code=500)
+        mock_resp = mock_client.post.return_value
+        mock_request = httpx.Request("POST", "http://localhost:8000/automation/process-news")
+        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "500 Internal Server Error", request=mock_request, response=MagicMock()
+        )
+
+        with (
+            patch("app.automation.scheduled_tasks.asyncio.sleep", side_effect=mock_sleep),
+            patch.dict("os.environ", {"INTERNAL_API_TOKEN": "tok"}),
+            patch("httpx.AsyncClient", mock_class),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await process_news_loop(interval_seconds=1, on_error=on_error)
+
+        assert len(on_error_calls) == 1
+        assert isinstance(on_error_calls[0], httpx.HTTPStatusError)
+        assert 60 in sleep_calls
+
+    @pytest.mark.asyncio
+    async def test_process_news_loop_2xx_does_not_trigger_on_error(self) -> None:
+        """200 レスポンス → raise_for_status() は例外を上げず on_error は呼ばれない。"""
+        from app.automation.scheduled_tasks import process_news_loop
+
+        sleep_count = 0
+
+        async def mock_sleep(seconds: float) -> None:
+            nonlocal sleep_count
+            sleep_count += 1
+            if sleep_count >= 2:
+                raise asyncio.CancelledError()
+
+        on_error_calls: list[Exception] = []
+
+        def on_error(exc: Exception) -> None:
+            on_error_calls.append(exc)
+
+        mock_class, mock_client = self._make_httpx_mock(status_code=200)
+        mock_resp = mock_client.post.return_value
+        mock_resp.raise_for_status.return_value = None  # 正常: 例外なし
+
+        with (
+            patch("app.automation.scheduled_tasks.asyncio.sleep", side_effect=mock_sleep),
+            patch.dict("os.environ", {"INTERNAL_API_TOKEN": "tok"}),
+            patch("httpx.AsyncClient", mock_class),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await process_news_loop(interval_seconds=1, on_error=on_error)
+
+        assert len(on_error_calls) == 0

--- a/backend/tests/test_scheduled_tasks.py
+++ b/backend/tests/test_scheduled_tasks.py
@@ -1763,3 +1763,32 @@ class TestProcessNewsLoop:
                 await process_news_loop(interval_seconds=1, on_error=on_error)
 
         assert len(on_error_calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_process_news_loop_passes_dry_run_false(self) -> None:
+        """P1: POST に dry_run=false クエリパラメータが付与されること。
+        デフォルト dry_run=True のエンドポイントに対し、本番実行モードを明示する。
+        """
+        from app.automation.scheduled_tasks import process_news_loop
+
+        sleep_count = 0
+
+        async def mock_sleep(seconds: float) -> None:
+            nonlocal sleep_count
+            sleep_count += 1
+            if sleep_count >= 2:
+                raise asyncio.CancelledError()
+
+        mock_class, mock_client = self._make_httpx_mock()
+
+        with (
+            patch("app.automation.scheduled_tasks.asyncio.sleep", side_effect=mock_sleep),
+            patch.dict("os.environ", {"INTERNAL_API_TOKEN": "test-token"}),
+            patch("httpx.AsyncClient", mock_class),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await process_news_loop(interval_seconds=1)
+
+        mock_client.post.assert_called_once()
+        params = mock_client.post.call_args.kwargs["params"]
+        assert params.get("dry_run") == "false"

--- a/backend/tests/test_scheduled_tasks.py
+++ b/backend/tests/test_scheduled_tasks.py
@@ -1476,3 +1476,185 @@ class TestStopMethodExceptionBranches:
                 await manager.start_learning()
 
         await manager.stop_learning()
+
+
+# ---------------------------------------------------------------------------
+# process_news_loop — POST /automation/process-news with X-Internal-Token
+# ---------------------------------------------------------------------------
+
+
+class TestProcessNewsLoop:
+    """process_news_loop のテスト。
+
+    - X-Internal-Token ヘッダーを付与して POST すること
+    - INTERNAL_API_TOKEN 未設定時はスキップすること
+    - asyncio.CancelledError を伝播すること
+    - 例外発生時は on_error を呼び 60 秒待機すること
+    """
+
+    @staticmethod
+    def _make_httpx_mock(status_code: int = 200) -> tuple[object, AsyncMock]:
+        """httpx.AsyncClient のモック (class, client_instance) を返す。"""
+        mock_response = MagicMock()
+        mock_response.status_code = status_code
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        cm = AsyncMock()
+        cm.__aenter__ = AsyncMock(return_value=mock_client)
+        cm.__aexit__ = AsyncMock(return_value=None)
+
+        mock_class = MagicMock(return_value=cm)
+        return mock_class, mock_client
+
+    @pytest.mark.asyncio
+    async def test_sends_x_internal_token_header(self) -> None:
+        """X-Internal-Token ヘッダーに INTERNAL_API_TOKEN を付与して POST する。"""
+        from app.automation.scheduled_tasks import process_news_loop
+
+        sleep_count = 0
+
+        async def mock_sleep(seconds: float) -> None:
+            nonlocal sleep_count
+            sleep_count += 1
+            if sleep_count >= 2:
+                raise asyncio.CancelledError()
+
+        mock_class, mock_client = self._make_httpx_mock()
+
+        with (
+            patch("app.automation.scheduled_tasks.asyncio.sleep", side_effect=mock_sleep),
+            patch.dict("os.environ", {"INTERNAL_API_TOKEN": "test-token-abc"}),
+            patch("httpx.AsyncClient", mock_class),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await process_news_loop(interval_seconds=1)
+
+        mock_client.post.assert_called_once()
+        headers = mock_client.post.call_args.kwargs["headers"]
+        assert headers == {"X-Internal-Token": "test-token-abc"}
+
+    @pytest.mark.asyncio
+    async def test_posts_to_correct_url(self) -> None:
+        """BACKEND_BASE_URL/automation/process-news に POST する。"""
+        from app.automation.scheduled_tasks import process_news_loop
+
+        sleep_count = 0
+
+        async def mock_sleep(seconds: float) -> None:
+            nonlocal sleep_count
+            sleep_count += 1
+            if sleep_count >= 2:
+                raise asyncio.CancelledError()
+
+        mock_class, mock_client = self._make_httpx_mock()
+
+        with (
+            patch("app.automation.scheduled_tasks.asyncio.sleep", side_effect=mock_sleep),
+            patch.dict(
+                "os.environ",
+                {"INTERNAL_API_TOKEN": "tok", "BACKEND_BASE_URL": "http://backend:8000"},
+            ),
+            patch("httpx.AsyncClient", mock_class),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await process_news_loop(interval_seconds=1)
+
+        posted_url = mock_client.post.call_args.args[0]
+        assert posted_url == "http://backend:8000/automation/process-news"
+
+    @pytest.mark.asyncio
+    async def test_skips_when_token_not_set(self) -> None:
+        """INTERNAL_API_TOKEN が空のとき httpx を呼ばない。"""
+        from app.automation.scheduled_tasks import process_news_loop
+
+        sleep_count = 0
+
+        async def mock_sleep(seconds: float) -> None:
+            nonlocal sleep_count
+            sleep_count += 1
+            if sleep_count >= 2:
+                raise asyncio.CancelledError()
+
+        mock_class, mock_client = self._make_httpx_mock()
+
+        with (
+            patch("app.automation.scheduled_tasks.asyncio.sleep", side_effect=mock_sleep),
+            patch.dict("os.environ", {"INTERNAL_API_TOKEN": ""}),
+            patch("httpx.AsyncClient", mock_class),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await process_news_loop(interval_seconds=1)
+
+        mock_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_propagates(self) -> None:
+        """asyncio.CancelledError はループ外に伝播する（再 raise される）。"""
+        from app.automation.scheduled_tasks import process_news_loop
+
+        async def mock_sleep(seconds: float) -> None:
+            raise asyncio.CancelledError()
+
+        with patch("app.automation.scheduled_tasks.asyncio.sleep", side_effect=mock_sleep):
+            with pytest.raises(asyncio.CancelledError):
+                await process_news_loop(interval_seconds=1)
+
+    @pytest.mark.asyncio
+    async def test_on_error_callback_called_on_exception(self) -> None:
+        """httpx 例外時に on_error が呼ばれ、60 秒待機してループ継続する。"""
+        from app.automation.scheduled_tasks import process_news_loop
+
+        sleep_calls: list[float] = []
+
+        async def mock_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+            if seconds == 60:
+                raise asyncio.CancelledError()
+
+        on_error_calls: list[Exception] = []
+
+        def on_error(exc: Exception) -> None:
+            on_error_calls.append(exc)
+
+        failing_class = MagicMock(side_effect=RuntimeError("connection refused"))
+
+        with (
+            patch("app.automation.scheduled_tasks.asyncio.sleep", side_effect=mock_sleep),
+            patch.dict("os.environ", {"INTERNAL_API_TOKEN": "tok"}),
+            patch("httpx.AsyncClient", failing_class),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await process_news_loop(interval_seconds=1, on_error=on_error)
+
+        assert len(on_error_calls) == 1
+        assert isinstance(on_error_calls[0], RuntimeError)
+        assert 60 in sleep_calls
+
+    @pytest.mark.asyncio
+    async def test_on_error_callback_raises_internally(self) -> None:
+        """on_error 自体が例外を投げても 60 秒待機でループを継続する。"""
+        from app.automation.scheduled_tasks import process_news_loop
+
+        sleep_calls: list[float] = []
+
+        async def mock_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+            if seconds == 60:
+                raise asyncio.CancelledError()
+
+        def on_error(exc: Exception) -> None:
+            raise RuntimeError("on_error internal failure")
+
+        failing_class = MagicMock(side_effect=RuntimeError("httpx error"))
+
+        with (
+            patch("app.automation.scheduled_tasks.asyncio.sleep", side_effect=mock_sleep),
+            patch.dict("os.environ", {"INTERNAL_API_TOKEN": "tok"}),
+            patch("httpx.AsyncClient", failing_class),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await process_news_loop(interval_seconds=1, on_error=on_error)
+
+        assert 60 in sleep_calls

--- a/docs/integration/backend_deps.md
+++ b/docs/integration/backend_deps.md
@@ -54,6 +54,17 @@
 - **影響範囲**: 新規 router 追加のみ。既存 endpoint への影響なし。`TestCoexistenceWithLegacyEndpoints` (2件) で既存 endpoint の404でないことを保証。
 - **承認**: feature/f8a-fees-api-readonly → main の通常フロー経由（PR #127）
 
+
+### 変更 #5: process_news_loop 起動 (PR #157 / 2026-04-27)
+- **コミット範囲**: `5ea9120` – `ce53ea9` (fix/production-401-unauthorized)
+- **変更内容**:
+  - `from app.automation.scheduled_tasks import process_news_loop` を `startup_data_feeds` 内で動的 import
+  - `asyncio.create_task(process_news_loop(interval_seconds=pn_interval))` で起動
+  - `PROCESS_NEWS_INTERVAL_SECONDS` 環境変数 (デフォルト 300秒 = 5分) で間隔を制御
+- **理由**: production backend で 24h に 189件発生していた `/automation/process-news` 401 Unauthorized エラーを解消するため。ホスト cron (root crontab) の旧呼び出し方式を廃止し、アプリ内スケジューラーから X-Internal-Token ヘッダー付きで `/automation/process-news?dry_run=false` を叩く方式に統一。
+- **影響範囲**: startup シーケンスのみ。`PROCESS_NEWS_INTERVAL_SECONDS` 未設定時は 300秒間隔で動作。既存の `/automation/process-news` エンドポイントは無変更で、内部から HTTP POST で叩く構造。
+- **承認**: fix/production-401-unauthorized → main の通常フロー経由（PR #157）
+
 ## backend/app/database.py
 
 変更なし（現時点）


### PR DESCRIPTION
## Summary

- **問題**: `POST /automation/process-news` が 211件/日 の 401 Unauthorized エラー（5分ごと）
- **根本原因**: 外部スケジューラー（ホストの cron と推定）が `X-Internal-Token` ヘッダーなしで呼んでいた
- **修正**: `process_news_loop` を `scheduled_tasks.py` に新設し、FastAPI アプリ内部から `INTERNAL_API_TOKEN` を付与して呼ぶ

## 変更内容

| ファイル | 変更 |
|---------|------|
| `backend/app/automation/scheduled_tasks.py` | `process_news_loop` 新設（`X-Internal-Token` 付与、`PROCESS_NEWS_INTERVAL_SECONDS` で間隔設定可） |
| `backend/app/main.py` | `startup_data_feeds` から `asyncio.create_task(process_news_loop(...))` で起動 |
| `backend/tests/test_scheduled_tasks.py` | `TestProcessNewsLoop` クラス（6テスト）追加 |

## DoD チェック

- [x] Gate 1: `ruff check .` ✅
- [x] Gate 2: `ruff format --check .` ✅
- [x] Gate 3: `mypy` — no issues in 233 files ✅
- [x] Gate 4: `pytest` — 2672 passed, coverage 84.97% ✅
- [x] Gate 5: `ruff --select S` ✅
- [ ] Gate 6: `tsc --noEmit` ❌ pre-existing（`custom-audit/page.ts` の型エラー、本 PR と無関係）

## テスト内容

`TestProcessNewsLoop` (6 tests):
1. `test_sends_x_internal_token_header` — 正しいヘッダーで POST されること
2. `test_posts_to_correct_url` — `BACKEND_BASE_URL/automation/process-news` に POST されること
3. `test_skips_when_token_not_set` — トークン未設定時は httpx を呼ばないこと
4. `test_cancelled_error_propagates` — `CancelledError` が伝播すること
5. `test_on_error_callback_called_on_exception` — 例外時に `on_error` + 60秒待機
6. `test_on_error_callback_raises_internally` — `on_error` 自体が例外を投げても継続

## 残件（手動対応）

外部 cron ジョブ（root crontab 内の推定エントリ）の削除:
```
sudo crontab -l -u root  # エントリ確認
sudo crontab -e -u root  # process-news の行を削除
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)