### PR TITLE
Lane-PRIVY: Fix Multiple PrivyProvider in (user)/layout.tsx (5/14 UAT発覚)

### DIFF
--- a/frontend/app/(user)/layout.tsx
+++ b/frontend/app/(user)/layout.tsx
@@ -2,7 +2,6 @@
 // Unauthorized copying or distribution is strictly prohibited.
 import { NextIntlClientProvider } from 'next-intl'
 import { getLocale, getMessages } from 'next-intl/server'
-import { PrivyRootProvider } from '@/lib/wallet/PrivyRootProvider'
 import { UserProviders } from '@/components/user/UserProviders'
 import { UserHeader } from '@/components/user/UserHeader'
 import { BottomNav } from '@/components/shared/BottomNav'
@@ -17,16 +16,14 @@ export default async function UserAppLayout({
   const messages = await getMessages()
   return (
     <NextIntlClientProvider locale={locale} messages={messages}>
-      <PrivyRootProvider>
-        <UserProviders>
-          <UserHeader />
-          <div className="min-h-screen pb-16">
-            {children}
-          </div>
-          <BottomNav />
-          <EmergencyStopFloat />
-        </UserProviders>
-      </PrivyRootProvider>
+      <UserProviders>
+        <UserHeader />
+        <div className="min-h-screen pb-16">
+          {children}
+        </div>
+        <BottomNav />
+        <EmergencyStopFloat />
+      </UserProviders>
     </NextIntlClientProvider>
   )
 }


### PR DESCRIPTION
## 真因

HOTFIX 146f9cc (2026-05-13 14:09 PR #230) で `PartnerProviders` + `UserProviders` の内部で `PrivyRootClient` を wrap するよう修正したが、既存 `frontend/app/(user)/layout.tsx` の `PrivyRootProvider` ラップを除去せず → `(user)/*` route group 配下 14 ルートで PrivyProvider 二重マウント。

## 症状 (2026-05-14 山本 UAT で発覚)

- console: `Multiple PrivyProvider instances found` 大量出力 (15+ 件)
- `(user)/*` 配下で wallet 接続押下 → `Application error: a client-side exception has occurred`
- 影響: `(user)/*` route group 配下 14 ルート全て

## 修正

`frontend/app/(user)/layout.tsx` から `PrivyRootProvider` 関連 3 行削除 + 入れ子減少に伴う indent 補正:
1. `import { PrivyRootProvider } from '@/lib/wallet/PrivyRootProvider'`
2. `<PrivyRootProvider>` 開始タグ
3. `</PrivyRootProvider>` 閉じタグ

HOTFIX 146f9cc で `UserProviders` 内部の `PrivyRootClient` に集約済 (line 70/77) のため、layout 側の wrap は冗長で二重マウントの原因だった。

## DoD (Gate 0-7)

| Gate | 結果 | 備考 |
|---|---|---|
| 0 Sepolia hardcode | ✅ | mainnet で Sepolia なし |
| 1 ruff check | ✅ | |
| 2 ruff format | ✅ | |
| 3 mypy | ✅ | |
| 4 pytest 84.8% / 2629 passed | ✅ | 309s |
| 5 ruff security | ✅ | |
| 6 tsc --noEmit | ❌ **pre-existing (本修正と無関係)** | `e2e/lane-f3-lead-verification.spec.ts:463` (PR #226 で導入) + `e2e/referral-flow.spec.ts:329-330` (PR #201 で導入)。origin/main HEAD でも同じ 3 errors 出る。本修正ファイル `frontend/app/(user)/layout.tsx` には tsc error なし |
| 7 npm run build | ✅ | Next.js build は e2e/*.spec.ts を含めない、本番 deploy artifact 健全 |

**注**: Gate 6 失敗は origin/main にすでに存在する pre-existing tsc errors であり、本 PR が新たに導入したものではない。別途 e2e tsc 修正タスクを起票推奨。本 P0 launch blocker を優先する判断で進める。

## 影響範囲

### 修正で復旧するルート (14, `(user)/*` route group 配下)
ai-feed / approve / connect / copy-trading / decisions / grid / history / onboarding / privacy-policy / risk-disclosure / settings / strategies / terms / trade

### 影響を受けないルート (回帰確認推奨)
- `/user/*` (literal): HOTFIX 後すでに単一マウント
- `/(partner)/*`: 単独配置

## Gate 4 (Playwright E2E)

CF Access 未整備で自動 E2E は blocked (Lane LOGIN Gate 4 retry #2 で確認済)。代替:
1. Lead staging-new 手動 OTP 検証
2. 本番 deploy 後 Claude in Chrome で wallet 接続フロー実機確認

## Tier 判定

B (frontend のみ、コンポーネント階層の冗長性削除、3 行 + indent 補正)

## 関連

- HOTFIX commit: 146f9cc (PR #230, 2026-05-13)
- Lane LOGIN (Asana 1214476231020622、5/14 close 済) からの延長調査
- ハブ 1214767073644510 (5/14 UAT 総括 comment 1214796782622873)

## ローンチ影響

5/31 メインネットローンチに対する **P0 ブロッカー** 解消。

🤖 Generated with Claude Code (Lane-PRIVY)