### PR TITLE
feat(deploy): Gate 8 post-deploy healthcheck (PR-B / Phase 3b)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -26,3 +26,20 @@ jobs:
             cd ~/ultra-autotrade
             ./deploy.sh staging
             echo "✅ Staging deployment completed"
+
+      - name: Gate 8 — Post-deploy healthcheck (staging)
+        # RCA: docs/postmortems/2026-05-09_staging_api_502.md
+        # internal mode のみ (external は Phase 3b PR-A 完了後に vars.HEALTHCHECK_MODE=both で有効化)
+        uses: appleboy/ssh-action@v1
+        env:
+          HEALTHCHECK_MODE: ${{ vars.HEALTHCHECK_MODE || 'internal' }}
+        with:
+          host: ${{ secrets.HETZNER_HOST }}
+          username: ${{ secrets.HETZNER_USER }}
+          key: ${{ secrets.HETZNER_SSH_KEY }}
+          envs: HEALTHCHECK_MODE
+          script: |
+            cd ~/ultra-autotrade
+            export SLACK_WEBHOOK_URL=$(grep '^SLACK_WEBHOOK_URL=' .env.production | cut -d= -f2-)
+            ./scripts/post_deploy_healthcheck.sh --env=staging
+            echo "✅ Gate 8 healthcheck passed"

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -46,3 +46,26 @@ jobs:
           DEPLOY_SCRIPT
 
           echo "Deploy completed successfully"
+
+      - name: Gate 8 — Post-deploy healthcheck (staging)
+        # RCA: docs/postmortems/2026-05-09_staging_api_502.md
+        # internal mode のみ (external は Phase 3b PR-A 完了後に有効化)
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.HETZNER_SSH_KEY }}
+          HETZNER_HOST: ${{ secrets.HETZNER_HOST }}
+          HETZNER_USER: ${{ secrets.HETZNER_USER || 'root' }}
+          HEALTHCHECK_MODE: ${{ vars.HEALTHCHECK_MODE || 'internal' }}
+        run: |
+          if [ -z "$SSH_PRIVATE_KEY" ] || [ -z "$HETZNER_HOST" ]; then
+            echo "::warning::SSH credentials not configured. Skipping Gate 8 healthcheck."
+            exit 0
+          fi
+
+          # SLACK_WEBHOOK_URL を .env.production から取得 (Hetzner 側で既存)
+          ssh -i ~/.ssh/deploy_key "${HETZNER_USER}@${HETZNER_HOST}" \
+              "cd /opt/ultra-autotrade && \
+               SLACK_WEBHOOK_URL=\"\$(grep '^SLACK_WEBHOOK_URL=' .env.production | cut -d= -f2-)\" \
+               HEALTHCHECK_MODE='${HEALTHCHECK_MODE}' \
+               ./scripts/post_deploy_healthcheck.sh --env=staging"
+
+          echo "Gate 8 healthcheck passed"

--- a/scripts/post_deploy_healthcheck.sh
+++ b/scripts/post_deploy_healthcheck.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# scripts/post_deploy_healthcheck.sh
+#
+# Gate 8 — deploy 後の外形 healthcheck
+# RCA: docs/postmortems/2026-05-09_staging_api_502.md
+#
+# 目的: 内部 (Hetzner localhost) と外部 (cloudflared 経由 public URL) の両方で
+#       deploy 直後に /health 200 + scheduler_healthy=true を確認する。
+#       内部だけ確認する従来の deploy_*.sh では「cloudflared ingress port mismatch」型
+#       インシデント (2026-05-09) を検知できなかったため Gate 8 として CI に統合。
+#
+# Usage:
+#   ./scripts/post_deploy_healthcheck.sh --env=staging
+#   ./scripts/post_deploy_healthcheck.sh --env=production --mode=both
+#   HEALTHCHECK_MODE=external CF_ACCESS_CLIENT_ID=... ./scripts/post_deploy_healthcheck.sh --env=staging
+#
+# Environment variables:
+#   HEALTHCHECK_MODE         = internal | external | both (default: internal)
+#   HEALTHCHECK_RETRIES      = リトライ回数 (default: 5)
+#   HEALTHCHECK_DELAY        = リトライ間隔 秒 (default: 6)
+#   CF_ACCESS_CLIENT_ID      = CF Access Service Token Client ID (external/both mode の staging で必須)
+#   CF_ACCESS_CLIENT_SECRET  = CF Access Service Token Client Secret (同上)
+#   SLACK_WEBHOOK_URL        = 失敗時 Slack 通知先 (省略時は通知なし)
+#
+# Exit codes:
+#   0 = all targets healthy
+#   1 = one or more targets failed
+#   2 = invalid arguments
+#
+# 注意:
+#   - external mode (staging) は Phase 3b PR-A (2026-05-14 Tunnel + config.yml IaC) 完了までは
+#     Service Token 反映問題により 302 を返すため、`HEALTHCHECK_MODE=internal` (default) で運用すること。
+#   - PR-A 完了後に CI 側で `HEALTHCHECK_MODE=both` に切替予定。
+
+set -euo pipefail
+
+# ─── Args ───────────────────────────────────────────────────────────
+ENV=""
+MODE="${HEALTHCHECK_MODE:-internal}"
+RETRIES="${HEALTHCHECK_RETRIES:-5}"
+DELAY="${HEALTHCHECK_DELAY:-6}"
+
+usage() {
+    cat <<'USAGE'
+Usage: post_deploy_healthcheck.sh --env=<staging|production> [--mode=<internal|external|both>]
+
+Required:
+  --env=staging      または  --env=production
+
+Optional:
+  --mode=internal    (default) localhost のみ
+  --mode=external    public URL のみ
+  --mode=both        内部 + 外部
+USAGE
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --env=*)  ENV="${arg#*=}" ;;
+        --mode=*) MODE="${arg#*=}" ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "ERROR: Unknown argument: $arg" >&2; usage; exit 2 ;;
+    esac
+done
+
+if [[ -z "$ENV" ]]; then
+    echo "ERROR: --env=staging|production is required" >&2
+    usage
+    exit 2
+fi
+if [[ "$ENV" != "staging" && "$ENV" != "production" ]]; then
+    echo "ERROR: --env must be 'staging' or 'production' (got: $ENV)" >&2
+    exit 2
+fi
+if [[ "$MODE" != "internal" && "$MODE" != "external" && "$MODE" != "both" ]]; then
+    echo "ERROR: --mode must be 'internal', 'external', or 'both' (got: $MODE)" >&2
+    exit 2
+fi
+
+# ─── Endpoint table ─────────────────────────────────────────────────
+declare -a INTERNAL_TARGETS
+case "$ENV" in
+    staging)
+        INTERNAL_TARGETS=(
+            "blue:http://127.0.0.1:8020/health"
+            "green:http://127.0.0.1:8021/health"
+            "nginx:http://127.0.0.1:8082/health"
+        )
+        EXTERNAL_URL="https://api-staging.ultra-auto-trade.com/health"
+        EXTERNAL_NEEDS_TOKEN="true"
+        ;;
+    production)
+        INTERNAL_TARGETS=(
+            "blue:http://127.0.0.1:8010/health"
+            "green:http://127.0.0.1:8011/health"
+            "nginx:http://127.0.0.1:8080/health"
+        )
+        EXTERNAL_URL="https://api.ultra-auto-trade.com/health"
+        EXTERNAL_NEEDS_TOKEN="false"
+        ;;
+esac
+
+failures=()
+
+# ─── Helpers ────────────────────────────────────────────────────────
+log() {
+    echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] $*"
+}
+
+check_url_status() {
+    # $1 = label, $2 = url, $3 = needs CF token (true|false)
+    local label="$1"
+    local url="$2"
+    local need_token="${3:-false}"
+
+    local -a curl_headers=()
+    if [[ "$need_token" == "true" ]]; then
+        if [[ -z "${CF_ACCESS_CLIENT_ID:-}" || -z "${CF_ACCESS_CLIENT_SECRET:-}" ]]; then
+            log "  SKIP ${label} (${url}): CF_ACCESS_CLIENT_ID/SECRET not set"
+            return 0
+        fi
+        curl_headers=(
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}"
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}"
+        )
+    fi
+
+    local attempt code
+    for attempt in $(seq 1 "$RETRIES"); do
+        code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+                    "${curl_headers[@]}" "$url" 2>/dev/null || echo "000")
+        if [[ "$code" == "200" ]]; then
+            log "  ✅ ${label}  (${url})  → 200  (attempt ${attempt}/${RETRIES})"
+            return 0
+        fi
+        log "  attempt ${attempt}/${RETRIES}: ${label} → ${code}"
+        if [[ "$attempt" -lt "$RETRIES" ]]; then
+            sleep "$DELAY"
+        fi
+    done
+
+    log "  ❌ ${label}  (${url})  → FAILED after ${RETRIES} attempts (last code: ${code})"
+    failures+=("${label} (${url})")
+    return 1
+}
+
+check_scheduler_healthy() {
+    # $1 = label, $2 = url, $3 = needs CF token (true|false)
+    local label="$1"
+    local url="$2"
+    local need_token="${3:-false}"
+
+    local -a curl_headers=()
+    if [[ "$need_token" == "true" ]]; then
+        if [[ -z "${CF_ACCESS_CLIENT_ID:-}" || -z "${CF_ACCESS_CLIENT_SECRET:-}" ]]; then
+            log "  SKIP scheduler_healthy ${label}: CF_ACCESS_CLIENT_ID/SECRET not set"
+            return 0
+        fi
+        curl_headers=(
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}"
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}"
+        )
+    fi
+
+    local body sched
+    body=$(curl -sf --max-time 10 "${curl_headers[@]}" "$url" 2>/dev/null || echo '{}')
+    sched=$(echo "$body" | python3 -c \
+        "import sys,json; print(json.load(sys.stdin).get('scheduler_healthy','unknown'))" \
+        2>/dev/null || echo "unknown")
+
+    case "$sched" in
+        True|true)
+            log "  ✅ scheduler_healthy=true  (${label})"
+            return 0
+            ;;
+        False|false)
+            log "  ❌ scheduler_healthy=false  (${label})"
+            failures+=("scheduler_healthy=false at ${label}")
+            return 1
+            ;;
+        *)
+            log "  ⚠️  scheduler_healthy=unknown  (${label})  body=${body:0:120}"
+            failures+=("scheduler_healthy=unknown at ${label}")
+            return 1
+            ;;
+    esac
+}
+
+# ─── Run ────────────────────────────────────────────────────────────
+log "=== Gate 8 post-deploy healthcheck ==="
+log "    env=${ENV}  mode=${MODE}  retries=${RETRIES}  delay=${DELAY}s"
+
+if [[ "$MODE" == "internal" || "$MODE" == "both" ]]; then
+    log "--- Internal targets ---"
+    for target in "${INTERNAL_TARGETS[@]}"; do
+        label="${target%%:*}"
+        url="${target#*:}"
+        check_url_status "$label" "$url" "false" || true
+    done
+    # nginx は scheduler_healthy も確認 (active backend を向いていることを保証)
+    nginx_url="${INTERNAL_TARGETS[2]#*:}"
+    check_scheduler_healthy "nginx" "$nginx_url" "false" || true
+fi
+
+if [[ "$MODE" == "external" || "$MODE" == "both" ]]; then
+    log "--- External target (cloudflared 経由) ---"
+    check_url_status "external-${ENV}" "$EXTERNAL_URL" "$EXTERNAL_NEEDS_TOKEN" || true
+    check_scheduler_healthy "external-${ENV}" "$EXTERNAL_URL" "$EXTERNAL_NEEDS_TOKEN" || true
+fi
+
+# ─── Result + Slack ─────────────────────────────────────────────────
+if [[ ${#failures[@]} -eq 0 ]]; then
+    log "✅ All healthcheck targets passed (env=${ENV} mode=${MODE})"
+    exit 0
+fi
+
+log "❌ Healthcheck FAILED: ${#failures[@]} target(s)"
+for f in "${failures[@]}"; do
+    log "    - $f"
+done
+
+if [[ -n "${SLACK_WEBHOOK_URL:-}" ]]; then
+    # JSON-safe: 改行を \n に変換、ダブルクオートをエスケープ
+    fail_lines=""
+    for f in "${failures[@]}"; do
+        escaped=$(echo -n "$f" | sed 's/"/\\"/g')
+        fail_lines="${fail_lines}- ${escaped}\\n"
+    done
+    payload=$(printf '{"text":"❌ *Gate 8 healthcheck FAILED* (env=%s mode=%s)\\n\\n%s\\nSee deploy logs for details. RCA: docs/postmortems/2026-05-09_staging_api_502.md"}' \
+        "$ENV" "$MODE" "$fail_lines")
+    curl -s -X POST -H "Content-Type: application/json" \
+         -d "$payload" "$SLACK_WEBHOOK_URL" >/dev/null 2>&1 \
+         || log "  (Slack notification failed)"
+fi
+
+exit 1


### PR DESCRIPTION
## Summary

**Phase 3b PR-B**: 2026-05-09 staging api 502 RCA から派生する Gate 8 (deploy 後外形 healthcheck) の実装。

**RCA**: docs/postmortems/2026-05-09_staging_api_502.md (PR #199)

### 何を解決するか
2026-04-27 PR #154 で staging nginx port を 8001 → 8082 に移動した際、Cloudflare Dashboard で手動管理されている cloudflared ingress が追従せず、12 日間 502 が放置された。既存の deploy スクリプトは内部 curl のみで外形 (cloudflared 経由 public URL) の検証がゼロ。本 PR で deploy 完了後に外形 healthcheck を CI から実行し、同型バグを即時検知する。

## 変更内容

### `scripts/post_deploy_healthcheck.sh` (新規, 236 行)

| 機能 | 内容 |
|---|---|
| Internal mode | `127.0.0.1:{8020,8021,8082}` (staging) or `{8010,8011,8080}` (production) の `/health` 200 + `scheduler_healthy=true` |
| External mode | `https://api{,-staging}.ultra-auto-trade.com/health` (staging は CF Access Service Token 必須) |
| Both mode | 内部 + 外部両方 |
| リトライ | 5 回 / 6 秒間隔 (環境変数で上書き可) |
| 失敗時通知 | `SLACK_WEBHOOK_URL` に Slack 通知 |
| Exit code | 0 = 全 pass / 1 = 1 件以上失敗 / 2 = 引数エラー |

### `.github/workflows/staging-deploy.yml` + `deploy-staging.yml` (修正)
- deploy 完了後に Gate 8 step 追加
- 失敗時 deploy job fail 化
- `vars.HEALTHCHECK_MODE` で internal/external/both 切替 (default: internal)

## external mode の運用方針

⚠️ Service Token 反映問題 (2026-05-09 確認、CF Access が Service Token を認識せず 302) が解決するまで `HEALTHCHECK_MODE=internal` で運用。

**Phase 3b PR-A** (2026-05-14 Tunnel 完全分離 + config.yml IaC 化) 完了後に GitHub repo Settings → Secrets and variables → Actions → Variables で `HEALTHCHECK_MODE=both` に切替予定。

切替時に必要な repo Secrets:
- `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` (Hetzner `.env.production` 経由でも可)

## CLAUDE.md Gate 8

PR #199 で既に `CLAUDE.md` の Testing 順序に Gate 8 として追記済 (`post-deploy-healthcheck (deploy後 自動)`)。本 PR は実装側の対応。

## 検証

- [x] `bash -n scripts/post_deploy_healthcheck.sh` syntax OK
- [x] python yaml lint OK (両 workflow)
- [x] production external smoke test (`HEALTHCHECK_MODE=external --env=production`) → 200 + scheduler_healthy=true
- [x] staging external smoke test (Service Token 未設定時) → SKIP messages, exit 0 (期待動作)
- [x] invalid args test (`--env=foo`) → exit 2

## Test plan (merge 前)

- [ ] Hetzner で internal mode を手動実行: `ssh ... 'cd /opt/ultra-autotrade && SLACK_WEBHOOK_URL=... ./scripts/post_deploy_healthcheck.sh --env=staging'` → 全 6 target pass を確認
- [ ] 故意に backend-blue を停止 → script が ❌ FAILED を返し、Slack 通知が `#ultra-auto-project` に届くことを確認
- [ ] backend-blue 復旧後に再実行 → ✅ All passed

## Phase 3b スケジュール (本 PR は B)

| PR | 期限 | 状態 |
|---|---|---|
| PR-C #199 (Postmortem + CLAUDE.md ルール 1-5) | 5/9 | ✅ open |
| **PR-B 本 PR (healthcheck + Gate 8 実装)** | **5/10** | **✅ this** |
| PR-D (drift 検知 + 水平展開) | 5/12 | pending |
| PR-E (Loki + API polling) | 5/12 | pending |
| PR-A (Tunnel 完全分離 + IaC) | 5/14 深夜 | pending |
| PR-F (CLAUDE.md ルール 6-9) | 5/14 | PR-A 後 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)