### PR TITLE
feat(frontend): Base Mainnet (chain 8453) support (P0 PR-B)

### DIFF
--- a/frontend/lib/wallet/PrivyRootClient.tsx
+++ b/frontend/lib/wallet/PrivyRootClient.tsx
@@ -14,6 +14,11 @@ const appId = process.env.NEXT_PUBLIC_PRIVY_APP_ID || ''
 // Skip PrivyProvider when App ID is absent — JWT auth remains fully functional.
 const isPrivyConfigured = appId && appId !== 'clplaceholder000000000000000000000'
 
+// 2026-05-01: defaultChain を hardcode (baseSepolia) から env 駆動に変更 (mainnet 切替)
+// NEXT_PUBLIC_DEFAULT_CHAIN_ID は build-time に Docker build.args から焼き込まれる
+const defaultChainId = parseInt(process.env.NEXT_PUBLIC_DEFAULT_CHAIN_ID || '8453')
+const defaultChain = defaultChainId === 8453 ? base : baseSepolia
+
 export function PrivyRootClient({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient())
   if (!isPrivyConfigured) {
@@ -34,8 +39,8 @@ export function PrivyRootClient({ children }: { children: ReactNode }) {
           theme: 'dark',
           accentColor: '#6366f1',
         },
-        supportedChains: [baseSepolia, base],
-        defaultChain: baseSepolia,
+        supportedChains: [base, baseSepolia],
+        defaultChain,
         embeddedWallets: {
           ethereum: { createOnLogin: 'users-without-wallets' },
         },

--- a/frontend/lib/web3/config.ts
+++ b/frontend/lib/web3/config.ts
@@ -18,6 +18,14 @@ export const AAVE_V3_ADDRESSES = {
     PoolDataProvider: '0x69FA688f1Dc47d4B5d8029D5a35FB7a548310654',
     Oracle: '0xb56c2F0B653B2e0b10C9b928C8580Ac5Df02C7C5',
   },
+  // Aave V3 Base Mainnet (chain 8453)
+  // bgd-labs/aave-address-book + PoolAddressesProvider.getPool/Oracle/PoolDataProvider() で
+  // 2026-05-01 にオンチェーン照合済み (mainnet.base.org RPC)
+  base: {
+    Pool: '0xA238Dd80C259a72e81d7e4664a9801593F98d1c5',
+    PoolDataProvider: '0x0F43731EB8d45A581f4a36DD74F5f358bc90C73A',
+    Oracle: '0x2Cc0Fc26eD4563A5ce5e8bdcfe1A2878676Ae156',
+  },
 } as const
 
 // 対応トークンアドレス（チェーン別）
@@ -42,6 +50,18 @@ export const TOKEN_ADDRESSES = {
     WETH: '0x4200000000000000000000000000000000000006',
     WBTC: '0x6Bf14CB0A831078629D993FDeBcB182b21A8774C',
     DAI:  '0xc5E420e74Fd98Da91dAC7Bca77f00a6aECde02d4',
+  },
+  // Base Mainnet token addresses (chain 8453)
+  // - Aave V3 Base reserves (オンチェーン取得 2026-05-01): USDC, WETH, cbBTC のみ
+  //   (cbBTC は Aave で WBTC alias 扱い)
+  // - USDT, DAI は Base 上に存在するが Aave Base mainnet には未上場 (deposit/borrow 不可)
+  // - SupportedToken 型 (USDC|USDT|WETH|WBTC|DAI) を満たすため全 5 キー必須
+  base: {
+    USDC: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    USDT: '0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2',
+    WETH: '0x4200000000000000000000000000000000000006',
+    WBTC: '0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf',
+    DAI: '0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb',
   },
 } as const
 
@@ -79,12 +99,15 @@ export type AaveChainKey = keyof typeof AAVE_V3_ADDRESSES
 export type SupportedToken = keyof typeof TOKEN_ADDRESSES.arbitrum
 
 export const DEFAULT_CHAIN: SupportedChainKey =
-  (process.env.NEXT_PUBLIC_DEFAULT_CHAIN as SupportedChainKey) || 'base-sepolia'
+  (process.env.NEXT_PUBLIC_DEFAULT_CHAIN as SupportedChainKey) || 'base'
 
 export const MINIMUM_USD_BALANCE = 3000
 
-// Supported chain IDs (Base Sepolia testnet only)
-export const SUPPORTED_CHAIN_IDS = [84532]
+// Supported chain IDs — env-driven (default: Base Mainnet 8453)
+// 2026-05-01: testnet hardcode [84532] から env 駆動に変更 (mainnet 切替対応)
+export const SUPPORTED_CHAIN_IDS = [
+  parseInt(process.env.NEXT_PUBLIC_DEFAULT_CHAIN_ID || '8453'),
+]
 
 export function getChainKey(chainId: number): SupportedChainKey | null {
   if (chainId === 84532) return 'base-sepolia'


### PR DESCRIPTION
## P0 mainnet 切替 PR-B

frontend chain 設定に Base Mainnet (chain 8453) を追加。env (\`NEXT_PUBLIC_DEFAULT_CHAIN_ID\`) で testnet/mainnet を切替可能に。コード変更のみ、env と build.args は PR-C で追加。

## 変更ファイル

### \`frontend/lib/web3/config.ts\` (+24/-2)
- \`AAVE_V3_ADDRESSES.base\` 追加 (Pool / PoolDataProvider / Oracle)
- \`TOKEN_ADDRESSES.base\` 追加 (USDC / USDT / WETH / WBTC=cbBTC alias / DAI)
- \`DEFAULT_CHAIN\` fallback を \`'base-sepolia'\` → \`'base'\`
- \`SUPPORTED_CHAIN_IDS = [84532]\` hardcode → env 駆動 \`[parseInt(env || '8453')]\`

### \`frontend/lib/wallet/PrivyRootClient.tsx\` (+7/-2)
- \`defaultChain\` を hardcode \`baseSepolia\` → env 駆動 (\`env === 8453\` → \`base\`、else → \`baseSepolia\`)
- \`supportedChains\` 順序を \`[base, baseSepolia]\` に変更 (mainnet 先頭)

## アドレス検証 (オンチェーン 2026-05-01)

\`mainnet.base.org\` 公開 RPC で \`chain_id=8453\` 確認 + PoolAddressesProvider
(\`0xe20fCBdBfFC4Dd138cE8b2E6FBb6CB49777ad64D\`) で照会:

| 項目 | 値 | claude.ai 期待値 | 一致 |
|---|---|---|---|
| Pool | \`0xA238Dd80C259a72e81d7e4664a9801593F98d1c5\` | 同じ | ✅ |
| AaveOracle | \`0x2Cc0Fc26eD4563A5ce5e8bdcfe1A2878676Ae156\` | 同じ | ✅ |
| PoolDataProvider | \`0x0F43731EB8d45A581f4a36DD74F5f358bc90C73A\` | (オンチェーン取得) | — |

Aave Base reserves (\`getAllReservesTokens()\`):
WETH, cbETH, USDbC, wstETH, USDC, weETH, cbBTC, ezETH, GHO, wrsETH, LBTC, EURC, AAVE, tBTC, syrupUSDC

**USDT/DAI は Aave Base 未上場**。frontend の \`SupportedToken\` 型を満たすため well-known Base address (Tether \`0xfde4...\`, Maker DAI \`0x50c5...\`) を追加した。ランタイムで USDT/DAI deposit/borrow を試みると Aave 側で失敗する点は仕様。

## DoD

- [x] \`npx tsc --noEmit\`: pass
- [x] \`npm run lint\`: 既存 warning のみ、エラーなし
- [x] \`npm run build\`: pass
- [ ] CI pass
- [ ] (任意) Codex review

## Gate 4 (Playwright 本番 URL E2E) について

本 PR では env と build.args を変更しないため (production はまだ \`NEXT_PUBLIC_DEFAULT_CHAIN_ID\` 未設定 = fallback で \`8453\` に切替わる **コード上の動作変更**)、本番 URL での E2E は PR-C デプロイ後に実施する (claude.ai 判断)。本 PR の DoD は CI ビルド成功で代替。

## 関連

- Asana: https://app.asana.com/0/1213996126630018/1214445965769454
- Phase 1 read-only 完了済み
- PR-A: https://github.com/milechy/ultra-autotrade-project/pull/174 (merged at \`c87ab6f\`)
- 次: PR-C (.env.production 書換 + docker-compose.production.yml build.args + Hetzner デプロイ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)