### PR TITLE
feat(ai): prompt v4 HOLD bias 解消版 (#1214890565948368)

### DIFF
--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -119,6 +119,48 @@ _V3_USER_TEMPLATE = """## Specialist Agent Reports:
 Synthesize the agent reports and provide your final judgment in JSON format only."""
 
 
+# v4: HOLD bias 解消版 — 中庸 confidence でも方向シグナルがあれば BUY/SELL 許可
+# agents disagree → default to HOLD (v3 ルール) を廃止し、多数派方向に従う
+# リスク guard (compound risk→HOLD, HF<1.6→保守) は維持
+_V4_SYSTEM = """You are the Decision Agent of Ultra AutoTrade, a DeFi robo-advisor.
+
+You receive analysis from 4 specialist agents:
+1. Indicator Agent — Aave on-chain metrics (HF, utilization, APY)
+2. Pattern Agent — behavioral analysis (recent decision patterns, win rate)
+3. Risk Agent — composite risk (geopolitical, stablecoin, compound risks)
+4. Macro Agent — macro-economic environment (FED policy, news sentiment)
+
+Your job: Synthesize all agent signals into a SINGLE final judgment.
+
+Decision rules (v4 — reduced HOLD bias):
+- HARD STOP (always HOLD): Risk Agent detects COMPOUND RISK, or HF < 1.6
+- SELL: Indicator or Macro Agent reports BEARISH with confidence >= 70%
+- BUY: 2+ agents lean BULLISH, OR a single agent reports BULLISH with confidence >= 65%
+- HOLD: Use HOLD only when no single agent has confidence >= 65% AND no majority direction exists
+- Disagreement does NOT automatically mean HOLD — if 2+ agents agree on a direction, act on it
+- Moderate confidence (45–65) with a clear directional signal warrants BUY or SELL, not HOLD
+
+Weight for confidence calculation: Risk Agent 40%, Indicator 25%, Macro 20%, Pattern 15%
+
+Respond in JSON format ONLY:
+{
+    "action": "BUY" | "SELL" | "HOLD",
+    "confidence": 0-100,
+    "reason": "Brief explanation referencing agent signals"
+}"""
+
+_V4_USER_TEMPLATE = """## Specialist Agent Reports:
+{agent_signals}
+
+## Retrieved Context (from Knowledge Hub):
+{context}
+
+## Analysis Request:
+{query}
+
+Synthesize the agent reports and provide your final judgment in JSON format only."""
+
+
 PROMPT_REGISTRY: Dict[str, PromptTemplate] = {
     "v1": PromptTemplate(
         version="v1",
@@ -137,6 +179,12 @@ PROMPT_REGISTRY: Dict[str, PromptTemplate] = {
         description="Multi-Agent Decision — 4 specialist agents + synthesizer",
         system_prompt=_V3_SYSTEM,
         user_template=_V3_USER_TEMPLATE,
+    ),
+    "v4": PromptTemplate(
+        version="v4",
+        description="HOLD bias 解消版 — 中庸 confidence でも方向シグナルがあれば BUY/SELL 許可",
+        system_prompt=_V4_SYSTEM,
+        user_template=_V4_USER_TEMPLATE,
     ),
 }
 

--- a/backend/tests/test_ai_judge.py
+++ b/backend/tests/test_ai_judge.py
@@ -485,12 +485,34 @@ class TestPromptVersioning:
         tmpl = get_prompt_template("v99")
         assert tmpl.version == "v1"
 
+    def test_get_prompt_template_v4(self):
+        from app.ai.prompts import get_prompt_template
+
+        tmpl = get_prompt_template("v4")
+        assert tmpl.version == "v4"
+        assert "HOLD bias" in tmpl.description
+        assert "COMPOUND RISK" in tmpl.system_prompt
+        assert "HF < 1.6" in tmpl.system_prompt
+        assert "Disagreement" in tmpl.system_prompt
+        assert "{agent_signals}" in tmpl.user_template
+        assert "{context}" in tmpl.user_template
+        assert "{query}" in tmpl.user_template
+
+    def test_v4_no_absolute_hold_bias(self):
+        from app.ai.prompts import get_prompt_template
+
+        tmpl = get_prompt_template("v4")
+        assert "迷ったら HOLD" not in tmpl.system_prompt
+        assert "Disagreement" in tmpl.system_prompt
+        assert "does NOT automatically mean HOLD" in tmpl.system_prompt
+
     def test_list_versions(self):
         from app.ai.prompts import list_versions
 
         versions = list_versions()
         assert "v1" in versions
         assert "v2" in versions
+        assert "v4" in versions
 
     def test_prompt_version_default_in_llm_decision(self):
         from app.ai.schemas import LLMDecision, LLMProvider, TradeAction


### PR DESCRIPTION
## 概要

AI 判定の HOLD bias 99.2% 問題 (Asana GID 1214890565948368) に対応。
`PROMPT_REGISTRY` に `v4` を追加。v1-v3 は不変のため**即ロールバック可能**。

## 真因 (Asana Phase 2 調査より)

- v1: 「迷ったら HOLD を選ぶ」絶対バイアス
- v2: 「conf<50 自動 HOLD」「2観点一致必須」
- v3: 「agents disagree → default to HOLD」
→ 両 LLM (Sonnet + GPT-4o) がこの指示に忠実なため、mixed シグナルで高 confidence HOLD が合理的帰結。
threshold 変更が無効だった理由が確定。

## v4 変更点

| ルール | v3 | v4 |
|---|---|---|
| agents 不一致 | default to HOLD | 多数派方向に従う (2+ agents 合意なら BUY/SELL) |
| 中庸 confidence (45-65) | HOLD | 方向シグナルがあれば BUY/SELL 許可 |
| COMPOUND RISK | HOLD ✅ | HOLD ✅ (維持) |
| HF < 1.6 | HOLD ✅ | HOLD ✅ (維持) |
| BEARISH conf >= 70% | HOLD/SELL ✅ | HOLD/SELL ✅ (維持) |

## ⚠️ HUMAN-REVIEW-REQUIRED

- **本 PR は `prompts.py` のコード追加のみ。本番反映しない。**
- `AI_PROMPT_VERSION=v4` の env 変更は別途 staging テスト + 小林承認後に実施
- staging テスト計画: `AI_PROMPT_VERSION=v4` で 1日観測 → proposals 生成数を確認
- 本番 apply 前に山本さん事前 DM 必須

## Gate 結果

- Gate 1-3: ruff check ✅ / ruff format ✅ / mypy 0 errors ✅
- Gate 4 (pytest): 2783 passed, 21 skipped, coverage 85.23% (gate 80% ✅)
- Gate 5 (孤立コード): 新規 public 関数なし、既存 registry への追加のみ → n/a
- Gate 6 (Codex): prompt 文字列追加のみのため skip
- Gate 7 (Chrome): UI 変更なし → n/a

## 関連

- Asana GID: 1214890565948368
- Phase 2 調査ファイル: `/tmp/uata_phase2_hold_bias_plan.md` (dev VPS)
- 次のステップ: staging で `AI_PROMPT_VERSION=v4` を設定 → 1日テスト → 小林承認 → 本番反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)