### PR TITLE
fix(scripts): uata-morning-report.sh SSH取得パス更新 (#1214891888483740)

### DIFF
--- a/scripts/uata-morning-report.sh
+++ b/scripts/uata-morning-report.sh
@@ -89,12 +89,17 @@ fi
 # ─── 6. 山本さん UAT 状況 (R3: 正ロール=ultra。heredoc で $$ 安全化) ───
 
 YAMAMOTO_STATUS=$(ssh "${SSH_OPTS[@]}" ultra@77.42.46.155 bash -s <<'ENDSSH' 2>/dev/null
-docker exec ultra-autotrade-postgres-production \
-  psql -U ultra -d ultra_autotrade -t -A -F'|' -c \
-  "SELECT
-     (SELECT COUNT(*) FROM proposals    WHERE user_id=11 AND status='pending'),
-     (SELECT COUNT(*) FROM transactions WHERE user_id=11),
-     (SELECT MAX(created_at) FROM proposals WHERE user_id=11);"
+PG_CONTAINER=$(docker ps --filter 'name=postgres-production' --filter 'status=running' --format '{{.Names}}' | head -1)
+if [ -z "$PG_CONTAINER" ]; then
+  echo "(postgres-production コンテナが見つかりません)"
+else
+  docker exec "$PG_CONTAINER" \
+    psql -U ultra -d ultra_autotrade -t -A -F'|' -c \
+    "SELECT
+       (SELECT COUNT(*) FROM proposals    WHERE user_id=11 AND status='pending'),
+       (SELECT COUNT(*) FROM transactions WHERE user_id=11),
+       (SELECT MAX(created_at) FROM proposals WHERE user_id=11);"
+fi
 ENDSSH
 )
 [ -z "$YAMAMOTO_STATUS" ] && YAMAMOTO_STATUS="(取得失敗)"


### PR DESCRIPTION
## 概要
uata-morning-report.sh の docker exec コンテナ名をハードコードから
`docker ps --filter` 動的取得に変更 (RC-4 準拠)。

## 変更内容
- コンテナ名: `ultra-autotrade-postgres-production` ハードコード → SSH経由で `docker ps --filter name=postgres-production` 動的取得
- コンテナ未起動時のエラーメッセージを追加（サイレント失敗を防止）
- DB名 (`ultra_autotrade`) / ユーザー (`ultra`) / SSH先 (`ultra@77.42.46.155`) は正しい値で維持

## Gate
- `bash -n`: ✅ 構文エラーなし

Closes GID 1214891888483740

🤖 Generated with [Claude Code](https://claude.com/claude-code)