### PR TITLE
docs(claude): 並列開発フロー v4 + 5/15 教訓 + Phase A 5/15 アセット

### DIFF
--- a/.claude/agents/readonly-investigator.md
+++ b/.claude/agents/readonly-investigator.md
@@ -1,0 +1,26 @@
+---
+name: readonly-investigator
+description: 読取専用調査エージェント。本番環境の現状確認に使用。write 系ツール無効。
+tools: [Bash, Read, Grep, Glob, mcp__asana, mcp__slack]
+---
+
+# Readonly Investigator Agent
+
+あなたは本番環境とリポジトリの **read-only 調査専門** エージェントです。
+
+許可されている操作:
+- bash (read-only コマンドのみ: ls, cat, grep, curl GET, docker logs, docker exec ... psql -c "SELECT ...", ssh ... "<read-only コマンド>")
+- ファイル view / grep / glob
+- Asana MCP get_task / search_tasks / get_users
+- Slack MCP slack_read_channel / slack_search_public
+
+禁止操作 (実行しようとした場合は停止して claude.ai に報告):
+- str_replace / create_file / Write / Edit / MultiEdit
+- bash の rm / mv / cp の write side / > / >> / sed -i
+- INSERT / UPDATE / DELETE / ALTER / DROP / CREATE on production DB
+- docker compose up -d / docker restart / nginx reload
+- git commit / git push / git merge / git worktree add
+- Asana create_tasks / update_tasks / add_comment
+- Slack slack_send_message / slack_schedule_message
+
+調査結果は plan.md / report.md に出力。

--- a/.claude/hooks/post-lane-notify.sh
+++ b/.claude/hooks/post-lane-notify.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Lane 内で write 系成功後にトリガー
+# 完了通知は手動で send-lane-completion.sh から呼ぶ仕様
+exit 0

--- a/.claude/hooks/pre-tool-guard.sh
+++ b/.claude/hooks/pre-tool-guard.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Lane 越境 + .env.production 並列書込 物理ブロック
+# 環境変数 LANE_NAME / LANE_ROOT / LANE_PERMITS_ENV_WRITE を各 Lane で export
+
+TOOL_NAME="${CLAUDE_TOOL_NAME:-}"
+TOOL_INPUT="${CLAUDE_TOOL_INPUT:-}"
+CWD=$(pwd)
+
+# 1. .env.production への write ブロック (LANE_PERMITS_ENV_WRITE=1 の Lane のみ許可)
+if echo "$TOOL_INPUT" | grep -qE "\.env\.production[^.]"; then
+  if [ "${LANE_PERMITS_ENV_WRITE:-0}" != "1" ]; then
+    case "$TOOL_NAME" in
+      str_replace|create_file|Write|Edit|MultiEdit)
+        echo "BLOCKED by hook: .env.production write not permitted in Lane ${LANE_NAME:-unknown}"
+        exit 2
+        ;;
+    esac
+  fi
+fi
+
+# 2. 他 Lane worktree への侵入ブロック
+if [ -n "${LANE_ROOT:-}" ]; then
+  for other in lane-c-gpt4o lane-d-knowledge lane-f-fee-verify lane-login-investigate lane-amt-investigate; do
+    if [ "$other" != "$LANE_ROOT" ] && echo "$TOOL_INPUT" | grep -q "$other"; then
+      case "$TOOL_NAME" in
+        str_replace|create_file|Write|Edit|MultiEdit|Bash)
+          if echo "$TOOL_INPUT" | grep -qE "(rm |mv |cp |> |>>)"; then
+            echo "BLOCKED by hook: Lane ${LANE_NAME} cannot write to $other"
+            exit 2
+          fi
+          ;;
+      esac
+    fi
+  done
+fi
+
+# 3. main / Tier S ファイル編集ブロック (本日 5/14 全 Lane で禁止)
+TIER_S_FILES="backend/app/main.py|requirements.txt|package.json|docker-compose|scheduled_tasks.py|monitoring_service.py|database.py|migrations/versions"
+if echo "$TOOL_INPUT" | grep -qE "$TIER_S_FILES"; then
+  case "$TOOL_NAME" in
+    str_replace|create_file|Write|Edit|MultiEdit)
+      echo "BLOCKED by hook: Tier S file edit not permitted today (Lane ${LANE_NAME})"
+      exit 2
+      ;;
+  esac
+fi
+
+# 4. /api/ai/trigger 手動実行ブロック
+if echo "$TOOL_INPUT" | grep -qE "(/api/ai/trigger|ai_trigger)"; then
+  echo "BLOCKED by hook: /api/ai/trigger manual trigger禁止 (Lane ${LANE_NAME})"
+  exit 2
+fi
+
+exit 0

--- a/.claude/output-styles/lane-json.md
+++ b/.claude/output-styles/lane-json.md
@@ -1,0 +1,27 @@
+---
+name: lane-json
+description: 5 Lane 並列開発時の構造化出力スタイル。完了報告は JSON ブロックで出力する。
+---
+
+# Lane 出力スタイル
+
+各 Phase 完了時、以下構造の JSON を **コード ブロック内に必ず含める** (claude.ai 側が機械的にマージレビューするため):
+
+```json
+{
+  "lane": "<C|D|F|LOGIN|AMT>",
+  "phase": <1|2|3>,
+  "status": "<in_progress|completed|blocked|requires_review>",
+  "root_cause": "<1行サマリ、調査結果の真因>",
+  "files_to_modify": <int、Phase 3 で編集予定ファイル数>,
+  "files_list": ["path/to/file:line", ...],
+  "tier": "<S|A|B>",
+  "duration_sec": <int>,
+  "next_action": "<claude.ai_review|self_close|phase3_start|escalate>",
+  "blockers": [<文字列リスト、ブロッカーがあれば>],
+  "ut_uat_impact": "<none|low|medium|high>",
+  "playwright_e2e_needed": <true|false>
+}
+```
+
+通常応答テキストは簡潔に。詳細は plan.md / report.md に書く。

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -159,5 +159,18 @@
       "/Users/hkobayashi/.claude/projects/-Users-hkobayashi-projects-ultra-autotrade",
       "/Users/hkobayashi/projects/ultra-autotrade/.claude"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/pre-tool-guard.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,7 @@ frontend/e2e/screenshots/uat-pre-check-*/
 frontend/e2e/screenshots/login-375.png
 frontend/e2e/screenshots/login-mobile.png
 frontend/e2e/uat-pre-check-*.spec.ts.bak*
+
+# Phase A screenshots (5/15)
+frontend/e2e/screenshots/uat-pre-check/
+frontend/e2e/screenshots/yamamoto-partner/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,14 +291,102 @@ curl -s -X POST "$WEBHOOK" \
   -d '{"text": "❌ [チームメイト名] エラー: [タスク名]\n原因: [エラー内容]"}'
 ```
 
-### 並列開発: Tier 分類 + Agent Teams + Worktree (2026-05-01 確立)
+### 並列開発フロー v4 (2026-05-15 確立 / v3 全面置換)
 
-#### コンフリクト多発の真因 (過去ログ分析)
-1. dev/main 同時進行で 12-40 コミット乖離 → 12+ ファイルコンフリクト発生 (3/8, 3/31, 4/1)
-2. 巨大ファイルへの集中編集 (main.py / scheduled_tasks.py / monitoring_service.py / package.json)
-3. delete vs modify 衝突 (stash + upstream delete のミックス)
+#### v4 改訂の経緯
 
-#### Tier 分類
+v3 (2026-05-01 確立) で 3-5 Lane 並列が「Tier B + worktree + tmux + Agent Teams」で運用可能になった。
+しかし 5/15 の Phase A 起動で以下の系統的問題が露呈:
+
+1. **claude.ai プロジェクトファイルを正本扱いした推測連鎖** (古いdocs を実体と誤認 → Lane プロンプト全部やり直し)
+2. **CLI レポートの「保守的判定」を文脈確認せず鵜呑み** (Lane A-3 中断レポート過剰反応で 4 Lane 全停止指示)
+3. **Phase 計画立案時の現環境制約軸の事前列挙不足** (production 凍結期限 / 山本さん UAT 状況 / Opus 障害可能性 等)
+4. **Lane プロンプト発行前の「実 endpoint パス CLI 確認」抜け** (推測パスで Lane プロンプト発行)
+5. **Opus 障害時の Sonnet 退避ルートが言語化されていなかった** (Opus 4.6/4.7 elevated error rate で 3 Lane 停止)
+
+v4 はこれらの根本対策を CLAUDE.md §0 / §6 / §14 と接続して制度化する。
+
+---
+
+#### v4 コア原則 (v3 の鉄則 7 つに 3 つ追加 + 強化)
+
+##### v3 から継承する鉄則 7 つ (変更なし)
+
+1. **Hetzner pull only / ローカル merge only** (CLAUDE.md ABSOLUTE)
+2. **Tier S ファイルは 1 日 1 PR まで**
+3. **PR 起票前に必ず `git fetch origin && git rebase origin/main`** (古い base の指数的乖離防止)
+4. **並列レーンは Tier B のみで構成**
+5. **Phase A (Tier B 並列) → main マージ → Phase B (Tier S シリアル)** の段階実行
+6. **stash / 未コミット変更を残さない** (delete vs modify 衝突防止)
+7. **package.json / requirements.txt は誰も触らない週**を作る
+
+##### v4 で追加する鉄則 8-10
+
+**8. 正本確認は CLI 経由 cat 必須 (claude.ai プロジェクトファイル古い前提)**
+
+朝プロトコルで「正本確認」を行う際、claude.ai プロジェクトファイルは memory 同等扱い (古い可能性あり)。
+必ず CLI で以下を流して結果を貼り戻してから Phase 計画立案を開始する:
+
+```bash
+# 朝プロトコル正本確認テンプレート (read-only / 15分)
+cd ~/projects/ultra-autotrade
+
+# 直近 docs 変更コミット (claude.ai プロジェクトファイル sync 後の変更可視化)
+git log --since="2026-04-15" --oneline -- docs/ | head -30
+
+# 主要 docs の最終更新コミット
+for f in docs/14_test_strategy.md docs/22_production_release_checklist.md \
+         docs/42_production_e2e_runbook.md docs/13_security_design.md \
+         docs/15_rollback_procedures.md CLAUDE.md; do
+  echo "=== $f ==="
+  git log -1 --format="%h %ci %s" -- "$f"
+done
+
+# 直近 postmortem の有無
+ls docs/postmortems/ 2>/dev/null | tail -10
+
+# CLAUDE.md 教訓セクション最新分
+grep -nE "^### 教訓|^#### Lesson Learned|^## 20[0-9]{2}-[0-9]{2}-[0-9]{2}" CLAUDE.md | tail -20
+```
+
+CLI 結果を claude.ai に貼り戻してから Phase 計画開始。**プロジェクトファイル内検索だけで Phase 計画を立てることを禁止**。
+
+**9. Lane プロンプト発行前に「実 endpoint」「実 import path」CLI 確認必須**
+
+Lane プロンプトに endpoint パス / import path / クラス名を書く前に、必ず CLI で実コード grep:
+
+```bash
+# Lane プロンプト発行前テンプレート (該当 module ごと)
+grep -rn "@router\." backend/app/<対象module>/  # 実 endpoint
+grep -rn "class <ClassName>" backend/app/       # 実 import path
+grep -rn "<module>.*include_router\|<module_router>" backend/app/main.py  # main登録
+git log -1 --format="%h %ci %s" -- backend/app/<対象module>/  # 最終更新時期
+```
+
+claude.ai プロジェクトファイルの記述から推測で書かない。
+
+**10. Opus 障害時の Sonnet 退避ルート確立**
+
+Opus 4.6/4.7 elevated error rate / outage 時に **Phase 全停止しない**。
+以下を Sonnet 4.6 で進める:
+
+| 作業カテゴリ | Sonnet 採用可否 |
+|---|---|
+| read-only 調査 (真因確定 / 影響範囲評価) | ✅ |
+| .claude/agents/ + .claude/skills/ 作成 | ✅ |
+| docs / Asana 整理 / postmortem 起草 | ✅ |
+| pytest / E2E 追加のみの PR | ✅ |
+| 既存実装の Lane プロンプト Phase 1-2 (コード把握 + test 設計) | ✅ |
+| Lane プロンプト Phase 5 PR 作成 (Gate 4 一部保留可) | ✅ |
+| Tier S 直列 / 大規模リファクタ / セキュリティ系本体修正 | ❌ Opus 復旧待ち |
+| 安全装置系の配線変更 (workflow.py / scheduled_tasks.py) | ❌ Opus 復旧待ち |
+| 本体修正の最終実装 | ❌ Opus 復旧待ち |
+
+Sonnet で Phase 1-2 + テスト書き起こし + PR (Gate 4 保留版) まで進めれば、Opus 復旧後 15-30 分で完走できる状態を作れる。
+
+---
+
+#### Tier 分類 (v3 から変更なし)
 
 **Tier S: 同時編集禁止 (1日1PR)**
 - backend/app/main.py
@@ -306,10 +394,10 @@ curl -s -X POST "$WEBHOOK" \
 - frontend/package.json / frontend/package-lock.json
 - .github/workflows/ci.yml
 - docker-compose.production.yml / docker-compose.staging.yml
-- nginx/upstream.production.conf / nginx/upstream.staging.conf
+- nginx/upstream.{production,staging}.conf
 - backend/migrations/versions/*.py (新規追加)
 - backend/app/database.py
-- backend/app/automation/scheduled_tasks.py / monitoring_service.py
+- backend/app/automation/scheduled_tasks.py / monitoring_service.py / workflow.py
 - CLAUDE.md
 
 **Tier A: 同セクション編集のみ衝突**
@@ -324,17 +412,114 @@ curl -s -X POST "$WEBHOOK" \
 - frontend/components/*.tsx (別ファイル)
 - backend/app/protocols/*/*.py (Phase 2 PoC は完全分離)
 - scripts/*.sh (新規ファイル)
-- .claude/agents/*.md (新規ファイル)
+- .claude/agents/*.md / .claude/skills/*.md / .claude/hooks/*.sh (新規ファイル)
 
-#### 並列開発の鉄則 7つ
+---
 
-1. **Hetzner pull only / ローカル merge only** (CLAUDE.md ABSOLUTE)
-2. **Tier S ファイルは 1 日 1 PR まで**
-3. **PR 起票前に必ず `git fetch origin && git rebase origin/main`** (古い base の指数的乖離防止)
-4. **並列レーンは Tier B のみで構成**
-5. **Phase A (Tier B 並列) → main マージ → Phase B (Tier S シリアル)** の段階実行
-6. **stash / 未コミット変更を残さない** (delete vs modify 衝突防止)
-7. **package.json / requirements.txt は誰も触らない週**を作る
+#### Phase 計画立案 必須セクション (v4 新設)
+
+新 Phase 計画立案時、claude.ai は以下 5 軸を CLI で事前確認 + Phase 計画書に明記:
+
+| 制約軸 | 確認内容 | 確認ソース CLI |
+|---|---|---|
+| 凍結期限 | 当日 production 反映可否 | `cat docs/15_rollback_procedures.md \| grep -iE "凍結\|期限\|RAS"` |
+| 山本さん状況 | production UAT 進行段階 (wallet/SUPPLY/proposals) | `docker exec postgres psql -c "SELECT ... FROM users WHERE id=11"` |
+| API 障害 | Opus / Sonnet 可用性 | status.claude.com スクショ + 状態判定 |
+| 期限タスク | docs/45-48 Fee 移行 / F-シリーズ / その他 due 近接 | Asana search_tasks_preview で due 7日以内 |
+| 残務 | 過去 postmortem の P1 未済 | `ls docs/postmortems/ && grep -l "P1" docs/postmortems/*.md` |
+
+5 軸すべて確認後に Phase 計画を Asana ハブとして起票。
+**5 軸抜けで Phase 計画を立てた場合、その Phase は推測ベースとして扱い、起動前に再立案する**。
+
+---
+
+#### Lane プロンプト DoD 強化版 (v4 必須テンプレ)
+
+各 Lane プロンプトの DoD は以下 6 セクション必須:
+
+**A. 機能完了 (Lane 個別)**
+- Lane 元 DoD 項目
+
+**B. Gate 全通過 (CLAUDE.md §5 + §test_strategy 準拠)**
+- Gate 1-3: verify.sh 全 pass
+- Gate 4: Playwright E2E 新規 spec staging baseURL 全 pass
+- Gate 5: 孤立コード検出 (大きなリファクタ + DeFi 安全系変更時必須)
+- Gate 6: Codex Review (Aave/セキュリティ変更時は adversarial review 追加)
+- Gate 7: Claude in Chrome (UI 変更 Lane / staging で CF Access ブロック時は Playwright mobile 代替明記)
+
+**C. 教訓記録 (CLAUDE.md §0「新規教訓・ルールは正本に追記」遵守)**
+- 詰まった箇所 / 推測失敗 / 環境分離違反 / memory 仮定起因失敗 を CLAUDE.md「教訓-YYYY-MM-DD」セクションに追記
+- 該当なしの場合も「特記なし」と明示 (silent skip 禁止)
+- §6 / §12 / §13 / §14 違反は太字で記録
+
+**D. Asana 連携**
+- PR description に該当 Asana GID + Closes 記述
+- Lane 完了時 notes に PR link + Gate 結果 + 教訓サマリ
+- PR main マージ後 close
+
+**E. Slack JSON 通知 (.claude/hooks/send-lane-completion.sh / lane-json.md スキーマ)**
+```json
+{
+  "lane": "X-N",
+  "phase": "Phase X",
+  "status": "completed | partial_complete | blocked | failed",
+  "tier": "S | B",
+  "root_cause": "(blocked/failed 時のみ)",
+  "lessons_learned_count": N,
+  "gate_results": {
+    "1-3_verify": "pass | fail",
+    "4_e2e": "X/Y pass | deferred_to_<reason>",
+    "5_dead_code": "pass | n/a",
+    "6_codex": "approved | minor | major",
+    "7_chrome": "pass | n/a | skipped_<reason>"
+  },
+  "pr_url": "...",
+  "next_action": "..."
+}
+```
+
+**F. claude.ai 引継ぎ**
+- PR URL / Gate 1-7 個別判定 / 教訓記録 CLAUDE.md 追記行 / staging 実機検証実値 / 次 Lane への blocker
+
+---
+
+#### CLI レポート受領時の判断プロトコル (v4 新設)
+
+CLI から以下のような保守的判定 / 制約レポートが来た場合、claude.ai は**鵜呑みにせず文脈確認**してから採用判断:
+
+- 「中止推奨」「全停止」「制約あり」「Lane 不可能」等の保守的判定
+- 「Tier 超過」「設計欠陥」「事前計画乖離」等の構造判定
+
+必須確認 4 軸:
+
+| 確認軸 | 質問 |
+|---|---|
+| 観測軸 | 制約は curl 側か frontend 側か agent 側か backend 側か |
+| 環境軸 | production / staging-new / staging旧 のどれの話か |
+| 時間軸 | 今日発生 / 既解消 / 未解消 / 過去のもの |
+| 影響軸 | 当該 Lane だけ / Phase 全体 / プロジェクト全体 |
+
+4 軸確認後に判断:
+- 全 Lane 影響かつ未解消 → 全停止指示
+- 当該 Lane のみ → 当該 Lane 修正 + 他 Lane 継続
+- 環境違いの話 → 当該 Lane 注意点として記録のみで継続
+- 既解消の話 → 継続
+
+**4 軸確認なしの「全停止」「全撤回」指示を出してはならない**。
+
+---
+
+#### Phase 終了処理 (v4 新設 / 各 Phase 末尾必須)
+
+Phase 全 Lane 完了後、claude.ai セッションで以下を 1-2 時間で実行:
+
+1. **教訓集約**: 各 Lane が CLAUDE.md「教訓-YYYY-MM-DD」に追記したものを横断レビュー → Phase 全体レベルの教訓抽出 → 「教訓-YYYY-MM-DD Phase X 総括」セクション新設
+2. **Postmortem (重大インシデント時)**: docs/postmortems/YYYY-MM-DD_*.md 作成
+3. **ルール改訂判断**: Phase 教訓から新規 hook / agent / skill / ルール追加が必要か判断 → 必要なら CLAUDE.md 該当セクション更新 + claude.ai プロジェクト指示文改訂起案
+4. **次 Phase 起動ハブ Asana 起票**: 5 軸事前確認 + Lane 構成 + DoD 強化版 全包含
+5. **山本さん共有 (必要時)**: §10 文面禁止 / 小林さん本人で送信
+
+---
 
 #### Agent Teams + Worktree モード (推奨、コンフリクト物理回避)
 
@@ -350,8 +535,7 @@ Each teammate gets its own git worktree.
 
 各 Teammate が独立した worktree で作業 → main マージ時のみコンフリクト可能性。
 
-#### 落とし穴 (2026-02 以降の実運用知見)
-
+落とし穴 (2026-02 以降の実運用知見):
 - **Agent Teams は file conflict detection なし** — 他 Teammate の変更を**警告なしで上書き**することがある。File ownership を初期プロンプトで**明示**必須。
 - **3-5 Teammate がスイートスポット** — 6+ は coordination overhead 過多。
 - **Tokens 約 7 倍** (plan mode、複数 Teammate) — Sonnet/Haiku を実装係に割り当て、Lead のみ Opus。
@@ -367,17 +551,48 @@ Teammate 間のコミュニケーション不要、独立タスクのみなら `
 
 Agent Teams は teammate が share/challenge する必要があるときに使用。
 
-#### claude.ai 側の責務 (PM/アーキテクト)
+---
 
-並列開発を計画する際、claude.ai は以下を**質問なしで**実行:
+#### tmux 5 ペイン起動コマンド (v4 標準化)
 
-1. 各タスクの Tier 判定 (notes の「触るファイル」から自動)
-2. 並列レーン化 (3-5 本のスイートスポット)
-3. CLI 用包括プロンプト 5 本一括生成 (細切れ確認禁止)
-4. Asana タスク notes に並列レーン情報を追記
-5. ユーザーは tmux で 5 ターミナル起動するだけ
+```bash
+cd ~/projects/ultra-autotrade
+tmux new-session -d -s phase-<X>
+tmux split-window -h -t phase-<X>
+tmux split-window -v -t phase-<X>:0.0
+tmux split-window -v -t phase-<X>:0.1
+tmux split-window -h -t phase-<X>:0.3
+tmux attach -t phase-<X>
 
-「やっていいですか?」の質問は禁止。設計判断のみ claude.ai に残す。
+# 各ペインで claude-uata (UATa の sic.nozawa@gmail.com 切替 alias)
+# Lane X-1 (Tier S) → 左上 / Opus 4.7
+# Lane X-2 (Tier B) → 左中 / Opus 4.7 or Sonnet 4.6
+# Lane X-3 (Tier B) → 左下 / Opus 4.7 or Sonnet 4.6
+# Lane X-4 (Tier B) → 右上 / Sonnet 4.6
+# Lane X-5 (Tier B) → 右下 / Sonnet 4.6
+
+# 復帰
+tmux attach -t phase-<X>
+# Ctrl+b → d でデタッチ
+```
+
+---
+
+#### claude.ai 側の責務 (PM/アーキテクト / v4 強化版)
+
+並列開発計画時、claude.ai は質問なしで以下を実行:
+
+1. **5 軸事前確認** (Phase 計画立案前 / CLI 経由必須)
+2. **各タスクの Tier 判定** (notes の「触るファイル」から自動)
+3. **並列レーン化** (3-5 本のスイートスポット / Opus と Sonnet 配分判断)
+4. **CLI 用包括プロンプト 5 本一括生成** (細切れ確認禁止)
+5. **Asana タスク notes に並列レーン情報追記**
+6. **CLI レポート受領時の 4 軸確認** (鵜呑み禁止)
+7. **Phase 終了処理 (教訓集約 + postmortem + 次 Phase ハブ起票)**
+
+ユーザーは tmux で 5 ペイン起動するだけ。
+「やっていいですか?」の細切れ確認は禁止 (5/15 で実証された浪費パターン)。
+設計判断と 4 軸確認のみ claude.ai に残す。
 
 ---
 
@@ -1420,3 +1635,45 @@ docker compose -f docker-compose.production.yml --env-file .env.production \
 image hash が変化していなければ rebuild されていないため、旧コードが動き続ける。
 
 **参照**: `docs/postmortems/2026-05-12_uat_blocker_full_day_failure.md`
+
+---
+
+## 2026-05-15追加（Phase A PoC staging endpoint 未実装パターン教訓）
+
+### 教訓-2026-05-15: PoC 段階の schemas-only 定義と staging 実機検証の関係
+
+**事象**: Lane A-4 (AI Optimizer staging E2E) で、`OptimizerRequest` / `OptimizerResponse` が
+`app/ai/optimizer/schemas.py` に定義されているにも関わらず、対応する router が存在せず
+`/api/optimizer/recommend` エンドポイントが staging に存在しない状態でタスクが完了指定されそうになった。
+また `app/protocols/risk/router.py` の `/api/protocols/health` は main.py に登録済みだが、
+`DummyClient` を使用しているため staging で `500: DummyClient cannot be used in staging environment` が返る。
+
+**真因**: Phase 2 PoC では「schemas 先行定義 → router は実装フェーズで追加」という開発順序を取る。
+CLAUDE.md の「Phase 4: staging 実機検証」フローに「PoC 段階でエンドポイントが未実装の場合の代替」が明記されていなかった。
+
+**再発防止ルール**:
+
+1. **staging 実機検証の前にエンドポイント存在確認を必須化**
+   ```bash
+   # curl の前に必ずエンドポイント存在を確認
+   ssh -i ~/.ssh/hetzner_direct ultra@77.42.46.155 \
+     "curl -sf http://localhost:8082/openapi.json | python3 -c \"import sys,json; paths=json.load(sys.stdin)['paths']; print('\\n'.join(paths.keys()))\"" \
+     | grep -E "optimizer|recommend"
+   # 0件なら → PoC仕様 → pytest E2E で代替、その旨を DoD に明記
+   ```
+
+2. **PoC 段階の schemas-only 定義は「孤立コード検出」対象**
+   router が存在しない `OptimizerRequest` / `OptimizerResponse` は P1 孤立として記録する。
+   Lane 完了時の孤立コード検出でこれらを捕捉し、`[P1: router 実装待ち]` とラベリングして別タスク化する。
+
+3. **DummyClient を使うプロトコルの staging 実機検証は skip 明示**
+   `DummyClient` / `DummyLidoClient` / `DummyPendleClient` を使用するエンドポイントは
+   staging で必ず 500 になる。pytest mock E2E で代替し、
+   DoD に `Gate 4: staging スキップ (DummyClient - PoC仕様)` と明記すること。
+
+4. **孤立クラスの P0/P1 分類基準**
+   | 分類 | 対象 | 対応期限 |
+   |---|---|---|
+   | P0 | 安全装置・緊急停止・避難系 (AutoEvacuator, CompoundRiskAssessor 等) | 当日中 |
+   | P1 | API スキーマ・router 待ち定義 (OptimizerRequest 等) | 次スプリント |
+   | P2 | ユーティリティ・将来機能 | バックログ |

--- a/frontend/e2e/health-detail.spec.ts
+++ b/frontend/e2e/health-detail.spec.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Ultra AutoTrade. All rights reserved.
+// E2E for GET /health/detail (admin only, 5/14 DoD #6)
+//
+// Run with:
+//   BACKEND_URL=http://127.0.0.1:8082 \
+//   ADMIN_TOKEN=<jwt-of-admin-user> \
+//   VIEWER_TOKEN=<jwt-of-non-admin-user> \
+//   npx playwright test e2e/health-detail.spec.ts
+//
+// Token minting helper (run on Hetzner inside the backend container):
+//   docker exec ultra-autotrade-backend-green-staging-new python -c \
+//     "from app.auth.service import AuthService; \
+//      t,_ = AuthService.create_access_token(user_id=1, email='admin@x.com', role='admin'); print(t)"
+
+import { test, expect } from '@playwright/test'
+
+const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8000'
+const ADMIN_TOKEN = process.env.ADMIN_TOKEN ?? ''
+const VIEWER_TOKEN = process.env.VIEWER_TOKEN ?? ''
+
+test.describe('GET /health/detail (admin multi-layer health)', () => {
+  test('admin → 200 + 4-component schema', async ({ request }) => {
+    test.skip(
+      !ADMIN_TOKEN,
+      '理由: ADMIN_TOKEN 未設定。staging 環境変数注入が必要。詳細はファイル冒頭コメント参照'
+    )
+    const resp = await request.get(`${BACKEND_URL}/health/detail`, {
+      headers: { Authorization: `Bearer ${ADMIN_TOKEN}` },
+    })
+    expect(resp.status()).toBe(200)
+    const body = await resp.json()
+
+    expect(['ok', 'degraded', 'down']).toContain(body.status)
+    expect(body.components).toBeDefined()
+    expect(body.components.scheduler.ok).toBeDefined()
+    expect(body.components.quota.openai.reachable).toBeDefined()
+    expect(body.components.quota.perplexity.reachable).toBeDefined()
+    expect(body.components.cross_judgment.last_6h_total).toBeDefined()
+    expect(body.components.safety.limiter_mode).toMatch(/^(strict|custom)$/)
+    expect(Array.isArray(body.warnings)).toBe(true)
+    expect(body.cached_at).toBeDefined()
+  })
+
+  test('viewer → 403 Admin access required', async ({ request }) => {
+    test.skip(
+      !VIEWER_TOKEN,
+      '理由: VIEWER_TOKEN 未設定。staging 環境変数注入が必要。詳細はファイル冒頭コメント参照'
+    )
+    const resp = await request.get(`${BACKEND_URL}/health/detail`, {
+      headers: { Authorization: `Bearer ${VIEWER_TOKEN}` },
+    })
+    expect(resp.status()).toBe(403)
+    const body = await resp.json()
+    expect(body.detail).toBe('Admin access required')
+  })
+
+  test('no token → 401 Not authenticated', async ({ request }) => {
+    test.skip(
+      !ADMIN_TOKEN,
+      '理由: BACKEND_URL 経由のテスト。ADMIN_TOKEN 設定セッションでのみ実行'
+    )
+    const resp = await request.get(`${BACKEND_URL}/health/detail`)
+    expect(resp.status()).toBe(401)
+  })
+})

--- a/frontend/e2e/scripts/refresh-cf-access.ts
+++ b/frontend/e2e/scripts/refresh-cf-access.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+//
+// CF Access Cookie リフレッシュスクリプト
+//
+// 使用方法:
+//   npx ts-node e2e/scripts/refresh-cf-access.ts
+//
+// または Playwright コードでの実行:
+//   npx playwright codegen https://staging.ultra-auto-trade.com \
+//     --save-storage=.auth/cf-access.json
+//
+// 手順:
+//   1. このスクリプトを実行するとブラウザが開く
+//   2. Cloudflare Access の OTP 画面で hkobayashi@mooores.com にメールを送信
+//   3. メールに届いたコードを入力して認証
+//   4. staging.ultra-auto-trade.com が表示されたら Enter を押す
+//   5. .auth/cf-access.json が更新される
+
+import { chromium } from '@playwright/test'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as readline from 'readline'
+
+const STAGING_URL = process.env.STAGING_URL ?? 'https://staging.ultra-auto-trade.com'
+const AUTH_PATH = path.join(process.cwd(), 'e2e', '.auth', 'cf-access.json')
+
+async function main() {
+  console.log('[CF Access Refresh] ブラウザを起動して CF Access 認証を行います...')
+  console.log(`[CF Access Refresh] Target: ${STAGING_URL}`)
+
+  const browser = await chromium.launch({ headless: false })
+  const context = await browser.newContext()
+  const page = await context.newPage()
+
+  await page.goto(STAGING_URL)
+
+  console.log('\n[CF Access Refresh] CF Access OTP 認証を完了してください:')
+  console.log('  1. hkobayashi@mooores.com にコードを送信')
+  console.log('  2. 届いたコードを入力して認証')
+  console.log('  3. staging サイトが表示されたら Enter を押す\n')
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+  await new Promise<void>((resolve) => {
+    rl.question('staging サイトが表示されたら Enter を押してください...', () => {
+      rl.close()
+      resolve()
+    })
+  })
+
+  // Cookie を保存
+  const storageState = await context.storageState()
+  const dir = path.dirname(AUTH_PATH)
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(AUTH_PATH, JSON.stringify(storageState, null, 2))
+
+  const cfCookie = storageState.cookies.find((c) => c.name === 'CF_Authorization')
+  if (cfCookie) {
+    console.log(`\n[CF Access Refresh] ✅ CF_Authorization cookie を保存しました`)
+    console.log(`[CF Access Refresh] 保存先: ${AUTH_PATH}`)
+  } else {
+    console.warn('\n[CF Access Refresh] ⚠️  CF_Authorization cookie が見つかりません。認証が完了しているか確認してください。')
+  }
+
+  await browser.close()
+}
+
+main().catch((e) => {
+  console.error('[CF Access Refresh] エラー:', e)
+  process.exit(1)
+})

--- a/frontend/e2e/uat-pre-check-2026-05-10.spec.ts
+++ b/frontend/e2e/uat-pre-check-2026-05-10.spec.ts
@@ -1,0 +1,433 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+//
+// [Lead 検証] UAT pre-check 2026-05-10 — 8 シナリオ A-H
+//
+// 目的: 山本さん UAT 依頼前に Lead 側で staging 実環境を通し確認
+//   A: Lane A 旧按分 UI 削除確認
+//   B: Lane C BottomNav (hamburger) 紹介プログラム
+//   C: Lane D /connect → partner ロールは /partner/dashboard に redirect
+//   D: Lane E InviteModal 廃止 + /partner/referral 遷移
+//   E: Lane B WalletConnectCard + POST /auth/wallet/link mock
+//   F: 取引履歴非開示 (tx_hash / wallet_address が DOM・API に出ない) ★最重要
+//   G: i18n — 英語切替 + "Referral" 系英語テキスト表示
+//   H: モバイル対応 — viewport 393x852 + overflow なし + BottomNav 確認
+//
+// 実環境: https://staging.ultra-auto-trade.com (実 frontend + 実 backend + 実 DB)
+// CF Access: .auth/cf-access.json (CF_Authorization cookie)
+// Partner 認証: setupPartnerAuth (JWT inject + /auth/me mock)
+//
+// 実行: npx playwright test e2e/uat-pre-check-2026-05-10.spec.ts --reporter=list,html
+// 全 pass 後: claude.ai に報告 → 山本さん UAT 通知 Slack
+
+import { test, expect, Page } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+import { setupPartnerAuth } from './helpers/partner-auth'
+
+const STAGING_URL = process.env.STAGING_URL ?? 'https://staging.ultra-auto-trade.com'
+const SCREENSHOT_DIR = path.join('e2e', 'screenshots', 'uat-pre-check-2026-05-10')
+
+const CF_CLIENT_ID = process.env.CF_ACCESS_CLIENT_ID ?? ''
+const CF_CLIENT_SECRET = process.env.CF_ACCESS_CLIENT_SECRET ?? ''
+const CF_HEADERS: Record<string, string> =
+  CF_CLIENT_ID && CF_CLIENT_SECRET
+    ? { 'CF-Access-Client-Id': CF_CLIENT_ID, 'CF-Access-Client-Secret': CF_CLIENT_SECRET }
+    : {}
+
+function ensureDir() {
+  if (!fs.existsSync(SCREENSHOT_DIR)) fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
+}
+
+async function shot(page: Page, name: string) {
+  await page.screenshot({ path: path.join(SCREENSHOT_DIR, `${name}.png`), fullPage: true })
+}
+
+// --- Mock data ---
+
+const MOCK_REFERRED_USERS = [
+  {
+    id: 20,
+    email_masked: 'ua**@example.com',
+    role: 'viewer',
+    created_at: '2026-05-01T00:00:00+00:00',
+  },
+]
+
+
+const MOCK_WALLET_LINK_RESPONSE = {
+  wallet_address: '0xA1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2',
+  network: 'Base Sepolia',
+}
+
+const MOCK_USERS_LIST = [
+  {
+    id: 20,
+    email: 'uat-test-002@example.com',
+    username: 'uat-test-002',
+    role: 'viewer',
+    is_active: true,
+    created_at: '2026-05-01T00:00:00+00:00',
+    updated_at: '2026-05-01T00:00:00+00:00',
+    terms_accepted_at: null,
+    terms_version: null,
+    risk_mode: 'conservative',
+    invited_by: null,
+    tier: 'GENERAL',
+    risk_mode_label: 'ローリスク',
+  },
+]
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+// 注: describe.serial ではなく describe を使用。
+//   serial だと C (Lane D 未デプロイ) の失敗で D-H がすべて skipped になるため。
+//   各テストは独立した page fixture を持つため、並列実行でも問題なし。
+test.describe('[Lead UAT Pre-check 2026-05-10] 8 シナリオ A-H', () => {
+  test.use({
+    extraHTTPHeaders: CF_HEADERS,
+    storageState: '.auth/cf-access.json',
+  })
+
+  test.beforeEach(ensureDir)
+
+  // ── A: Lane A 旧按分 UI 削除確認 ────────────────────────────────────────────
+  test('A: 旧按分 UI 削除確認 — /partner/dashboard', async ({ page }) => {
+    await setupPartnerAuth(page)
+    await page.goto(`${STAGING_URL}/partner/dashboard`, { waitUntil: 'domcontentloaded' })
+    // heading 待機 (networkidle は polling 通信で永続タイムアウトするため不使用)
+    await page.getByText('パートナーダッシュボード').waitFor({ timeout: 10_000 })
+    expect(page.url()).toContain('/partner/dashboard')
+
+    // 「資金割り振り一覧」セクションが表示されること (= セクション自体は残る)
+    await expect(page.getByText('資金割り振り一覧')).toBeVisible({ timeout: 10_000 })
+
+    // 「+ 追加」ボタン (旧 Lane A 削除対象) が存在しないこと
+    const addBtn = page.getByRole('button', { name: /^\+?\s*追加$/ })
+    await expect(addBtn).toHaveCount(0)
+
+    // 「閲覧のみ（廃止予定）」バッジが表示されること (Lane A 追加 UI)
+    await expect(page.getByText(/閲覧のみ（廃止予定）/)).toBeVisible({ timeout: 10_000 })
+
+    await shot(page, 'A_no_allocation_add_button')
+  })
+
+  // ── B: Lane C BottomNav (hamburger) 紹介プログラム ──────────────────────────
+  test('B: hamburger menu に「紹介プログラム」→ /partner/referral 遷移 (mobile 393x852)', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 393, height: 852 })
+    await setupPartnerAuth(page)
+    // /partner/settings を使用 — /partner/dashboard は staging の auth redirect loop で不安定
+    // (test E が /partner/settings で安定動作することを確認済み)
+    await page.goto(`${STAGING_URL}/partner/settings`, { waitUntil: 'domcontentloaded' })
+    await page.getByText('ウォレット未接続').waitFor({ timeout: 10_000 })
+    expect(page.url(), `[B] auth 失敗: ${page.url()}`).toContain('/partner/settings')
+    await shot(page, 'B_settings_loaded')
+
+    // AppShell: モバイルでは hamburger ボタン (aria-label="メニュー") を開く
+    const hamburgerBtn = page.getByRole('button', { name: 'メニュー' })
+    if (await hamburgerBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await hamburgerBtn.click()
+      await page.waitForTimeout(500)
+    }
+
+    // 「紹介プログラム」リンクが表示されること
+    const referralLink = page.getByRole('link', { name: '紹介プログラム' }).first()
+    await expect(referralLink).toBeVisible({ timeout: 10_000 })
+    // href が /partner/referral を指していること (Mobile Chrome touch-click の ERR_ABORTED 回避のため click ではなく href 検証)
+    const href = await referralLink.getAttribute('href')
+    expect(href, `「紹介プログラム」リンクの href: ${href}`).toMatch(/\/partner\/referral/)
+    await shot(page, 'B_hamburger_referral_link')
+    // href 検証で完結 — Mobile Chrome touch-click の ERR_ABORTED 回避のため goto は省略
+  })
+
+  // ── C: Lane D /connect → partner ロールは /partner/dashboard に redirect ────────
+  // Lane D が未デプロイの場合 FAIL (期待: /partner/dashboard、実際: /connect or /user/*)
+  test('C: [Lane D] /connect に partner でアクセス → /partner/dashboard に redirect', async ({
+    page,
+  }) => {
+    await setupPartnerAuth(page)
+    await page.goto(`${STAGING_URL}/connect`, { waitUntil: 'domcontentloaded' })
+
+    // redirect を最大 8 秒待機
+    try {
+      await page.waitForURL(/\/partner\/dashboard/, { timeout: 15_000 })
+    } catch {
+      // redirect なければ現在 URL をアサーション (Lane D 未デプロイなら /connect のまま → FAIL)
+    }
+
+    expect(
+      page.url(),
+      `[Lane D 未デプロイ] partner は /connect ではなく /partner/dashboard に redirect されるべき。現在 URL: ${page.url()}`,
+    ).toContain('/partner/dashboard')
+
+    await shot(page, 'C_connect_redirect')
+  })
+
+  // ── D: Lane E InviteModal 廃止 — 「テスターを招待」→ /partner/referral ────────
+  test('D: InviteModal 廃止 — 「テスターを招待」クリック → /partner/referral 遷移', async ({
+    page,
+  }) => {
+    // POST /api/invitations が発火しないことを監視
+    const invitationRequests: string[] = []
+    page.on('request', (req) => {
+      if (/\/invitations/.test(req.url())) {
+        invitationRequests.push(req.url())
+      }
+    })
+
+    // /users API をモックしてユーザー 1 件を表示
+    await page.route('**/users', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(MOCK_USERS_LIST),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await setupPartnerAuth(page)
+    await page.goto(`${STAGING_URL}/partner/users`, { waitUntil: 'domcontentloaded' })
+    expect(page.url()).toContain('/partner/users')
+
+    // 「テスターを招待」ボタンが表示されること (表示完了を兼ねた待機)
+    const inviteBtn = page.getByRole('link', { name: /テスターを招待/ })
+    await expect(inviteBtn).toBeVisible({ timeout: 10_000 })
+
+    // クリック → /partner/referral に遷移 (旧 InviteModal は開かない)
+    await Promise.all([
+      page.waitForURL(/\/partner\/referral/, { timeout: 10_000 }),
+      inviteBtn.click(),
+    ])
+
+    // POST /api/invitations が 0 件であること
+    expect(invitationRequests.length).toBe(0)
+    expect(page.url()).toContain('/partner/referral')
+    await shot(page, 'D_invite_button_to_referral')
+  })
+
+  // ── E: Lane B WalletConnectCard + POST /auth/wallet/link mock ───────────────
+  test('E: WalletConnectCard 表示 + POST /auth/wallet/link 200 → 接続済み UI', async ({ page }) => {
+    // POST /auth/wallet/link を mock (実 Privy modal は skip)
+    await page.route('**/auth/wallet/link', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(MOCK_WALLET_LINK_RESPONSE),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await setupPartnerAuth(page)
+    await page.goto(`${STAGING_URL}/partner/settings`, { waitUntil: 'domcontentloaded' })
+
+    // 「ウォレット未接続」状態が表示されること (表示完了を兼ねた待機)
+    await expect(page.getByText('ウォレット未接続')).toBeVisible({ timeout: 10_000 })
+    const connectBtn = page.getByRole('button', { name: 'ウォレット接続' })
+    await expect(connectBtn).toBeVisible()
+    await shot(page, 'E_wallet_connect_card')
+
+    // 接続ボタンクリック → 接続済み UI に切り替わること
+    await connectBtn.click()
+    await expect(page.getByText(/接続済み/)).toBeVisible({ timeout: 8_000 })
+    await shot(page, 'E_wallet_connected')
+  })
+
+  // ── F: 取引履歴非開示 ★最重要 ─────────────────────────────────────────────────
+  test('F: 取引履歴非開示 — tx_hash / wallet_address が DOM・API レスポンスに存在しない ★最重要', async ({
+    page,
+  }) => {
+    test.setTimeout(60_000)
+
+    // GET /partner/referral/users/*/transactions をモック (取引データあり・tx_hash/wallet_address なし)
+    await page.route('**/partner/referral/users/*/transactions', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            { type: 'deposit', amount: '100000.00', occurred_at: '2026-05-01T00:00:00+00:00' },
+            { type: 'withdraw', amount: '50000.00', occurred_at: '2026-05-02T00:00:00+00:00' },
+          ]),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    // API レスポンスを監視して tx_hash / wallet_address キーが含まれていないことを確認
+    const txApiItems: Record<string, unknown>[] = []
+    page.on('response', async (response) => {
+      if (
+        response.url().includes('/referral/') &&
+        (response.url().includes('transaction') || response.url().includes('Transaction'))
+      ) {
+        try {
+          const body = (await response.json()) as unknown
+          if (Array.isArray(body)) {
+            txApiItems.push(...(body as Record<string, unknown>[]))
+          }
+        } catch {
+          /* ignore */
+        }
+      }
+    })
+
+    await setupPartnerAuth(page)
+    // リスト→クリックの 2 ステップを省略し詳細ページへ直接遷移 (タイムアウト対策)
+    await page.goto(`${STAGING_URL}/partner/referral/20`, { waitUntil: 'domcontentloaded' })
+
+    // ローディング完了を待つ (skeleton → テーブル or 「データなし」)
+    await expect(page.locator('text=/データなし|取引履歴一覧/').first()).toBeVisible({ timeout: 15_000 })
+    expect(page.url()).toContain('/partner/referral/20')
+
+    await shot(page, 'F_transactions_page')
+
+    // 取引データが表示されていること (モックで deposit / withdraw を注入済み)
+    await expect(page.getByText('入金')).toBeVisible({ timeout: 5_000 })
+
+    // wallet address パターン (0x + 40 hex) が DOM に存在しないこと
+    const walletAddressCount = await page.locator('text=/0x[a-fA-F0-9]{40}/').count()
+    expect(walletAddressCount, 'wallet address (0x...) が DOM に露出している').toBe(0)
+
+    // data-testid="tx-hash" が DOM に存在しないこと
+    await expect(page.locator('[data-testid="tx-hash"]')).toHaveCount(0)
+
+    // table 内テキストに tx_hash / wallet_address が含まれていないこと
+    const tableText = await page.locator('table').innerText().catch(() => '')
+    expect(tableText, 'table 内に "tx_hash" が存在する').not.toContain('tx_hash')
+    expect(tableText, 'table 内に "wallet_address" が存在する').not.toContain('wallet_address')
+
+    // API レスポンスを受信した場合 → キーに tx_hash / wallet_address が含まれないこと
+    for (const item of txApiItems) {
+      const keys = Object.keys(item)
+      expect(keys, `API に tx_hash キー: ${JSON.stringify(item)}`).not.toContain('tx_hash')
+      expect(keys, `API に wallet_address キー: ${JSON.stringify(item)}`).not.toContain('wallet_address')
+    }
+
+    await shot(page, 'F_no_tx_hash')
+  })
+
+  // ── G: i18n — 英語切替 + "Referral" 系英語テキスト表示 ──────────────────────
+  test('G: i18n — 英語切替 + "Referral" 系英語テキスト表示 + 日本語ハードコードなし', async ({
+    page,
+  }) => {
+    // NEXT_LOCALE=en を Cookie に設定 (next-intl middleware が初回リクエスト時に読む)
+    await page.context().addCookies([
+      {
+        name: 'NEXT_LOCALE',
+        value: 'en',
+        domain: '.ultra-auto-trade.com',
+        path: '/',
+        secure: true,
+        sameSite: 'Lax',
+      },
+    ])
+
+    // referral API をモックして page がロードされるようにする
+    await page.route('**/referral/code', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            referral_code: '6J7XMCTG',
+            share_url: `${STAGING_URL}/r/6J7XMCTG`,
+          }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+    await page.route('**/referral/list', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([]),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await setupPartnerAuth(page)
+    await page.goto(`${STAGING_URL}/partner/referral`, { waitUntil: 'domcontentloaded' })
+    // 紹介コード or 英語 Referral 要素が出るまで待つ (最大 10 秒)
+    await page.locator('text=/紹介プログラム|Referral/').first().waitFor({ timeout: 10_000 }).catch(() => {})
+    await shot(page, 'G_en_referral')
+
+    // 英語 "Referral" 系テキストが表示されること (Referral Link / Referral Program 等)
+    const bodyText = await page.evaluate(() => (document.body as HTMLElement).innerText ?? '')
+    const hasEnglishReferral =
+      bodyText.includes('Referral Link') ||
+      bodyText.includes('Referral Program') ||
+      bodyText.includes('Referral')
+    expect(hasEnglishReferral, '英語 "Referral" 系テキストが表示されていない').toBeTruthy()
+
+    // 日本語ハードコード「紹介プログラム」「紹介コード」「紹介者」が
+    // script/style 外のテキストノードに存在しないこと
+    const jpHardcodeNodes = await page.evaluate(() => {
+      const SKIP_TAGS = new Set(['SCRIPT', 'STYLE', 'NOSCRIPT'])
+      const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+        acceptNode(node) {
+          const tag = node.parentElement?.tagName ?? ''
+          return SKIP_TAGS.has(tag) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
+        },
+      })
+      const matches: string[] = []
+      let node: Node | null
+      while ((node = walker.nextNode())) {
+        const text = (node.textContent ?? '').trim()
+        if (text && /紹介プログラム|紹介コード|紹介者/.test(text)) {
+          matches.push(text)
+        }
+      }
+      return matches
+    })
+    expect(
+      jpHardcodeNodes.length,
+      `英語モードで日本語ハードコードが残存: ${jpHardcodeNodes.slice(0, 3).join(', ')}`,
+    ).toBe(0)
+  })
+
+  // ── H: モバイル対応 — viewport 393x852 + overflow なし + BottomNav 確認 ───────
+  test('H: モバイル対応 — viewport 393x852 + 横 overflow なし + BottomNav アイテム表示', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 393, height: 852 })
+    await setupPartnerAuth(page)
+    await page.goto(`${STAGING_URL}/partner/dashboard`, { waitUntil: 'domcontentloaded' })
+    await page.getByText('パートナーダッシュボード').waitFor({ timeout: 10_000 })
+    expect(page.url()).toContain('/partner/dashboard')
+
+    // レイアウト崩れなし — 横スクロールが発生していないこと
+    const hasOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    )
+    expect(hasOverflow, '横スクロール (overflow) が発生している').toBe(false)
+
+    // BottomNav (shared) または AppShell hamburger が表示されていること
+    // shared BottomNav (partner): ホーム, 承認, テスター, AI提案, 設定 = 5 アイテム
+    // AppShell: hamburger button が表示
+    const bottomNavLinks = page.locator('nav.fixed a')
+    const navCount = await bottomNavLinks.count()
+    if (navCount > 0) {
+      // shared BottomNav が表示されている場合: 5 アイテム (partnerNavItems)
+      expect(navCount).toBe(5)
+    } else {
+      // AppShell hamburger が表示されていること
+      const hamburgerBtn = page.getByRole('button', { name: 'メニュー' })
+      await expect(hamburgerBtn).toBeVisible({ timeout: 5_000 })
+    }
+
+    await shot(page, 'H_mobile_dashboard')
+  })
+})

--- a/frontend/e2e/uat-pre-check.spec.ts
+++ b/frontend/e2e/uat-pre-check.spec.ts
@@ -1,0 +1,241 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+//
+// [Phase D Step 1.5] UAT pre-check (実 UI 統合テスト 8 シナリオ A-H)
+//
+// 目的: 山本さん UAT 依頼前に Lead 側で staging 実環境を通し確認
+// 実環境: https://staging.ultra-auto-trade.com (実 frontend + 実 backend + 実 DB)
+// page.route 等の mock は一切使わない (= 真の統合テスト)
+//
+// 認証: PARTNER_JWT を localStorage に inject (login UI はシナリオ A のみで確認)
+// クリーンアップ: シナリオ G で作成した user は afterAll で削除
+
+import { test, expect, Page, BrowserContext } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+
+const STAGING_URL = 'https://staging.ultra-auto-trade.com'
+
+// CF Access service token (staging は CF Access 保護下)
+// Cloudflare Dashboard → Access → Service Auth → Service Tokens で発行
+const CF_CLIENT_ID = process.env.CF_ACCESS_CLIENT_ID ?? ''
+const CF_CLIENT_SECRET = process.env.CF_ACCESS_CLIENT_SECRET ?? ''
+const CF_HEADERS =
+  CF_CLIENT_ID && CF_CLIENT_SECRET
+    ? { 'CF-Access-Client-Id': CF_CLIENT_ID, 'CF-Access-Client-Secret': CF_CLIENT_SECRET }
+    : {}
+
+const PARTNER_JWT = fs.readFileSync('/tmp/staging_partner_jwt.txt', 'utf-8').trim()
+const SCREENSHOT_DIR = path.join('e2e', 'screenshots', 'uat-pre-check')
+if (!fs.existsSync(SCREENSHOT_DIR)) fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
+
+const TS = Math.floor(Date.now() / 1000)
+const TEST_NEW_USER_EMAIL = `uat-precheck-newuser-${TS}@gateb-test.com`
+
+let CAPTURED_REFERRAL_CODE: string | null = null
+
+async function shot(page: Page, name: string) {
+  await page.screenshot({ path: path.join(SCREENSHOT_DIR, `${name}.png`), fullPage: true })
+}
+
+async function injectAuth(page: Page) {
+  // staging frontend が JWT を localStorage から読む
+  await page.addInitScript(
+    (args) => {
+      localStorage.setItem(args.tokenKey, args.token)
+      localStorage.setItem(args.expiresKey, String(args.expires))
+    },
+    {
+      tokenKey: 'ultra_auth_token',
+      expiresKey: 'ultra_auth_expires',
+      token: PARTNER_JWT,
+      expires: Date.now() + 2 * 60 * 60 * 1000, // 2h
+    },
+  )
+}
+
+test.describe.serial('[UAT Pre-check] F-17 + RAS Phase 1 / staging 実環境 8 シナリオ A-H', () => {
+  test.use({
+    extraHTTPHeaders: CF_HEADERS,
+    storageState: '.auth/cf-access.json',
+  })
+
+  // ─── A: ログイン画面到達 ──────────────────────────────────────────────
+  test('A: /login 到達 + ログインフォーム表示', async ({ page }) => {
+    await page.goto(`${STAGING_URL}/login`, { waitUntil: 'domcontentloaded' })
+    // メール / パスワード入力欄が表示
+    await expect(page.getByLabel(/メールアドレス|email/i)).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByLabel(/パスワード|password/i)).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByRole('button', { name: /ログイン/ })).toBeVisible({ timeout: 5_000 })
+    await shot(page, 'A_login_form')
+  })
+
+  // ─── B: partner で /partner/dashboard 到達 (JWT inject) ───────────────
+  test('B: JWT inject で /partner/dashboard 到達', async ({ page }) => {
+    await injectAuth(page)
+    await page.goto(`${STAGING_URL}/partner/dashboard`, { waitUntil: 'domcontentloaded' })
+    // dashboard 系の固有コンテンツが表示される (ヘッダー or KPI)
+    await expect(page).toHaveURL(/\/partner\/dashboard/, { timeout: 10_000 })
+    // とりあえずダッシュボードらしき要素 (ヘッダー or サイドバー or 統計)
+    await page.waitForLoadState('networkidle', { timeout: 15_000 })
+    await shot(page, 'B_partner_dashboard')
+  })
+
+  // ─── C: /partner/referral で referral_code 表示 (実 API 呼び出し) ─────
+  test('C: /partner/referral で実 API 経由 referral_code 表示', async ({ page }) => {
+    await injectAuth(page)
+    await page.goto(`${STAGING_URL}/partner/referral`, { waitUntil: 'domcontentloaded' })
+    await page.waitForLoadState('networkidle', { timeout: 20_000 })
+
+    // 8 桁英数字 (大文字 + digit) パターンの code を検出
+    const codeLocator = page.locator('text=/\\b[A-Z0-9]{8}\\b/').first()
+    await expect(codeLocator).toBeVisible({ timeout: 15_000 })
+    const codeText = await codeLocator.textContent()
+    const match = codeText?.match(/\b([A-Z0-9]{8})\b/)
+    if (!match) throw new Error(`8桁 code が抽出できない: ${codeText}`)
+    CAPTURED_REFERRAL_CODE = match[1]
+    console.log(`✓ captured referral_code: ${CAPTURED_REFERRAL_CODE}`)
+    await shot(page, 'C_referral_code_displayed')
+  })
+
+  // ─── D: 「コピー」ボタン → toast「コピーしました」 ──────────────────
+  test('D: コピーボタン → toast 表示', async ({ page, context }) => {
+    await injectAuth(page)
+    // clipboard 権限付与
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+    await page.goto(`${STAGING_URL}/partner/referral`, { waitUntil: 'domcontentloaded' })
+    await page.waitForLoadState('networkidle', { timeout: 15_000 })
+
+    const copyBtn = page.getByRole('button', { name: /コピー/ })
+    await expect(copyBtn).toBeVisible({ timeout: 10_000 })
+    await copyBtn.click()
+
+    // sonner toast
+    await expect(page.getByText(/コピーしました/)).toBeVisible({ timeout: 5_000 })
+    await shot(page, 'D_copy_toast')
+  })
+
+  // ─── E: /r/<code> → /auth/register?ref=<code> リダイレクト (Incognito) ─
+  test('E: /r/<code> → /auth/register?ref=<code> リダイレクト', async ({ browser }) => {
+    if (!CAPTURED_REFERRAL_CODE) test.skip(true, 'referral_code 未取得')
+    const ctx = await browser.newContext()
+    const page = await ctx.newPage()
+    try {
+      await page.goto(`${STAGING_URL}/r/${CAPTURED_REFERRAL_CODE}`, { waitUntil: 'domcontentloaded' })
+      // クライアントサイドリダイレクト完了を待つ
+      await page.waitForURL(/\/auth\/register/, { timeout: 10_000 })
+      const url = page.url()
+      expect(url).toContain('/auth/register')
+      expect(url).toContain(`ref=${CAPTURED_REFERRAL_CODE}`)
+      await shot(page, 'E_redirect_to_register')
+    } finally {
+      await ctx.close()
+    }
+  })
+
+  // ─── F: /auth/register?ref=<code> ページ確認 + consent UI ─────────────
+  test('F: /auth/register に referral_code prefill + consent checkbox', async ({ browser }) => {
+    if (!CAPTURED_REFERRAL_CODE) test.skip(true, 'referral_code 未取得')
+    const ctx = await browser.newContext()
+    const page = await ctx.newPage()
+    try {
+      await page.goto(`${STAGING_URL}/auth/register?ref=${CAPTURED_REFERRAL_CODE}`, { waitUntil: 'domcontentloaded' })
+      await page.waitForLoadState('networkidle', { timeout: 15_000 })
+
+      // referral_code が画面のどこかに表示されている (input value or 表示テキスト)
+      const codeOnPage = page.locator(`text=/\\b${CAPTURED_REFERRAL_CODE}\\b/`).first()
+      await expect(codeOnPage).toBeVisible({ timeout: 10_000 })
+
+      // consent checkbox の存在確認
+      const consentCheckbox = page.locator('input[type="checkbox"]').first()
+      await expect(consentCheckbox).toBeVisible({ timeout: 5_000 })
+
+      await shot(page, 'F_register_page_with_referral')
+    } finally {
+      await ctx.close()
+    }
+  })
+
+  // ─── G: 新規ユーザー登録 (consent ON) → 成功 ──────────────────────────
+  test('G: /auth/register?ref=<code> で実 API 経由ユーザー登録', async ({ browser }) => {
+    if (!CAPTURED_REFERRAL_CODE) test.skip(true, 'referral_code 未取得')
+    const ctx = await browser.newContext()
+    const page = await ctx.newPage()
+    try {
+      await page.goto(`${STAGING_URL}/auth/register?ref=${CAPTURED_REFERRAL_CODE}`, { waitUntil: 'domcontentloaded' })
+      await page.waitForLoadState('networkidle', { timeout: 15_000 })
+
+      // メール / パスワード / username 入力
+      const emailInput = page.getByLabel(/メールアドレス|email/i).first()
+      const passwordInput = page.getByLabel(/パスワード|password/i).first()
+      const usernameInput = page.getByLabel(/ユーザー名|username/i).first()
+      await emailInput.fill(TEST_NEW_USER_EMAIL)
+      await passwordInput.fill('UATPreCheck!2026')
+      await usernameInput.fill(`uat-pc-${TS}`)
+
+      // consent checkbox ON
+      const consentCheckbox = page.locator('input[type="checkbox"]').first()
+      await consentCheckbox.check({ force: true })
+
+      await shot(page, 'G_register_form_filled')
+
+      // 登録ボタン
+      const submitBtn = page.getByRole('button', { name: /登録|register/i }).first()
+      await submitBtn.click()
+
+      // 成功 → /user/dashboard or /user/connect or 成功画面
+      await page.waitForURL(/\/(user|dashboard|connect)/, { timeout: 15_000 })
+      await shot(page, 'G_register_success')
+      console.log(`✓ registered new user: ${TEST_NEW_USER_EMAIL}`)
+    } finally {
+      await ctx.close()
+    }
+  })
+
+  // ─── H: partner /partner/referral で新ユーザー反映 + 取引履歴 wallet/tx_hash 非開示 ─
+  test('H: partner 側一覧反映 + 取引履歴 wallet/tx_hash 非開示', async ({ page }) => {
+    await injectAuth(page)
+    // /partner/referral リロード → 新ユーザー出現
+    await page.goto(`${STAGING_URL}/partner/referral`, { waitUntil: 'domcontentloaded' })
+    await page.waitForLoadState('networkidle', { timeout: 20_000 })
+
+    // mask された email (例: ua****-${TS}@gateb-test.com の prefix だけ)
+    const maskedEmailPattern = new RegExp(`uat-pc.*\\*\\*.*@gateb-test\\.com|ua\\*\\*.*@gateb-test\\.com`, 'i')
+    // 簡易: gateb-test.com を含む行があれば OK
+    const newUserRow = page.locator(`text=/gateb-test\\.com/`).first()
+    await expect(newUserRow).toBeVisible({ timeout: 15_000 })
+    await shot(page, 'H1_referred_user_in_list')
+
+    // 取引履歴 link クリック
+    const detailLink = page.getByRole('link', { name: /取引履歴/ }).first()
+    await expect(detailLink).toBeVisible({ timeout: 5_000 })
+    await Promise.all([
+      page.waitForURL(/\/partner\/referral\/\d+/, { timeout: 10_000 }),
+      detailLink.click(),
+    ])
+    await page.waitForLoadState('networkidle', { timeout: 10_000 })
+    expect(page.url()).toMatch(/\/partner\/referral\/\d+/)
+
+    // 取引履歴テーブル or 「データなし」
+    const tableOrEmpty = page.locator('table, text=/データなし/').first()
+    await expect(tableOrEmpty).toBeVisible({ timeout: 10_000 })
+    await shot(page, 'H2_transactions_page')
+
+    // wallet address pattern (0x + 40 hex) が DOM に存在しない
+    const walletAddressCount = await page.locator('text=/0x[a-fA-F0-9]{40}/').count()
+    expect(walletAddressCount).toBe(0)
+
+    // data-testid="tx-hash" が DOM に存在しない
+    await expect(page.locator('[data-testid="tx-hash"]')).toHaveCount(0)
+
+    // 取引履歴テーブル領域 innerText に wallet / tx_hash が無い (table タグがあれば)
+    const tableLocator = page.locator('table')
+    if (await tableLocator.count() > 0) {
+      const tableText = await tableLocator.innerText()
+      expect(tableText).not.toContain('tx_hash')
+      expect(tableText).not.toContain('wallet_address')
+    }
+
+    await shot(page, 'H3_no_wallet_no_tx_hash')
+  })
+})


### PR DESCRIPTION
## Summary

5/15 Phase A 完了後の教訓と並列フロー v4 + Phase A 中に追加された CLAUDE.md / .claude/ アセットを main 反映。

## 変更内容

### CLAUDE.md
- L294-380 並列開発フロー v3 → v4 全面置換 (鉄則 8/9/10 追加)
  - 8: 正本確認 = CLI 経由 cat 必須
  - 9: Lane プロンプト発行前に実 endpoint / import path CLI 確認
  - 10: Opus 障害時の Sonnet 退避ルート
- Phase 計画立案 5 軸事前確認テンプレ
- Lane プロンプト DoD 強化版 6 セクション
- CLI レポート受領時の 4 軸確認プロトコル
- Phase 終了処理 5 項目
- tmux 5 ペイン起動コマンド標準化
- 「教訓-2026-05-15 PoC staging endpoint 未実装パターン」追記

### .claude/
- settings.json: PreToolUse hook 設定
- agents/readonly-investigator.md: read-only 調査用 agent
- hooks/pre-tool-guard.sh: 推測防止 hook (Lane 越境 + .env.production 並列書込 + Tier S 編集 + /api/ai/trigger 手動実行をブロック)
- hooks/post-lane-notify.sh: Lane 完了通知 hook (現状 no-op、手動 send-lane-completion.sh 仕様)
- output-styles/lane-json.md: Lane 出力スタイル

### frontend/e2e/
- health-detail.spec.ts: PR #233 で導入された /health/detail E2E (admin only、4-component schema 検証)
- uat-pre-check.spec.ts: 山本さん UAT 事前チェック spec (8 シナリオ A-H / page.route mock なしの真の統合テスト)
- uat-pre-check-2026-05-10.spec.ts: 5/10 時点の UAT pre-check
- scripts/refresh-cf-access.ts: CF Access token refresh helper

### .gitignore
- frontend/e2e/screenshots/uat-pre-check/ 追加 (manual screenshot)
- frontend/e2e/screenshots/yamamoto-partner/ 追加 (manual screenshot)

## なぜ Tier S 例外として今コミットするのか

5/15 Phase A の教訓を CLAUDE.md 正本化しないと 5/16 朝の Phase 計画立案で参照できない。
Phase A 全 Lane (A-1 待機 / A-2 / A-3 / A-4 / A-5) 完全クローズ後の単独 commit のため、他 Lane との Tier S 競合なし。

## Test plan

- [x] ruff / mypy / pytest 影響なし (docs + .claude/ + .ts のみ)
- [x] verify.sh は skip OK (Tier S docs 専用 + .ts 追加のみ)
- [ ] CI Playwright は test-only spec のため pass 想定 (env 未設定なら test.skip)

## Related

- 5/16 朝起動ハブ: GID 1214822157954782
- 5/15 Phase A 親ハブ: GID 1214820920078899
- Lane A-2 PR #236 / A-3 PR #237 / A-4 PR #234 / A-5 PR #235 / /health/detail PR #233