### PR TITLE
[Phase A-3] Pendle PoC staging E2E (pytest + Playwright spec / staging検証は P0-1 fix 待ち)

### DIFF
--- a/backend/tests/test_protocols_pendle_integration.py
+++ b/backend/tests/test_protocols_pendle_integration.py
@@ -1,0 +1,270 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/test_protocols_pendle_integration.py
+"""Pendle Finance API 統合テスト。
+
+DummyPendleClient / DummyLidoClient を用いて Router → Service → Client の
+全レイヤーを HTTP レベルで検証する。実 RPC / 実 DB 不使用。
+
+カバー範囲:
+  1. /api/protocols/pendle/markets         — マーケット一覧
+  2. /api/protocols/pendle/market/{addr}   — マーケット詳細
+  3. /api/protocols/pendle/mint            — PT/YT ミント (dry_run)
+  4. /api/protocols/pendle/redeem          — PT/YT リデーム (dry_run)
+  5. /api/protocols/pendle/strategies      — 戦略比較
+  6. /api/protocols/health/pendle          — ProtocolMonitor 正常パス
+  7. 入力バリデーション (422)
+  8. staging 環境での DummyClient 禁止ガード (500/503)
+
+注意: Phase 4 実機検証 (staging-new) は P0-1 fix (LIDO_SANDBOX=false in staging) 完了後。
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# テスト対象 router
+from app.protocols.pendle.router import router as pendle_router
+from app.protocols.risk.router import router as health_router
+
+DUMMY_MARKET_ADDRESS = "0x" + "ab" * 20
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def pendle_app() -> FastAPI:
+    """Pendle 関連エンドポイントのみを持つ最小 FastAPI アプリ (DB 不要)。"""
+    app = FastAPI()
+    app.include_router(pendle_router)
+    app.include_router(health_router)
+    return app
+
+
+@pytest.fixture(autouse=True)
+def sandbox_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """development + sandbox モードでテストを実行する。
+
+    APP_ENV を未設定にすると get_pendle_client / get_lido_client 内の
+    デフォルト "development" に倒れ、LIDO_SANDBOX=true + PENDLE_SANDBOX=true でも
+    DummyClient が許可される。
+    """
+    monkeypatch.setenv("PENDLE_SANDBOX", "true")
+    monkeypatch.setenv("LIDO_SANDBOX", "true")
+    monkeypatch.delenv("APP_ENV", raising=False)
+
+
+@pytest.fixture()
+def client(pendle_app: FastAPI, sandbox_env: None) -> TestClient:  # noqa: ARG001
+    return TestClient(pendle_app)
+
+
+# ---------------------------------------------------------------------------
+# 1. マーケット一覧 GET /api/protocols/pendle/markets
+# ---------------------------------------------------------------------------
+
+
+class TestMarketsEndpoint:
+    def test_returns_200(self, client: TestClient) -> None:
+        resp = client.get("/api/protocols/pendle/markets")
+        assert resp.status_code == 200
+
+    def test_returns_list_with_one_market(self, client: TestClient) -> None:
+        data = client.get("/api/protocols/pendle/markets").json()
+        assert isinstance(data, list)
+        assert len(data) == 1
+
+    def test_market_has_required_fields(self, client: TestClient) -> None:
+        market = client.get("/api/protocols/pendle/markets").json()[0]
+        for field in ("market_address", "implied_apy", "pt_price", "yt_price", "tvl_usd"):
+            assert field in market, f"フィールド '{field}' が見つかりません"
+
+    def test_implied_apy_is_numeric_string(self, client: TestClient) -> None:
+        """Decimal は JSON 上で文字列シリアライズされること。"""
+        market = client.get("/api/protocols/pendle/markets").json()[0]
+        float(market["implied_apy"])  # 数値変換可能であることを確認
+
+
+# ---------------------------------------------------------------------------
+# 2. マーケット詳細 GET /api/protocols/pendle/market/{address}
+# ---------------------------------------------------------------------------
+
+
+class TestMarketDetailEndpoint:
+    def test_returns_200(self, client: TestClient) -> None:
+        resp = client.get(f"/api/protocols/pendle/market/{DUMMY_MARKET_ADDRESS}")
+        assert resp.status_code == 200
+
+    def test_market_address_matches_request(self, client: TestClient) -> None:
+        data = client.get(f"/api/protocols/pendle/market/{DUMMY_MARKET_ADDRESS}").json()
+        assert data["market_address"] == DUMMY_MARKET_ADDRESS
+
+    def test_underlying_asset_is_steth(self, client: TestClient) -> None:
+        data = client.get(f"/api/protocols/pendle/market/{DUMMY_MARKET_ADDRESS}").json()
+        assert data["underlying_asset"] == "stETH"
+
+    def test_days_to_maturity_is_positive(self, client: TestClient) -> None:
+        data = client.get(f"/api/protocols/pendle/market/{DUMMY_MARKET_ADDRESS}").json()
+        assert int(data["days_to_maturity"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# 3. ミント POST /api/protocols/pendle/mint
+# ---------------------------------------------------------------------------
+
+
+class TestMintEndpoint:
+    @staticmethod
+    def _payload(strategy: str = "pt_fixed", dry_run: bool = True) -> dict[str, object]:
+        return {
+            "asset": "stETH",
+            "amount": "1.0",
+            "strategy": strategy,
+            "market_address": DUMMY_MARKET_ADDRESS,
+            "dry_run": dry_run,
+        }
+
+    def test_pt_fixed_dry_run_returns_200(self, client: TestClient) -> None:
+        resp = client.post("/api/protocols/pendle/mint", json=self._payload())
+        assert resp.status_code == 200
+
+    def test_pt_fixed_operation_is_mint_pt(self, client: TestClient) -> None:
+        data = client.post("/api/protocols/pendle/mint", json=self._payload()).json()
+        assert data["operation"] == "MINT_PT"
+
+    def test_pt_fixed_dry_run_flag_is_true(self, client: TestClient) -> None:
+        data = client.post("/api/protocols/pendle/mint", json=self._payload()).json()
+        assert data["dry_run"] is True
+
+    def test_pt_fixed_tx_hash_is_null_on_dry_run(self, client: TestClient) -> None:
+        """dry_run=True では tx_hash が null であること (オンチェーン未実行)。"""
+        data = client.post("/api/protocols/pendle/mint", json=self._payload()).json()
+        assert data["tx_hash"] is None
+
+    def test_yt_leverage_dry_run_returns_200(self, client: TestClient) -> None:
+        resp = client.post("/api/protocols/pendle/mint", json=self._payload("yt_leverage"))
+        assert resp.status_code == 200
+
+    def test_yt_leverage_operation_is_mint_yt(self, client: TestClient) -> None:
+        data = client.post("/api/protocols/pendle/mint", json=self._payload("yt_leverage")).json()
+        assert data["operation"] == "MINT_YT"
+
+    def test_amount_zero_returns_422(self, client: TestClient) -> None:
+        payload = {**self._payload(), "amount": "0"}
+        assert client.post("/api/protocols/pendle/mint", json=payload).status_code == 422
+
+    def test_invalid_strategy_returns_422(self, client: TestClient) -> None:
+        payload = {**self._payload(), "strategy": "invalid_strategy"}
+        assert client.post("/api/protocols/pendle/mint", json=payload).status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# 4. リデーム POST /api/protocols/pendle/redeem
+# ---------------------------------------------------------------------------
+
+
+class TestRedeemEndpoint:
+    @staticmethod
+    def _payload(token_type: str = "PT") -> dict[str, object]:
+        return {
+            "token_type": token_type,
+            "amount": "1.0",
+            "market_address": DUMMY_MARKET_ADDRESS,
+            "dry_run": True,
+        }
+
+    def test_redeem_pt_before_maturity_returns_503(self, client: TestClient) -> None:
+        """DummyClient は days_to_maturity > 0 を返すため PT リデームは満期前エラーになる。"""
+        assert (
+            client.post("/api/protocols/pendle/redeem", json=self._payload("PT")).status_code == 503
+        )
+
+    def test_redeem_pt_before_maturity_error_message(self, client: TestClient) -> None:
+        data = client.post("/api/protocols/pendle/redeem", json=self._payload("PT")).json()
+        assert "maturity" in data.get("detail", "").lower()
+
+    def test_redeem_yt_operation_is_redeem_yt(self, client: TestClient) -> None:
+        data = client.post("/api/protocols/pendle/redeem", json=self._payload("YT")).json()
+        assert data["operation"] == "REDEEM_YT"
+
+    def test_redeem_yt_returns_200(self, client: TestClient) -> None:
+        assert (
+            client.post("/api/protocols/pendle/redeem", json=self._payload("YT")).status_code == 200
+        )
+
+    def test_invalid_token_type_returns_422(self, client: TestClient) -> None:
+        payload = {**self._payload(), "token_type": "SY"}  # Literal["PT","YT"] 外
+        assert client.post("/api/protocols/pendle/redeem", json=payload).status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# 5. 戦略比較 GET /api/protocols/pendle/strategies
+# ---------------------------------------------------------------------------
+
+
+class TestStrategiesEndpoint:
+    def test_returns_200(self, client: TestClient) -> None:
+        resp = client.get("/api/protocols/pendle/strategies?amount=1.0")
+        assert resp.status_code == 200
+
+    def test_has_best_strategy_and_strategies_fields(self, client: TestClient) -> None:
+        data = client.get("/api/protocols/pendle/strategies?amount=1.0").json()
+        assert "best_strategy" in data
+        assert "strategies" in data
+
+    def test_strategies_count_is_at_least_two(self, client: TestClient) -> None:
+        """複数の戦略比較オプションを返すこと (aave_only / lido_aave / lido_pendle_pt 等)。"""
+        data = client.get("/api/protocols/pendle/strategies?amount=1.0").json()
+        assert len(data["strategies"]) >= 2
+
+    def test_invalid_amount_returns_400(self, client: TestClient) -> None:
+        resp = client.get("/api/protocols/pendle/strategies?amount=not_a_number")
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# 6. プロトコルヘルス GET /api/protocols/health/pendle
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolHealthPendleEndpoint:
+    def test_returns_200(self, client: TestClient) -> None:
+        resp = client.get("/api/protocols/health/pendle")
+        assert resp.status_code == 200
+
+    def test_protocol_field_is_pendle(self, client: TestClient) -> None:
+        data = client.get("/api/protocols/health/pendle").json()
+        assert data["protocol"] == "pendle"
+
+    def test_risk_level_is_valid(self, client: TestClient) -> None:
+        data = client.get("/api/protocols/health/pendle").json()
+        assert data["risk_level"] in ("low", "medium", "high", "critical")
+
+    def test_is_operational_is_bool(self, client: TestClient) -> None:
+        data = client.get("/api/protocols/health/pendle").json()
+        assert isinstance(data["is_operational"], bool)
+
+
+# ---------------------------------------------------------------------------
+# 7. staging 環境 DummyClient 禁止ガード
+# ---------------------------------------------------------------------------
+
+
+class TestStagingGuard:
+    def test_staging_env_with_sandbox_returns_5xx(
+        self, pendle_app: FastAPI, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """APP_ENV=staging + PENDLE_SANDBOX=true は 5xx を返す。
+
+        TestClient を raise_server_exceptions=False で生成して
+        RuntimeError が HTTP 500 にマップされることを確認する。
+        """
+        monkeypatch.setenv("APP_ENV", "staging")
+        staging_client = TestClient(pendle_app, raise_server_exceptions=False)
+        resp = staging_client.get("/api/protocols/pendle/markets")
+        assert resp.status_code in (500, 503)

--- a/frontend/e2e/pendle-staging-poc.spec.ts
+++ b/frontend/e2e/pendle-staging-poc.spec.ts
@@ -1,0 +1,261 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+//
+// [Phase A-3] Pendle PoC staging End-to-End 検証
+//
+// 目的: staging-new で Pendle Finance PoC (PT / YT / fixed yield) の
+//       フロントエンド表示 + バックエンド API 疎通を E2E 確認する。
+//
+// シナリオ:
+//   A: /admin/protocols — Pendle プロトコルカード表示確認
+//   B: /user/strategies — Pendle PT 戦略カード表示確認
+//   C: GET /api/protocols/pendle/markets — 200 + PendleMarketInfo 構造検証
+//   D: GET /api/protocols/health/pendle — is_operational + risk_level 検証
+//   E: POST /api/protocols/pendle/mint dry_run=true — MINT_PT レスポンス検証
+//
+// 前提 / CF Access:
+//   - .auth/cf-access.json (CF_Authorization cookie)
+//   - CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET (API curl 用)
+//
+// P0-1 fix 待ちテスト:
+//   シナリオ C-E は staging-new で LIDO_SANDBOX=true の間 API が 500/503 を返す。
+//   P0-1 fix (LIDO_SANDBOX=false) 完了後に test.fixme 解除すること。
+//   詳細: docs/postmortems/2026-05-12_uat_blocker_full_day_failure.md
+//
+// 実行:
+//   # 通常 (staging URL)
+//   npx playwright test e2e/pendle-staging-poc.spec.ts --reporter=list,html
+//
+//   # ローカル Next.js dev server
+//   STAGING_URL=http://localhost:3000 npx playwright test e2e/pendle-staging-poc.spec.ts
+
+import { test, expect, type Page } from '@playwright/test'
+import { setupPartnerAuth, PARTNER_MOCK_USER } from './helpers/partner-auth'
+
+const STAGING_URL = process.env.STAGING_URL ?? 'https://staging.ultra-auto-trade.com'
+const API_URL = process.env.STAGING_API_URL ?? 'http://localhost:8082'
+
+const CF_CLIENT_ID = process.env.CF_ACCESS_CLIENT_ID ?? ''
+const CF_CLIENT_SECRET = process.env.CF_ACCESS_CLIENT_SECRET ?? ''
+const CF_HEADERS: Record<string, string> =
+  CF_CLIENT_ID && CF_CLIENT_SECRET
+    ? { 'CF-Access-Client-Id': CF_CLIENT_ID, 'CF-Access-Client-Secret': CF_CLIENT_SECRET }
+    : {}
+
+const ADMIN_MOCK_USER = {
+  ...PARTNER_MOCK_USER,
+  id: 1,
+  role: 'admin',
+  email: 'admin@ultra-autotrade.com',
+}
+
+/** 管理者 JWT を localStorage + /auth/me mock で注入。 */
+async function setupAdminAuth(page: Page): Promise<void> {
+  await page.addInitScript(
+    (args) => {
+      localStorage.setItem(args.tokenKey, args.token)
+      localStorage.setItem(args.expiresKey, String(Date.now() + 86400 * 1000))
+    },
+    { tokenKey: 'ultra_auth_token', expiresKey: 'ultra_auth_expires', token: 'dummy-admin-token' }
+  )
+  await page.route('**/auth/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(ADMIN_MOCK_USER),
+    })
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 共通設定
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('[Phase A-3] Pendle PoC staging E2E', () => {
+  test.use({
+    extraHTTPHeaders: CF_HEADERS,
+    storageState: (() => {
+      try {
+        // .auth/cf-access.json が存在する場合のみ使用
+        require('fs').statSync('e2e/.auth/cf-access.json')
+        return 'e2e/.auth/cf-access.json'
+      } catch {
+        return undefined
+      }
+    })(),
+  })
+
+  // ── A: /admin/protocols — Pendle プロトコルカード ─────────────────────────
+
+  test.describe('A: /admin/protocols — Pendle プロトコルカード', () => {
+    test('A-1: ページが 200 で読み込まれる', async ({ page }) => {
+      await setupAdminAuth(page)
+      const resp = await page.goto(`${STAGING_URL}/admin/protocols`, {
+        waitUntil: 'domcontentloaded',
+        timeout: 15_000,
+      })
+      // 認証リダイレクト (302→/login) または 200 を許容
+      expect([200, 302, null].includes(resp?.status() ?? null)).toBeTruthy()
+    })
+
+    test('A-2: Pendle セクションが表示される (mock data)', async ({ page }) => {
+      await setupAdminAuth(page)
+      await page.goto(`${STAGING_URL}/admin/protocols`, { waitUntil: 'domcontentloaded' })
+
+      // ページが正常レンダリングまたはログインページを表示していること
+      const pendleCard = page.getByText('Pendle').first()
+      const loginPage = page.getByText('ログイン').first()
+
+      const appeared = await Promise.race([
+        pendleCard.waitFor({ state: 'visible', timeout: 10_000 }).then(() => 'pendle'),
+        loginPage.waitFor({ state: 'visible', timeout: 10_000 }).then(() => 'login'),
+      ]).catch(() => 'timeout')
+
+      // Pendle が表示されるか、認証が必要なログイン画面のいずれか
+      expect(['pendle', 'login']).toContain(appeared)
+    })
+
+    test('A-3: Pendle プロトコルカードに PT / YT レートが含まれる (mock data)', async ({ page }) => {
+      await setupAdminAuth(page)
+      await page.goto(`${STAGING_URL}/admin/protocols`, { waitUntil: 'domcontentloaded' })
+
+      // ログイン画面にリダイレクトされた場合はスキップ
+      const isLoginPage = await page.getByRole('button', { name: 'ログイン' }).isVisible().catch(() => false)
+      if (isLoginPage) {
+        test.skip(true, 'admin auth が注入できないためスキップ (local dev では setupAdminAuth が機能する)')
+        return
+      }
+
+      // mock data に含まれる pt_rate / yt_rate が表示されること
+      const bodyText = await page.locator('body').textContent() ?? ''
+      // "95" や "4.7" などの数値がある、または "Pendle" テキストが存在する
+      expect(bodyText).toMatch(/Pendle|PT|YT|利回り/i)
+    })
+  })
+
+  // ── B: /user/strategies — Pendle 戦略カード ────────────────────────────────
+
+  test.describe('B: /user/strategies — Pendle 戦略カード', () => {
+    test('B-1: ページが読み込まれる', async ({ page }) => {
+      await setupPartnerAuth(page)
+      const resp = await page.goto(`${STAGING_URL}/user/strategies`, {
+        waitUntil: 'domcontentloaded',
+        timeout: 15_000,
+      })
+      expect([200, 302, null].includes(resp?.status() ?? null)).toBeTruthy()
+    })
+
+    test('B-2: Pendle PT 戦略カードが表示される', async ({ page }) => {
+      await setupPartnerAuth(page)
+      await page.goto(`${STAGING_URL}/user/strategies`, { waitUntil: 'domcontentloaded' })
+
+      // 「Pendle」「PT」「固定利回り」等のいずれかが存在すること
+      const bodyText = await page.locator('body').textContent().catch(() => '') ?? ''
+      const hasPendle = /Pendle|固定利回り|PT|YT/i.test(bodyText)
+      const hasLoginPage = /ログイン|サインイン/i.test(bodyText)
+
+      expect(hasPendle || hasLoginPage).toBeTruthy()
+    })
+
+    test('B-3: 戦略リストに APY 表示がある', async ({ page }) => {
+      await setupPartnerAuth(page)
+      await page.goto(`${STAGING_URL}/user/strategies`, { waitUntil: 'domcontentloaded' })
+
+      const bodyText = await page.locator('body').textContent().catch(() => '') ?? ''
+
+      // APY / % / データなし のいずれかがある（API 失敗時は「データなし」が表示される）
+      expect(bodyText).toMatch(/%|APY|データなし|ログイン/)
+    })
+  })
+
+  // ── C: GET /api/protocols/pendle/markets (P0-1 fix 待ち) ──────────────────
+
+  test.describe('C: GET /api/protocols/pendle/markets', () => {
+    test.fixme(
+      true,
+      'P0-1 fix 待ち: staging-new で LIDO_SANDBOX=false に変更後に解除。'
+      + ' 現状: LIDO_SANDBOX=true により ProtocolMonitor が 500 を返す。'
+    )
+
+    test('C-1: 200 を返しマーケット一覧を含む', async ({ request }) => {
+      const resp = await request.get(`${API_URL}/api/protocols/pendle/markets`)
+      expect(resp.status()).toBe(200)
+
+      const data = await resp.json()
+      expect(Array.isArray(data)).toBeTruthy()
+      expect(data.length).toBeGreaterThan(0)
+
+      const market = data[0]
+      expect(market).toHaveProperty('market_address')
+      expect(market).toHaveProperty('implied_apy')
+      expect(market).toHaveProperty('pt_price')
+      expect(market).toHaveProperty('yt_price')
+    })
+
+    test('C-2: implied_apy が数値文字列として返る', async ({ request }) => {
+      const resp = await request.get(`${API_URL}/api/protocols/pendle/markets`)
+      const data = await resp.json()
+      expect(() => parseFloat(data[0].implied_apy)).not.toThrow()
+    })
+  })
+
+  // ── D: GET /api/protocols/health/pendle (P0-1 fix 待ち) ──────────────────
+
+  test.describe('D: GET /api/protocols/health/pendle', () => {
+    test.fixme(
+      true,
+      'P0-1 fix 待ち: LIDO_SANDBOX=false 後に解除。現状 500 を返す。'
+    )
+
+    test('D-1: 200 + is_operational + risk_level を返す', async ({ request }) => {
+      const resp = await request.get(`${API_URL}/api/protocols/health/pendle`)
+      expect(resp.status()).toBe(200)
+
+      const data = await resp.json()
+      expect(data.protocol).toBe('pendle')
+      expect(typeof data.is_operational).toBe('boolean')
+      expect(['low', 'medium', 'high', 'critical']).toContain(data.risk_level)
+    })
+  })
+
+  // ── E: POST /api/protocols/pendle/mint dry_run=true (P0-1 fix 待ち) ───────
+
+  test.describe('E: POST /api/protocols/pendle/mint (dry_run)', () => {
+    test.fixme(
+      true,
+      'P0-1 fix 待ち: LIDO_SANDBOX=false 後に解除。'
+    )
+
+    test('E-1: MINT_PT レスポンスが返り tx_hash が null', async ({ request }) => {
+      const resp = await request.post(`${API_URL}/api/protocols/pendle/mint`, {
+        data: {
+          asset: 'stETH',
+          amount: '1.0',
+          strategy: 'pt_fixed',
+          market_address: '0x' + 'ab'.repeat(20),
+          dry_run: true,
+        },
+      })
+      expect(resp.status()).toBe(200)
+
+      const data = await resp.json()
+      expect(data.operation).toBe('MINT_PT')
+      expect(data.dry_run).toBe(true)
+      expect(data.tx_hash).toBeNull()
+    })
+
+    test('E-2: MINT_YT レスポンスが返る', async ({ request }) => {
+      const resp = await request.post(`${API_URL}/api/protocols/pendle/mint`, {
+        data: {
+          asset: 'stETH',
+          amount: '1.0',
+          strategy: 'yt_leverage',
+          market_address: '0x' + 'ab'.repeat(20),
+          dry_run: true,
+        },
+      })
+      expect(resp.status()).toBe(200)
+      expect((await resp.json()).operation).toBe('MINT_YT')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- **pytest 統合テスト 30 ケース**: `backend/tests/test_protocols_pendle_integration.py`
  - Router → Service → Client 全レイヤーを FastAPI TestClient で検証 (DB 不要)
  - DummyPendleClient + PENDLE_SANDBOX=true で dev モード実行
  - markets / market detail / mint (pt_fixed, yt_leverage) / redeem (YT ok, PT 満期前 503) / strategies / protocol health / staging guard の 8 シナリオ
- **Playwright E2E spec**: `frontend/e2e/pendle-staging-poc.spec.ts`
  - シナリオ A-B (UI smoke: /admin/protocols, /user/strategies) は即時実行可
  - シナリオ C-E (API direct: markets / health / mint) は `test.fixme` — P0-1 fix 待ち

## Why fixme for C-E

staging-new は `LIDO_SANDBOX=true` + `APP_ENV=staging` のため、`ProtocolMonitor.__init__()` が LidoClient の DummyClient ガードで RuntimeError → 全 protocol health エンドポイントが 500/503。P0-1 fix = `LIDO_SANDBOX=false` を staging-new に設定するだけ (コード変更不要)。

## Scope

- `backend/app/protocols/pendle/*` — **変更なし** (read only, write 禁止)
- `backend/app/protocols/lido/*` — **変更なし** (Lane A-2 領域)
- Tier B ファイルのみ追加 (tests/*.py, e2e/*.ts)

## Test plan

- [x] `ruff check .` — 0 errors
- [x] `ruff format --check .` — 463 files already formatted
- [x] `mypy app/` — no issues
- [x] `pytest tests/` — 2669 passed, coverage 84.67% (>80%)
- [x] `pytest tests/test_protocols_pendle_integration.py` — 30/30 passed
- [ ] Playwright C-E: P0-1 fix (LIDO_SANDBOX=false in staging-new) 後に fixme 解除

## Related

- Asana GID: 1214820621160336
- P0-1 fix: staging-new コンテナで `LIDO_SANDBOX=false` に変更 → 再起動 → fixme 解除して Playwright C-E 実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)