### PR TITLE
Lane D: Fix rag_context_json=None hardcoded + GDELT backoff>budget

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -70,6 +70,7 @@ def save_ai_decision(
     result: CrossValidationResult,
     query: str,
     user_id: Optional[int] = None,
+    rag_context: Optional[RAGContext] = None,
 ) -> AIDecision:
     """CrossValidationResult を ai_decisions テーブルに保存して返す。
 
@@ -78,6 +79,7 @@ def save_ai_decision(
         result: AI クロスバリデーション結果。
         query: 判定に使ったクエリ文字列。
         user_id: 紐づけるユーザー ID（None = システム判定）。
+        rag_context: 判定に使った RAG コンテキスト。None の場合は保存しない。
 
     Returns:
         保存済みの AIDecision インスタンス。
@@ -95,7 +97,7 @@ def save_ai_decision(
         secondary_action=result.secondary.action.value if result.secondary else None,
         secondary_confidence=result.secondary.confidence if result.secondary else None,
         agreed=result.agreed,
-        rag_context_json=None,
+        rag_context_json=rag_context.model_dump() if rag_context else None,
     )
     db.add(decision)
     db.flush()  # id を確定させる
@@ -310,7 +312,7 @@ def run_ai_judgment_job(db: Optional[Session] = None) -> dict[str, Any]:
         )
 
         # DB 保存
-        decision = save_ai_decision(db, result, _DEFAULT_QUERY)
+        decision = save_ai_decision(db, result, _DEFAULT_QUERY, rag_context=rag_ctx)
 
         # BUY / SELL 時は Proposal 作成
         proposals_created = 0

--- a/backend/app/data_feeds/geopolitical.py
+++ b/backend/app/data_feeds/geopolitical.py
@@ -83,8 +83,8 @@ def get_cached_geo_risk() -> GeoRiskResult:
 GDELT_GKG_URL = "https://api.gdeltproject.org/api/v2/doc/doc"
 
 _GDELT_MAX_RETRIES = 3
-_GDELT_BASE_BACKOFF_SECONDS = 30
-_GDELT_BUDGET_SECONDS = 20
+_GDELT_BASE_BACKOFF_SECONDS = 5  # was 30: exceeded budget on first retry (30 > 20)
+_GDELT_BUDGET_SECONDS = 60
 
 
 async def fetch_gdelt_events(client: httpx.AsyncClient) -> GDELTEvent:

--- a/backend/tests/test_ai_judgment_scheduler.py
+++ b/backend/tests/test_ai_judgment_scheduler.py
@@ -118,6 +118,29 @@ def test_save_ai_decision_creates_record(db_session):
     assert decision.agreed is True
 
 
+def test_save_ai_decision_with_rag_context_persists(db_session):
+    """save_ai_decision が rag_context を rag_context_json に保存すること。"""
+    from app.ai.schemas import RAGContext  # noqa: PLC0415
+
+    result = _make_cross_validation_result(TradeAction.HOLD)
+    rag_ctx = RAGContext(chunks=["chunk A", "chunk B"], query="btc", source_count=2)
+    decision = save_ai_decision(db_session, result, "test query", rag_context=rag_ctx)
+    db_session.commit()
+
+    assert decision.rag_context_json is not None
+    assert decision.rag_context_json["chunks"] == ["chunk A", "chunk B"]
+    assert decision.rag_context_json["source_count"] == 2
+
+
+def test_save_ai_decision_without_rag_context_saves_null(db_session):
+    """save_ai_decision が rag_context=None の場合 rag_context_json=None を保存すること。"""
+    result = _make_cross_validation_result(TradeAction.HOLD)
+    decision = save_ai_decision(db_session, result, "test query")
+    db_session.commit()
+
+    assert decision.rag_context_json is None
+
+
 # ---------------------------------------------------------------------------
 # run_ai_judgment_job のテスト
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 修正内容

### 1. ai_judgment_scheduler.py: rag_context_json=None ハードコード廃止
- 元のコードが `rag_context_json=None` を DB に書き込んでいた
- 結果: ai_decisions レコードで `rag_context_json` が全件 NULL
- 修正: `save_ai_decision()` に `rag_context: Optional[RAGContext]` 引数追加、実際の RAG コンテキストを保存
- 朝プロトコルで観測されていた「rag_context_json = null (全5件)」の真因

### 2. geopolitical.py: GDELT base_backoff(30) > budget(20) の設定ミス
- 元: `_GDELT_BASE_BACKOFF_SECONDS=30` 、`_GDELT_BUDGET_SECONDS=20`
- attempt=0 で 429 → delay≈30s > budget 20s → 即 fallback（リトライ0回）
- 修正: base_backoff=5秒、budget=60秒 → 5/10/20秒で複数回 retry 可
- 朝プロトコルで観測されていた「GDELT 429 連発」の真因

### 3. knowledge_items 「不在」問題の解決
- `relation "knowledge_items" does not exist` の出元は手動確認クエリ
- 実際は `knowledge_sources / knowledge_documents / knowledge_chunks` の3テーブル構成で実装済み
- DDL 不要、コード変更不要

## DoD
- [x] Gate 1: `ruff check` — エラー 0
- [x] Gate 2: `ruff format --check` — 違反 0
- [x] Gate 3: `mypy` — エラー 0
- [x] Gate 1-3 総合: `pytest` 2731 passed, coverage 84.84% (gate 80%)
- [x] 新規テスト追加: `test_save_ai_decision_with_rag_context_persists` / `test_save_ai_decision_without_rag_context_saves_null`
- [x] Tier B (別ファイル/別関数の編集、コンフリクト無し)
- [ ] Gate 4 (Playwright E2E): 不要 (frontend 影響なし)

## 検証ポイント (本番マージ後)
- 次回の自然 AI 判定で `ai_decisions.rag_context_json` が NULL でない値になること
- GDELT 429 発生時に budget exhausted ではなく retry 経路を通ること（ログで確認）

## 関連
- Asana: 1214767072765224
- Lane D 並列開発 (5/14 実施)

## Test Plan
- [x] `pytest tests/test_ai_judgment_scheduler.py -k "rag_context"` — 2 passed
- [x] `pytest tests/test_geopolitical.py` — 全件通過
- [x] `pytest tests/ --cov=app --cov-fail-under=80` — 2731 passed, 84.84%

🤖 Generated with [Claude Code](https://claude.ai/claude-code)