### PR TITLE
hotfix(connect+docs): Base Mainnet badge + CLAUDE.md lessons-learned (deploy violation)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -656,6 +656,25 @@ docker exec <frontend> grep -r "http://77" /app/.next/static/chunks/ | wc -l
 ### 2026-04-03追加（デプロイ・運用）
 
 - **`scripts/deploy_production.sh` を必ず使う。**（2026-04-17 B案リネーム: 旧 `deploy_staging.sh`）手打ちデプロイは孤立コンテナ（Conflict）、`--env-file` 忘れ（`NEXT_PUBLIC_*` 未焼き込み）、ビルドスキップ（古いイメージ起動）の3問題を毎回引き起こす。`deploy_production.sh` は `down --remove-orphans` → `docker rm -f` → `build --no-cache` → `up -d` → ヘルスチェック → Slack通知まで全自動。`--frontend-only` / `--backend-only` / `--no-build` オプションあり
+
+#### Lesson Learned: 2026-05-03 手打ちdeploy違反インシデント（claude.ai生成プロンプト起因）
+
+**事象**: PR #191 デプロイで `docker compose -p ultra-autotrade-project -f docker-compose.production.yml build --no-cache frontend` を**手打ち実行**し、`--env-file .env.production` が抜けて `NEXT_PUBLIC_PRIVY_APP_ID` が空展開でビルドされた。本番ウォレット接続ボタンが完全死亡し、本番テスター（山本さん）が詰まり、復旧に追加 4-5 時間を要した。
+
+**真因**: claude.ai が生成したデプロイプロンプトに `docker compose ... build` 直接コマンドが含まれていた。CLAUDE.md に「`deploy_production.sh` 必須」と上記で明記されていたが、claude.ai 側でルール参照漏れ。`compose config` で確認すると `--env-file` なしでは `${NEXT_PUBLIC_PRIVY_APP_ID:-}` が空展開、ありでは正しい値が解決される、と機械的に再現できた。
+
+**再発防止（絶対遵守）**:
+1. **本番 frontend 再ビルドは `./scripts/deploy_production.sh --frontend-only` のみ。** 手打ち `docker compose ... build` を含むプロンプトを生成・実行しない／受け取った場合は拒否して `deploy_production.sh` への置き換えを要求
+2. デプロイ後は必ず焼き込み確認（値が JS バンドルに入っているか grep で検証）:
+   ```bash
+   PRIVY_VAL=$(grep '^NEXT_PUBLIC_PRIVY_APP_ID=' /opt/ultra-autotrade/.env.production | cut -d= -f2-)
+   docker exec ultra-autotrade-frontend-production sh -c \
+     "grep -lE '$PRIVY_VAL' /app/.next/static/chunks/*.js | wc -l"
+   # 0件なら焼き込み失敗 → 即ロールバック
+   ```
+3. 焼き込み確認パス後も Gate 4 実機検証（Claude in Chrome / Playwright で Privy モーダル発火確認）必須
+4. `--env-file` を付け忘れる手打ちが疑われる場合は `docker compose -p ultra-autotrade-project --env-file .env.production -f docker-compose.production.yml config` で `${NEXT_PUBLIC_*}` の解決値を事前確認できる
+
 - **`docker compose build --no-cache` だけでは不十分な場合がある。** `--no-cache` はレイヤーキャッシュをスキップするが、**古いイメージ自体は残る**。COMPOSE_PROJECT_NAMEや--env-fileが不一致だと別名のイメージが使われ続ける。`deploy_production.sh` ではビルド前に `docker rmi -f` でイメージを完全削除してから再ビルドするため、この問題は自動的に回避される。手動で修正する場合は: `docker images | grep frontend | awk '{print $3}' | xargs -r docker rmi -f && docker compose build --no-cache frontend`
 - **`docker system prune -af` の後は全コンテナリビルドが必須。** イメージが削除されるため `up -d` しても起動しない。prune後は必ず `deploy_production.sh`（フルビルド）を実行
 - **テストアカウント（@ultra-autotrade.com系）は DB ボリューム再作成で消える可能性がある。** 消えた場合は `bcrypt` でハッシュ生成 → `INSERT INTO users` で再作成。Registration API が無効化されている場合がある（`INITIAL_ADMIN_EMAIL` 未設定）

--- a/frontend/app/(user)/connect/page.tsx
+++ b/frontend/app/(user)/connect/page.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { usePrivy, useWallets } from '@privy-io/react-auth'
 import { ethers } from 'ethers'
-import { Wallet, CheckCircle, AlertTriangle, ArrowRight } from 'lucide-react'
+import { Wallet, CheckCircle, AlertTriangle, ArrowRight, Network } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { useAuth } from '@/lib/auth'
@@ -167,6 +167,14 @@ export default function ConnectPage() {
 
         {/* Step Indicator */}
         <StepIndicator currentStep={currentStep} />
+
+        {/* Network Badge — env-driven, e.g. "Base メインネット (Chain 8453)" */}
+        <div className="text-center mb-3">
+          <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-blue-950/40 border border-blue-800 text-xs text-blue-300">
+            <Network className="w-3 h-3" />
+            {CHAIN_DISPLAY_NAMES[DEFAULT_CHAIN_ID] ?? `Chain ${DEFAULT_CHAIN_ID}`} (Chain {DEFAULT_CHAIN_ID})
+          </span>
+        </div>
 
         {/* Header */}
         <div className="text-center mb-8">


### PR DESCRIPTION
## 背景

2026-05-03 山本さん（本番テスター）ブロッカー対応の中で派生発見した残課題と、
PR #191 デプロイ時に発生した手打ちデプロイ違反インシデントを教訓化する。

レーンA（P0 Privy死亡 → `deploy_production.sh --frontend-only` 再実行）は
コード変更ゼロでデプロイ済。本PRはレーンBの一部（P2 + CLAUDE.md）。

## 修正内容

### P2: /connect Base Mainnet 明示UI
- `frontend/app/(user)/connect/page.tsx`
- StepIndicator 直下に env-driven バッジ追加: `Base メインネット (Chain 8453)`
- `CHAIN_DISPLAY_NAMES[DEFAULT_CHAIN_ID]` を使うので Base Sepolia (84532) 切替時も自動追従
- 既存テストへの破壊的変更なし（純粋追加）

### CLAUDE.md 補強: 手打ちdeploy禁止 Lesson Learned
- 2026-04-03 既存セクションに Lesson Learned 追記
- 真因: PR #191 デプロイで手打ち `docker compose ... build --no-cache frontend` 実行
  → `--env-file .env.production` 抜け → `\${NEXT_PUBLIC_PRIVY_APP_ID:-}` 空展開
  → Privy SDK 初期化失敗 → ウォレット接続ボタン死亡
- 再発防止4項目を明文化:
  1. 本番 frontend 再ビルドは `deploy_production.sh --frontend-only` のみ
  2. デプロイ後は焼き込み確認 (`grep -lE` で値の bundle 焼き込み件数を確認)
  3. 焼き込み確認パス後も Gate 4 実機検証必須
  4. `compose config` で `\${NEXT_PUBLIC_*}` 解決値を事前確認可能

### スコープ外（別タスク化）

P1（/connect 未認証ガード → /login リダイレクト）は本PR非対象:
- 既存 E2E 5-6 ファイル / ~20 件が連鎖破綻するため
- Playwright auth stub fixture 整備とセットで丁寧に設計し直す
- → Asana タスクで管理

## 関連タスク

- **P1切り出し**: https://app.asana.com/1/817733952351708/project/1213829744814355/task/1214467273975732
  （[P1] /connect 未認証ガード実装 + Playwright auth stub fixture整備、期限 2026-05-09）

## 山本さんブロッカー解消状況

- ✅ ログイン画面表示（PR #191 マージ・デプロイ済）
- ✅ Privy ウォレット接続ボタン復旧（レーンA `deploy_production.sh` 再実行・本日実機確認済）
- 🟢 **Base Mainnet 明示UI（本PR）**
- 🟢 **手打ちdeploy再発防止ルール（本PR）**
- 🟡 /connect 認証ガード（別タスク #1214467273975732）

## 検証

- ✅ `tsc --noEmit`: PASS
- ✅ `npm run build` (Gate 7): PASS、全ルート生成確認
- ✅ Gate 0 (chain config): No Sepolia hardcode in mainnet config
- ✅ Gate 4 (Playwright full): **226 passed / 98 skipped / 0 failed (1.9 min)**
  - ログ: `/tmp/gate4_full_laneB_20260503_112333.log`
  - flaky retry 観察ゼロ
- バックエンド変更なし → backend gates (1-5) 自動 pass

## デプロイ手順（マージ後）

**手打ち禁止。`deploy_production.sh` のみ。**

```bash
ssh -i ~/.ssh/hetzner_staging ultra@77.42.46.155
cd /opt/ultra-autotrade
git rev-parse HEAD > /tmp/pre_deploy_laneB_\$(date +%Y%m%d_%H%M%S).txt
md5sum .env.production > /tmp/env_md5_pre_laneB.txt
git fetch origin && git pull origin main
./scripts/deploy_production.sh --frontend-only 2>&1 | tee /tmp/deploy_laneB_\$(date +%Y%m%d_%H%M%S).log
```

## 影響範囲

- **frontend のみ**（バックエンド・DB スキーマ・compose・nginx 変更なし）
- **frozen files**: CLAUDE.md（Tier S だが本日初回 PR、ルール準拠）
- **recharts**: 不使用
- **DB migration**: 不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)