### PR TITLE
fix(allocation): Aave success + total_supply=0 → HF safe fallback

### DIFF
--- a/backend/app/partner/allocation_service.py
+++ b/backend/app/partner/allocation_service.py
@@ -369,6 +369,8 @@ def get_performance(
         account_data = aave_client.get_account_data(wallet_addr)
         total_supply = Decimal(str(account_data.total_collateral_usd))
         raw_hf = Decimal(str(account_data.health_factor))
+        if total_supply == 0:
+            raw_hf = _HF_INFINITY_DISPLAY
     except Exception:
         logger.exception("[allocation_service] Aave get_account_data failed; using zeros")
         total_supply = Decimal("0")

--- a/backend/tests/test_allocation_service.py
+++ b/backend/tests/test_allocation_service.py
@@ -355,6 +355,28 @@ class TestGetPerformance:
         assert summary.total_supply_usd == Decimal("0")
         assert summary.testers[0].current_value_usd == Decimal("0")
 
+    def test_aave_success_zero_supply_forces_hf_infinity(self, db: Session) -> None:
+        """Aave 成功 + total_supply=0 → raw_hf を _HF_INFINITY_DISPLAY に強制 (edge case)."""
+        partner = _make_partner(db)
+        _make_allocation(db, partner.id, "Alice", Decimal("100"))
+
+        edge_data = AccountData(
+            total_collateral_usd=Decimal("0"),
+            total_debt_usd=Decimal("0"),
+            available_borrows_usd=Decimal("0"),
+            health_factor=Decimal("1.5"),
+        )
+
+        with patch("app.partner.allocation_service.get_default_aave_client") as mock_factory:
+            mock_client = MagicMock()
+            mock_client.get_account_data.return_value = edge_data
+            mock_factory.return_value = mock_client
+
+            summary = get_performance(db, partner)
+
+        assert summary.total_supply_usd == Decimal("0")
+        assert summary.health_factor == _HF_INFINITY_DISPLAY
+
 
 # ---------------------------------------------------------------------------
 # エッジケース: 未カバー行を対象とした追加テスト


### PR DESCRIPTION
## 概要
山本 UAT 14:00 緊急対応。Aave RPC が成功した上で total_supply=0 を返す edge case で health_factor が Aave 返却値そのまま使われ dashboard で異常表示する問題を修正。

## 変更
- backend/app/partner/allocation_service.py:
  - get_performance: total_supply=0 のとき raw_hf=_HF_INFINITY_DISPLAY 強制 (2 行追加)
- backend/tests/test_allocation_service.py: 1 ケース追加 (test_aave_success_zero_supply_forces_hf_infinity, 22 行)

## /verify 結果 (変更ファイル限定)
- Gate 1 ruff check: ✅ All checks passed
- Gate 2 ruff format: ✅ 2 files already formatted
- Gate 3 mypy: ✅ Success no issues
- Gate 3 pytest: ✅ 28 passed (新規 1 + 既存 27)

注: 全リポジトリの ruff format で pre-existing tests/test_integration_aave.py 違反検知あり。本 PR スコープ外、別 PR で対応。

## スコープ外 (5/14 以降の別 PR)
- frontend page.tsx:113 /users → /api/partner/users
- frontend page.tsx:115 /ai/accuracy → /api/ai/accuracy
- pre-existing tests/test_integration_aave.py format 違反

## 関連
- Asana GID 1214729308091329 (元タスク = 本実装は最小版)
- B lane 新旧 session 2 回 hang → claude.ai と協議の上、直接実装に切替
- 改善 plan F (PR #228) に記録対象 — BG agent 自走 hang パターンの教訓追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)
