### PR TITLE
docs(claude-md): Next.js route group URL パターン教訓追記 (E2E spec 誤 URL 再発防止)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,29 @@ Docker ビルド・CI が失敗する。`npm install` は `package.json` ベー�
 - `grep -E "ignoreBuildErrors|ignoreDuringBuilds" frontend/next.config.js` でOOMワークアラウンド確認
 - Playwright E2E: デフォルトは本番URL直打ち。ローカルテスト時は `STAGING_URL=http://localhost:3000` + `npm run dev` 必須。77.42.46.155直IPは127.0.0.1バインドにより接続拒否される（正常）
 
+### Next.js App Router route group と URL の対応 (E2E spec 必須確認)
+
+**route group `(xxx)` はディレクトリ名が URL に含まれない。** E2E で `page.goto()` する URL は
+実ファイルパスではなくブラウザからアクセスできる URL に合わせること。
+
+| ファイルパス | URL | よくある誤り |
+|---|---|---|
+| `app/(admin)/protocols/page.tsx` | `/protocols` | ❌ `/admin/protocols` |
+| `app/(user)/strategies/page.tsx` | `/strategies` | ❌ `/user/strategies` |
+| `app/(partner)/partner/dashboard/page.tsx` | `/partner/dashboard` | ✅ (subfolder `partner/` が入る) |
+| `app/user/approve/page.tsx` (通常フォルダ) | `/user/approve` | ✅ (route group でない) |
+
+**確認方法:** E2E spec に URL を書く前に、必ず `AppShell.tsx` / `BottomNav.tsx` 等のナビリンクで
+使われている `href` 値を grep して確認すること:
+
+```bash
+grep -r "href=" frontend/src/components/ | grep -E "protocols|strategies" | head -10
+```
+
+**背景:** 2026-05-19 PR #307 で `pendle-staging-poc.spec.ts` / `phase2-admin-protocols.spec.ts` /
+`phase2-iphone-mobile.spec.ts` の 3 ファイルに `/admin/protocols` / `/user/strategies` という
+誤 URL が混入。`< 500` チェックのため 404 でもテストが通過し、長期間気づかれなかった。
+
 ---
 
 ## Key API Endpoints


### PR DESCRIPTION
## 概要

PR #307 の調査で発見した Next.js App Router route group の URL ミスパターンを CLAUDE.md に教訓として追記。

## 変更内容

`## Frontend ルール` セクションに以下を追加:
- route group `(xxx)` がディレクトリ名を URL に含まない仕様の対応表
- E2E spec に URL を書く前の grep 確認手順
- 誤 URL が `< 500` チェックで長期間通過していた背景の記録

## 発端

- `app/(admin)/protocols/page.tsx` → URL: `/protocols` (NOT `/admin/protocols`)
- `app/(user)/strategies/page.tsx` → URL: `/strategies` (NOT `/user/strategies`)
- 3 つの E2E spec ファイルで誤 URL を使用。`< 500` チェックのため 404 でもパスしていた

## Gate 結果

- Gate 1-3: CLAUDE.md のみ変更、verify.sh 対象外（docs 変更）
- Gate 5: 該当なし
- Gate 6: Codex Review (自動)

🤖 Generated with [Claude Code](https://claude.com/claude-code)