### PR TITLE
feat(partner): /api/partner stats/users/users-{id} 3 endpoints (Lane F-1 / GID 1214696920440504)

### DIFF
--- a/backend/app/partner/router.py
+++ b/backend/app/partner/router.py
@@ -25,6 +25,8 @@ from .schemas import (
     NotificationLogItem,
     NotificationLogPage,
     PartnerStatsResponse,
+    ReferralUserDetailResponse,
+    ReferralUserItem,
     TesterItem,
     UserStatsResponse,
 )
@@ -62,6 +64,39 @@ def get_partner_stats(
 ) -> PartnerStatsResponse:
     """パートナーが招待したユーザー全体の AUM・利回りを返す。"""
     return service.get_partner_stats(db, current_user.id)
+
+
+@router.get(
+    "/users",
+    response_model=list[ReferralUserItem],
+    summary="被紹介者一覧 (referrer_id モデル)",
+)
+def get_referral_users(
+    current_user: User = Depends(require_partner),
+    db: Session = Depends(get_db),
+) -> list[ReferralUserItem]:
+    """referrer_id 経由で登録された被紹介者一覧を返す。wallet_address / tx_hash は含まない。"""
+    return service.list_referral_users(db, current_user.id)
+
+
+@router.get(
+    "/users/{user_id}",
+    response_model=ReferralUserDetailResponse,
+    summary="被紹介者詳細 (referrer_id モデル)",
+)
+def get_referral_user_detail(
+    user_id: int,
+    current_user: User = Depends(require_partner),
+    db: Session = Depends(get_db),
+) -> ReferralUserDetailResponse:
+    """被紹介者の月別運用実績と AI 判定履歴要約を返す。wallet_address / tx_hash は含まない。"""
+    try:
+        return service.get_referral_user_detail(db, current_user.id, user_id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
 
 
 @router.get(

--- a/backend/app/partner/schemas.py
+++ b/backend/app/partner/schemas.py
@@ -17,6 +17,8 @@ class PartnerStatsResponse(BaseModel):
     month_return_pct: Optional[Decimal]
     yesterday_return_pct: Optional[Decimal]
     user_count: int
+    total_pnl: Optional[Decimal] = None
+    active_user_count: int = 0
 
 
 class UserStatsResponse(BaseModel):
@@ -37,6 +39,36 @@ class MonthlyStatsResponse(BaseModel):
     end_value: Decimal
     return_pct: Decimal
     user_count: int
+
+
+class ReferralUserItem(BaseModel):
+    """被紹介者一覧アイテム (referrer_id モデル)。wallet_address / tx_hash は含まない。"""
+
+    user_id: int
+    email_masked: str
+    total_aum: Decimal
+    month_return_pct: Optional[Decimal]
+    is_active: bool
+    last_judgment_at: Optional[datetime]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class JudgmentSummaryItem(BaseModel):
+    """AI 判定履歴要約アイテム。"""
+
+    action: str
+    confidence: int
+    created_at: datetime
+
+
+class ReferralUserDetailResponse(BaseModel):
+    """被紹介者詳細レスポンス (referrer_id モデル)。wallet_address / tx_hash は含まない。"""
+
+    user_id: int
+    email_masked: str
+    monthly_performance: list[MonthlyStatsResponse]
+    judgment_summary: list[JudgmentSummaryItem]
 
 
 class NotificationLogItem(BaseModel):

--- a/backend/app/partner/service.py
+++ b/backend/app/partner/service.py
@@ -8,22 +8,35 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Optional
 
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
+from app.ai.models import AIDecision
 from app.auth.models import User
 from app.portfolio.models import PortfolioHistory, PortfolioSnapshot
 
-from .schemas import MonthlyStatsResponse, PartnerStatsResponse, UserStatsResponse
+from .schemas import (
+    JudgmentSummaryItem,
+    MonthlyStatsResponse,
+    PartnerStatsResponse,
+    ReferralUserDetailResponse,
+    ReferralUserItem,
+    UserStatsResponse,
+)
 
 
 def _get_partner_user_ids(db: Session, partner_id: int) -> list[int]:
-    """users.invited_by からパートナーに紐づくユーザー ID を取得する。
-
-    マルチユース招待コード対応: Invitation.invited_user_id（1件のみ）ではなく
-    users.invited_by（ユーザーごとに記録）を参照する。
-    """
-    users = db.query(User.id).filter(User.invited_by == partner_id).all()
+    """users.referrer_id からパートナーに紐づくユーザー ID を取得する (RAS B モデル)。"""
+    users = db.query(User.id).filter(User.referrer_id == partner_id).all()
     return [u.id for u in users]
+
+
+def _mask_email(email: str) -> str:
+    """``y***@example.com`` 形式へマスクする。"""
+    if "@" not in email:
+        return email[:1] + "***"
+    local, domain = email.split("@", 1)
+    return (f"{local[0]}***@{domain}") if local else f"***@{domain}"
 
 
 def get_partner_stats(db: Session, partner_id: int) -> PartnerStatsResponse:
@@ -34,10 +47,18 @@ def get_partner_stats(db: Session, partner_id: int) -> PartnerStatsResponse:
     - yesterday_aum: 前日の最新スナップショット合計
     - month_return_pct: 当月の月次 portfolio_history から算出
     - yesterday_return_pct: 前日の日次 portfolio_history から算出
-    - user_count: 招待ユーザー数
+    - user_count: 被紹介ユーザー数 (referrer_id)
+    - total_pnl: 当月の pnl_usd 合計
+    - active_user_count: is_active=True の被紹介ユーザー数
     """
     user_ids = _get_partner_user_ids(db, partner_id)
     user_count = len(user_ids)
+
+    active_user_count: int = (
+        db.query(func.count(User.id))
+        .filter(User.referrer_id == partner_id, User.is_active.is_(True))
+        .scalar()
+    ) or 0
 
     now = datetime.now(timezone.utc)
     today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -72,6 +93,7 @@ def get_partner_stats(db: Session, partner_id: int) -> PartnerStatsResponse:
 
     yesterday_return_pct: Optional[Decimal] = None
     month_return_pct: Optional[Decimal] = None
+    total_pnl: Optional[Decimal] = None
 
     if user_ids:
         month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
@@ -109,13 +131,16 @@ def get_partner_stats(db: Session, partner_id: int) -> PartnerStatsResponse:
         if monthly_records:
             total_open = Decimal("0")
             total_close = Decimal("0")
+            pnl_sum = Decimal("0")
             for r in monthly_records:
                 total_open += Decimal(str(r.open_value_usd))
                 total_close += Decimal(str(r.close_value_usd))
+                pnl_sum += Decimal(str(r.pnl_usd))
             if total_open > Decimal("0"):
                 month_return_pct = (
                     (total_close - total_open) / total_open * Decimal("100")
                 ).quantize(Decimal("0.0001"))
+            total_pnl = pnl_sum
 
     return PartnerStatsResponse(
         total_aum=total_aum,
@@ -123,6 +148,8 @@ def get_partner_stats(db: Session, partner_id: int) -> PartnerStatsResponse:
         month_return_pct=month_return_pct,
         yesterday_return_pct=yesterday_return_pct,
         user_count=user_count,
+        total_pnl=total_pnl,
+        active_user_count=active_user_count,
     )
 
 
@@ -130,13 +157,12 @@ def get_user_stats(db: Session, partner_id: int, user_id: int) -> UserStatsRespo
     """
     特定ユーザーの運用実績を返す。
 
-    招待テーブルで partner_id との紐づきを確認する。
+    referrer_id で partner_id との紐づきを確認する。
     紐づきがない場合は ValueError を送出する。
     """
-    # users.invited_by でパートナーとの紐づきを確認（マルチユース招待コード対応）
-    target_user = db.query(User).filter(User.id == user_id, User.invited_by == partner_id).first()
+    target_user = db.query(User).filter(User.id == user_id, User.referrer_id == partner_id).first()
     if target_user is None:
-        raise ValueError(f"User {user_id} is not invited by partner {partner_id}")
+        raise ValueError(f"User {user_id} is not referred by partner {partner_id}")
 
     now = datetime.now(timezone.utc)
     today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -259,3 +285,129 @@ def get_monthly_stats(db: Session, partner_id: int) -> list[MonthlyStatsResponse
         )
 
     return result
+
+
+def list_referral_users(db: Session, partner_id: int) -> list[ReferralUserItem]:
+    """
+    被紹介者一覧を N+1 なしで返す (3 クエリ)。
+
+    Q1: referrer_id からユーザー一覧
+    Q2: 各ユーザーの最新スナップショット (subquery)
+    Q3: 当月の月次 portfolio_history から利回り計算
+    """
+    users = (
+        db.query(User).filter(User.referrer_id == partner_id).order_by(User.created_at.desc()).all()
+    )
+    if not users:
+        return []
+
+    user_ids = [u.id for u in users]
+
+    max_snap_sq = (
+        db.query(
+            PortfolioSnapshot.user_id,
+            func.max(PortfolioSnapshot.recorded_at).label("max_ts"),
+        )
+        .filter(PortfolioSnapshot.user_id.in_(user_ids))
+        .group_by(PortfolioSnapshot.user_id)
+        .subquery()
+    )
+    snaps = (
+        db.query(PortfolioSnapshot)
+        .join(
+            max_snap_sq,
+            (PortfolioSnapshot.user_id == max_snap_sq.c.user_id)
+            & (PortfolioSnapshot.recorded_at == max_snap_sq.c.max_ts),
+        )
+        .all()
+    )
+    snap_map: dict[int, Decimal] = {s.user_id: Decimal(str(s.total_value_usd)) for s in snaps}
+
+    now = datetime.now(timezone.utc)
+    month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    monthly_recs = (
+        db.query(PortfolioHistory)
+        .filter(
+            PortfolioHistory.user_id.in_(user_ids),
+            PortfolioHistory.period_type == "monthly",
+            PortfolioHistory.period_start >= month_start,
+        )
+        .all()
+    )
+    month_ret_map: dict[int, Optional[Decimal]] = {}
+    for rec in monthly_recs:
+        open_val = Decimal(str(rec.open_value_usd))
+        if open_val > Decimal("0"):
+            close_val = Decimal(str(rec.close_value_usd))
+            pct = (close_val - open_val) / open_val * Decimal("100")
+            month_ret_map[rec.user_id] = pct.quantize(Decimal("0.0001"))
+
+    return [
+        ReferralUserItem(
+            user_id=u.id,
+            email_masked=_mask_email(u.email),
+            total_aum=snap_map.get(u.id, Decimal("0")),
+            month_return_pct=month_ret_map.get(u.id),
+            is_active=u.is_active,
+            last_judgment_at=u.last_judgment_at,
+        )
+        for u in users
+    ]
+
+
+def get_referral_user_detail(
+    db: Session, partner_id: int, user_id: int
+) -> ReferralUserDetailResponse:
+    """
+    被紹介者の詳細を返す。
+
+    - referrer_id で partner_id との紐づきを確認
+    - 月別運用実績 (portfolio_history monthly)
+    - AI 判定履歴要約 (ai_decisions 直近 10 件)
+    """
+    user = db.query(User).filter(User.id == user_id, User.referrer_id == partner_id).first()
+    if user is None:
+        raise ValueError(f"User {user_id} is not referred by partner {partner_id}")
+
+    monthly_records = (
+        db.query(PortfolioHistory)
+        .filter(
+            PortfolioHistory.user_id == user_id,
+            PortfolioHistory.period_type == "monthly",
+        )
+        .order_by(PortfolioHistory.period_start.asc())
+        .all()
+    )
+    monthly_performance = [
+        MonthlyStatsResponse(
+            month=r.period_start.strftime("%Y-%m"),
+            start_value=Decimal(str(r.open_value_usd)),
+            end_value=Decimal(str(r.close_value_usd)),
+            return_pct=Decimal(str(r.pnl_pct)),
+            user_count=1,
+        )
+        for r in monthly_records
+    ]
+
+    decisions = (
+        db.query(AIDecision)
+        .filter(AIDecision.user_id == user_id)
+        .order_by(AIDecision.created_at.desc())
+        .limit(10)
+        .all()
+    )
+    judgment_summary = [
+        JudgmentSummaryItem(
+            action=d.action,
+            confidence=d.confidence,
+            created_at=d.created_at,
+        )
+        for d in decisions
+    ]
+
+    return ReferralUserDetailResponse(
+        user_id=user_id,
+        email_masked=_mask_email(user.email),
+        monthly_performance=monthly_performance,
+        judgment_summary=judgment_summary,
+    )

--- a/backend/tests/test_partner_integration.py
+++ b/backend/tests/test_partner_integration.py
@@ -1,0 +1,505 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_partner_integration.py
+"""Lane F-1: /api/partner stats / users / users-{id} 統合テスト。
+
+referrer_id モデル (RAS B) を使用する 3 エンドポイントを検証する。
+- wallet_address / tx_hash がレスポンスに含まれないことを schema レベルで保証
+- N+1 回避: 複数被紹介者でも正しい集計値が返ること
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Generator
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-partner-integration")
+
+from app.ai.models import AIDecision  # noqa: E402
+from app.auth.models import User  # noqa: E402
+from app.auth.router import router as auth_router  # noqa: E402
+from app.auth.service import AuthService  # noqa: E402
+from app.database import Base, get_db  # noqa: E402
+from app.partner.router import router as partner_router  # noqa: E402
+from app.portfolio.models import PortfolioHistory, PortfolioSnapshot  # noqa: E402
+from app.users.router import router as users_router  # noqa: E402
+
+_ADMIN_EMAIL = "pi-admin@example.com"
+_ADMIN_PASS = "adminpass123!"
+
+SessionFactory = sessionmaker[Session]
+
+
+def _create_test_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(auth_router)
+    app.include_router(users_router)
+    app.include_router(partner_router)
+    return app
+
+
+@pytest.fixture()
+def test_db() -> Generator[tuple[SessionFactory, object], None, None]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    factory: SessionFactory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    yield factory, engine
+    Base.metadata.drop_all(bind=engine)
+    os.unlink(path)
+
+
+@pytest.fixture()
+def client(
+    test_db: tuple[SessionFactory, object],
+    monkeypatch: pytest.MonkeyPatch,
+) -> TestClient:
+    monkeypatch.setenv("INITIAL_ADMIN_EMAIL", _ADMIN_EMAIL)
+    session_factory, _ = test_db
+    app = _create_test_app()
+
+    def override_get_db() -> Generator[Session, None, None]:
+        db = session_factory()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _register_admin(client: TestClient) -> str:
+    client.post(
+        "/auth/register",
+        json={"email": _ADMIN_EMAIL, "username": "piadmin", "password": _ADMIN_PASS},
+    )
+    r = client.post("/auth/login", json={"email": _ADMIN_EMAIL, "password": _ADMIN_PASS})
+    assert r.status_code == 200, r.text
+    return str(r.json()["access_token"])
+
+
+def _get_user_id(client: TestClient, token: str) -> int:
+    r = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200, r.text
+    return int(r.json()["id"])
+
+
+def _create_referred_user(
+    client: TestClient,
+    admin_token: str,
+    session_factory: SessionFactory,
+    partner_id: int,
+    email: str,
+    username: str,
+    is_active: bool = True,
+) -> int:
+    """admin 経由でユーザーを作成し referrer_id を設定する。"""
+    r = client.post(
+        "/users",
+        json={"email": email, "username": username, "password": "userpass123!", "role": "viewer"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 201, r.text
+    user_id = int(r.json()["id"])
+
+    db = session_factory()
+    try:
+        user = db.query(User).filter(User.id == user_id).first()
+        if user is not None:
+            user.referrer_id = partner_id
+            user.is_active = is_active
+            db.commit()
+    finally:
+        db.close()
+
+    return user_id
+
+
+def _create_user_invited_by_only(
+    session_factory: SessionFactory,
+    partner_id: int,
+    email: str,
+    username: str,
+) -> int:
+    """invited_by のみセット (referrer_id なし) のユーザーを直接 DB に作成。"""
+    db = session_factory()
+    try:
+        user = User(
+            email=email,
+            username=username,
+            hashed_password=AuthService.hash_password("pass123!"),
+            role="viewer",
+            invited_by=partner_id,
+            referrer_id=None,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        return user.id
+    finally:
+        db.close()
+
+
+def _add_snapshot(
+    session_factory: SessionFactory,
+    user_id: int,
+    total_value_usd: Decimal,
+) -> None:
+    db = session_factory()
+    try:
+        snap = PortfolioSnapshot(
+            user_id=user_id,
+            total_value_usd=total_value_usd,
+            total_supply_usd=total_value_usd,
+            total_borrow_usd=Decimal("0"),
+            health_factor=Decimal("2.5"),
+            recorded_at=datetime.now(timezone.utc),
+        )
+        db.add(snap)
+        db.commit()
+    finally:
+        db.close()
+
+
+def _add_monthly_history(
+    session_factory: SessionFactory,
+    user_id: int,
+    month_start: datetime,
+    open_val: Decimal,
+    close_val: Decimal,
+) -> None:
+    pnl = close_val - open_val
+    pnl_pct = (
+        (pnl / open_val * Decimal("100")).quantize(Decimal("0.0001")) if open_val else Decimal("0")
+    )
+    db = session_factory()
+    try:
+        hist = PortfolioHistory(
+            user_id=user_id,
+            period_type="monthly",
+            period_start=month_start,
+            period_end=month_start,
+            open_value_usd=open_val,
+            close_value_usd=close_val,
+            high_value_usd=close_val,
+            low_value_usd=open_val,
+            pnl_usd=pnl,
+            pnl_pct=pnl_pct,
+            avg_health_factor=Decimal("2.5"),
+            snapshot_count=1,
+        )
+        db.add(hist)
+        db.commit()
+    finally:
+        db.close()
+
+
+def _add_ai_decision(
+    session_factory: SessionFactory,
+    user_id: int,
+    action: str = "HOLD",
+    confidence: int = 70,
+) -> None:
+    db = session_factory()
+    try:
+        d = AIDecision(
+            user_id=user_id,
+            query="market query",
+            action=action,
+            confidence=confidence,
+            primary_provider="claude",
+            primary_action=action,
+            primary_confidence=confidence,
+            agreed=True,
+        )
+        db.add(d)
+        db.commit()
+    finally:
+        db.close()
+
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+
+class TestStatsUsesReferrerId:
+    def test_referrer_id_user_counted_not_invited_by(
+        self,
+        client: TestClient,
+        test_db: tuple[SessionFactory, object],
+    ) -> None:
+        """referrer_id のみのユーザーは集計に含まれ、invited_by のみは含まれない。"""
+        session_factory, _ = test_db
+        admin_token = _register_admin(client)
+        partner_id = _get_user_id(client, admin_token)
+
+        # referrer_id 経由のユーザー
+        uid = _create_referred_user(
+            client, admin_token, session_factory, partner_id, "ref@pi.com", "refuser"
+        )
+        _add_snapshot(session_factory, uid, Decimal("5000.00"))
+
+        # invited_by のみ (referrer_id なし) — カウントされないはず
+        _create_user_invited_by_only(session_factory, partner_id, "inv@pi.com", "invuser")
+
+        r = client.get("/api/partner/stats", headers={"Authorization": f"Bearer {admin_token}"})
+        assert r.status_code == 200
+        data = r.json()
+        assert data["user_count"] == 1
+        assert Decimal(data["total_aum"]) == Decimal("5000.00")
+
+
+class TestStatsNewFields:
+    def test_total_pnl_and_active_user_count_present(
+        self,
+        client: TestClient,
+        test_db: tuple[SessionFactory, object],
+    ) -> None:
+        """total_pnl と active_user_count が stats レスポンスに含まれる。"""
+        session_factory, _ = test_db
+        admin_token = _register_admin(client)
+        partner_id = _get_user_id(client, admin_token)
+
+        uid = _create_referred_user(
+            client, admin_token, session_factory, partner_id, "s1@pi.com", "suser1"
+        )
+        now = datetime.now(timezone.utc)
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        _add_monthly_history(session_factory, uid, month_start, Decimal("10000"), Decimal("10500"))
+
+        r = client.get("/api/partner/stats", headers={"Authorization": f"Bearer {admin_token}"})
+        assert r.status_code == 200
+        data = r.json()
+        assert "total_pnl" in data
+        assert "active_user_count" in data
+        assert Decimal(data["total_pnl"]) == Decimal("500")
+        assert data["active_user_count"] == 1
+
+    def test_active_user_count_excludes_inactive(
+        self,
+        client: TestClient,
+        test_db: tuple[SessionFactory, object],
+    ) -> None:
+        """is_active=False のユーザーは active_user_count に含まれない。"""
+        session_factory, _ = test_db
+        admin_token = _register_admin(client)
+        partner_id = _get_user_id(client, admin_token)
+
+        _create_referred_user(
+            client, admin_token, session_factory, partner_id, "a1@pi.com", "auser1", is_active=True
+        )
+        _create_referred_user(
+            client, admin_token, session_factory, partner_id, "a2@pi.com", "auser2", is_active=True
+        )
+        _create_referred_user(
+            client, admin_token, session_factory, partner_id, "a3@pi.com", "auser3", is_active=False
+        )
+
+        r = client.get("/api/partner/stats", headers={"Authorization": f"Bearer {admin_token}"})
+        assert r.status_code == 200
+        data = r.json()
+        assert data["user_count"] == 3
+        assert data["active_user_count"] == 2
+
+
+class TestUsersListEndpoint:
+    def test_no_wallet_or_tx_hash_in_response(
+        self,
+        client: TestClient,
+        test_db: tuple[SessionFactory, object],
+    ) -> None:
+        """wallet_address / tx_hash がレスポンスに含まれない (法務制約)。"""
+        session_factory, _ = test_db
+        admin_token = _register_admin(client)
+        partner_id = _get_user_id(client, admin_token)
+
+        _create_referred_user(
+            client, admin_token, session_factory, partner_id, "wl1@pi.com", "wluser1"
+        )
+
+        r = client.get("/api/partner/users", headers={"Authorization": f"Bearer {admin_token}"})
+        assert r.status_code == 200
+        rows = r.json()
+        assert len(rows) == 1
+        allowed_keys = {
+            "user_id",
+            "email_masked",
+            "total_aum",
+            "month_return_pct",
+            "is_active",
+            "last_judgment_at",
+        }
+        assert set(rows[0].keys()) == allowed_keys
+        assert "wallet_address" not in rows[0]
+        assert "tx_hash" not in rows[0]
+
+    def test_n1_safe_two_users_correct_aggregation(
+        self,
+        client: TestClient,
+        test_db: tuple[SessionFactory, object],
+    ) -> None:
+        """2 被紹介者で正しい AUM が返る (N+1 回避の回帰検証)。"""
+        session_factory, _ = test_db
+        admin_token = _register_admin(client)
+        partner_id = _get_user_id(client, admin_token)
+
+        uid1 = _create_referred_user(
+            client, admin_token, session_factory, partner_id, "n1@pi.com", "n1user"
+        )
+        uid2 = _create_referred_user(
+            client, admin_token, session_factory, partner_id, "n2@pi.com", "n2user"
+        )
+        _add_snapshot(session_factory, uid1, Decimal("3000.00"))
+        _add_snapshot(session_factory, uid2, Decimal("7000.00"))
+
+        r = client.get("/api/partner/users", headers={"Authorization": f"Bearer {admin_token}"})
+        assert r.status_code == 200
+        rows = r.json()
+        assert len(rows) == 2
+        aum_map = {row["user_id"]: Decimal(row["total_aum"]) for row in rows}
+        assert aum_map[uid1] == Decimal("3000.00")
+        assert aum_map[uid2] == Decimal("7000.00")
+
+    def test_empty_returns_empty_list(
+        self,
+        client: TestClient,
+    ) -> None:
+        admin_token = _register_admin(client)
+        r = client.get("/api/partner/users", headers={"Authorization": f"Bearer {admin_token}"})
+        assert r.status_code == 200
+        assert r.json() == []
+
+    def test_unauthenticated_returns_401(self, client: TestClient) -> None:
+        r = client.get("/api/partner/users")
+        assert r.status_code == 401
+
+
+class TestUsersDetailEndpoint:
+    def test_no_wallet_or_tx_hash_in_response(
+        self,
+        client: TestClient,
+        test_db: tuple[SessionFactory, object],
+    ) -> None:
+        """judgment_summary / monthly_performance に wallet/tx_hash が含まれない。"""
+        session_factory, _ = test_db
+        admin_token = _register_admin(client)
+        partner_id = _get_user_id(client, admin_token)
+
+        uid = _create_referred_user(
+            client, admin_token, session_factory, partner_id, "d1@pi.com", "d1user"
+        )
+        _add_ai_decision(session_factory, uid, "BUY", 85)
+        now = datetime.now(timezone.utc)
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        _add_monthly_history(session_factory, uid, month_start, Decimal("5000"), Decimal("5100"))
+
+        r = client.get(
+            f"/api/partner/users/{uid}",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert r.status_code == 200
+        data = r.json()
+
+        assert "wallet_address" not in data
+        assert "tx_hash" not in data
+
+        allowed_detail_keys = {"user_id", "email_masked", "monthly_performance", "judgment_summary"}
+        assert set(data.keys()) == allowed_detail_keys
+
+        if data["judgment_summary"]:
+            j = data["judgment_summary"][0]
+            assert "wallet_address" not in j
+            assert "tx_hash" not in j
+            assert set(j.keys()) == {"action", "confidence", "created_at"}
+
+        if data["monthly_performance"]:
+            m = data["monthly_performance"][0]
+            assert "wallet_address" not in m
+            assert "tx_hash" not in m
+
+    def test_404_for_non_referred_user(
+        self,
+        client: TestClient,
+        test_db: tuple[SessionFactory, object],
+    ) -> None:
+        """referrer_id が自分でないユーザーへのアクセスは 404。"""
+        session_factory, _ = test_db
+        admin_token = _register_admin(client)
+        partner_id = _get_user_id(client, admin_token)
+
+        # 別 partner の被紹介者を作る
+        other_user_id = _create_user_invited_by_only(
+            session_factory, partner_id + 9999, "other@pi.com", "otheruser"
+        )
+
+        r = client.get(
+            f"/api/partner/users/{other_user_id}",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert r.status_code == 404
+
+    def test_judgment_summary_returned(
+        self,
+        client: TestClient,
+        test_db: tuple[SessionFactory, object],
+    ) -> None:
+        session_factory, _ = test_db
+        admin_token = _register_admin(client)
+        partner_id = _get_user_id(client, admin_token)
+
+        uid = _create_referred_user(
+            client, admin_token, session_factory, partner_id, "j1@pi.com", "j1user"
+        )
+        _add_ai_decision(session_factory, uid, "BUY", 80)
+        _add_ai_decision(session_factory, uid, "HOLD", 60)
+
+        r = client.get(
+            f"/api/partner/users/{uid}",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert len(data["judgment_summary"]) == 2
+        actions = {j["action"] for j in data["judgment_summary"]}
+        assert "BUY" in actions
+        assert "HOLD" in actions
+
+    def test_monthly_performance_returned(
+        self,
+        client: TestClient,
+        test_db: tuple[SessionFactory, object],
+    ) -> None:
+        session_factory, _ = test_db
+        admin_token = _register_admin(client)
+        partner_id = _get_user_id(client, admin_token)
+
+        uid = _create_referred_user(
+            client, admin_token, session_factory, partner_id, "mp1@pi.com", "mp1user"
+        )
+        month_start = datetime(2026, 4, 1, tzinfo=timezone.utc)
+        _add_monthly_history(session_factory, uid, month_start, Decimal("10000"), Decimal("10200"))
+
+        r = client.get(
+            f"/api/partner/users/{uid}",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert len(data["monthly_performance"]) == 1
+        mp = data["monthly_performance"][0]
+        assert mp["month"] == "2026-04"
+        assert Decimal(mp["start_value"]) == Decimal("10000")
+        assert Decimal(mp["end_value"]) == Decimal("10200")
+        assert mp["user_count"] == 1

--- a/backend/tests/test_partner_stats.py
+++ b/backend/tests/test_partner_stats.py
@@ -116,12 +116,12 @@ def _create_viewer(
     assert r.status_code == 201, r.text
     user_id = int(r.json()["id"])
 
-    # users.invited_by に partner_id を設定して紐づきを記録する
+    # users.referrer_id に partner_id を設定して紐づきを記録する (RAS B モデル)
     db = session_factory()
     try:
         user = db.query(User).filter(User.id == user_id).first()
         if user is not None:
-            user.invited_by = partner_id
+            user.referrer_id = partner_id
             db.commit()
     finally:
         db.close()

--- a/backend/tests/test_partner_stats.py
+++ b/backend/tests/test_partner_stats.py
@@ -116,11 +116,12 @@ def _create_viewer(
     assert r.status_code == 201, r.text
     user_id = int(r.json()["id"])
 
-    # users.referrer_id に partner_id を設定して紐づきを記録する (RAS B モデル)
+    # invited_by (get_testers 用) と referrer_id (新 partner/users 用) 両方を設定する
     db = session_factory()
     try:
         user = db.query(User).filter(User.id == user_id).first()
         if user is not None:
+            user.invited_by = partner_id
             user.referrer_id = partner_id
             db.commit()
     finally:


### PR DESCRIPTION
## Summary

- **Migrate** partner module from `invited_by` → `referrer_id` (RAS B model, no affiliate/fund_allocations)
- **Update** `GET /api/partner/stats` — adds `total_pnl` (monthly pnl_usd sum) and `active_user_count` (is_active=True count)
- **New** `GET /api/partner/users` — referred user list: email_masked, total_aum, month_return_pct, is_active, last_judgment_at (N+1-free: 3 queries total)
- **New** `GET /api/partner/users/{id}` — individual detail: monthly_performance + AI judgment summary (recent 10)
- **Legal**: all new schemas enforce `wallet_address` / `tx_hash` exclusion at Pydantic `response_model` level

## Files changed

| File | Change |
|------|--------|
| `backend/app/partner/schemas.py` | Extend `PartnerStatsResponse` + add `ReferralUserItem`, `JudgmentSummaryItem`, `ReferralUserDetailResponse` |
| `backend/app/partner/service.py` | `referrer_id` pivot, `total_pnl`/`active_user_count`, `list_referral_users()`, `get_referral_user_detail()` |
| `backend/app/partner/router.py` | Add `GET /users`, `GET /users/{user_id}` (coexists with existing `/users/{user_id}/stats`) |
| `backend/tests/test_partner_stats.py` | `_create_viewer`: `invited_by` → `referrer_id` |
| `backend/tests/test_partner_integration.py` | **New** — 10 tests: referrer_id isolation, new fields, wallet/tx_hash absence, N+1 correctness, 404 guard |

## Test plan

- [x] `ruff check` — 0 errors
- [x] `ruff format --check` — 0 violations
- [x] `ruff check --select S` — 0 security warnings
- [ ] `pytest tests/test_partner_stats.py tests/test_partner_integration.py -v` — requires Docker backend env (fastapi not in CI shell)
- [ ] Gate 5: `curl /api/partner/stats` / `/users` / `/users/{id}` with partner JWT on staging-new
- [ ] Gate 6: `/codex:review --base main --background`

## Path conflict analysis

| Route | Status |
|-------|--------|
| `GET /api/partner/stats` | Updated (referrer_id + new fields) |
| `GET /api/partner/users` | **New** |
| `GET /api/partner/users/{user_id}` | **New** (coexists: existing suffix is `/users/{id}/stats`) |
| `GET /api/partner/users/{user_id}/stats` | Existing — guard updated (invited_by→referrer_id) |

https://claude.ai/code/session_01ADtp4D2ViQEJDUBx3Czbsq

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADtp4D2ViQEJDUBx3Czbsq)_