### PR TITLE
feat(deploy): ALLOW_TESTNET=1 bypass for Guard 1 (partner pre-validation phase)

### DIFF
--- a/docs/22_production_release_checklist.md
+++ b/docs/22_production_release_checklist.md
@@ -228,6 +228,15 @@ curl https://api.ultra-auto-trade.com/health
 # 期待値: {"status": "ok", "scheduler_healthy": true, "warnings": []}
 ```
 
+### ALLOW_TESTNET bypass（partner 先行検証フェーズ専用）
+
+`scripts/deploy_production.sh` の Guard 1 は `.env.production` で `AAVE_NETWORK=*sepolia*` を検出すると abort する（mainnet 強制）。
+partner 先行検証フェーズ等で意図的に testnet 運用する場合のみ、`ALLOW_TESTNET=1` を環境変数で指定して bypass 可能：
+```bash
+ALLOW_TESTNET=1 bash scripts/deploy_production.sh
+```
+mainnet 移行後は `ALLOW_TESTNET` 環境変数を外して通常運用に戻すこと。Guard 2-4（環境分離・compose 確認・健全性検証）は変更されない。
+
 ---
 
 ## 9. ポストデプロイ確認

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -299,11 +299,20 @@ if grep -qE '^BYBIT_SANDBOX=true' .env.production; then
   exit 1
 fi
 
-if [[ "${FRONTEND_ONLY}" != "true" ]] && grep -qE '^AAVE_NETWORK=.*sepolia' .env.production; then
-  echo "❌ FAIL: .env.production で AAVE_NETWORK に sepolia 含む (本番は mainnet 必須)"
-  exit 1
-elif [[ "${FRONTEND_ONLY}" == "true" ]] && grep -qE '^AAVE_NETWORK=.*sepolia' .env.production; then
-  echo "⚠️  WARN: AAVE_NETWORK に sepolia が含まれています (フロントエンドのみデプロイのためスキップ)"
+if grep -qE '^AAVE_NETWORK=.*sepolia' .env.production; then
+  if [[ "${FRONTEND_ONLY}" == "true" ]]; then
+    echo "⚠️  WARN: AAVE_NETWORK に sepolia が含まれています (フロントエンドのみデプロイのためスキップ)"
+  elif [[ "${ALLOW_TESTNET:-0}" == "1" ]]; then
+    # Partner 先行検証フェーズ等の意図的な testnet 運用を許容
+    # docs/22_production_release_checklist.md §「ALLOW_TESTNET bypass」参照
+    printf '\033[1;31m⚠️  ALLOW_TESTNET=1: AAVE_NETWORK に sepolia 含むまま production deploy 続行\033[0m\n'
+    printf '\033[1;31m⚠️  この bypass は partner 先行検証フェーズの意図的な testnet 運用専用です\033[0m\n'
+    printf '\033[1;31m⚠️  mainnet 移行後は ALLOW_TESTNET 環境変数を外してください\033[0m\n'
+  else
+    echo "❌ FAIL: .env.production で AAVE_NETWORK に sepolia 含む (本番は mainnet 必須)"
+    echo "    意図的な testnet 運用 (partner 先行検証等) の場合は ALLOW_TESTNET=1 を環境変数で指定してください"
+    exit 1
+  fi
 fi
 
 # Guard 2: 環境分離チェック (バックエンドに関わるキーのみ必須 — フロントエンドのみデプロイ時はスキップ)


### PR DESCRIPTION
## Summary

- `scripts/deploy_production.sh` の Guard 1 (`AAVE_NETWORK=*sepolia*` 検出 → fail) に `ALLOW_TESTNET=1` 環境変数による bypass を追加
- partner 先行検証フェーズ (山本さん Base Sepolia testnet USDC 等) で意図的な testnet 運用を許容
- `docs/22_production_release_checklist.md` §「ALLOW_TESTNET bypass」に使用ケース + mainnet 戻し手順を 1 セクション追記
- Guard 2-4 (環境分離 / compose 確認 / 健全性検証) は **変更なし**

## Background

Phase 4 production deploy (PR #159 + #161 + #160 反映) の途中で発覚:
- Production が partner 先行検証フェーズで意図的に `AAVE_NETWORK=base_sepolia` 稼働中
- 既存 bypass は `FRONTEND_ONLY=true` のみだが backend 変更があるため使えない
- 過去の base_sepolia 切替時の deploy 経緯不明 → 安全策として明示的な bypass オプションを追加

## Behavior change

| 状態 | 旧 | 新 |
|------|-----|-----|
| `AAVE_NETWORK=*sepolia*` (デフォルト) | ❌ FAIL | ❌ FAIL (変化なし) |
| `AAVE_NETWORK=*sepolia*` + `FRONTEND_ONLY=true` | ⚠️ WARN | ⚠️ WARN (変化なし) |
| `AAVE_NETWORK=*sepolia*` + `ALLOW_TESTNET=1` | (該当なし) | ⚠️ 赤色 WARN ログ × 3 行 + 続行 |

## Usage

```bash
ALLOW_TESTNET=1 bash scripts/deploy_production.sh
```

bypass 時は赤色 ANSI で 3 行警告を表示:
- `ALLOW_TESTNET=1: AAVE_NETWORK に sepolia 含むまま production deploy 続行`
- `この bypass は partner 先行検証フェーズの意図的な testnet 運用専用です`
- `mainnet 移行後は ALLOW_TESTNET 環境変数を外してください`

## Test plan

- [x] `bash -n scripts/deploy_production.sh` (構文 check) 通過
- [x] ANSI escape の printf 動作確認 (赤色表示、bash -e 互換)
- [ ] CI: Lint / Test / Trivy / E2E pass
- [ ] Codex review pass
- [ ] mainnet 切替時に `ALLOW_TESTNET` 環境変数を外す手順を docs/22 で明記

## Files

- `scripts/deploy_production.sh` (Guard 1 部分のみ +14 -5)
- `docs/22_production_release_checklist.md` (§「ALLOW_TESTNET bypass」+9 行)

## Related

- Phase 4 production deploy (PR #159 + #161 + #160 反映、山本さん本日テストブロッカー)
- 山本さん Base Sepolia testnet USDC でのテスト開始準備