### PR TITLE
feat(auth): add users_auth_method_check constraint

### DIFF
--- a/backend/alembic/versions/a0b1c2d3e4f5_add_users_auth_method_check.py
+++ b/backend/alembic/versions/a0b1c2d3e4f5_add_users_auth_method_check.py
@@ -1,0 +1,51 @@
+"""add_users_auth_method_check
+
+GID 1214176336328111: users_auth_method_check CHECK 制約追加 + hashed_password nullable 化。
+Privy-only ユーザー対応の前準備として、hashed_password を NULL 許容にしたうえで
+「hashed_password IS NOT NULL OR privy_did IS NOT NULL」CHECK 制約を追加する。
+
+Revision ID: a0b1c2d3e4f5
+Revises: f6a7b8c9d0e1
+Create Date: 2026-05-02 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a0b1c2d3e4f5"
+down_revision: Union[str, Sequence[str], None] = "f6a7b8c9d0e1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Make hashed_password nullable and add auth method check constraint."""
+    # hashed_password を nullable 化 (Privy-only ユーザーをサポートするため)
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.alter_column(
+            "hashed_password",
+            existing_type=sa.String(length=255),
+            nullable=True,
+        )
+    # CHECK 制約追加: 少なくとも一方の認証手段を必須化
+    op.create_check_constraint(
+        "users_auth_method_check",
+        "users",
+        "hashed_password IS NOT NULL OR privy_did IS NOT NULL",
+    )
+
+
+def downgrade() -> None:
+    """Remove auth method check constraint and restore hashed_password NOT NULL."""
+    op.drop_constraint("users_auth_method_check", "users", type_="check")
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.alter_column(
+            "hashed_password",
+            existing_type=sa.String(length=255),
+            nullable=False,
+        )

--- a/backend/app/auth/models.py
+++ b/backend/app/auth/models.py
@@ -19,6 +19,14 @@ CREATE UNIQUE INDEX IF NOT EXISTS ix_users_privy_did ON users (privy_did) WHERE 
 -- CheckConstraint と SQLAlchemy 側 server_default を Alembic migration で同期する。
 ALTER TABLE users ADD CONSTRAINT users_execution_policy_check
     CHECK (execution_policy IN ('auto_execute', 'require_approval', 'proposal_only'));
+
+-- GID 1214176336328111: auth method check + hashed_password nullable 化
+-- Privy-only ユーザーを将来サポートするため hashed_password を nullable に変更。
+-- hashed_password IS NOT NULL OR privy_did IS NOT NULL の CHECK constraint で
+-- 「どちらも NULL」な幽霊ユーザーを DB レベルで防ぐ。
+ALTER TABLE users ALTER COLUMN hashed_password DROP NOT NULL;
+ALTER TABLE users ADD CONSTRAINT users_auth_method_check
+    CHECK (hashed_password IS NOT NULL OR privy_did IS NOT NULL);
 """
 
 import logging
@@ -205,12 +213,16 @@ class User(Base):
             + ")",
             name="users_execution_policy_check",
         ),
+        CheckConstraint(
+            "hashed_password IS NOT NULL OR privy_did IS NOT NULL",
+            name="users_auth_method_check",
+        ),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
     username: Mapped[str] = mapped_column(String(100), unique=True, nullable=False, index=True)
-    hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)
+    hashed_password: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     role: Mapped[str] = mapped_column(String(20), nullable=False, default=UserRole.VIEWER.value)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -228,7 +228,9 @@ def change_password(
     Change the current user's password.
     """
     # Verify current password
-    if not AuthService.verify_password(request.current_password, user.hashed_password):
+    if not user.hashed_password or not AuthService.verify_password(
+        request.current_password, user.hashed_password
+    ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Current password is incorrect",

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -210,7 +210,7 @@ class AuthService:
             return None
         if not user.is_active:
             return None
-        if not cls.verify_password(password, user.hashed_password):
+        if not user.hashed_password or not cls.verify_password(password, user.hashed_password):
             return None
         return user
 

--- a/backend/tests/test_user_auth_method_check.py
+++ b/backend/tests/test_user_auth_method_check.py
@@ -1,0 +1,105 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_user_auth_method_check.py
+"""users_auth_method_check CHECK 制約の挙動検証テスト。
+
+GID 1214176336328111 で導入。
+
+検証観点:
+1. hashed_password / privy_did 両方 NULL → IntegrityError
+2. hashed_password のみ設定 → 正常 INSERT
+3. privy_did のみ設定 → 正常 INSERT
+"""
+
+import os
+import tempfile
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-auth-method-check")
+
+from app.auth.models import User  # noqa: E402
+from app.database import Base  # noqa: E402
+
+_INSERT_SQL = (
+    "INSERT INTO users "
+    "(email, username, role, is_active, notification_frequency, user_mode, "
+    "execution_policy, tier, created_at, updated_at, hashed_password, privy_did) "
+    "VALUES "
+    "(:email, :username, 'viewer', 1, 'important', 'managed', "
+    "'auto_execute', 'LOWER', datetime('now'), datetime('now'), :hashed_pw, :privy_did)"
+)
+
+
+@pytest.fixture()
+def test_db():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield engine, SessionLocal
+    Base.metadata.drop_all(bind=engine)
+    os.unlink(path)
+
+
+def test_both_null_raises_integrity_error(test_db) -> None:
+    """hashed_password と privy_did が両方 NULL なら CHECK 制約で IntegrityError。"""
+    engine, _ = test_db
+    with engine.begin() as conn:
+        with pytest.raises(IntegrityError, match="users_auth_method_check"):
+            conn.execute(
+                text(_INSERT_SQL),
+                {
+                    "email": "both_null@example.com",
+                    "username": "both_null",
+                    "hashed_pw": None,
+                    "privy_did": None,
+                },
+            )
+
+
+def test_hashed_password_only_succeeds(test_db) -> None:
+    """hashed_password のみ設定（privy_did=NULL）で INSERT 成功。"""
+    _, SessionLocal = test_db
+    session = SessionLocal()
+    try:
+        user = User(
+            email="pw_only@example.com",
+            username="pw_only",
+            hashed_password="$2b$12$hashed_password_value",
+            privy_did=None,
+        )
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+        assert user.hashed_password is not None
+        assert user.privy_did is None
+    finally:
+        session.close()
+
+
+def test_privy_did_only_succeeds(test_db) -> None:
+    """privy_did のみ設定（hashed_password=NULL）で INSERT 成功。"""
+    engine, _ = test_db
+    with engine.begin() as conn:
+        conn.execute(
+            text(_INSERT_SQL),
+            {
+                "email": "privy_only@example.com",
+                "username": "privy_only",
+                "hashed_pw": None,
+                "privy_did": "did:privy:test_abc123",
+            },
+        )
+        row = conn.execute(
+            text(
+                "SELECT hashed_password, privy_did FROM users "
+                "WHERE email = 'privy_only@example.com'"
+            )
+        ).fetchone()
+        assert row is not None
+        assert row[0] is None
+        assert row[1] == "did:privy:test_abc123"


### PR DESCRIPTION
## Summary
- `users` テーブルに `CHECK (hashed_password IS NOT NULL OR privy_did IS NOT NULL)` 制約を追加
- Privy-only ユーザーをサポートするため `hashed_password` を nullable 化（`Optional[str]`）
- `service.py` / `router.py` に `hashed_password=None` 時の None ガード追加（mypy 対応）
- Alembic migration: `a0b1c2d3e4f5`（ALTER COLUMN DROP NOT NULL + ADD CONSTRAINT）

## Scope
- staging-new への migration 適用済み（2026-05-02）
- production への適用は山本さん観察明け後、別途実施

## Test plan
- [ ] `test_user_auth_method_check.py` — 3 ケース（両方 NULL → IntegrityError / hashed_password のみ → 成功 / privy_did のみ → 成功）
- [ ] 全体 pytest: 2700 passed, coverage 85%
- [ ] ruff check / ruff format / mypy: エラー 0

Closes Asana GID 1214176336328111

🤖 Generated with [Claude Code](https://claude.com/claude-code)