### PR TITLE
fix(healthcheck): L2 last_judgment 閾値 60→270min (id=29 / ローンチカウント前提)

### DIFF
--- a/scripts/healthcheck_l1_l6.sh
+++ b/scripts/healthcheck_l1_l6.sh
@@ -137,7 +137,9 @@ check_l1() {
   printf '{"status":"%s","details":"%s"}' "${status}" "${details}"
 }
 
-# L2: スケジューラ — scheduler_healthy + last_judgment 経過時間 < 60min
+# L2: スケジューラ — scheduler_healthy + last_judgment 経過時間 < 270min
+#     (AI 判定は約4時間=240min 間隔のため、60min 閾値だと正常運用でも常時 FAIL に
+#      なる。docs/launch_decision_criteria_v2.md 準拠で 270min = 240 + 30 buffer)
 check_l2() {
   local status="PASS"
   local scheduler_healthy="unknown"
@@ -174,7 +176,7 @@ check_l2() {
       "import datetime; t=datetime.datetime.fromisoformat('${last_judgment}'.replace('Z','+00:00')); \
        now=datetime.datetime.now(datetime.timezone.utc); \
        print(int((now-t).total_seconds()/60))" 2>/dev/null || echo "-1")
-    if [[ "${last_judgment_age_min}" -gt 60 && "${last_judgment_age_min}" != "-1" ]]; then
+    if [[ "${last_judgment_age_min}" -gt 270 && "${last_judgment_age_min}" != "-1" ]]; then
       status="FAIL"
     fi
   fi


### PR DESCRIPTION
## 概要
L1-L6 ヘルスチェックの L2 (スケジューラ) 閾値を 60min → 270min に変更。

## 背景
AI 判定は約4時間 (240min) 間隔で実行される。L2 は `last_judgment` の経過
時間が **60min** を超えると FAIL 判定していたため、正常運用でも L2 が毎回
FAIL → L1-L6 連続 PASS (§17 ローンチカウント開始条件) が**構造的に達成不能**
だった (prerun audit E 項で確認)。

## 変更 (scripts/healthcheck_l1_l6.sh のみ / Tier B / 1行 + コメント)
- L2 last_judgment 経過時間閾値: `-gt 60` → `-gt 270` (240min 間隔 + 30 buffer)
- docs/launch_decision_criteria_v2.md の 270min 仕様に整合
- scheduler_healthy / warnings_count チェックは不変

## 検証
- `bash -n` 構文 OK
- L2 文脈の 60 残存なし (270 のみ)
- staging L1-L6 連続 PASS 確認は本番反映後 (本番 deploy = §15 フロー / 小林作業、
  自走は staging まで)

24h 自走 Phase 3。id=29。

🤖 Generated with [Claude Code](https://claude.com/claude-code)