### PR TITLE
feat(ras-l3): frontend referral UI — partner pages + register flow

### DIFF
--- a/frontend/app/(partner)/partner/referral/[id]/page.tsx
+++ b/frontend/app/(partner)/partner/referral/[id]/page.tsx
@@ -1,0 +1,113 @@
+'use client'
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+import { useCallback, useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import Link from 'next/link'
+import { ChevronLeft } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { getStoredToken } from '@/lib/auth'
+import { getReferralTransactions, type ReferralTransaction } from '@/lib/api/referral'
+
+const TYPE_LABELS: Record<string, string> = {
+  deposit: '入金',
+  withdraw: '出金',
+  borrow: '借入',
+  repay: '返済',
+  supply: '供給',
+}
+
+function formatType(type: string): string {
+  return TYPE_LABELS[type] ?? type
+}
+
+export default function ReferralUserDetailPage() {
+  const params = useParams()
+  const userId = Number(params.id)
+  const token = getStoredToken()
+
+  const [transactions, setTransactions] = useState<ReferralTransaction[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const load = useCallback(async () => {
+    if (!token || !userId) return
+    setLoading(true)
+    try {
+      const data = await getReferralTransactions(token, userId)
+      setTransactions(data)
+    } catch {
+      setTransactions([])
+    } finally {
+      setLoading(false)
+    }
+  }, [token, userId])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+      <div className="flex items-center gap-2">
+        <Link
+          href="/partner/referral"
+          className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          紹介一覧に戻る
+        </Link>
+      </div>
+
+      <h1 className="text-2xl font-bold">取引履歴</h1>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">取引履歴一覧</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="p-6 space-y-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-10 rounded" />
+              ))}
+            </div>
+          ) : transactions.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-8">データなし</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b bg-muted/50">
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">種別</th>
+                    <th className="text-right px-4 py-3 font-medium text-muted-foreground">金額</th>
+                    <th className="text-right px-4 py-3 font-medium text-muted-foreground">日時</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {transactions.map((tx, i) => (
+                    <tr key={i} className="border-b last:border-0 hover:bg-muted/30 transition-colors">
+                      <td className="px-4 py-3">{formatType(tx.type)}</td>
+                      <td className="px-4 py-3 text-right font-mono">
+                        {Number(tx.amount).toFixed(2)}
+                      </td>
+                      <td className="px-4 py-3 text-right text-muted-foreground">
+                        {new Date(tx.occurred_at).toLocaleDateString('ja-JP', {
+                          year: 'numeric',
+                          month: '2-digit',
+                          day: '2-digit',
+                          hour: '2-digit',
+                          minute: '2-digit',
+                        })}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/app/(partner)/partner/referral/page.tsx
+++ b/frontend/app/(partner)/partner/referral/page.tsx
@@ -1,0 +1,163 @@
+'use client'
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+import { useCallback, useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Copy, Users } from 'lucide-react'
+import { toast } from 'sonner'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import { getStoredToken } from '@/lib/auth'
+import {
+  postReferralCode,
+  getReferralList,
+  type ReferralCodeResponse,
+  type ReferredUser,
+} from '@/lib/api/referral'
+
+export default function PartnerReferralPage() {
+  const token = getStoredToken()
+
+  const [codeData, setCodeData] = useState<ReferralCodeResponse | null>(null)
+  const [codeLoading, setCodeLoading] = useState(true)
+  const [users, setUsers] = useState<ReferredUser[]>([])
+  const [usersLoading, setUsersLoading] = useState(true)
+
+  const loadCode = useCallback(async () => {
+    if (!token) return
+    setCodeLoading(true)
+    try {
+      const data = await postReferralCode(token)
+      setCodeData(data)
+    } catch {
+      toast.error('招待コードの取得に失敗しました')
+    } finally {
+      setCodeLoading(false)
+    }
+  }, [token])
+
+  const loadUsers = useCallback(async () => {
+    if (!token) return
+    setUsersLoading(true)
+    try {
+      const data = await getReferralList(token)
+      setUsers(data)
+    } catch {
+      setUsers([])
+    } finally {
+      setUsersLoading(false)
+    }
+  }, [token])
+
+  useEffect(() => {
+    void loadCode()
+    void loadUsers()
+  }, [loadCode, loadUsers])
+
+  const shareUrl = codeData
+    ? (typeof window !== 'undefined'
+        ? `${window.location.origin}/r/${codeData.referral_code}`
+        : codeData.share_url)
+    : ''
+
+  const handleCopy = async () => {
+    if (!shareUrl) return
+    try {
+      await navigator.clipboard.writeText(shareUrl)
+      toast.success('コピーしました')
+    } catch {
+      toast.error('コピーに失敗しました')
+    }
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+      <h1 className="text-2xl font-bold">紹介プログラム</h1>
+
+      {/* Referral code card */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">招待リンク</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {codeLoading ? (
+            <Skeleton className="h-10 rounded-md" />
+          ) : codeData ? (
+            <>
+              <div className="flex items-center gap-2 rounded-md border border-input bg-muted px-3 py-2 text-sm font-mono">
+                <span className="flex-1 truncate">{shareUrl}</span>
+              </div>
+              <Button variant="outline" size="sm" onClick={() => { void handleCopy() }} className="gap-2">
+                <Copy className="h-4 w-4" />
+                コピー
+              </Button>
+              <p className="text-xs text-muted-foreground">
+                コード: <span className="font-mono font-medium">{codeData.referral_code}</span>
+              </p>
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">データなし</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Referred users list */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2">
+            <Users className="h-4 w-4" />
+            紹介済みユーザー
+            {!usersLoading && (
+              <span className="text-sm font-normal text-muted-foreground">({users.length}件)</span>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {usersLoading ? (
+            <div className="p-6 space-y-2">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-10 rounded" />
+              ))}
+            </div>
+          ) : users.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-8">紹介したユーザーはいません</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b bg-muted/50">
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">メール</th>
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">登録日</th>
+                    <th className="text-right px-4 py-3 font-medium text-muted-foreground">詳細</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {users.map((u) => (
+                    <tr
+                      key={u.id}
+                      className="border-b last:border-0 hover:bg-muted/30 transition-colors"
+                    >
+                      <td className="px-4 py-3 text-muted-foreground">{u.email_masked}</td>
+                      <td className="px-4 py-3 text-muted-foreground">
+                        {new Date(u.created_at).toLocaleDateString('ja-JP')}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <Link
+                          href={`/partner/referral/${u.id}`}
+                          className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+                        >
+                          取引履歴
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/app/(partner)/partner/settings/page.tsx
+++ b/frontend/app/(partner)/partner/settings/page.tsx
@@ -25,6 +25,7 @@ import { PasswordChangeCard } from '@/app/(user)/settings/_components/PasswordCh
 import { getStoredToken } from '@/lib/auth'
 import { putJson, getJson } from '@/lib/api/http'
 import { WalletConnectCard } from '@/components/partner/WalletConnectCard'
+import { ReferralTab } from '@/components/partner/ReferralTab'
 
 // ---- Profile Card (email + username) ----------------------------------------
 
@@ -275,6 +276,7 @@ export default function PartnerSettingsPage() {
     <div className="max-w-2xl mx-auto px-4 py-8 space-y-6">
       <h1 className="text-2xl font-bold">設定</h1>
       <WalletConnectCard />
+      <ReferralTab />
       <ExecutionModeCard />
       <ProfileCard />
       <PasswordChangeCard />

--- a/frontend/app/auth/register/page.tsx
+++ b/frontend/app/auth/register/page.tsx
@@ -1,0 +1,214 @@
+'use client'
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useState, useEffect, FormEvent, Suspense } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { AlertCircle, CheckCircle2 } from 'lucide-react'
+import { registerWithReferral } from '@/lib/api/referral'
+
+function getReferralCookie(): string {
+  if (typeof document === 'undefined') return ''
+  const match = document.cookie.split('; ').find((row) => row.startsWith('referral_code='))
+  return match ? decodeURIComponent(match.split('=')[1]) : ''
+}
+
+function RegisterWithReferralForm() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const refCode = searchParams.get('ref') ?? ''
+
+  const [referralCode, setReferralCode] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [username, setUsername] = useState('')
+  const [consent, setConsent] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [noCode, setNoCode] = useState(false)
+
+  useEffect(() => {
+    const code = refCode || getReferralCookie()
+    if (code) {
+      setReferralCode(code)
+    } else {
+      setNoCode(true)
+    }
+  }, [refCode])
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    if (!consent) {
+      setError('紹介プログラムへの同意が必要です')
+      return
+    }
+    setError(null)
+    setSubmitting(true)
+    try {
+      const result = await registerWithReferral({
+        email,
+        password,
+        username,
+        referral_code: referralCode,
+        referred_consent: true,
+      })
+      localStorage.setItem('ultra_auth_token', result.access_token)
+      localStorage.setItem('ultra_auth_expires', String(Date.now() + result.expires_in * 1000))
+      // Clear referral cookie after successful registration
+      document.cookie = 'referral_code=; max-age=0; path=/'
+      router.replace('/user/dashboard')
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === 'object' && 'message' in err
+          ? String((err as { message: string }).message)
+          : '登録に失敗しました'
+      setError(message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (noCode) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-muted/40 p-4">
+        <Card className="w-full max-w-sm">
+          <CardHeader className="text-center">
+            <CardTitle className="text-2xl">Ultra AutoTrade</CardTitle>
+            <CardDescription>招待コードが必要です</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                招待コードが必要です。紹介者から受け取った招待リンク（/r/&lt;code&gt;）からアクセスしてください。
+              </AlertDescription>
+            </Alert>
+            <Button variant="outline" className="w-full" onClick={() => router.replace('/login')}>
+              ログインへ
+            </Button>
+          </CardContent>
+        </Card>
+      </main>
+    )
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-muted/40 p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">Ultra AutoTrade</CardTitle>
+          <CardDescription>招待登録</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={(e) => { void handleSubmit(e) }} className="space-y-4">
+            {error && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            {/* 招待コード（読み取り専用） */}
+            <div className="space-y-1.5">
+              <Label>招待コード</Label>
+              <div className="flex items-center gap-2 rounded-md border border-input bg-muted px-3 py-2 text-sm font-mono">
+                <span className="flex-1 truncate text-foreground">{referralCode}</span>
+                <CheckCircle2 className="h-4 w-4 text-green-600 shrink-0" />
+              </div>
+              <p className="text-xs text-green-600">招待コード適用済</p>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="email">メールアドレス</Label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoComplete="email"
+                disabled={submitting}
+                placeholder="you@example.com"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="username">表示名</Label>
+              <Input
+                id="username"
+                type="text"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                required
+                autoComplete="username"
+                disabled={submitting}
+                placeholder="山田太郎"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="password">パスワード</Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                autoComplete="new-password"
+                disabled={submitting}
+              />
+            </div>
+
+            {/* 紹介プログラム同意チェックボックス */}
+            <div className="flex items-start gap-2 rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950/20">
+              <input
+                id="consent"
+                type="checkbox"
+                checked={consent}
+                onChange={(e) => setConsent(e.target.checked)}
+                required
+                disabled={submitting}
+                className="mt-0.5 h-4 w-4 shrink-0 accent-blue-600"
+              />
+              <Label htmlFor="consent" className="text-xs leading-relaxed cursor-pointer">
+                紹介者があなたの取引履歴（種別/金額/日時、ウォレット情報を除く）を閲覧することに同意します
+              </Label>
+            </div>
+
+            <Button type="submit" className="w-full" disabled={submitting || !consent}>
+              {submitting ? '登録中...' : 'アカウントを作成'}
+            </Button>
+          </form>
+
+          <p className="mt-6 text-center text-xs text-muted-foreground">
+            すでにアカウントをお持ちの方は
+            <a href="/login" className="underline underline-offset-4 hover:text-primary ml-1">
+              ログイン
+            </a>
+          </p>
+        </CardContent>
+      </Card>
+    </main>
+  )
+}
+
+export default function AuthRegisterPage() {
+  return (
+    <>
+      <title>招待登録 - Ultra AutoTrade</title>
+      <Suspense
+        fallback={
+          <div className="flex min-h-screen items-center justify-center">
+            <p className="text-muted-foreground">読み込み中...</p>
+          </div>
+        }
+      >
+        <RegisterWithReferralForm />
+      </Suspense>
+    </>
+  )
+}

--- a/frontend/app/r/[code]/page.tsx
+++ b/frontend/app/r/[code]/page.tsx
@@ -1,0 +1,24 @@
+'use client'
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+import { useEffect } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+
+export default function ReferralRedirectPage() {
+  const params = useParams()
+  const router = useRouter()
+  const code = typeof params.code === 'string' ? params.code : ''
+
+  useEffect(() => {
+    if (!code) return
+    // Store referral code in cookie for 7 days
+    document.cookie = `referral_code=${encodeURIComponent(code)}; max-age=${7 * 24 * 60 * 60}; path=/; SameSite=Lax`
+    router.replace(`/auth/register?ref=${encodeURIComponent(code)}`)
+  }, [code, router])
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <p className="text-muted-foreground">リダイレクト中...</p>
+    </div>
+  )
+}

--- a/frontend/components/partner/ReferralTab.tsx
+++ b/frontend/components/partner/ReferralTab.tsx
@@ -1,0 +1,28 @@
+'use client'
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+import Link from 'next/link'
+import { Users } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+export function ReferralTab() {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Users className="h-4 w-4" />
+          紹介プログラム
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          招待リンクを発行して新しいユーザーを紹介できます。紹介したユーザーの取引履歴（種別/金額/日時）を確認できます。
+        </p>
+        <Button asChild variant="outline" size="sm">
+          <Link href="/partner/referral">招待リンクを管理</Link>
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/lib/api/referral.ts
+++ b/frontend/lib/api/referral.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+import { getJson, postJson } from '@/lib/api/http'
+
+export interface ReferralCodeResponse {
+  referral_code: string
+  share_url: string
+}
+
+export interface ReferredUser {
+  id: number
+  email_masked: string
+  role: string
+  created_at: string
+}
+
+export interface ReferralTransaction {
+  type: string
+  amount: string
+  occurred_at: string
+}
+
+export interface RegisterWithReferralPayload {
+  email: string
+  password: string
+  username: string
+  referral_code: string
+  referred_consent: boolean
+}
+
+export interface RegisterWithReferralResponse {
+  id: number
+  email: string
+  username: string
+  role: string
+  is_active: boolean
+  access_token: string
+  token_type: string
+  expires_in: number
+}
+
+export function postReferralCode(token: string): Promise<ReferralCodeResponse> {
+  return postJson<ReferralCodeResponse>('/referral/code', {}, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
+export function getReferralList(token: string): Promise<ReferredUser[]> {
+  return getJson<ReferredUser[]>('/referral/list', {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
+export function getReferralTransactions(token: string, userId: number): Promise<ReferralTransaction[]> {
+  return getJson<ReferralTransaction[]>(`/referral/users/${userId}/transactions`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
+export function registerWithReferral(payload: RegisterWithReferralPayload): Promise<RegisterWithReferralResponse> {
+  return postJson<RegisterWithReferralResponse>('/auth/register-with-referral', payload)
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -314,6 +314,32 @@
       "aggressive": "Aggressively pursuing high returns"
     }
   },
+  "referral": {
+    "code": {
+      "title": "Referral Link",
+      "copy": "Copy",
+      "copied": "Copied!"
+    },
+    "list": {
+      "empty": "No referred users yet",
+      "users": "Referred Users"
+    },
+    "transaction": {
+      "type": {
+        "deposit": "Deposit",
+        "withdraw": "Withdraw",
+        "borrow": "Borrow",
+        "repay": "Repay"
+      }
+    }
+  },
+  "register": {
+    "referralCode": {
+      "applied": "Referral code applied",
+      "consent": "I consent to the referrer viewing my transaction history (type/amount/date, excluding wallet info)",
+      "required": "An invitation code is required. Please access via the referral link (/r/<code>) provided by your referrer."
+    }
+  },
   "CopyTrading": {
     "title": "Copy Trading",
     "subtitle": "Follow professional strategists and auto-copy their trades",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -314,6 +314,32 @@
       "aggressive": "高リターンを重視して積極的に運用します"
     }
   },
+  "referral": {
+    "code": {
+      "title": "招待リンク",
+      "copy": "コピー",
+      "copied": "コピーしました"
+    },
+    "list": {
+      "empty": "紹介したユーザーはいません",
+      "users": "紹介済みユーザー"
+    },
+    "transaction": {
+      "type": {
+        "deposit": "入金",
+        "withdraw": "出金",
+        "borrow": "借入",
+        "repay": "返済"
+      }
+    }
+  },
+  "register": {
+    "referralCode": {
+      "applied": "招待コード適用済",
+      "consent": "紹介者があなたの取引履歴（種別/金額/日時、ウォレット情報を除く）を閲覧することに同意します",
+      "required": "招待コードが必要です。紹介者から受け取った招待リンク（/r/<code>）からアクセスしてください"
+    }
+  },
   "CopyTrading": {
     "title": "コピートレード",
     "subtitle": "プロのストラテジストをフォローして自動コピー",


### PR DESCRIPTION
## Summary

- `/partner/referral` — 招待コード表示 + 紹介済みユーザー一覧（partner ロール）
- `/partner/referral/[id]` — 紹介ユーザーの取引履歴詳細
- `/r/[code]` — 招待リンク着地ページ（コードを session に保存 → 登録ページへ誘導）
- `/auth/register` — 招待コード + 同意チェック付き会員登録ページ
- `ReferralTab` — partner 設定ページに組み込み
- `lib/api/referral.ts` — referral API クライアント
- `messages/ja.json` / `en.json` — i18n キー追加（referral / register.referralCode）

## Validation

- `tsc --noEmit` : エラー 0
- `npm run build` : Compiled with warnings（tslib/__spreadArray は WalletConnect 既知問題、新規コード由来なし）

## Test plan

- [ ] partner ロールでログイン → 設定ページに ReferralTab が表示されること
- [ ] 招待リンクをコピー → `/r/<code>` にアクセスするとコードが保存されること
- [ ] `/auth/register` で招待コード適用済み表示 + 同意チェックで登録できること
- [ ] `/partner/referral` — 招待済みユーザー一覧・取引履歴リンク確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)