### PR TITLE
docs(ops): 自動復旧スコープ設計 v1 + auto_recovery.sh プロトタイプ

### DIFF
--- a/docs/auto_recovery_scope.md
+++ b/docs/auto_recovery_scope.md
@@ -1,0 +1,232 @@
+# 自動復旧スコープ設計 v1
+
+**作成日**: 2026-05-18  
+**対象**: Ultra AutoTrade 本番環境 (Hetzner VPS)  
+**前提**: 1人プロジェクト (hkobayashi) — 深夜 22:00-06:00 は対応者不在  
+**関連スクリプト**: `scripts/healthcheck_l1_l6.sh` (L1-L6 検知)、`scripts/auto_recovery.sh` (本ドキュメントの実装先)  
+**関連 postmortem**: `docs/postmortems/2026-05-12_nginx_upstream_ip_pin.md` (nginx IP 固着 → 3h23m 復旧不在)
+
+---
+
+## 設計方針
+
+「対応者不在 = 警告無視と同じ」(PR #248 教訓) への対策として、
+単純かつ可逆な障害を自動復旧し、人間判断が必要なものは Pushover で確実に起こす。
+
+**自動復旧の原則:**
+1. 可逆性 — 自動アクションは `docker restart` / `docker reload` レベルに限定。データ変更・コード変更・設定変更は行わない
+2. 冪等性 — 同じ操作を繰り返しても副作用が出ない操作のみ許可
+3. クールダウン — 同一対象を1時間に3回 restart したら停止して人間を呼ぶ (alert fatigue 対策)
+4. ログ完全記録 — 何を・いつ・なぜ実行したかを `~/.claude-uata/logs/auto_recovery.log` に記録
+5. 非介入原則 — Aave / postgres / DB データ / コード には触れない
+
+---
+
+## 自動復旧する範囲 (AUTO-RECOVERABLE)
+
+### AR-1: nginx upstream IP 固着 → `docker restart nginx`
+
+| 項目 | 内容 |
+|------|------|
+| **検知** | L1 FAIL + 内部 `/health` 200 + 外形 `/health` non-200 |
+| **原因** | frontend-only deploy 後に backend が recreate され nginx が古い IP にプロキシし続ける |
+| **自動アクション** | `docker restart ultra-autotrade-nginx-production` |
+| **検証** | restart 後 30 秒以内に外形 `/health` 200 |
+| **クールダウン** | 1時間に3回まで。3回到達で Pushover priority=2 |
+| **参照** | `docs/postmortems/2026-05-12_nginx_upstream_ip_pin.md` |
+
+**実装メモ**: 内部 `127.0.0.1:8010/health` が 200 で外形が non-200 の場合のみ nginx restart を試みる。
+backend 自体が死んでいる場合はこのパターンに合致しないため過剰な restart は起きない。
+
+### AR-2: backend コンテナ unhealthy → `docker restart backend`
+
+| 項目 | 内容 |
+|------|------|
+| **検知** | L1 FAIL + `docker inspect --format='{{.State.Health.Status}}'` が `unhealthy` または `exited` |
+| **原因** | OOM killer / uvicorn ワーカー異常終了 / 一時的 exception ループ |
+| **自動アクション** | `docker restart ultra-autotrade-backend-production` |
+| **検証** | restart 後 60 秒以内に内部 `/health` 200 + `scheduler_healthy: true` |
+| **クールダウン** | 1時間に3回まで。3回到達で Pushover priority=2 |
+| **除外** | postgres が死んでいる場合は AR-2 を実行しない (L1 FAIL で postgres チェック先行) |
+
+### AR-3: scheduler dead → backend soft-reload
+
+| 項目 | 内容 |
+|------|------|
+| **検知** | L2 FAIL (scheduler_healthy=false または last_judgment_age > 60分) かつ backend コンテナは Up |
+| **原因** | scheduler loop が例外でクラッシュしたが uvicorn プロセスは生きている |
+| **自動アクション** | `docker restart ultra-autotrade-backend-production` (soft restart で scheduler loop 再起動) |
+| **検証** | restart 後 90 秒以内に L2 PASS |
+| **クールダウン** | 1時間に2回まで (重要度が高いため閾値を下げる)。2回到達で Pushover priority=2 |
+
+### AR-4: cloudflared コンテナ exited → `docker restart cloudflared`
+
+| 項目 | 内容 |
+|------|------|
+| **検知** | L1 FAIL + 外形 `/health` non-200 + `docker inspect cloudflared` が `exited` |
+| **原因** | Cloudflare Tunnel 側の一時的切断・SIGKILL |
+| **自動アクション** | `docker restart ultra-autotrade-cloudflared-production` |
+| **検証** | restart 後 60 秒以内に外形 `/health` 200 |
+| **クールダウン** | 1時間に3回まで。3回到達で Pushover priority=2 |
+
+---
+
+## 自動復旧しない範囲 (HUMAN-REQUIRED)
+
+以下はいずれも「人間の判断が必要」または「自動アクションが状況を悪化させるリスクが高い」。
+自動復旧は行わず、Pushover で hkobayashi を起こす。
+
+### HR-1: postgres コンテナ異常
+
+| 理由 | 詳細 |
+|------|------|
+| **SIGKILL ループ** | 2026-05-17 インシデント: postgres が 2,448 回クラッシュ。`docker restart` では解決しない。WAL 損傷 / OOM / disk 枯渇の根本原因調査が必要 |
+| **データ整合性リスク** | postgres restart 中に未フラッシュの WAL が残る場合あり。automated restart はデータロスを助長する可能性 |
+| **backup 確認必須** | 復旧前に `docs/31_backup_restore_procedures.md` に従い backup 取得・確認が必要 |
+| **Pushover** | priority=2 (深夜でも起こす) |
+
+### HR-2: Aave operation 失敗
+
+| 理由 | 詳細 |
+|------|------|
+| **資金安全性** | HF < 1.6 の HARD_STOP は自動復旧で解除しない (OR ロジック、`docs/33_emergency_stop_governance.md` §2) |
+| **RPC 障害** | RPC URL の変更・切替は `.env.production` 変更を伴い Tier S 操作 |
+| **Pushover** | priority=2 |
+
+### HR-3: 本番 DB スキーマ破損
+
+| 理由 | 詳細 |
+|------|------|
+| **不可逆** | テーブル・カラムの損傷は `docker restart` で復旧しない |
+| **バックアップ照合必須** | `docs/31_backup_restore_procedures.md` §3 の pg_restore 手順が必要 |
+| **Pushover** | priority=2 |
+
+### HR-4: 複数コンテナ同時 down (3個以上)
+
+| 理由 | 詳細 |
+|------|------|
+| **連鎖障害の可能性** | ネットワーク分離・OOM・disk 枯渇 等の全体障害。個別 restart では解決しない |
+| **対処** | `healthcheck_l1_l6.sh` の L1 containers_running < 5 で Pushover priority=2 |
+| **Pushover** | priority=2 |
+
+### HR-5: disk 使用率 > 85%
+
+| 理由 | 詳細 |
+|------|------|
+| **根本解決必要** | `docker system prune -af` は使用中イメージを削除するリスク (CLAUDE.md 絶対禁止)。週次 `docker_cleanup.sh` の手動確認が必要 |
+| **Pushover** | priority=1 (High) — 急ぐが深夜に起こすほどではない。朝確認可 |
+
+### HR-6: AI 判定 24h 件数ゼロ (L3 FAIL) かつ scheduler_healthy=true
+
+| 理由 | 詳細 |
+|------|------|
+| **設計バグの可能性** | scheduler は生きているが判定が出ていない = コード・設定の問題。restart では解決しない |
+| **Pushover** | priority=1 (High) |
+
+### HR-7: nginx / cloudflared クールダウン上限到達
+
+| 理由 | 詳細 |
+|------|------|
+| **ループ検出** | 1時間に N 回 restart しても復旧しない = 根本原因が别にある |
+| **Pushover** | priority=2 |
+
+---
+
+## 復旧トリガー設計
+
+```
+healthcheck_l1_l6.sh (5分cron, Hetzner)
+    │
+    ├── L1 FAIL
+    │   ├── postgres exited → [HR-1] Pushover priority=2
+    │   ├── コンテナ 5個未満 → [HR-4] Pushover priority=2
+    │   ├── 内部200 + 外形non-200
+    │   │   ├── cloudflared exited → [AR-4] docker restart cloudflared
+    │   │   └── nginx 問題の可能性 → [AR-1] docker restart nginx
+    │   └── backend unhealthy/exited → [AR-2] docker restart backend
+    │
+    ├── L2 FAIL (scheduler dead)
+    │   └── backend Up かつ scheduler_healthy=false → [AR-3] docker restart backend
+    │
+    ├── L3 FAIL かつ L2 PASS
+    │   └── [HR-6] Pushover priority=1
+    │
+    └── クールダウン上限到達
+        └── [HR-7] Pushover priority=2 + 自動復旧停止
+
+auto_recovery.sh (healthcheck_l1_l6.sh から呼び出し)
+    │
+    ├── クールダウンカウンタ確認 (ファイルベース、~/.claude-uata/recovery-cooldown/)
+    ├── 復旧アクション実行
+    ├── 検証 (30-90秒待機 → curl/docker inspect)
+    ├── ログ記録 (~/.claude-uata/logs/auto_recovery.log)
+    └── Slack 通知 (#ultra-auto-project)
+```
+
+---
+
+## クールダウン仕様
+
+| 対象 | 1時間あたりの最大 restart 回数 | 上限到達時の動作 |
+|------|-------------------------------|-----------------|
+| nginx | 3 | Pushover priority=2 + 自動復旧停止 |
+| backend | 3 | Pushover priority=2 + 自動復旧停止 |
+| cloudflared | 3 | Pushover priority=2 + 自動復旧停止 |
+| scheduler (backend経由) | 2 | Pushover priority=2 + 自動復旧停止 |
+
+**クールダウンカウンタのリセット**: 
+- 1時間のスライディングウィンドウ (現在時刻 - 1h 以前のエントリを削除)
+- 手動リセット: `rm ~/.claude-uata/recovery-cooldown/<container>-*.ts`
+
+---
+
+## Pushover priority=2 発火条件 (docs/24h-automation-runbook.md §Pushover 優先度マッピング の補強)
+
+priority=2 (Critical / 深夜でも電話呼出 / retry=60 expire=3600) を発火する条件:
+
+| 状況 | 検知元 | 備考 |
+|------|--------|------|
+| 本番 /health (外形) 5分連続 non-200 | uata-supervisor.sh | 既存 |
+| postgres コンテナ exited / SIGKILL ループ | auto_recovery.sh | **新規** |
+| 複数コンテナ同時 down (3個以上) | auto_recovery.sh | **新規** |
+| nginx/backend/cloudflared クールダウン上限 (1h に N 回 restart) | auto_recovery.sh | **新規** |
+| Aave HARD_STOP 発動 (HF < 1.6) | backend scheduler | 既存 (MonitoringService) |
+| mainnet wallet 不正操作試行 | backend security layer | 既存 |
+| DB スキーマ破損検知 | auto_recovery.sh | **新規** (L1 FAIL + psql 接続不可) |
+
+priority=1 (High / 目立つが深夜は起こさない) を発火する条件:
+
+| 状況 | 検知元 | 備考 |
+|------|--------|------|
+| disk 使用率 > 85% | auto_recovery.sh or healthcheck | **新規** |
+| AI 判定 24h 件数ゼロ (L3 FAIL) かつ scheduler 生存 | auto_recovery.sh | **新規** |
+| UATa タスク 3件以上連続 failed (2h 内) | uata-supervisor.sh | 既存 |
+| Tier S 承認待ち | uata-supervisor.sh | 既存 |
+
+---
+
+## 今後の実装計画 (別 Tier S タスク)
+
+本ドキュメントはあくまで **設計** である。
+実際に Hetzner 本番環境へ配置・cron 登録するには以下の Tier S 操作が必要:
+
+1. `scripts/auto_recovery.sh` を Hetzner に配置 (`/opt/ultra-autotrade/scripts/`)
+2. `scripts/healthcheck_l1_l6.sh` を更新して `auto_recovery.sh` を呼び出す
+3. Hetzner cron に `*/5 * * * *` でヘルスチェック + 自動復旧を登録
+4. `~/.claude-uata/recovery-cooldown/` ディレクトリ作成 (Hetzner 上)
+5. 動作確認: `DRY_RUN=true bash scripts/auto_recovery.sh` で空振りテスト
+
+**Tier S 理由**: `scripts/healthcheck_l1_l6.sh` および cron 設定は本番インフラ変更のため。
+実装は別日に Opus モデルで Tier S シリアル実行する。
+
+---
+
+## 参照
+
+- `docs/15_rollback_procedures.md` — ロールバック手順
+- `docs/33_emergency_stop_governance.md` — 緊急停止ガバナンス
+- `docs/24h-automation-runbook.md` — 24h 自動化 Pushover 優先度マッピング
+- `scripts/healthcheck_l1_l6.sh` — L1-L6 ヘルスチェック実装
+- `scripts/uata-pushover-notify.sh` — Pushover 通知関数
+- `scripts/uata-supervisor.sh` — stuck 検出 + rollback supervisor
+- `docs/postmortems/2026-05-12_nginx_upstream_ip_pin.md` — nginx IP 固着インシデント

--- a/scripts/auto_recovery.sh
+++ b/scripts/auto_recovery.sh
@@ -1,0 +1,386 @@
+#!/usr/bin/env bash
+# scripts/auto_recovery.sh
+#
+# Ultra AutoTrade 自動復旧スクリプト (プロトタイプ)
+# 設計仕様: docs/auto_recovery_scope.md
+#
+# [注意] 本スクリプトは Tier B 設計ドキュメントに対応するプロトタイプ。
+#         本番 Hetzner への配置は別途 Tier S タスクで実施する。
+#
+# 使い方:
+#   DRY_RUN=true bash scripts/auto_recovery.sh --check-all   # 全チェック (空振り)
+#   bash scripts/auto_recovery.sh --action nginx-restart     # nginx のみ復旧
+#   bash scripts/auto_recovery.sh --action backend-restart   # backend のみ復旧
+#
+# 環境変数:
+#   DRY_RUN                true の場合 docker コマンドを実行しない (デフォルト: false)
+#   UATA_CONFIG            ~/.claude-uata (デフォルト)
+#   HEALTH_URL_INTERNAL    http://127.0.0.1:8010/health (デフォルト)
+#   HEALTH_URL_EXTERNAL    https://api.ultra-auto-trade.com/health (デフォルト)
+#   RECOVERY_LOG           $UATA_CONFIG/logs/auto_recovery.log
+
+set -uo pipefail
+
+# =============================================================================
+# 設定
+# =============================================================================
+UATA_CONFIG="${UATA_CONFIG:-$HOME/.claude-uata}"
+RECOVERY_LOG="${RECOVERY_LOG:-$UATA_CONFIG/logs/auto_recovery.log}"
+COOLDOWN_DIR="${COOLDOWN_DIR:-$UATA_CONFIG/recovery-cooldown}"
+DRY_RUN="${DRY_RUN:-false}"
+
+HEALTH_URL_INTERNAL="${HEALTH_URL_INTERNAL:-http://127.0.0.1:8010/health}"
+HEALTH_URL_EXTERNAL="${HEALTH_URL_EXTERNAL:-https://api.ultra-auto-trade.com/health}"
+CURL_TIMEOUT=10
+
+# コンテナ名 (production)
+CONTAINER_BACKEND="ultra-autotrade-backend-production"
+CONTAINER_NGINX="ultra-autotrade-nginx-production"
+CONTAINER_CLOUDFLARED="ultra-autotrade-cloudflared-production"
+CONTAINER_POSTGRES="ultra-autotrade-postgres-production"
+
+# クールダウン設定 (1時間スライディングウィンドウ)
+COOLDOWN_WINDOW_SEC=3600
+declare -A COOLDOWN_MAX=(
+    ["nginx"]=3
+    ["backend"]=3
+    ["cloudflared"]=3
+    ["scheduler"]=2
+)
+
+mkdir -p "$(dirname "$RECOVERY_LOG")" "$COOLDOWN_DIR"
+exec >> "$RECOVERY_LOG" 2>&1
+
+# =============================================================================
+# ユーティリティ
+# =============================================================================
+ts() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+log() { echo "$(ts) [auto_recovery] $*"; }
+
+send_slack() {
+    local text="$1"
+    local env_file="${ENV_FILE:-/opt/ultra-autotrade/.env.production}"
+    local webhook=""
+    if [[ -f "$env_file" ]]; then
+        webhook=$(grep "^SLACK_WEBHOOK_URL=" "$env_file" | cut -d= -f2- | tr -d '"' || true)
+    fi
+    [[ -z "$webhook" ]] && { log "SLACK_WEBHOOK_URL 未設定 — Slack 通知スキップ"; return 0; }
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log "[DRY_RUN] Slack: $text"; return 0
+    fi
+    curl -sf -X POST "$webhook" -H "Content-Type: application/json" \
+        -d "{\"text\": \"$text\"}" > /dev/null || log "Slack 通知失敗"
+}
+
+# Pushover 通知 (scripts/uata-pushover-notify.sh に委譲)
+pushover_critical() {
+    local title="$1" message="$2"
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log "[DRY_RUN] Pushover CRITICAL: $title — $message"; return 0
+    fi
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [[ -f "$script_dir/uata-pushover-notify.sh" ]]; then
+        # shellcheck disable=SC1090
+        source "$script_dir/uata-pushover-notify.sh" 2>/dev/null || true
+        uata_notify_critical "$title" "$message" 2>/dev/null || log "Pushover 送信失敗: $title"
+    else
+        log "uata-pushover-notify.sh not found — Pushover スキップ"
+    fi
+}
+
+pushover_high() {
+    local title="$1" message="$2"
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log "[DRY_RUN] Pushover HIGH: $title — $message"; return 0
+    fi
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [[ -f "$script_dir/uata-pushover-notify.sh" ]]; then
+        # shellcheck disable=SC1090
+        source "$script_dir/uata-pushover-notify.sh" 2>/dev/null || true
+        uata_notify_high "$title" "$message" 2>/dev/null || log "Pushover 送信失敗: $title"
+    fi
+}
+
+# =============================================================================
+# クールダウン管理
+# =============================================================================
+
+# 過去 COOLDOWN_WINDOW_SEC 内の restart 回数を返す
+cooldown_count() {
+    local target="$1"
+    local now window_start count=0
+    now=$(date +%s)
+    window_start=$(( now - COOLDOWN_WINDOW_SEC ))
+    for f in "$COOLDOWN_DIR/${target}"-*.ts; do
+        [[ -f "$f" ]] || continue
+        local ts_val
+        ts_val=$(cat "$f" 2>/dev/null || echo 0)
+        if [[ "$ts_val" -ge "$window_start" ]]; then
+            count=$(( count + 1 ))
+        else
+            rm -f "$f"
+        fi
+    done
+    echo "$count"
+}
+
+# クールダウン記録
+cooldown_record() {
+    local target="$1"
+    echo "$(date +%s)" > "$COOLDOWN_DIR/${target}-$(date +%s%N).ts"
+}
+
+# クールダウン上限チェック (true=上限超過)
+cooldown_exceeded() {
+    local target="$1"
+    local max="${COOLDOWN_MAX[$target]:-3}"
+    local count
+    count=$(cooldown_count "$target")
+    log "クールダウンカウント: $target=$count/$max"
+    [[ "$count" -ge "$max" ]]
+}
+
+# =============================================================================
+# ヘルスチェックユーティリティ
+# =============================================================================
+
+check_internal_health() {
+    curl -sf --connect-timeout "$CURL_TIMEOUT" --max-time "$CURL_TIMEOUT" \
+        "$HEALTH_URL_INTERNAL" > /dev/null 2>&1
+}
+
+check_external_health() {
+    local code
+    code=$(curl -s --connect-timeout "$CURL_TIMEOUT" --max-time "$CURL_TIMEOUT" \
+        -o /dev/null -w "%{http_code}" "$HEALTH_URL_EXTERNAL" 2>/dev/null)
+    [[ "$code" == "200" ]]
+}
+
+container_state() {
+    local name="$1"
+    docker inspect --format='{{.State.Status}}' "$name" 2>/dev/null || echo "not_found"
+}
+
+container_health() {
+    local name="$1"
+    docker inspect --format='{{.State.Health.Status}}' "$name" 2>/dev/null || echo "none"
+}
+
+# =============================================================================
+# 復旧アクション
+# =============================================================================
+
+# AR-1 / AR-4: コンテナ restart
+do_restart() {
+    local target="$1" container="$2" verify_fn="$3" wait_sec="${4:-30}"
+
+    log "[$target] restart 開始: $container"
+
+    if cooldown_exceeded "$target"; then
+        log "[$target] クールダウン上限超過 → 自動復旧停止"
+        pushover_critical "UATa 自動復旧停止: $target" \
+            "1時間に${COOLDOWN_MAX[$target]:-3}回 restart しても復旧しません。手動確認が必要です。container=$container"
+        send_slack "🚨 [auto_recovery] *$target クールダウン上限到達*: 自動復旧を停止しました。container=$container"
+        return 1
+    fi
+
+    cooldown_record "$target"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log "[DRY_RUN] docker restart $container"
+    else
+        docker restart "$container" || {
+            log "[$target] docker restart 失敗"
+            send_slack "❌ [auto_recovery] $target docker restart 失敗: $container"
+            return 1
+        }
+    fi
+
+    log "[$target] restart 完了。${wait_sec}秒待機して検証..."
+    sleep "$wait_sec"
+
+    if $verify_fn; then
+        log "[$target] 復旧確認: OK"
+        send_slack "✅ [auto_recovery] *$target 自動復旧成功*: $container を restart しました。$(ts)"
+        return 0
+    else
+        log "[$target] 復旧確認: FAIL — restart したが復旧していない"
+        pushover_critical "UATa 自動復旧失敗: $target" \
+            "$container を restart しましたが復旧していません。手動確認が必要です。"
+        send_slack "❌ [auto_recovery] $target restart 後も復旧せず: $container"
+        return 1
+    fi
+}
+
+# AR-1: nginx restart
+action_nginx_restart() {
+    do_restart "nginx" "$CONTAINER_NGINX" check_external_health 30
+}
+
+# AR-2 / AR-3: backend restart
+action_backend_restart() {
+    do_restart "backend" "$CONTAINER_BACKEND" check_internal_health 60
+}
+
+# AR-4: cloudflared restart
+action_cloudflared_restart() {
+    do_restart "cloudflared" "$CONTAINER_CLOUDFLARED" check_external_health 60
+}
+
+# =============================================================================
+# 判断ロジック (healthcheck_l1_l6.sh からの呼び出し用)
+# =============================================================================
+
+# L1 FAIL 時のトリアージ
+triage_l1_fail() {
+    log "L1 FAIL トリアージ開始"
+
+    # postgres チェック (HR-1: 人間必須)
+    local pg_state
+    pg_state=$(container_state "$CONTAINER_POSTGRES")
+    if [[ "$pg_state" != "running" ]]; then
+        log "postgres が $pg_state — HR-1: 人間必須"
+        pushover_critical "UATa CRITICAL: postgres $pg_state" \
+            "postgres コンテナが $pg_state です。手動復旧が必要です。docs/31_backup_restore_procedures.md 参照。"
+        send_slack "🚨 [auto_recovery] *postgres $pg_state*: 自動復旧不可。手動確認必須。"
+        return 0
+    fi
+
+    # 複数コンテナ down チェック (HR-4)
+    local up_count
+    up_count=$(docker ps --filter "name=ultra-autotrade" --filter "status=running" \
+        --format "{{.Names}}" 2>/dev/null | wc -l | tr -d '[:space:]')
+    if [[ "${up_count:-0}" -lt 5 ]]; then
+        log "コンテナ $up_count/7 Up — HR-4: 人間必須"
+        pushover_critical "UATa CRITICAL: $up_count コンテナのみ Up" \
+            "通常7コンテナのところ $up_count しか Up していません。複合障害の可能性があります。"
+        send_slack "🚨 [auto_recovery] *複数コンテナ down* ($up_count/7 Up): 自動復旧不可。手動確認必須。"
+        return 0
+    fi
+
+    # 内部 200 + 外形 non-200 → nginx or cloudflared の問題
+    if check_internal_health && ! check_external_health; then
+        log "内部 OK / 外形 FAIL — cloudflared or nginx チェック"
+
+        local cf_state
+        cf_state=$(container_state "$CONTAINER_CLOUDFLARED")
+        if [[ "$cf_state" == "exited" ]]; then
+            log "cloudflared exited → AR-4 実行"
+            action_cloudflared_restart
+            return $?
+        fi
+
+        log "cloudflared は Running → nginx IP 固着の可能性 → AR-1 実行"
+        action_nginx_restart
+        return $?
+    fi
+
+    # backend unhealthy
+    local be_health
+    be_health=$(container_health "$CONTAINER_BACKEND")
+    local be_state
+    be_state=$(container_state "$CONTAINER_BACKEND")
+    if [[ "$be_health" == "unhealthy" ]] || [[ "$be_state" == "exited" ]]; then
+        log "backend $be_state/$be_health → AR-2 実行"
+        action_backend_restart
+        return $?
+    fi
+
+    log "L1 FAIL 原因特定不可 — Slack 通知のみ"
+    send_slack "⚠️ [auto_recovery] L1 FAIL だが原因特定不可。手動確認してください。"
+}
+
+# L2 FAIL 時のトリアージ
+triage_l2_fail() {
+    log "L2 FAIL トリアージ開始"
+
+    local be_state
+    be_state=$(container_state "$CONTAINER_BACKEND")
+    if [[ "$be_state" == "running" ]]; then
+        log "backend は Running かつ scheduler dead → AR-3 実行"
+        do_restart "scheduler" "$CONTAINER_BACKEND" check_internal_health 90
+    else
+        log "backend が $be_state — triage_l1_fail に移譲"
+        triage_l1_fail
+    fi
+}
+
+# L3 FAIL + L2 PASS → HR-6
+triage_l3_fail_l2_pass() {
+    log "L3 FAIL (AI 判定 0件) + L2 PASS — HR-6: Pushover HIGH"
+    pushover_high "UATa: AI 判定 24h ゼロ" \
+        "scheduler は生存していますが、24h AI 判定が出ていません。コード・設定の確認が必要です。"
+    send_slack "⚠️ [auto_recovery] AI 判定 24h ゼロ (L3 FAIL)。scheduler は生存中。手動確認推奨。"
+}
+
+# 全体チェック & トリアージ (healthcheck_l1_l6.sh からの呼び出し想定)
+check_all() {
+    log "=== 全体チェック開始 ==="
+
+    # disk チェック (Linux/macOS 両対応)
+    local disk_pct
+    disk_pct=$(df / 2>/dev/null | awk 'NR==2 {gsub(/%/, "", $5); print $5}' || echo "0")
+    if [[ "${disk_pct:-0}" -ge 85 ]]; then
+        log "disk $disk_pct% > 85% — HR-5: Pushover HIGH"
+        pushover_high "UATa: disk 使用率 ${disk_pct}%" \
+            "disk 使用率が $disk_pct% です。docker_cleanup.sh の手動実行を検討してください。"
+        send_slack "⚠️ [auto_recovery] disk 使用率 $disk_pct%。docs/35_docker_maintenance_runbook.md 参照。"
+    fi
+
+    log "=== 全体チェック完了 ==="
+}
+
+# =============================================================================
+# CLI エントリーポイント
+# =============================================================================
+usage() {
+    cat <<EOF
+使い方: $0 [オプション]
+
+オプション:
+  --check-all                   全体チェック実行 (disk, etc.)
+  --action nginx-restart        AR-1: nginx restart
+  --action backend-restart      AR-2/AR-3: backend restart
+  --action cloudflared-restart  AR-4: cloudflared restart
+  --triage-l1                   L1 FAIL トリアージ
+  --triage-l2                   L2 FAIL トリアージ
+  --triage-l3-l2-pass           L3 FAIL + L2 PASS → Pushover HIGH
+
+環境変数:
+  DRY_RUN=true  docker コマンドを実行せず、ログのみ出力
+
+例:
+  DRY_RUN=true bash scripts/auto_recovery.sh --check-all
+  bash scripts/auto_recovery.sh --triage-l1
+EOF
+}
+
+main() {
+    local action="${1:-}"
+
+    case "$action" in
+        --check-all)
+            check_all
+            ;;
+        --action)
+            case "${2:-}" in
+                nginx-restart)       action_nginx_restart ;;
+                backend-restart)     action_backend_restart ;;
+                cloudflared-restart) action_cloudflared_restart ;;
+                *)                   echo "不明なアクション: ${2:-}"; usage; exit 1 ;;
+            esac
+            ;;
+        --triage-l1)      triage_l1_fail ;;
+        --triage-l2)      triage_l2_fail ;;
+        --triage-l3-l2-pass) triage_l3_fail_l2_pass ;;
+        --help|-h)        usage ;;
+        *)
+            log "引数なし — check_all のみ実行"
+            check_all
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- `docs/auto_recovery_scope.md`: 1人プロジェクト深夜自動復旧の設計文書を新規作成
  - **自動復旧 (AR-1~AR-4)**: nginx IP 固着 / backend unhealthy / scheduler dead / cloudflared exited → `docker restart` のみ
  - **人間必須 (HR-1~HR-7)**: postgres 異常 / Aave HARD_STOP / DB 破損 / 複数コンテナ同時 down → Pushover priority=2
  - **クールダウン**: 1時間に3回 restart → 上限到達で自動復旧停止 + Pushover priority=2
- `scripts/auto_recovery.sh`: 設計に対応するプロトタイプ (本番配置は別 Tier S タスク)
  - DRY_RUN=true で動作確認済み
  - `healthcheck_l1_l6.sh` からの呼び出し形式で設計

## Pushover priority=2 発火条件の明文化 (24h-automation-runbook.md 補強)

| 状況 | 新規/既存 |
|------|---------|
| postgres exited / SIGKILL ループ | **新規** |
| 複数コンテナ同時 down (3個以上) | **新規** |
| nginx/backend クールダウン上限 (1h に N 回 restart) | **新規** |
| DB スキーマ破損検知 | **新規** |
| 本番 /health 5分連続 non-200 | 既存 |

## DoD: 自動復旧範囲設計 v1 + プロトタイプ + 警告エスカレーション

- [x] docs/auto_recovery_scope.md 新規作成 (自動復旧/非復旧範囲 + トリガー + クールダウン仕様)
- [x] scripts/auto_recovery.sh プロトタイプ作成 (設計のみ、本番配置は別 Tier S)
- [x] Pushover priority=2 発火条件の明文化
- [x] DRY_RUN=true でスクリプト動作確認
- [x] bash -n syntax check 通過
- Gate 1-3 (verify.sh): n/a (docs/scripts のみ、Python/TS 変更なし)
- Gate 4 (E2E): n/a
- Gate 5 (孤立コード): n/a
- Gate 6 (Codex): 省略 (設計ドキュメント + shell プロトタイプ)

## 注意事項

- `scripts/auto_recovery.sh` を本番 Hetzner に配置・cron 登録するには別 Tier S タスクが必要
- `scripts/healthcheck_l1_l6.sh` の更新も Tier S (Tier S ファイル list に含まれるため)
- Tier S 実装時は `docs/auto_recovery_scope.md` §今後の実装計画 を参照

Related: Lane B-4 / queue id=14