### PR TITLE
fix(aave): mainnet-safe defaults in Web3AaveClient (P0 PR-A)

### DIFF
--- a/backend/app/aave/client.py
+++ b/backend/app/aave/client.py
@@ -124,6 +124,12 @@ _POOL_ADDRESS_ARBITRUM_SEPOLIA = "0xBfC91D59fdAA134A4ED45f7B584cAf96D7792Eff"
 # Arbitrum Sepolia USDC
 _USDC_ADDRESS_ARBITRUM_SEPOLIA = "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d"
 
+# Aave V3 Pool アドレス（Base Mainnet） — chains.py registry の base.pool_address と一致
+_POOL_ADDRESS_BASE_MAINNET = "0xA238Dd80C259a72e81d7e4664a9801593F98d1c5"
+
+# Aave V3 Pool アドレス（Base Sepolia） — chains.py registry の base_sepolia.pool_address と一致
+_POOL_ADDRESS_BASE_SEPOLIA = "0x8bAB6d1b75f19e9eD9fCe8b9BD338844fF79aE27"
+
 
 class _NonceTracker:
     """1 フロー内の連続 tx に対してローカルに nonce を管理するトラッカー。
@@ -369,10 +375,13 @@ class Web3AaveClient(AaveClientBase):
     def __init__(
         self,
         rpc_url: Optional[str] = None,
-        pool_address: str = _POOL_ADDRESS_SEPOLIA,
+        pool_address: Optional[str] = None,
         settings: Optional[AaveSettings] = None,
         flashbots_rpc_url: Optional[str] = None,
     ) -> None:
+        # 2026-05-01: pool_address のデフォルトを Sepolia hardcode から None に変更。
+        # 旧デフォルトは mainnet 切替後に silent regression (testnet pool に書き込み) を
+        # 起こすため、env (AAVE_POOL_ADDRESS) または引数の明示を必須化する。
         # web3 はモジュールレベルで参照（テスト時にモックしやすくするため）
         if Web3 is None:
             raise AaveClientError("web3 package is required. Install with: pip install web3")
@@ -392,6 +401,13 @@ class Web3AaveClient(AaveClientBase):
         else:
             if not rpc_url:
                 raise AaveClientError("AAVE_RPC_URL is required for Web3AaveClient")
+            if pool_address is None:
+                pool_address = os.getenv("AAVE_POOL_ADDRESS")
+                if not pool_address:
+                    raise AaveClientError(
+                        "AAVE_POOL_ADDRESS env var or pool_address argument is "
+                        "required for Web3AaveClient"
+                    )
             effective_rpc_url = rpc_url
             effective_pool_address = pool_address
 
@@ -930,8 +946,8 @@ class Web3AaveClient(AaveClientBase):
 def make_aave_client(
     client_type: str,
     rpc_url: Optional[str] = None,
-    pool_address: str = _POOL_ADDRESS_SEPOLIA,
-    network: str = "sepolia",
+    pool_address: Optional[str] = None,
+    network: Optional[str] = None,
     flashbots_rpc_url: Optional[str] = None,
     chain_name: Optional[str] = None,
 ) -> AaveClientBase:
@@ -941,10 +957,16 @@ def make_aave_client(
     Args:
         client_type: "dummy" または "web3"
         rpc_url: web3 の場合は必須
-        pool_address: Aave V3 Pool コントラクトアドレス
-        network: ネットワーク名 ("sepolia", "arbitrum", "arbitrum-sepolia")
+        pool_address: Aave V3 Pool コントラクトアドレス。未指定時は network 経由 or
+            AAVE_POOL_ADDRESS env から解決
+        network: ネットワーク名 ("sepolia", "arbitrum", "arbitrum-sepolia",
+            "base", "base_sepolia")。未指定時は AAVE_NETWORK env を参照
         flashbots_rpc_url: Flashbots Protect RPC URL（MEV対策、オプション）
         chain_name: チェーン名（chains.py のレジストリから設定を解決する、オプション）
+
+    2026-05-01: pool_address / network のデフォルトを Sepolia hardcode から
+    None に変更。silent testnet regression (mainnet 切替後に sepolia に書き込む)
+    の防止が目的。Base Mainnet (chain 8453) を _network_pool に追加。
     """
     if client_type == "dummy":
         return DummyAaveClient()
@@ -962,12 +984,20 @@ def make_aave_client(
             )
         if not rpc_url:
             raise ValueError("AAVE_CLIENT_TYPE=web3 の場合は AAVE_RPC_URL が必須です")
+
+        # network 未指定時は env (AAVE_NETWORK) から解決
+        if network is None:
+            network = os.getenv("AAVE_NETWORK")
+
         _network_pool = {
             "sepolia": _POOL_ADDRESS_SEPOLIA,
             "arbitrum": _POOL_ADDRESS_ARBITRUM,
             "arbitrum-sepolia": _POOL_ADDRESS_ARBITRUM_SEPOLIA,
+            "base": _POOL_ADDRESS_BASE_MAINNET,
+            "base_sepolia": _POOL_ADDRESS_BASE_SEPOLIA,
         }
-        if pool_address == _POOL_ADDRESS_SEPOLIA and network in _network_pool:
+        # pool_address 未指定 + network 既知 → network から解決
+        if pool_address is None and network is not None and network in _network_pool:
             pool_address = _network_pool[network]
         return Web3AaveClient(
             rpc_url=rpc_url,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -42,6 +42,11 @@ def _ensure_test_env_vars() -> None:
     os.environ.setdefault("EXCHANGE_CLIENT_TYPE", "dummy")
     os.environ.setdefault("INITIAL_ADMIN_EMAIL", "terms_admin@example.com")
     os.environ.setdefault("LOGIN_RATE_LIMIT", "1000/minute")
+    # 2026-05-01: Web3AaveClient.__init__ で pool_address required 化したため
+    # 既存テスト互換用に Sepolia ダミー値を default で供給する。
+    # 個別テストで env を明示的に空にする / 別値で上書きすることは可能。
+    os.environ.setdefault("AAVE_POOL_ADDRESS", "0x6Ae43d3271ff6888e7Fc43Fd7321a503ff738951")
+    os.environ.setdefault("AAVE_USDC_ADDRESS", "0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8")
 
 
 _ensure_project_root_in_sys_path()

--- a/backend/tests/test_aave_client.py
+++ b/backend/tests/test_aave_client.py
@@ -544,6 +544,78 @@ class TestMakeAaveClient:
             make_aave_client("invalid_type")
 
 
+class TestWeb3AaveClientPoolAddressRequired:
+    """2026-05-01 PR-A: pool_address のデフォルト None 化に対する require テスト。
+
+    silent testnet regression (mainnet 切替後に Sepolia pool に書き込む) を防ぐため、
+    Web3AaveClient.__init__ は pool_address を 引数 or AAVE_POOL_ADDRESS env から
+    必須で要求する。両方欠落していれば AaveClientError を raise する。
+    """
+
+    def test_missing_pool_address_and_env_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """引数 pool_address なし + AAVE_POOL_ADDRESS env なし → AaveClientError。"""
+        monkeypatch.delenv("AAVE_POOL_ADDRESS", raising=False)
+
+        with pytest.raises(AaveClientError, match="AAVE_POOL_ADDRESS"):
+            Web3AaveClient(rpc_url="https://mock-rpc.example.com")
+
+    @patch("app.aave.client.Web3")
+    def test_pool_address_from_env_when_argument_missing(
+        self,
+        mock_web3_cls: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """AAVE_POOL_ADDRESS env 設定 + 引数なし → 正常 instantiate (env 値を採用)。"""
+        env_pool = "0xA238Dd80C259a72e81d7e4664a9801593F98d1c5"  # Base Mainnet
+        monkeypatch.setenv("AAVE_POOL_ADDRESS", env_pool)
+
+        captured: dict[str, str] = {}
+
+        def _to_checksum(value: str) -> str:
+            captured["address"] = value
+            return value
+
+        mock_w3 = MagicMock()
+        mock_w3.is_connected.return_value = True
+        mock_web3_cls.return_value = mock_w3
+        mock_web3_cls.HTTPProvider = MagicMock()
+        mock_web3_cls.to_checksum_address = _to_checksum
+
+        client = Web3AaveClient(rpc_url="https://mock-rpc.example.com")
+
+        assert isinstance(client, Web3AaveClient)
+        assert captured["address"] == env_pool
+
+    @patch("app.aave.client.Web3")
+    def test_explicit_pool_address_overrides_env(
+        self,
+        mock_web3_cls: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """引数 pool_address が明示されていれば env より優先される。"""
+        monkeypatch.setenv("AAVE_POOL_ADDRESS", "0xENVADDRESS")
+        explicit = "0xA238Dd80C259a72e81d7e4664a9801593F98d1c5"
+
+        captured: dict[str, str] = {}
+
+        def _to_checksum(value: str) -> str:
+            captured["address"] = value
+            return value
+
+        mock_w3 = MagicMock()
+        mock_w3.is_connected.return_value = True
+        mock_web3_cls.return_value = mock_w3
+        mock_web3_cls.HTTPProvider = MagicMock()
+        mock_web3_cls.to_checksum_address = _to_checksum
+
+        Web3AaveClient(
+            rpc_url="https://mock-rpc.example.com",
+            pool_address=explicit,
+        )
+
+        assert captured["address"] == explicit
+
+
 class TestFlashbotsProtect:
     """Flashbots Protect RPC のテスト。"""
 


### PR DESCRIPTION
## P0 mainnet 切替 PR-A

mainnet 切替前に backend AaveClient の testnet hardcoded default を解消。silent regression (mainnet RPC + sepolia pool address で書き込む) 防止が目的。

## 変更内容

### Web3AaveClient.\_\_init\_\_ (backend/app/aave/client.py)
- \`pool_address\` のデフォルトを \`_POOL_ADDRESS_SEPOLIA\` → \`None\` に変更
- 未指定時は \`AAVE_POOL_ADDRESS\` env から fallback
- 引数も env も無ければ \`AaveClientError\` を raise (fail-fast)
- \`settings\` 経由のチェックは既存ロジック (line 386-389) を維持

### make_aave_client (shim factory)
- \`pool_address\` default → None
- \`network\` default \`\"sepolia\"\` → None (None 時は \`AAVE_NETWORK\` env を参照)
- \`_network_pool\` dict に \`base\` (\`0xA238Dd80...\`) と \`base_sepolia\` (\`0x8bAB6d1b...\`) 追加
- \`chain_name\` 経路 (chains.py registry) は変更なし

### A3 (env 自動分岐拡張) は見送り
Phase 1 観察「production は \`AAVE_CLIENT_TYPE=web3\` 明示で動いているため、APP_ENV の自動分岐拡張は silent regression リスクがあり現状維持が安全」を踏まえてスキップ。

## DoD 結果

- [x] \`ruff check\` / \`ruff format --check\`: pass
- [x] \`mypy\`: Success: no issues found
- [x] \`pytest tests/test_aave_client.py\`: 35 passed (+3 new)
- [x] Aave 関連スイープ (9 ファイル): 222 passed, 9 skipped
- [x] \`./scripts/verify.sh\`: All 7 gates pass (319s)
- [ ] CI pass
- [ ] (任意) Codex review

## 関連
- Asana: https://app.asana.com/0/1213996126630018/1214445965769454
- Phase 1 read-only 完了済み
- 次: PR-B (frontend chain 設定 mainnet 対応)

🤖 Generated with [Claude Code](https://claude.com/claude-code)