### PR TITLE
fix(scripts): seed_test_data.sh にコンテナ名ガードを追加 (CLAUDE.md 2026-05-02)

### DIFF
--- a/scripts/seed_test_data.sh
+++ b/scripts/seed_test_data.sh
@@ -30,12 +30,23 @@ fi
 DB_NAME="$(echo "$DB_URL" | sed -E 's|.*/([^/?]+)(\?.*)?$|\1|')"
 
 # ────────────────────────────────────────────────
-# 2. 本番 DB ガード
+# 2. 本番 DB ガード (CLAUDE.md 2026-05-02 ルール準拠)
 # ────────────────────────────────────────────────
+# 2-a. DB 名チェック
 if [[ "$DB_NAME" != "ultra_autotrade_staging" ]]; then
-  echo "❌ ERROR: This script is for staging only."
+  echo "❌ ERROR: テストデータ投入は staging DB のみ許可。production への投入は禁止。"
   echo "   Expected DB: ultra_autotrade_staging"
   echo "   Got DB:      $DB_NAME"
+  exit 1
+fi
+
+# 2-b. コンテナ名チェック (POSTGRES_CONTAINER が設定されている場合)
+#      docker exec 経由で psql を実行する場合は POSTGRES_CONTAINER を設定すること。
+CONTAINER="${POSTGRES_CONTAINER:-}"
+if [[ -n "$CONTAINER" && "$CONTAINER" != *"staging"* ]]; then
+  echo "❌ ERROR: テストデータ投入は staging コンテナのみ許可。production への投入は禁止。"
+  echo "   Expected container: *staging*"
+  echo "   Got container:      $CONTAINER"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

CLAUDE.md 2026-05-02追加ルール「スクリプト先頭で staging コンテナ名チェック必須」を実装。

## Changes

- `scripts/seed_test_data.sh`: DB 名チェック(既存)に加え、`POSTGRES_CONTAINER` 環境変数が設定されている場合に `*staging*` パターンを検証
- production コンテナ (`*-production`) が渡された場合は EXIT 1

## Test plan

- [x] `DATABASE_URL=..../ultra_autotrade` → ❌ 拒否 (DB名ガード)
- [x] `POSTGRES_CONTAINER=ultra-autotrade-postgres-production` → ❌ 拒否 (コンテナ名ガード)
- [x] `DATABASE_URL=..../ultra_autotrade_staging` → ✅ 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)