### PR TITLE
fix(e2e): pendle spec の /admin/protocols → /protocols、/user/strategies → /strategies に修正

### DIFF
--- a/frontend/e2e/pendle-staging-poc.spec.ts
+++ b/frontend/e2e/pendle-staging-poc.spec.ts
@@ -7,8 +7,8 @@
 //       フロントエンド表示 + バックエンド API 疎通を E2E 確認する。
 //
 // シナリオ:
-//   A: /admin/protocols — Pendle プロトコルカード表示確認
-//   B: /user/strategies — Pendle PT 戦略カード表示確認
+//   A: /protocols — Pendle プロトコルカード表示確認
+//   B: /strategies — Pendle PT 戦略カード表示確認
 //   C: GET /api/protocols/pendle/markets — 200 + PendleMarketInfo 構造検証
 //   D: GET /api/protocols/health/pendle — is_operational + risk_level 検証
 //   E: POST /api/protocols/pendle/mint dry_run=true — MINT_PT レスポンス検証
@@ -84,22 +84,23 @@ test.describe('[Phase A-3] Pendle PoC staging E2E', () => {
     })(),
   })
 
-  // ── A: /admin/protocols — Pendle プロトコルカード ─────────────────────────
+  // ── A: /protocols — Pendle プロトコルカード ─────────────────────────────────
+  // 注: (admin) は Next.js route group のため URL には含まれない → /protocols
 
-  test.describe('A: /admin/protocols — Pendle プロトコルカード', () => {
+  test.describe('A: /protocols — Pendle プロトコルカード', () => {
     test('A-1: ページが 200 で読み込まれる', async ({ page }) => {
       await setupAdminAuth(page)
-      const resp = await page.goto(`${STAGING_URL}/admin/protocols`, {
+      const resp = await page.goto(`${STAGING_URL}/protocols`, {
         waitUntil: 'domcontentloaded',
         timeout: 15_000,
       })
-      // 認証リダイレクト (302→/login) または 200 を許容
-      expect([200, 302, null].includes(resp?.status() ?? null)).toBeTruthy()
+      // 認証リダイレクト (302/307→/login) または 200 を許容
+      expect([200, 301, 302, 307, 308, null].includes(resp?.status() ?? null)).toBeTruthy()
     })
 
     test('A-2: Pendle セクションが表示される (mock data)', async ({ page }) => {
       await setupAdminAuth(page)
-      await page.goto(`${STAGING_URL}/admin/protocols`, { waitUntil: 'domcontentloaded' })
+      await page.goto(`${STAGING_URL}/protocols`, { waitUntil: 'domcontentloaded' })
 
       // ページが正常レンダリングまたはログインページを表示していること
       const pendleCard = page.getByText('Pendle').first()
@@ -121,7 +122,7 @@ test.describe('[Phase A-3] Pendle PoC staging E2E', () => {
 
     test('A-3: Pendle プロトコルカードに PT / YT レートが含まれる (mock data)', async ({ page }) => {
       await setupAdminAuth(page)
-      await page.goto(`${STAGING_URL}/admin/protocols`, { waitUntil: 'domcontentloaded' })
+      await page.goto(`${STAGING_URL}/protocols`, { waitUntil: 'domcontentloaded' })
 
       // ログイン画面にリダイレクトされた場合はスキップ
       const isLoginPage = await page.getByRole('button', { name: 'ログイン' }).isVisible().catch(() => false)
@@ -137,21 +138,23 @@ test.describe('[Phase A-3] Pendle PoC staging E2E', () => {
     })
   })
 
-  // ── B: /user/strategies — Pendle 戦略カード ────────────────────────────────
+  // ── B: /strategies — Pendle 戦略カード ─────────────────────────────────────
+  // 注: (user) は Next.js route group のため URL には含まれない → /strategies
 
-  test.describe('B: /user/strategies — Pendle 戦略カード', () => {
+  test.describe('B: /strategies — Pendle 戦略カード', () => {
     test('B-1: ページが読み込まれる', async ({ page }) => {
       await setupPartnerAuth(page)
-      const resp = await page.goto(`${STAGING_URL}/user/strategies`, {
+      const resp = await page.goto(`${STAGING_URL}/strategies`, {
         waitUntil: 'domcontentloaded',
         timeout: 15_000,
       })
-      expect([200, 302, null].includes(resp?.status() ?? null)).toBeTruthy()
+      // 認証リダイレクト (302/307→/login) または 200 を許容
+      expect([200, 301, 302, 307, 308, null].includes(resp?.status() ?? null)).toBeTruthy()
     })
 
     test('B-2: Pendle PT 戦略カードが表示される', async ({ page }) => {
       await setupPartnerAuth(page)
-      await page.goto(`${STAGING_URL}/user/strategies`, { waitUntil: 'domcontentloaded' })
+      await page.goto(`${STAGING_URL}/strategies`, { waitUntil: 'domcontentloaded' })
 
       // 「Pendle」「PT」「固定利回り」等のいずれかが存在すること
       const bodyText = await page.locator('body').textContent().catch(() => '') ?? ''
@@ -163,7 +166,7 @@ test.describe('[Phase A-3] Pendle PoC staging E2E', () => {
 
     test('B-3: 戦略リストに APY 表示がある', async ({ page }) => {
       await setupPartnerAuth(page)
-      await page.goto(`${STAGING_URL}/user/strategies`, { waitUntil: 'domcontentloaded' })
+      await page.goto(`${STAGING_URL}/strategies`, { waitUntil: 'domcontentloaded' })
 
       const bodyText = await page.locator('body').textContent().catch(() => '') ?? ''
 

--- a/frontend/e2e/phase2-admin-protocols.spec.ts
+++ b/frontend/e2e/phase2-admin-protocols.spec.ts
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 Ultra AutoTrade. All rights reserved.
-// E2E smoke test: /admin/protocols (Phase 2 プロトコルヘルスモニター)
+// E2E smoke test: /protocols (Phase 2 プロトコルヘルスモニター)
+// 注: (admin) は Next.js route group のため URL に含まれない → /protocols
 //
 // Run with:
 //   STAGING_URL=http://localhost:3000 npx playwright test e2e/phase2-admin-protocols.spec.ts
@@ -10,9 +11,9 @@ import { test, expect } from '@playwright/test'
 
 const BASE = process.env.STAGING_URL ?? 'https://app.ultra-auto-trade.com'
 
-test.describe('/admin/protocols — 標準チェックリスト smoke', () => {
+test.describe('/protocols — 標準チェックリスト smoke', () => {
   test('未認証アクセス → login/dashboard リダイレクト or 200', async ({ page }) => {
-    const res = await page.goto(`${BASE}/admin/protocols`)
+    const res = await page.goto(`${BASE}/protocols`)
     const url = page.url()
     // AdminGuard は非admin を /login か /user/dashboard か /partner/dashboard へ遷移させる
     const isRedirected =
@@ -24,19 +25,19 @@ test.describe('/admin/protocols — 標準チェックリスト smoke', () => {
   })
 
   test('ページが 5xx を返さない', async ({ page }) => {
-    const res = await page.goto(`${BASE}/admin/protocols`)
+    const res = await page.goto(`${BASE}/protocols`)
     expect(res?.status() ?? 200).toBeLessThan(500)
   })
 
   test('英語ハードコードテキスト "Paused"/"Frozen" が画面に存在しない', async ({ page }) => {
-    await page.goto(`${BASE}/admin/protocols`)
+    await page.goto(`${BASE}/protocols`)
     const bodyText = await page.textContent('body') ?? ''
     expect(bodyText).not.toContain('Paused')
     expect(bodyText).not.toContain('Frozen')
   })
 
   test('api.ultra-auto-trade.com 内部 URL が body に露出していない', async ({ page }) => {
-    await page.goto(`${BASE}/admin/protocols`)
+    await page.goto(`${BASE}/protocols`)
     const bodyText = await page.textContent('body') ?? ''
     expect(bodyText).not.toContain('77.42.46.155')
   })

--- a/frontend/e2e/phase2-iphone-mobile.spec.ts
+++ b/frontend/e2e/phase2-iphone-mobile.spec.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Ultra AutoTrade. All rights reserved.
-// E2E iPhone viewport smoke: /user/strategies + /admin/protocols
+// E2E iPhone viewport smoke: /strategies + /protocols
 // 5/13 ハブ課題「iPhone partner UI 未実装」DoD #5 対応
+// 注: (user)/(admin) は Next.js route group のため URL に含まれない
+//     /user/strategies → /strategies、/admin/protocols → /protocols
 //
 // Run with:
 //   STAGING_URL=http://localhost:3000 npx playwright test e2e/phase2-iphone-mobile.spec.ts --project='Mobile Chrome'
@@ -13,33 +15,33 @@ const BASE = process.env.STAGING_URL ?? 'https://app.ultra-auto-trade.com'
 test.describe('iPhone viewport — Phase 2 画面レイアウト確認', () => {
   test.use({ viewport: { width: 390, height: 844 } }) // iPhone 14 Pro
 
-  test('/user/strategies — モバイルで 5xx なし', async ({ page }) => {
-    const res = await page.goto(`${BASE}/user/strategies`)
+  test('/strategies — モバイルで 5xx なし', async ({ page }) => {
+    const res = await page.goto(`${BASE}/strategies`)
     expect(res?.status() ?? 200).toBeLessThan(500)
   })
 
-  test('/user/strategies — モバイルで横スクロール発生しない', async ({ page }) => {
-    await page.goto(`${BASE}/user/strategies`)
+  test('/strategies — モバイルで横スクロール発生しない', async ({ page }) => {
+    await page.goto(`${BASE}/strategies`)
     const bodyWidth = await page.evaluate(() => document.body.scrollWidth)
     const viewportWidth = page.viewportSize()?.width ?? 390
     // body が viewport 幅を大幅に超えていないこと（10px の余裕を許容）
     expect(bodyWidth).toBeLessThanOrEqual(viewportWidth + 10)
   })
 
-  test('/admin/protocols — モバイルで 5xx なし', async ({ page }) => {
-    const res = await page.goto(`${BASE}/admin/protocols`)
+  test('/protocols — モバイルで 5xx なし', async ({ page }) => {
+    const res = await page.goto(`${BASE}/protocols`)
     expect(res?.status() ?? 200).toBeLessThan(500)
   })
 
-  test('/admin/protocols — モバイルで横スクロール発生しない', async ({ page }) => {
-    await page.goto(`${BASE}/admin/protocols`)
+  test('/protocols — モバイルで横スクロール発生しない', async ({ page }) => {
+    await page.goto(`${BASE}/protocols`)
     const bodyWidth = await page.evaluate(() => document.body.scrollWidth)
     const viewportWidth = page.viewportSize()?.width ?? 390
     expect(bodyWidth).toBeLessThanOrEqual(viewportWidth + 10)
   })
 
-  test('/user/strategies — "近日公開" が表示される（英語 Coming Soon なし）', async ({ page }) => {
-    await page.goto(`${BASE}/user/strategies`)
+  test('/strategies — "近日公開" が表示される（英語 Coming Soon なし）', async ({ page }) => {
+    await page.goto(`${BASE}/strategies`)
     const bodyText = await page.textContent('body') ?? ''
     expect(bodyText).not.toContain('Coming Soon')
   })


### PR DESCRIPTION
## Summary
- `pendle-staging-poc.spec.ts` が CI で常に E2E fail していた問題を修正
- 原因: Next.js App Router の route group `(admin)` / `(user)` は URL に含まれないが、テストが誤った URL を参照していた
  - `/admin/protocols` → 正しくは `/protocols` (`app/(admin)/protocols/page.tsx`)
  - `/user/strategies` → 正しくは `/strategies` (`app/(user)/strategies/page.tsx`)
- リダイレクト許容ステータスに `301 / 307 / 308` も追加（Next.js App Router は `redirect()` で 307 を使用）

## Root Cause
`app/(admin)/protocols/page.tsx` → URL: `/protocols` (route group `(admin)` は URL から除外)  
`app/(user)/strategies/page.tsx` → URL: `/strategies` (route group `(user)` は URL から除外)  

`AppShell.tsx` の nav link が `/protocols`、`BottomNav.tsx` が `/strategies` を正しく使用していることで確認済み。

## Test plan
- [x] `pendle-staging-poc.spec.ts` の全 URL 参照が正しいパスに更新
- [x] A-1 / B-1 のステータスチェックに 301/307/308 を追加
- [ ] CI E2E Smoke Tests pass を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)