### PR TITLE
fix(infra): postgres/loki を 127.0.0.1 バインドに変更 (production)

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -54,7 +54,7 @@ services:
     image: grafana/loki:2.9.0
     container_name: ultra-autotrade-loki-production
     ports:
-      - "3100:3100"
+      - "127.0.0.1:3100:3100"
     volumes:
       - ./docker/loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro
       - loki-data:/loki
@@ -95,7 +95,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB:-ultra_autotrade}
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     restart: always


### PR DESCRIPTION
## Summary

production compose の postgres と loki のポートバインドをループバックアドレスに制限する。

- `postgres`: `"5432:5432"` → `"127.0.0.1:5432:5432"`
- `loki`: `"3100:3100"` → `"127.0.0.1:3100:3100"`

staging では既に `127.0.0.1` バインド済み (`127.0.0.1:5433:5432` / `127.0.0.1:3101:3100`)。production を同じセキュリティ境界に揃える。

## Why

- DB (5432) が `0.0.0.0` バインドだと外部から直接接続可能 → `127.0.0.1` で Hetzner 上の他ホストからの接続を遮断
- Loki (3100) も同様。Cloudflare Tunnel 経由以外からのアクセスを防ぐ

## Test Plan

- [x] `git diff HEAD` でポートバインド変更を確認
- [ ] deploy 後: `ss -tlnp | grep -E '5432|3100'` で `127.0.0.1` バインドを確認
- [ ] `curl -f http://127.0.0.1:8010/health` でバックエンド正常応答確認
- [ ] **注意**: `--force-recreate` または フルデプロイが必要 (`restart` では HostConfig が更新されない)

## Deploy Note

```bash
# 本番デプロイ時 (小林さん専権)
./scripts/deploy_production.sh  # フルデプロイ推奨
# または個別サービスを force-recreate
docker compose -f docker-compose.production.yml --env-file .env.production \
  up -d --no-deps --force-recreate postgres loki
```

Closes Asana GID 1214696986929996

🤖 Generated with [Claude Code](https://claude.com/claude-code)