### PR TITLE
fix(frontend): add credentials:include to all fetch calls (CF Access)

### DIFF
--- a/frontend/lib/api/data-feeds.ts
+++ b/frontend/lib/api/data-feeds.ts
@@ -58,43 +58,43 @@ export interface AgentsData {
 }
 
 export async function fetchGeoRisk(token: string): Promise<GeoRiskData> {
-  const res = await fetch(`${API_BASE}/api/data-feeds/geo-risk`, { headers: authHeaders(token) });
+  const res = await fetch(`${API_BASE}/api/data-feeds/geo-risk`, { credentials: "include", headers: authHeaders(token) });
   if (!res.ok) throw new Error(`geo-risk: ${res.status}`);
   return res.json();
 }
 
 export async function fetchNews(token: string): Promise<NewsFeedData> {
-  const res = await fetch(`${API_BASE}/api/data-feeds/news`, { headers: authHeaders(token) });
+  const res = await fetch(`${API_BASE}/api/data-feeds/news`, { credentials: "include", headers: authHeaders(token) });
   if (!res.ok) throw new Error(`news: ${res.status}`);
   return res.json();
 }
 
 export async function fetchFinance(token: string): Promise<FinanceFeedData> {
-  const res = await fetch(`${API_BASE}/api/data-feeds/finance`, { headers: authHeaders(token) });
+  const res = await fetch(`${API_BASE}/api/data-feeds/finance`, { credentials: "include", headers: authHeaders(token) });
   if (!res.ok) throw new Error(`finance: ${res.status}`);
   return res.json();
 }
 
 export async function fetchAgents(token: string): Promise<AgentsData> {
-  const res = await fetch(`${API_BASE}/api/data-feeds/agents`, { headers: authHeaders(token) });
+  const res = await fetch(`${API_BASE}/api/data-feeds/agents`, { credentials: "include", headers: authHeaders(token) });
   if (!res.ok) throw new Error(`agents: ${res.status}`);
   return res.json();
 }
 
 export async function refreshGeoRisk(token: string): Promise<GeoRiskData> {
-  const res = await fetch(`${API_BASE}/api/data-feeds/geo-risk/refresh`, { method: "POST", headers: authHeaders(token) });
+  const res = await fetch(`${API_BASE}/api/data-feeds/geo-risk/refresh`, { method: "POST", credentials: "include", headers: authHeaders(token) });
   if (!res.ok) throw new Error(`geo-risk refresh: ${res.status}`);
   return res.json();
 }
 
 export async function refreshNews(token: string): Promise<NewsFeedData> {
-  const res = await fetch(`${API_BASE}/api/data-feeds/news/refresh`, { method: "POST", headers: authHeaders(token) });
+  const res = await fetch(`${API_BASE}/api/data-feeds/news/refresh`, { method: "POST", credentials: "include", headers: authHeaders(token) });
   if (!res.ok) throw new Error(`news refresh: ${res.status}`);
   return res.json();
 }
 
 export async function refreshFinance(token: string): Promise<FinanceFeedData> {
-  const res = await fetch(`${API_BASE}/api/data-feeds/finance/refresh`, { method: "POST", headers: authHeaders(token) });
+  const res = await fetch(`${API_BASE}/api/data-feeds/finance/refresh`, { method: "POST", credentials: "include", headers: authHeaders(token) });
   if (!res.ok) throw new Error(`finance refresh: ${res.status}`);
   return res.json();
 }

--- a/frontend/lib/api/http.ts
+++ b/frontend/lib/api/http.ts
@@ -23,6 +23,7 @@ export async function getJson<T>(path: string, init?: RequestInit): Promise<T> {
   const url = base ? `${base}${path}` : path;
 
   const res = await fetch(url, {
+    credentials: "include",
     ...init,
     method: "GET",
     headers: { "Accept": "application/json", ...init?.headers },
@@ -50,6 +51,7 @@ export async function postJson<T>(
   const url = base ? `${base}${path}` : path;
 
   const res = await fetch(url, {
+    credentials: "include",
     ...init,
     method: "POST",
     headers: {
@@ -82,6 +84,7 @@ export async function putJson<T>(
   const url = base ? `${base}${path}` : path;
 
   const res = await fetch(url, {
+    credentials: "include",
     ...init,
     method: "PUT",
     headers: {
@@ -110,6 +113,7 @@ export async function deleteJson<T>(path: string, init?: RequestInit): Promise<T
   const url = base ? `${base}${path}` : path;
 
   const res = await fetch(url, {
+    credentials: "include",
     ...init,
     method: "DELETE",
     headers: { "Accept": "application/json", ...init?.headers },


### PR DESCRIPTION
## Summary

- `frontend/lib/api/http.ts` の `getJson` / `postJson` / `putJson` / `deleteJson` 全 4 関数に `credentials: "include"` を追加
- `frontend/lib/api/data-feeds.ts` の `fetchGeoRisk` / `fetchNews` / `fetchFinance` / `fetchAgents` / `refreshGeoRisk` / `refreshNews` / `refreshFinance` 全 7 関数に `credentials: "include"` を追加

## 背景

SPA (`app.ultra-auto-trade.com`) から CF Access 保護下の API サブドメイン (`api.ultra-auto-trade.com`) に cross-origin fetch する際、`credentials: "include"` がないと CF Access Cookie (`CF_Authorization`) が送信されず 302 ループになる。

参照: CLAUDE.md §2026-05-09追加「CF Access SPA cross-origin Cookie 問題」

## Test plan

- [ ] TypeScript コンパイルエラーなし (`tsc --noEmit`)
- [ ] staging 環境で CF Access 経由 API 呼び出しが 302 ループにならないことを確認
- [ ] 既存 E2E テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)