### PR TITLE
chore(backend): ruff バージョン上限付与 >=0.15,<0.16 (バージョンドリフト再発防止)

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -7,7 +7,7 @@ vcrpy>=6.0
 pytest-recording>=0.13.0
 
 # Linting & Type checking
-ruff>=0.4.0
+ruff>=0.15,<0.16
 mypy>=1.10
 
 # Type stubs


### PR DESCRIPTION
## Summary
- `backend/requirements-dev.txt` の `ruff>=0.4.0`（上限なし）を `ruff>=0.15,<0.16` に変更
- 現在の開発 VPS 実環境バージョン: `ruff 0.15.13`
- dev VPS / CI / pre-commit 間のバージョンドリフトを防止

## Background
Gate1 で I001 (isort) 違反が検出されたが root cause はバージョンドリフト。
上限なし pin では ruff がマイナーバージョンアップした際に新ルールが突然有効化され、
CI/ローカル間で lint 結果が変わることがある。

## Test plan
- [x] `ruff check .` → All checks passed!
- [x] `ruff format --check .` → 473 files already formatted (no changes)
- [x] CI 自動実行（push 後）

## Asana
GID: 1214890619154653 (requirements-dev.txt ruff pin 上限付与)

🤖 Generated with [Claude Code](https://claude.com/claude-code)