### PR TITLE
fix(e2e): resolve tsc errors in E2E spec files (queue id=25)

### DIFF
--- a/frontend/e2e/lane-f3-lead-verification.spec.ts
+++ b/frontend/e2e/lane-f3-lead-verification.spec.ts
@@ -460,7 +460,7 @@ test.describe('TC-I: KPI 接続確認 (/api/partner/stats)', () => {
     expect(responseStatus).toBe(200)
 
     // PartnerStatsResponse スキーマ検証
-    const body = capturedResponse as Record<string, unknown>
+    const body = capturedResponse as unknown as Record<string, unknown>
     expect(body).toHaveProperty('total_aum')
     expect(body).toHaveProperty('yesterday_aum')
     expect(body).toHaveProperty('user_count')

--- a/frontend/e2e/referral-flow.spec.ts
+++ b/frontend/e2e/referral-flow.spec.ts
@@ -326,8 +326,9 @@ test.describe('[RAS] referral registration', () => {
     // POST /auth/register-with-referral に referred_consent=true が送られていること
     await page.waitForTimeout(2_000)
     expect(capturedBody).not.toBeNull()
-    expect(capturedBody?.referred_consent).toBe(true)
-    expect(capturedBody?.referral_code).toBe('ABC123')
+    const body = capturedBody as unknown as Record<string, unknown>
+    expect(body['referred_consent']).toBe(true)
+    expect(body['referral_code']).toBe('ABC123')
 
     await saveScreenshot(page, 'tc6-register-with-referral-success')
   })

--- a/frontend/e2e/uat-pre-check.spec.ts
+++ b/frontend/e2e/uat-pre-check.spec.ts
@@ -20,7 +20,7 @@ const STAGING_URL = 'https://staging.ultra-auto-trade.com'
 // Cloudflare Dashboard → Access → Service Auth → Service Tokens で発行
 const CF_CLIENT_ID = process.env.CF_ACCESS_CLIENT_ID ?? ''
 const CF_CLIENT_SECRET = process.env.CF_ACCESS_CLIENT_SECRET ?? ''
-const CF_HEADERS =
+const CF_HEADERS: Record<string, string> =
   CF_CLIENT_ID && CF_CLIENT_SECRET
     ? { 'CF-Access-Client-Id': CF_CLIENT_ID, 'CF-Access-Client-Secret': CF_CLIENT_SECRET }
     : {}


### PR DESCRIPTION
## Summary

- **uat-pre-check.spec.ts**: `CF_HEADERS` に `Record<string, string>` 型注釈を追加。TypeScript が falsy ブランチの `{}` を `{ key?: undefined }` と推論し `extraHTTPHeaders` の型と不一致になっていた
- **lane-f3-lead-verification.spec.ts**: `null → Record<string, unknown>` 直接キャストを `as unknown as` ダブルキャストに変更（TS2352）
- **referral-flow.spec.ts**: TypeScript 5.9 の CFA がクロージャ内変数を `null` に narrowing し、Playwright の `expect().not.toBeNull()` が `never` 型を生成していた問題を修正。`capturedBody as unknown as Record<string, unknown>` で型を明示

## Test plan

- [x] DoD: Gate 1-3 `verify.sh` PASS (exit 0、474秒)
  - ruff check ✅
  - ruff format ✅
  - mypy ✅
  - pytest: 2739 passed, 21 skipped, coverage 84.68% ✅
  - tsc --noEmit: 0 errors ✅
  - npm run build ✅
- [ ] Gate 4: E2E (staging実機、UAT前に実施予定)
- [x] Gate 5: 孤立コード N/A（E2E spec のみ変更）
- [x] Gate 6: Codex Review 不要（微小型修正）

Closes Asana GID 1214798922743037 (queue id=25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)