### PR TITLE
fix(ops): backup_db.sh 自己検証 + 失敗時 Slack 通知 (RC-4 Asana GID 1214882070742107)

### DIFF
--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 # backup_db.sh — PostgreSQL 日次バックアップ (production / staging-new 切替)
+# 自己検証機能: バックアップ後にファイルサイズ + gzip 整合性を検証。
+#               失敗時は Slack #ultra-auto-project に通知して exit 1。
+#               (RC-4 Asana GID 1214882070742107)
 #
 # Usage:
 #   ENVIRONMENT=production    bash scripts/backup_db.sh
@@ -48,8 +51,32 @@ esac
 DB_USER="${POSTGRES_USER:-ultra}"
 BACKUP_DIR="${BACKUP_DIR:-/opt/ultra-autotrade/db_backups}"
 RETENTION_DAYS="${RETENTION_DAYS:-7}"
+MIN_SIZE_BYTES="${MIN_SIZE_BYTES:-10240}"   # 10 KB 未満は異常とみなす
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
 BACKUP_FILE="${BACKUP_DIR}/${ENVIRONMENT}_ultra_autotrade_${TIMESTAMP}.sql.gz"
+
+# ── Slack 通知ヘルパー ─────────────────────────────
+_slack_send() {
+  local text="$1"
+  local webhook
+  webhook="$(grep '^SLACK_WEBHOOK_URL=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- || true)"
+  if [ -n "${webhook}" ]; then
+    curl -sf -X POST "${webhook}" \
+      -H "Content-Type: application/json" \
+      -d "{\"text\": \"${text}\"}" || true
+  fi
+}
+
+# ── 失敗通知 + クリーンアップ ──────────────────────
+_notify_failure() {
+  local reason="$1"
+  echo "❌ [${ENVIRONMENT}] Backup FAILED: ${reason}" >&2
+  _slack_send "❌ [${ENVIRONMENT}] backup_db.sh FAILED: ${reason}"
+  rm -f "${BACKUP_FILE}" 2>/dev/null || true
+}
+
+# ERR トラップ: pg_dump 失敗等の予期しないエラーも Slack 通知する
+trap '_notify_failure "unexpected error at line ${LINENO} (exit $?)"' ERR
 
 # ── バックアップ実行 ──────────────────────────────
 mkdir -p "$BACKUP_DIR"
@@ -57,19 +84,29 @@ mkdir -p "$BACKUP_DIR"
 echo "[${TIMESTAMP}] [${ENVIRONMENT}] Starting PostgreSQL backup (container: ${CONTAINER_NAME}, db: ${DB_NAME})..."
 docker exec "$CONTAINER_NAME" pg_dump -U "$DB_USER" "$DB_NAME" | gzip > "$BACKUP_FILE"
 
+# ── 自己検証 1: ファイルサイズ ───────────────────
 FILESIZE="$(stat -f%z "$BACKUP_FILE" 2>/dev/null || stat -c%s "$BACKUP_FILE" 2>/dev/null || echo 0)"
-echo "✅ [${ENVIRONMENT}] Backup created: ${BACKUP_FILE} ($(( FILESIZE / 1024 )) KB)"
+if [ "${FILESIZE}" -lt "${MIN_SIZE_BYTES}" ]; then
+  _notify_failure "file too small: ${FILESIZE} bytes (minimum: ${MIN_SIZE_BYTES})"
+  exit 1
+fi
+
+# ── 自己検証 2: gzip 整合性 ──────────────────────
+if ! gzip -t "${BACKUP_FILE}" 2>/dev/null; then
+  _notify_failure "gzip integrity check failed (corrupted archive)"
+  exit 1
+fi
+
+# 検証完了後は ERR トラップを解除（クリーンアップ失敗で誤通知しない）
+trap - ERR
+
+echo "✅ [${ENVIRONMENT}] Backup verified: ${BACKUP_FILE} ($(( FILESIZE / 1024 )) KB, gzip OK)"
 
 # ── 古いバックアップ削除 (同じ ENVIRONMENT のものだけ) ──
 find "$BACKUP_DIR" -maxdepth 1 -name "${ENVIRONMENT}_ultra_autotrade_*.sql.gz" -mtime +"${RETENTION_DAYS}" -delete
 echo "🗑️ [${ENVIRONMENT}] Old backups cleaned (retention: ${RETENTION_DAYS} days)"
 
-# ── Slack通知（WEBHOOK設定時のみ）────────────────
-WEBHOOK="$(grep '^SLACK_WEBHOOK_URL=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- || true)"
-if [ -n "${WEBHOOK}" ]; then
-  curl -sf -X POST "${WEBHOOK}" \
-    -H "Content-Type: application/json" \
-    -d "{\"text\": \"🗄️ [${ENVIRONMENT}] DB backup completed: $(basename "${BACKUP_FILE}") ($(( FILESIZE / 1024 )) KB)\"}" || true
-fi
+# ── Slack 成功通知（WEBHOOK設定時のみ）───────────
+_slack_send "🗄️ [${ENVIRONMENT}] DB backup completed: $(basename "${BACKUP_FILE}") ($(( FILESIZE / 1024 )) KB)"
 
 echo "[${TIMESTAMP}] [${ENVIRONMENT}] Backup finished."


### PR DESCRIPTION
## 変更概要

`backup_db.sh` にバックアップ後の自己検証ロジックを追加。RC-4 (P0 RCA) 対応。

### 問題 (RC-4)
`backup_db.sh` がバックアップ後にファイル存在・サイズを検証せず、pg_dump が失敗したり空/破損したアーカイブを生成しても「✅ Backup created」と表示してサイレント失敗していた。

### 変更内容

**自己検証 1: ファイルサイズチェック**
- バックアップ後、gzip ファイルが `MIN_SIZE_BYTES` (デフォルト 10 KB) 未満の場合は異常と判断
- 失敗時: Slack #ultra-auto-project に通知 + 不完全ファイルを削除 + exit 1

**自己検証 2: gzip 整合性チェック**
- `gzip -t` で圧縮ファイルの整合性を検証
- 破損アーカイブを即検出して同様に通知 + exit 1

**ERR トラップ**
- `trap '...' ERR` を追加し、pg_dump パイプ失敗等の予期しないエラーも Slack 通知対象に

**Slack 通知リファクタ**
- `_slack_send` ヘルパー関数を抽出 (成功・失敗で共通使用)

## DoD

- [x] backup_db.sh にファイルサイズ検証ロジック追加
- [x] gzip 整合性検証追加
- [x] 失敗時 Slack #ultra-auto-project 通知
- [x] ERR トラップで予期しない失敗も捕捉
- [x] Gate 1-3: verify.sh PASS (ruff/mypy/pytest 84.68%, tsc/npm はワークツリー環境制約で node_modules なし)
- [x] Asana GID 1214882070742107 (S-2 / RC-4)

## テスト

ローカルでの検証テスト:
- 空ファイル → サイズチェックで正しく拒否 ✅
- 有効な gzip → 整合性チェック通過 ✅
- 破損した gzip → 整合性チェックで正しく拒否 ✅
- 50KB のランダムデータ gzip → 両チェック通過 ✅

Closes Asana GID 1214882070742107