### PR TITLE
fix(ops): deploy_staging.sh git pull origin dev → main

### DIFF
--- a/scripts/deploy_staging.sh
+++ b/scripts/deploy_staging.sh
@@ -290,8 +290,8 @@ log "現在の active slot: $(read_active_slot)"
 # ───────────────────────────────────────────────
 # 共通ステップ
 # ───────────────────────────────────────────────
-log "git pull origin dev"
-git pull origin dev
+log "git pull origin main"
+git pull origin main
 
 log "${ENV_FILE} を読み込み（ビルド ARG 用）"
 # shellcheck disable=SC2046


### PR DESCRIPTION
deploy_staging.sh L293-294 が git pull origin dev でレガシー残存。CLAUDE.md / docs/22 / docs/42 の正規フロー (main-only / pull-only) と矛盾。1 行修正。