### PR TITLE
feat(notifications): ai_proposal_notification を Proposal 作成 2 経路に配線（通知ログ DB 紐付け）

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -218,6 +218,26 @@ def _create_proposals_for_users(
         user.last_judgment_at = now
         count += 1
 
+        # ai_proposal_notification: best-effort（失敗しても Proposal 作成は継続）
+        try:
+            from app.notifications.factory import get_notification_service  # noqa: PLC0415
+            from app.notifications.templates import ai_proposal_notification  # noqa: PLC0415
+
+            _payload = ai_proposal_notification(
+                operation=operation,
+                asset=_PROPOSAL_ASSET,
+                amount=_PROPOSAL_AMOUNT,
+                confidence=result.final_confidence,
+            )
+            _payload.notification_message.user_id = user.id
+            get_notification_service().send(_payload.notification_message)
+        except Exception as _notif_exc:  # noqa: BLE001
+            logger.warning(
+                "ai_proposal_notification failed for user %d (skipping): %s",
+                user.id,
+                _notif_exc,
+            )
+
     return count
 
 

--- a/backend/app/automation/workflow.py
+++ b/backend/app/automation/workflow.py
@@ -668,20 +668,22 @@ def _create_proposal_from_judgment(
         action.value,
         expires_at,
     )
-    # LINE notification for proposal created (best-effort)
+    # ai_proposal_notification: best-effort（失敗しても Proposal 作成は継続）
+    # 旧 LINE Notify (LINE_NOTIFY_TOKEN) 経路を get_notification_service() に統一
     try:
-        import os  # noqa: PLC0415
+        from app.notifications.factory import get_notification_service  # noqa: PLC0415
+        from app.notifications.templates import ai_proposal_notification  # noqa: PLC0415
 
-        from app.notifications.line_notifier import notify_proposal_created  # noqa: PLC0415
-
-        if os.getenv("LINE_NOTIFY_TOKEN"):
-            notify_proposal_created(
-                operation=action.value,
-                asset="USDC",
-                amount=float(trade_amount_usd),
-            )
-    except Exception as _line_exc:
-        logger.debug("notify_proposal_created failed (skipping): %s", _line_exc)
+        _payload = ai_proposal_notification(
+            operation=action.value,
+            asset="USDC",
+            amount=trade_amount_usd,
+            confidence=50,
+        )
+        _payload.notification_message.user_id = user_id if user_id else None
+        get_notification_service().send(_payload.notification_message)
+    except Exception as _notif_exc:  # noqa: BLE001
+        logger.debug("ai_proposal_notification failed (skipping): %s", _notif_exc)
 
 
 def _process_single_item(

--- a/backend/tests/automation/test_proposals_notification.py
+++ b/backend/tests/automation/test_proposals_notification.py
@@ -1,0 +1,231 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/automation/test_proposals_notification.py
+"""
+ai_proposal_notification wiring test.
+
+Verifies that _create_proposals_for_users() and _create_proposal_from_judgment()
+both call get_notification_service().send() with a NotificationMessage where
+notification_message.user_id is set correctly.
+
+Regression guard: legacy LINE_NOTIFY_TOKEN route must not be called.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from app.ai.schemas import CrossValidationResult, LLMDecision, LLMProvider, TradeAction
+from app.auth.constants import ExecutionPolicy
+from app.auth.models import InvestmentTier
+from app.automation.ai_judgment_scheduler import _create_proposals_for_users
+from app.automation.workflow import _create_proposal_from_judgment
+from app.notifications.schemas import NotificationMessage
+
+
+def _make_cross_result(action: TradeAction, confidence: int = 70) -> CrossValidationResult:
+    prim = LLMDecision(
+        provider=LLMProvider.CLAUDE,
+        action=action,
+        confidence=confidence,
+        reason="test reason",
+        raw_response="{}",
+    )
+    return CrossValidationResult(
+        primary=prim,
+        secondary=None,
+        final_action=action,
+        final_confidence=confidence,
+        final_reason="test reason",
+        agreed=True,
+    )
+
+
+def _make_user(user_id: int = 1) -> MagicMock:
+    user = MagicMock()
+    user.id = user_id
+    user.is_active = True
+    user.execution_policy = ExecutionPolicy.REQUIRE_APPROVAL.value
+    user.tier = InvestmentTier.LOWER.value
+    user.last_judgment_at = None
+    return user
+
+
+def _make_decision(decision_id: int = 99) -> MagicMock:
+    dec = MagicMock()
+    dec.id = decision_id
+    return dec
+
+
+def _make_fee(should_trade: bool = True) -> MagicMock:
+    fee = MagicMock()
+    fee.should_trade = should_trade
+    fee.fee_rate = Decimal("0.01")
+    fee.fee_amount = Decimal("10")
+    fee.reason = "test"
+    return fee
+
+
+class TestCreateProposalsForUsersNotification:
+    """_create_proposals_for_users sends a notification per user."""
+
+    def _run(
+        self,
+        action: TradeAction = TradeAction.BUY,
+        confidence: int = 70,
+        should_trade: bool = True,
+        user_id: int = 42,
+    ) -> tuple[MagicMock, list[Any]]:
+        user = _make_user(user_id=user_id)
+        decision = _make_decision()
+        result = _make_cross_result(action, confidence)
+
+        mock_db = MagicMock()
+        mock_db.scalars.return_value.all.return_value = [user]
+
+        sent_msgs: list[Any] = []
+
+        with (
+            patch(
+                "app.billing.dynamic_fee.calculate_fee_by_market",
+                return_value=_make_fee(should_trade),
+            ),
+            patch("app.notifications.factory.get_notification_service") as mock_get_svc,
+        ):
+            mock_svc = MagicMock()
+            mock_svc.send.side_effect = lambda m: sent_msgs.append(m)
+            mock_get_svc.return_value = mock_svc
+            _create_proposals_for_users(mock_db, decision, result)
+
+        return mock_svc.send, sent_msgs
+
+    def test_send_called_once_for_one_user(self) -> None:
+        """BUY: one notification per user."""
+        _, msgs = self._run(action=TradeAction.BUY)
+        assert len(msgs) == 1
+
+    def test_notification_message_type(self) -> None:
+        """send() receives a NotificationMessage."""
+        _, msgs = self._run(action=TradeAction.BUY)
+        assert isinstance(msgs[0], NotificationMessage)
+
+    def test_notification_user_id_set(self) -> None:
+        """notification_message.user_id equals user.id."""
+        _, msgs = self._run(action=TradeAction.BUY, user_id=42)
+        assert msgs[0].user_id == 42
+
+    def test_no_send_when_should_trade_false(self) -> None:
+        """DynamicFee should_trade=False: no notification."""
+        _, msgs = self._run(should_trade=False)
+        assert len(msgs) == 0
+
+    def test_send_called_for_sell_action(self) -> None:
+        """SELL: notification is also sent."""
+        _, msgs = self._run(action=TradeAction.SELL)
+        assert len(msgs) == 1
+
+    def test_notification_failure_does_not_raise(self) -> None:
+        """Notification failure must not abort Proposal creation."""
+        user = _make_user(user_id=7)
+        decision = _make_decision()
+        result = _make_cross_result(TradeAction.BUY)
+        mock_db = MagicMock()
+        mock_db.scalars.return_value.all.return_value = [user]
+
+        with (
+            patch(
+                "app.billing.dynamic_fee.calculate_fee_by_market",
+                return_value=_make_fee(should_trade=True),
+            ),
+            patch(
+                "app.notifications.factory.get_notification_service",
+                side_effect=RuntimeError("notification failure"),
+            ),
+        ):
+            count = _create_proposals_for_users(mock_db, decision, result)
+
+        assert count == 1
+
+
+class TestCreateProposalFromJudgmentNotification:
+    """_create_proposal_from_judgment sends a notification via get_notification_service()."""
+
+    def _run(
+        self,
+        user_id: int = 10,
+        action: TradeAction = TradeAction.BUY,
+    ) -> tuple[MagicMock, list[Any]]:
+        mock_db = MagicMock()
+        sent_msgs: list[Any] = []
+
+        with patch("app.notifications.factory.get_notification_service") as mock_get_svc:
+            mock_svc = MagicMock()
+            mock_svc.send.side_effect = lambda m: sent_msgs.append(m)
+            mock_get_svc.return_value = mock_svc
+            _create_proposal_from_judgment(
+                db=mock_db,
+                item_id=1,
+                action=action,
+                reason="test",
+                trade_amount_usd=Decimal("1000"),
+                user_id=user_id,
+            )
+
+        return mock_svc.send, sent_msgs
+
+    def test_send_called_once(self) -> None:
+        """send() is called exactly once."""
+        _, msgs = self._run()
+        assert len(msgs) == 1
+
+    def test_notification_message_type(self) -> None:
+        """send() receives a NotificationMessage."""
+        _, msgs = self._run()
+        assert isinstance(msgs[0], NotificationMessage)
+
+    def test_notification_user_id_set(self) -> None:
+        """notification_message.user_id equals argument user_id."""
+        _, msgs = self._run(user_id=10)
+        assert msgs[0].user_id == 10
+
+    def test_user_id_zero_becomes_none(self) -> None:
+        """user_id=0 (default falsy) -> notification_message.user_id is None."""
+        _, msgs = self._run(user_id=0)
+        assert msgs[0].user_id is None
+
+    def test_notification_failure_does_not_raise(self) -> None:
+        """Notification failure must not prevent Proposal DB write."""
+        mock_db = MagicMock()
+        with patch(
+            "app.notifications.factory.get_notification_service",
+            side_effect=RuntimeError("notification failure"),
+        ):
+            _create_proposal_from_judgment(
+                db=mock_db,
+                item_id=1,
+                action=TradeAction.BUY,
+                reason="test",
+                trade_amount_usd=Decimal("500"),
+                user_id=5,
+            )
+        mock_db.add.assert_called_once()
+        mock_db.flush.assert_called_once()
+
+    def test_old_line_notify_not_used(self) -> None:
+        """Regression guard: legacy notify_proposal_created must not be called."""
+        mock_db = MagicMock()
+        with (
+            patch("app.notifications.factory.get_notification_service"),
+            patch("app.notifications.line_notifier.notify_proposal_created") as mock_legacy,
+        ):
+            _create_proposal_from_judgment(
+                db=mock_db,
+                item_id=1,
+                action=TradeAction.BUY,
+                reason="test",
+                trade_amount_usd=Decimal("500"),
+                user_id=5,
+            )
+        mock_legacy.assert_not_called()


### PR DESCRIPTION
## Summary

- `_create_proposals_for_users()`（`ai_judgment_scheduler.py`）の Proposal 作成ループ末尾に `get_notification_service().send()` を追加。`notification_message.user_id` にユーザー ID を設定し、`notification_logs` テーブルへのユーザー紐付き記録を実現
- `_create_proposal_from_judgment()`（`workflow.py`）の旧 LINE Notify トークン経路（`line_notifier.notify_proposal_created` + `LINE_NOTIFY_TOKEN` 条件分岐）を削除し、`get_notification_service()` + `ai_proposal_notification()` に統一
- 両経路とも best-effort（通知失敗 → `logger.warning/debug` で継続、Proposal 作成は止めない）

## Test plan

- [x] `pytest tests/automation/test_proposals_notification.py -v` — 12/12 通過
- [x] `ruff check` — エラーなし
- [x] `ruff format --check` — 差分なし
- [x] `mypy app/automation/ai_judgment_scheduler.py app/automation/workflow.py` — エラーなし
- [x] フルスイート `pytest tests/ --cov=app --cov-fail-under=80` — 2728 passed / coverage 84.88%（80% ゲート通過）
- [x] 再発防止テスト `test_old_line_notify_not_used` — 旧 LINE Notify 経路が再混入したら CI が赤になる

## Staging 検証手順（deploy 後）

```bash
# staging-new で proposal 作成後
docker exec ultra-autotrade-postgres-staging psql -U ultra -d ultra_autotrade_staging \
  -c "SELECT id, user_id, channel, title, created_at FROM notification_logs ORDER BY id DESC LIMIT 5;"
# user_id が NULL でない行が存在すること
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)