### PR TITLE
fix(protocols): allow DummyClient in staging (lido/pendle) — Phase A-1 P0-1

### DIFF
--- a/backend/app/protocols/lido/client.py
+++ b/backend/app/protocols/lido/client.py
@@ -432,7 +432,7 @@ def get_lido_client(config: LidoConfig) -> AbstractLidoClient:
     import os  # noqa: PLC0415
 
     app_env = os.getenv("APP_ENV", "development")
-    if app_env in ("staging", "production") and config.sandbox:
+    if app_env == "production" and config.sandbox:
         logger.error("DummyClient is forbidden in %s environment", app_env)
         raise RuntimeError(f"DummyClient cannot be used in {app_env} environment")
     if config.sandbox:

--- a/backend/app/protocols/pendle/client.py
+++ b/backend/app/protocols/pendle/client.py
@@ -383,7 +383,7 @@ def get_pendle_client(config: PendleConfig) -> AbstractPendleClient:
     import os  # noqa: PLC0415
 
     app_env = os.getenv("APP_ENV", "development")
-    if app_env in ("staging", "production") and config.sandbox:
+    if app_env == "production" and config.sandbox:
         logger.error("DummyClient is forbidden in %s environment", app_env)
         raise RuntimeError(f"DummyClient cannot be used in {app_env} environment")
     if config.sandbox:

--- a/backend/tests/protocols/test_lido/test_lido_client.py
+++ b/backend/tests/protocols/test_lido/test_lido_client.py
@@ -99,12 +99,12 @@ class TestGetLidoClient:
         with pytest.raises(RuntimeError, match="DummyClient cannot be used in production"):
             get_lido_client(config)
 
-    def test_staging_env_with_sandbox_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """APP_ENV=staging + sandbox=True でエラーが発生すること。"""
+    def test_staging_env_with_sandbox_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Phase 1 期間中、APP_ENV=staging + sandbox=True は DummyClient を返すこと（docs/13 §1.4）。"""
         monkeypatch.setenv("APP_ENV", "staging")
         config = LidoConfig(sandbox=True)
-        with pytest.raises(RuntimeError, match="DummyClient cannot be used in staging"):
-            get_lido_client(config)
+        client = get_lido_client(config)
+        assert isinstance(client, DummyLidoClient)
 
     def test_development_env_with_sandbox_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """APP_ENV=development + sandbox=True は正常動作すること。"""

--- a/backend/tests/protocols/test_pendle/test_pendle_client.py
+++ b/backend/tests/protocols/test_pendle/test_pendle_client.py
@@ -145,12 +145,12 @@ class TestGetPendleClient:
         with pytest.raises(RuntimeError, match="DummyClient cannot be used in production"):
             get_pendle_client(config)
 
-    def test_staging_env_with_sandbox_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """APP_ENV=staging + sandbox=True でエラーが発生すること。"""
+    def test_staging_env_with_sandbox_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Phase 1 期間中、APP_ENV=staging + sandbox=True は DummyClient を返すこと（docs/13 §1.4）。"""
         monkeypatch.setenv("APP_ENV", "staging")
         config = PendleConfig(sandbox=True)
-        with pytest.raises(RuntimeError, match="DummyClient cannot be used in staging"):
-            get_pendle_client(config)
+        client = get_pendle_client(config)
+        assert isinstance(client, DummyPendleClient)
 
     def test_development_env_with_sandbox_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """APP_ENV=development + sandbox=True は正常動作すること。"""

--- a/backend/tests/test_protocols_pendle_integration.py
+++ b/backend/tests/test_protocols_pendle_integration.py
@@ -251,20 +251,25 @@ class TestProtocolHealthPendleEndpoint:
 
 
 # ---------------------------------------------------------------------------
-# 7. staging 環境 DummyClient 禁止ガード
+# 7. 環境別 DummyClient 許可ガード (Phase 1: staging 許可 / production 禁止)
 # ---------------------------------------------------------------------------
 
 
-class TestStagingGuard:
-    def test_staging_env_with_sandbox_returns_5xx(
+class TestEnvGuard:
+    def test_staging_env_with_sandbox_returns_200(
         self, pendle_app: FastAPI, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """APP_ENV=staging + PENDLE_SANDBOX=true は 5xx を返す。
-
-        TestClient を raise_server_exceptions=False で生成して
-        RuntimeError が HTTP 500 にマップされることを確認する。
-        """
+        """Phase 1 期間中、APP_ENV=staging + PENDLE_SANDBOX=true は DummyClient で 200 を返す（docs/13 §1.4）。"""
         monkeypatch.setenv("APP_ENV", "staging")
+        staging_client = TestClient(pendle_app, raise_server_exceptions=False)
+        resp = staging_client.get("/api/protocols/pendle/markets")
+        assert resp.status_code == 200
+
+    def test_production_env_with_sandbox_returns_5xx(
+        self, pendle_app: FastAPI, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """APP_ENV=production + PENDLE_SANDBOX=true は 5xx を返す。"""
+        monkeypatch.setenv("APP_ENV", "production")
         staging_client = TestClient(pendle_app, raise_server_exceptions=False)
         resp = staging_client.get("/api/protocols/pendle/markets")
         assert resp.status_code in (500, 503)


### PR DESCRIPTION
## Summary

- Phase A-1 P0-1 fix: `app/protocols/lido/client.py` L435 と `app/protocols/pendle/client.py` L386 の DummyClient guard を `app_env in ("staging","production")` から `app_env == "production"` のみに緩和
- staging で `LIDO_SANDBOX=true` / `PENDLE_SANDBOX=true` が設定されているにも関わらず guard 条件が staging を含んでいたため、`/api/protocols/health` が 500 (`DummyClient cannot be used in staging environment`) を返していた問題を解消
- Phase 1 期間中は staging でも DummyClient を許容する仕様（docs/13 §1.4）に整合
- 対応 unit / 統合テストを反転（staging で DummyClient 取得 = 成功、production は引き続き 500）

## 真因（read-only 確認済み）

- staging 環境変数: `APP_ENV=staging` / `LIDO_SANDBOX=true` (`ultra-autotrade-backend-blue-staging-new`)
- staging で再現: `GET /api/protocols/health` → `500 DummyClient cannot be used in staging environment`
- §1-A grep 結果: lido:435 / pendle:386 が想定通り

## Scope

- production 反映は禁止（Phase 1 凍結期間 = F-16 / 2026-05-18 まで）
- staging（Hetzner 上）まで反映で完了

## Test plan

- [x] Gate 1-3: ruff check / ruff format / mypy → pass
- [x] Gate 4: pytest 2733 passed (coverage 84.66%) → pass
- [x] Gate 5: ruff --select S → pass
- [ ] staging 実機: main マージ後 Hetzner で `./scripts/deploy_staging.sh --backend-only` → `/api/protocols/health/{lido,pendle}` 全 200 確認

## Asana

- 1214821930631284 (Phase A-1 P0-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)