### PR TITLE
fix(e2e): referral TC2 clipboard-write 権限追加 + toast タイムアウト延長 (flaky 修正)

### DIFF
--- a/frontend/e2e/referral-flow.spec.ts
+++ b/frontend/e2e/referral-flow.spec.ts
@@ -99,6 +99,8 @@ async function mockReferralList(page: Page): Promise<void> {
 // ─── TC1-TC4: partner 紹介フロー ─────────────────────────────────────────────
 
 test.describe('[RAS] partner referral flow', () => {
+  // clipboard-write 権限を付与 (headless Chrome で navigator.clipboard が保護されるため)
+  test.use({ permissions: ['clipboard-write'] })
   test.beforeEach(ensureScreenshotDir)
 
   test('TC1: POST /referral/code 200 → /partner/referral で referral_code 表示', async ({
@@ -143,7 +145,7 @@ test.describe('[RAS] partner referral flow', () => {
     await expect(copyBtn).toBeVisible({ timeout: 5_000 })
     await copyBtn.click()
 
-    await expect(page.getByText('コピーしました')).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText('コピーしました')).toBeVisible({ timeout: 8_000 })
 
     await saveScreenshot(page, 'tc2-copy-toast')
   })


### PR DESCRIPTION
## Summary
- `test.use({ permissions: ['clipboard-write'] })` を describe ブロックに追加
- toast タイムアウト 5000ms → 8000ms に延長

## Root Cause
headless Chrome (CI 環境) では `navigator.clipboard` が保護コンテキストとして扱われる。
`addInitScript` でのモック置換が一部のChromium バージョンで機能しないケースがあり、
clipboard.writeText が失敗 → `catch` ブロック → "コピーに失敗しました" toast が表示される。
`permissions: ['clipboard-write']` を付与することでブラウザレベルで権限を明示し、
モックと実APIの両方が正常に動作するようにする。

## Test plan
- [x] `npx tsc --noEmit` → exit 0
- [x] CI 自動実行

## Asana
GID: 1214700777375012 (flaky E2E referral TC2 コピーボタン)

🤖 Generated with [Claude Code](https://claude.com/claude-code)