### PR TITLE
feat(ras-l2): backend referral API + register referral_code path

### DIFF
--- a/backend/app/auth/models.py
+++ b/backend/app/auth/models.py
@@ -19,6 +19,14 @@ CREATE UNIQUE INDEX IF NOT EXISTS ix_users_privy_did ON users (privy_did) WHERE 
 -- CheckConstraint と SQLAlchemy 側 server_default を Alembic migration で同期する。
 ALTER TABLE users ADD CONSTRAINT users_execution_policy_check
     CHECK (execution_policy IN ('auto_execute', 'require_approval', 'proposal_only'));
+
+-- RAS (Referral / Partner Affiliate System) Lane 1 schema. Lane 1 が DB schema 本体を
+-- 所有するが、Lane 2 (本ファイル) でも型解決のため同一定義を先行追加している。
+-- Lane 1 マージ時は同一定義のため conflict 解消は trivial。
+ALTER TABLE users ADD COLUMN IF NOT EXISTS referral_code VARCHAR(16) NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS ix_users_referral_code ON users (referral_code) WHERE referral_code IS NOT NULL;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS referrer_id INTEGER NULL REFERENCES users(id);
+ALTER TABLE users ADD COLUMN IF NOT EXISTS referred_consent_at TIMESTAMP WITH TIME ZONE NULL;
 """
 
 import logging
@@ -261,6 +269,16 @@ class User(Base):
         String(20), nullable=False, default=InvestmentTier.LOWER.value
     )
     last_judgment_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
+    # RAS Lane 1 schema (Lane 2 先行定義 / 同一定義のため Lane 1 merge 時 conflict は trivial)
+    referral_code: Mapped[Optional[str]] = mapped_column(
+        String(16), unique=True, nullable=True, index=True, default=None
+    )
+    referrer_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("users.id"), nullable=True, default=None
+    )
+    referred_consent_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True, default=None
     )
 

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -75,9 +75,44 @@ def register(
     """
     Register a user.
 
+    - With referral_code (RAS Lane 2): register as viewer via partner referral.
     - With invitation_code: register as viewer via partner invitation.
-    - Without invitation_code: initial admin registration (first user only).
+    - Without either: initial admin registration (first user only).
     """
+    # ── RAS Lane 2: referral_code path ────────────────────────────────────
+    if request.referral_code:
+        if not request.referred_consent:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="紹介プログラム同意が必要です",
+            )
+        referrer = db.query(User).filter(User.referral_code == request.referral_code).first()
+        if referrer is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="無効な紹介コード",
+            )
+        try:
+            user = AuthService.create_user(db, request, role=UserRole.VIEWER.value)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        user.referrer_id = referrer.id
+        user.referred_consent_at = datetime.now(timezone.utc)
+        db.commit()
+        db.refresh(user)
+        logger.info(
+            "User registered via referral: %s (referrer_id=%d, code=%s)",
+            user.email,
+            referrer.id,
+            request.referral_code,
+        )
+        token, expires_in = AuthService.create_access_token(user.id, user.email, user.role)
+        return RegisterResponse(
+            **UserResponse.model_validate(user).model_dump(),
+            access_token=token,
+            expires_in=expires_in,
+        )
+
     if request.invitation_code:
         from app.invitations import service as invitation_service  # noqa: PLC0415
 

--- a/backend/app/auth/schemas.py
+++ b/backend/app/auth/schemas.py
@@ -27,12 +27,18 @@ from app.auth.models import InvestmentTier as InvestmentTier  # noqa: E402, F401
 
 
 class RegisterRequest(BaseModel):
-    """初回管理者登録リクエスト（招待コードがある場合は招待登録）。"""
+    """初回管理者登録リクエスト（招待コードがある場合は招待登録）。
+
+    RAS Lane 2: referral_code / referred_consent を追加。
+    referral_code 指定時は紹介経由登録となり referrer_id / referred_consent_at が記録される。
+    """
 
     email: EmailStr
     username: str = Field(min_length=3, max_length=50)
     password: str = Field(min_length=8, max_length=100)
     invitation_code: Optional[str] = None
+    referral_code: Optional[str] = None
+    referred_consent: bool = False
 
     @field_validator("username")
     @classmethod

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -71,6 +71,7 @@ from app.proposals.router import router as proposals_router
 from app.protocols.lido.router import router as lido_router
 from app.protocols.pendle.router import router as pendle_router
 from app.protocols.risk.router import router as protocol_health_router
+from app.referral.router import router as referral_router
 from app.reports.router import router as reports_router
 from app.rss.router import router as rss_router
 from app.transactions.router import admin_router as admin_transactions_router
@@ -244,6 +245,7 @@ def create_app() -> FastAPI:
     app.include_router(lido_router)  # Lido Finance (Phase 2)
     app.include_router(pendle_router)  # Pendle Finance (Phase 2)
     app.include_router(protocol_health_router)  # Protocol Health Monitor (Phase 2)
+    app.include_router(referral_router)  # RAS Lane 2 (Referral / Partner Affiliate System)
 
     # Register global error handlers (production safety)
     register_error_handlers(app)

--- a/backend/app/referral/__init__.py
+++ b/backend/app/referral/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/referral/__init__.py
+"""RAS (Referral / Partner Affiliate System) Lane 2 module.
+
+partner ロール用の紹介コード API と、register エンドポイントから参照される
+紹介コード処理を提供する。
+"""
+
+from .router import router as router
+
+__all__ = ["router"]

--- a/backend/app/referral/code_generator.py
+++ b/backend/app/referral/code_generator.py
@@ -1,0 +1,54 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/referral/code_generator.py
+"""紹介コード生成器。
+
+8 桁英数字 (大文字 + 数字、混同しやすい I/O/0/1 は除外) で生成し、
+DB ユニーク衝突時は最大 5 回リトライする。
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+
+from sqlalchemy.orm import Session
+
+from app.auth.models import User
+
+logger = logging.getLogger(__name__)
+
+# 混同しやすい I/O/0/1 を除外したアルファベット (28 文字)。
+_REFERRAL_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+REFERRAL_CODE_LENGTH = 8
+MAX_RETRY = 5
+
+
+def _random_code() -> str:
+    """暗号学的乱数で 8 桁の紹介コード候補を返す。"""
+    return "".join(secrets.choice(_REFERRAL_ALPHABET) for _ in range(REFERRAL_CODE_LENGTH))
+
+
+def generate_referral_code(db: Session) -> str:
+    """DB ユニーク衝突を考慮しながら 8 桁紹介コードを生成する。
+
+    Args:
+        db: 衝突確認に使う DB セッション。
+
+    Returns:
+        DB 上で未使用の 8 桁英数字コード。
+
+    Raises:
+        RuntimeError: ``MAX_RETRY`` 回連続で衝突した場合 (運用上ほぼ起こらない)。
+    """
+    for attempt in range(1, MAX_RETRY + 1):
+        candidate = _random_code()
+        existing = db.query(User).filter(User.referral_code == candidate).first()
+        if existing is None:
+            if attempt > 1:
+                logger.info("referral_code generated after %d retries", attempt)
+            return candidate
+        logger.warning("referral_code collision on attempt=%d (candidate=%s)", attempt, candidate)
+
+    logger.error("referral_code generation exhausted retries (max=%d)", MAX_RETRY)
+    raise RuntimeError("Failed to generate unique referral_code after retries")

--- a/backend/app/referral/router.py
+++ b/backend/app/referral/router.py
@@ -1,0 +1,111 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/referral/router.py
+"""RAS Lane 2 ルーター。
+
+partner-only エンドポイント (admin / user は 403):
+  - POST /referral/code                            紹介コード取得 (未発行なら発行)
+  - GET  /referral/list                            配下ユーザー一覧
+  - GET  /referral/users/{user_id}/transactions    配下ユーザーの取引履歴
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.auth.dependencies import require_active_user
+from app.auth.models import User, UserRole
+from app.database import get_db
+from app.transactions.models import Transaction
+
+from . import service
+from .schemas import (
+    ReferralCodeResponse,
+    ReferralTransactionResponse,
+    ReferredUserResponse,
+)
+
+router = APIRouter(prefix="/referral", tags=["referral"])
+
+
+def require_partner_only(
+    user: User = Depends(require_active_user),
+) -> User:
+    """RAS 専用 RBAC: ``role == PARTNER`` のみ許可。
+
+    既存 ``require_partner`` は admin も通すが、紹介プログラムは partner 固有のため
+    admin / 一般ユーザーはいずれも 403 を返す。
+    """
+    if user.role != UserRole.PARTNER.value:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Partner role required",
+        )
+    return user
+
+
+@router.post(
+    "/code",
+    response_model=ReferralCodeResponse,
+    summary="紹介コード取得 (partner 専用、未発行なら発行)",
+)
+def post_referral_code(
+    current_user: User = Depends(require_partner_only),
+    db: Session = Depends(get_db),
+) -> ReferralCodeResponse:
+    """partner の紹介コードを取得する。未発行なら自動発行する。"""
+    code = service.get_or_create_code(db, current_user)
+    return ReferralCodeResponse(
+        referral_code=code,
+        share_url=service.build_share_url(code),
+    )
+
+
+@router.get(
+    "/list",
+    response_model=list[ReferredUserResponse],
+    summary="紹介経由で登録されたユーザー一覧 (partner 専用)",
+)
+def get_referral_list(
+    current_user: User = Depends(require_partner_only),
+    db: Session = Depends(get_db),
+) -> list[ReferredUserResponse]:
+    """partner 配下のユーザー一覧を返す (email はマスクして返却)。"""
+    referred_users = service.list_referred_users(db, current_user.id)
+    return [
+        ReferredUserResponse(
+            id=u.id,
+            email_masked=service.mask_email(u.email),
+            role=u.role,
+            created_at=u.created_at,
+        )
+        for u in referred_users
+    ]
+
+
+@router.get(
+    "/users/{user_id}/transactions",
+    response_model=list[ReferralTransactionResponse],
+    summary="配下ユーザーの取引履歴 (partner 専用、wallet/tx は含まない)",
+)
+def get_referral_transactions(
+    user_id: int,
+    current_user: User = Depends(require_partner_only),
+    db: Session = Depends(get_db),
+) -> list[ReferralTransactionResponse]:
+    """配下ユーザーの取引履歴を返す。
+
+    - operation が deposit / withdraw / borrow / repay のもののみ
+    - wallet_address / tx_hash はレスポンスに含めない (法務未クリア)
+    """
+    txs: list[Transaction] = service.list_transactions(db, current_user.id, user_id)
+    return [
+        ReferralTransactionResponse(
+            # service.list_transactions が _ALLOWED_TX_TYPES でフィルタ済み。
+            type=tx.operation,
+            amount=str(tx.amount),
+            occurred_at=tx.created_at,
+        )
+        for tx in txs
+    ]

--- a/backend/app/referral/schemas.py
+++ b/backend/app/referral/schemas.py
@@ -1,0 +1,45 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/referral/schemas.py
+"""RAS Lane 2 Pydantic スキーマ。
+
+法務未クリアのため、レスポンスには ``wallet_address`` / ``tx_hash`` を含めない。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ReferralCodeResponse(BaseModel):
+    """紹介コード取得レスポンス。"""
+
+    referral_code: str
+    share_url: str
+
+
+class ReferredUserResponse(BaseModel):
+    """紹介経由で登録されたユーザーの一覧アイテム。"""
+
+    id: int
+    email_masked: str  # "y***@example.com" 形式
+    role: str
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ReferralTransactionResponse(BaseModel):
+    """紹介ユーザーの取引履歴アイテム。
+
+    ※ ``wallet_address`` / ``tx_hash`` は法務未クリアのため意図的に含めない。
+    """
+
+    type: Literal["deposit", "withdraw", "borrow", "repay"]
+    amount: str  # Decimal を文字列で返却 (CLAUDE.md ルール)
+    occurred_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/referral/service.py
+++ b/backend/app/referral/service.py
@@ -1,0 +1,116 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/referral/service.py
+"""RAS Lane 2 サービス層。
+
+partner ロール用に以下を提供する:
+  - 紹介コードの取得 / 自動発行
+  - 紹介経由で登録された配下ユーザー一覧
+  - 配下ユーザーの取引履歴 (deposit / withdraw / borrow / repay のみ、wallet/tx は除外)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+from fastapi import HTTPException, status
+
+from app.auth.models import User
+from app.transactions.models import Transaction
+
+from .code_generator import generate_referral_code
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+# /referral/users/{id}/transactions が返す operation 値のホワイトリスト。
+_ALLOWED_TX_TYPES = ("deposit", "withdraw", "borrow", "repay")
+
+
+def _share_base_url() -> str:
+    """招待 URL の base host を環境変数から取得する。"""
+    return os.getenv("PUBLIC_FRONTEND_URL", "https://app.ultra-auto-trade.com").rstrip("/")
+
+
+def get_or_create_code(db: Session, partner_user: User) -> str:
+    """partner の紹介コードを取得 (未発行なら自動発行)。
+
+    Args:
+        db: DB セッション。
+        partner_user: 紹介コードを発行する partner ユーザー。
+
+    Returns:
+        partner に紐づく 8 桁紹介コード。
+    """
+    if partner_user.referral_code:
+        return partner_user.referral_code
+
+    code = generate_referral_code(db)
+    partner_user.referral_code = code
+    db.commit()
+    db.refresh(partner_user)
+    logger.info("Issued referral_code partner_id=%d code=%s", partner_user.id, code)
+    return code
+
+
+def build_share_url(referral_code: str) -> str:
+    """紹介コードから招待 URL を組み立てる。"""
+    return f"{_share_base_url()}/register?ref={referral_code}"
+
+
+def list_referred_users(db: Session, partner_id: int) -> list[User]:
+    """``referrer_id == partner_id`` のユーザー一覧 (新しい順)。"""
+    return (
+        db.query(User).filter(User.referrer_id == partner_id).order_by(User.created_at.desc()).all()
+    )
+
+
+def list_transactions(db: Session, partner_id: int, referred_user_id: int) -> list[Transaction]:
+    """配下ユーザーの取引履歴を返す (RBAC 込み)。
+
+    Args:
+        db: DB セッション。
+        partner_id: 呼び出し元 partner の id。
+        referred_user_id: 取引を取得したい配下ユーザーの id。
+
+    Returns:
+        operation が deposit/withdraw/borrow/repay の Transaction 一覧 (新しい順)。
+
+    Raises:
+        HTTPException: 対象ユーザーが存在しない、または partner 配下でない場合 (403/404)。
+    """
+    referred = db.query(User).filter(User.id == referred_user_id).first()
+    if referred is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Referred user not found",
+        )
+    if referred.referrer_id != partner_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not your referred user",
+        )
+
+    return (
+        db.query(Transaction)
+        .filter(
+            Transaction.user_id == referred_user_id,
+            Transaction.operation.in_(_ALLOWED_TX_TYPES),
+        )
+        .order_by(Transaction.created_at.desc())
+        .all()
+    )
+
+
+def mask_email(email: str) -> str:
+    """``y***@example.com`` 形式へマスクする。"""
+    if "@" not in email:
+        return email[:1] + "***"
+    local, domain = email.split("@", 1)
+    if not local:
+        return f"***@{domain}"
+    return f"{local[0]}***@{domain}"

--- a/backend/tests/test_referral_code_generator.py
+++ b/backend/tests/test_referral_code_generator.py
@@ -1,0 +1,97 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/test_referral_code_generator.py
+"""RAS Lane 2: 紹介コード生成のユニットテスト。"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Generator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-referral-codegen")
+
+from app.auth.models import User, UserRole  # noqa: E402
+from app.database import Base  # noqa: E402
+from app.referral import code_generator  # noqa: E402
+from app.referral.code_generator import (  # noqa: E402
+    MAX_RETRY,
+    REFERRAL_CODE_LENGTH,
+    generate_referral_code,
+)
+
+
+@pytest.fixture()
+def db() -> Generator[Session, None, None]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = factory()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+        os.unlink(path)
+
+
+def _make_partner(db: Session, email: str, username: str, code: str | None = None) -> User:
+    u = User(
+        email=email,
+        username=username,
+        hashed_password="$dummy$",  # noqa: S106
+        role=UserRole.PARTNER.value,
+        referral_code=code,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def test_generate_referral_code_format(db: Session) -> None:
+    code = generate_referral_code(db)
+    assert len(code) == REFERRAL_CODE_LENGTH
+    assert code.isalnum()
+    # 混同しやすい I/O/0/1 を含まない
+    assert all(ch not in code for ch in "IO01")
+
+
+def test_generate_referral_code_uniqueness(db: Session) -> None:
+    codes = {generate_referral_code(db) for _ in range(20)}
+    # 20 個生成しても重複が極めて少ない (一意性は最大32^8≈10^12なので衝突確率ほぼ0)
+    assert len(codes) >= 19
+
+
+def test_generate_referral_code_retries_then_succeeds(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """最初は既存コードと衝突、リトライで成功することを確認。"""
+    _make_partner(db, "p1@example.com", "p1user", code="COLLIDE1")
+    _make_partner(db, "p2@example.com", "p2user", code="COLLIDE2")
+
+    candidates = iter(["COLLIDE1", "COLLIDE2", "FRESHCOD"])
+    monkeypatch.setattr(code_generator, "_random_code", lambda: next(candidates))
+
+    code = generate_referral_code(db)
+    assert code == "FRESHCOD"
+
+
+def test_generate_referral_code_exhausts_retries(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """5 回連続で衝突したら RuntimeError を投げる。"""
+    _make_partner(db, "p1@example.com", "p1user", code="DUPLCODE")
+    monkeypatch.setattr(code_generator, "_random_code", lambda: "DUPLCODE")
+
+    with pytest.raises(RuntimeError):
+        generate_referral_code(db)
+
+    # MAX_RETRY 定数が想定どおり (テストの仕様確認)
+    assert MAX_RETRY == 5

--- a/backend/tests/test_referral_router.py
+++ b/backend/tests/test_referral_router.py
@@ -1,0 +1,467 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/test_referral_router.py
+"""RAS Lane 2: referral ルーターと register 改修の統合テスト。"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Generator
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-referral-router")
+
+from app.auth.models import User, UserRole  # noqa: E402
+from app.auth.router import router as auth_router  # noqa: E402
+from app.auth.service import AuthService  # noqa: E402
+from app.database import Base, get_db  # noqa: E402
+from app.referral.router import router as referral_router  # noqa: E402
+from app.transactions.models import Transaction  # noqa: E402
+
+_ADMIN_EMAIL = "ras-l2-admin@example.com"
+_ADMIN_PASS = "adminpass123!"
+
+
+SessionFactory = sessionmaker[Session]
+
+
+def _create_test_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(auth_router)
+    app.include_router(referral_router)
+    return app
+
+
+@pytest.fixture()
+def test_db() -> Generator[SessionFactory, None, None]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    factory: SessionFactory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    yield factory
+    Base.metadata.drop_all(bind=engine)
+    os.unlink(path)
+
+
+@pytest.fixture()
+def client(
+    test_db: SessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> Generator[TestClient, None, None]:
+    monkeypatch.setenv("INITIAL_ADMIN_EMAIL", _ADMIN_EMAIL)
+    app = _create_test_app()
+
+    def override_get_db() -> Generator[Session, None, None]:
+        db = test_db()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+
+
+# ── ヘルパー ─────────────────────────────────────────────────────────────────
+
+
+def _register_initial_admin(client: TestClient) -> str:
+    r = client.post(
+        "/auth/register",
+        json={
+            "email": _ADMIN_EMAIL,
+            "username": "rasl2admin",
+            "password": _ADMIN_PASS,
+        },
+    )
+    assert r.status_code == 201, r.text
+    return str(r.json()["access_token"])
+
+
+def _create_user_with_role(
+    db_factory: SessionFactory,
+    email: str,
+    username: str,
+    password: str,
+    role: str,
+    referral_code: str | None = None,
+) -> User:
+    db = db_factory()
+    try:
+        user = User(
+            email=email,
+            username=username,
+            hashed_password=AuthService.hash_password(password),
+            role=role,
+            referral_code=referral_code,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        return user
+    finally:
+        db.close()
+
+
+def _login(client: TestClient, email: str, password: str) -> str:
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    assert r.status_code == 200, r.text
+    return str(r.json()["access_token"])
+
+
+# ── 1. POST /referral/code (partner JWT) → 200 + 8 桁 ────────────────────────
+
+
+def test_post_referral_code_partner_returns_200_with_8char(
+    client: TestClient, test_db: SessionFactory
+) -> None:
+    _register_initial_admin(client)
+    _create_user_with_role(
+        test_db,
+        "partner-a@example.com",
+        "partnera",
+        "partnerpass1!",
+        UserRole.PARTNER.value,
+    )
+    token = _login(client, "partner-a@example.com", "partnerpass1!")
+    r = client.post("/referral/code", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["referral_code"]) == 8
+    assert body["referral_code"].isalnum()
+    assert "share_url" in body
+    assert body["referral_code"] in body["share_url"]
+
+
+def test_post_referral_code_returns_same_code_on_repeat(
+    client: TestClient, test_db: SessionFactory
+) -> None:
+    _register_initial_admin(client)
+    _create_user_with_role(
+        test_db,
+        "partner-b@example.com",
+        "partnerb",
+        "partnerpass2!",
+        UserRole.PARTNER.value,
+    )
+    token = _login(client, "partner-b@example.com", "partnerpass2!")
+    r1 = client.post("/referral/code", headers={"Authorization": f"Bearer {token}"})
+    r2 = client.post("/referral/code", headers={"Authorization": f"Bearer {token}"})
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r1.json()["referral_code"] == r2.json()["referral_code"]
+
+
+# ── 2. POST /referral/code (user/admin JWT) → 403 ───────────────────────────
+
+
+def test_post_referral_code_viewer_returns_403(client: TestClient, test_db: SessionFactory) -> None:
+    _register_initial_admin(client)
+    _create_user_with_role(
+        test_db,
+        "viewer-a@example.com",
+        "viewera",
+        "viewerpass1!",
+        UserRole.VIEWER.value,
+    )
+    token = _login(client, "viewer-a@example.com", "viewerpass1!")
+    r = client.post("/referral/code", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 403
+
+
+def test_post_referral_code_admin_returns_403(client: TestClient) -> None:
+    """admin は紹介プログラム対象外なので 403 (partner-only)。"""
+    admin_token = _register_initial_admin(client)
+    r = client.post("/referral/code", headers={"Authorization": f"Bearer {admin_token}"})
+    assert r.status_code == 403
+
+
+def test_post_referral_code_unauthenticated_returns_401(client: TestClient) -> None:
+    r = client.post("/referral/code")
+    assert r.status_code == 401
+
+
+# ── 3. GET /referral/list → 200 + [] ───────────────────────────────────────
+
+
+def test_get_referral_list_empty(client: TestClient, test_db: SessionFactory) -> None:
+    _register_initial_admin(client)
+    _create_user_with_role(
+        test_db,
+        "partner-c@example.com",
+        "partnerc",
+        "partnerpass3!",
+        UserRole.PARTNER.value,
+    )
+    token = _login(client, "partner-c@example.com", "partnerpass3!")
+    r = client.get("/referral/list", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_get_referral_list_returns_referred_users_with_masked_email(
+    client: TestClient, test_db: SessionFactory
+) -> None:
+    _register_initial_admin(client)
+    partner = _create_user_with_role(
+        test_db,
+        "partner-d@example.com",
+        "partnerd",
+        "partnerpass4!",
+        UserRole.PARTNER.value,
+        referral_code="PARTNERD",
+    )
+
+    # 配下ユーザーを 1 人作る (referrer_id=partner.id)
+    db = test_db()
+    try:
+        viewer = User(
+            email="yamada@example.com",
+            username="yamada1",
+            hashed_password=AuthService.hash_password("yamadapass!"),
+            role=UserRole.VIEWER.value,
+            referrer_id=partner.id,
+            referred_consent_at=datetime.now(timezone.utc),
+        )
+        db.add(viewer)
+        db.commit()
+    finally:
+        db.close()
+
+    token = _login(client, "partner-d@example.com", "partnerpass4!")
+    r = client.get("/referral/list", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200
+    rows = r.json()
+    assert len(rows) == 1
+    assert rows[0]["email_masked"] == "y***@example.com"
+    assert rows[0]["role"] == UserRole.VIEWER.value
+    # email 平文がレスポンスに漏れていない
+    assert "email" not in rows[0]
+
+
+# ── 4. POST /auth/register (referral_code + consent=true) → 201 + referrer_id ─
+
+
+def test_register_with_referral_code_sets_referrer_and_consent(
+    client: TestClient, test_db: SessionFactory
+) -> None:
+    _register_initial_admin(client)
+    partner = _create_user_with_role(
+        test_db,
+        "partner-e@example.com",
+        "partnere",
+        "partnerpass5!",
+        UserRole.PARTNER.value,
+        referral_code="PARTNERE",
+    )
+
+    r = client.post(
+        "/auth/register",
+        json={
+            "email": "newuser@example.com",
+            "username": "newuser",
+            "password": "newuserpass1!",
+            "referral_code": "PARTNERE",
+            "referred_consent": True,
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["email"] == "newuser@example.com"
+    assert body["role"] == UserRole.VIEWER.value
+
+    # DB 側で referrer_id / referred_consent_at が記録されている
+    db = test_db()
+    try:
+        new_user = db.query(User).filter(User.email == "newuser@example.com").first()
+        assert new_user is not None
+        assert new_user.referrer_id == partner.id
+        assert new_user.referred_consent_at is not None
+    finally:
+        db.close()
+
+
+# ── 5. POST /auth/register (consent=false) → 422 ────────────────────────────
+
+
+def test_register_without_consent_returns_422(client: TestClient, test_db: SessionFactory) -> None:
+    _register_initial_admin(client)
+    _create_user_with_role(
+        test_db,
+        "partner-f@example.com",
+        "partnerf",
+        "partnerpass6!",
+        UserRole.PARTNER.value,
+        referral_code="PARTNERF",
+    )
+
+    r = client.post(
+        "/auth/register",
+        json={
+            "email": "noconsent@example.com",
+            "username": "noconsent",
+            "password": "noconsentpass1!",
+            "referral_code": "PARTNERF",
+            "referred_consent": False,
+        },
+    )
+    assert r.status_code == 422
+    assert "紹介プログラム同意" in r.json()["detail"]
+
+
+# ── 6. POST /auth/register (referral_code='DEADBEEF') → 404 ─────────────────
+
+
+def test_register_with_invalid_referral_code_returns_404(client: TestClient) -> None:
+    _register_initial_admin(client)
+    r = client.post(
+        "/auth/register",
+        json={
+            "email": "deadbeef@example.com",
+            "username": "deadbeef",
+            "password": "deadbeefpass1!",
+            "referral_code": "DEADBEEF",
+            "referred_consent": True,
+        },
+    )
+    assert r.status_code == 404
+    assert r.json()["detail"] == "無効な紹介コード"
+
+
+# ── 7. GET /referral/users/{id}/transactions → wallet/tx_hash 含まない ──────
+
+
+def test_transactions_endpoint_excludes_wallet_and_tx_hash(
+    client: TestClient, test_db: SessionFactory
+) -> None:
+    _register_initial_admin(client)
+    partner = _create_user_with_role(
+        test_db,
+        "partner-g@example.com",
+        "partnerg",
+        "partnerpass7!",
+        UserRole.PARTNER.value,
+        referral_code="PARTNERG",
+    )
+
+    # 配下ユーザー + 取引データを作成
+    db = test_db()
+    try:
+        viewer = User(
+            email="referred@example.com",
+            username="referred1",
+            hashed_password=AuthService.hash_password("referredpass!"),
+            role=UserRole.VIEWER.value,
+            referrer_id=partner.id,
+            referred_consent_at=datetime.now(timezone.utc),
+        )
+        db.add(viewer)
+        db.commit()
+        db.refresh(viewer)
+
+        # 含まれるべき取引 (deposit / withdraw / borrow / repay)
+        for op in ("deposit", "withdraw", "borrow", "repay"):
+            tx = Transaction(
+                user_id=viewer.id,
+                wallet_address="0xabc123abc123abc123abc123abc123abc123",
+                operation=op,
+                asset="USDC",
+                amount=Decimal("100.50"),
+                amount_usd=Decimal("100.50"),
+                tx_hash="0xdeadbeef" + op,
+                chain="base",
+                status="confirmed",
+            )
+            db.add(tx)
+        # 含まれないべき取引 (rebalance)
+        rebalance_tx = Transaction(
+            user_id=viewer.id,
+            wallet_address="0xdef",
+            operation="rebalance",
+            asset="USDC",
+            amount=Decimal("999.00"),
+            amount_usd=Decimal("999.00"),
+            tx_hash="0xignoreme",
+            chain="base",
+            status="confirmed",
+        )
+        db.add(rebalance_tx)
+        db.commit()
+        viewer_id = viewer.id
+    finally:
+        db.close()
+
+    token = _login(client, "partner-g@example.com", "partnerpass7!")
+    r = client.get(
+        f"/referral/users/{viewer_id}/transactions",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200
+    rows = r.json()
+    assert len(rows) == 4
+    types = {row["type"] for row in rows}
+    assert types == {"deposit", "withdraw", "borrow", "repay"}
+
+    for row in rows:
+        # 法務未クリア項目がレスポンスに含まれていない
+        assert "wallet_address" not in row
+        assert "tx_hash" not in row
+        assert set(row.keys()) == {"type", "amount", "occurred_at"}
+        # amount は文字列で返却される (Decimal の文字列化)
+        assert isinstance(row["amount"], str)
+
+
+def test_transactions_endpoint_403_for_other_partners_referred_user(
+    client: TestClient, test_db: SessionFactory
+) -> None:
+    _register_initial_admin(client)
+    partner_a = _create_user_with_role(
+        test_db,
+        "partner-h@example.com",
+        "partnerh",
+        "partnerpass8!",
+        UserRole.PARTNER.value,
+        referral_code="PARTNERH",
+    )
+    _create_user_with_role(
+        test_db,
+        "partner-i@example.com",
+        "partneri",
+        "partnerpass9!",
+        UserRole.PARTNER.value,
+        referral_code="PARTNERI",
+    )
+
+    # partner_a 配下のユーザー
+    db = test_db()
+    try:
+        viewer = User(
+            email="under-a@example.com",
+            username="undera",
+            hashed_password=AuthService.hash_password("xpass!"),
+            role=UserRole.VIEWER.value,
+            referrer_id=partner_a.id,
+        )
+        db.add(viewer)
+        db.commit()
+        db.refresh(viewer)
+        viewer_id = viewer.id
+    finally:
+        db.close()
+
+    # partner_i (別 partner) のトークンで取得しようとする → 403
+    token_i = _login(client, "partner-i@example.com", "partnerpass9!")
+    r = client.get(
+        f"/referral/users/{viewer_id}/transactions",
+        headers={"Authorization": f"Bearer {token_i}"},
+    )
+    assert r.status_code == 403

--- a/docs/integration/backend_deps.md
+++ b/docs/integration/backend_deps.md
@@ -65,6 +65,16 @@
 - **影響範囲**: startup シーケンスのみ。`PROCESS_NEWS_INTERVAL_SECONDS` 未設定時は 300秒間隔で動作。既存の `/automation/process-news` エンドポイントは無変更で、内部から HTTP POST で叩く構造。
 - **承認**: fix/production-401-unauthorized → main の通常フロー経由（PR #157）
 
+### 変更 #6: RAS Phase 1 referral_router 登録 (PR #194 / 2026-05-08)
+- **コミット範囲**: `72148ce` (feature/ras-l2-backend-api)
+- **変更内容**:
+  - `from app.referral.router import router as referral_router` を追加
+  - `app.include_router(referral_router)` を register_routers() に 1 行追加
+  - 計 2 行追加のみ
+- **理由**: F-17 + RAS Phase 1 (Asana 1214629980953220) — 紹介機能 (Referral Attribution System Phase 1) の API 群 (POST /referral/code / GET /referral/list / GET /referral/users/{id}/transactions) を FastAPI app に登録。partner ロールが自身の紹介コードを発行・紹介済みユーザー一覧と取引履歴 (deposit/withdraw/borrow/repay のみ、wallet/tx_hash 非開示) を閲覧する Phase 1 機能。
+- **影響範囲**: 新規 router 追加のみ。既存 endpoint への影響なし。tests/test_referral_router.py で既存 endpoint の404でないことを保証。
+- **承認**: feature/ras-l2-backend-api → main の通常フロー経由（PR #194）
+
 ## backend/app/database.py
 
 変更なし（現時点）


### PR DESCRIPTION
## Summary

RAS Lane 2 (Referral / Partner Affiliate System) backend implementation.

- `backend/app/referral/` 新規モジュール:
  - `POST /referral/code` (partner-only) — 紹介コード取得/未発行なら自動発行
  - `GET /referral/list` (partner-only) — 配下ユーザー一覧 (email マスク)
  - `GET /referral/users/{user_id}/transactions` (partner-only) — 配下ユーザーの取引履歴
- 8 桁英数字 (混同しやすい I/O/0/1 を除外) 紹介コード生成、衝突時 5 回リトライ
- `POST /auth/register` 改修: `referral_code` + `referred_consent` 受付
  - 同意なし → 422 / 無効コード → 404 / 成功時 `referrer_id` + `referred_consent_at` を記録
- 取引履歴レスポンスから `wallet_address` / `tx_hash` を除外 (法務未クリア)
- partner-only RBAC: `role == PARTNER` のみ許可 (admin/viewer は 403)

## File ownership

- `backend/app/referral/*` (新規)
- `backend/app/auth/router.py` (register 改修のみ)
- `backend/app/auth/schemas.py` (RegisterRequest に 2 フィールド追加)
- `backend/app/auth/models.py` (Lane 1 schema を先行追加 — Lane 1 マージ時 conflict は trivial)
- `backend/app/main.py` (referral_router include 1 行)
- `backend/tests/test_referral_*.py` (新規)

## Lane 1 dependency

Lane 1 (DB schema) 未マージ時点で本 PR は実装完了しているが、staging Gate B (curl 7 ケース) は **Lane 1 main マージ後** に実行する。理由: 本番/staging DB に `referral_code` / `referrer_id` / `referred_consent_at` カラムがまだ存在しない。

## Verification

- ✅ `ruff check .` — All checks passed
- ✅ `ruff format --check .` — 462 files formatted
- ✅ `mypy app/ --config-file ../pyproject.toml` — 239 source files clean
- ✅ pytest (auth + referral 関連 101 件) all green
- ✅ referral 単体 16/16 pass

## Test plan

- [ ] Lane 1 main マージ後、staging-new で curl 7 ケース実行
  - 1. POST /referral/code (partner JWT) → 200 + 8 桁
  - 2. POST /referral/code (user/admin JWT) → 403
  - 3. GET /referral/list (partner JWT) → 200 + []
  - 4. POST /auth/register (referral_code + consent=true) → 201 + referrer_id セット
  - 5. POST /auth/register (consent=false) → 422
  - 6. POST /auth/register (referral_code="DEADBEEF") → 404
  - 7. GET /referral/users/{id}/transactions レスポンスに wallet_address/tx_hash が含まれない

🤖 Generated with [Claude Code](https://claude.com/claude-code)