### PR TITLE
feat(ops): uata-stuck-detector + lint baseline fix

### DIFF
--- a/.claude/hooks/update-heartbeat.sh
+++ b/.claude/hooks/update-heartbeat.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# update-heartbeat.sh — PostToolUse hook: tool 実行ごとに heartbeat を更新
+# uata-stuck-detector.sh がこのファイルの更新時刻を監視する
+date +%s > /tmp/uata-heartbeat

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -171,6 +171,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/update-heartbeat.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -889,6 +889,28 @@ deferred tools、MCPサーバー（Asana/Slack）、カスタムエージェン�
 - `slack_notify.py` (Notification / Stop) — Slack 完了通知
 - `slack_permission.py` (PreToolUse) — Slack パーミッションリクエスト
 - `post-lane-notify.sh` / `send-lane-completion.sh` — Agent Teams Lane 完了通知
+- `update-heartbeat.sh` (PostToolUse) — `/tmp/uata-heartbeat` を更新 (stuck-detector 監視用)
+
+### 並列 tool call は最大 2 本まで（24h 自走 / Agent Teams 必須ルール）
+
+**背景:** Claude Code GitHub issues #43866, #44068, #39830, #46767 で報告されている
+`[Tool result missing due to internal error]` バグは、**3本以上の並列 tool call** で
+発生頻度が高い。24h 自走中に stuck すると人間が「続けて」と指示するまで停止する。
+
+**ルール:**
+- 並列 tool call は **最大 2 本**まで。3 本以上は順次実行 or 2 本ずつのバッチに分ける
+- 独立性が高い調査でも 2 本 → 結果確認 → 2 本の順で実行
+- `uata-stuck-detector.sh` が `/tmp/uata-heartbeat` の更新を 5 分間隔で監視し、
+  30 分間更新なし → Slack `#ultra-auto-project` に `STUCK-DETECTED` 通知
+
+**24h 自走起動手順:**
+```bash
+# stuck detector を起動してから claude を起動する
+cd /opt/ultra-autotrade/main
+./scripts/uata-stuck-detector.sh start
+# → "stuck-detector 起動 (PID=XXXX, log=/tmp/uata-stuck-detector.log)"
+claude --resume   # または新規セッション起動
+```
 
 ---
 

--- a/backend/tests/automation/test_rebalance_job.py
+++ b/backend/tests/automation/test_rebalance_job.py
@@ -66,7 +66,9 @@ def test_run_check_uses_get_notification_service() -> None:
         patch("app.aave.service.AaveService", return_value=MagicMock()),
         patch("app.aave.state_manager.get_default_state_manager", return_value=MagicMock()),
         patch("app.automation.state.get_monitoring_service", return_value=MagicMock()),
-        patch("app.notifications.factory.get_notification_service", return_value=MagicMock()) as mock_get_notif,
+        patch(
+            "app.notifications.factory.get_notification_service", return_value=MagicMock()
+        ) as mock_get_notif,
     ):
         # Inline _run_check logic by importing and triggering via module internals
         # We verify that get_notification_service is importable from the factory module

--- a/backend/tests/data_feeds/test_finance_feed.py
+++ b/backend/tests/data_feeds/test_finance_feed.py
@@ -16,7 +16,6 @@ os.environ.setdefault("JWT_SECRET_KEY", "test-finance-feed-key")
 
 from app.data_feeds.finance_feed import FinanceFeedResult, fetch_finance_data  # noqa: E402
 
-
 # ---------------------------------------------------------------------------
 # Unit tests: FinanceFeedResult construction
 # ---------------------------------------------------------------------------

--- a/scripts/uata-stuck-detector.sh
+++ b/scripts/uata-stuck-detector.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# uata-stuck-detector.sh — Claude Code session stuck detection + Slack alert
+#
+# 背景: Claude Code の [Tool result missing due to internal error] バグ
+#   (GitHub issues #43866, #44068, #39830, #46767) により 24h 自走中に
+#   session が無応答になることがある。本スクリプトで検知して Slack 通知する。
+#
+# 仕組み:
+#   1. PostToolUse hook (update-heartbeat.sh) が各 tool 実行後に /tmp/uata-heartbeat に書込み
+#   2. 本スクリプト (daemon) が 5 分ごとに heartbeat の更新時刻を確認
+#   3. 30 分間更新なし → STUCK-DETECTED を Slack #ultra-auto-project に送信
+#
+# 使い方:
+#   ./scripts/uata-stuck-detector.sh start   — バックグラウンドで監視開始
+#   ./scripts/uata-stuck-detector.sh stop    — 監視停止
+#   ./scripts/uata-stuck-detector.sh status  — 現在の状態表示
+#   ./scripts/uata-stuck-detector.sh test    — 模擬 stuck で Slack 通知テスト
+#
+# 環境変数:
+#   STUCK_THRESHOLD_MIN  — 無応答判定時間 (分、デフォルト 30)
+#   CHECK_INTERVAL_SEC   — チェック間隔 (秒、デフォルト 300 = 5分)
+#   SLACK_WEBHOOK_URL    — Webhook URL (未設定時は .env.production / SSH fallback)
+#   DRY_RUN              — 1 のとき Slack 送信をスキップ (dry-run テスト用)
+
+set -euo pipefail
+
+# ── 設定 ─────────────────────────────────────────────────────────────────
+STUCK_THRESHOLD_MIN="${STUCK_THRESHOLD_MIN:-30}"
+CHECK_INTERVAL_SEC="${CHECK_INTERVAL_SEC:-300}"
+HEARTBEAT_FILE="${HEARTBEAT_FILE:-/tmp/uata-heartbeat}"
+PID_FILE="/tmp/uata-stuck-detector.pid"
+LOG_FILE="/tmp/uata-stuck-detector.log"
+SESSION_LOG_DIR="${HOME}/.claude-uata/projects/-opt-ultra-autotrade-main"
+GIT_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || echo "")"
+
+# ── Webhook 取得 ──────────────────────────────────────────────────────────
+get_webhook() {
+  # 1. 環境変数
+  if [[ -n "${SLACK_WEBHOOK_URL:-}" ]]; then
+    echo "$SLACK_WEBHOOK_URL"
+    return
+  fi
+  # 2. ~/.config/uata/slack-webhook (dev VPS 用ローカル設定ファイル)
+  if [[ -f "${HOME}/.config/uata/slack-webhook" ]]; then
+    cat "${HOME}/.config/uata/slack-webhook"
+    return
+  fi
+  # 3. git root の .env.production (本番VPS / ローカルMac)
+  if [[ -n "$GIT_ROOT" && -f "${GIT_ROOT}/.env.production" ]]; then
+    grep "^SLACK_WEBHOOK_URL=" "${GIT_ROOT}/.env.production" | head -1 | cut -d= -f2-
+    return
+  fi
+  # 4. SSH fallback (Hetzner本番VPS — dev VPS からは接続不可の場合あり)
+  local ssh_key="${HOME}/.ssh/hetzner_direct"
+  if [[ -f "$ssh_key" ]]; then
+    ssh -i "$ssh_key" \
+      -o ConnectTimeout=5 -o StrictHostKeyChecking=no -o BatchMode=yes \
+      ultra@77.42.46.155 \
+      'grep SLACK_WEBHOOK_URL /opt/ultra-autotrade/.env.production | head -1 | cut -d= -f2-' \
+      2>/dev/null || echo ""
+  else
+    echo ""
+  fi
+}
+
+send_slack() {
+  local message="$1"
+  local webhook="$2"
+  if [[ -z "$webhook" ]]; then
+    echo "[send_slack] WARNING: webhook URL が空、Slack 送信をスキップ" >&2
+    return 0
+  fi
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    echo "[DRY_RUN] Slack 送信スキップ: ${message:0:100}" >&2
+    return 0
+  fi
+  curl -sS -X POST "$webhook" \
+    -H "Content-Type: application/json" \
+    --data-raw "{\"text\": \"${message}\"}" \
+    --max-time 10 >/dev/null 2>&1 || {
+    echo "[send_slack] WARNING: curl 失敗 (非致命的)" >&2
+  }
+}
+
+log() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" | tee -a "$LOG_FILE"
+}
+
+# ── heartbeat 確認 ──────────────────────────────────────────────────────────
+get_heartbeat_age_min() {
+  # 1. heartbeat ファイルがあればそれを使用
+  if [[ -f "$HEARTBEAT_FILE" ]]; then
+    local last_mod
+    last_mod=$(stat -c %Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+    echo $(( ($(date +%s) - last_mod) / 60 ))
+    return
+  fi
+  # 2. fallback: session log (.jsonl) の最終更新時刻
+  local latest_log
+  latest_log=$(find "$SESSION_LOG_DIR" -name "*.jsonl" -type f 2>/dev/null \
+    | xargs ls -t 2>/dev/null | head -1)
+  if [[ -n "$latest_log" ]]; then
+    local last_mod
+    last_mod=$(stat -c %Y "$latest_log" 2>/dev/null || echo 0)
+    echo $(( ($(date +%s) - last_mod) / 60 ))
+    return
+  fi
+  # 3. heartbeat もセッションログもない → 監視不可
+  echo -1
+}
+
+# ── メイン監視ループ ──────────────────────────────────────────────────────
+monitor_loop() {
+  local webhook
+  webhook=$(get_webhook)
+  if [[ -z "$webhook" ]]; then
+    log "ERROR: SLACK_WEBHOOK_URL が取得できません。Slack 通知は無効化されます。"
+  fi
+
+  log "Stuck detector 開始 (threshold=${STUCK_THRESHOLD_MIN}min, interval=${CHECK_INTERVAL_SEC}s)"
+  log "heartbeat_file=${HEARTBEAT_FILE} session_log_dir=${SESSION_LOG_DIR}"
+
+  local last_alerted_at=0
+
+  while true; do
+    sleep "$CHECK_INTERVAL_SEC"
+
+    local age_min
+    age_min=$(get_heartbeat_age_min)
+
+    if [[ "$age_min" -eq -1 ]]; then
+      log "INFO: heartbeat / session log なし。監視スキップ。"
+      continue
+    fi
+
+    log "heartbeat_age=${age_min}min (threshold=${STUCK_THRESHOLD_MIN}min)"
+
+    if [[ "$age_min" -ge "$STUCK_THRESHOLD_MIN" ]]; then
+      local now
+      now=$(date +%s)
+      # 30分以内に同じ stuck で重複アラートを出さない
+      if (( now - last_alerted_at > 1800 )); then
+        local claude_pid
+        claude_pid=$(pgrep -x claude 2>/dev/null | head -1 || echo "不明")
+        local git_branch
+        git_branch=$(git -C "${GIT_ROOT}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "不明")
+
+        local msg
+        msg="🚨 *STUCK-DETECTED* \`uata-stuck-detector\`\\n"
+        msg+="最終 tool 実行から *${age_min}分* 経過 (閾値: ${STUCK_THRESHOLD_MIN}分)\\n"
+        msg+="Claude PID: \`${claude_pid}\`  ブランチ: \`${git_branch}\`\\n"
+        msg+="対処: ターミナルで \`claude --resume\` を実行してセッションを再開\\n"
+        msg+="ログ: \`tail -20 ${LOG_FILE}\`"
+
+        send_slack "$msg" "$webhook"
+        log "STUCK-ALERT 送信 (age=${age_min}min, pid=${claude_pid})"
+        last_alerted_at=$now
+      else
+        log "STUCK 継続中 (age=${age_min}min) — 重複アラート抑制"
+      fi
+    else
+      last_alerted_at=0
+    fi
+  done
+}
+
+# ── サブコマンド ──────────────────────────────────────────────────────────
+cmd="${1:-help}"
+
+case "$cmd" in
+  start)
+    if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+      echo "stuck-detector は既に起動中 (PID=$(cat "$PID_FILE"))"
+      exit 0
+    fi
+    monitor_loop &
+    echo $! > "$PID_FILE"
+    echo "stuck-detector 起動 (PID=$!, log=${LOG_FILE})"
+    ;;
+
+  stop)
+    if [[ -f "$PID_FILE" ]]; then
+      local_pid=$(cat "$PID_FILE")
+      kill "$local_pid" 2>/dev/null && echo "stuck-detector 停止 (PID=${local_pid})" || echo "PID=${local_pid} は既に終了"
+      rm -f "$PID_FILE"
+    else
+      echo "stuck-detector は起動していません"
+    fi
+    ;;
+
+  status)
+    if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+      local_pid=$(cat "$PID_FILE")
+      age_min=$(get_heartbeat_age_min)
+      echo "状態: 稼働中 (PID=${local_pid})"
+      echo "heartbeat_age: ${age_min}min / 閾値: ${STUCK_THRESHOLD_MIN}min"
+      echo "最新ログ:"
+      tail -5 "$LOG_FILE" 2>/dev/null || echo "(ログなし)"
+    else
+      echo "状態: 停止"
+    fi
+    ;;
+
+  test)
+    echo "=== dry-run テスト: STUCK 模擬 Slack 通知 ==="
+    webhook=$(get_webhook)
+    if [[ -z "$webhook" ]]; then
+      echo "ERROR: webhook URL が取得できません"
+      exit 1
+    fi
+    test_msg="🧪 *[TEST] STUCK-DETECTED 模擬通知* \`uata-stuck-detector dry-run\`\\n"
+    test_msg+="これは dry-run テスト送信です。本番 stuck 検知ではありません。\\n"
+    test_msg+="threshold=${STUCK_THRESHOLD_MIN}min / interval=${CHECK_INTERVAL_SEC}s"
+
+    if [[ "${DRY_RUN:-0}" == "1" ]]; then
+      echo "[DRY_RUN] 送信予定メッセージ:"
+      echo "$test_msg"
+    else
+      send_slack "$test_msg" "$webhook"
+      echo "Slack 送信完了 (#ultra-auto-project)"
+    fi
+    ;;
+
+  help|*)
+    echo "使い方: $0 {start|stop|status|test}"
+    echo ""
+    echo "  start   バックグラウンドで監視開始"
+    echo "  stop    監視停止"
+    echo "  status  現在の状態表示"
+    echo "  test    模擬 stuck で Slack 通知テスト"
+    echo ""
+    echo "環境変数:"
+    echo "  STUCK_THRESHOLD_MIN  無応答判定時間 (分、デフォルト 30)"
+    echo "  CHECK_INTERVAL_SEC   チェック間隔 (秒、デフォルト 300)"
+    echo "  DRY_RUN=1            Slack 送信スキップ (テスト用)"
+    ;;
+esac


### PR DESCRIPTION
## Summary
- scripts/uata-stuck-detector.sh — 24h 自走中の stuck 検知 daemon (start/stop/status/test)
- .claude/hooks/update-heartbeat.sh — PostToolUse hook で heartbeat 書込み
- .claude/settings.json — PostToolUse hook 登録
- CLAUDE.md — 並列 tool call 最大 2本ルール追記 + 24h 起動手順
- backend/tests/data_feeds/test_finance_feed.py — ruff I001 import sort fix (PR #257-#268 共通 lint baseline 解消)
- backend/tests/automation/test_rebalance_job.py — ruff format fix

## 背景
Claude Code 公式 issue #43866 / #44068 / #39830 / #46767 の \`[Tool result missing due to internal error]\` バグで Lane が stuck する事象を 2026-05-19 朝の調査 Lane で実機再現。24h 自走前に stuck 検知 + Slack 通知の仕組みを実装。

合わせて、調査 Lane で判明した PR #257-#268 共通 lint baseline 問題 (test_finance_feed.py:17 import sort) を本 PR に同梱、12本の CI lint failure を連鎖解消。

## DoD
- [x] Gate 1-3: ruff check / ruff format / mypy / pytest PASS
- [x] dry-run テスト: Slack webhook 通知発火確認 (#ultra-auto-project)
- [x] PostToolUse hook 動作確認
- [x] CLAUDE.md ルール追記

## 関連
- 調査 Lane 出力: /tmp/uata_phase1_3_prerun_audit.md
- Asana GID 1214890565948368 (AI HOLD bias、別途真因再調査)