### PR TITLE
feat(backup): 週次 DB バックアップ retention を 4 週 + 月次 6 ヶ月に改善

### DIFF
--- a/docs/35_docker_maintenance_runbook.md
+++ b/docs/35_docker_maintenance_runbook.md
@@ -181,9 +181,93 @@ grep "Docker cleanup started" /opt/ultra-autotrade/logs/docker_cleanup.log
 
 3. ディスクが完全に埋まった場合は手動でスペースを確保してから再実行
 
+---
+
+## PostgreSQL 週次バックアップ
+
+### 概要
+
+| 項目 | 方針 |
+|---|---|
+| 実行スクリプト | `scripts/backup_db.sh` |
+| 実行頻度 | 週次（毎週日曜 03:00 JST）|
+| 保存先 | `/opt/ultra-autotrade/db_backups/` |
+| 月次アーカイブ | `/opt/ultra-autotrade/db_backups/monthly/` |
+| 保持期間（週次） | 直近 28 日（4 週分） |
+| 保持期間（月次） | 6 ヶ月 |
+| 検証 | ファイルサイズ 10KB 以上 + gzip 整合性チェック |
+| Slack 通知 | 成功/失敗とも `#ultra-auto-project` |
+
+### cron 登録手順（Hetzner ultra ユーザー / 初回のみ）
+
+```bash
+# Hetzner VPS にログイン (production VPS: ultra@77.42.46.155)
+ssh -i ~/.ssh/hetzner_direct ultra@77.42.46.155
+
+# crontab 編集
+crontab -e
+
+# 以下の行を追加 (毎週日曜 03:00 JST)
+0 3 * * 0 ENVIRONMENT=production /opt/ultra-autotrade/scripts/backup_db.sh >> /opt/ultra-autotrade/logs/backup_db.log 2>&1
+
+# 確認
+crontab -l | grep backup_db
+```
+
+### ログディレクトリ確認
+
+```bash
+# ログディレクトリが存在しない場合は作成
+mkdir -p /opt/ultra-autotrade/logs
+
+# バックアップ先ディレクトリ確認
+ls -lh /opt/ultra-autotrade/db_backups/ 2>/dev/null || echo "ディレクトリなし (初回実行で自動作成)"
+```
+
+### 手動実行テスト
+
+```bash
+# production VPS で手動実行
+ENVIRONMENT=production /opt/ultra-autotrade/scripts/backup_db.sh
+
+# 成功確認
+ls -lh /opt/ultra-autotrade/db_backups/production_*.sql.gz | tail -5
+ls -lh /opt/ultra-autotrade/db_backups/monthly/ 2>/dev/null
+```
+
+### トラブルシューティング
+
+#### バックアップが空 (20 bytes) の場合
+
+2026-05-17 インシデント: backup_db.sh が空 gzip を量産 → ハードコードされたコンテナ名が実際と不一致だった。
+
+現行スクリプトは動的コンテナ名解決のため再発しないが、確認手順:
+
+```bash
+# postgres コンテナが起動中か確認
+docker ps --filter "name=postgres-production" --filter "status=running"
+
+# バックアップファイルサイズ確認
+stat -c%s /opt/ultra-autotrade/db_backups/production_*.sql.gz | sort -n | tail -5
+# 10240 (10KB) 未満なら異常 → Slack 通知が届いているはず
+```
+
+#### 月次アーカイブが作成されない
+
+月初（1日）以降の初回実行時に自動作成される。手動で作成する場合:
+
+```bash
+CURRENT_MONTH=$(date +%Y%m)
+cp /opt/ultra-autotrade/db_backups/production_$(ls /opt/ultra-autotrade/db_backups/production_*.sql.gz | sort | tail -1 | xargs basename) \
+   /opt/ultra-autotrade/db_backups/monthly/production_monthly_${CURRENT_MONTH}.sql.gz
+```
+
+---
+
 ## 関連ドキュメント
 
 - `docs/19_operations_runbook.md` — 全体的な運用手順
 - `docs/16_infra_deployment_guide.md` — インフラ・デプロイガイド
-- `scripts/backup_db.sh` — 日次 DB バックアップ（同様の cron 運用パターン）
+- `scripts/backup_db.sh` — 週次 DB バックアップ（4 週保持 + 月次 6 ヶ月アーカイブ）
 - `scripts/deploy_production.sh` — `slack_notify()` の参照元実装
+- `docs/postmortems/2026-05-17_backup_silent_failure.md` — バックアップ無音失敗 RCA

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -50,10 +50,12 @@ esac
 
 DB_USER="${POSTGRES_USER:-ultra}"
 BACKUP_DIR="${BACKUP_DIR:-/opt/ultra-autotrade/db_backups}"
-RETENTION_DAYS="${RETENTION_DAYS:-7}"
-MIN_SIZE_BYTES="${MIN_SIZE_BYTES:-10240}"   # 10 KB 未満は異常とみなす
+RETENTION_DAYS="${RETENTION_DAYS:-28}"     # 直近 4 週分を保持
+MONTHLY_RETENTION_MONTHS="${MONTHLY_RETENTION_MONTHS:-6}"  # 月次アーカイブ 6 ヶ月
+MIN_SIZE_BYTES="${MIN_SIZE_BYTES:-10240}"  # 10 KB 未満は異常とみなす
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
 BACKUP_FILE="${BACKUP_DIR}/${ENVIRONMENT}_ultra_autotrade_${TIMESTAMP}.sql.gz"
+MONTHLY_DIR="${BACKUP_DIR}/monthly"
 
 # ── Slack 通知ヘルパー ─────────────────────────────
 _slack_send() {
@@ -90,7 +92,7 @@ if [ -z "${CONTAINER_NAME}" ]; then
 fi
 
 # ── バックアップ実行 ──────────────────────────────
-mkdir -p "$BACKUP_DIR"
+mkdir -p "$BACKUP_DIR" "$MONTHLY_DIR"
 
 echo "[${TIMESTAMP}] [${ENVIRONMENT}] Starting PostgreSQL backup (container: ${CONTAINER_NAME}, db: ${DB_NAME})..."
 docker exec "$CONTAINER_NAME" pg_dump -U "$DB_USER" "$DB_NAME" | gzip > "$BACKUP_FILE"
@@ -113,9 +115,30 @@ trap - ERR
 
 echo "✅ [${ENVIRONMENT}] Backup verified: ${BACKUP_FILE} ($(( FILESIZE / 1024 )) KB, gzip OK)"
 
-# ── 古いバックアップ削除 (同じ ENVIRONMENT のものだけ) ──
+# ── 月次アーカイブ: 月の最初のバックアップを monthly/ にコピー ──
+CURRENT_MONTH="$(date +%Y%m)"
+MONTHLY_FILE="${MONTHLY_DIR}/${ENVIRONMENT}_monthly_${CURRENT_MONTH}.sql.gz"
+if [ ! -f "${MONTHLY_FILE}" ]; then
+  cp "${BACKUP_FILE}" "${MONTHLY_FILE}"
+  echo "📦 [${ENVIRONMENT}] Monthly archive saved: ${MONTHLY_FILE}"
+fi
+
+# ── 古いバックアップ削除 (直近 RETENTION_DAYS 日分を保持) ──
 find "$BACKUP_DIR" -maxdepth 1 -name "${ENVIRONMENT}_ultra_autotrade_*.sql.gz" -mtime +"${RETENTION_DAYS}" -delete
 echo "🗑️ [${ENVIRONMENT}] Old backups cleaned (retention: ${RETENTION_DAYS} days)"
+
+# ── 古い月次アーカイブ削除 (MONTHLY_RETENTION_MONTHS ヶ月以前を削除) ──
+MONTHLY_CUTOFF="$(date -d "${MONTHLY_RETENTION_MONTHS} months ago" +%Y%m 2>/dev/null \
+  || date -v-${MONTHLY_RETENTION_MONTHS}m +%Y%m 2>/dev/null \
+  || echo "000000")"
+for f in "${MONTHLY_DIR}/${ENVIRONMENT}_monthly_"*.sql.gz; do
+  [ -f "$f" ] || continue
+  file_month="$(basename "$f" | grep -oE '[0-9]{6}' | head -1)"
+  if [ -n "${file_month}" ] && [ "${file_month}" \< "${MONTHLY_CUTOFF}" ]; then
+    rm -f "$f"
+    echo "🗑️ [${ENVIRONMENT}] Old monthly archive deleted: $(basename "$f")"
+  fi
+done
 
 # ── Slack 成功通知（WEBHOOK設定時のみ）───────────
 _slack_send "🗄️ [${ENVIRONMENT}] DB backup completed: $(basename "${BACKUP_FILE}") ($(( FILESIZE / 1024 )) KB)"


### PR DESCRIPTION
## Summary

- `backup_db.sh` の保持期間を 7 日 → 28 日（4 週分）に延長
- `monthly/` サブディレクトリへ月次アーカイブ（その月最初のバックアップ）を自動コピー
- 月次アーカイブは 6 ヶ月で自動削除
- `docs/35_docker_maintenance_runbook.md` に PostgreSQL 週次バックアップセクションを追加

## Changes

```
scripts/backup_db.sh
  RETENTION_DAYS: 7 → 28
  MONTHLY_RETENTION_MONTHS: 6 (new)
  月次アーカイブロジック追加 (monthly/ へのコピー + 古い月次の削除)

docs/35_docker_maintenance_runbook.md
  ## PostgreSQL 週次バックアップ セクション新設
  cron 登録手順 / 手動テスト / トラブルシューティング
```

## Crontab Registration (HUMAN-REVIEW-REQUIRED)

小林さんが本番 VPS で以下を実行して完了:

```bash
# Hetzner 本番 VPS で
crontab -e
# 追加:
0 3 * * 0 ENVIRONMENT=production /opt/ultra-autotrade/scripts/backup_db.sh >> /opt/ultra-autotrade/logs/backup_db.log 2>&1
```

## Test Plan

- [x] `bash scripts/backup_db.sh --help` → 正常終了
- [x] `git diff --stat HEAD` で変更が scripts/backup_db.sh と docs/35 のみ
- [ ] 本番 VPS で `ENVIRONMENT=production bash scripts/backup_db.sh` 手動実行（要本番 VPS アクセス）
- [ ] `/opt/ultra-autotrade/db_backups/monthly/` に月次ファイルが作成されること

Closes Asana GID 1214702770084840

🤖 Generated with [Claude Code](https://claude.com/claude-code)