### PR TITLE
fix(auth): execution_policy Enum + DB CheckConstraint (P1 GID 1214176344039867)

### DIFF
--- a/backend/alembic/versions/a7b8c9d0e1f2_add_execution_policy_check_constraint.py
+++ b/backend/alembic/versions/a7b8c9d0e1f2_add_execution_policy_check_constraint.py
@@ -1,0 +1,71 @@
+"""add_execution_policy_check_constraint_and_default
+
+Add CHECK constraint on users.execution_policy to enforce the three valid
+ExecutionPolicy values, preventing future drift between code and DB state.
+
+Background (GID 1214176344039867, P1):
+- staging users で execution_policy = 'shadow' のような無効値が紛れ込んでいた
+- a1b2c3d4e5f6 で server_default = 'auto_execute' は既に設定済みだが、
+  DB レベルの値検証が欠落しており、API バリデーションを回避すると不正値が入る
+- ExecutionPolicy enum (app.auth.constants) と DB CHECK を同期させる
+
+Idempotent: 既に同名の制約が存在する場合はスキップする (本番 SQL 直適用済みケース対策)。
+
+Revision ID: a7b8c9d0e1f2
+Revises: f6a7b8c9d0e1
+Create Date: 2026-05-01 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a7b8c9d0e1f2"
+down_revision: Union[str, Sequence[str], None] = "f6a7b8c9d0e1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+CONSTRAINT_NAME = "users_execution_policy_check"
+VALID_POLICIES = ("auto_execute", "require_approval", "proposal_only")
+
+
+def upgrade() -> None:
+    """Add CHECK constraint on users.execution_policy.
+
+    server_default は a1b2c3d4e5f6 で既に 'auto_execute' に設定済み。
+    本マイグレーションでは CHECK 制約のみを追加する。
+    """
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        # 既存制約があれば一旦削除してから再作成 (idempotent + 値リスト変更にも追随)
+        op.execute(
+            f"ALTER TABLE users DROP CONSTRAINT IF EXISTS {CONSTRAINT_NAME}",
+        )
+        values_sql = ", ".join(f"'{v}'" for v in VALID_POLICIES)
+        op.execute(
+            f"ALTER TABLE users ADD CONSTRAINT {CONSTRAINT_NAME} "
+            f"CHECK (execution_policy IN ({values_sql}))"
+        )
+    else:
+        # SQLite 等は batch mode で対応 (テスト用 fallback)
+        with op.batch_alter_table("users") as batch_op:
+            values_sql = ", ".join(f"'{v}'" for v in VALID_POLICIES)
+            batch_op.create_check_constraint(
+                CONSTRAINT_NAME,
+                f"execution_policy IN ({values_sql})",
+            )
+
+
+def downgrade() -> None:
+    """Remove CHECK constraint on users.execution_policy."""
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute(
+            f"ALTER TABLE users DROP CONSTRAINT IF EXISTS {CONSTRAINT_NAME}",
+        )
+    else:
+        with op.batch_alter_table("users") as batch_op:
+            batch_op.drop_constraint(CONSTRAINT_NAME, type_="check")

--- a/backend/app/auth/constants.py
+++ b/backend/app/auth/constants.py
@@ -1,0 +1,43 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/auth/constants.py
+"""auth ドメインで参照する定数 / Enum 定義。
+
+GID 1214176344039867 (P1) で導入。
+
+`execution_policy` の文字列リテラルがコードベース全体に散在し、
+DB 側 default (`auto_execute`) と運用上の期待値 (`require_approval`) が
+ずれる事故が発生したため、Enum + DB CheckConstraint + server_default で
+一元化する (再発防止)。
+
+値はハードコード文字列と完全一致する必要がある。リネーム禁止:
+- DB users.execution_policy カラムに直接保存される
+- API リクエスト / レスポンスで文字列として往復する
+- 既存テスト・運用ドキュメントが値を直参照している
+"""
+
+from enum import Enum
+
+
+class ExecutionPolicy(str, Enum):
+    """ユーザーの自動執行ポリシー。
+
+    値:
+      - AUTO_EXECUTE: AI 判定後、追加承認なしに発注する (managed モード)
+      - REQUIRE_APPROVAL: AI 判定で Proposal を作成し、ユーザー承認後に発注 (active モード)
+      - PROPOSAL_ONLY: Proposal を作成するのみ。発注は手動 (pro モード)
+
+    値リネーム禁止 (DB 永続化値、API 互換性のため)。
+    """
+
+    AUTO_EXECUTE = "auto_execute"
+    REQUIRE_APPROVAL = "require_approval"
+    PROPOSAL_ONLY = "proposal_only"
+
+    @classmethod
+    def values(cls) -> list[str]:
+        """全ての有効値を文字列リストで返す。
+
+        CheckConstraint の SQL 生成およびバリデーションで使用する。
+        """
+        return [member.value for member in cls]

--- a/backend/app/auth/models.py
+++ b/backend/app/auth/models.py
@@ -13,6 +13,12 @@ ALTER TABLE users ADD COLUMN last_judgment_at TIMESTAMP WITH TIME ZONE NULL;
 
 ALTER TABLE users ADD COLUMN IF NOT EXISTS privy_did VARCHAR(255) NULL;
 CREATE UNIQUE INDEX IF NOT EXISTS ix_users_privy_did ON users (privy_did) WHERE privy_did IS NOT NULL;
+
+-- GID 1214176344039867 (P1): execution_policy CHECK + server_default 強化
+-- DB default は a1b2c3d4e5f6 で 'auto_execute' 設定済み。
+-- CheckConstraint と SQLAlchemy 側 server_default を Alembic migration で同期する。
+ALTER TABLE users ADD CONSTRAINT users_execution_policy_check
+    CHECK (execution_policy IN ('auto_execute', 'require_approval', 'proposal_only'));
 """
 
 import logging
@@ -21,9 +27,10 @@ from decimal import Decimal
 from enum import Enum
 from typing import Optional
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, Numeric, String
+from sqlalchemy import Boolean, CheckConstraint, DateTime, ForeignKey, Integer, Numeric, String
 from sqlalchemy.orm import Mapped, mapped_column
 
+from app.auth.constants import ExecutionPolicy
 from app.database import Base
 
 logger = logging.getLogger(__name__)
@@ -191,6 +198,14 @@ class User(Base):
     """
 
     __tablename__ = "users"
+    __table_args__ = (
+        CheckConstraint(
+            "execution_policy IN ("
+            + ", ".join(f"'{value}'" for value in ExecutionPolicy.values())
+            + ")",
+            name="users_execution_policy_check",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
@@ -228,7 +243,10 @@ class User(Base):
     )
     user_mode: Mapped[str] = mapped_column(String(20), nullable=False, default="managed")
     execution_policy: Mapped[str] = mapped_column(
-        String(20), nullable=False, default="auto_execute"
+        String(20),
+        nullable=False,
+        default=ExecutionPolicy.AUTO_EXECUTE.value,
+        server_default=ExecutionPolicy.AUTO_EXECUTE.value,
     )
     wallet_address: Mapped[Optional[str]] = mapped_column(
         String(42), unique=True, nullable=True, index=True, default=None

--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -24,6 +24,7 @@ from app.ai.judgment_log import get_judgment_logger
 from app.ai.models import AIDecision
 from app.ai.schemas import CrossValidationResult, RAGContext, TradeAction
 from app.ai.service import AIService
+from app.auth.constants import ExecutionPolicy
 from app.auth.models import InvestmentTier, User, normalize_tier
 from app.automation.aave_data_fetcher import fetch_aave_market_data_safe
 from app.data_feeds.context import build_market_context
@@ -158,7 +159,7 @@ def _create_proposals_for_users(
     active_users = db.scalars(
         select(User).where(
             User.is_active == True,  # noqa: E712
-            User.execution_policy == "require_approval",
+            User.execution_policy == ExecutionPolicy.REQUIRE_APPROVAL.value,
         )
     ).all()
 

--- a/backend/app/automation/automation_router.py
+++ b/backend/app/automation/automation_router.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from app.ai.service import AIService
+from app.auth.constants import ExecutionPolicy
 from app.auth.dependencies import require_active_user, require_admin, verify_internal_token
 from app.automation.monitoring_service import MonitoringService
 from app.automation.rate_limiter import RateLimiterService, get_rate_limiter
@@ -84,7 +85,7 @@ def process_news(
             exchange_service=get_exchange_service(),
             monitoring_service=monitoring_service,
             dry_run=dry_run,
-            execution_policy="auto_execute",
+            execution_policy=ExecutionPolicy.AUTO_EXECUTE.value,
         )
         monitoring_service.record_news_fetch()
     except Exception as exc:

--- a/backend/app/automation/router.py
+++ b/backend/app/automation/router.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import Session
 
 from app.ai.models import AIDecision
 from app.ai.service import AIService
+from app.auth.constants import ExecutionPolicy
 from app.automation.workflow import process_pending_knowledge
 from app.database import get_db
 from app.exchange.router import get_exchange_service
@@ -182,7 +183,7 @@ def run_workflow(
         exchange_service=exchange_service,
         monitoring_service=monitoring,
         dry_run=dry_run,
-        execution_policy="auto_execute",
+        execution_policy=ExecutionPolicy.AUTO_EXECUTE.value,
     )
 
     # Sanitize error messages (no internal details in API response)

--- a/backend/app/automation/workflow.py
+++ b/backend/app/automation/workflow.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session
 from app.ai.judgment_log import JudgmentRecord, get_judgment_logger
 from app.ai.schemas import AIAnalysisResult, RAGContext, TradeAction
 from app.ai.service import AIService
+from app.auth.constants import ExecutionPolicy
 from app.auth.models import User, normalize_tier
 from app.automation.monitoring_service import MonitoringService
 from app.automation.schemas import ComponentType, WorkflowRunResult, WorkflowStepError
@@ -542,7 +543,7 @@ def process_pending_knowledge(
     # HF emergency override: always auto_execute if HF < 1.6
     effective_policy = execution_policy
     if hf is not None and hf < Decimal("1.6"):
-        effective_policy = "auto_execute"
+        effective_policy = ExecutionPolicy.AUTO_EXECUTE.value
         logger.info("HF emergency override: execution_policy forced to auto_execute (hf=%s)", hf)
 
     for item in pending:
@@ -754,7 +755,10 @@ def _process_single_item(
 
     order_result: Optional[OrderResult] = None
     if action in (TradeAction.BUY, TradeAction.SELL) and confidence >= 40:
-        if execution_policy in ("require_approval", "proposal_only"):
+        if execution_policy in (
+            ExecutionPolicy.REQUIRE_APPROVAL.value,
+            ExecutionPolicy.PROPOSAL_ONLY.value,
+        ):
             # 動的手数料計算 (B-2)
             import os  # noqa: PLC0415
 

--- a/backend/app/users/settings_router.py
+++ b/backend/app/users/settings_router.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
+from app.auth.constants import ExecutionPolicy
 from app.auth.dependencies import require_active_user
 from app.auth.models import User, UserRole
 from app.database import get_db
@@ -34,9 +35,9 @@ def update_user_settings(
 ) -> UserSettingsResponse:
     """ユーザー設定を更新する。"""
     _USER_MODE_TO_POLICY = {
-        "managed": "auto_execute",
-        "active": "require_approval",
-        "pro": "proposal_only",
+        "managed": ExecutionPolicy.AUTO_EXECUTE.value,
+        "active": ExecutionPolicy.REQUIRE_APPROVAL.value,
+        "pro": ExecutionPolicy.PROPOSAL_ONLY.value,
     }
 
     if request.notification_frequency is not None:
@@ -77,11 +78,10 @@ def update_user_settings(
         current_user.user_mode = request.user_mode
         current_user.execution_policy = _USER_MODE_TO_POLICY[request.user_mode]
     if request.execution_policy is not None:
-        _VALID_POLICIES = ("auto_execute", "require_approval", "proposal_only")
-        if request.execution_policy not in _VALID_POLICIES:
+        if request.execution_policy not in ExecutionPolicy.values():
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail="execution_policy must be one of: auto_execute, require_approval, proposal_only",
+                detail=("execution_policy must be one of: " + ", ".join(ExecutionPolicy.values())),
             )
         current_user.execution_policy = request.execution_policy
     db.add(current_user)

--- a/backend/tests/test_execution_policy_enum.py
+++ b/backend/tests/test_execution_policy_enum.py
@@ -1,0 +1,208 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_execution_policy_enum.py
+"""ExecutionPolicy enum / CHECK 制約 / server_default の挙動検証テスト。
+
+GID 1214176344039867 (P1) で導入。
+
+検証観点:
+1. ExecutionPolicy.values() が全 valid 値を返す
+2. CHECK 制約が無効値の直 INSERT を拒否する
+3. PUT /api/user/settings が enum と整合した値検証を行う
+4. User 作成時に execution_policy 未指定で default ('auto_execute') が適用される
+"""
+
+import os
+import tempfile
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-execution-policy-enum")
+
+from app.auth.constants import ExecutionPolicy  # noqa: E402
+from app.auth.models import User  # noqa: E402
+from app.database import Base, get_db  # noqa: E402
+from app.main import create_app  # noqa: E402
+
+# 他テスト (test_invitations 等) が import 時に INITIAL_ADMIN_EMAIL を別値で上書きするため、
+# 本テスト固有の email を client fixture 内で都度セットする。test_user_settings_role_auth 準拠。
+_ADMIN_EMAIL = "exec_policy_admin@example.com"
+_ADMIN_PASSWORD = "execpolicy12345"
+
+
+@pytest.fixture()
+def test_db():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db() -> Generator:
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    yield override_get_db, engine, SessionLocal
+    Base.metadata.drop_all(bind=engine)
+    os.unlink(path)
+
+
+@pytest.fixture()
+def client(test_db) -> TestClient:
+    override_get_db, _, _ = test_db
+    # 他テストの import-time 副作用で INITIAL_ADMIN_EMAIL が書き換わっているため、
+    # 本テスト固有値で必ず上書きしてから create_app() を呼ぶ。
+    os.environ["INITIAL_ADMIN_EMAIL"] = _ADMIN_EMAIL
+    app = create_app()
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app)
+
+
+def _register_and_login(client: TestClient) -> str:
+    """admin として register → login し、access_token を返す。"""
+    rr = client.post(
+        "/auth/register",
+        json={
+            "email": _ADMIN_EMAIL,
+            "username": "exec_policy_admin",
+            "password": _ADMIN_PASSWORD,
+        },
+    )
+    if rr.status_code in (200, 201):
+        payload = rr.json()
+        if "access_token" in payload:
+            return payload["access_token"]
+    r = client.post(
+        "/auth/login",
+        json={"email": _ADMIN_EMAIL, "password": _ADMIN_PASSWORD},
+    )
+    payload = r.json()
+    assert "access_token" in payload, (
+        f"register={rr.status_code} body={rr.json()}, login status={r.status_code}, body={payload}"
+    )
+    return payload["access_token"]
+
+
+# ---------------------------------------------------------------------------
+# 1. enum.values()
+# ---------------------------------------------------------------------------
+
+
+def test_execution_policy_values_returns_all_valid_strings() -> None:
+    """``ExecutionPolicy.values()`` が CHECK 制約と一致する全 valid 値を返す。"""
+    values = ExecutionPolicy.values()
+    assert set(values) == {"auto_execute", "require_approval", "proposal_only"}
+    assert len(values) == 3
+
+
+def test_valid_values_accepted_by_user_creation(test_db) -> None:
+    """有効値 3 種それぞれで User を作成・保存できる。"""
+    _, _, SessionLocal = test_db
+    session = SessionLocal()
+    try:
+        for idx, policy in enumerate(ExecutionPolicy.values()):
+            user = User(
+                email=f"valid{idx}@example.com",
+                username=f"valid{idx}",
+                hashed_password="hashed",
+                is_active=True,
+                execution_policy=policy,
+            )
+            session.add(user)
+        session.commit()
+        # 全件 commit 成功 (= CHECK 制約をパス)
+        rows = session.execute(text("SELECT execution_policy FROM users")).all()
+        assert {row[0] for row in rows} == set(ExecutionPolicy.values())
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# 2. CHECK 制約による無効値拒否
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_value_rejected_by_db_constraint(test_db) -> None:
+    """生 SQL で 'shadow' 等の無効値を INSERT すると IntegrityError になる。"""
+    _, engine, _ = test_db
+    with engine.begin() as conn:
+        with pytest.raises(IntegrityError):
+            conn.execute(
+                text(
+                    "INSERT INTO users "
+                    "(email, username, hashed_password, role, is_active, "
+                    "notification_frequency, user_mode, execution_policy, tier) "
+                    "VALUES (:email, :username, :pw, 'viewer', 1, "
+                    "'important', 'managed', :policy, 'LOWER')"
+                ),
+                {
+                    "email": "invalid@example.com",
+                    "username": "invaliduser",
+                    "pw": "hashed",
+                    "policy": "shadow",  # 無効値
+                },
+            )
+
+
+# ---------------------------------------------------------------------------
+# 3. PUT /api/user/settings の enum 整合性
+# ---------------------------------------------------------------------------
+
+
+def test_settings_api_accepts_all_enum_values(client: TestClient) -> None:
+    """PUT /api/user/settings で全 ExecutionPolicy 値が受け入れられる。"""
+    token = _register_and_login(client)
+    for policy in ExecutionPolicy.values():
+        r = client.put(
+            "/api/user/settings",
+            json={"execution_policy": policy},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200, f"policy={policy}: {r.text}"
+        assert r.json()["execution_policy"] == policy
+
+
+def test_settings_api_rejects_invalid_value(client: TestClient) -> None:
+    """PUT /api/user/settings で enum 外の値は 422 で拒否される。"""
+    token = _register_and_login(client)
+    r = client.put(
+        "/api/user/settings",
+        json={"execution_policy": "shadow"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 422
+    # detail に enum 値リストが含まれること (運用者が valid 値を把握できる)
+    detail = r.json().get("detail", "")
+    for policy in ExecutionPolicy.values():
+        assert policy in detail, f"detail missing {policy}: {detail}"
+
+
+# ---------------------------------------------------------------------------
+# 4. server_default の適用
+# ---------------------------------------------------------------------------
+
+
+def test_default_value_on_user_creation(test_db) -> None:
+    """User() で execution_policy 未指定時に default 'auto_execute' が適用される。"""
+    _, _, SessionLocal = test_db
+    session = SessionLocal()
+    try:
+        user = User(
+            email="default@example.com",
+            username="defaultuser",
+            hashed_password="hashed",
+            is_active=True,
+        )
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+        assert user.execution_policy == ExecutionPolicy.AUTO_EXECUTE.value
+    finally:
+        session.close()


### PR DESCRIPTION
## Summary

- **背景**: staging で `users.execution_policy = 'shadow'` のような無効値が紛れ込み、本日 staging 全員を `'require_approval'` に手動修正したインシデント (GID 1214284563669672) の再発防止。
- **対策**: `ExecutionPolicy` Enum (`app.auth.constants`) で 3 値を一元管理 + DB CHECK 制約 + `server_default` 同期で、コード/DB/API 層を全て揃える。

## 変更ファイル

| 種別 | ファイル | 内容 |
|---|---|---|
| 新規 | `backend/app/auth/constants.py` | `ExecutionPolicy(str, Enum)` 定義 + `values()` classmethod |
| 新規 | `backend/alembic/versions/a7b8c9d0e1f2_*.py` | CHECK 制約追加 (PostgreSQL / SQLite 両対応, idempotent) |
| 新規 | `backend/tests/test_execution_policy_enum.py` | 6 ケース (enum, CHECK, API, default) |
| 修正 | `backend/app/auth/models.py` | `__table_args__` に CheckConstraint, `server_default` 明示, ALTER TABLE コメント追記 |
| 修正 | `backend/app/automation/ai_judgment_scheduler.py` | `User.execution_policy == "require_approval"` → enum 参照 |
| 修正 | `backend/app/users/settings_router.py` | `_USER_MODE_TO_POLICY` map と validation を enum 参照に |
| 修正 | `backend/app/automation/workflow.py` | HF emergency override / proposal 振分の文字列を enum 参照に |
| 修正 | `backend/app/automation/automation_router.py` / `router.py` | `process_pending_knowledge` の `execution_policy` 引数を enum 参照に |

## 検証結果 (DoD Gates 1-4)

- ✅ `ruff check .` : All checks passed
- ✅ `ruff format --check .` : 455 files formatted OK
- ✅ `mypy app/ --config-file ../pyproject.toml` : 234 source files, no issues
- ✅ `pytest tests/ --cov=app --cov-fail-under=80` : **2687 passed, 9 skipped, coverage 85.05%**

## 既知の落とし穴 (CLAUDE.md ABSOLUTE 教訓反映)

- `server_default` を SQLAlchemy 側にも明示 → Alembic autogenerate との不整合を防止
- CheckConstraint の SQL 生成は Python `repr()` ではなく明示的に `f"'{value}'"` (single-quote 形式)
- Alembic migration は idempotent (`DROP IF EXISTS` → `ADD CONSTRAINT`) で本番 SQL 直適用済みケースに対応

## 衝突回避

- `aave_data_fetcher.py` / `scripts/check_db_migration_gap.sh` / `scripts/deploy_production.sh` は他タブ担当範囲につき本 PR 対象外

## 本番適用タイミング (要判断)

- 現状 production users id=1, 11 は既に `'require_approval'` で valid なため、CHECK 制約適用前の追加修正は不要
- migration 適用は Phase 3 (デプロイ) と統合するか、独立して staging → production 順に流すか **要相談**

## Test plan

- [x] `pytest tests/test_execution_policy_enum.py -v` で 6 ケース通過
- [x] `pytest tests/ --cov=app --cov-fail-under=80` 全体通過
- [ ] `staging` で migration 適用 → 既存 6 ユーザーへの影響なし確認
- [ ] `production` migration 適用は別判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)