### PR TITLE
fix(e2e): uat-pre-check top-level readFileSync で E2E Smoke job 全体が落ちる baseline 解消

### DIFF
--- a/frontend/e2e/uat-pre-check.spec.ts
+++ b/frontend/e2e/uat-pre-check.spec.ts
@@ -25,7 +25,13 @@ const CF_HEADERS =
     ? { 'CF-Access-Client-Id': CF_CLIENT_ID, 'CF-Access-Client-Secret': CF_CLIENT_SECRET }
     : {}
 
-const PARTNER_JWT = fs.readFileSync('/tmp/staging_partner_jwt.txt', 'utf-8').trim()
+// staging 実環境専用スペック。CI / 非 staging では JWT ファイルが無いため、
+// トップレベル readFileSync で全 E2E Smoke job をクラッシュさせない
+// (import 時に落ちると Playwright 収集が失敗し全 spec が FAILURE になる baseline 問題)。
+const JWT_PATH = '/tmp/staging_partner_jwt.txt'
+const PARTNER_JWT = fs.existsSync(JWT_PATH)
+  ? fs.readFileSync(JWT_PATH, 'utf-8').trim()
+  : ''
 const SCREENSHOT_DIR = path.join('e2e', 'screenshots', 'uat-pre-check')
 if (!fs.existsSync(SCREENSHOT_DIR)) fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
 
@@ -55,6 +61,13 @@ async function injectAuth(page: Page) {
 }
 
 test.describe.serial('[UAT Pre-check] F-17 + RAS Phase 1 / staging 実環境 8 シナリオ A-H', () => {
+  // PARTNER_JWT 未配置 (CI / 非 staging) では全シナリオを skip。
+  // このスペックは staging 実環境専用 (実 frontend + 実 backend + 実 DB)。
+  test.skip(
+    !PARTNER_JWT,
+    'PARTNER_JWT 未配置のため skip (staging 実環境専用スペック / CI baseline)',
+  )
+
   test.use({
     extraHTTPHeaders: CF_HEADERS,
     storageState: '.auth/cf-access.json',


### PR DESCRIPTION
## 概要
全 PR (#257-#268 含む) の E2E Smoke Tests が一律 FAILURE になっていた baseline 障害を解消。

## 真因
`frontend/e2e/uat-pre-check.spec.ts:28` がモジュールトップレベルで
`fs.readFileSync('/tmp/staging_partner_jwt.txt')` を実行。CI / 非 staging
環境では同ファイルが存在しないため import 時点で ENOENT を throw し、
Playwright のテスト収集自体が失敗 → E2E Smoke job が全 spec FAILURE。

E2E job は `continue-on-error: true` のため workflow 全体は緑になるが、
`E2E Smoke Tests (Playwright)` チェックは全 PR で赤 → mergeStateStatus=UNSTABLE。

## 修正 (frontend/e2e/uat-pre-check.spec.ts のみ / Tier B)
- JWT を `fs.existsSync` ガード付きで読み、不在時は空文字
- `test.describe.serial` 先頭に `test.skip(!PARTNER_JWT, ...)` を追加し、
  staging 実環境専用シナリオ A-H を CI では skip

## 検証
- JWT 不在で `npx playwright test --list` → **516 tests / 38 files をクラッシュせず収集** (修正前: 収集失敗)
- 他 spec の `fs.readFileSync` は全て関数/テスト本体内 (トップレベル不在) を確認済

24h 自走 Phase 1「E2E partner_jwt 不在の baseline 問題」対処。これを先行 merge
すると後続 PR は rebase で E2E が実走するようになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)