### PR TITLE
feat(main): AI Optimizer router を main.py に登録 (Phase B / Tier S)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -37,6 +37,7 @@ from app.aave.router import router as aave_router
 from app.aave.transparency_router import router as transparency_router
 from app.ai.decisions_router import router as ai_decisions_router
 from app.ai.feedback_router import router as ai_feedback_router
+from app.ai.optimizer.router import router as ai_optimizer_router
 from app.ai.router import router as ai_router
 from app.api.alias_router import router as alias_router
 from app.api.automation_dashboard import router as automation_dashboard_router
@@ -233,6 +234,7 @@ def create_app() -> FastAPI:
     app.include_router(fees_v10_router, prefix="/api/v1")  # Fee Model v10 API (/api/v1/fees/*)
     app.include_router(ai_decisions_router)  # AI Decisions API
     app.include_router(ai_feedback_router)  # AI Feedback API (Layer 4)
+    app.include_router(ai_optimizer_router)  # AI Optimizer (Phase 2 / ENB)
     app.include_router(transactions_router)  # Transactions API
     app.include_router(admin_transactions_router)  # Admin Transactions API
     app.include_router(proposals_router)  # Proposals API


### PR DESCRIPTION
## Summary
- `app.ai.optimizer.router` を `main.py` の `include_router` に追加
- エンドポイント有効化: `POST /api/ai/optimizer/recommend`
- Phase 2 / ENB (Expected Net Benefit) 戦略推奨 API

## 変更
- `backend/app/main.py`: import 1行 + include_router 1行

## 依存
- PR #282 (MERGED): `backend/app/ai/optimizer/router.py` 実装済み
- Tier S ファイル (main.py) のため単独 PR

## Test plan
- [ ] ruff check pass
- [ ] mypy pass
- [ ] pytest 80%+ pass
- [ ] POST /api/ai/optimizer/recommend が 422 (不正入力) を返すことを確認

🤖 Generated with Claude Sonnet 4.6