### PR TITLE
fix(security): .env パーミッション 600 ガード追加 (deploy + check_env_separation)

### DIFF
--- a/scripts/check_env_separation.sh
+++ b/scripts/check_env_separation.sh
@@ -125,6 +125,22 @@ _add_violation_or_warn() {
 }
 
 # ---------------------------------------------------------------------------
+# .env ファイルのパーミッション検証 (600 必須)
+# ---------------------------------------------------------------------------
+_check_env_permission() {
+  local env_file="$1"
+  local label="$2"
+  if [[ ! -f "${env_file}" ]]; then return; fi
+  local perm
+  perm=$(stat -c '%a' "${env_file}" 2>/dev/null || stat -f '%OLp' "${env_file}" 2>/dev/null || echo "unknown")
+  if [[ "${perm}" != "600" ]]; then
+    echo "⚠️  ${label} のパーミッションが ${perm} です (推奨: 600)。'chmod 600 ${env_file}' で修正してください。"
+  fi
+}
+_check_env_permission "${PRODUCTION_FILE}" ".env.production"
+_check_env_permission "${STAGING_FILE}" ".env.staging"
+
+# ---------------------------------------------------------------------------
 # 違反収集
 # ---------------------------------------------------------------------------
 VIOLATIONS=()

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -278,6 +278,14 @@ if [[ ! -f "${ENV_FILE}" ]]; then
   exit 1
 fi
 
+# .env ファイルのパーミッション検証 (600 必須 / 2026-05-19 セキュリティガード追加)
+_ENV_PERM=$(stat -c '%a' "${ENV_FILE}" 2>/dev/null || stat -f '%OLp' "${ENV_FILE}" 2>/dev/null || echo "unknown")
+if [[ "${_ENV_PERM}" != "600" ]]; then
+  err "${ENV_FILE} のパーミッションが ${_ENV_PERM} です。600 でなければデプロイを中止します。"
+  err "修正: chmod 600 ${ENV_FILE}"
+  exit 1
+fi
+
 if [[ ! -f "${UPSTREAM_CONF}" ]]; then
   err "${UPSTREAM_CONF} が見つかりません — Blue/Green 構成が壊れている可能性"
   err "復旧: docker/nginx/upstream.production.conf を 'set \$backend backend-blue:8000;' で作成してください"


### PR DESCRIPTION
## Summary
- `scripts/deploy_production.sh`: `.env.production` のパーミッションが 600 以外の場合にデプロイを abort
- `scripts/check_env_separation.sh`: `.env` ファイルのパーミッション不正を警告表示

## Background
2026-05-11 セキュリティ Phase 1 調査で `.env.production` が 664 (他ユーザー読取可) と判明。
`chmod 600` で当時修正済みだが、運用ルールがなく再発リスクがあった。

## Behavior
```bash
# deploy 時に 644 だった場合:
[deploy] ERROR: .env.production のパーミッションが 644 です。600 でなければデプロイを中止します。
[deploy] ERROR: 修正: chmod 600 .env.production
# → exit 1
```

## Test plan
- [x] `ruff check .` → All checks passed
- [x] `ruff format --check .` → no violations
- [x] CI 自動実行

## Asana
GID: 1214700755246752 (.env パーミッション運用ルール化)

🤖 Generated with [Claude Code](https://claude.com/claude-code)