### PR TITLE
fix(partner): Tier 表示バグ hotfix — TierBadge 3 値化 + 現在 tier ハイライト

### DIFF
--- a/frontend/app/(partner)/partner/dashboard/_components/AllocationTable.tsx
+++ b/frontend/app/(partner)/partner/dashboard/_components/AllocationTable.tsx
@@ -32,18 +32,34 @@ function fmtUsd(v: number): string {
   }).format(v)
 }
 
+// Tier ラベル辞書 (backend TIER_JP_LABELS と整合 — app/auth/models.py)
+// GENERAL は v9 互換 (LOWER と同義、F-13 で削除予定)
+const TIER_LABELS: Record<string, string> = {
+  LOWER: '一般',
+  MIDDLE: 'ミドル',
+  UPPER: 'アッパー',
+  GENERAL: '一般',
+}
+
+function tierBadgeClass(tier: string): string {
+  if (tier === 'UPPER') {
+    return 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
+  }
+  if (tier === 'MIDDLE') {
+    return 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400'
+  }
+  return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+}
+
 function TierBadge({ tier }: { tier?: string }) {
   if (!tier) return <span className="text-muted-foreground text-xs">—</span>
-  const isUpper = tier === 'UPPER'
+  const label = TIER_LABELS[tier] ?? tier
   return (
     <span
-      className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
-        isUpper
-          ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
-          : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
-      }`}
+      data-testid={`tier-badge-${tier}`}
+      className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${tierBadgeClass(tier)}`}
     >
-      {isUpper ? 'アッパー' : '一般'}
+      {label}
     </span>
   )
 }

--- a/frontend/app/(partner)/partner/dashboard/page.tsx
+++ b/frontend/app/(partner)/partner/dashboard/page.tsx
@@ -16,7 +16,7 @@ import {
   type Allocation,
   type TesterPerformance,
 } from '@/lib/api/allocations'
-import { getStoredToken } from '@/lib/auth'
+import { getStoredToken, useAuth } from '@/lib/auth'
 import PerformanceSummaryKPI from './_components/PerformanceSummaryKPI'
 import AllocationTable from './_components/AllocationTable'
 import type { MonthlyData } from './_components/MonthlyChartRecharts'
@@ -90,18 +90,44 @@ function returnTrend(v: number | undefined): 'up' | 'down' | 'flat' {
   return v > 0 ? 'up' : 'down'
 }
 
+// Tier ラベル辞書 (backend TIER_JP_LABELS と整合 — app/auth/models.py)
+// GENERAL は v9 互換 (LOWER と同義、F-13 で削除予定)
+const TIER_LABELS: Record<string, string> = {
+  LOWER: '一般',
+  MIDDLE: 'ミドル',
+  UPPER: 'アッパー',
+  GENERAL: '一般',
+}
+
+function tierBadgeClass(tier: string): string {
+  if (tier === 'UPPER') {
+    return 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
+  }
+  if (tier === 'MIDDLE') {
+    return 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400'
+  }
+  return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+}
+
+function tierCardClass(tier: string): string {
+  if (tier === 'UPPER') {
+    return 'border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/20'
+  }
+  if (tier === 'MIDDLE') {
+    return 'border-violet-200 bg-violet-50 dark:border-violet-800 dark:bg-violet-950/20'
+  }
+  return 'border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/20'
+}
+
 function TierBadge({ tier }: { tier?: string }) {
   if (!tier) return <span className="text-muted-foreground text-xs">—</span>
-  const isUpper = tier === 'UPPER'
+  const label = TIER_LABELS[tier] ?? tier
   return (
     <span
-      className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
-        isUpper
-          ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
-          : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
-      }`}
+      data-testid={`tier-badge-${tier}`}
+      className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${tierBadgeClass(tier)}`}
     >
-      {isUpper ? 'アッパー' : '一般'}
+      {label}
     </span>
   )
 }
@@ -109,6 +135,10 @@ function TierBadge({ tier }: { tier?: string }) {
 // ---- Page ----
 
 export default function PartnerDashboardPage() {
+  const { user: currentUser } = useAuth()
+  // GENERAL は LOWER 同義 (v9 互換)
+  const currentTier = currentUser?.tier === 'GENERAL' ? 'LOWER' : currentUser?.tier
+
   const { data: stats, loading: statsLoading } = useAuthFetch<PartnerStats>('/api/partner/stats', { refreshInterval: 300000 })
   const { data: usersRaw, loading: usersLoading } = useAuthFetch<UsersResponse | PartnerUser[]>('/users', { refreshInterval: 300000 })
   const { data: monthly, loading: monthlyLoading } = useAuthFetch<MonthlyData[]>('/api/partner/monthly', { refreshInterval: 300000 })
@@ -239,25 +269,36 @@ export default function PartnerDashboardPage() {
               <Skeleton className="h-24 rounded-lg" />
             ) : feeSchedule ? (
               <div className="space-y-3">
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                  {feeSchedule.schedule.map((item) => (
-                    <div
-                      key={item.tier}
-                      className={`rounded-lg border p-4 ${
-                        item.tier === 'UPPER'
-                          ? 'border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/20'
-                          : 'border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/20'
-                      }`}
-                    >
-                      <div className="flex items-center gap-2 mb-2">
-                        <TierBadge tier={item.tier} />
-                        <span className="text-sm font-medium">{item.description}</span>
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                  {feeSchedule.schedule.map((item) => {
+                    const isCurrent = item.tier === currentTier
+                    return (
+                      <div
+                        key={item.tier}
+                        data-testid={`fee-card-${item.tier}`}
+                        data-current={isCurrent ? 'true' : 'false'}
+                        className={`rounded-lg border p-4 transition-shadow ${tierCardClass(item.tier)} ${
+                          isCurrent ? 'ring-2 ring-offset-2 ring-primary shadow-md' : 'opacity-80'
+                        }`}
+                      >
+                        <div className="flex flex-wrap items-center gap-2 mb-2">
+                          <TierBadge tier={item.tier} />
+                          {isCurrent && (
+                            <span
+                              data-testid="current-tier-label"
+                              className="text-[10px] font-semibold uppercase tracking-wider text-primary"
+                            >
+                              あなたのティア
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-xs text-muted-foreground mb-1">{item.description}</p>
+                        <p className="text-2xl font-bold">
+                          {item.min_rate_pct}〜{item.max_rate_pct}%
+                        </p>
                       </div>
-                      <p className="text-2xl font-bold">
-                        {item.min_rate_pct}〜{item.max_rate_pct}%
-                      </p>
-                    </div>
-                  ))}
+                    )
+                  })}
                 </div>
                 <p className="text-xs text-muted-foreground">{feeSchedule.note}</p>
               </div>

--- a/frontend/e2e/partner-dashboard-tier.spec.ts
+++ b/frontend/e2e/partner-dashboard-tier.spec.ts
@@ -1,0 +1,240 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+//
+// /partner/dashboard 手数料体系セクションの tier 別表示検証 (P0 hotfix 2026-05-12)
+//
+// 背景:
+//   2026-05-12 production の test-partner-001 (tier=LOWER) で
+//   - 2 枚目の MIDDLE カードが「一般」と誤表示
+//   - UPPER カードが常時オレンジ枠ハイライト (ユーザー tier 無関係)
+//   - 「あなたのティア」インジケータが存在しない
+//   の 3 連バグが発覚。frontend hotfix 適用後の回帰検証。
+//
+// 検証方針:
+//   /auth/me を 3 通り (LOWER / MIDDLE / UPPER) で mock し、
+//   - fee-card-{TIER} に data-current="true" が立つこと
+//   - 他 2 枚は data-current="false" であること
+//   - tier-badge-{TIER} のテキストが TIER_LABELS と一致すること
+//   - 「あなたのティア」ラベルが該当カードにだけ出ること
+//
+// 実行:
+//   STAGING_URL=http://localhost:3000 npx playwright test e2e/partner-dashboard-tier.spec.ts
+//
+// 認証: DB に依存しない (全 API mock)。E2E_PARTNER_EMAIL/PASSWORD 不要。
+
+import { test, expect, Page } from '@playwright/test'
+
+const FEE_SCHEDULE = {
+  schedule: [
+    {
+      tier: 'LOWER',
+      label: '一般',
+      min_rate: '0.03',
+      max_rate: '0.10',
+      min_rate_pct: '3',
+      max_rate_pct: '10',
+      description: 'デポジット 100 万円以下のティア',
+    },
+    {
+      tier: 'MIDDLE',
+      label: 'ミドル',
+      min_rate: '0.08',
+      max_rate: '0.18',
+      min_rate_pct: '8',
+      max_rate_pct: '18',
+      description: 'デポジット 100 万〜1000 万円のティア',
+    },
+    {
+      tier: 'UPPER',
+      label: 'アッパー',
+      min_rate: '0.15',
+      max_rate: '0.25',
+      min_rate_pct: '15',
+      max_rate_pct: '25',
+      description: 'デポジット 1000 万円以上のティア',
+    },
+  ],
+  note: '手数料率は実利益に対して適用されます',
+}
+
+async function setupAuth(page: Page, tier: string): Promise<void> {
+  await page.addInitScript(
+    (args) => {
+      localStorage.setItem(args.tokenKey, args.token)
+      localStorage.setItem(args.expiresKey, String(args.expires))
+    },
+    {
+      tokenKey: 'ultra_auth_token',
+      token: 'mock-tier-display-token',
+      expiresKey: 'ultra_auth_expires',
+      expires: Date.now() + 24 * 60 * 60 * 1000,
+    },
+  )
+
+  await page.route('**/auth/me', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue()
+      return
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 16,
+        email: 'test-partner-tier@ultra-autotrade.com',
+        username: 'test-partner-tier',
+        role: 'partner',
+        is_active: true,
+        created_at: '2026-01-01T00:00:00+00:00',
+        updated_at: '2026-01-01T00:00:00+00:00',
+        tier,
+        risk_mode: 'conservative',
+        risk_mode_label: 'ローリスク',
+      }),
+    })
+  })
+
+  // /partner/dashboard をレンダリングするのに最低限必要な API を mock
+  const mocks: Array<[string, unknown]> = [
+    ['**/users/fee-schedule', FEE_SCHEDULE],
+    [
+      '**/api/partner/stats',
+      {
+        total_aum: 0,
+        yesterday_aum: 0,
+        month_return_pct: 0,
+        yesterday_return_pct: 0,
+        user_count: 0,
+      },
+    ],
+    ['**/api/partner/monthly', []],
+    ['**/api/partner/allocations', []],
+    [
+      '**/api/partner/performance',
+      {
+        total_allocated_usd: 0,
+        total_supply_usd: 0,
+        health_factor: null,
+        testers: [],
+      },
+    ],
+    [
+      '**/ai/accuracy',
+      {
+        total_decisions: 0,
+        correct_count: 0,
+        accuracy_pct: 0,
+        last_30d_accuracy_pct: 0,
+      },
+    ],
+    ['**/users', { items: [] }],
+  ]
+  for (const [pattern, body] of mocks) {
+    await page.route(pattern, async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(body),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+  }
+}
+
+const TIER_LABELS: Record<string, string> = {
+  LOWER: '一般',
+  MIDDLE: 'ミドル',
+  UPPER: 'アッパー',
+  GENERAL: '一般',
+}
+
+async function assertTierHighlight(
+  page: Page,
+  currentTier: 'LOWER' | 'MIDDLE' | 'UPPER',
+): Promise<void> {
+  // 手数料体系セクション全体が描画されるまで待つ
+  await expect(page.getByText('手数料体系', { exact: true })).toBeVisible({
+    timeout: 15_000,
+  })
+
+  // 3 枚のカードが全て描画される (LOWER / MIDDLE / UPPER)
+  for (const tier of ['LOWER', 'MIDDLE', 'UPPER'] as const) {
+    await expect(page.getByTestId(`fee-card-${tier}`)).toBeVisible({
+      timeout: 10_000,
+    })
+  }
+
+  // 各 tier の badge ラベルが TIER_LABELS と一致
+  // (MIDDLE が「一般」と表示される旧バグの回帰防止)
+  for (const tier of ['LOWER', 'MIDDLE', 'UPPER'] as const) {
+    const badge = page.getByTestId(`fee-card-${tier}`).getByTestId(`tier-badge-${tier}`)
+    await expect(badge).toHaveText(TIER_LABELS[tier])
+  }
+
+  // 現在ユーザーの tier のカードだけ data-current="true"
+  // (UPPER 固定ハイライト旧バグの回帰防止)
+  for (const tier of ['LOWER', 'MIDDLE', 'UPPER'] as const) {
+    const card = page.getByTestId(`fee-card-${tier}`)
+    const expected = tier === currentTier ? 'true' : 'false'
+    await expect(card).toHaveAttribute('data-current', expected)
+  }
+
+  // 「あなたのティア」ラベルは currentTier のカードに 1 つだけ
+  const currentLabel = page
+    .getByTestId(`fee-card-${currentTier}`)
+    .getByTestId('current-tier-label')
+  await expect(currentLabel).toBeVisible()
+  await expect(currentLabel).toHaveText('あなたのティア')
+
+  // 他 2 枚にラベルが付いていないこと
+  const otherTiers = (['LOWER', 'MIDDLE', 'UPPER'] as const).filter(
+    (t) => t !== currentTier,
+  )
+  for (const tier of otherTiers) {
+    await expect(
+      page.getByTestId(`fee-card-${tier}`).getByTestId('current-tier-label'),
+    ).toHaveCount(0)
+  }
+}
+
+test.describe('Tier 表示バグ hotfix (P0 2026-05-12)', () => {
+  test('tier=LOWER ユーザー → LOWER カードがハイライトされる + 3 枚全て正しいラベル', async ({
+    page,
+  }) => {
+    await setupAuth(page, 'LOWER')
+    await page.goto('/partner/dashboard')
+    await page.waitForLoadState('domcontentloaded')
+    await assertTierHighlight(page, 'LOWER')
+  })
+
+  test('tier=MIDDLE ユーザー → MIDDLE カードがハイライトされる + バッジが「ミドル」', async ({
+    page,
+  }) => {
+    await setupAuth(page, 'MIDDLE')
+    await page.goto('/partner/dashboard')
+    await page.waitForLoadState('domcontentloaded')
+    await assertTierHighlight(page, 'MIDDLE')
+  })
+
+  test('tier=UPPER ユーザー → UPPER カードがハイライトされる + バッジが「アッパー」', async ({
+    page,
+  }) => {
+    await setupAuth(page, 'UPPER')
+    await page.goto('/partner/dashboard')
+    await page.waitForLoadState('domcontentloaded')
+    await assertTierHighlight(page, 'UPPER')
+  })
+
+  test('tier=GENERAL (v9 互換) ユーザー → LOWER カードがハイライトされる', async ({
+    page,
+  }) => {
+    await setupAuth(page, 'GENERAL')
+    await page.goto('/partner/dashboard')
+    await page.waitForLoadState('domcontentloaded')
+    // GENERAL は LOWER 同義として扱う
+    await assertTierHighlight(page, 'LOWER')
+  })
+})

--- a/frontend/lib/api/auth.ts
+++ b/frontend/lib/api/auth.ts
@@ -33,6 +33,9 @@ export interface UserResponse {
   created_at: string;
   updated_at: string;
   invited_by?: number | null;
+  tier?: "LOWER" | "MIDDLE" | "UPPER" | "GENERAL";
+  risk_mode?: "conservative" | "balanced" | "aggressive";
+  risk_mode_label?: string;
 }
 
 export interface PasswordChangeRequest {


### PR DESCRIPTION
## Summary
production の partner/dashboard 手数料体系セクションで発覚した 3 連バグの hotfix。frontend のみで完結し API 契約変更なし。

### 真因 (production /partner/dashboard, test-partner-001 tier=LOWER で再現)
- `TierBadge` が 2 値判定 (`tier === 'UPPER'` か否か) → MIDDLE カードのバッジが「一般」と誤表示
- 手数料カードのハイライトが `item.tier === 'UPPER'` 固定 → ユーザー tier 無関係に常に UPPER カードがオレンジ枠強調
- 「あなたのティア」インジケータが未実装

### 修正内容
- `frontend/lib/api/auth.ts` `UserResponse` に `tier` / `risk_mode` / `risk_mode_label` 追加 (backend は既に送信中、TS 型が追いついていなかっただけ)
- `TIER_LABELS` / `tierBadgeClass` / `tierCardClass` を導入し `TierBadge` を 3 値化 (LOWER=一般 / MIDDLE=ミドル / UPPER=アッパー、GENERAL は v9 互換で LOWER 同義)
- 手数料体系カードを 3 カラム grid 化 + `useAuth().user.tier` に基づく動的ハイライト + 「あなたのティア」ラベル
- `AllocationTable.tsx` の `TierBadge` も同等の 3 値判定に揃える
- `e2e/partner-dashboard-tier.spec.ts` 新規 (LOWER / MIDDLE / UPPER / GENERAL × Desktop + Mobile = 8 ケース)

### 採用案と却下案 (claude.ai レビュー済み)
- **A 案 (採用): frontend のみで `user.tier` ベース判定** — 30 分、`--frontend-only` deploy 可、API 契約変更なし、12:00 マージ間に合う
- B 案: backend `FeeRateRange.is_current_user_tier` 追加 — backend デプロイ必要で 12:00 不可
- C 案: backend が tier 込みで `schedule[]` 出力 — 同上、影響さらに大

## Test plan
- [x] `npx tsc --noEmit` 私の changed files に新規エラーなし (3 件の TS エラーは origin/main 由来の pre-existing、別件)
- [x] `npm run build` pass
- [x] Playwright `partner-dashboard-tier.spec.ts` Desktop Chrome 4/4 pass (LOWER / MIDDLE / UPPER / GENERAL)
- [x] Playwright `partner-dashboard-tier.spec.ts` Mobile Chrome 4/4 pass
- [ ] Codex Review (`/codex:review --base main --background`)
- [ ] main マージ後 Hetzner で `./scripts/deploy_production.sh --frontend-only`
- [ ] 本番 /partner/dashboard を test-partner-001 (LOWER) でログインし「一般」カードがハイライトされ「あなたのティア」ラベルが付くことを目視確認

## DoD 検証ルール (CLAUDE.md 標準チェックリスト)
- 全テキスト日本語 / ハードコード値なし (TIER_LABELS は backend `TIER_JP_LABELS` と整合)
- backend / DB / API 契約変更なし → `--frontend-only` deploy で完結
- `useAuth()` 経由で `user.tier` を取得 (新規 API 呼び出しなし、既存 `/auth/me` のレスポンスを型に反映するだけ)

## 関連
- Asana: 1214739358136502 (P0 本日 14:00 山本さん UAT 維持)
- 関連バグ: backend `app/auth/models.py` `TIER_JP_LABELS` (LOWER=一般 / MIDDLE=ミドル / UPPER=アッパー) と整合

🤖 Generated with [Claude Code](https://claude.com/claude-code)