### PR TITLE
fix(frontend): UserErrorBoundary 誤表示修正 (P0 - セッション切れ誤表示)

### DIFF
--- a/frontend/app/user/_components/UserErrorBoundary.tsx
+++ b/frontend/app/user/_components/UserErrorBoundary.tsx
@@ -4,8 +4,9 @@
 
 // frontend/app/user/_components/UserErrorBoundary.tsx
 // Error boundary for /user/* pages.
-// Catches unhandled React render errors (including 401-triggered crashes)
-// and shows a graceful "session expired" UI instead of a blank crash screen.
+// Catches unhandled React render errors and shows a graceful error UI.
+// NOTE: handle401 (in lib/api/client.ts) redirects to /login directly, so
+// 401 errors from API calls do NOT reach this boundary.
 
 import { Component, ReactNode } from 'react'
 
@@ -15,27 +16,45 @@ interface Props {
 
 interface State {
   hasError: boolean
+  errorMessage: string | null
 }
 
 export class UserErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props)
-    this.state = { hasError: false }
+    this.state = { hasError: false, errorMessage: null }
   }
 
-  static getDerivedStateFromError(): State {
-    return { hasError: true }
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, errorMessage: error?.message ?? null }
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('[UserErrorBoundary] Uncaught error:', error, info.componentStack)
   }
 
   render() {
     if (this.state.hasError) {
       return (
         <div className="flex items-center justify-center min-h-screen">
-          <div className="text-center space-y-4">
-            <p className="text-lg text-zinc-300">セッションが切れました</p>
-            <a href="/login" className="text-blue-400 underline text-sm">
-              再ログインしてください
-            </a>
+          <div className="text-center space-y-4 max-w-sm px-4">
+            <p className="text-lg text-zinc-300">予期しないエラーが発生しました</p>
+            {this.state.errorMessage && (
+              <p className="text-xs text-zinc-500 font-mono break-all">
+                {this.state.errorMessage}
+              </p>
+            )}
+            <div className="flex flex-col gap-2 items-center">
+              <button
+                onClick={() => window.location.reload()}
+                className="text-blue-400 underline text-sm"
+              >
+                ページを再読み込み
+              </button>
+              <a href="/login" className="text-zinc-500 underline text-xs">
+                ログイン画面へ
+              </a>
+            </div>
           </div>
         </div>
       )


### PR DESCRIPTION
## Summary

- 全Renderエラーを「セッションが切れました」と誤表示していた問題を修正
- テスター（山本さん招待）が取引履歴ページで「セッション切れ」と表示されると報告（Asana GID: 1214926712551357）
- F12コンソールで `TypeError: Cannot read properties of undefined (reading 'id')` を確認 → 認証とは無関係のJSクラッシュが「セッション切れ」に見えていた

## 変更点

- `UserErrorBoundary.tsx`: 全エラーを一律「セッションが切れました」→「予期しないエラーが発生しました」に変更
- エラーメッセージをUIに表示してデバッグ容易化
- `componentDidCatch` でconsole.errorログ出力追加
- 再読み込みボタン追加（ログイン画面への誘導のみ廃止）

## Test plan

- [ ] TypeScript型チェック: `tsc --noEmit` 通過
- [ ] ビルドエラーなし: `npm run build`
- [ ] 手動確認: Renderエラーが発生した場合に「予期しないエラーが発生しました」+ エラー詳細が表示されること
- [ ] 401エラーは `handle401` がリダイレクト処理済み → この境界には届かない（既存動作変わらず）

## 関連

- Asana: GID 1214926712551357
- 本番deploy: HUMAN-REVIEW-REQUIRED (小林専権)

🤖 Generated with [Claude Code](https://claude.com/claude-code)