### PR TITLE
fix(frontend): /ai/accuracy → /api/ai/accuracy パス修正 (404解消)

### DIFF
--- a/frontend/app/(partner)/partner/dashboard/page.tsx
+++ b/frontend/app/(partner)/partner/dashboard/page.tsx
@@ -142,7 +142,7 @@ export default function PartnerDashboardPage() {
   const { data: stats, loading: statsLoading } = useAuthFetch<PartnerStats>('/api/partner/stats', { refreshInterval: 300000 })
   const { data: usersRaw, loading: usersLoading } = useAuthFetch<UsersResponse | PartnerUser[]>('/users', { refreshInterval: 300000 })
   const { data: monthly, loading: monthlyLoading } = useAuthFetch<MonthlyData[]>('/api/partner/monthly', { refreshInterval: 300000 })
-  const { data: accuracy, loading: accuracyLoading } = useAuthFetch<AiAccuracy>('/ai/accuracy', { refreshInterval: 300000 })
+  const { data: accuracy, loading: accuracyLoading } = useAuthFetch<AiAccuracy>('/api/ai/accuracy', { refreshInterval: 300000 })
   const { data: feeSchedule, loading: feeLoading } = useAuthFetch<FeeSchedule>('/users/fee-schedule', { refreshInterval: 0 })
 
   const [allocations, setAllocations] = useState<Allocation[]>([])

--- a/frontend/app/user/dashboard/_components/AiAccuracyCard.tsx
+++ b/frontend/app/user/dashboard/_components/AiAccuracyCard.tsx
@@ -35,7 +35,7 @@ function AccuracyValue({ value, label }: { value: number | null; label: string }
 }
 
 export function AiAccuracyCard() {
-  const { data, loading, error } = useAuthFetch<AiAccuracyResponse>('/ai/accuracy')
+  const { data, loading, error } = useAuthFetch<AiAccuracyResponse>('/api/ai/accuracy')
 
   return (
     <div className="rounded-2xl border border-zinc-800 bg-zinc-900 p-4 space-y-4">


### PR DESCRIPTION
## Summary

- \`AiAccuracyCard\` と \`partner/dashboard\` が \`/ai/accuracy\` (404) を呼んでいた
- バックエンドの実パスは \`/api/ai/accuracy\` (\`prefix="/api"\` + router \`prefix="/ai"\`)
- historyページのクラッシュとは**独立した別バグ**（同時発覚）

## 変更点

1. \`frontend/app/user/dashboard/_components/AiAccuracyCard.tsx\`: \`/ai/accuracy\` → \`/api/ai/accuracy\`
2. \`frontend/app/(partner)/partner/dashboard/page.tsx\`: \`/ai/accuracy\` → \`/api/ai/accuracy\`

## Test plan

- [ ] \`tsc --noEmit\` 通過
- [ ] ユーザーdashboardのAI的中率カードが実データを表示すること
- [ ] パートナーdashboardのAI的中率が実データを表示すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)