### PR TITLE
feat(auth): separate admin login route to /admin/login

### DIFF
--- a/frontend/app/admin/login/page.tsx
+++ b/frontend/app/admin/login/page.tsx
@@ -1,0 +1,216 @@
+'use client'
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+
+// frontend/app/admin/login/page.tsx
+//
+// 管理者専用ログインページ (/admin/login)。
+// /login (汎用) からの分離。設計仕様書 §1.1「管理者=メール/PW、ユーザー=ウォレット」に準拠。
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useEffect, FormEvent, Suspense } from "react";
+import Script from "next/script";
+import { useAuth, AuthProvider } from "@/lib/auth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertCircle, ShieldCheck } from "lucide-react";
+
+const RECAPTCHA_SITE_KEY = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY ?? "";
+
+interface GrecaptchaWindow {
+  grecaptcha?: {
+    ready: (cb: () => void) => void;
+    execute: (siteKey: string, options: { action: string }) => Promise<string>;
+  };
+}
+
+function getSafeRedirect(redirect: string | null): string {
+  const defaultPath = "/dashboard";
+  if (!redirect) return defaultPath;
+  if (redirect.startsWith("/") && !redirect.startsWith("//")) return redirect;
+  return defaultPath;
+}
+
+async function getRecaptchaToken(): Promise<string | null> {
+  if (!RECAPTCHA_SITE_KEY) return null;
+  if (typeof window === "undefined") return null;
+  const w = window as unknown as GrecaptchaWindow;
+  if (!w.grecaptcha) return null;
+  return new Promise<string | null>((resolve) => {
+    w.grecaptcha!.ready(() => {
+      w.grecaptcha!
+        .execute(RECAPTCHA_SITE_KEY, { action: "admin_login" })
+        .then((token) => resolve(token))
+        .catch(() => resolve(null));
+    });
+  });
+}
+
+function AdminLoginForm() {
+  const { login, logout, isAuthenticated, isLoading, isAdmin, user } = useAuth();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const redirectParam = searchParams.get("redirect");
+
+  useEffect(() => {
+    if (isLoading) return;
+    if (isAuthenticated && isAdmin) {
+      const dest = redirectParam ? getSafeRedirect(redirectParam) : "/dashboard";
+      router.replace(dest);
+    }
+  }, [isAuthenticated, isAdmin, isLoading, redirectParam, router]);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      // reCAPTCHA v3 トークン取得 (サイトキー未設定時はスキップ)。
+      // 取得した token はバックエンドが将来検証する想定 (現状は理論的足場)。
+      await getRecaptchaToken();
+
+      const loggedInUser = await login(email, password);
+
+      if (loggedInUser.role !== "admin") {
+        // 管理者以外でログインを試みた場合は即ログアウトしてエラー表示。
+        await logout();
+        setError("このページは管理者専用です。一般ユーザーはトップページからアクセスしてください。");
+        return;
+      }
+
+      const dest = redirectParam ? getSafeRedirect(redirectParam) : "/dashboard";
+      router.replace(dest);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "ログインに失敗しました";
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-muted-foreground">読み込み中...</p>
+      </div>
+    );
+  }
+
+  // 既に管理者でログイン済みなら useEffect でリダイレクト済み。
+  // それ以外 (未ログイン or 非管理者) はフォームを表示する。
+  if (isAuthenticated && isAdmin) {
+    return null;
+  }
+
+  // 非管理者で既にログイン中の場合: フォーム上部に切り替え案内を表示。
+  const wrongRoleNotice =
+    isAuthenticated && user?.role && user.role !== "admin"
+      ? `現在 ${user.role} ロールでログイン中です。管理者で再ログインするか、トップページに戻ってください。`
+      : null;
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-muted/40 p-4">
+      {RECAPTCHA_SITE_KEY ? (
+        <Script
+          src={`https://www.google.com/recaptcha/api.js?render=${RECAPTCHA_SITE_KEY}`}
+          strategy="afterInteractive"
+        />
+      ) : null}
+      <Card className="w-full max-w-sm" data-testid="admin-login-card">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+            <ShieldCheck className="h-5 w-5 text-primary" />
+          </div>
+          <CardTitle className="text-2xl">管理者ログイン</CardTitle>
+          <CardDescription>Ultra AutoTrade 運用ダッシュボード</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {wrongRoleNotice ? (
+            <Alert className="mb-4" data-testid="admin-login-wrong-role">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{wrongRoleNotice}</AlertDescription>
+            </Alert>
+          ) : null}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {error && (
+              <Alert variant="destructive" data-testid="admin-login-error">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="admin-email">メールアドレス</Label>
+              <Input
+                id="admin-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoComplete="email"
+                disabled={submitting}
+                placeholder="admin@example.com"
+                data-testid="admin-login-email"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="admin-password">パスワード</Label>
+              <Input
+                id="admin-password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                autoComplete="current-password"
+                disabled={submitting}
+                data-testid="admin-login-password"
+              />
+            </div>
+
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={submitting}
+              data-testid="admin-login-submit"
+            >
+              {submitting ? "ログイン中..." : "管理者としてログイン"}
+            </Button>
+          </form>
+
+          <p className="mt-6 text-center text-xs text-muted-foreground">
+            このページは管理者専用です。一般ユーザーは{" "}
+            <a href="/" className="underline">トップページ</a>
+            {" "}からアクセスしてください。
+          </p>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}
+
+export default function AdminLoginPage() {
+  return (
+    <AuthProvider>
+      <title>管理者ログイン - Ultra AutoTrade</title>
+      <Suspense
+        fallback={
+          <div className="flex min-h-screen items-center justify-center">
+            <p className="text-muted-foreground">読み込み中...</p>
+          </div>
+        }
+      >
+        <AdminLoginForm />
+      </Suspense>
+    </AuthProvider>
+  );
+}

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -141,6 +141,15 @@ function LoginForm() {
           <p className="mt-6 text-center text-xs text-muted-foreground">
             初期設定が必要な場合は管理者にお問い合わせください。
           </p>
+          <p className="mt-2 text-center text-xs text-muted-foreground">
+            <a
+              href="/admin/login"
+              className="underline hover:text-foreground"
+              data-testid="login-admin-link"
+            >
+              管理者の方はこちら
+            </a>
+          </p>
         </CardContent>
       </Card>
     </main>

--- a/frontend/components/providers/AdminProviders.tsx
+++ b/frontend/components/providers/AdminProviders.tsx
@@ -14,7 +14,7 @@ function AdminGuard({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (isLoading) return
     if (!isAuthenticated) {
-      router.replace('/login')
+      router.replace('/admin/login')
       return
     }
     if (!isAdmin) {

--- a/frontend/e2e/admin-login-separation.spec.ts
+++ b/frontend/e2e/admin-login-separation.spec.ts
@@ -1,0 +1,155 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+//
+// Asana 1214162094588652: 管理者 /admin/login 分離 E2E
+//
+// 目的:
+//   - /admin/login が独立した管理者専用ログインページとして機能すること
+//   - /admin/* (e.g. /dashboard) アクセス時に未認証なら /admin/login にリダイレクトされること
+//   - 不正な credential で 401 + エラー表示
+//   - 管理者 credential で /dashboard にリダイレクトされること (任意、E2E_ADMIN_* 設定時のみ)
+//   - 一般ユーザー (partner/viewer) credential では /dashboard にアクセスできないこと
+//   - /login に「管理者の方はこちら」リンクが存在し /admin/login に飛ぶこと
+//
+// 実行方法:
+//   # 本番向け (デフォルト)
+//   npx playwright test e2e/admin-login-separation.spec.ts
+//
+//   # staging 向け
+//   STAGING_URL=https://staging.ultra-auto-trade.com \
+//   npx playwright test e2e/admin-login-separation.spec.ts
+//
+// 認証: ベースのテストは未認証で動作する。フル認証フローは
+//   E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD が設定されている場合のみ実行。
+
+import { test, expect } from '@playwright/test'
+
+const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL
+const ADMIN_PASSWORD = process.env.E2E_ADMIN_PASSWORD
+const PARTNER_EMAIL = process.env.E2E_PARTNER_EMAIL
+const PARTNER_PASSWORD = process.env.E2E_PARTNER_PASSWORD
+
+test.describe('/admin/login — ページ表示と基本構造', () => {
+  test('/admin/login が 200 で読み込める', async ({ page }) => {
+    const response = await page.goto('/admin/login')
+    expect(response?.status()).toBe(200)
+  })
+
+  test('/admin/login に email/password フォームが表示される', async ({ page }) => {
+    await page.goto('/admin/login')
+    await page.waitForLoadState('domcontentloaded')
+
+    await expect(page.getByTestId('admin-login-card')).toBeVisible()
+    await expect(page.getByTestId('admin-login-email')).toBeVisible()
+    await expect(page.getByTestId('admin-login-password')).toBeVisible()
+    await expect(page.getByTestId('admin-login-submit')).toBeVisible()
+  })
+
+  test('/admin/login にタイトル「管理者ログイン」が表示される', async ({ page }) => {
+    await page.goto('/admin/login')
+    await page.waitForLoadState('domcontentloaded')
+
+    await expect(page.getByText('管理者ログイン').first()).toBeVisible()
+  })
+})
+
+test.describe('/admin/login — エラー処理', () => {
+  test('不正な credential でエラーメッセージが表示される', async ({ page }) => {
+    await page.goto('/admin/login')
+    await page.waitForLoadState('domcontentloaded')
+
+    await page.getByTestId('admin-login-email').fill('not-a-real-user@example.invalid')
+    await page.getByTestId('admin-login-password').fill('definitely-wrong-password')
+    await page.getByTestId('admin-login-submit').click()
+
+    // エラー表示は最大 10s 待つ (バックエンド rate limit / network 起因の遅延を許容)
+    await expect(page.getByTestId('admin-login-error')).toBeVisible({ timeout: 10_000 })
+  })
+})
+
+test.describe('/admin/* — 未認証ロール check', () => {
+  test('未認証で /dashboard にアクセスすると /admin/login へリダイレクトされる', async ({ page }) => {
+    // localStorage を確実にクリアして未認証状態を作る
+    await page.goto('/admin/login')
+    await page.evaluate(() => {
+      localStorage.removeItem('ultra_auth_token')
+      localStorage.removeItem('ultra_auth_expires')
+    })
+
+    await page.goto('/dashboard')
+    await page.waitForLoadState('domcontentloaded')
+
+    // AdminGuard の useEffect は client-side リダイレクトのため少し待つ
+    await page.waitForURL(/\/admin\/login/, { timeout: 10_000 }).catch(() => {})
+
+    expect(page.url()).toContain('/admin/login')
+  })
+})
+
+test.describe('/login — 管理者の方はこちらリンク', () => {
+  test('/login に「管理者の方はこちら」リンクが存在する', async ({ page }) => {
+    await page.goto('/login')
+    await page.waitForLoadState('domcontentloaded')
+
+    const adminLink = page.getByTestId('login-admin-link')
+    await expect(adminLink).toBeVisible()
+    await expect(adminLink).toHaveText(/管理者の方はこちら/)
+  })
+
+  test('「管理者の方はこちら」リンクが /admin/login に飛ぶ', async ({ page }) => {
+    await page.goto('/login')
+    await page.waitForLoadState('domcontentloaded')
+
+    await page.getByTestId('login-admin-link').click()
+    await page.waitForURL(/\/admin\/login/, { timeout: 10_000 })
+
+    expect(page.url()).toContain('/admin/login')
+    await expect(page.getByTestId('admin-login-card')).toBeVisible()
+  })
+})
+
+// ----------------------------------------------------------------
+// 認証フローテスト (E2E_ADMIN_* / E2E_PARTNER_* 設定時のみ)
+// ----------------------------------------------------------------
+
+test.describe('/admin/login — 認証フロー (credentials 設定時のみ)', () => {
+  test('正規 admin credential で /dashboard にリダイレクトされる', async ({ page }) => {
+    test.skip(
+      !ADMIN_EMAIL || !ADMIN_PASSWORD,
+      'E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD 未設定のためスキップ',
+    )
+
+    await page.goto('/admin/login')
+    await page.waitForLoadState('domcontentloaded')
+
+    await page.getByTestId('admin-login-email').fill(ADMIN_EMAIL!)
+    await page.getByTestId('admin-login-password').fill(ADMIN_PASSWORD!)
+    await page.getByTestId('admin-login-submit').click()
+
+    await page.waitForURL(/\/dashboard($|\?)/, { timeout: 15_000 })
+    expect(page.url()).toContain('/dashboard')
+    expect(page.url()).not.toContain('/admin/login')
+  })
+
+  test('一般ユーザー (partner) credential では admin としてログインできない', async ({ page }) => {
+    test.skip(
+      !PARTNER_EMAIL || !PARTNER_PASSWORD,
+      'E2E_PARTNER_EMAIL / E2E_PARTNER_PASSWORD 未設定のためスキップ',
+    )
+
+    await page.goto('/admin/login')
+    await page.waitForLoadState('domcontentloaded')
+
+    await page.getByTestId('admin-login-email').fill(PARTNER_EMAIL!)
+    await page.getByTestId('admin-login-password').fill(PARTNER_PASSWORD!)
+    await page.getByTestId('admin-login-submit').click()
+
+    // 期待動作: ログイン自体は成功するが role !== admin のため即ログアウト + エラー表示。
+    // フォームは /admin/login に残ったまま。
+    await expect(page.getByTestId('admin-login-error')).toBeVisible({ timeout: 15_000 })
+    expect(page.url()).toContain('/admin/login')
+
+    const errorText = await page.getByTestId('admin-login-error').textContent()
+    expect(errorText ?? '').toMatch(/管理者専用|admin/i)
+  })
+})


### PR DESCRIPTION
## Summary
- 管理者専用ログインを `/admin/login` に新設 (UI 設計仕様書 §1.1「管理者=メール/PW、ユーザー=ウォレット」二系統分離の前段)
- `(admin)` 配下の AdminGuard を `/admin/login` リダイレクトに切り替え。`/login` はフッターから `/admin/login` への移行リンクを表示
- reCAPTCHA v3 足場を追加 (`NEXT_PUBLIC_RECAPTCHA_SITE_KEY` 設定時のみ起動、未設定なら fallback でスキップ)
- 一般ユーザー (role !== `admin`) が `/admin/login` でログインに成功した場合は即ログアウト + エラー表示

Asana: [GID 1214162094588652](https://app.asana.com/0/1213880674050095/1214162094588652)

## 設計判断: 選択肢A (/admin/login 新設)
notes 記載の選択肢 A を採用。理由は「設計書に忠実」「IPホワイトリストでの恒久分離」。
IPホワイトリスト (Cloudflare Zero Trust) は別タスク [GID 1214118619733935] で対応予定。

## 変更ファイル
- `frontend/app/admin/login/page.tsx` (新規)
- `frontend/app/login/page.tsx` (フッターリンク追加)
- `frontend/components/providers/AdminProviders.tsx` (リダイレクト先変更)
- `frontend/e2e/admin-login-separation.spec.ts` (新規, 9 tests)

## ローカル検証
- `npx tsc --noEmit`: pass
- `npm run build`: pass (`/admin/login` 10.3 kB)
- E2E (localhost:3000, Desktop Chrome): **7 passed / 2 skipped** (skip は `E2E_ADMIN_*` / `E2E_PARTNER_*` 設定時のみ実行する認証フロー系)

## staging-new 検証
- `feature/admin-login-separation` を staging に checkout し frontend を再ビルド
- 新規 E2E をリモート baseURL で再実行 → green 確認 (PR コメント参照)

## Test plan
- [x] `frontend/app/admin/login/page.tsx` がレンダリングされる
- [x] `/login` 「管理者の方はこちら」リンクが `/admin/login` に飛ぶ
- [x] 不正 credential で `data-testid=admin-login-error` が表示される
- [x] 未認証 `/dashboard` → `/admin/login` リダイレクト
- [ ] 山本さん観察明け後: F (PR #180 /connect 統一) と同セットで main マージ + production deploy

## 関連
- F (PR #180): `/connect` 統一、本日 PR 起票完了 (山本さん観察明け後にまとめて main マージ予定)
- IPホワイトリスト: GID 1214118619733935

🤖 Generated with [Claude Code](https://claude.com/claude-code)