### PR TITLE
[hotfix] frontend chain check & display: Sepolia -> Mainnet (production P0)

### DIFF
--- a/frontend/app/(user)/connect/page.tsx
+++ b/frontend/app/(user)/connect/page.tsx
@@ -17,11 +17,13 @@ type UserMode = 'managed' | 'active' | 'pro'
 
 const USER_MODE_STORAGE_KEY = 'ultra_user_mode'
 
-// Base Sepolia (testnet only)
-const SUPPORTED_CHAIN_IDS = [84532]
+// Default chain id is env-driven (2026-05-01: mainnet switch). 8453 = Base Mainnet, 84532 = Base Sepolia.
+const DEFAULT_CHAIN_ID = parseInt(process.env.NEXT_PUBLIC_DEFAULT_CHAIN_ID || '8453', 10)
+const SUPPORTED_CHAIN_IDS = [DEFAULT_CHAIN_ID]
 
 const CHAIN_DISPLAY_NAMES: Record<number, string> = {
   84532: 'Base Sepolia',
+  8453: 'Base メインネット',
 }
 
 function getNetworkDisplayName(chainId: number | null): string {
@@ -218,16 +220,16 @@ export default function ConnectPage() {
                     <div className="flex items-start gap-2">
                       <AlertTriangle className="h-5 w-5 text-yellow-400 shrink-0 mt-0.5" />
                       <p className="text-sm text-yellow-300">
-                        Base Sepoliaに切り替えてください
+                        {CHAIN_DISPLAY_NAMES[DEFAULT_CHAIN_ID] ?? `Chain ${DEFAULT_CHAIN_ID}`}に切り替えてください
                       </p>
                     </div>
                     <Button
                       variant="outline"
                       size="sm"
                       className="w-full border-blue-600 text-blue-400 hover:bg-blue-950/40"
-                      onClick={() => wallet?.switchChain(84532)}
+                      onClick={() => wallet?.switchChain(DEFAULT_CHAIN_ID)}
                     >
-                      Base Sepolia (テスト用) に切り替える
+                      {CHAIN_DISPLAY_NAMES[DEFAULT_CHAIN_ID] ?? `Chain ${DEFAULT_CHAIN_ID}`} に切り替える
                     </Button>
                   </div>
                 )}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -61,12 +61,12 @@ const faqItems = [
   {
     question: '対応ウォレットは何ですか？',
     answer:
-      'MetaMask、WalletConnect対応ウォレットに対応予定です。Base Sepoliaネットワークへの接続が必要です（テストネット）。',
+      'MetaMask、WalletConnect対応ウォレットに対応予定です。Base メインネットへの接続が必要です。',
   },
   {
     question: 'どのチェーン・プロトコルに対応していますか？',
     answer:
-      'Base Sepolia上のAave V3に対応しています（テストネット）。今後、Base Mainnetや他のチェーンへの対応も検討しています。',
+      'Base メインネット上のAave V3に対応しています。今後、他のチェーンへの対応も検討しています。',
   },
 ]
 
@@ -133,7 +133,7 @@ export default function LandingPage() {
             対応プロトコル・チェーン
           </h2>
           <div className="flex flex-wrap justify-center gap-4">
-            {['Aave V3', 'Base Sepolia'].map((label) => (
+            {['Aave V3', 'Base メインネット'].map((label) => (
               <span
                 key={label}
                 className="inline-flex items-center rounded-full border border-blue-500/40 bg-blue-500/10 px-5 py-2 text-sm font-medium text-blue-300"

--- a/frontend/app/user/page.tsx
+++ b/frontend/app/user/page.tsx
@@ -14,7 +14,7 @@ const steps = [
     number: 1,
     icon: Wallet,
     title: 'ウォレットを接続',
-    description: 'MetaMask / WalletConnect 対応ウォレットをBase Sepoliaネットワークに接続',
+    description: 'MetaMask / WalletConnect 対応ウォレットをBase メインネットに接続',
   },
   {
     number: 2,
@@ -60,7 +60,7 @@ export default function LandingPage() {
               Aave V3
             </Badge>
             <Badge variant="outline" className="text-indigo-400 border-indigo-400/50">
-              Base Sepolia
+              Base メインネット
             </Badge>
           </div>
         </div>

--- a/frontend/app/user/wallet/WalletContent.tsx
+++ b/frontend/app/user/wallet/WalletContent.tsx
@@ -14,7 +14,8 @@ export function WalletContent() {
   const { address, isConnected, chain } = useAccount()
   const { data: balance } = useBalance({ address })
   const { disconnect } = useDisconnect()
-  const ALLOWED_CHAIN_IDS = [84532]
+  const defaultChainId = parseInt(process.env.NEXT_PUBLIC_DEFAULT_CHAIN_ID || '8453', 10)
+  const ALLOWED_CHAIN_IDS = [defaultChainId]
   const isCorrectChain = chain?.id != null && ALLOWED_CHAIN_IDS.includes(chain.id)
 
   if (!isConnected) {
@@ -26,7 +27,7 @@ export function WalletContent() {
           </CardHeader>
           <CardContent className="space-y-3 text-sm text-muted-foreground">
             <Step num={1} text="MetaMask または WalletConnect 対応ウォレットを準備" />
-            <Step num={2} text="Base Sepolia ネットワークを追加・切り替え" />
+            <Step num={2} text="Base メインネットを追加・切り替え" />
             <Step num={3} text="下のボタンからウォレットを接続" />
           </CardContent>
         </Card>
@@ -68,7 +69,7 @@ export function WalletContent() {
           <AlertTriangle className="h-4 w-4" />
           <AlertTitle>ネットワークが違います</AlertTitle>
           <AlertDescription>
-            Base Sepolia ネットワークに切り替えてください。現在: {chain?.name ?? '不明'}
+            Base メインネットに切り替えてください。現在: {chain?.name ?? '不明'}
           </AlertDescription>
         </Alert>
       )}

--- a/frontend/app/user/wallet/page.tsx
+++ b/frontend/app/user/wallet/page.tsx
@@ -13,7 +13,7 @@ export default function WalletPage() {
       <div>
         <h1 className="text-2xl font-bold">ウォレット接続</h1>
         <p className="text-sm text-muted-foreground mt-1">
-          Base Sepolia ネットワークに接続してください
+          Base メインネットに接続してください
         </p>
       </div>
       <WalletContent />

--- a/frontend/lib/wallet/config.ts
+++ b/frontend/lib/wallet/config.ts
@@ -6,8 +6,8 @@ import { injected } from 'wagmi/connectors'
 
 export const projectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || ''
 
-// Default chain is Base Sepolia (testnet). Override via NEXT_PUBLIC_DEFAULT_CHAIN_ID.
-const defaultChainId = parseInt(process.env.NEXT_PUBLIC_DEFAULT_CHAIN_ID || '84532') // Base Sepolia
+// Default chain is Base メインネット (8453). Override via NEXT_PUBLIC_DEFAULT_CHAIN_ID. 84532 = Base Sepolia.
+const defaultChainId = parseInt(process.env.NEXT_PUBLIC_DEFAULT_CHAIN_ID || '8453')
 
 const allChains = [baseSepolia, base, arbitrum, optimism, mainnet] as const
 


### PR DESCRIPTION
## 概要
山本さんが本番運用停止中の P0 不具合を修正。

5/1 mainnet切替時、`PrivyRootClient.tsx` は env 駆動 (`NEXT_PUBLIC_DEFAULT_CHAIN_ID`) になったが、ダウンストリームのネットワークチェック (`connect/page.tsx` の `SUPPORTED_CHAIN_IDS`、`WalletContent.tsx` の `ALLOWED_CHAIN_IDS`) が **84532 (Sepolia) ハードコードのまま**残っていた。

結果、本番ユーザーが Base メインネット (8453) にウォレットを接続しても「ネットワークが違います / Base Sepoliaに切り替えてください」で弾かれ、ダッシュボードに到達できなかった。

ランディングの表示テキストも Sepolia 表記が残っており、これも併せて修正。

## 修正内容

### 1. テキスト修正 (ユーザー向け文言)
- `frontend/app/page.tsx` L64/L69/L136 — FAQ 2項目 + 対応プロトコルバッジ
- `frontend/app/user/page.tsx` L17/L63 — ステップ説明 + Powered-by バッジ
- `frontend/app/user/wallet/page.tsx` L16 — ヘッダーサブタイトル
- `frontend/app/user/wallet/WalletContent.tsx` L29/L71 — Step2 + チェーン不一致アラート

### 2. チェーンチェックロジックの env 駆動化 (本来の P0 ブロッカー)
- `frontend/app/(user)/connect/page.tsx`:
  - `SUPPORTED_CHAIN_IDS` を `NEXT_PUBLIC_DEFAULT_CHAIN_ID` から読む (default 8453)
  - `CHAIN_DISPLAY_NAMES` に `8453: 'Base メインネット'` を追加
  - `switchChain` / 警告 / ボタンテキストを動的化
- `frontend/app/user/wallet/WalletContent.tsx`:
  - `ALLOWED_CHAIN_IDS` を `NEXT_PUBLIC_DEFAULT_CHAIN_ID` から読む (default 8453)
- `frontend/lib/wallet/config.ts`:
  - フォールバック default を 84532 → 8453 に変更 (PrivyRootClient.tsx と整合)

## 検証 (Gate 1-3)
- `npm run lint` — pass (warning は既存分のみ)
- `npx tsc --noEmit` — pass
- `npm run build` — pass

## 既知のフォローアップ (別 PR で対応)
- `frontend/app/(user)/onboarding/page.tsx` は依然として Sepolia ChainList 検索 URL と SepoliaETH faucet リンクを参照しており、ラベル置換だけでは不十分 (mainnet 用に「実 ETH 購入」フローへ書き換えが必要)。本 hotfix では触らない。

## 緊急マージ理由
山本さん本番運用停止中、即 production deploy が必須。observation 待ちルールの例外として admin merge 申請。

## 影響範囲
- frontend のみ
- backend / .env.production は無変更
- `NEXT_PUBLIC_DEFAULT_CHAIN_ID=8453` が production env に既に設定されている前提 (2026-05-01 mainnet 切替時に設定済みのはず)。未設定でも default 8453 にフォールバックするため Mainnet で動作する

## 関連
- Asana: 1214462618475072
- 山本さん観察追跡: 1214449314259100

🤖 Generated with [Claude Code](https://claude.com/claude-code)