### PR TITLE
fix(frontend): user/history undefined.id クラッシュ防御 (P0)

### DIFF
--- a/frontend/app/user/history/page.tsx
+++ b/frontend/app/user/history/page.tsx
@@ -102,12 +102,13 @@ function AaveHistoryTab() {
       params.set('offset', String(newOffset))
       if (operationFilter) params.set('operation', operationFilter)
       const res = await apiFetch<AaveTransactionListResponse>(`/api/transactions?${params.toString()}`)
+      const safeItems = Array.isArray(res?.items) ? res.items : []
       if (newOffset === 0) {
-        setTransactions(res.items)
+        setTransactions(safeItems)
       } else {
-        setTransactions(prev => [...prev, ...res.items])
+        setTransactions(prev => [...prev, ...safeItems])
       }
-      setTotal(res.total)
+      setTotal(res?.total ?? 0)
       setOffset(newOffset)
     } catch {
       setError(t('fetchError'))
@@ -281,7 +282,7 @@ function HistoryTable({ records }: { records: TradeRecord[] }) {
           </tr>
         </thead>
         <tbody className="divide-y">
-          {records.map(r => (
+          {records.filter((r): r is TradeRecord => r != null).map(r => (
             <tr key={r.id} className="hover:bg-muted/30 transition-colors">
               <td className="px-3 py-2.5 text-xs text-muted-foreground whitespace-nowrap">
                 {r.created_at
@@ -350,8 +351,8 @@ function HistoryPage() {
         `/exchange/history?${params.toString()}`,
         { headers: { Authorization: `Bearer ${token}` } }
       )
-      setRecords(data.items)
-      setTotal(data.total)
+      setRecords(Array.isArray(data?.items) ? data.items : [])
+      setTotal(data?.total ?? 0)
     } catch {
       // endpoint may not exist yet — show empty state
       setRecords([])


### PR DESCRIPTION
## Summary

- `app/user/history/page.tsx` の `AaveHistoryTab` / `HistoryTable` に防御的nullガードを追加
- APIレスポンスの `items` が `undefined` の場合に `setTransactions(undefined)` が呼ばれてレンダリングクラッシュする問題を修正
- `HistoryTable` の `records.map(r => <tr key={r.id}>` で `r` が null の場合をフィルタ

## 変更点

1. `AaveHistoryTab.fetchAave`: `setTransactions(res.items)` → `setTransactions(Array.isArray(res?.items) ? res.items : [])`
2. `HistoryPage.fetchHistory`: `setRecords(data.items)` → `setRecords(Array.isArray(data?.items) ? data.items : [])`
3. `HistoryTable` render: `records.map(r =>` → `records.filter((r): r is TradeRecord => r != null).map(r =>`

## 関連

- Asana: GID 1214926712551357
- 併用PR: #292 (UserErrorBoundary改善)
- 本番deploy: HUMAN-REVIEW-REQUIRED (小林専権)

## Test plan

- [ ] `tsc --noEmit` 通過
- [ ] ビルドエラーなし
- [ ] APIが予期しない形式を返してもクラッシュせずエラーメッセージを表示すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)