### PR TITLE
fix(ci/security): resolve Trivy pip CVE root cause (Approach A+B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,7 @@ jobs:
           output: trivy-backend.sarif
           severity: CRITICAL,HIGH
           exit-code: '0'
+          limit-severities-for-sarif: true
 
       - name: Trivy filesystem scan (frontend)
         uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8  # v0.24.0
@@ -209,6 +210,7 @@ jobs:
           output: trivy-frontend.sarif
           severity: CRITICAL,HIGH
           exit-code: '0'
+          limit-severities-for-sarif: true
 
       - name: Build Docker image for scanning
         run: docker build -t ultra-autotrade:ci -f Dockerfile .
@@ -223,6 +225,7 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           trivyignores: .trivyignore
+          limit-severities-for-sarif: true
 
       - name: Upload Trivy backend scan results
         if: always()

--- a/.trivyignore
+++ b/.trivyignore
@@ -10,12 +10,3 @@ GHSA-h25m-26qc-wcjf
 # Next.js 14→15 upgrade tracked as Asana 1214129072009759 (due 2026-05-31)
 # Temporary suppression until upgrade is completed
 GHSA-q4gf-8mx6-v5v3
-
-# pip 24.0 MEDIUM/LOW CVEs in python:3.11-slim base image
-# Root cause: trivy-action uses limit-severities-for-sarif=false (default), so
-# SARIF output includes all severities and exit-code=1 triggers on ANY result.
-# These are MEDIUM/LOW severity and do not affect the running application.
-# Proper fix: upgrade pip in Dockerfile runtime stage OR set
-# limit-severities-for-sarif: true in ci.yml (tracked separately).
-CVE-2025-8869
-CVE-2026-1703

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ RUN apt-get update && apt-get upgrade -y --no-install-recommends \
 
 # builder の wheel をコピーしてインストール（ネットワーク不要）
 COPY --from=builder /wheels /wheels
-RUN pip install --no-cache-dir --no-index --find-links /wheels /wheels/*.whl \
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir --no-index --find-links /wheels /wheels/*.whl \
     && rm -rf /wheels
 
 # アプリケーションコードをコピー（Cythonコンパイル済み成果物を含む）


### PR DESCRIPTION
## Summary

- **Approach A**: `Dockerfile` runtime stage に `pip install --upgrade pip` を追加し、CVE-2025-8869 / CVE-2026-1703 をイメージから根本排除
- **Approach B**: CI の全 Trivy ステップに `limit-severities-for-sarif: true` を追加し、SARIF 出力を CRITICAL/HIGH のみに制限
- `.trivyignore` から pip CVE 2件（CVE-2025-8869, CVE-2026-1703）とその暫定コメントを削除

## 背景

`pip 24.0`（`python:3.11-slim` ベースイメージ同梱）に MEDIUM/LOW CVE が存在し、Trivy イメージスキャンが `exit-code: 1` で fail していた。根本原因: `limit-severities-for-sarif` のデフォルト `false` により SARIF が全 severity を含み、CI が MEDIUM/LOW にも反応していた。

## 関連

- Asana GID: 1214129562453840
- 元タスク: GID 1214120548802540 (CI 既存失敗3件)

## Test plan

- [x] `ruff check .` — 0 errors
- [x] `ruff format --check .` — 0 violations
- [x] `mypy app/ --config-file ../pyproject.toml` — 0 errors (234 files)
- [x] `pytest tests/ --cov=app --cov-fail-under=80` — 2697 passed, 85.08% coverage
- [ ] CI Trivy スキャンが pip MEDIUM/LOW で fail しないこと（PR 起票後の CI 結果で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)