### PR TITLE
docs(mainnet): prevent Sepolia residual after chain switch (incident postmortem)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,3 +40,23 @@
 - 要件変更が含まれていないこと
 - フェーズ範囲外の作業をしていないこと
 - 仕様書（.md）が最新と一致していること
+
+---
+
+## チェーン設定関連 (チェーン関連の PR のみ)
+
+本 PR は **チェーン (mainnet/testnet) の切替** または **chain ID 設定** を含みますか?
+
+- [ ] いいえ (チェーン設定の変更なし)
+- [ ] はい — 以下のチェックを実施
+
+チェーン関連 PR の場合は以下を確認:
+- [ ] `grep -rn "Sepolia" frontend/` の出力をすべて確認・修正済み
+- [ ] `.env.production` の `NEXT_PUBLIC_*` チェーン設定を本番値に更新済み
+- [ ] `frontend/components/PrivyProvider.tsx` の chain config 確認済み
+- [ ] post-deploy `curl <production URL> | grep -i "sepolia"` で出力ゼロ確認済み
+- [ ] ブラウザで実機ランディング目視確認済み (スクリーンショット添付)
+
+参照:
+- docs/43_mainnet_wallet_switch_guide.md §2.5 (frontend 表示テキスト確認)
+- 2026-05-02 インシデント: Asana GID 1214462619161978

--- a/docs/43_mainnet_wallet_switch_guide.md
+++ b/docs/43_mainnet_wallet_switch_guide.md
@@ -224,6 +224,43 @@ curl -sf https://api.ultra-auto-trade.com/aave/status | python3 -m json.tool
 
 ---
 
+## 2.5 frontend 表示テキスト確認 (NEW — 2026-05-02 インシデント対策)
+
+> 2026-05-02 に `frontend/app/page.tsx` の "Base Sepolia" ハードコード残存が検出されなかったことに起因。
+> 技術設定 (env/RPC) のチェックに加え、**ユーザー目に触れる表示テキスト**も必ずチェックすること。
+
+### 2.5.1 コードベース grep チェック (デプロイ前必須)
+
+```bash
+grep -rn "Sepolia" frontend/app/ frontend/components/ frontend/lib/ \
+  | grep -v "__mocks__\|\.spec\.\|\.test\."
+
+grep -rn "テストネット\|testnet" frontend/app/ frontend/components/ \
+  | grep -v "__mocks__\|\.spec\."
+```
+
+期待: 出力ゼロ (mainnet 切替後)
+発見された場合: mainnet 表記に修正してから deploy すること
+
+### 2.5.2 post-deploy curl チェック (deploy 直後必須)
+
+```bash
+curl -s https://app.ultra-auto-trade.com 2>&1 | grep -iE "sepolia|テストネット"
+# 期待: 出力ゼロ
+
+curl -s https://app.ultra-auto-trade.com 2>&1 | grep -iE "メインネット|mainnet"
+# 期待: 複数箇所でヒット
+```
+
+### 2.5.3 ブラウザ目視確認 (deploy 直後推奨)
+
+以下を実機ブラウザで確認:
+- ランディング (/) の「対応プロトコル・チェーン」セクション → "Base メインネット" 表示
+- FAQ の「対応ウォレット」「対応チェーン・プロトコル」項目を展開し Sepolia 表記がないこと
+- スクリーンショットを `docs/images/mainnet_switch/` に保存し PR に添付
+
+---
+
 ## 5. 切替後監視 (24h)
 
 | 確認項目 | 方法 | 頻度 |

--- a/docs/lessons_learned/2026-05-02_mainnet_frontend_text_oversight.md
+++ b/docs/lessons_learned/2026-05-02_mainnet_frontend_text_oversight.md
@@ -1,0 +1,49 @@
+# Lesson Learned: 2026-05-02 mainnet 切替時の frontend 表示テキスト見落とし
+
+## サマリ
+
+2026-05-01 の Base Sepolia → Base Mainnet 切替時、backend env と RPC は移行されたが、
+`frontend/app/page.tsx` 内の "Base Sepolia" / "テストネット" ハードコード表記が残存し、
+山本さん (production tester) が「ネットワーク選択肢が testnet しかない」と報告 (2026-05-02 朝)。
+
+## 何が起きたか
+
+- 5/1 21:00 JST: backend mainnet 切替完了 (chain_id=8453, AAVE_NETWORK=base)
+- 5/1 20:31 JST: frontend image 再ビルド (mainnet build.args)
+- 5/1 22:30 JST: 山本さんに mainnet 切替完了 DM 送信
+- 5/2 朝: 山本さんから「ネットワークが Sepolia (testnet) のみ表示」報告
+- 原因: `frontend/app/page.tsx` に L64/L69/L136 の 3 箇所で "Base Sepolia" がハードコード
+
+## なぜ起きたか
+
+1. **docs/43_mainnet_wallet_switch_guide.md にユーザー表記チェックが完全欠落**
+   - 技術設定 (env / RPC / Pool address) のチェックリストはあった
+   - 「ユーザー目に触れる表示テキスト」のチェック項目がなかった
+
+2. **5/1 検証で「frontend HTML chain_id 表示なし = build-time 焼き込み想定通り」と誤判定**
+   - HTML レンダリング後のテキスト内容を `curl/grep` で確認していれば検出できた
+
+3. **既存 E2E テストが画面遷移・ボタン操作のみテスト、表記内容を検証していなかった**
+   - Gate 4 E2E 50/0 fail でも "Base Sepolia" 表記は通過した
+
+## どう防ぐか (本 PR の対応)
+
+- `docs/43` §2.5 に frontend 表示テキスト確認セクション新規追加
+- `scripts/verify.sh` に Gate 0 として chain config consistency check 追加
+- `frontend/e2e/landing-mainnet.spec.ts` 新規 (Sepolia 表記検出 E2E)
+- `.github/PULL_REQUEST_TEMPLATE.md` にチェーン関連チェックリスト追加
+
+## 教訓
+
+1. **「build-time 焼き込み = 確認不能」は誤った前提**: HTML curl で確認可能
+2. **Gate 4 E2E pass = 全て OK ではない**: 表記内容は別途検証必要
+3. **チェックリストは「技術設定」と「ユーザー表記」の 2 軸でカバーすべき**
+4. **chain ID の数値監視と画面表記テキスト監視は別レイヤー**
+
+## 関連
+
+- インシデント Asana: 1214462618475072
+- 再発防止 Asana (本タスク): 1214462619161978
+- 5/1 切替検証 (見落としタスク): 1214447554925211
+- 5/1 切替実装: 1214445769180837
+- docs/43: GID 1214115535703860

--- a/frontend/e2e/landing-mainnet.spec.ts
+++ b/frontend/e2e/landing-mainnet.spec.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+import { test, expect } from '@playwright/test';
+
+/**
+ * Production landing page chain text consistency check
+ *
+ * 2026-05-02 incident: frontend/app/page.tsx had hardcoded "Base Sepolia" text
+ * that was not detected by existing E2E tests during 5/1 mainnet switch.
+ *
+ * This test prevents recurrence by verifying the landing page does NOT show
+ * testnet text and DOES show mainnet text.
+ *
+ * Asana: GID 1214462619161978
+ */
+test.describe('ランディングページ チェーン表記一貫性チェック (mainnet)', () => {
+  test('Sepolia / テストネット 表記が含まれていない', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const html = await page.content();
+
+    expect(html, 'Landing page should not contain "Sepolia" text').not.toMatch(/Sepolia/i);
+    expect(html, 'Landing page should not contain "テストネット" text').not.toContain('テストネット');
+  });
+
+  test('メインネット / Mainnet 表記が含まれている', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const html = await page.content();
+
+    expect(
+      html,
+      'Landing page should contain "メインネット" or "Mainnet" text'
+    ).toMatch(/メインネット|Mainnet/i);
+  });
+
+  test('FAQ セクション: チェーン関連の表記に Sepolia がない', async ({ page }) => {
+    await page.goto('/');
+
+    const faqTrigger = page.getByRole('button', {
+      name: /対応チェーン|プロトコル/i,
+    });
+
+    if (await faqTrigger.isVisible()) {
+      await faqTrigger.click();
+
+      const faqContent = await page.locator('[role="region"]').textContent();
+      expect(faqContent, 'FAQ chain content should not mention Sepolia').not.toMatch(/Sepolia/i);
+    }
+  });
+});

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -19,6 +19,36 @@ fail() {
   exit 1
 }
 
+# ── Gate 0: Chain Config Consistency ─────────
+
+step "[0/7] Chain Config Consistency"
+if [ -f "$PROJECT_ROOT/.env.production" ]; then
+  CHAIN_ID=$(grep "^NEXT_PUBLIC_DEFAULT_CHAIN_ID=" "$PROJECT_ROOT/.env.production" 2>/dev/null | cut -d= -f2)
+  if [ "$CHAIN_ID" = "8453" ]; then
+    if grep -rn "Sepolia" \
+        "$PROJECT_ROOT/frontend/app/" \
+        "$PROJECT_ROOT/frontend/components/" \
+        "$PROJECT_ROOT/frontend/lib/" \
+        2>/dev/null \
+        | grep -v "__mocks__\|\.spec\.\|\.test\." > /tmp/sepolia_check.log 2>&1; then
+      echo "ERROR: Chain is mainnet (8453) but 'Sepolia' is hard-coded in frontend:"
+      cat /tmp/sepolia_check.log
+      echo ""
+      echo "Fix: Update the above files to use 'メインネット' or 'Mainnet'"
+      rm -f /tmp/sepolia_check.log
+      exit 1
+    fi
+    rm -f /tmp/sepolia_check.log
+    echo "✅ Gate 0 pass: No Sepolia hardcode in mainnet config"
+  elif [ "$CHAIN_ID" = "84532" ]; then
+    echo "ℹ Gate 0 skipped: Chain is Sepolia testnet (84532)"
+  else
+    echo "⚠ Gate 0 skipped: NEXT_PUBLIC_DEFAULT_CHAIN_ID not 8453 or 84532, value: '$CHAIN_ID'"
+  fi
+else
+  echo "⚠ Gate 0 skipped: .env.production not found (CI environment)"
+fi
+
 # ── Backend ──────────────────────────────────
 
 step "[1/7] ruff check"


### PR DESCRIPTION
## 背景
2026-05-02 朝、山本さんから production で 'Base Sepolia (testnet) のみ表示' の P0 不具合報告。
原因は frontend/app/page.tsx に Sepolia ハードコード残存 (5/1 切替時の見落とし)。
hotfix は別 PR で対応中、本 PR は再発防止策のみ。

## 変更内容
- `docs/43_mainnet_wallet_switch_guide.md` §2.5: frontend 表示テキスト確認セクション新規追加
- `scripts/verify.sh`: Gate 0 (chain config consistency check) 新規追加
- `frontend/e2e/landing-mainnet.spec.ts`: 新規 E2E (Sepolia 表記検出)
- `.github/PULL_REQUEST_TEMPLATE.md`: チェーン関連チェックリスト追加
- `docs/lessons_learned/2026-05-02_mainnet_frontend_text_oversight.md`: インシデント postmortem

## 即マージ可能
docs/scripts/E2E のみ、frontend/backend 機能コード無変更。
山本さん観察期間に1ミリも干渉しないため観察明け待ち不要。

## Test plan
- [ ] `scripts/verify.sh` Gate 0 が `.env.production` なしで skip することを確認
- [ ] `frontend/e2e/landing-mainnet.spec.ts` の TypeScript syntax が正常

## 関連
- 元インシデント: Asana 1214462618475072
- 本タスク: Asana 1214462619161978
- hotfix: 別 lane で進行中 (衝突なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)