### PR TITLE
fix(ci): .env.staging docker-compose 参照ガード + .dockerignore 追加

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# 環境ファイル — Docker build context に secrets を含めない
+# .env.staging は 2026-04-17 以降 .env.staging-new が正式
+.env
+.env.*
+!.env.example
+!.env.*.example
+
+# Git / CI — build context 削減
+.git/
+.github/
+.gitignore
+
+# Python キャッシュ
+__pycache__/
+*.pyc
+*.pyo
+.venv/
+backend/.venv/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# フロントエンド成果物 (backend context: . では不要)
+frontend/node_modules/
+frontend/.next/
+frontend/playwright-report/
+frontend/test-results/
+
+# ログ / バックアップ
+*.log
+db_backups/

--- a/.github/workflows/env-separation-check.yml
+++ b/.github/workflows/env-separation-check.yml
@@ -30,6 +30,15 @@ jobs:
           cp backend/.env.production.example .env.production
           cp backend/.env.staging.example .env.staging
           bash scripts/check_env_separation.sh
+      - name: Check .env.staging not referenced in docker-compose
+        run: |
+          # 2026-04-17以降は .env.staging-new が正式。docker-compose に旧 .env.staging 参照が
+          # 再混入していないことを検証する。
+          if grep -rn '\.env\.staging[^-]' docker-compose*.yml 2>/dev/null; then
+            echo "::error::docker-compose ファイルが旧 .env.staging を参照しています。.env.staging-new を使用してください。"
+            exit 1
+          fi
+          echo "✅ docker-compose に .env.staging 参照なし"
       - name: Shellcheck
         uses: ludeeus/action-shellcheck@master
         with:


### PR DESCRIPTION
## Summary

- `env-separation-check.yml` に docker-compose ファイルへの旧 `.env.staging` 参照を検知する CI ステップを追加
- プロジェクトルートに `.dockerignore` を新設（環境ファイル・`.git/`・node_modules 等を build context から除外）

## Background

GID 1214696986457078: 2026-04-17 B案リネームで `.env.staging-new` が正式となったが `.env.staging` が Hetzner 上に残存。今後 docker-compose に旧ファイルが誤参照されることを CI で検知する。

物理削除（Hetzner 上の `.env.staging`）は小林さん専権（HUMAN-REVIEW-REQUIRED）。

## Changes

### `.github/workflows/env-separation-check.yml`
- `Check .env.staging not referenced in docker-compose` ステップを追加
- `grep -rn '\.env\.staging[^-]' docker-compose*.yml` で旧ファイル参照を検知

### `.dockerignore` (新規)
- 環境ファイル (`.env.*`) を Docker build context から除外
- `.git/`、`frontend/node_modules/`、`.github/` 等を除外してビルドコンテキストを最小化

## Test plan

- [ ] `env-separation-check.yml` CI ステップが pass することを確認
- [ ] `.dockerignore` で backend の `COPY backend/ backend/` が正常動作することを確認（ファイル内容変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)