### PR TITLE
feat(scheduler): startup イベントに 7 ループ起動配線を追加

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -433,41 +433,100 @@ def create_app() -> FastAPI:
         Controlled by environment variables:
             ENABLE_DAILY_REPORTS=1: enable daily reports
             ENABLE_WEEKLY_REPORTS=1: enable weekly reports
+            DISABLE_BACKGROUND_MONITORING=1: disable all 7 operational loops
+
+        7 operational loops (always-on unless DISABLE_BACKGROUND_MONITORING=1):
+            proposal_timeout / rebalance_check / price_monitor / health_check /
+            latency_monitor / rss_fetch / dca
         """
+        from app.automation.scheduled_tasks import get_scheduled_task_manager  # noqa: PLC0415
+        from app.notifications.config import get_notification_settings  # noqa: PLC0415
+
         enable_daily = os.getenv("ENABLE_DAILY_REPORTS", "0") == "1"
         enable_weekly = os.getenv("ENABLE_WEEKLY_REPORTS", "0") == "1"
 
+        settings = get_notification_settings()
+        scheduled_manager = get_scheduled_task_manager()
+
+        # --- Optional report tasks ---
         if not enable_daily and not enable_weekly:
             logger.info(
                 "Scheduled reports disabled "
                 "(set ENABLE_DAILY_REPORTS=1 or ENABLE_WEEKLY_REPORTS=1 to enable)"
             )
+        else:
+            try:
+                if enable_daily:
+                    await scheduled_manager.start_daily_reports(
+                        channel=settings.default_channel,
+                        on_error=_make_scheduler_error_handler("日次レポートスケジューラー"),
+                    )
+                    logger.info("Daily reports scheduled successfully")
+
+                if enable_weekly:
+                    await scheduled_manager.start_weekly_reports(
+                        channel=settings.default_channel,
+                        on_error=_make_scheduler_error_handler("週次レポートスケジューラー"),
+                    )
+                    logger.info("Weekly reports scheduled successfully")
+            except BaseException as exc:
+                logger.error("Failed to start report tasks: %s", exc)
+
+        # --- 7 operational loops (always-on, fail-safe each) ---
+        if not _is_background_monitoring_enabled():
+            logger.info("Operational loops disabled (DISABLE_BACKGROUND_MONITORING=1)")
             return
 
-        try:
-            from app.automation.scheduled_tasks import get_scheduled_task_manager
-            from app.notifications.config import get_notification_settings
-
-            settings = get_notification_settings()
-            scheduled_manager = get_scheduled_task_manager()
-
-            if enable_daily:
-                await scheduled_manager.start_daily_reports(
-                    channel=settings.default_channel,
-                    on_error=_make_scheduler_error_handler("日次レポートスケジューラー"),
-                )
-                logger.info("Daily reports scheduled successfully")
-
-            if enable_weekly:
-                await scheduled_manager.start_weekly_reports(
-                    channel=settings.default_channel,
-                    on_error=_make_scheduler_error_handler("週次レポートスケジューラー"),
-                )
-                logger.info("Weekly reports scheduled successfully")
-
-        except BaseException as exc:
-            logger.error("Failed to start scheduled tasks: %s", exc)
-            # Scheduled task startup failure does not block app startup (fail-safe)
+        _loops: list[tuple[str, object]] = [
+            (
+                "proposal_timeout",
+                scheduled_manager.start_proposal_timeout(
+                    on_error=_make_scheduler_error_handler("proposal_timeout_loop"),
+                ),
+            ),
+            (
+                "rebalance_check",
+                scheduled_manager.start_rebalance_check(
+                    on_error=_make_scheduler_error_handler("rebalance_check_loop"),
+                ),
+            ),
+            (
+                "price_monitor",
+                scheduled_manager.start_price_monitor(
+                    on_error=_make_scheduler_error_handler("price_monitor_loop"),
+                ),
+            ),
+            (
+                "health_check",
+                scheduled_manager.start_health_check(
+                    on_error=_make_scheduler_error_handler("health_check_loop"),
+                ),
+            ),
+            (
+                "latency_monitor",
+                scheduled_manager.start_latency_monitor(
+                    on_error=_make_scheduler_error_handler("latency_monitor_loop"),
+                ),
+            ),
+            (
+                "rss_fetch",
+                scheduled_manager.start_rss_fetch(
+                    on_error=_make_scheduler_error_handler("rss_fetch_loop"),
+                ),
+            ),
+            (
+                "dca",
+                scheduled_manager.start_dca(
+                    on_error=_make_scheduler_error_handler("dca_loop"),
+                ),
+            ),
+        ]
+        for name, coro in _loops:
+            try:
+                await coro  # type: ignore[misc]
+                logger.info("Operational loop started: %s", name)
+            except BaseException as exc:
+                logger.error("Failed to start loop %s: %s", name, exc)
 
     @app.on_event("startup")
     async def startup_ai_judgment_scheduler() -> None:
@@ -511,9 +570,8 @@ def create_app() -> FastAPI:
 
             scheduled_manager = get_scheduled_task_manager()
 
-            if scheduled_manager.is_daily_running or scheduled_manager.is_weekly_running:
-                await scheduled_manager.stop_all()
-                logger.info("Scheduled tasks stopped")
+            await scheduled_manager.stop_all()
+            logger.info("Scheduled tasks stopped")
 
         except Exception as exc:
             logger.error("Error during scheduled tasks shutdown: %s", exc)


### PR DESCRIPTION
## Summary

- `ScheduledTaskManager` の `start_proposal_timeout` / `start_rebalance_check` / `start_price_monitor` / `start_health_check` / `start_latency_monitor` / `start_rss_fetch` / `start_dca` が実装済みだが `main.py` startup から一度も呼ばれていなかった孤立状態を解消
- `startup_scheduled_tasks` の早期リターン（`if not enable_daily and not enable_weekly: return`）を削除し、7 ループを常時起動するブロックを追加
- `shutdown_scheduled_tasks` の `is_daily_running or is_weekly_running` ガードを削除し、`stop_all()` を無条件呼び出しに変更（7 ループが起動していても正しく停止されるように）

**Asana:** https://app.asana.com/0/1213741124336104/1214729370686454

## 変更ファイル

- `backend/app/main.py` (編集) — 85 insertions, 27 deletions

## 設計判断

- 案 A（最小修正）: 12:00 Backend deploy 同梱優先のため最小実装を選択
- 各ループは独立した `try/except BaseException` でラップ（1 ループ起動失敗が他をブロックしない fail-safe 設計）
- `DISABLE_BACKGROUND_MONITORING=1` で 7 ループを一括無効化可能（既存フラグを流用）

## Test plan

- [x] `ruff check backend/app/main.py` — PASS
- [x] `ruff format --check backend/app/main.py` — PASS
- [x] `mypy backend/app/main.py --config-file pyproject.toml` — PASS
- [x] `pytest backend/tests/` — 2694 passed, coverage 84.64% (>80%)
- [x] `ruff check backend/app/main.py --select S` — PASS
- [ ] staging-new 起動ログ確認 (PR 作成後に別途実施): `docker logs <backend> 2>&1 | grep -E "proposal_timeout|rebalance|price_monitor|health_check|latency_monitor|rss_fetch|dca"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)