### PR TITLE
feat(ci): PR-J — GHCR build workflow + Hetzner pull-first deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,9 +1,10 @@
 name: Deploy to Staging
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Build and Push to GHCR"]
+    types: [completed]
+    branches: [main]
 
 concurrency:
   group: staging-deployment
@@ -13,6 +14,7 @@ jobs:
   deploy:
     name: Deploy to Hetzner Staging
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Deploy via SSH
@@ -27,5 +29,5 @@ jobs:
             cd /opt/ultra-autotrade
             git fetch origin
             git reset --hard origin/main
-            ./scripts/deploy_staging.sh
+            ./scripts/deploy_staging.sh --backend-only
             echo "✅ Staging deployment completed"

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -1,0 +1,91 @@
+name: Build and Push to GHCR
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ghcr-build
+  cancel-in-progress: true
+
+jobs:
+  build-backend:
+    name: Build backend image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/milechy/ultra-autotrade-backend
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-frontend-staging:
+    name: Build frontend (staging) image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/milechy/ultra-autotrade-frontend-staging
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            NEXT_PUBLIC_BACKEND_BASE_URL=https://api-staging.ultra-auto-trade.com
+            NEXT_PUBLIC_API_BASE_URL=https://api-staging.ultra-auto-trade.com
+            NEXT_PUBLIC_API_URL=https://api-staging.ultra-auto-trade.com
+            NEXT_PUBLIC_DEFAULT_CHAIN_ID=84532
+            NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=${{ secrets.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
+            NEXT_PUBLIC_PRIVY_APP_ID=${{ secrets.STAGING_NEXT_PUBLIC_PRIVY_APP_ID }}
+            NEXT_PUBLIC_VAPID_PUBLIC_KEY=${{ secrets.NEXT_PUBLIC_VAPID_PUBLIC_KEY }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -122,6 +122,7 @@ services:
 
   backend-blue:
     container_name: ultra-autotrade-backend-blue-staging-new
+    image: ghcr.io/milechy/ultra-autotrade-backend:latest
     build:
       context: .
       dockerfile: Dockerfile
@@ -162,6 +163,7 @@ services:
 
   backend-green:
     container_name: ultra-autotrade-backend-green-staging-new
+    image: ghcr.io/milechy/ultra-autotrade-backend:latest
     build:
       context: .
       dockerfile: Dockerfile
@@ -227,6 +229,7 @@ services:
 
   frontend:
     container_name: ultra-autotrade-frontend-staging-new
+    image: ghcr.io/milechy/ultra-autotrade-frontend-staging:latest
     build:
       context: ./frontend
       dockerfile: Dockerfile

--- a/scripts/deploy_staging.sh
+++ b/scripts/deploy_staging.sh
@@ -194,8 +194,13 @@ deploy_backend_zero_downtime() {
   log "Blue/Green 切替開始 (staging): active=${active_slot} → new=${inactive_slot}(:${inactive_port})"
 
   if ! "${NO_BUILD}"; then
-    log "backend-${inactive_slot} をビルド中..."
-    ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" build "backend-${inactive_slot}"
+    log "GHCR から backend イメージを pull (ローカルビルド省略)..."
+    if ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" pull "backend-${inactive_slot}" 2>/dev/null; then
+      log "✅ GHCR pull 成功"
+    else
+      log "WARN: GHCR pull 失敗 — ローカルビルドにフォールバック..."
+      ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" build "backend-${inactive_slot}"
+    fi
   fi
 
   log "backend-${inactive_slot} を起動..."
@@ -287,6 +292,14 @@ DC=$(resolve_dc)
 log "docker compose コマンド: ${DC}"
 log "現在の active slot: $(read_active_slot)"
 
+# GHCR 認証 (GHCR_PAT が .env.staging-new に設定されている場合)
+if [[ -n "${GHCR_PAT:-}" ]]; then
+  log "GHCR 認証中 (ghcr.io/milechy)..."
+  echo "${GHCR_PAT}" | docker login ghcr.io -u "${GHCR_USER:-milechy}" --password-stdin 2>/dev/null \
+    && log "✅ GHCR 認証成功" \
+    || log "WARN: GHCR 認証失敗 — ローカルビルドにフォールバックします"
+fi
+
 # ───────────────────────────────────────────────
 # 共通ステップ
 # ───────────────────────────────────────────────
@@ -315,17 +328,22 @@ if "${FRONTEND_ONLY}"; then
   docker rm -f "${FRONTEND_CONTAINER}" 2>/dev/null || true
 
   if ! "${NO_BUILD}"; then
-    log "古いフロントエンドイメージを完全削除..."
-    docker images --format "{{.Repository}} {{.ID}}" \
-      | grep -E "frontend.*staging-new|ultra-autotrade-staging.*front" \
-      | awk '{print $2}' \
-      | xargs -r docker rmi -f 2>/dev/null || true
+    log "GHCR から frontend イメージを pull (ローカルビルド省略)..."
+    if ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" pull frontend 2>/dev/null; then
+      log "✅ GHCR pull 成功"
+    else
+      log "WARN: GHCR pull 失敗 — ローカルビルドにフォールバック..."
+      log "古いフロントエンドイメージを完全削除..."
+      docker images --format "{{.Repository}} {{.ID}}" \
+        | grep -E "frontend.*staging-new|ultra-autotrade-staging.*front|ultra-autotrade-frontend-staging" \
+        | awk '{print $2}' \
+        | xargs -r docker rmi -f 2>/dev/null || true
 
-    log "frontend をビルド中..."
-    ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" build --no-cache frontend
+      ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" build --no-cache frontend
 
-    log "古いビルドキャッシュを削除（1時間以上前のエントリ）..."
-    docker builder prune --filter until=1h -f 2>/dev/null || true
+      log "古いビルドキャッシュを削除（1時間以上前のエントリ）..."
+      docker builder prune --filter until=1h -f 2>/dev/null || true
+    fi
   fi
 
   ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" up -d frontend
@@ -358,18 +376,24 @@ else
   docker volume prune -f 2>/dev/null || true
 
   if ! "${NO_BUILD}"; then
-    log "古いフロントエンドイメージを完全削除..."
-    docker images --format "{{.Repository}} {{.ID}}" \
-      | grep -E "frontend.*staging-new|ultra-autotrade-staging.*front" \
-      | awk '{print $2}' \
-      | xargs -r docker rmi -f 2>/dev/null || true
+    log "GHCR からイメージを pull (ローカルビルド省略)..."
+    if ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" pull frontend backend-blue backend-green 2>/dev/null; then
+      log "✅ GHCR pull 成功 (frontend + backend-blue + backend-green)"
+    else
+      log "WARN: GHCR pull 失敗 — ローカルビルドにフォールバック..."
+      log "古いフロントエンドイメージを完全削除..."
+      docker images --format "{{.Repository}} {{.ID}}" \
+        | grep -E "frontend.*staging-new|ultra-autotrade-staging.*front|ultra-autotrade-frontend-staging" \
+        | awk '{print $2}' \
+        | xargs -r docker rmi -f 2>/dev/null || true
 
-    log "frontend / backend-blue / backend-green をビルド中..."
-    ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" build --no-cache frontend
-    ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" build backend-blue backend-green
+      log "frontend / backend-blue / backend-green をビルド中..."
+      ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" build --no-cache frontend
+      ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" build backend-blue backend-green
 
-    log "古いビルドキャッシュを削除（1時間以上前のエントリ）..."
-    docker builder prune --filter until=1h -f 2>/dev/null || true
+      log "古いビルドキャッシュを削除（1時間以上前のエントリ）..."
+      docker builder prune --filter until=1h -f 2>/dev/null || true
+    fi
   fi
 
   log "全サービスを起動 (staging: postgres → backend-blue → nginx → frontend)"


### PR DESCRIPTION
## 問題

Hetzner上で `docker compose build` (特にNext.js frontend) を実行するとCPU枯渇・SSH切断が発生。
PR #202 で `--backend-only` が squash-merge 時に欠落し、full deploy (frontend build含む) がmain pushごとに走っていた。

## 解決策

GitHub ActionsでDockerイメージをビルドしてGHCRにpushし、HetznerはpullするだけにするCI/CD構成に変更。

## 変更内容

### 新規: `.github/workflows/ghcr-build.yml`
- `push: main` トリガー
- **backend**: `ghcr.io/milechy/ultra-autotrade-backend:latest` + `sha-{sha}`
- **frontend-staging**: `ghcr.io/milechy/ultra-autotrade-frontend-staging:latest` + `sha-{sha}`
  - NEXT_PUBLIC値を staging 固定値 + GitHub Secrets でビルド時注入
- GHA cache (`type=gha`) で2回目以降のビルドを大幅短縮

### 変更: `.github/workflows/deploy-staging.yml`
- トリガーを `push: main` → `workflow_run: "Build and Push to GHCR" (completed)` に変更
  - GHCRビルド成功後にのみデプロイ実行 (古いイメージのデプロイを防止)
- `--backend-only` 復元 (PR #202 squash-merge で消えていた)

### 変更: `docker-compose.staging.yml`
- backend-blue / backend-green / frontend に `image:` ディレクティブ追加
  - `docker compose pull` がGHCRイメージを取得できるようになる
  - `build:` はローカルビルドフォールバック用に残置

### 変更: `scripts/deploy_staging.sh`
- `GHCR_PAT` が `.env.staging-new` に設定されている場合 `docker login ghcr.io` を実行
- --backend-only / --frontend-only / フルデプロイ の全3パスで `docker compose pull` を先行し、失敗時のみローカルビルドにフォールバック

## デプロイフロー (変更後)

```
push to main
  → ghcr-build.yml (並列: backend ~5min + frontend-staging ~8min)
    → 成功後 deploy-staging.yml
      → Hetzner: git reset --hard origin/main
        → deploy_staging.sh --backend-only
          → docker compose pull backend-{inactive}  ← GHCRから取得 (~30sec)
          → docker compose up -d (pull済みイメージを起動)
```

## セットアップ手順 (初回のみ)

### GitHub Actions Secrets に追加
| Secret名 | 値の例 |
|---|---|
| `STAGING_NEXT_PUBLIC_PRIVY_APP_ID` | `clxxx...` |
| `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` | `abc123...` |
| `NEXT_PUBLIC_VAPID_PUBLIC_KEY` | `BxVc...` |

### GHCRパッケージの公開設定 (推奨)
初回ビルド後: GitHub → Packages → `ultra-autotrade-backend` / `ultra-autotrade-frontend-staging` → Settings → Change visibility → Public

### Hetzner (privateの場合のみ)
```bash
# .env.staging-new に追加
echo "GHCR_PAT=ghp_xxx" >> /opt/ultra-autotrade/.env.staging-new
```

## テスト計画
- [ ] `ghcr-build.yml` が main push で両ジョブを実行し GHCR に push されること
- [ ] `deploy-staging.yml` が `ghcr-build` 完了後に起動すること
- [ ] Hetzner: `docker compose pull backend-blue` でイメージが取得できること
- [ ] `deploy_staging.sh --backend-only` がローカルビルドなしで完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)