### PR TITLE
fix(test): rebalance_job notify テストを実API(.send)へ整合 (baseline FAIL 解消)

### DIFF
--- a/backend/tests/test_rebalance_job.py
+++ b/backend/tests/test_rebalance_job.py
@@ -189,7 +189,6 @@ class TestRebalanceCheckLoopExecution:
         mock_service.simulate.return_value = mock_proposal
 
         mock_notifier = MagicMock()
-        _mock_cns_class.return_value = mock_notifier
 
         with (
             patch("asyncio.sleep", side_effect=mock_sleep),
@@ -201,12 +200,19 @@ class TestRebalanceCheckLoopExecution:
             patch("app.aave.service.AaveService"),
             patch("app.aave.state_manager.get_default_state_manager"),
             patch("app.automation.state.get_monitoring_service"),
+            patch(
+                "app.notifications.factory.get_notification_service",
+                return_value=mock_notifier,
+            ),
         ):
             with pytest.raises(asyncio.CancelledError):
                 await rebalance_check_loop()
 
         mock_service.simulate.assert_called_once()
-        mock_notifier.notify.assert_called_once()
+        # rebalance_job は get_notification_service().send(NotificationMessage(...))
+        # を呼ぶ。旧テストは存在しない .notify() を assert していたため baseline FAIL
+        # していた (2026-05-19 修正)。
+        mock_notifier.send.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_run_check_needs_rebalance_false(self) -> None:


### PR DESCRIPTION
## 概要
`backend/tests/test_rebalance_job.py::TestRebalanceCheckLoopExecution::test_run_check_needs_rebalance_true` が main で baseline FAIL していた問題を修正。

## 真因
- テストは sys.modules に `app.notifications.composite` (未実装モジュール) の stub を登録し、その `CompositeNotificationService.notify()` が呼ばれることを assert していた
- 実コード `app/automation/rebalance_job.py` は `app.notifications.factory.get_notification_service()` → `app.notifications.service.CompositeNotificationService.send()` を呼ぶ
- stub 配線 (`_mock_cns_class.return_value`) は実コードパスに無関係 → `notify` は永遠に 0 回 → `AssertionError: Expected 'notify' to have been called once. Called 0 times.`

## 修正
- dead な `_mock_cns_class.return_value` 配線を削除
- `with` ブロックに `patch("app.notifications.factory.get_notification_service", return_value=mock_notifier)` を追加
- assert を実 API に整合: `mock_notifier.send.assert_called_once()`

## 検証
- `pytest tests/test_rebalance_job.py` → 10 passed (修正前: 1 failed)
- `ruff check tests/test_rebalance_job.py` → All checks passed

Tier B (backend/tests のみ)。24h 自走 Phase 1「pytest notify test failure 対処」の一環。

🤖 Generated with [Claude Code](https://claude.com/claude-code)