### PR TITLE
fix(test): ruff I001 import sort + format baseline fix (CI lint for #…

### DIFF
--- a/backend/tests/automation/test_rebalance_job.py
+++ b/backend/tests/automation/test_rebalance_job.py
@@ -66,7 +66,9 @@ def test_run_check_uses_get_notification_service() -> None:
         patch("app.aave.service.AaveService", return_value=MagicMock()),
         patch("app.aave.state_manager.get_default_state_manager", return_value=MagicMock()),
         patch("app.automation.state.get_monitoring_service", return_value=MagicMock()),
-        patch("app.notifications.factory.get_notification_service", return_value=MagicMock()) as mock_get_notif,
+        patch(
+            "app.notifications.factory.get_notification_service", return_value=MagicMock()
+        ) as mock_get_notif,
     ):
         # Inline _run_check logic by importing and triggering via module internals
         # We verify that get_notification_service is importable from the factory module

--- a/backend/tests/data_feeds/test_finance_feed.py
+++ b/backend/tests/data_feeds/test_finance_feed.py
@@ -16,7 +16,6 @@ os.environ.setdefault("JWT_SECRET_KEY", "test-finance-feed-key")
 
 from app.data_feeds.finance_feed import FinanceFeedResult, fetch_finance_data  # noqa: E402
 
-
 # ---------------------------------------------------------------------------
 # Unit tests: FinanceFeedResult construction
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
…257-#268)

- tests/data_feeds/test_finance_feed.py: I001 import block un-sorted (1 blank line removed)
- tests/automation/test_rebalance_job.py: ruff format compliance

Both issues were pre-existing on main and caused Lint (ruff + mypy) CI failure across all open PRs #257-#268. This fix restores the lint baseline so downstream PRs can pass CI without carrying these errors.

# 🔀 Pull Request Template

## 📝 このPRの目的
（何を実装 / 修正したかを明確に説明）

---

## 🔧 変更内容（概要）
- （主要な変更点を箇条書き）
- 
---

## 📁 変更したファイル
（例）
- backend/app/ai/analyzer.py
- docs/05_ai_judgement_rules.md

---

## 🧪 動作確認
- [ ] ローカルテスト済み
- [ ] フェーズ要件に沿っている
- [ ] .mdとコードの整合性チェック済み
- [ ] 破壊的変更なし

---

## 📘 関連Issue
例：Closes #23

---

## 📚 ドキュメント更新
- [ ] docs/*.md 更新済み  
- [ ] 変更内容が仕様書と一致している

---

## ⚠ 注意事項
- 要件変更が含まれていないこと
- フェーズ範囲外の作業をしていないこと
- 仕様書（.md）が最新と一致していること

---

## チェーン設定関連 (チェーン関連の PR のみ)

本 PR は **チェーン (mainnet/testnet) の切替** または **chain ID 設定** を含みますか?

- [ ] いいえ (チェーン設定の変更なし)
- [ ] はい — 以下のチェックを実施

チェーン関連 PR の場合は以下を確認:
- [ ] `grep -rn "Sepolia" frontend/` の出力をすべて確認・修正済み
- [ ] `.env.production` の `NEXT_PUBLIC_*` チェーン設定を本番値に更新済み
- [ ] `frontend/components/PrivyProvider.tsx` の chain config 確認済み
- [ ] post-deploy `curl <production URL> | grep -i "sepolia"` で出力ゼロ確認済み
- [ ] ブラウザで実機ランディング目視確認済み (スクリーンショット添付)

参照:
- docs/43_mainnet_wallet_switch_guide.md §2.5 (frontend 表示テキスト確認)
- 2026-05-02 インシデント: Asana GID 1214462619161978
