### PR TITLE
[Phase A-2] Lido PoC staging E2E (pytest 20 cases + Playwright spec / Gate 4 P0-1 fix 待ち)

### DIFF
--- a/backend/tests/test_protocols_lido_integration.py
+++ b/backend/tests/test_protocols_lido_integration.py
@@ -1,0 +1,174 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""Lido Finance FastAPI router integration test (DummyClient 契約検証).
+
+Phase A-2 staging E2E の前提検証。
+Gate 4 staging 実機検証は P0-1 (Asana GID 1214821930631284) fix 後に実施。
+"""
+
+from __future__ import annotations
+
+import os
+from decimal import Decimal
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# DummyClient を許可するため development モードで起動
+os.environ.setdefault("APP_ENV", "development")
+os.environ.setdefault("LIDO_SANDBOX", "true")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-lido-integration")
+
+from app.protocols.lido.router import router as lido_router  # noqa: E402
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(lido_router)
+    return app
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    return TestClient(_make_app())
+
+
+# ---------------------------------------------------------------------------
+# GET /api/protocols/lido/status
+# ---------------------------------------------------------------------------
+
+
+class TestLidoStatus:
+    def test_status_returns_200(self, client: TestClient) -> None:
+        res = client.get("/api/protocols/lido/status")
+        assert res.status_code == 200
+
+    def test_status_required_fields_present(self, client: TestClient) -> None:
+        data = client.get("/api/protocols/lido/status").json()
+        for field in (
+            "steth_balance",
+            "staking_apr",
+            "steth_eth_ratio",
+            "peg_deviation_pct",
+            "chain",
+            "sandbox",
+        ):
+            assert field in data, f"missing field: {field}"
+
+    def test_status_sandbox_true(self, client: TestClient) -> None:
+        data = client.get("/api/protocols/lido/status").json()
+        assert data["sandbox"] is True
+
+    def test_status_chain_is_holesky(self, client: TestClient) -> None:
+        data = client.get("/api/protocols/lido/status").json()
+        assert data["chain"] == "holesky"
+
+    def test_status_no_float_values(self, client: TestClient) -> None:
+        """Decimal フィールドが JSON で float ではなく文字列で返ること。"""
+        data = client.get("/api/protocols/lido/status").json()
+        for field in ("steth_balance", "staking_apr", "steth_eth_ratio", "peg_deviation_pct"):
+            val = data[field]
+            assert not isinstance(val, float), f"{field} is float (must be string)"
+            Decimal(str(val))  # パース可能であること
+
+
+# ---------------------------------------------------------------------------
+# GET /api/protocols/lido/apr
+# ---------------------------------------------------------------------------
+
+
+class TestLidoApr:
+    def test_apr_returns_200(self, client: TestClient) -> None:
+        res = client.get("/api/protocols/lido/apr")
+        assert res.status_code == 200
+
+    def test_apr_fields_present(self, client: TestClient) -> None:
+        data = client.get("/api/protocols/lido/apr").json()
+        assert "staking_apr" in data
+        assert "source" in data
+
+    def test_apr_dummy_value_is_3_5(self, client: TestClient) -> None:
+        data = client.get("/api/protocols/lido/apr").json()
+        assert Decimal(str(data["staking_apr"])) == Decimal("3.5")
+
+    def test_apr_source_is_dummy(self, client: TestClient) -> None:
+        data = client.get("/api/protocols/lido/apr").json()
+        assert data["source"] == "dummy"
+
+
+# ---------------------------------------------------------------------------
+# POST /api/protocols/lido/stake
+# ---------------------------------------------------------------------------
+
+
+class TestLidoStake:
+    def test_stake_dry_run_default_true(self, client: TestClient) -> None:
+        res = client.post("/api/protocols/lido/stake", json={"amount_eth": "0.1"})
+        assert res.status_code == 200
+        data = res.json()
+        assert data["dry_run"] is True
+
+    def test_stake_dry_run_no_tx_hash(self, client: TestClient) -> None:
+        data = client.post(
+            "/api/protocols/lido/stake", json={"amount_eth": "0.1", "dry_run": True}
+        ).json()
+        assert data["tx_hash"] is None
+
+    def test_stake_dry_run_response_fields(self, client: TestClient) -> None:
+        data = client.post(
+            "/api/protocols/lido/stake", json={"amount_eth": "0.5", "dry_run": True}
+        ).json()
+        assert data["operation"] == "STAKE"
+        assert Decimal(str(data["amount_eth"])) == Decimal("0.5")
+        assert Decimal(str(data["received_steth"])) == Decimal("0.5")
+        assert Decimal(str(data["staking_apr"])) == Decimal("3.5")
+
+    def test_stake_live_returns_tx_hash(self, client: TestClient) -> None:
+        """dry_run=False でトランザクションハッシュが返ること（DummyClient）。"""
+        data = client.post(
+            "/api/protocols/lido/stake", json={"amount_eth": "0.01", "dry_run": False}
+        ).json()
+        assert data["dry_run"] is False
+        assert data["tx_hash"] is not None
+        assert str(data["tx_hash"]).startswith("0x")
+
+    def test_stake_rejects_zero_amount(self, client: TestClient) -> None:
+        res = client.post("/api/protocols/lido/stake", json={"amount_eth": "0"})
+        assert res.status_code == 422
+
+    def test_stake_rejects_negative_amount(self, client: TestClient) -> None:
+        res = client.post("/api/protocols/lido/stake", json={"amount_eth": "-1"})
+        assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /api/protocols/lido/withdraw
+# ---------------------------------------------------------------------------
+
+
+class TestLidoWithdraw:
+    def test_withdraw_dry_run_default_true(self, client: TestClient) -> None:
+        res = client.post("/api/protocols/lido/withdraw", json={"amount_steth": "0.1"})
+        assert res.status_code == 200
+        data = res.json()
+        assert data["dry_run"] is True
+
+    def test_withdraw_operation_type(self, client: TestClient) -> None:
+        data = client.post("/api/protocols/lido/withdraw", json={"amount_steth": "0.5"}).json()
+        assert data["operation"] == "WITHDRAW_REQUEST"
+
+    def test_withdraw_dry_run_no_tx_hash(self, client: TestClient) -> None:
+        data = client.post(
+            "/api/protocols/lido/withdraw", json={"amount_steth": "0.1", "dry_run": True}
+        ).json()
+        assert data["tx_hash"] is None
+
+    def test_withdraw_note_contains_claim_info(self, client: TestClient) -> None:
+        data = client.post("/api/protocols/lido/withdraw", json={"amount_steth": "0.1"}).json()
+        assert "note" in data
+        assert data["note"]  # 空でないこと
+
+    def test_withdraw_rejects_zero(self, client: TestClient) -> None:
+        res = client.post("/api/protocols/lido/withdraw", json={"amount_steth": "0"})
+        assert res.status_code == 422

--- a/frontend/e2e/lido-staging-poc.spec.ts
+++ b/frontend/e2e/lido-staging-poc.spec.ts
@@ -132,11 +132,15 @@ test.describe('[Phase A-2] Lido PoC — staging 実機検証', () => {
   // Sanity check (常時実行可能 — Gate 4 保留関係なし)
   // -----------------------------------------------------------------------
   test('[sanity] staging backend が応答すること', async ({ request }) => {
-    const res = await request.get(`${STAGING_API}/health`)
-    // staging backend が起動していれば 200、停止なら skip
-    if (res.status() === 0) {
+    // Playwright は接続不可時に例外を throw するため try-catch で処理
+    let status: number
+    try {
+      const res = await request.get(`${STAGING_API}/health`)
+      status = res.status()
+    } catch {
       test.skip(true, 'staging backend 到達不可 — SSH / CF Access 設定を確認')
+      return
     }
-    expect(res.status()).toBeLessThan(500)
+    expect(status).toBeLessThan(500)
   })
 })

--- a/frontend/e2e/lido-staging-poc.spec.ts
+++ b/frontend/e2e/lido-staging-poc.spec.ts
@@ -1,0 +1,142 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+//
+// [Phase A-2] Lido PoC staging 実機検証 E2E
+//
+// 目的: staging-new の Lido エンドポイント 4 本 + health を HTTP レベルで検証
+// 認証: CF Access Service Token (Bearer トークン不要 / 内部 API)
+//
+// 実行前提条件 (Gate 4 実行可能条件):
+//   1. P0-1 fix (Asana GID 1214821930631284): DummyLidoClient 本番ガード
+//      /api/protocols/lido/status が 503 ではなく 200 を返すこと
+//   2. SSH 鍵: ssh-add ~/.ssh/hetzner_staging で agent にロード済み
+//   3. 環境変数: CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET 設定済み
+//
+// 現在の状態 (2026-05-15):
+//   staging lido health = 500 → Gate 4 は P0-1 fix 後 (明日朝 Opus セッション) に実施
+//
+// 実行方法 (P0-1 fix 後):
+//   CF_ACCESS_CLIENT_ID=xxx CF_ACCESS_CLIENT_SECRET=yyy \
+//   npx playwright test e2e/lido-staging-poc.spec.ts
+
+import { test, expect, APIRequestContext } from '@playwright/test'
+
+const STAGING_API = process.env.STAGING_API_URL ?? 'http://localhost:8082'
+
+// CF Access Service Token (staging は CF Access 保護下)
+const CF_CLIENT_ID = process.env.CF_ACCESS_CLIENT_ID ?? ''
+const CF_CLIENT_SECRET = process.env.CF_ACCESS_CLIENT_SECRET ?? ''
+const CF_HEADERS: Record<string, string> =
+  CF_CLIENT_ID && CF_CLIENT_SECRET
+    ? {
+        'CF-Access-Client-Id': CF_CLIENT_ID,
+        'CF-Access-Client-Secret': CF_CLIENT_SECRET,
+      }
+    : {}
+
+// Gate 4 保留: P0-1 (DummyLidoClient guard) fix が完了するまでスキップ
+const STAGING_GATE4_READY = process.env.STAGING_GATE4_READY === 'true'
+
+test.describe('[Phase A-2] Lido PoC — staging 実機検証', () => {
+  test.use({ extraHTTPHeaders: CF_HEADERS })
+
+  // -----------------------------------------------------------------------
+  // GET /api/protocols/lido/status
+  // -----------------------------------------------------------------------
+  test('GET /api/protocols/lido/status → 200 + 必須フィールド', async ({ request }) => {
+    test.skip(!STAGING_GATE4_READY, 'P0-1 fix (GID 1214821930631284) 待ち — STAGING_GATE4_READY=true で解除')
+
+    const res = await request.get(`${STAGING_API}/api/protocols/lido/status`)
+    expect(res.status()).toBe(200)
+
+    const data = await res.json()
+    expect(data).toHaveProperty('steth_balance')
+    expect(data).toHaveProperty('staking_apr')
+    expect(data).toHaveProperty('steth_eth_ratio')
+    expect(data).toHaveProperty('peg_deviation_pct')
+    expect(data).toHaveProperty('chain')
+    expect(data).toHaveProperty('sandbox')
+
+    // staging は sandbox モード
+    expect(data.sandbox).toBe(true)
+    // Decimal 値が文字列で返ること (float 禁止)
+    expect(typeof data.staking_apr).not.toBe('number')
+  })
+
+  // -----------------------------------------------------------------------
+  // GET /api/protocols/lido/apr
+  // -----------------------------------------------------------------------
+  test('GET /api/protocols/lido/apr → 200 + APR フィールド', async ({ request }) => {
+    test.skip(!STAGING_GATE4_READY, 'P0-1 fix 待ち — STAGING_GATE4_READY=true で解除')
+
+    const res = await request.get(`${STAGING_API}/api/protocols/lido/apr`)
+    expect(res.status()).toBe(200)
+
+    const data = await res.json()
+    expect(data).toHaveProperty('staking_apr')
+    expect(data).toHaveProperty('source')
+    expect(typeof data.staking_apr).not.toBe('number')
+  })
+
+  // -----------------------------------------------------------------------
+  // POST /api/protocols/lido/stake (dry_run)
+  // -----------------------------------------------------------------------
+  test('POST /api/protocols/lido/stake dry_run → 200 + dry_run=true', async ({ request }) => {
+    test.skip(!STAGING_GATE4_READY, 'P0-1 fix 待ち — STAGING_GATE4_READY=true で解除')
+
+    const res = await request.post(`${STAGING_API}/api/protocols/lido/stake`, {
+      data: { amount_eth: '0.01', dry_run: true },
+    })
+    expect(res.status()).toBe(200)
+
+    const data = await res.json()
+    expect(data.dry_run).toBe(true)
+    expect(data.tx_hash).toBeNull()
+    expect(data.operation).toBe('STAKE')
+  })
+
+  // -----------------------------------------------------------------------
+  // POST /api/protocols/lido/withdraw (dry_run)
+  // -----------------------------------------------------------------------
+  test('POST /api/protocols/lido/withdraw dry_run → 200 + WITHDRAW_REQUEST', async ({ request }) => {
+    test.skip(!STAGING_GATE4_READY, 'P0-1 fix 待ち — STAGING_GATE4_READY=true で解除')
+
+    const res = await request.post(`${STAGING_API}/api/protocols/lido/withdraw`, {
+      data: { amount_steth: '0.01', dry_run: true },
+    })
+    expect(res.status()).toBe(200)
+
+    const data = await res.json()
+    expect(data.dry_run).toBe(true)
+    expect(data.tx_hash).toBeNull()
+    expect(data.operation).toBe('WITHDRAW_REQUEST')
+    expect(data.note).toBeTruthy()
+  })
+
+  // -----------------------------------------------------------------------
+  // GET /api/protocols/health/lido (Protocol Health Monitor)
+  // -----------------------------------------------------------------------
+  test('GET /api/protocols/health/lido → 200 + ProtocolHealth フィールド', async ({ request }) => {
+    test.skip(!STAGING_GATE4_READY, 'P0-1 fix 待ち — STAGING_GATE4_READY=true で解除')
+
+    const res = await request.get(`${STAGING_API}/api/protocols/health/lido`)
+    expect(res.status()).toBe(200)
+
+    const data = await res.json()
+    expect(data).toHaveProperty('protocol')
+    expect(data).toHaveProperty('status')
+    expect(data.protocol).toBe('lido')
+  })
+
+  // -----------------------------------------------------------------------
+  // Sanity check (常時実行可能 — Gate 4 保留関係なし)
+  // -----------------------------------------------------------------------
+  test('[sanity] staging backend が応答すること', async ({ request }) => {
+    const res = await request.get(`${STAGING_API}/health`)
+    // staging backend が起動していれば 200、停止なら skip
+    if (res.status() === 0) {
+      test.skip(true, 'staging backend 到達不可 — SSH / CF Access 設定を確認')
+    }
+    expect(res.status()).toBeLessThan(500)
+  })
+})


### PR DESCRIPTION
## 背景

Phase A staging 展開 5 Lane の Lane A-2。
Phase 2 コア Lido PoC (main 配線済) の HTTP API 契約を pytest で検証し、
staging 実機検証用 Playwright spec を追加。

## 変更内容

### 追加ファイル (test only / Tier B)
- `backend/tests/test_protocols_lido_integration.py` — pytest 20 ケース
- `frontend/e2e/lido-staging-poc.spec.ts` — Playwright staging 検証 spec

### pytest 20 ケース (DummyClient 契約検証)
| Class | Endpoint | Cases |
|---|---|---|
| TestLidoStatus | GET /api/protocols/lido/status | 5 |
| TestLidoApr | GET /api/protocols/lido/apr | 4 |
| TestLidoStake | POST /api/protocols/lido/stake | 6 |
| TestLidoWithdraw | POST /api/protocols/lido/withdraw | 5 |

### Playwright spec (Gate 4 保留版)
- 対象エンドポイント: status / apr / stake / withdraw / health/lido
- `STAGING_GATE4_READY=true` 環境変数で有効化
- CF Access Service Token 対応済み
- P0-1 (GID 1214821930631284) fix 後に実行

## Gate 結果

| Gate | 状態 |
|---|---|
| Gate 1: ruff check | ✅ |
| Gate 2: ruff format | ✅ |
| Gate 3: mypy (240 files) | ✅ |
| Gate 4: pytest 2659 passed, 84.35% | ✅ |
| Gate 5: security check | ✅ |
| Gate 6: tsc | ⚠️ pre-existing errors (lane-f3/referral-flow, **lido spec = 0 errors**) |
| Gate 7: npm build | ✅ exit code 0 |
| Codex Review | ✅ APPROVED (P2 fix 済み: sanity test try-catch 修正) |

## 保留事項

- **Gate 4 staging 実機**: 現在 lido health = 500。P0-1 (DummyLidoClient guard, GID 1214821930631284) fix 後に実行
- **明日朝再開条件 3 点**:
  1. P0-1 (GID 1214821930631284) fix 完了確認
  2. `ssh-add ~/.ssh/hetzner_staging` で SSH 鍵を agent にロード
  3. `STAGING_GATE4_READY=true npx playwright test e2e/lido-staging-poc.spec.ts`
- production 反映: 本日凍結 → Phase A 完了後 RAS Phase 1 一括 deploy

## 教訓 (2026-05-15 Lane A-2)

1. claude.ai 生成プロンプトの endpoint パス (`/protocols/risk/lido`, `/protocols/lido/*` 等) がコード正本 (`router.py` + `main.py`) と乖離 → CLI 実装確認で検出 (策 11 / 3層確認)
2. worktree に node_modules 不在 → main プロジェクトから symlink で解消
3. Codex P2: Playwright connection error は `try-catch` 必須（`status() === 0` パターン不可）

## Test plan

- [x] pytest 20 cases pass locally
- [x] verify.sh Gate 1-5, 7 pass
- [x] lido-staging-poc.spec.ts TypeScript errors = 0
- [x] Codex Review APPROVED (P2 sanity test try-catch fix 済み)
- [ ] Gate 4 staging 実機検証 (P0-1 fix 後 / 明日朝再開)

Closes #1214820966010739