### PR TITLE
fix(ras): rename referral API to /partner/referral + disable invitations + add nav [PR-H]

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,7 +57,8 @@ from app.dca.router import router as dca_router
 from app.error_handlers import register_error_handlers
 from app.exchange.router import router as exchange_router
 from app.hooks.router import router as hooks_router
-from app.invitations.router import router as invitations_router
+
+# from app.invitations.router import router as invitations_router  # Phase 2 物理削除予定
 from app.knowledge.router import router as knowledge_router
 from app.notifications.models import (
     NotificationLog,  # noqa: F401 — ensure table registered with Base.metadata
@@ -204,7 +205,7 @@ def create_app() -> FastAPI:
 
     # --- Router registration ---
     app.include_router(auth_router)  # Auth (Phase12)
-    app.include_router(invitations_router)  # Invitations (Wave 2)
+    # app.include_router(invitations_router)  # Phase 2 物理削除予定 (/partner/referral に置換)
     app.include_router(partner_router)  # Partner stats (Wave 2)
     app.include_router(
         allocation_router, prefix="/api/partner", tags=["partner-allocations"]

--- a/backend/app/referral/router.py
+++ b/backend/app/referral/router.py
@@ -4,9 +4,9 @@
 """RAS Lane 2 ルーター。
 
 partner-only エンドポイント (admin / user は 403):
-  - POST /referral/code                            紹介コード取得 (未発行なら発行)
-  - GET  /referral/list                            配下ユーザー一覧
-  - GET  /referral/users/{user_id}/transactions    配下ユーザーの取引履歴
+  - POST /partner/referral/code                            紹介コード取得 (未発行なら発行)
+  - GET  /partner/referral/list                            配下ユーザー一覧
+  - GET  /partner/referral/users/{user_id}/transactions    配下ユーザーの取引履歴
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ from .schemas import (
     ReferredUserResponse,
 )
 
-router = APIRouter(prefix="/referral", tags=["referral"])
+router = APIRouter(prefix="/partner/referral", tags=["referral"])
 
 
 def require_partner_only(

--- a/backend/tests/test_invitations.py
+++ b/backend/tests/test_invitations.py
@@ -194,6 +194,7 @@ class TestInvitationService:
 # ────────────────────────────────────────────────────────────────
 
 
+@pytest.mark.skip(reason="invitations_router は PR #201 で disabled (Phase 2 物理削除予定)")
 class TestInvitationAPI:
     """招待コード API のテスト。"""
 
@@ -267,6 +268,7 @@ class TestInvitationAPI:
 # ────────────────────────────────────────────────────────────────
 
 
+@pytest.mark.skip(reason="invitations_router は PR #201 で disabled (Phase 2 物理削除予定)")
 class TestRegistrationWithInvitation:
     """招待コード付き登録フローのテスト。"""
 

--- a/backend/tests/test_referral_router.py
+++ b/backend/tests/test_referral_router.py
@@ -133,7 +133,7 @@ def test_post_referral_code_partner_returns_200_with_8char(
         UserRole.PARTNER.value,
     )
     token = _login(client, "partner-a@example.com", "partnerpass1!")
-    r = client.post("/referral/code", headers={"Authorization": f"Bearer {token}"})
+    r = client.post("/partner/referral/code", headers={"Authorization": f"Bearer {token}"})
     assert r.status_code == 200, r.text
     body = r.json()
     assert len(body["referral_code"]) == 8
@@ -154,8 +154,8 @@ def test_post_referral_code_returns_same_code_on_repeat(
         UserRole.PARTNER.value,
     )
     token = _login(client, "partner-b@example.com", "partnerpass2!")
-    r1 = client.post("/referral/code", headers={"Authorization": f"Bearer {token}"})
-    r2 = client.post("/referral/code", headers={"Authorization": f"Bearer {token}"})
+    r1 = client.post("/partner/referral/code", headers={"Authorization": f"Bearer {token}"})
+    r2 = client.post("/partner/referral/code", headers={"Authorization": f"Bearer {token}"})
     assert r1.status_code == 200
     assert r2.status_code == 200
     assert r1.json()["referral_code"] == r2.json()["referral_code"]
@@ -174,19 +174,19 @@ def test_post_referral_code_viewer_returns_403(client: TestClient, test_db: Sess
         UserRole.VIEWER.value,
     )
     token = _login(client, "viewer-a@example.com", "viewerpass1!")
-    r = client.post("/referral/code", headers={"Authorization": f"Bearer {token}"})
+    r = client.post("/partner/referral/code", headers={"Authorization": f"Bearer {token}"})
     assert r.status_code == 403
 
 
 def test_post_referral_code_admin_returns_403(client: TestClient) -> None:
     """admin は紹介プログラム対象外なので 403 (partner-only)。"""
     admin_token = _register_initial_admin(client)
-    r = client.post("/referral/code", headers={"Authorization": f"Bearer {admin_token}"})
+    r = client.post("/partner/referral/code", headers={"Authorization": f"Bearer {admin_token}"})
     assert r.status_code == 403
 
 
 def test_post_referral_code_unauthenticated_returns_401(client: TestClient) -> None:
-    r = client.post("/referral/code")
+    r = client.post("/partner/referral/code")
     assert r.status_code == 401
 
 
@@ -203,7 +203,7 @@ def test_get_referral_list_empty(client: TestClient, test_db: SessionFactory) ->
         UserRole.PARTNER.value,
     )
     token = _login(client, "partner-c@example.com", "partnerpass3!")
-    r = client.get("/referral/list", headers={"Authorization": f"Bearer {token}"})
+    r = client.get("/partner/referral/list", headers={"Authorization": f"Bearer {token}"})
     assert r.status_code == 200
     assert r.json() == []
 
@@ -238,7 +238,7 @@ def test_get_referral_list_returns_referred_users_with_masked_email(
         db.close()
 
     token = _login(client, "partner-d@example.com", "partnerpass4!")
-    r = client.get("/referral/list", headers={"Authorization": f"Bearer {token}"})
+    r = client.get("/partner/referral/list", headers={"Authorization": f"Bearer {token}"})
     assert r.status_code == 200
     rows = r.json()
     assert len(rows) == 1
@@ -402,7 +402,7 @@ def test_transactions_endpoint_excludes_wallet_and_tx_hash(
 
     token = _login(client, "partner-g@example.com", "partnerpass7!")
     r = client.get(
-        f"/referral/users/{viewer_id}/transactions",
+        f"/partner/referral/users/{viewer_id}/transactions",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert r.status_code == 200
@@ -461,7 +461,7 @@ def test_transactions_endpoint_403_for_other_partners_referred_user(
     # partner_i (別 partner) のトークンで取得しようとする → 403
     token_i = _login(client, "partner-i@example.com", "partnerpass9!")
     r = client.get(
-        f"/referral/users/{viewer_id}/transactions",
+        f"/partner/referral/users/{viewer_id}/transactions",
         headers={"Authorization": f"Bearer {token_i}"},
     )
     assert r.status_code == 403

--- a/docs/integration/backend_deps.md
+++ b/docs/integration/backend_deps.md
@@ -75,6 +75,26 @@
 - **影響範囲**: 新規 router 追加のみ。既存 endpoint への影響なし。tests/test_referral_router.py で既存 endpoint の404でないことを保証。
 - **承認**: feature/ras-l2-backend-api → main の通常フロー経由（PR #194）
 
+### 変更 #7: RAS Phase 1 cleanup — invitations_router 無効化 + referral prefix 修正 (PR #201 / 2026-05-09)
+- **コミット範囲**: `e3210c8` (hotfix/ras-partner-referral-cleanup)
+- **変更内容**:
+  - `from app.invitations.router import router as invitations_router` をコメントアウト
+  - `app.include_router(invitations_router)` をコメントアウト（Phase 2 物理削除予定）
+  - `referral_router` の APIRouter prefix を `/referral` → `/partner/referral` に修正
+    (PR #194 変更 #6 で mount 時の prefix 設定漏れを補完)
+- **理由**: hkobayashi 判断 (A) 置換 / 2026-05-09 UAT pre-check 中に発覚した以下の問題を一括修正:
+  1. `POST /referral/code` (backend) と `POST /partner/referral/code` (仕様) の prefix 不一致
+  2. 旧 `/api/invitations` と新 `/partner/referral` の二重化 → invitations を Phase 2 まで disabled
+  3. partner ナビゲーションに紹介プログラムリンクが未追加 (AppShell.tsx で追加)
+  RAS Phase 1 教訓: PR description に API path 一覧を必須記載 (CLAUDE.md ルール 11 追加予定)
+- **影響範囲**:
+  - `/api/invitations/*` エンドポイントが全て 404 になる (既存 Wave 2 招待フローは無効化)
+  - `POST /referral/code` → `POST /partner/referral/code` (既存の frontend も同時更新)
+  - `register/page.tsx` が `/api/invitations/{code}` を呼ぶ旧登録フローは Phase 2 で移行予定
+  - `frontend/app/register/page.tsx` の挙動変化: 旧招待コード登録 → 404 (UAT 影響なし / 旧フローは非推奨)
+- **承認**: hkobayashi 判断 (A) 置換 / hotfix/ras-partner-referral-cleanup → main (PR #201)
+- **ロールバック**: `git revert e3210c8` → invitations_router を再有効化 + prefix を `/referral` に戻す
+
 ## backend/app/database.py
 
 変更なし（現時点）

--- a/docs/integration/backend_deps.md
+++ b/docs/integration/backend_deps.md
@@ -76,24 +76,28 @@
 - **承認**: feature/ras-l2-backend-api → main の通常フロー経由（PR #194）
 
 ### 変更 #7: RAS Phase 1 cleanup — invitations_router 無効化 + referral prefix 修正 (PR #201 / 2026-05-09)
-- **コミット範囲**: `e3210c8` (hotfix/ras-partner-referral-cleanup)
+- **コミット範囲**: `e3210c8` + `95d51f3` (hotfix/ras-partner-referral-cleanup)
 - **変更内容**:
   - `from app.invitations.router import router as invitations_router` をコメントアウト
   - `app.include_router(invitations_router)` をコメントアウト（Phase 2 物理削除予定）
-  - `referral_router` の APIRouter prefix を `/referral` → `/partner/referral` に修正
-    (PR #194 変更 #6 で mount 時の prefix 設定漏れを補完)
-- **理由**: hkobayashi 判断 (A) 置換 / 2026-05-09 UAT pre-check 中に発覚した以下の問題を一括修正:
-  1. `POST /referral/code` (backend) と `POST /partner/referral/code` (仕様) の prefix 不一致
-  2. 旧 `/api/invitations` と新 `/partner/referral` の二重化 → invitations を Phase 2 まで disabled
-  3. partner ナビゲーションに紹介プログラムリンクが未追加 (AppShell.tsx で追加)
-  RAS Phase 1 教訓: PR description に API path 一覧を必須記載 (CLAUDE.md ルール 11 追加予定)
+  - 変更は計 2 行コメントアウト + ruff I001 自動修正のみ。新規ロジック追加なし
+- **理由**: hkobayashi 判断 (A) 置換 (Asana 1214653767574265 / RAS F-17) /
+  2026-05-09 UAT pre-check 中に発覚した以下の問題を一括修正:
+  1. `APIRouter(prefix="/referral")` vs 仕様 `/partner/referral` の不一致
+     — `referral/router.py` 側で prefix 変更 (main.py の include_router 行は変更なし)
+  2. 旧 `/api/invitations` (Wave 2、16文字コード + 期限) と新 `/partner/referral` (RAS Phase 1、8文字) の二重化解消
+  3. AppShell.tsx partner nav に「紹介プログラム」リンク未追加 → UI 側で追加
 - **影響範囲**:
-  - `/api/invitations/*` エンドポイントが全て 404 になる (既存 Wave 2 招待フローは無効化)
-  - `POST /referral/code` → `POST /partner/referral/code` (既存の frontend も同時更新)
-  - `register/page.tsx` が `/api/invitations/{code}` を呼ぶ旧登録フローは Phase 2 で移行予定
-  - `frontend/app/register/page.tsx` の挙動変化: 旧招待コード登録 → 404 (UAT 影響なし / 旧フローは非推奨)
+  - `/api/invitations/*` エンドポイントが全て 404 になる (Wave 2 招待フロー無効化)
+  - `frontend/app/register/page.tsx` の旧招待コード登録フロー → 404 (非推奨フロー、UAT 影響なし)
+  - production deploy 予定: **2026-05-15 Phase E** (staging 検証後)
+  - staging には `ALTER TABLE users ADD COLUMN IF NOT EXISTS referral_code VARCHAR(16) NULL` 適用済み前提
 - **承認**: hkobayashi 判断 (A) 置換 / hotfix/ras-partner-referral-cleanup → main (PR #201)
-- **ロールバック**: `git revert e3210c8` → invitations_router を再有効化 + prefix を `/referral` に戻す
+- **関連**: Asana RAS Phase 1 GID 1214639261103650 / PR-H Asana GID 1214653767574265
+- **ロールバック**:
+  1. `git revert e3210c8` → invitations_router を再有効化、referral prefix を `/referral` に戻す
+  2. staging: `docker compose -f docker-compose.staging.yml restart backend-blue`
+  3. production (Phase E 後): `docker compose -f docker-compose.production.yml restart backend-blue`
 
 ## backend/app/database.py
 

--- a/frontend/app/(partner)/partner/users/page.tsx
+++ b/frontend/app/(partner)/partner/users/page.tsx
@@ -3,7 +3,7 @@
 // Unauthorized copying or distribution is strictly prohibited.
 
 import { useState, useMemo, useEffect } from 'react'
-import { Users, Search, UserPlus } from 'lucide-react'
+import { Users, Search } from 'lucide-react'
 import {
   Table,
   TableBody,
@@ -16,7 +16,6 @@ import { Button } from '@/components/ui/button'
 import { useAuth } from '@/lib/auth'
 import { apiFetch } from '@/lib/api/client'
 import type { UserResponse } from '@/lib/api/auth'
-import { InviteModal } from './_components/InviteModal'
 import { UserDetailModal } from './_components/UserDetailModal'
 import { UserEditModal } from './_components/UserEditModal'
 
@@ -53,8 +52,6 @@ export default function PartnerUsersPage() {
   const [statusFilter, setStatusFilter] = useState<'all' | 'active' | 'inactive'>('all')
   const [selectedUser, setSelectedUser] = useState<UserResponse | null>(null)
   const [editingUser, setEditingUser] = useState<UserResponse | null>(null)
-  const [showInviteModal, setShowInviteModal] = useState(false)
-
   useEffect(() => {
     if (!token) return
     setLoading(true)
@@ -122,14 +119,6 @@ export default function PartnerUsersPage() {
           </div>
         </div>
 
-        <Button
-          size="sm"
-          onClick={() => setShowInviteModal(true)}
-          className="bg-blue-600 hover:bg-blue-700 text-white flex items-center gap-1.5"
-        >
-          <UserPlus className="h-4 w-4" />
-          ユーザーを招待
-        </Button>
       </div>
 
       {/* ── Filters ──────────────────────────────────────────────────────── */}
@@ -178,11 +167,6 @@ export default function PartnerUsersPage() {
       </p>
 
       {/* ── Modals ───────────────────────────────────────────────────────── */}
-      <InviteModal
-        open={showInviteModal}
-        onClose={() => setShowInviteModal(false)}
-      />
-
       <UserDetailModal
         user={selectedUser}
         token={token}

--- a/frontend/components/layout/AppShell.tsx
+++ b/frontend/components/layout/AppShell.tsx
@@ -22,6 +22,7 @@ const adminNavLinks = [
 
 const partnerNavLinks: Array<{ href: string; label: string; highlight?: boolean }> = [
   { href: "/partner/dashboard", label: "ダッシュボード" },
+  { href: "/partner/referral", label: "紹介プログラム" },
   { href: "/partner/users", label: "テスター管理" },
   { href: "/partner/proposals", label: "AI提案" },
   { href: "/partner/notifications", label: "通知ログ" },

--- a/frontend/e2e/referral-flow.spec.ts
+++ b/frontend/e2e/referral-flow.spec.ts
@@ -68,7 +68,7 @@ async function saveScreenshot(page: Page, name: string): Promise<void> {
 
 /** POST /referral/code をモック (partner 紹介コード取得/生成) */
 async function mockReferralCode(page: Page): Promise<void> {
-  await page.route('**/referral/code', async (route) => {
+  await page.route('**/partner/referral/code', async (route) => {
     if (route.request().method() === 'POST') {
       await route.fulfill({
         status: 200,
@@ -83,7 +83,7 @@ async function mockReferralCode(page: Page): Promise<void> {
 
 /** GET /referral/list をモック */
 async function mockReferralList(page: Page): Promise<void> {
-  await page.route('**/referral/list', async (route) => {
+  await page.route('**/partner/referral/list', async (route) => {
     if (route.request().method() === 'GET') {
       await route.fulfill({
         status: 200,
@@ -176,7 +176,7 @@ test.describe('[RAS] partner referral flow', () => {
     await mockReferralCode(page)
     await mockReferralList(page)
 
-    await page.route('**/referral/users/*/transactions', async (route) => {
+    await page.route('**/partner/referral/users/*/transactions', async (route) => {
       if (route.request().method() === 'GET') {
         await route.fulfill({
           status: 200,

--- a/frontend/lib/api/referral.ts
+++ b/frontend/lib/api/referral.ts
@@ -40,19 +40,19 @@ export interface RegisterWithReferralResponse {
 }
 
 export function postReferralCode(token: string): Promise<ReferralCodeResponse> {
-  return postJson<ReferralCodeResponse>('/referral/code', {}, {
+  return postJson<ReferralCodeResponse>('/partner/referral/code', {}, {
     headers: { Authorization: `Bearer ${token}` },
   })
 }
 
 export function getReferralList(token: string): Promise<ReferredUser[]> {
-  return getJson<ReferredUser[]>('/referral/list', {
+  return getJson<ReferredUser[]>('/partner/referral/list', {
     headers: { Authorization: `Bearer ${token}` },
   })
 }
 
 export function getReferralTransactions(token: string, userId: number): Promise<ReferralTransaction[]> {
-  return getJson<ReferralTransaction[]>(`/referral/users/${userId}/transactions`, {
+  return getJson<ReferralTransaction[]>(`/partner/referral/users/${userId}/transactions`, {
     headers: { Authorization: `Bearer ${token}` },
   })
 }


### PR DESCRIPTION
## Summary

RAS Phase 1 クリーンアップ。3 つの問題を一括修正:

1. **API prefix 不一致** — `POST /referral/code` → `POST /partner/referral/code` (backend + frontend 同期)
2. **ナビゲーション未追加** — AppShell partner nav に「紹介プログラム」リンク追加 (ダッシュボードの隣)
3. **旧 invitations 機能の無効化** — `/api/invitations` を main.py から切断 (Phase 2 物理削除予定)

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `backend/app/referral/router.py` | `prefix="/referral"` → `prefix="/partner/referral"` |
| `backend/app/main.py` | `invitations_router` を comment-out (disabled) |
| `frontend/lib/api/referral.ts` | fetch paths `/referral/*` → `/partner/referral/*` |
| `frontend/components/layout/AppShell.tsx` | partner nav に「紹介プログラム」追加 |
| `frontend/app/(partner)/partner/users/page.tsx` | InviteModal 削除 (invitations 廃止) |
| `backend/tests/test_referral_router.py` | テスト URL 更新 `/partner/referral/*` |
| `frontend/e2e/referral-flow.spec.ts` | mock routes 更新 `**/partner/referral/*` |

## API path 一覧

```
POST /partner/referral/code           (was /referral/code)
GET  /partner/referral/list           (was /referral/list)
GET  /partner/referral/users/{id}/transactions  (was /referral/users/{id}/transactions)
POST /api/invitations                 → disabled (Phase 2 物理削除)
POST /auth/register-with-referral     → 変更なし (auth router 配下)
```

## 教訓

- PR #194 (RAS-L2) で `APIRouter(prefix="/partner/referral")` と書くべきところを `/referral` で mount
- PR #198 (RAS-L3) で frontend page を実装したが AppShell nav へのリンク追加を忘れた
- 詳細: `docs/postmortems/2026-05-09_staging_api_502.md` 第三章 + CLAUDE.md ルール 11 (PR #199 で追記)

## Test plan

- [x] `pytest tests/test_referral_router.py tests/test_referral_code_generator.py tests/test_auth_register_with_referral.py` — 23 passed
- [x] `ruff check app/referral/ app/main.py` — no new errors
- [ ] staging deploy → `curl -H "Authorization: Bearer $TOKEN" -X POST https://api-staging.ultra-auto-trade.com/partner/referral/code` → 200
- [ ] staging frontend nav に「紹介プログラム」表示確認
- [ ] `/api/invitations` endpoint が 404 になること確認
- [ ] UAT pre-check シナリオ C-H 全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)