### PR TITLE
feat(e2e): support staging URL via Cloudflare Access service token

### DIFF
--- a/docs/14_test_strategy.md
+++ b/docs/14_test_strategy.md
@@ -352,6 +352,15 @@ PR マージ前に、既存機能が壊れていないことを担保する。
    > **Playwright実行方法:**
    > - 本番URL対象（デフォルト）: `cd frontend && npx playwright test`
    > - ローカル開発サーバー対象: `npm run dev` を起動後、`STAGING_URL=http://localhost:3000 npx playwright test`
+   > - staging URL対象（CF Accessトークン必須）:
+   >   ```bash
+   >   STAGING_URL=https://app-staging.ultra-auto-trade.com \
+   >   CF_ACCESS_CLIENT_ID=<service-token-id> \
+   >   CF_ACCESS_CLIENT_SECRET=<service-token-secret> \
+   >   npx playwright test
+   >   ```
+   >   CF Accessトークンの発行: Cloudflare Dashboard > Access > Service Auth > Service Tokens
+   >   バックエンドもCF Access配下の場合は `NEXT_PUBLIC_BACKEND_BASE_URL=https://api-staging.ultra-auto-trade.com` も指定
    > - 77.42.46.155 直IPはproduction.ymlで127.0.0.1バインド済みのため接続拒否される（正常動作）
 
 5. **孤立コード検出（手動トリガー）** — PR作成前。安全装置・リスク管理の配線漏れ検出。大量タスク一括完了後は必須

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -46,3 +46,12 @@ NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your_walletconnect_project_id_here
 NEXT_PUBLIC_DEFAULT_CHAIN=arbitrum-sepolia
 NEXT_PUBLIC_ARBITRUM_SEPOLIA_RPC=https://arb-sepolia.g.alchemy.com/v2/YOUR_ALCHEMY_KEY
 NEXT_PUBLIC_ARBITRUM_ONE_RPC=https://arb1.arbitrum.io/rpc
+
+# =============================================================================
+# Cloudflare Access Service Token (Playwright E2E — staging URL 対象時のみ)
+# =============================================================================
+# CF Dashboard で「Access > Service Auth > Service Tokens」から発行
+# staging URL (STAGING_URL=https://app-staging.ultra-auto-trade.com) で
+# E2E を実行する場合のみ設定が必要。本番URL対象の E2E では未設定でOK。
+CF_ACCESS_CLIENT_ID=
+CF_ACCESS_CLIENT_SECRET=

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -20,9 +20,17 @@ export default async function globalSetup(): Promise<void> {
   const backendUrl =
     process.env.NEXT_PUBLIC_BACKEND_BASE_URL ?? 'https://api.ultra-auto-trade.com'
 
+  const cfHeaders: Record<string, string> =
+    process.env.CF_ACCESS_CLIENT_ID && process.env.CF_ACCESS_CLIENT_SECRET
+      ? {
+          'CF-Access-Client-Id': process.env.CF_ACCESS_CLIENT_ID,
+          'CF-Access-Client-Secret': process.env.CF_ACCESS_CLIENT_SECRET,
+        }
+      : {}
+
   const res = await fetch(`${backendUrl}/auth/login`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...cfHeaders },
     body: JSON.stringify({ email, password }),
   })
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,6 +1,14 @@
 // Copyright (c) 2026 Ultra AutoTrade. All rights reserved.
 import { defineConfig, devices } from '@playwright/test'
 
+const cfAccessHeaders: Record<string, string> =
+  process.env.CF_ACCESS_CLIENT_ID && process.env.CF_ACCESS_CLIENT_SECRET
+    ? {
+        'CF-Access-Client-Id': process.env.CF_ACCESS_CLIENT_ID,
+        'CF-Access-Client-Secret': process.env.CF_ACCESS_CLIENT_SECRET,
+      }
+    : {}
+
 export default defineConfig({
   globalSetup: require.resolve('./e2e/global-setup'),
   testDir: './e2e',
@@ -15,6 +23,7 @@ export default defineConfig({
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'off',
+    extraHTTPHeaders: cfAccessHeaders,
   },
   projects: [
     {


### PR DESCRIPTION
## Summary

- `playwright.config.ts`: `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` が設定されている場合のみ `extraHTTPHeaders` に CF Access ヘッダーを付与
- `e2e/global-setup.ts`: `/auth/login` fetch にも同ヘッダーを追加（staging CF Access 経由ログインに対応）
- `frontend/.env.local.example`: CF Access トークン変数を追加（コメント付き）
- `docs/14_test_strategy.md` §10 Gate 4: staging URL での E2E 実行手順を追記

**互換性:** 両変数とも未設定の場合はヘッダー追加なし → 本番 URL E2E は変更なしで動作

**スコープ:** Phase 2 (config + docs) のみ。Phase 1 (CF Dashboard でのサービストークン発行) と Phase 3 (staging URL での動作確認) はユーザーが手動で実施。

## Test plan

- [x] `npx tsc --noEmit` — 型エラーなし
- [x] `./scripts/verify.sh` — Gate 1-7 全通過 (2697 passed, coverage 85%, build OK)
- [ ] Phase 1: CF Dashboard > Access > Service Auth > Service Tokens でトークン発行（ユーザー手動）
- [ ] Phase 3: `STAGING_URL=https://app-staging.ultra-auto-trade.com CF_ACCESS_CLIENT_ID=xxx CF_ACCESS_CLIENT_SECRET=yyy npx playwright test` で動作確認（ユーザー手動）

## Asana

GID: 1214280530443990 — Phase 2 完了。Phase 1/3 は引継ぎ事項参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)