### PR TITLE
fix(frontend): /history ページに AuthGuard 追加（未認証リダイレクト漏れ）

### DIFF
--- a/frontend/app/(user)/history/page.tsx
+++ b/frontend/app/(user)/history/page.tsx
@@ -11,6 +11,7 @@ import {
 import type { Transaction, OperationType } from './_components'
 import { apiFetch } from '@/lib/api/client'
 import { Skeleton } from '@/components/ui/skeleton'
+import AuthGuard from '@/components/AuthGuard'
 
 // ---------------------------------------------------------------------------
 // API response types
@@ -71,7 +72,7 @@ function mapToTransaction(item: TransactionAPIResponse): Transaction {
 
 const LIMIT = 20
 
-export default function HistoryPage() {
+function HistoryPageContent() {
   const [activeType, setActiveType] = useState<OperationType>('ALL')
   // Initialize to 30-day range to match DateRangeFilter's default visual state
   const [dateRange, setDateRange] = useState<{ from: Date; to: Date } | 'all'>(() => {
@@ -218,5 +219,14 @@ export default function HistoryPage() {
         )}
       </div>
     </div>
+  )
+}
+
+
+export default function HistoryPage() {
+  return (
+    <AuthGuard>
+      <HistoryPageContent />
+    </AuthGuard>
   )
 }


### PR DESCRIPTION
## Summary
- `(user)/history/page.tsx` に `AuthGuard` が欠けていた
- 未認証状態でアクセスすると `apiFetch` の 401 ハンドラが `/login` にリダイレクトする（セッション切れに見える）という不明瞭な動作をしていた
- `AuthGuard` でラップすることで `/login?redirect=/history` に明示的にリダイレクトされるようになる

## Background
P0 GID 1214926712551357（取引履歴セッション切れ調査）で発見した予防的修正。
本番ログで `/api/transactions` への 401 がゼロのため直接の原因ではないが、
`/history` には AuthGuard がなく `/user/history` にはあるという非対称な状態を解消する。

## Test plan
- [ ] `npx tsc --noEmit` 通過（確認済み）
- [ ] 未認証状態で `/history` にアクセス → `/login?redirect=%2Fhistory` にリダイレクト
- [ ] 認証済み状態で `/history` にアクセス → 取引履歴が正常表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)