### PR TITLE
docs(ops): users テーブルに referral 3カラムを追記 (02_db_tables.md)

### DIFF
--- a/docs/ops/02_db_tables.md
+++ b/docs/ops/02_db_tables.md
@@ -52,6 +52,9 @@ docker exec ultra-autotrade-postgres-production \
 | invited_by | Integer FK(users.id) | YES | 招待者ID |
 | tier | String(20) | NO | 投資ティア |
 | last_judgment_at | DateTime(tz) | YES | 最後のAI判定日時 |
+| referral_code | String(16) UNIQUE | YES | 紹介コード (8文字英数字) |
+| referrer_id | Integer FK(users.id) | YES | 紹介者 users.id |
+| referred_consent_at | DateTime(tz) | YES | 紹介プログラム同意日時 |
 
 **INDEX**: `email`, `username`
 


### PR DESCRIPTION
## Summary
- PR #306 で `01_api_endpoints.md` に referral エンドポイントを追記済み
- 対応する DB カラムが `02_db_tables.md` に記載されていなかったため追記

追記したカラム（`users` テーブル）:

| カラム | 型 | NULL | 説明 |
|--------|-----|------|------|
| `referral_code` | String(16) UNIQUE | YES | 紹介コード (8文字英数字) |
| `referrer_id` | Integer FK(users.id) | YES | 紹介者 users.id |
| `referred_consent_at` | DateTime(tz) | YES | 紹介プログラム同意日時 |

**確認方法**: `backend/app/auth/models.py` L26-29 の ALTER TABLE コメント + L275-281 の `mapped_column` 定義と照合済み。

## Test plan
- [x] `docs/ops/02_db_tables.md` の `users` テーブル定義と `auth/models.py` を照合し整合確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)