### PR TITLE
docs: 2026-05-19 24h autonomous launch prep lessons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1965,3 +1965,54 @@ docker inspect <container> --format '{{.Created}}'
 # logging driver 適用確認
 docker inspect <container> --format '{{.HostConfig.LogConfig.Type}}'
 ```
+
+---
+
+## 2026-05-19追加（24h 自走起動準備の教訓）
+
+> 24h 自走起動の準備フェーズで Bypass Permissions が不発し承認要求で実質停止、
+> 設定修正のため session 再起動した経緯から確立。起動前チェックリストは
+> `docs/ops/uata_24h_autonomous_startup_checklist.md`（8 項目）を参照。
+
+### 1. Bypass Permissions の正しい有効化手順
+
+- `.claude/settings.json` の **`permissions.defaultMode = "bypassPermissions"`** に
+  ネストする。**root 直下に `defaultMode` を書いても効かない**。
+- 公式 doc 推奨の確実な方法は CLI フラグ **`claude --dangerously-skip-permissions`**。
+- `defaultMode` が settings.json から反映されない bug が GitHub issue
+  **#29026 / #34923 / #12604** で継続報告中。settings.json 方式が不発のときは
+  CLI フラグにフォールバックする。
+- 公式 valid values: `default` / `acceptEdits` / `plan` / `dontAsk` / `bypassPermissions`。
+- Bypass Permissions の警告画面で Yes は**新規セッション起動扱い**。進行中の
+  session は `/resume` で復帰可能だが、**auto-memory に書かれていない進捗は失われる**。
+  重要な setup 変更は session 起動前に完了させること。
+
+### 2. dev VPS と Mac の secrets 分離原則
+
+- Slack webhook / Pushover env / `scripts/uata-pushover-notify.sh` は
+  **Mac 側のみに存在することが多い**。dev VPS で使うには以下 4 手順:
+  1. `scp` で dev VPS の `~/.claude-uata/secrets/` 配下へ配置
+  2. `chmod 600` で権限を絞る
+  3. `~/.bashrc` に `source` 行を追加（起動時自動 load）
+  4. 動作確認（`gh auth status` / webhook curl / `uata-pushover-notify.sh test`）
+- **既存設定を前提にしない**。毎回 dev VPS 上で `grep` 確認してから使う。
+- 標準配置: `~/.claude-uata/secrets/{github.env,slack.env,pushover.env}`（mode 600）。
+
+### 3. 24h 自走起動前チェックリスト（8 項目 / 詳細は docs/ops）
+
+1. Bypass Permissions が settings.json に正しくネスト or CLI フラグ起動
+2. GitHub PAT（`github.env`, scope `repo`/`workflow`）が env load 済
+3. Slack webhook（`slack.env`）配置・到達可能
+4. Pushover（`pushover.env` + `uata-pushover-notify.sh`）配置・`test` 送信 OK
+5. stuck-detector 起動済（`ps` で PID 確認 + `touch /tmp/uata-heartbeat` でリセット）
+6. 正本確認（鉄則8）完了・結果をセッションに貼付
+7. 安全境界をセッション冒頭に明示（本番 deploy 禁止 / HUMAN-REVIEW-REQUIRED 範囲 / 並列 2 本上限）
+8. Phase 分解・DoD・auto-memory 逐次記録方針が確定
+
+### 4. Claude Code session 再起動時のリスク
+
+- Bypass Permissions 警告画面の Yes は**新規セッション起動扱い**になる。
+- 進行中の session は `/resume` で復帰可能。ただし **auto-memory（MEMORY.md）に
+  書かれていない進捗は失われる**。
+- 重要な setup 変更（settings.json / secrets / hooks）は **session 起動前に
+  完了**させ、起動後に再起動を要する変更を残さない。

--- a/docs/ops/uata_24h_autonomous_startup_checklist.md
+++ b/docs/ops/uata_24h_autonomous_startup_checklist.md
@@ -1,0 +1,49 @@
+# UATa 24h 自走起動前チェックリスト
+
+> 確立: 2026-05-19（24h 自走起動準備フェーズの教訓から）
+> 目的: Bypass Permissions 不発・secrets 未配置・session 再起動による進捗喪失を起動前に潰す。
+
+24h 自走（Claude Code CLI）を起動する**前に**、以下 8 項目を順に確認する。
+1 項目でも未充足なら起動しない。
+
+## チェックリスト（8 項目）
+
+1. **Bypass Permissions が settings.json に正しくネストされている**
+   `permissions.defaultMode = "bypassPermissions"`（root 直下は無効）。
+   または起動を `claude --dangerously-skip-permissions` で行う（公式推奨の確実な方法）。
+   確認: `python3 -c "import json,sys;d=json.load(open('.claude/settings.json'));print(d.get('permissions',{}).get('defaultMode'))"`
+
+2. **GitHub PAT が env に読み込まれている**
+   `~/.claude-uata/secrets/github.env` に `GH_TOKEN`（scope: `repo`, `workflow`）。
+   確認: `set -a; source ~/.claude-uata/secrets/github.env; set +a; gh auth status`
+
+3. **Slack webhook が配置・到達可能**
+   `~/.claude-uata/secrets/slack.env` に `SLACK_WEBHOOK_URL`（#ultra-auto-project）。
+   確認: `grep -q SLACK_WEBHOOK_URL ~/.claude-uata/secrets/slack.env && echo OK`
+
+4. **Pushover が配置・到達可能**
+   `~/.claude-uata/secrets/pushover.env` に `PUSHOVER_APP_TOKEN` / `PUSHOVER_USER_KEY`、
+   `scripts/uata-pushover-notify.sh` が存在し実行可能（mode 600 の secrets を source）。
+   確認: `bash scripts/uata-pushover-notify.sh test`（Normal + High が届く）
+
+5. **stuck-detector が起動済み**
+   `./scripts/uata-stuck-detector.sh start` 実行済、`ps aux | grep stuck-detector` で PID 確認。
+   起動直後の誤発火防止に `touch /tmp/uata-heartbeat` でリセット。
+
+6. **正本確認（鉄則8）完了**
+   CLAUDE.md「並列開発フロー v4 鉄則8」の朝プロトコル正本確認テンプレートを CLI で流し、
+   結果をセッションに貼付済（claude.ai プロジェクトファイルは古い前提）。
+
+7. **安全境界がセッション冒頭に明示されている**
+   本番 deploy 禁止 / DB migration・.env・secrets・金融閾値・法務 = HUMAN-REVIEW-REQUIRED で停止 /
+   並列 tool call 最大 2 本 / HUMAN-REVIEW-REQUIRED は Pushover High。
+
+8. **タスク計画と auto-memory への記録方針が確定**
+   Phase 分解・DoD・Asana 連携先を起動前に決め、進捗は逐次 auto-memory に書く
+   （session 再起動で auto-memory 未記録の進捗は失われるため）。
+
+## 関連教訓
+
+- Bypass Permissions / dev VPS secrets / session 再起動リスク の詳細は
+  CLAUDE.md「## 2026-05-19追加（24h 自走起動準備の教訓）」を参照。
+- 並列 tool call 最大 2 本の根拠は CLAUDE.md「### 並列 tool call は最大 2 本まで」を参照。


### PR DESCRIPTION
## 概要
24h 自走起動準備フェーズ (2026-05-19) の教訓を CLAUDE.md と docs/ops に追記。

## 変更
- **CLAUDE.md**: 「## 2026-05-19追加（24h 自走起動準備の教訓）」新設
  1. Bypass Permissions 正しい有効化 (permissions.defaultMode ネスト必須 / --dangerously-skip-permissions / issue #29026 #34923 #12604)
  2. dev VPS-Mac secrets 分離原則 (scp→chmod 600→.bashrc source→動作確認)
  3. 24h 自走起動前チェックリスト 8 項目
  4. session 再起動リスク (警告 Yes=新規起動 / auto-memory 未記録分喪失)
- **docs/ops/uata_24h_autonomous_startup_checklist.md** 新規 (8 項目詳細)

## Tier 注記
CLAUDE.md = **Tier S**。本日 CLAUDE.md を触る他 PR (#257 / #266 split / #267) と
1日1PR 競合の可能性。merge 順序は小林さん判断事項として Phase 4 報告で整理。

## DoD
- [x] PR 作成
- [ ] CI Lint pass (確認中)
- commit sha: 後述コメント参照

🤖 Generated with [Claude Code](https://claude.com/claude-code)