### PR TITLE
docs(claude-md): Next.js bundle 反映確認の盲点教訓追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2065,3 +2065,32 @@ docker inspect <container> --format '{{.HostConfig.LogConfig.Type}}'
   書かれていない進捗は失われる**。
 - 重要な setup 変更（settings.json / secrets / hooks）は **session 起動前に
   完了**させ、起動後に再起動を要する変更を残さない。
+
+---
+
+## 2026-05-19追加（Next.js bundle 反映確認の盲点 — Asana GID 1214828247132605）
+
+### 教訓: `static/chunks/` のみの grep は不十分
+
+**事象**: `grep -l 'LOWER' /app/.next/static/chunks/*.js` が 0 件 → 「frontend 未反映」と誤判定。
+実際は Next.js が SSR ページファイル (`/app/.next/server/`) にも出力するため、
+`static/chunks/` のみでは検出できないケースがある。
+
+**誤判定の影響**:
+- 「アップデートにダウンタイムあり」と誤った判断につながる危険性
+- 不要なフルビルド実行を誘発する
+
+### 正しい確認コマンド
+
+```bash
+# Next.js build 反映確認は /app/.next/ 全体を再帰検索する
+docker exec ultra-autotrade-frontend-production sh -c \
+  "grep -rn '<検索文字列>' /app/.next/ 2>/dev/null | head -10"
+
+# 存在確認のみなら -l で高速化
+docker exec ultra-autotrade-frontend-production sh -c \
+  "grep -rl '<検索文字列>' /app/.next/ 2>/dev/null | head -5"
+```
+
+**禁止**: `static/chunks/` のみ、`/app/.next/static/` のみの限定検索。
+`/app/.next/server/` を含む全体を必ず検索すること。


### PR DESCRIPTION
## Summary
- CLAUDE.md に Next.js bundle 反映確認の盲点教訓を追記
- `/app/.next/static/chunks/` のみ grep では `/app/.next/server/` 配下を検出できず誤判定するリスクを明記
- 正しい確認コマンド（全体再帰検索）と禁止事項を追加

## Asana
Closes GID 1214828247132605

## Test plan
- [ ] CLAUDE.md のドキュメント変更のみ、コード変更なし
- [ ] CI: Lint/Mypy/Pytest への影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)