### PR TITLE
feat(ras-l2.1): add /auth/register-with-referral endpoint (referral-only signup)

### DIFF
--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -41,6 +41,7 @@ from .schemas import (
     PasswordChangeRequest,
     RegisterRequest,
     RegisterResponse,
+    RegisterWithReferralRequest,
     RiskModeUpdateRequest,
     TermsAcceptRequest,
     TermsStatusResponse,
@@ -75,44 +76,9 @@ def register(
     """
     Register a user.
 
-    - With referral_code (RAS Lane 2): register as viewer via partner referral.
     - With invitation_code: register as viewer via partner invitation.
-    - Without either: initial admin registration (first user only).
+    - Without code: initial admin registration (first user only).
     """
-    # ── RAS Lane 2: referral_code path ────────────────────────────────────
-    if request.referral_code:
-        if not request.referred_consent:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail="紹介プログラム同意が必要です",
-            )
-        referrer = db.query(User).filter(User.referral_code == request.referral_code).first()
-        if referrer is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="無効な紹介コード",
-            )
-        try:
-            user = AuthService.create_user(db, request, role=UserRole.VIEWER.value)
-        except ValueError as e:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
-        user.referrer_id = referrer.id
-        user.referred_consent_at = datetime.now(timezone.utc)
-        db.commit()
-        db.refresh(user)
-        logger.info(
-            "User registered via referral: %s (referrer_id=%d, code=%s)",
-            user.email,
-            referrer.id,
-            request.referral_code,
-        )
-        token, expires_in = AuthService.create_access_token(user.id, user.email, user.role)
-        return RegisterResponse(
-            **UserResponse.model_validate(user).model_dump(),
-            access_token=token,
-            expires_in=expires_in,
-        )
-
     if request.invitation_code:
         from app.invitations import service as invitation_service  # noqa: PLC0415
 
@@ -178,6 +144,78 @@ def register(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         )
+
+
+@router.post(
+    "/register-with-referral",
+    response_model=RegisterResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Referral-based user registration (invitation-only signup)",
+)
+def register_with_referral(
+    request: RegisterWithReferralRequest,
+    db: Session = Depends(get_db),
+) -> RegisterResponse:
+    """
+    Register a new user via partner referral code.
+
+    Validation order (per spec):
+    1. referral_code format (8-char alphanumeric) — Pydantic 422
+    2. referral_code DB lookup — 404
+    3. referred_consent == true — 422
+    4. email duplicate — 409
+    5. create user (role=viewer fixed)
+    6. set referrer_id + referred_consent_at
+    7. issue JWT → 201
+    """
+    # Step 2: DB lookup
+    referrer = db.query(User).filter(User.referral_code == request.referral_code).first()
+    if referrer is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="referral code not found",
+        )
+
+    # Step 3: consent check
+    if not request.referred_consent:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="referral consent required",
+        )
+
+    # Step 4: email duplicate
+    if AuthService.get_user_by_email(db, request.email):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="email already registered",
+        )
+
+    # Step 5: create user (role=viewer, fixed)
+    try:
+        user = AuthService.create_user(db, request, role=UserRole.VIEWER.value)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    # Step 6: set referral fields
+    user.referrer_id = referrer.id
+    user.referred_consent_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(user)
+
+    logger.info(
+        "User registered via referral: %s (referrer_id=%d, code=%s)",
+        user.email,
+        referrer.id,
+        request.referral_code,
+    )
+
+    # Step 7: JWT
+    token, expires_in = AuthService.create_access_token(user.id, user.email, user.role)
+    return RegisterResponse(
+        **UserResponse.model_validate(user).model_dump(),
+        access_token=token,
+        expires_in=expires_in,
+    )
 
 
 @router.post(

--- a/backend/app/auth/schemas.py
+++ b/backend/app/auth/schemas.py
@@ -27,26 +27,18 @@ from app.auth.models import InvestmentTier as InvestmentTier  # noqa: E402, F401
 
 
 class RegisterRequest(BaseModel):
-    """初回管理者登録リクエスト（招待コードがある場合は招待登録）。
-
-    RAS Lane 2: referral_code / referred_consent を追加。
-    referral_code 指定時は紹介経由登録となり referrer_id / referred_consent_at が記録される。
-    """
+    """初回管理者登録または招待コード登録リクエスト。"""
 
     email: EmailStr
     username: str = Field(min_length=3, max_length=50)
     password: str = Field(min_length=8, max_length=100)
     invitation_code: Optional[str] = None
-    referral_code: Optional[str] = None
-    referred_consent: bool = False
 
     @field_validator("username")
     @classmethod
     def validate_username(cls, v: str) -> str:
-        # アンダースコアとハイフンを除去した後、英数字のみかチェック
         if not v.replace("_", "").replace("-", "").isalnum():
             raise ValueError("Username must be alphanumeric (with _ or - allowed)")
-        # 先頭は英数字のみ許可（_や-で始まることを禁止）
         if not v[0].isalnum():
             raise ValueError("Username must start with a letter or number")
         return v.lower()
@@ -57,6 +49,39 @@ class RegisterRequest(BaseModel):
         if len(v) < 8:
             raise ValueError("Password must be at least 8 characters")
         return v
+
+
+class RegisterWithReferralRequest(BaseModel):
+    """紹介コード経由ユーザー登録リクエスト (RAS Lane 2.1)。"""
+
+    email: EmailStr
+    username: str = Field(min_length=3, max_length=50)
+    password: str = Field(min_length=8, max_length=100)
+    referral_code: str
+    referred_consent: bool
+
+    @field_validator("username")
+    @classmethod
+    def validate_username(cls, v: str) -> str:
+        if not v.replace("_", "").replace("-", "").isalnum():
+            raise ValueError("Username must be alphanumeric (with _ or - allowed)")
+        if not v[0].isalnum():
+            raise ValueError("Username must start with a letter or number")
+        return v.lower()
+
+    @field_validator("password")
+    @classmethod
+    def validate_password(cls, v: str) -> str:
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters")
+        return v
+
+    @field_validator("referral_code")
+    @classmethod
+    def validate_referral_code_format(cls, v: str) -> str:
+        if len(v) != 8 or not v.isalnum():
+            raise ValueError("invalid referral code format")
+        return v.upper()
 
 
 class LoginRequest(BaseModel):

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm import Session
 from web3 import Web3
 
 from .models import User, UserRole
-from .schemas import RegisterRequest, UserCreateRequest
+from .schemas import RegisterRequest, RegisterWithReferralRequest, UserCreateRequest
 
 logger = logging.getLogger(__name__)
 
@@ -218,7 +218,7 @@ class AuthService:
     def create_user(
         cls,
         db: Session,
-        request: RegisterRequest | UserCreateRequest,
+        request: RegisterRequest | RegisterWithReferralRequest | UserCreateRequest,
         role: str = UserRole.VIEWER.value,
     ) -> User:
         """

--- a/backend/tests/test_auth_register_with_referral.py
+++ b/backend/tests/test_auth_register_with_referral.py
@@ -1,0 +1,286 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/test_auth_register_with_referral.py
+"""RAS Lane 2.1: POST /auth/register-with-referral エンドポイントのテスト。
+
+Gate B ケース:
+  Case 4  : 正常 (consent=true / 有効 code) → 201 + referrer_id セット確認
+  Case 4-1: 同一 email 重複 → 409
+  Case 4-2: code 形式不正 (7桁 "ABC1234") → 422
+  Case 5  : consent=false → 422
+  Case 6  : 不正 code (DEADBEEF → DB 未登録) → 404
+  Extra   : /auth/register が referral_code を受け付けない (削除確認) → 403
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Generator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-ras-l2.1")
+
+from app.auth.models import User, UserRole  # noqa: E402
+from app.auth.router import router as auth_router  # noqa: E402
+from app.auth.service import AuthService  # noqa: E402
+from app.database import Base, get_db  # noqa: E402
+
+_ADMIN_EMAIL = "ras-l21-admin@example.com"
+_ADMIN_PASS = "adminpass123!"
+_VALID_CODE = "PARTNER1"
+
+SessionFactory = sessionmaker[Session]
+
+
+def _create_test_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(auth_router)
+    return app
+
+
+@pytest.fixture()
+def test_db() -> Generator[SessionFactory, None, None]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    factory: SessionFactory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    yield factory
+    Base.metadata.drop_all(bind=engine)
+    os.unlink(path)
+
+
+@pytest.fixture()
+def client(
+    test_db: SessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> Generator[TestClient, None, None]:
+    monkeypatch.setenv("INITIAL_ADMIN_EMAIL", _ADMIN_EMAIL)
+    app = _create_test_app()
+
+    def override_get_db() -> Generator[Session, None, None]:
+        db = test_db()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _register_admin(client: TestClient) -> str:
+    r = client.post(
+        "/auth/register",
+        json={"email": _ADMIN_EMAIL, "username": "rasl21admin", "password": _ADMIN_PASS},
+    )
+    assert r.status_code == 201, r.text
+    return str(r.json()["access_token"])
+
+
+def _create_partner_with_code(db_factory: SessionFactory, referral_code: str) -> User:
+    db = db_factory()
+    try:
+        user = User(
+            email=f"partner-{referral_code.lower()}@example.com",
+            username=f"partner{referral_code.lower()}",
+            hashed_password=AuthService.hash_password("partnerpass1!"),
+            role=UserRole.PARTNER.value,
+            referral_code=referral_code,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        return user
+    finally:
+        db.close()
+
+
+# ── Case 4: 正常登録 → 201 + referrer_id / referred_consent_at セット ────────
+
+
+def test_register_with_referral_success_201(client: TestClient, test_db: SessionFactory) -> None:
+    _register_admin(client)
+    partner = _create_partner_with_code(test_db, _VALID_CODE)
+
+    r = client.post(
+        "/auth/register-with-referral",
+        json={
+            "email": "case4@example.com",
+            "username": "case4user",
+            "password": "case4pass1!",
+            "referral_code": _VALID_CODE,
+            "referred_consent": True,
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["email"] == "case4@example.com"
+    assert body["role"] == UserRole.VIEWER.value
+    assert "access_token" in body
+    assert body["expires_in"] > 0
+
+    # DB 側確認
+    db = test_db()
+    try:
+        new_user = db.query(User).filter(User.email == "case4@example.com").first()
+        assert new_user is not None
+        assert new_user.referrer_id == partner.id
+        assert new_user.referred_consent_at is not None
+        assert new_user.role == UserRole.VIEWER.value
+    finally:
+        db.close()
+
+
+# ── Case 4-1: 同一 email 重複 → 409 ──────────────────────────────────────────
+
+
+def test_register_with_referral_duplicate_email_409(
+    client: TestClient, test_db: SessionFactory
+) -> None:
+    _register_admin(client)
+    _create_partner_with_code(test_db, _VALID_CODE)
+
+    # 1回目: 成功
+    r1 = client.post(
+        "/auth/register-with-referral",
+        json={
+            "email": "dup@example.com",
+            "username": "dupuser1",
+            "password": "duppass1!",
+            "referral_code": _VALID_CODE,
+            "referred_consent": True,
+        },
+    )
+    assert r1.status_code == 201, r1.text
+
+    # 2回目: 同一 email → 409
+    r2 = client.post(
+        "/auth/register-with-referral",
+        json={
+            "email": "dup@example.com",
+            "username": "dupuser2",
+            "password": "duppass2!",
+            "referral_code": _VALID_CODE,
+            "referred_consent": True,
+        },
+    )
+    assert r2.status_code == 409
+    assert "email already registered" in r2.json()["detail"]
+
+
+# ── Case 4-2: referral_code 形式不正 (7桁) → 422 ──────────────────────────────
+
+
+def test_register_with_referral_invalid_code_format_422(client: TestClient) -> None:
+    _register_admin(client)
+
+    r = client.post(
+        "/auth/register-with-referral",
+        json={
+            "email": "fmt@example.com",
+            "username": "fmtuser",
+            "password": "fmtpass1!",
+            "referral_code": "ABC1234",  # 7桁
+            "referred_consent": True,
+        },
+    )
+    assert r.status_code == 422
+    assert "invalid referral code format" in r.text
+
+
+# ── Case 5: referred_consent=false → 422 (DB lookup 後) ──────────────────────
+
+
+def test_register_with_referral_no_consent_422(client: TestClient, test_db: SessionFactory) -> None:
+    _register_admin(client)
+    _create_partner_with_code(test_db, _VALID_CODE)
+
+    r = client.post(
+        "/auth/register-with-referral",
+        json={
+            "email": "noconsent@example.com",
+            "username": "noconsentuser",
+            "password": "noconsentpass1!",
+            "referral_code": _VALID_CODE,
+            "referred_consent": False,
+        },
+    )
+    assert r.status_code == 422
+    assert r.json()["detail"] == "referral consent required"
+
+
+# ── Case 6: referral_code DB 未登録 → 404 ────────────────────────────────────
+
+
+def test_register_with_referral_code_not_found_404(client: TestClient) -> None:
+    _register_admin(client)
+
+    r = client.post(
+        "/auth/register-with-referral",
+        json={
+            "email": "notfound@example.com",
+            "username": "notfounduser",
+            "password": "notfoundpass1!",
+            "referral_code": "DEADBEEF",
+            "referred_consent": True,
+        },
+    )
+    assert r.status_code == 404
+    assert r.json()["detail"] == "referral code not found"
+
+
+# ── Extra: 特殊文字を含む referral_code 形式不正 → 422 ────────────────────────
+
+
+def test_register_with_referral_code_special_chars_422(client: TestClient) -> None:
+    _register_admin(client)
+
+    r = client.post(
+        "/auth/register-with-referral",
+        json={
+            "email": "spec@example.com",
+            "username": "specuser",
+            "password": "specpass1!",
+            "referral_code": "AB!@#$%^",  # 8文字だが非英数字
+            "referred_consent": True,
+        },
+    )
+    assert r.status_code == 422
+    assert "invalid referral code format" in r.text
+
+
+# ── DoD: /auth/register が referral_code を受け付けない (削除確認) ─────────────
+
+
+def test_register_endpoint_does_not_accept_referral_code(
+    client: TestClient, test_db: SessionFactory
+) -> None:
+    """referral_code フィールドは RegisterRequest から削除済み。
+    /auth/register に referral_code を送っても referral 登録にはならず、
+    admin ガードで 403 になることを確認する。
+    """
+    _register_admin(client)
+    _create_partner_with_code(test_db, _VALID_CODE)
+
+    # 非 admin email で referral_code を含めて POST → 403 (referral パスなし)
+    r = client.post(
+        "/auth/register",
+        json={
+            "email": "sneaky@example.com",
+            "username": "sneakyuser",
+            "password": "sneakypass1!",
+            "referral_code": _VALID_CODE,
+            "referred_consent": True,
+        },
+    )
+    assert r.status_code == 403

--- a/backend/tests/test_referral_router.py
+++ b/backend/tests/test_referral_router.py
@@ -248,7 +248,7 @@ def test_get_referral_list_returns_referred_users_with_masked_email(
     assert "email" not in rows[0]
 
 
-# ── 4. POST /auth/register (referral_code + consent=true) → 201 + referrer_id ─
+# ── 4. POST /auth/register-with-referral (referral_code + consent=true) → 201 ─
 
 
 def test_register_with_referral_code_sets_referrer_and_consent(
@@ -265,7 +265,7 @@ def test_register_with_referral_code_sets_referrer_and_consent(
     )
 
     r = client.post(
-        "/auth/register",
+        "/auth/register-with-referral",
         json={
             "email": "newuser@example.com",
             "username": "newuser",
@@ -290,7 +290,7 @@ def test_register_with_referral_code_sets_referrer_and_consent(
         db.close()
 
 
-# ── 5. POST /auth/register (consent=false) → 422 ────────────────────────────
+# ── 5. POST /auth/register-with-referral (consent=false) → 422 ──────────────
 
 
 def test_register_without_consent_returns_422(client: TestClient, test_db: SessionFactory) -> None:
@@ -305,7 +305,7 @@ def test_register_without_consent_returns_422(client: TestClient, test_db: Sessi
     )
 
     r = client.post(
-        "/auth/register",
+        "/auth/register-with-referral",
         json={
             "email": "noconsent@example.com",
             "username": "noconsent",
@@ -315,16 +315,16 @@ def test_register_without_consent_returns_422(client: TestClient, test_db: Sessi
         },
     )
     assert r.status_code == 422
-    assert "紹介プログラム同意" in r.json()["detail"]
+    assert "referral consent required" in r.json()["detail"]
 
 
-# ── 6. POST /auth/register (referral_code='DEADBEEF') → 404 ─────────────────
+# ── 6. POST /auth/register-with-referral (referral_code='DEADBEEF') → 404 ───
 
 
 def test_register_with_invalid_referral_code_returns_404(client: TestClient) -> None:
     _register_initial_admin(client)
     r = client.post(
-        "/auth/register",
+        "/auth/register-with-referral",
         json={
             "email": "deadbeef@example.com",
             "username": "deadbeef",
@@ -334,7 +334,7 @@ def test_register_with_invalid_referral_code_returns_404(client: TestClient) -> 
         },
     )
     assert r.status_code == 404
-    assert r.json()["detail"] == "無効な紹介コード"
+    assert r.json()["detail"] == "referral code not found"
 
 
 # ── 7. GET /referral/users/{id}/transactions → wallet/tx_hash 含まない ──────


### PR DESCRIPTION
## Summary

- New `POST /auth/register-with-referral` endpoint implementing referral-only signup
- Removed `referral_code` / `referred_consent` from `RegisterRequest` and `/auth/register` handler (resolves conflict with `INITIAL_ADMIN_EMAIL` guard)
- Added `RegisterWithReferralRequest` schema with Pydantic 8-char alphanumeric format validator
- Updated `AuthService.create_user` type hint to accept the new request type
- Migrated `test_referral_router.py` tests 4/5/6 to new endpoint (English error messages)
- Added `test_auth_register_with_referral.py`: 7 Gate B cases (4, 4-1, 4-2, 5, 6, extra + DoD check)

## Validation order (spec-compliant)
1. `referral_code` format (8-char alphanumeric) — Pydantic 422
2. DB lookup for referral_code — 404 `"referral code not found"`
3. `referred_consent == true` — 422 `"referral consent required"`
4. Email duplicate check — 409 `"email already registered"`
5. `create_user(role="viewer")` → set `referrer_id` + `referred_consent_at` → JWT → 201

## Test plan
- [x] `ruff check` — 0 errors
- [x] `ruff format` — 463 files formatted
- [x] `mypy` — 0 issues (239 source files)
- [x] `pytest` — 2720 passed, coverage 85.18% (gate: 80%)
- [x] `ruff --select S` — 0 security warnings
- [x] Gate B Case 4 (201 + referrer_id) / 4-1 (409) / 4-2 (422 format) / 5 (422 consent) / 6 (404) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)