### PR TITLE
docs(claude): 朝プロトコル §9 Step 0 強制化 + 鉄則8違反根絶ルール (Lane B-6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1276,6 +1276,70 @@ done; echo
 
 ---
 
+## 朝プロトコル §9
+
+### Step 0 (絶対実行 = 完了していなければ §9 進行禁止) — 2026-05-17 追加
+
+claude.ai は §9 開始前に以下が claude.ai セッション内に貼り付けられていることを確認する。
+貼り付けられていない場合は「朝プロトコル進行不可、Step 0 を実行してください」と返し、
+他の作業を一切受け付けない。
+
+CLI で実行 (所要 1分):
+
+```bash
+cd ~/projects/ultra-autotrade
+
+echo "=== /mnt/project/CLAUDE.md head 80 (本指示文との整合確認用) ==="
+head -80 /mnt/project/CLAUDE.md
+
+echo ""
+echo "=== /mnt/project/production_operation_checklist.md 全文 ==="
+cat /mnt/project/production_operation_checklist.md
+
+echo ""
+echo "=== /mnt/project/CLAUDE.md デプロイ時の教訓セクション (最新) ==="
+sed -n '521,$p' /mnt/project/CLAUDE.md | head -200
+
+echo ""
+echo "=== 直近 postmortem (5件) ==="
+ls -lt docs/postmortems/ 2>/dev/null | head -6
+
+echo ""
+echo "=== CLAUDE.md v4.1 反映確認 ==="
+grep -n "並列開発フロー v4" CLAUDE.md
+wc -l CLAUDE.md
+
+echo ""
+echo "=== 既install plugin 状態 ==="
+claude plugin list 2>&1 | head -10
+```
+
+**claude.ai 側の責務**:
+- 上記が貼り付けられていない時点で「§9 進行不可」を返す
+- 貼り付け確認後、Step 1-5 (R2C ソート等) に進む
+- §9 開始宣言に **「Step 0 確認済 (cat 結果セッション内に貼付)」を必ず含める**
+
+### Step 0 違反の扱い
+
+claude.ai が Step 0 をスキップして §9 を実行した場合、それは **鉄則8違反**。
+- 1回目: 本人 (claude.ai) が指摘を受けて Step 0 やり直し
+- 2回目以降: hkobayashi から claude.ai への信頼コスト発生、claude.ai は設計判断資格を失う
+- 本指示文 v4 §3 「メモリルール3件以上参照 / 適用判定」と並んで運用される
+- Step 0 未完のまま §9 を進めた事実は、§9 進行禁止ルールへの直接違反として記録される
+
+### 経緯
+
+2026-05-17 セッションで claude.ai が CLAUDE.md / production_operation_checklist.md /
+31_backup_restore_procedures.md を view せず、本指示文 v4 のみで作業判断を進めた結果、
+3回連続で鉄則8違反 (CLI 側 STOP 判断で救済)。同セッション中の P0 (postgres 2,448回クラッシュ
++ backup 全滅) 対応時にも /mnt/project/31_backup_restore_procedures.md を見ずに復旧手順を
+推測しており、hkobayashi 直接指摘で発覚。
+
+これを「気をつける」では防げないため、Step 0 強制化で **claude.ai が物理的に view せざるを得ない**
+状態を作る。鉄則8違反の再発は本セクションの「Step 0 違反の扱い」に従って処理する。
+
+---
+
 ## 参照ファイル
 
 | ファイル | 内容 | いつ読むか |


### PR DESCRIPTION
## Lane B-6: 朝プロトコル §9 Step 0 強制化 (鉄則8違反根絶)

**DoD: 朝プロトコル §9 Step 0 強制化 + 鉄則8違反根絶ルール実装**

### 目的
RC-8 (claude.ai が CLAUDE.md / docs の教訓を読まずに作業した、本セッション3回違反) の根絶。
朝プロトコル §9 の前段に Step 0 (CLI cat 強制) を追加し、Step 0 完了が確認できない時点で
claude.ai が §9 進行を拒否する仕組みを制度化。

### 変更内容
- `CLAUDE.md` に新規セクション `## 朝プロトコル §9` を追加 (参照ファイルセクション直前)
  - `### Step 0 (絶対実行 = 完了していなければ §9 進行禁止)` — CLI cat 強制テンプレート
  - `### Step 0 違反の扱い` — 鉄則8違反としての処理ルール (1回目/2回目以降)
  - `### 経緯` — 2026-05-17 セッションでの3回連続鉄則8違反 + P0 backup全滅対応の RCA

### DoD 検証結果
- [x] CLAUDE.md §9 に Step 0 強制化追記 (新規 `## 朝プロトコル §9` セクション)
- [x] `grep -c "Step 0" CLAUDE.md` = **9** (>= 3)
- [x] `grep -c "鉄則8違反" CLAUDE.md` = **3** (>= 2)
- [x] `grep -cE "進行禁止|進行不可" CLAUDE.md` = **4** (>= 2)
- [x] バックアップ `CLAUDE.md.bak.20260517-b6-step0` 存在
- [x] §9 既存 Step 1-5 / 本指示文 v4 / 他セクション 改変なし

### Gate
- Gate 1-3 (verify.sh): n/a — docs専用変更 (CLAUDE.md のみ、コード非変更)
- Gate 4 (Playwright E2E): n/a — UI/API 非変更
- Gate 5 (孤立コード検出): n/a — コード非変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)
