### PR TITLE
fix(promtail): bump image to resolve Docker API version mismatch

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -69,7 +69,7 @@ services:
         max-file: "3"
 
   promtail:
-    image: grafana/promtail:2.9.0
+    image: grafana/promtail:3.0.0
     container_name: ultra-autotrade-promtail-production
     volumes:
       - ./docker/promtail/promtail-config.yaml:/etc/promtail/promtail-config.yaml:ro

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -70,7 +70,7 @@ services:
         max-file: "3"
 
   promtail:
-    image: grafana/promtail:2.9.0
+    image: grafana/promtail:3.0.0
     container_name: ultra-autotrade-promtail-staging-new
     volumes:
       - ./docker/promtail/promtail-config.yaml:/etc/promtail/promtail-config.yaml:ro


### PR DESCRIPTION
## Summary
- `grafana/promtail:2.9.0` → `grafana/promtail:3.0.0` (production + staging)
- Root cause: promtail 2.9.0 uses Docker API client 1.42; host Docker requires >= 1.44
- Closes Asana GID 1214252923421610

## Changes
- `docker-compose.production.yml`: promtail image bumped to 3.0.0
- `docker-compose.staging.yml`: promtail image bumped to 3.0.0

## Constraint
- **Only promtail touched.** backend / nginx / cloudflared / postgres are not modified.

## Deploy (after approval)
```bash
ssh -i ~/.ssh/hetzner_staging ultra@77.42.46.155 \
  "cd /opt/ultra-autotrade && git pull origin main && \
   docker compose -f docker-compose.production.yml --env-file .env.production -p ultra-autotrade-project pull promtail && \
   docker compose -f docker-compose.production.yml --env-file .env.production -p ultra-autotrade-project up -d --no-deps promtail"
```

## Test plan
- [ ] `docker logs ultra-autotrade-promtail-production --tail 50` — API mismatch error gone
- [ ] Grafana Loki: log stream from containers continues normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)