### PR TITLE
feat(header): Wallet badge を partner ロールにも表示 — F-17/2 (Lane C)

### DIFF
--- a/frontend/components/user/UserHeader.tsx
+++ b/frontend/components/user/UserHeader.tsx
@@ -117,7 +117,7 @@ export function UserHeader() {
           </nav>
 
           <div className="flex items-center gap-2 shrink-0">
-            {isAdmin && address && (
+            {(isAdmin || isPartner) && address && (
               <>
                 <Badge variant="outline" className="font-mono text-xs hidden sm:flex">
                   {`${address.slice(0, 6)}...${address.slice(-4)}`}

--- a/frontend/e2e/yamamoto-partner-flow.spec.ts
+++ b/frontend/e2e/yamamoto-partner-flow.spec.ts
@@ -684,3 +684,78 @@ test.describe('TC8: AuthProvider getMe() タイムアウト (2026-04-24 P1-NEW)'
     await expect(banner).toHaveCount(0)
   })
 })
+
+// ─── Wallet badge TC (F-17/2 / Lane C) ────────────────────────────────────
+//
+// UserHeader.tsx の Wallet badge 条件を isAdmin → isAdmin || isPartner に変更した
+// 回帰テスト。badge は wagmi の address (実ウォレット接続) を要するため、
+// E2E 環境 (wallet 未接続) では badge は常に非表示となる。
+// 以下は「接続なし = badge 非表示」の regression TC。
+// wallet 接続後の badge 表示確認は Lane G (Privy E2E 統合) に委任。
+
+test.describe('Wallet badge 条件変更 — isAdmin || isPartner (Lane C)', () => {
+  async function setupMockAuth(
+    page: Page,
+    role: 'admin' | 'partner' | 'viewer',
+  ): Promise<void> {
+    await page.addInitScript((args) => {
+      localStorage.setItem(args.tokenKey, args.token)
+      localStorage.setItem(args.expiresKey, String(args.expires))
+    }, {
+      tokenKey: 'ultra_auth_token',
+      token: 'mock-badge-test-token',
+      expiresKey: 'ultra_auth_expires',
+      expires: Date.now() + 24 * 60 * 60 * 1000,
+    })
+
+    await page.route('**/auth/me', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 99,
+          email: `${role}-badge@ultra-autotrade.com`,
+          username: `${role}-badge-test`,
+          role,
+          is_active: true,
+          created_at: '2026-01-01T00:00:00+00:00',
+          updated_at: '2026-01-01T00:00:00+00:00',
+          tier: 'GENERAL',
+          risk_mode: 'conservative',
+          risk_mode_label: 'ローリスク',
+        }),
+      })
+    })
+  }
+
+  test('partner ロール / wallet 未接続 → badge 非表示', async ({ page }) => {
+    await setupMockAuth(page, 'partner')
+    await page.goto('/user/approve')
+    // wallet address badge は 0x から始まる短縮アドレスを表示する
+    await expect(
+      page.locator('header').getByText(/^0x[0-9a-fA-F]{4}\.\.\./)
+    ).toHaveCount(0)
+  })
+
+  test('admin ロール / wallet 未接続 → badge 非表示 (regression)', async ({ page }) => {
+    await setupMockAuth(page, 'admin')
+    await page.goto('/user/dashboard')
+    await expect(
+      page.locator('header').getByText(/^0x[0-9a-fA-F]{4}\.\.\./)
+    ).toHaveCount(0)
+  })
+
+  test('viewer ロール / wallet 未接続 → badge 非表示 (regression)', async ({ page }) => {
+    await setupMockAuth(page, 'viewer')
+    await page.goto('/user/dashboard')
+    await expect(
+      page.locator('header').getByText(/^0x[0-9a-fA-F]{4}\.\.\./)
+    ).toHaveCount(0)
+  })
+
+  // wallet 接続済み partner の badge 表示は Privy E2E 統合が必要 → Lane G に委任
+  // GID 1214691705320525 / バグ-F-17 教訓 (mock E2E pass → 実環境 fail 防止) 参照
+  test.skip('partner ロール / wallet 接続済み → badge 表示 [Lane G: Privy 統合後]', async () => {
+    // TODO(Lane G): Privy test token で wallet 接続 → UserHeader badge 表示確認
+  })
+})


### PR DESCRIPTION
## Summary

- `UserHeader.tsx` L119 の Wallet badge 条件を `isAdmin` → `(isAdmin || isPartner)` に変更 (1行)
- wallet 未接続時の badge 非表示 regression TC 追加 (yamamoto-partner-flow.spec.ts)

## 変更理由

F-17/2 で報告: partner ロールでログイン時に Wallet badge が表示されない。
`isAdmin` のみ判定していたため、PR #209 (Lane C) 完了後も badge が partner に非表示だった。

## Test plan

- [x] `tsc --noEmit` — 変更ファイル由来のエラーなし (referral-flow / uat-pre-check は既存問題)
- [x] `npm run build` — ✓ warnings のみ (tslib 既存)
- [x] E2E TC 追加 (wallet 未接続 / partner/admin/viewer 3 パターン)
- [ ] Gate 4 staging-new 実環境での E2E 実行 (Lane G 完了後に partner wallet 接続 TC と合わせて実施)

## スコープ外

- backend 変更なし
- Privy wallet 接続済み partner の badge 表示 TC → Lane G (GID 1214691705320525) に委任

## Asana

- GID: 1214658214474943 (Lane C)
- F-17/2: 1214628619105545 (クローズ保留解消)

🤖 Generated with [Claude Code](https://claude.com/claude-code)