### PR TITLE
fix: proposals期限72h延長 + tscエラー修正 (#1214888726531992)

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -62,7 +62,7 @@ _DEFAULT_QUERY = "DeFi market analysis"
 _PROPOSAL_ASSET = "USDC"
 _PROPOSAL_AMOUNT = Decimal("1000")
 _PROPOSAL_AMOUNT_USD = Decimal("1000.00")
-_PROPOSAL_EXPIRES_HOURS = 24
+_PROPOSAL_EXPIRES_HOURS = 72
 
 
 def save_ai_decision(

--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -400,7 +400,7 @@ def create_proposal(
     db: Session = Depends(get_db),
 ) -> ProposalResponse:
     """提案を作成する（内部呼び出し用）。"""
-    expires_at = request.expires_at or (datetime.now(timezone.utc) + timedelta(hours=24))
+    expires_at = request.expires_at or (datetime.now(timezone.utc) + timedelta(hours=72))
     proposal = Proposal(
         user_id=request.user_id,
         ai_decision_id=request.ai_decision_id,


### PR DESCRIPTION
## 概要
1. proposals.expires_at: 24h → 72h (山本さん UAT 期限切れブロッカー解消)
   - `backend/app/proposals/router.py`: 手動作成 proposals の期限
   - `backend/app/automation/ai_judgment_scheduler.py`: `_PROPOSAL_EXPIRES_HOURS = 24 → 72` (AI生成 proposals の期限)
2. `frontend/e2e/uat-pre-check.spec.ts`: ファイル自体に変更なし。tsc エラーは worktree の node_modules 不在が原因で、main frontend では 0 errors を確認済み。

## ⚠️ 本番反映は小林さん専権
proposals の期限変更は PR merge → 小林さんによる本番 deploy で有効化。
staging deploy スキップ (今回スコープ外)。

## Gate 結果
- ruff check: ✅ (proposals/router.py + ai_judgment_scheduler.py)
- ruff format: ✅
- pytest (proposals): ✅ 91 passed
- npx tsc --noEmit: ✅ 0 errors (main frontend node_modules 使用確認)

Closes GID 1214888726531992
Closes GID 1214798922743037

🤖 Generated with [Claude Code](https://claude.com/claude-code)