### PR TITLE
fix(scripts): verify.sh Gate 0 grep set -e 問題修正 (#1214799077230304)

### DIFF
--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -25,12 +25,13 @@ step "[0/7] Chain Config Consistency"
 if [ -f "$PROJECT_ROOT/.env.production" ]; then
   CHAIN_ID=$(grep "^NEXT_PUBLIC_DEFAULT_CHAIN_ID=" "$PROJECT_ROOT/.env.production" 2>/dev/null | cut -d= -f2 || true)
   if [ "$CHAIN_ID" = "8453" ]; then
-    if grep -rn "Sepolia" \
+    grep -rn "Sepolia" \
         "$PROJECT_ROOT/frontend/app/" \
         "$PROJECT_ROOT/frontend/components/" \
         "$PROJECT_ROOT/frontend/lib/" \
         2>/dev/null \
-        | grep -v "__mocks__\|\.spec\.\|\.test\." > /tmp/sepolia_check.log 2>&1; then
+        | grep -v "__mocks__\|\.spec\.\|\.test\." > /tmp/sepolia_check.log 2>&1 || true
+    if [ -s /tmp/sepolia_check.log ]; then
       echo "ERROR: Chain is mainnet (8453) but 'Sepolia' is hard-coded in frontend:"
       cat /tmp/sepolia_check.log
       echo ""


### PR DESCRIPTION
## 概要
verify.sh の Gate 0 チェックで grep が一致なし (exit code 1) を返したとき、
set -euo pipefail によりスクリプト全体が落ちる問題を修正。

## 修正内容

**問題のコード (修正前):**
```bash
if grep -rn "Sepolia" ... | grep -v "..." > /tmp/sepolia_check.log 2>&1; then
```
- パイプラインの最初の `grep` が一致なし (exit code 1) で終了すると、`set -o pipefail` により
  パイプライン全体が非ゼロで終了し、`set -e` でスクリプトが即座に終了していた
- これにより、Sepolia ハードコードが存在しない正常なケースでも verify.sh が Gate 0 で落ちていた

**修正後:**
```bash
grep -rn "Sepolia" ... | grep -v "..." > /tmp/sepolia_check.log 2>&1 || true
if [ -s /tmp/sepolia_check.log ]; then
```
- パイプライン末尾に `|| true` を追加してグレップ失敗を無視
- ファイルサイズ判定 (`-s`) で実際にマッチがあるかどうかを判断するように変更

## Gate 結果
- bash -n (構文チェック): ✅
- bash scripts/verify.sh (Gate 0 通過確認): ✅ (`.env.production` 未存在でスキップ、set -e で落ちない)

Closes GID 1214799077230304

🤖 Generated with [Claude Code](https://claude.com/claude-code)