### PR TITLE
chore(alembic): install CLI and sync alembic_version stamp

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,6 +14,7 @@ eth-account>=0.11.0
 python-dotenv>=1.0.0
 
 # Authentication & Database (Phase 12)
+alembic>=1.13.0
 sqlalchemy>=2.0.0
 bcrypt>=4.1.0
 PyJWT[crypto]>=2.9.0    # [crypto] extra で cryptography (RS256/ES256 等) を有効化 — Privy ID Token 検証に必要

--- a/docs/22_production_release_checklist.md
+++ b/docs/22_production_release_checklist.md
@@ -105,12 +105,25 @@ Ultra AutoTrade – Production リリース前チェックリスト
 - [ ] `PRIVATE_KEY` が本番ウォレット秘密鍵（staging と完全に異なること）
 - [ ] `SLACK_WEBHOOK_URL` が本番チャネル向け URL
 
-### マイグレーション（手動方式）
-- [x] alembic は未インストール。手動 `ALTER TABLE` 方式で運用 ✅
-- [ ] 新カラム追加が必要な場合はバックアップ取得後に手動実行:
+### マイグレーション（alembic 方式、2026-05-02〜）
+- [x] `alembic>=1.13.0` を `backend/requirements.txt` に追加済み ✅
+- [ ] 新しいマイグレーションファイルを適用する場合:
+  ```bash
+  # staging
+  docker exec -w /app/backend ultra-autotrade-backend-green-staging-new alembic upgrade head
+  # production（デプロイ後に実行）
+  docker exec -w /app/backend ultra-autotrade-backend-blue-production alembic upgrade head
+  ```
+- [ ] 現在の revision 確認:
+  ```bash
+  docker exec -w /app/backend ultra-autotrade-backend-blue-production alembic current
+  ```
+- [ ] 新カラムを手動適用する必要がある場合（alembic upgrade で失敗時フォールバック）:
   ```bash
   docker exec ultra-autotrade-postgres-production psql -U ultra -d ultra_autotrade -c \
     "ALTER TABLE <table> ADD COLUMN IF NOT EXISTS <column> <type>;"
+  # その後 alembic stamp <revision> で version を同期
+  docker exec -w /app/backend ultra-autotrade-backend-blue-production alembic stamp <revision>
   ```
 
 ### ヘルスチェック
@@ -217,11 +230,10 @@ docker compose -f docker-compose.production.yml up -d --no-deps --build backend
 docker compose -f docker-compose.production.yml build --no-cache frontend
 docker compose -f docker-compose.production.yml up -d --no-deps frontend
 
-# 5. DB マイグレーション（手動方式）
-# ⚠️ alembic は使用しない（未インストール、exit code 127 の原因）
-# 新しいカラムが必要な場合は手動で ALTER TABLE を実行:
-# docker exec ultra-autotrade-postgres-production psql -U ultra -d ultra_autotrade -c \
-#   "ALTER TABLE <table> ADD COLUMN IF NOT EXISTS <column> <type>;"
+# 5. DB マイグレーション（alembic 方式、2026-05-02〜）
+docker exec -w /app/backend ultra-autotrade-backend-blue-production alembic upgrade head
+# 確認: alembic current → 最新 revision (head) が表示されること
+docker exec -w /app/backend ultra-autotrade-backend-blue-production alembic current
 
 # 6. ヘルスチェック
 curl https://api.ultra-auto-trade.com/health

--- a/docs/42_production_e2e_runbook.md
+++ b/docs/42_production_e2e_runbook.md
@@ -86,7 +86,7 @@ docker network inspect ultra-autotrade-project_default | grep -E '(Name|Containe
 
 ```bash
 # alembic migration ファイル一覧
-ls backend/migrations/versions/ | sort
+ls backend/alembic/versions/ | sort
 
 # 本番DBに適用済み migration 一覧
 docker exec ultra-autotrade-postgres-production psql -U ultra -d ultra_autotrade \
@@ -746,7 +746,7 @@ docker exec ultra-autotrade-backend-blue-production env | grep -E "AAVE_NETWORK|
 
 ### 6.4 DB migration 失敗時のロールバック
 
-**alembic 未インストール環境** (CLAUDE.md 教訓): production / staging は alembic コマンドが container 内に存在しない。migration は **手動 SQL 適用方式**。
+**alembic インストール済み** (2026-05-02〜): `alembic>=1.13.0` が `requirements.txt` に追加され、container 内で `alembic upgrade head` が使用可能。migration は alembic 方式が優先。手動 ALTER TABLE が必要な場合は `alembic stamp <revision>` で version を同期すること。
 
 **バックアップから復元 (full restore)**:
 ```bash

--- a/docs/integration/backend_deps.md
+++ b/docs/integration/backend_deps.md
@@ -75,6 +75,13 @@
 
 ## backend/requirements.txt
 
+### 変更 #3: alembic>=1.13.0 追加（alembic CLI + alembic_version stamp 同期）(PR #181 / 2026-05-02)
+- **コミット範囲**: `chore/alembic-version-sync`
+- **変更内容**: `alembic>=1.13.0` を Authentication & Database セクションに追加
+- **理由**: Alembic CLI インストールと `alembic_version` stamp の同期。マイグレーション管理の整備。
+- **影響範囲**: alembic パッケージの追加のみ。既存アプリケーションロジックへの影響なし。
+- **承認**: chore/alembic-version-sync → main の通常フロー経由（PR #181）
+
 ### 変更 #2: PyJWT[crypto] extra 追加（Privy ID Token 検証対応）(PR #155 / 2026-04-27)
 - **コミット範囲**: `c88dfd2` – `41f77d7` (feature/privy-did-storage)
 - **変更内容**: `PyJWT>=2.9.0` → `PyJWT[crypto]>=2.9.0`


### PR DESCRIPTION
## Summary
- Add `alembic>=1.13.0` to `backend/requirements.txt` so `alembic` CLI is available inside the backend container
- Staging: stamped `alembic_version` to `a7b8c9d0e1f2` (execution_policy CHECK constraint — Phase 3 Step 4 後始末)
- Update migration docs: `alembic upgrade head` is now the standard deploy procedure
- Fix typo in `docs/42_production_e2e_runbook.md`: path was `backend/migrations/versions/` → `backend/alembic/versions/`

## Staging verification
```
# alembic version
alembic 1.18.4

# alembic current (after stamp)
a7b8c9d0e1f2 (head)
```

## Test plan
- [ ] Container rebuild includes alembic (verify: `docker exec -w /app/backend <backend> alembic --version`)
- [ ] `alembic current` returns `a7b8c9d0e1f2 (head)` on staging after deploy
- [ ] Docs updated: `22_production_release_checklist.md` §マイグレーション reflects alembic workflow

## Related
- Asana GID 1214442875870691
- Prerequisite: GID 1214441077086118 (staging DB schema diff — J task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)