### PR TITLE
feat(ops): L1-L6 自動ヘルスチェック cron スクリプト (RC-7 observability 改善)

### DIFF
--- a/scripts/healthcheck_l1_l6.sh
+++ b/scripts/healthcheck_l1_l6.sh
@@ -12,7 +12,7 @@
 #   DRY_RUN=true ./scripts/healthcheck_l1_l6.sh  # Slack送信をスキップしてJSONを表示
 #
 # cron登録例 (Hetzner /opt/ultra-autotrade/scripts/ に配置後):
-#   */5 * * * * /opt/ultra-autotrade/scripts/healthcheck_l1_l6.sh >> /var/log/ultra-autotrade/healthcheck.log 2>&1
+#   */5 * * * * /opt/ultra-autotrade/scripts/healthcheck_l1_l6.sh >> /opt/ultra-autotrade/logs/healthcheck_l1_l6.log 2>&1
 
 set -uo pipefail
 
@@ -21,7 +21,7 @@ set -uo pipefail
 # ============================================================
 ENV_FILE="${ENV_FILE:-/opt/ultra-autotrade/.env.production}"
 PASS_STAMP_FILE="${PASS_STAMP_FILE:-/tmp/.last_healthcheck_pass}"
-LOG_DIR="${LOG_DIR:-/var/log/ultra-autotrade}"
+LOG_DIR="${LOG_DIR:-/opt/ultra-autotrade/logs}"
 TIMEOUT="${TIMEOUT:-10}"
 DRY_RUN="${DRY_RUN:-false}"
 

--- a/scripts/healthcheck_l1_l6.sh
+++ b/scripts/healthcheck_l1_l6.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+# scripts/healthcheck_l1_l6.sh
+#
+# Ultra AutoTrade L1-L6 自動ヘルスチェック (5分間隔 cron)
+#
+# PASS時: 1時間に1回通知 (/tmp/.last_healthcheck_pass タイムスタンプで管理)
+# FAIL時: 即通知
+# L6 FAIL: UAT期間中は常態化、warn扱い (エスカレーション対象外)
+#
+# 使用例:
+#   ./scripts/healthcheck_l1_l6.sh          # 通常実行
+#   DRY_RUN=true ./scripts/healthcheck_l1_l6.sh  # Slack送信をスキップしてJSONを表示
+#
+# cron登録例 (Hetzner /opt/ultra-autotrade/scripts/ に配置後):
+#   */5 * * * * /opt/ultra-autotrade/scripts/healthcheck_l1_l6.sh >> /var/log/ultra-autotrade/healthcheck.log 2>&1
+
+set -uo pipefail
+
+# ============================================================
+# 設定
+# ============================================================
+ENV_FILE="${ENV_FILE:-/opt/ultra-autotrade/.env.production}"
+PASS_STAMP_FILE="${PASS_STAMP_FILE:-/tmp/.last_healthcheck_pass}"
+LOG_DIR="${LOG_DIR:-/var/log/ultra-autotrade}"
+TIMEOUT="${TIMEOUT:-10}"
+DRY_RUN="${DRY_RUN:-false}"
+
+POSTGRES_CONTAINER="ultra-autotrade-postgres-production"
+DB_USER="ultra"
+DB_NAME="ultra_autotrade"
+BACKEND_BLUE_URL="http://127.0.0.1:8010"
+BACKEND_PUBLIC_URL="https://api.ultra-auto-trade.com"
+
+# 期待する常時起動コンテナ (7台)
+REQUIRED_CONTAINERS=(
+  "ultra-autotrade-loki-production"
+  "ultra-autotrade-promtail-production"
+  "ultra-autotrade-postgres-production"
+  "ultra-autotrade-backend-blue-production"
+  "ultra-autotrade-nginx-production"
+  "ultra-autotrade-cloudflared-production"
+  "ultra-autotrade-frontend-production"
+)
+
+# env ファイルから Slack Webhook を取得
+SLACK_WEBHOOK_URL="${SLACK_WEBHOOK_URL:-}"
+if [[ -z "$SLACK_WEBHOOK_URL" && -f "$ENV_FILE" ]]; then
+  SLACK_WEBHOOK_URL="$(grep '^SLACK_WEBHOOK_URL=' "$ENV_FILE" | cut -d= -f2-)"
+fi
+
+mkdir -p "$LOG_DIR"
+TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+NEXT_CHECK="$(date -u -d "+5 minutes" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+# ============================================================
+# ユーティリティ
+# ============================================================
+run_psql() {
+  docker exec "$POSTGRES_CONTAINER" \
+    psql -U "$DB_USER" -d "$DB_NAME" -tAc "$1" 2>/dev/null || echo ""
+}
+
+# ============================================================
+# L1: インフラチェック
+# ============================================================
+check_l1() {
+  local status="PASS"
+  local details=""
+  local failed=()
+
+  for c in "${REQUIRED_CONTAINERS[@]}"; do
+    local running
+    running="$(docker inspect -f '{{.State.Running}}' "$c" 2>/dev/null || echo "false")"
+    if [[ "$running" != "true" ]]; then
+      failed+=("$c")
+    fi
+  done
+
+  if [[ ${#failed[@]} -gt 0 ]]; then
+    status="FAIL"
+    details="containers down: $(IFS=','; echo "${failed[*]}")"
+  fi
+
+  # 内部 /health (backend-blue)
+  local local_code
+  local_code="$(curl -sf -o /dev/null -w "%{http_code}" \
+    --connect-timeout "$TIMEOUT" --max-time "$TIMEOUT" \
+    "$BACKEND_BLUE_URL/health" 2>/dev/null || echo "000")"
+  if [[ "$local_code" != "200" ]]; then
+    status="FAIL"
+    details="${details:+$details; }local /health HTTP $local_code"
+  fi
+
+  # 外形 /health (Cloudflare経由)
+  local pub_code
+  pub_code="$(curl -sf -o /dev/null -w "%{http_code}" \
+    --connect-timeout "$TIMEOUT" --max-time "$TIMEOUT" \
+    "$BACKEND_PUBLIC_URL/health" 2>/dev/null || echo "000")"
+  if [[ "$pub_code" != "200" ]]; then
+    status="FAIL"
+    details="${details:+$details; }public /health HTTP $pub_code"
+  fi
+
+  [[ "$status" == "PASS" ]] && details="all ${#REQUIRED_CONTAINERS[@]} containers up, /health 200"
+  printf '{"status":"%s","details":"%s"}' "$status" "$details"
+}
+
+# ============================================================
+# L2: スケジューラーチェック
+# ============================================================
+check_l2() {
+  local status="PASS"
+  local details=""
+  local scheduler_healthy="false"
+  local last_age_min=0
+
+  local body
+  body="$(curl -sf --connect-timeout "$TIMEOUT" --max-time "$TIMEOUT" \
+    "$BACKEND_BLUE_URL/health" 2>/dev/null || echo "{}")"
+
+  scheduler_healthy="$(echo "$body" | jq -r '.scheduler_healthy // .scheduler // false' 2>/dev/null || echo "false")"
+  local last_judgment
+  last_judgment="$(echo "$body" | jq -r '.last_judgment // empty' 2>/dev/null || echo "")"
+  local warnings_count
+  warnings_count="$(echo "$body" | jq '.warnings | length // 0' 2>/dev/null || echo 0)"
+
+  if [[ "$scheduler_healthy" != "true" ]]; then
+    status="FAIL"
+    details="scheduler_healthy=$scheduler_healthy"
+  fi
+
+  if [[ -n "$last_judgment" ]]; then
+    local now_epoch lj_epoch
+    now_epoch="$(date +%s)"
+    lj_epoch="$(date -d "$last_judgment" +%s 2>/dev/null || echo "$now_epoch")"
+    last_age_min=$(( (now_epoch - lj_epoch) / 60 ))
+    if [[ $last_age_min -gt 60 ]]; then
+      status="FAIL"
+      details="${details:+$details; }last_judgment ${last_age_min}min ago (>60)"
+    fi
+  fi
+
+  if [[ "$warnings_count" -gt 0 ]]; then
+    status="FAIL"
+    local warnings_text
+    warnings_text="$(echo "$body" | jq -r '.warnings[]' 2>/dev/null | tr '\n' ',' | sed 's/,$//')"
+    details="${details:+$details; }warnings: $warnings_text"
+  fi
+
+  [[ "$status" == "PASS" ]] && details="scheduler_healthy=true, last_judgment ${last_age_min}min ago"
+  local sh_bool
+  [[ "$scheduler_healthy" == "true" ]] && sh_bool="true" || sh_bool="false"
+  printf '{"status":"%s","scheduler_healthy":%s,"last_judgment_age_min":%d,"details":"%s"}' \
+    "$status" "$sh_bool" "$last_age_min" "$details"
+}
+
+# ============================================================
+# L3: AI判定チェック (24h >= 3件)
+# ============================================================
+check_l3() {
+  local status="PASS"
+  local count
+  count="$(run_psql "SELECT COUNT(*) FROM ai_decisions WHERE created_at > NOW() - INTERVAL '24 hours';" | tr -d '[:space:]')"
+  count="${count:-0}"
+  [[ "$count" -lt 3 ]] && status="FAIL"
+  printf '{"status":"%s","ai_decisions_24h":%s}' "$status" "$count"
+}
+
+# ============================================================
+# L4: ユーザー反応チェック (proposals expired率 < 0.5)
+# ============================================================
+check_l4() {
+  local status="PASS"
+  local expired_rate="0.00"
+
+  local result
+  result="$(run_psql "SELECT COUNT(*), COUNT(*) FILTER (WHERE status='expired') FROM proposals WHERE created_at > NOW() - INTERVAL '24 hours';")"
+  result="$(echo "$result" | tr -d '[:space:]')"
+
+  local total="${result%%|*}"
+  local expired="${result##*|}"
+  total="${total:-0}"
+  expired="${expired:-0}"
+
+  if [[ "$total" -gt 0 ]]; then
+    expired_rate="$(awk "BEGIN {printf \"%.2f\", $expired / $total}")"
+    if awk "BEGIN {exit !($expired_rate >= 0.5)}"; then
+      status="FAIL"
+    fi
+  fi
+
+  printf '{"status":"%s","proposals_24h":%s,"expired_rate":%s}' \
+    "$status" "$total" "$expired_rate"
+}
+
+# ============================================================
+# L5: 実取引チェック (tx_hash NULL率 < 0.2)
+# ============================================================
+check_l5() {
+  local status="PASS"
+
+  local result
+  result="$(run_psql "SELECT COUNT(*), COUNT(*) FILTER (WHERE tx_hash IS NULL AND is_dry_run = false) FROM transactions WHERE created_at > NOW() - INTERVAL '24 hours';")"
+  result="$(echo "$result" | tr -d '[:space:]')"
+
+  local total="${result%%|*}"
+  local failed="${result##*|}"
+  total="${total:-0}"
+  failed="${failed:-0}"
+
+  if [[ "$total" -gt 0 && "$failed" -gt 0 ]]; then
+    local fail_rate
+    fail_rate="$(awk "BEGIN {printf \"%.2f\", $failed / $total}")"
+    if awk "BEGIN {exit !($fail_rate >= 0.2)}"; then
+      status="FAIL"
+    fi
+  fi
+
+  printf '{"status":"%s","tx_24h":%s,"tx_failed_24h":%s}' "$status" "$total" "$failed"
+}
+
+# ============================================================
+# L6: 収益チェック (zero_value < 50%, UAT期間中はWARN)
+# ============================================================
+check_l6() {
+  local status="PASS"
+  local zero_pct=0
+
+  local result
+  result="$(run_psql "SELECT COUNT(*), COUNT(*) FILTER (WHERE total_value_usd = 0 OR total_value_usd IS NULL) FROM portfolio_snapshots WHERE recorded_at > NOW() - INTERVAL '1 day';")"
+  result="$(echo "$result" | tr -d '[:space:]')"
+
+  local total="${result%%|*}"
+  local zero_count="${result##*|}"
+  total="${total:-0}"
+  zero_count="${zero_count:-0}"
+
+  if [[ "$total" -gt 0 ]]; then
+    zero_pct="$(awk "BEGIN {printf \"%d\", $zero_count / $total * 100}")"
+    if [[ "$zero_pct" -ge 50 ]]; then
+      status="WARN"
+    fi
+  fi
+
+  local note
+  [[ "$status" == "WARN" ]] && note="UAT期間中常態化" || note="ok"
+  printf '{"status":"%s","zero_value_pct":%d,"note":"%s"}' "$status" "$zero_pct" "$note"
+}
+
+# ============================================================
+# Slack 通知
+# ============================================================
+send_slack() {
+  local payload="$1"
+
+  if [[ -z "${SLACK_WEBHOOK_URL:-}" ]]; then
+    echo "[WARN] SLACK_WEBHOOK_URL not set, skipping notification" >&2
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "[DRY_RUN] Would send to Slack:" >&2
+    echo "$payload" | jq . >&2
+    return 0
+  fi
+
+  local slack_text
+  slack_text="$(echo "$payload" | jq -c '@json')"
+  curl -sf -X POST "$SLACK_WEBHOOK_URL" \
+    -H "Content-Type: application/json" \
+    -d "{\"text\": $slack_text}" >/dev/null 2>&1 || \
+    echo "[WARN] Slack notification failed" >&2
+}
+
+# ============================================================
+# メイン
+# ============================================================
+main() {
+  local l1 l2 l3 l4 l5 l6
+  l1="$(check_l1)"
+  l2="$(check_l2)"
+  l3="$(check_l3)"
+  l4="$(check_l4)"
+  l5="$(check_l5)"
+  l6="$(check_l6)"
+
+  # L6 WARNは全体FAILにしない (UAT期間中の常態)
+  local overall="PASS"
+  for result in "$l1" "$l2" "$l3" "$l4" "$l5"; do
+    if echo "$result" | jq -e '.status == "FAIL"' >/dev/null 2>&1; then
+      overall="FAIL"
+      break
+    fi
+  done
+
+  local payload
+  payload="$(jq -nc \
+    --arg task "healthcheck_l1_l6" \
+    --arg status "$overall" \
+    --arg ts "$TIMESTAMP" \
+    --arg next "$NEXT_CHECK" \
+    --argjson l1 "$l1" \
+    --argjson l2 "$l2" \
+    --argjson l3 "$l3" \
+    --argjson l4 "$l4" \
+    --argjson l5 "$l5" \
+    --argjson l6 "$l6" \
+    '{
+      task: $task,
+      status: $status,
+      timestamp: $ts,
+      results: {L1: $l1, L2: $l2, L3: $l3, L4: $l4, L5: $l5, L6: $l6},
+      next_check: $next
+    }')"
+
+  echo "$payload"
+
+  # 通知ポリシー
+  if [[ "$overall" == "FAIL" ]]; then
+    send_slack "$payload"
+  else
+    local now_epoch last_pass elapsed
+    now_epoch="$(date +%s)"
+    last_pass="$(cat "$PASS_STAMP_FILE" 2>/dev/null || echo 0)"
+    elapsed=$(( now_epoch - last_pass ))
+    if [[ $elapsed -ge 3600 ]]; then
+      send_slack "$payload"
+      echo "$now_epoch" > "$PASS_STAMP_FILE"
+    fi
+  fi
+}
+
+main "$@"

--- a/scripts/healthcheck_l1_l6.sh
+++ b/scripts/healthcheck_l1_l6.sh
@@ -28,8 +28,9 @@ DRY_RUN="${DRY_RUN:-false}"
 POSTGRES_CONTAINER="ultra-autotrade-postgres-production"
 DB_USER="ultra"
 DB_NAME="ultra_autotrade"
-BACKEND_BLUE_URL="http://127.0.0.1:8010"
-BACKEND_PUBLIC_URL="https://api.ultra-auto-trade.com"
+# 環境変数オーバーライド可能 (テスト・違反シミュレーション用)
+BACKEND_BLUE_URL="${BACKEND_BLUE_URL:-http://127.0.0.1:8010}"
+BACKEND_PUBLIC_URL="${BACKEND_PUBLIC_URL:-https://api.ultra-auto-trade.com}"
 
 # 期待する常時起動コンテナ (7台)
 REQUIRED_CONTAINERS=(

--- a/scripts/healthcheck_l1_l6.sh
+++ b/scripts/healthcheck_l1_l6.sh
@@ -96,10 +96,12 @@ check_l1() {
   fi
 
   # 内部 /health (backend-blue)
+  # curl -w "%{http_code}" は失敗時も "000" を stdout に書くため || echo は不要
   local local_code
   local_code="$(curl -sf -o /dev/null -w "%{http_code}" \
     --connect-timeout "$TIMEOUT" --max-time "$TIMEOUT" \
-    "$BACKEND_BLUE_URL/health" 2>/dev/null || echo "000")"
+    "$BACKEND_BLUE_URL/health" 2>/dev/null || true)"
+  local_code="${local_code:-000}"
   if [[ "$local_code" != "200" ]]; then
     status="FAIL"
     details="${details:+$details; }local /health HTTP $local_code"
@@ -109,7 +111,8 @@ check_l1() {
   local pub_code
   pub_code="$(curl -sf -o /dev/null -w "%{http_code}" \
     --connect-timeout "$TIMEOUT" --max-time "$TIMEOUT" \
-    "$BACKEND_PUBLIC_URL/health" 2>/dev/null || echo "000")"
+    "$BACKEND_PUBLIC_URL/health" 2>/dev/null || true)"
+  pub_code="${pub_code:-000}"
   if [[ "$pub_code" != "200" ]]; then
     status="FAIL"
     details="${details:+$details; }public /health HTTP $pub_code"

--- a/scripts/healthcheck_l1_l6.sh
+++ b/scripts/healthcheck_l1_l6.sh
@@ -60,6 +60,19 @@ run_psql() {
     psql -U "$DB_USER" -d "$DB_NAME" -tAc "$1" 2>/dev/null || echo ""
 }
 
+# python3 で JSON フィールドを取得
+py_json_get() {
+  local json="$1" key="$2" default="${3:-}"
+  echo "$json" | python3 -c \
+    "import sys,json; d=json.load(sys.stdin); print(d.get('$key', '$default'))" \
+    2>/dev/null || echo "$default"
+}
+
+# JSON 文字列エスケープ (Slack text用)
+py_json_escape() {
+  python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))" 2>/dev/null
+}
+
 # ============================================================
 # L1: インフラチェック
 # ============================================================
@@ -102,7 +115,10 @@ check_l1() {
   fi
 
   [[ "$status" == "PASS" ]] && details="all ${#REQUIRED_CONTAINERS[@]} containers up, /health 200"
-  printf '{"status":"%s","details":"%s"}' "$status" "$details"
+  # JSON特殊文字をエスケープ
+  local escaped_details
+  escaped_details="${details//\"/\\\"}"
+  printf '{"status":"%s","details":"%s"}' "$status" "$escaped_details"
 }
 
 # ============================================================
@@ -118,39 +134,61 @@ check_l2() {
   body="$(curl -sf --connect-timeout "$TIMEOUT" --max-time "$TIMEOUT" \
     "$BACKEND_BLUE_URL/health" 2>/dev/null || echo "{}")"
 
-  scheduler_healthy="$(echo "$body" | jq -r '.scheduler_healthy // .scheduler // false' 2>/dev/null || echo "false")"
-  local last_judgment
-  last_judgment="$(echo "$body" | jq -r '.last_judgment // empty' 2>/dev/null || echo "")"
-  local warnings_count
-  warnings_count="$(echo "$body" | jq '.warnings | length // 0' 2>/dev/null || echo 0)"
+  # scheduler_healthy と last_judgment を python3 で取得
+  local parsed
+  parsed="$(echo "$body" | python3 - <<'PYEOF' 2>/dev/null
+import sys, json
+from datetime import datetime, timezone
+
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print("false|0|0")
+    sys.exit(0)
+
+sh = d.get('scheduler_healthy', d.get('scheduler', False))
+scheduler_healthy = 'true' if sh else 'false'
+
+lj = d.get('last_judgment', '')
+age_min = 0
+if lj:
+    try:
+        lj_dt = datetime.fromisoformat(lj.replace('Z', '+00:00'))
+        now = datetime.now(timezone.utc)
+        age_min = int((now - lj_dt).total_seconds() / 60)
+    except Exception:
+        age_min = 0
+
+warnings = d.get('warnings', [])
+warnings_count = len(warnings) if isinstance(warnings, list) else 0
+print(f"{scheduler_healthy}|{age_min}|{warnings_count}")
+PYEOF
+)"
+
+  scheduler_healthy="${parsed%%|*}"
+  local remainder="${parsed#*|}"
+  last_age_min="${remainder%%|*}"
+  local warnings_count="${remainder##*|}"
 
   if [[ "$scheduler_healthy" != "true" ]]; then
     status="FAIL"
     details="scheduler_healthy=$scheduler_healthy"
   fi
 
-  if [[ -n "$last_judgment" ]]; then
-    local now_epoch lj_epoch
-    now_epoch="$(date +%s)"
-    lj_epoch="$(date -d "$last_judgment" +%s 2>/dev/null || echo "$now_epoch")"
-    last_age_min=$(( (now_epoch - lj_epoch) / 60 ))
-    if [[ $last_age_min -gt 60 ]]; then
-      status="FAIL"
-      details="${details:+$details; }last_judgment ${last_age_min}min ago (>60)"
-    fi
+  if [[ -n "$last_age_min" ]] && [[ "$last_age_min" -gt 60 ]] 2>/dev/null; then
+    status="FAIL"
+    details="${details:+$details; }last_judgment ${last_age_min}min ago (>60)"
   fi
 
-  if [[ "$warnings_count" -gt 0 ]]; then
+  if [[ -n "$warnings_count" ]] && [[ "$warnings_count" -gt 0 ]] 2>/dev/null; then
     status="FAIL"
-    local warnings_text
-    warnings_text="$(echo "$body" | jq -r '.warnings[]' 2>/dev/null | tr '\n' ',' | sed 's/,$//')"
-    details="${details:+$details; }warnings: $warnings_text"
+    details="${details:+$details; }warnings count=${warnings_count}"
   fi
 
   [[ "$status" == "PASS" ]] && details="scheduler_healthy=true, last_judgment ${last_age_min}min ago"
   local sh_bool
   [[ "$scheduler_healthy" == "true" ]] && sh_bool="true" || sh_bool="false"
-  printf '{"status":"%s","scheduler_healthy":%s,"last_judgment_age_min":%d,"details":"%s"}' \
+  printf '{"status":"%s","scheduler_healthy":%s,"last_judgment_age_min":%s,"details":"%s"}' \
     "$status" "$sh_bool" "$last_age_min" "$details"
 }
 
@@ -162,7 +200,8 @@ check_l3() {
   local count
   count="$(run_psql "SELECT COUNT(*) FROM ai_decisions WHERE created_at > NOW() - INTERVAL '24 hours';" | tr -d '[:space:]')"
   count="${count:-0}"
-  [[ "$count" -lt 3 ]] && status="FAIL"
+  [[ -z "$count" ]] && count=0
+  [[ "$count" -lt 3 ]] 2>/dev/null && status="FAIL"
   printf '{"status":"%s","ai_decisions_24h":%s}' "$status" "$count"
 }
 
@@ -174,17 +213,18 @@ check_l4() {
   local expired_rate="0.00"
 
   local result
-  result="$(run_psql "SELECT COUNT(*), COUNT(*) FILTER (WHERE status='expired') FROM proposals WHERE created_at > NOW() - INTERVAL '24 hours';")"
-  result="$(echo "$result" | tr -d '[:space:]')"
+  result="$(run_psql "SELECT COUNT(*), COUNT(*) FILTER (WHERE status='expired') FROM proposals WHERE created_at > NOW() - INTERVAL '24 hours';" | tr -d '[:space:]')"
 
   local total="${result%%|*}"
   local expired="${result##*|}"
   total="${total:-0}"
   expired="${expired:-0}"
+  [[ -z "$total" ]] && total=0
+  [[ -z "$expired" ]] && expired=0
 
-  if [[ "$total" -gt 0 ]]; then
-    expired_rate="$(awk "BEGIN {printf \"%.2f\", $expired / $total}")"
-    if awk "BEGIN {exit !($expired_rate >= 0.5)}"; then
+  if [[ "$total" -gt 0 ]] 2>/dev/null; then
+    expired_rate="$(awk "BEGIN {printf \"%.2f\", $expired / $total}" 2>/dev/null || echo "0.00")"
+    if awk "BEGIN {exit !($expired_rate >= 0.5)}" 2>/dev/null; then
       status="FAIL"
     fi
   fi
@@ -200,18 +240,19 @@ check_l5() {
   local status="PASS"
 
   local result
-  result="$(run_psql "SELECT COUNT(*), COUNT(*) FILTER (WHERE tx_hash IS NULL AND is_dry_run = false) FROM transactions WHERE created_at > NOW() - INTERVAL '24 hours';")"
-  result="$(echo "$result" | tr -d '[:space:]')"
+  result="$(run_psql "SELECT COUNT(*), COUNT(*) FILTER (WHERE tx_hash IS NULL AND is_dry_run = false) FROM transactions WHERE created_at > NOW() - INTERVAL '24 hours';" | tr -d '[:space:]')"
 
   local total="${result%%|*}"
   local failed="${result##*|}"
   total="${total:-0}"
   failed="${failed:-0}"
+  [[ -z "$total" ]] && total=0
+  [[ -z "$failed" ]] && failed=0
 
-  if [[ "$total" -gt 0 && "$failed" -gt 0 ]]; then
+  if [[ "$total" -gt 0 && "$failed" -gt 0 ]] 2>/dev/null; then
     local fail_rate
-    fail_rate="$(awk "BEGIN {printf \"%.2f\", $failed / $total}")"
-    if awk "BEGIN {exit !($fail_rate >= 0.2)}"; then
+    fail_rate="$(awk "BEGIN {printf \"%.2f\", $failed / $total}" 2>/dev/null || echo "0.00")"
+    if awk "BEGIN {exit !($fail_rate >= 0.2)}" 2>/dev/null; then
       status="FAIL"
     fi
   fi
@@ -227,17 +268,18 @@ check_l6() {
   local zero_pct=0
 
   local result
-  result="$(run_psql "SELECT COUNT(*), COUNT(*) FILTER (WHERE total_value_usd = 0 OR total_value_usd IS NULL) FROM portfolio_snapshots WHERE recorded_at > NOW() - INTERVAL '1 day';")"
-  result="$(echo "$result" | tr -d '[:space:]')"
+  result="$(run_psql "SELECT COUNT(*), COUNT(*) FILTER (WHERE total_value_usd = 0 OR total_value_usd IS NULL) FROM portfolio_snapshots WHERE recorded_at > NOW() - INTERVAL '1 day';" | tr -d '[:space:]')"
 
   local total="${result%%|*}"
   local zero_count="${result##*|}"
   total="${total:-0}"
   zero_count="${zero_count:-0}"
+  [[ -z "$total" ]] && total=0
+  [[ -z "$zero_count" ]] && zero_count=0
 
-  if [[ "$total" -gt 0 ]]; then
-    zero_pct="$(awk "BEGIN {printf \"%d\", $zero_count / $total * 100}")"
-    if [[ "$zero_pct" -ge 50 ]]; then
+  if [[ "$total" -gt 0 ]] 2>/dev/null; then
+    zero_pct="$(awk "BEGIN {printf \"%d\", $zero_count / $total * 100}" 2>/dev/null || echo 0)"
+    if [[ "$zero_pct" -ge 50 ]] 2>/dev/null; then
       status="WARN"
     fi
   fi
@@ -259,13 +301,13 @@ send_slack() {
   fi
 
   if [[ "$DRY_RUN" == "true" ]]; then
-    echo "[DRY_RUN] Would send to Slack:" >&2
-    echo "$payload" | jq . >&2
+    echo "[DRY_RUN] Would send to Slack (JSON valid):" >&2
+    echo "$payload" | python3 -m json.tool >&2
     return 0
   fi
 
   local slack_text
-  slack_text="$(echo "$payload" | jq -c '@json')"
+  slack_text="$(echo "$payload" | py_json_escape)"
   curl -sf -X POST "$SLACK_WEBHOOK_URL" \
     -H "Content-Type: application/json" \
     -d "{\"text\": $slack_text}" >/dev/null 2>&1 || \
@@ -287,31 +329,44 @@ main() {
   # L6 WARNは全体FAILにしない (UAT期間中の常態)
   local overall="PASS"
   for result in "$l1" "$l2" "$l3" "$l4" "$l5"; do
-    if echo "$result" | jq -e '.status == "FAIL"' >/dev/null 2>&1; then
+    if echo "$result" | python3 -c \
+      "import sys,json; d=json.load(sys.stdin); sys.exit(0 if d.get('status')=='FAIL' else 1)" \
+      2>/dev/null; then
       overall="FAIL"
       break
     fi
   done
 
+  # 最終 JSON ペイロードをpython3で構築
   local payload
-  payload="$(jq -nc \
-    --arg task "healthcheck_l1_l6" \
-    --arg status "$overall" \
-    --arg ts "$TIMESTAMP" \
-    --arg next "$NEXT_CHECK" \
-    --argjson l1 "$l1" \
-    --argjson l2 "$l2" \
-    --argjson l3 "$l3" \
-    --argjson l4 "$l4" \
-    --argjson l5 "$l5" \
-    --argjson l6 "$l6" \
-    '{
-      task: $task,
-      status: $status,
-      timestamp: $ts,
-      results: {L1: $l1, L2: $l2, L3: $l3, L4: $l4, L5: $l5, L6: $l6},
-      next_check: $next
-    }')"
+  payload="$(L1="$l1" L2="$l2" L3="$l3" L4="$l4" L5="$l5" L6="$l6" \
+    TASK="healthcheck_l1_l6" STATUS="$overall" TS="$TIMESTAMP" NEXT="$NEXT_CHECK" \
+    python3 - <<'PYEOF'
+import os, json
+
+def load(key):
+    try:
+        return json.loads(os.environ.get(key, '{}'))
+    except Exception:
+        return {"status": "ERROR"}
+
+result = {
+    "task": os.environ["TASK"],
+    "status": os.environ["STATUS"],
+    "timestamp": os.environ["TS"],
+    "results": {
+        "L1": load("L1"),
+        "L2": load("L2"),
+        "L3": load("L3"),
+        "L4": load("L4"),
+        "L5": load("L5"),
+        "L6": load("L6"),
+    },
+    "next_check": os.environ["NEXT"],
+}
+print(json.dumps(result))
+PYEOF
+)"
 
   echo "$payload"
 


### PR DESCRIPTION
## Summary

- RC-7 (observability「動いていることになっているだけ」) を解決するため、L1-L6 を5分間隔で自動チェックする `scripts/healthcheck_l1_l6.sh` を追加
- 閾値違反時は即 Slack 通知 (PASS は1時間1回まで)、L6 UAT常態 WARN はエスカレーション対象外
- jq 未インストール環境 (Hetzner) 対応のため python3 で JSON 処理

## チェック仕様

| レイヤ | 判定基準 |
|---|---|
| L1 インフラ | 7コンテナUp + /health 200 (内部8010 + 外形Cloudflare) |
| L2 スケジューラ | scheduler_healthy=true + last_judgment 1h以内 + warnings空 |
| L3 AI判定 | ai_decisions 24h >= 3件 |
| L4 ユーザー反応 | proposals expired率 < 50% |
| L5 実取引 | tx_hash NULL率 < 20% |
| L6 収益 | portfolio zero_value < 50% (UAT中はWARN専用) |

## 実機検証結果 (Hetzner 2026-05-17)

```
L1: PASS — all 7 containers up, /health 200 (内部:8010 + 外形:Cloudflare)
L2: FAIL — scheduler_healthy=false  ← 実環境の実障害を検知 (別タスク要対応)
L3: PASS — ai_decisions_24h: 3件 (閾値>=3)
L4: PASS — proposals_24h: 0件 (expired_rate: 0.0)
L5: PASS — tx_24h: 0件 (tx_failed: 0件)
L6: WARN — zero_value_pct: 100% (UAT期間中常態化)
```

## DoD: L1-L6全PASS実機検証 + 違反シミュレーション成功

- [x] Gate 1-3: `bash -n scripts/healthcheck_l1_l6.sh` 構文OK (Hetzner Ubuntu 24.04 + macOS 両確認)
- [x] Gate 4 n/a: スクリプト系、E2E不要
- [x] Gate 5 n/a: 新規スクリプト追加のみ、既存コード無変更
- [x] Hetzner cron 登録済み: `*/5 * * * * /opt/ultra-autotrade/scripts/healthcheck_l1_l6.sh >> /opt/ultra-autotrade/logs/healthcheck_l1_l6.log 2>&1` (`crontab -l` 確認済)
- [x] L1-L6 全項目が結果を返すことを手動実行で確認 (PASS/FAIL/WARN いずれか)
- [x] Slack dry-run: `DRY_RUN=true` で JSON 出力、`python3 -m json.tool` でパース成功 (jq 未インストール環境に対応)
- [x] L1 違反シミュレーション: `BACKEND_BLUE_URL=http://127.0.0.1:9999` で FAIL 検知 → `L1 details: local /health HTTP 000; public /health HTTP 000` → Slack FAIL 通知送信
- [x] L1 復旧確認: 正常 URL に戻す → `L1 status: PASS, details: all 7 containers up, /health 200`

## 注目発見事項

- **L2 FAIL (scheduler_healthy=false)**: このスクリプトにより初めて検知。`scheduler: true` でも `_healthy: false` のケースを正確に捕捉 (CLAUDE.md §2026-05-16-17 案件)。別タスクで原因調査が必要
- LOG_DIR は `/opt/ultra-autotrade/logs` 使用 (`/var/log/ultra-autotrade` はultraユーザー書き込み不可のため)
- curl 失敗時の `-w "%{http_code}"` が "000" を出力するため `|| echo "000"` を排除 (`|| true` に変更)

## cron 設定

```bash
# Hetzner: crontab -e で確認
*/5 * * * * /opt/ultra-autotrade/scripts/healthcheck_l1_l6.sh >> /opt/ultra-autotrade/logs/healthcheck_l1_l6.log 2>&1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)