### PR TITLE
fix(scripts): backup_db.sh 自己検証型書き換え RC-4 (#1214882070742107)

### DIFF
--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -33,12 +33,12 @@ ENVIRONMENT="${ENVIRONMENT:-production}"
 
 case "$ENVIRONMENT" in
   production)
-    CONTAINER_NAME="ultra-autotrade-postgres-production"
+    CONTAINER_FILTER="postgres-production"
     ENV_FILE="${PROJECT_ROOT}/.env.production"
     DB_NAME="ultra_autotrade"
     ;;
   staging-new)
-    CONTAINER_NAME="ultra-autotrade-postgres-staging-new"
+    CONTAINER_FILTER="postgres-staging"
     ENV_FILE="${PROJECT_ROOT}/.env.staging-new"
     DB_NAME="ultra_autotrade_staging"
     ;;
@@ -77,6 +77,17 @@ _notify_failure() {
 
 # ERR トラップ: pg_dump 失敗等の予期しないエラーも Slack 通知する
 trap '_notify_failure "unexpected error at line ${LINENO} (exit $?)"' ERR
+
+# ── コンテナ名の動的取得 (ハードコード禁止 / RC-4) ──
+CONTAINER_NAME="$(docker ps --filter "name=${CONTAINER_FILTER}" --filter "status=running" \
+  --format "{{.Names}}" | head -1)"
+if [ -z "${CONTAINER_NAME}" ]; then
+  # ERR トラップを外してから手動で通知 (トラップのネストを避ける)
+  trap - ERR
+  echo "ERROR: [${ENVIRONMENT}] postgres コンテナが起動していません (filter: ${CONTAINER_FILTER})" >&2
+  _slack_send "❌ [${ENVIRONMENT}] backup_db.sh: postgres コンテナ未起動 (filter: ${CONTAINER_FILTER})"
+  exit 1
+fi
 
 # ── バックアップ実行 ──────────────────────────────
 mkdir -p "$BACKUP_DIR"


### PR DESCRIPTION
## 概要
2026-05-17 P0 インシデント (postgres 2448回クラッシュ + バックアップ全滅) の
RC-4 対策として backup_db.sh を自己検証型に書き換え。

## 変更内容
- コンテナ名: ハードコード (`CONTAINER_NAME="ultra-autotrade-postgres-production"`) → `docker ps --filter "name=postgres-production" --filter "status=running"` 動的取得
- コンテナ未起動時: Slack 通知 + `exit 1` で早期失敗 (2026-05-17 RCA CLAUDE.md 教訓準拠)
- バックアップサイズ検証: 10KB 未満で `exit 1` + Slack 通知 (既存実装 MIN_SIZE_BYTES=10240 維持)
- 成功時 Slack 通知 (既存実装維持)

## Gate
- [x] bash -n: pass

Closes GID 1214882070742107

🤖 Generated with [Claude Code](https://claude.com/claude-code)