### PR TITLE
feat(auth): unify general user signup to /connect (Privy)

### DIFF
--- a/frontend/app/(user)/connect/page.tsx
+++ b/frontend/app/(user)/connect/page.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { usePrivy, useWallets } from '@privy-io/react-auth'
 import { ethers } from 'ethers'
-import { Wallet, CheckCircle, AlertTriangle, ArrowRight } from 'lucide-react'
+import { Wallet, CheckCircle, AlertTriangle, ArrowRight, Info } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { useAuth } from '@/lib/auth'
@@ -88,10 +88,16 @@ function StepIndicator({ currentStep }: { currentStep: number }) {
 
 export default function ConnectPage() {
   const router = useRouter()
-  const { loginWithWallet } = useAuth()
+  const { loginWithWallet, isAuthenticated, user } = useAuth()
   const { login, authenticated } = usePrivy()
   const { wallets } = useWallets()
   const { checkMinimum, minimumUSD } = useMinimumBalance()
+
+  // tester_onboarding 途中ユーザー: メール/PW で /register 完了済 (JWT あり) かつ
+  // wallet 未接続 (Privy authenticated=false) の場合、ガイダンスを表示する。
+  // 管理者は /register が引き続き正規動線なので除外。
+  const showResumeFromEmailGuidance =
+    isAuthenticated && !authenticated && user?.role !== 'admin'
 
   const [termsAccepted, setTermsAccepted] = useState(false)
   const [riskAccepted, setRiskAccepted] = useState(false)
@@ -173,6 +179,27 @@ export default function ConnectPage() {
             ウォレットまたはメールアドレスで接続してください
           </p>
         </div>
+
+        {/* tester_onboarding 途中ユーザー向けガイダンス */}
+        {showResumeFromEmailGuidance && (
+          <div
+            data-testid="resume-from-email-banner"
+            className="mb-6 rounded-lg border border-blue-700 bg-blue-950/40 px-4 py-3 text-sm"
+          >
+            <div className="flex items-start gap-2">
+              <Info className="h-4 w-4 text-blue-400 mt-0.5 shrink-0" />
+              <div className="space-y-1">
+                <p className="font-semibold text-blue-200">
+                  メール登録は完了しています
+                </p>
+                <p className="text-blue-100/80 text-xs leading-relaxed">
+                  運用を開始するには、続けてウォレットを接続してください。
+                  接続後にダッシュボードへ遷移します。
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
 
         <div className="space-y-4">
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -96,8 +96,11 @@ export default function LandingPage() {
               size="lg"
               className="bg-blue-500 hover:bg-blue-600 text-white text-base px-8 py-6 h-auto"
             >
-              <Link href="/connect">ウォレットを接続する</Link>
+              <Link href="/connect">ウォレットで始める</Link>
             </Button>
+            <p className="mt-4 text-xs text-gray-500">
+              メールアドレス不要。ウォレットを接続するだけで開始できます。
+            </p>
           </div>
         </div>
       </section>
@@ -234,7 +237,7 @@ export default function LandingPage() {
             size="lg"
             className="bg-blue-500 hover:bg-blue-600 text-white text-base px-8 py-6 h-auto"
           >
-            <Link href="/connect">ウォレットを接続する</Link>
+            <Link href="/connect">ウォレットで始める</Link>
           </Button>
         </div>
       </section>

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -13,7 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
+import { AlertCircle, CheckCircle2, Loader2, Wallet } from "lucide-react";
 
 interface InvitationResponse {
   valid: boolean;
@@ -94,11 +94,34 @@ function RegisterForm() {
     (Boolean(urlCode) && codeStatus === "invalid");
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-muted/40 p-4">
+    <main className="flex min-h-screen flex-col items-center justify-center bg-muted/40 p-4">
+      {/* Deprecation banner: 一般ユーザーは /connect (Privy) に誘導、管理者専用 */}
+      <div
+        role="status"
+        aria-label="メール登録は管理者専用です"
+        data-testid="register-deprecation-banner"
+        className="w-full max-w-sm mb-4 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100"
+      >
+        <p className="font-semibold flex items-center gap-2">
+          <AlertCircle className="h-4 w-4" />
+          メール登録は管理者専用です
+        </p>
+        <p className="mt-1 text-xs">
+          一般ユーザーの方は<a href="/connect" className="font-semibold underline underline-offset-2 mx-1">ウォレット接続</a>で開始してください。
+        </p>
+        <a
+          href="/connect"
+          className="mt-2 inline-flex items-center gap-1.5 rounded border border-amber-400 bg-white px-3 py-1.5 text-xs font-medium text-amber-900 hover:bg-amber-100 dark:bg-amber-900 dark:text-amber-50 dark:hover:bg-amber-800"
+          data-testid="register-banner-connect-link"
+        >
+          <Wallet className="h-3.5 w-3.5" />
+          ウォレットで始める
+        </a>
+      </div>
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <CardTitle className="text-2xl">Ultra AutoTrade</CardTitle>
-          <CardDescription>アカウント登録</CardDescription>
+          <CardDescription>アカウント登録（管理者用）</CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-4">

--- a/frontend/e2e/connect-privy-unify.spec.ts
+++ b/frontend/e2e/connect-privy-unify.spec.ts
@@ -1,0 +1,256 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+//
+// E2E: ユーザー登録動線の /connect 統一 (Asana GID 1214180175562193)
+//
+// 目的: B案改で実装した「一般ユーザーは /connect (Privy) で開始、管理者のみ
+//      /register でメール登録」の動線が UI レベルで成立していることを保証する。
+//
+// 検証範囲:
+//   1. ランディング (/) の CTA が「ウォレットで始める」 → /connect に遷移する
+//   2. /register に「管理者専用」の deprecation バナーが表示され、/connect への
+//      動線リンクが存在する
+//   3. /connect ページのウォレット接続 UI (Privy login ボタン + ステップ
+//      インジケーター) が初期表示される
+//   4. tester_onboarding 途中ユーザー (メール登録済 / wallet 未接続) 向けの
+//      「resume-from-email-banner」が、認証済セッションでのみ表示される
+//   5. 管理者用 /login (メール/PW) のフォームは引き続き存在する
+//
+// Privy モーダル本体の操作 (メール OTP / wallet 作成 / signMessage) は本番の
+// Privy インスタンスに依存し、CI/staging から in-line でモックできないため、
+// バックエンド POST /auth/wallet/connect を route intercept でスタブし、
+// 「Privy で署名済 → JWT 取得 → /user/dashboard 遷移」までをシミュレートする。
+//
+// 実行:
+//   STAGING_URL=https://staging.ultra-auto-trade.com npx playwright test \
+//     e2e/connect-privy-unify.spec.ts
+//
+// 既存の管理者向け email/PW テスト (smoke/landing, login など) は touched せず、
+// 「管理者ロール想定」の意味づけだけここで明文化する。
+
+import { test, expect } from '@playwright/test'
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 共通ヘルパー
+// ──────────────────────────────────────────────────────────────────────────────
+
+const MOCK_JWT = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test.signature'
+
+/** localStorage に有効な JWT を入れて「メール登録済 / wallet 未接続」を再現 */
+async function seedAuthenticatedSession(page: import('@playwright/test').Page) {
+  await page.addInitScript((token: string) => {
+    const expires = Date.now() + 60 * 60 * 1000 // 1 hour
+    localStorage.setItem('ultra_auth_token', token)
+    localStorage.setItem('ultra_auth_expires', String(expires))
+  }, MOCK_JWT)
+}
+
+/** GET /auth/me を viewer ロールで返してログイン状態を完成させる */
+async function stubAuthMe(
+  page: import('@playwright/test').Page,
+  role: 'admin' | 'partner' | 'viewer' = 'viewer'
+) {
+  await page.route('**/auth/me', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 99,
+        email: 'tester@example.com',
+        username: 'tester',
+        role,
+        is_active: true,
+      }),
+    })
+  })
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 1. ランディング → /connect 動線
+// ──────────────────────────────────────────────────────────────────────────────
+
+test.describe('[ConnectUnify] ランディング → /connect 動線', () => {
+  test('ランディングのヒーローCTAが「ウォレットで始める」になっている', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await page.waitForLoadState('domcontentloaded')
+
+    const heroCta = page.getByRole('link', { name: 'ウォレットで始める' }).first()
+    await expect(heroCta).toBeVisible()
+  })
+
+  test('「メール登録」「メールアドレスで登録」等の旧CTAは存在しない', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await page.waitForLoadState('domcontentloaded')
+
+    // アカウント新規作成系の旧文言が hero / footer CTA で復活していないことを確認
+    const heroSection = page.locator('section').first()
+    const heroText = (await heroSection.textContent()) ?? ''
+    expect(heroText).not.toMatch(/メール登録|メールアドレスで登録|無料登録/)
+  })
+
+  test('ヒーローCTAをクリックすると /connect に遷移する', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('link', { name: 'ウォレットで始める' }).first().click()
+    await expect(page).toHaveURL(/\/connect/)
+    await expect(
+      page.getByRole('heading', { name: 'ウォレットを接続' })
+    ).toBeVisible()
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 2. /register deprecation バナー
+// ──────────────────────────────────────────────────────────────────────────────
+
+test.describe('[ConnectUnify] /register deprecation バナー', () => {
+  test('/register に「管理者専用」バナーが表示される', async ({ page }) => {
+    await page.goto('/register')
+    await page.waitForLoadState('domcontentloaded')
+
+    const banner = page.getByTestId('register-deprecation-banner')
+    await expect(banner).toBeVisible()
+    await expect(banner).toContainText('メール登録は管理者専用')
+  })
+
+  test('バナー内に /connect への動線リンクがある', async ({ page }) => {
+    await page.goto('/register')
+    await page.waitForLoadState('domcontentloaded')
+
+    const link = page.getByTestId('register-banner-connect-link')
+    await expect(link).toBeVisible()
+    await expect(link).toHaveAttribute('href', '/connect')
+  })
+
+  test('バナーの誘導リンクをクリックすると /connect に遷移する', async ({
+    page,
+  }) => {
+    await page.goto('/register')
+    await page.getByTestId('register-banner-connect-link').click()
+    await expect(page).toHaveURL(/\/connect/)
+  })
+
+  test('カードタイトルに「管理者用」が明記されている', async ({ page }) => {
+    await page.goto('/register')
+    await expect(page.getByText('アカウント登録（管理者用）')).toBeVisible()
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 3. /connect 初期 UI (Privy login ボタン)
+// ──────────────────────────────────────────────────────────────────────────────
+
+test.describe('[ConnectUnify] /connect 初期表示', () => {
+  test('「ウォレットを接続する」ボタンが表示される', async ({ page }) => {
+    await page.goto('/connect')
+    await expect(
+      page.getByRole('button', { name: /ウォレットを接続する/ })
+    ).toBeVisible()
+  })
+
+  test('3ステップインジケーター (接続 / NW / 規約) が並ぶ', async ({ page }) => {
+    await page.goto('/connect')
+    await expect(page.getByText('ウォレット接続').first()).toBeVisible()
+    await expect(page.getByText('ネットワーク確認')).toBeVisible()
+    await expect(page.getByText('規約同意')).toBeVisible()
+  })
+
+  test('未認証時は resume-from-email-banner が表示されない', async ({ page }) => {
+    await page.goto('/connect')
+    await expect(page.getByTestId('resume-from-email-banner')).toHaveCount(0)
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 4. tester_onboarding 途中ユーザー: 「メール登録済 / wallet 未接続」
+// ──────────────────────────────────────────────────────────────────────────────
+
+test.describe('[ConnectUnify] resume-from-email ガイダンス', () => {
+  test('viewer ロールで認証済の場合、ガイダンスバナーが表示される', async ({
+    page,
+  }) => {
+    await stubAuthMe(page, 'viewer')
+    await seedAuthenticatedSession(page)
+
+    await page.goto('/connect')
+    await page.waitForLoadState('domcontentloaded')
+
+    const banner = page.getByTestId('resume-from-email-banner')
+    await expect(banner).toBeVisible({ timeout: 10_000 })
+    await expect(banner).toContainText('メール登録は完了しています')
+    await expect(banner).toContainText('続けてウォレットを接続')
+  })
+
+  test('admin ロールでは resume-from-email-banner は出ない', async ({ page }) => {
+    await stubAuthMe(page, 'admin')
+    await seedAuthenticatedSession(page)
+
+    await page.goto('/connect')
+    await page.waitForLoadState('domcontentloaded')
+
+    // useAuth().user の解決を待つ猶予
+    await page.waitForTimeout(500)
+    await expect(page.getByTestId('resume-from-email-banner')).toHaveCount(0)
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 5. 管理者向け /login (メール/PW) は維持されている
+// ──────────────────────────────────────────────────────────────────────────────
+
+test.describe('[ConnectUnify] 管理者ログイン経路の維持', () => {
+  test('/login にメール/PW フォームが存在する', async ({ page }) => {
+    await page.goto('/login')
+    await page.waitForLoadState('domcontentloaded')
+
+    // input[type=email] と input[type=password] が存在することで管理者経路を担保
+    await expect(page.locator('input[type="email"]')).toBeVisible()
+    await expect(page.locator('input[type="password"]')).toBeVisible()
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 6. /connect → POST /auth/wallet/connect → /user/dashboard 完全フロー
+//
+//    Privy のモーダル操作 (OTP / 署名) は in-line でモックできないため、
+//    バックエンドの /auth/wallet/connect を route intercept でスタブし、
+//    「署名後に JWT が返る」「ダッシュボードに遷移する」部分の連結だけを検証する。
+//    Privy SDK 自体の動作は @privy-io/react-auth が担保。
+// ──────────────────────────────────────────────────────────────────────────────
+
+test.describe('[ConnectUnify] 完全フロー (バックエンド連結確認)', () => {
+  test('POST /auth/wallet/connect が成功すれば /user/dashboard に遷移する', async ({
+    page,
+  }) => {
+    // Privy モーダルが現実環境では出るため、CI/staging で安定実行できる範囲を
+    // 「バックエンド POST 成功 → router.push('/user/dashboard') が走る」までに
+    // 限定する。Privy SDK 内部の処理は本テストの対象外。
+    test.skip(
+      true,
+      'Privy モーダル経由の signMessage は CI からモック不可。staging 上で 手動回帰 (docs/22 §9) で確認する。'
+    )
+
+    let walletConnectCalled = false
+    await page.route('**/auth/wallet/connect', async (route) => {
+      walletConnectCalled = true
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: MOCK_JWT,
+          token_type: 'bearer',
+          expires_in: 3600,
+        }),
+      })
+    })
+    await stubAuthMe(page, 'viewer')
+
+    await page.goto('/connect')
+    // ここで Privy modal を操作する手段がないため、本来は手動回帰で確認する
+    await page.waitForURL('**/user/dashboard', { timeout: 30_000 })
+    expect(walletConnectCalled).toBe(true)
+  })
+})

--- a/frontend/e2e/smoke/landing.spec.ts
+++ b/frontend/e2e/smoke/landing.spec.ts
@@ -17,13 +17,13 @@ test.describe('U-01 ランディングページ (/)', () => {
     await expect(hero).toBeVisible();
   });
 
-  test('CTAボタン「ウォレットを接続する」が表示される', async ({ page }) => {
-    const cta = page.getByRole('link', { name: 'ウォレットを接続する' }).first();
+  test('CTAボタン「ウォレットで始める」が表示される', async ({ page }) => {
+    const cta = page.getByRole('link', { name: 'ウォレットで始める' }).first();
     await expect(cta).toBeVisible();
   });
 
   test('CTAボタンクリックで /connect に遷移する', async ({ page }) => {
-    const cta = page.getByRole('link', { name: 'ウォレットを接続する' }).first();
+    const cta = page.getByRole('link', { name: 'ウォレットで始める' }).first();
     await cta.click();
     await page.waitForURL('**/connect');
     expect(page.url()).toContain('/connect');

--- a/frontend/e2e/wallet-connect.spec.ts
+++ b/frontend/e2e/wallet-connect.spec.ts
@@ -53,14 +53,14 @@ async function clickConnectAndWait(page: import('@playwright/test').Page) {
 test.describe('[Landing] CTAボタン', () => {
   test('ヒーローセクションにCTAボタンが表示される', async ({ page }) => {
     await page.goto('/')
-    // The hero section link button text
-    const cta = page.getByRole('link', { name: 'ウォレットを接続する' }).first()
+    // The hero section link button text (B案改: ウォレットファーストCTA)
+    const cta = page.getByRole('link', { name: 'ウォレットで始める' }).first()
     await expect(cta).toBeVisible()
   })
 
   test('CTAボタンをクリックすると /connect に遷移する', async ({ page }) => {
     await page.goto('/')
-    await page.getByRole('link', { name: 'ウォレットを接続する' }).first().click()
+    await page.getByRole('link', { name: 'ウォレットで始める' }).first().click()
     await expect(page).toHaveURL(/\/connect/)
     await expect(page.getByRole('heading', { name: 'ウォレットを接続' })).toBeVisible()
   })
@@ -317,7 +317,7 @@ test.describe('[Mobile 375px] 基本フロー', () => {
 
   test('ランディングページのCTAボタンがモバイルで表示される', async ({ page }) => {
     await page.goto('/')
-    const cta = page.getByRole('link', { name: 'ウォレットを接続する' }).first()
+    const cta = page.getByRole('link', { name: 'ウォレットで始める' }).first()
     await expect(cta).toBeVisible()
   })
 


### PR DESCRIPTION
## Summary
- 一般ユーザーの新規登録/ログイン動線を `/connect` (Privy) に統一
- 管理者は引き続き `/login` (メール/PW) を利用 (タスク GID 1214162094588652 とセット)

## Asana
- GID **1214180175562193** [P1] frontend: ユーザー登録動線を /connect に統一、/register 段階廃止

## 変更内容
1. ランディング (/) のヒーロー + フッター CTA を「ウォレットで始める」 → `/connect` に変更
2. `/register` に「管理者専用」 deprecation バナー + `/connect` 誘導リンクを追加
   - CardDescription を「アカウント登録（管理者用）」に明記
3. `/connect` に **resume-from-email-banner** を追加
   - 条件: メール登録済 (JWT あり) かつ wallet 未接続 (Privy `authenticated=false`) かつ admin でない
4. 新規 E2E spec: `frontend/e2e/connect-privy-unify.spec.ts`
   - landing CTA / register banner / connect UI / resume guidance / 管理者 /login 維持を網羅
   - Privy モーダル経由のフルフロー部分は staging 手動回帰前提で `test.skip` 明記
5. 既存 `wallet-connect.spec.ts` / `smoke/landing.spec.ts` の CTA テキストを更新

## DoD (verify.sh)
- ✅ ruff check / format / mypy
- ✅ pytest --cov-fail-under=80 (バックエンド変更なし)
- ✅ tsc --noEmit
- ✅ npm run build
- ✅ ruff security check
- 実行時間: 400s (`bash scripts/verify.sh`)

## Staging E2E (staging-new, http://127.0.0.1:3001 SSH tunnel)
- ✅ `e2e/connect-privy-unify.spec.ts` — **26 passed / 2 skipped**
  (skip 2 件は Privy モーダル操作で staging 手動回帰前提)
- ✅ `e2e/smoke/landing.spec.ts` + `e2e/wallet-connect.spec.ts` — 32 passed / 34 skipped (既存skip)
- ✅ staging-new 上の HTML に「ウォレットで始める」を確認

## デプロイ手順 (staging-new)
\`\`\`bash
ssh -i ~/.ssh/hetzner_staging ultra@77.42.46.155 \\
  "cd /opt/ultra-autotrade && \\
   git fetch origin feature/auth-connect-unify-registration && \\
   git checkout feature/auth-connect-unify-registration && \\
   docker compose -f docker-compose.staging.yml --env-file .env.staging-new \\
     -p ultra-autotrade-staging build frontend && \\
   docker compose -f docker-compose.staging.yml --env-file .env.staging-new \\
     -p ultra-autotrade-staging up -d --no-deps --force-recreate frontend backend-green"
\`\`\`

## 制約 / 残課題
- main マージは **山本さん観察明け待ち** (本日は PR 起票まで)
- production deploy も同様に保留 (本ブランチには production 用変更なし)
- Privy モーダル本体の自動 E2E は CI 環境からの mock 不可。staging 上で
  `docs/22_production_release_checklist.md §9` の手動回帰で確認する想定

## 2026-04-21 教訓 (E2E 先行 + 3層確認) 適用状況
- ✅ E2E 新規テスト追加し staging で green 確認後にドキュメント/PR 化
- ✅ フロント (UI) / バックエンド (`/auth/wallet/connect`, `privy_did` 列, 既存) /
  DB (privy_did 列、 2026-05-01 mainnet 切替で適用済) の 3 層が揃った状態で
  リリース動線を構築

## Test plan
- [x] `bash scripts/verify.sh` (Gate 1-7) green
- [x] `STAGING_URL=http://localhost:3001 npx playwright test e2e/connect-privy-unify.spec.ts` green
- [x] staging-new 上で `curl /` に「ウォレットで始める」が含まれることを確認
- [ ] (山本さん観察明け後) main マージ
- [ ] (山本さん観察明け後) production deploy + 手動 Privy フロー回帰

🤖 Generated with [Claude Code](https://claude.com/claude-code)