### PR TITLE
fix(deploy): build-first strategy for --frontend-only (prevent image loss)

### DIFF
--- a/docs/ops/03_deploy_procedures.md
+++ b/docs/ops/03_deploy_procedures.md
@@ -99,6 +99,11 @@ git pull origin main
 > git diff main --name-only | grep "^frontend/lib/api/" # ありならフルデプロイ
 > ```
 
+> **`--frontend-only` のイメージ管理 (2026-05-13 RCA)**
+> ビルド先行方式（ビルド成功後にコンテナ入れ替え）を採用。
+> 旧順序（stop → rmi → build）だとビルド失敗時にイメージもコンテナも消えて起動不可になる。
+> ビルドが失敗した場合は ERR トラップが発火し、旧コンテナを維持したまま終了する。
+
 ---
 
 ## .env.production の必須チェック項目

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -372,18 +372,21 @@ if "${FRONTEND_ONLY}"; then
   # ─── フロントエンドのみ ───────────────────────
   log "フロントエンドのみデプロイ"
 
+  if ! "${NO_BUILD}"; then
+    log "frontend をビルド中（コンテナ停止前にビルド先行）..."
+    # ビルドを先行させる。旧順序（stop → rmi → build）だとビルド失敗時に
+    # コンテナもイメージも消えて起動不可になる。
+    # 2026-05-13 RCA: GID 1214762107679590
+    ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" build --no-cache frontend
+  fi
+
+  log "旧 frontend コンテナを停止・削除..."
   ${DC} -f "${COMPOSE_FILE}" stop frontend
   docker rm -f "${FRONTEND_CONTAINER}" 2>/dev/null || true
 
   if ! "${NO_BUILD}"; then
-    log "古いフロントエンドイメージを完全削除..."
-    docker images --format "{{.Repository}} {{.ID}}" \
-      | grep -E "frontend|ultra-autotrade.*front" \
-      | awk '{print $2}' \
-      | xargs -r docker rmi -f 2>/dev/null || true
-
-    log "frontend をビルド中..."
-    ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" build --no-cache frontend
+    log "dangling（タグなし）イメージを削除..."
+    docker image prune -f 2>/dev/null || true
 
     log "古いビルドキャッシュを削除（1時間以上前のエントリ）..."
     docker builder prune --filter until=1h -f 2>/dev/null || true


### PR DESCRIPTION
## Summary

- `deploy_production.sh --frontend-only` でビルド失敗時にイメージが消えて起動不可になる問題を修正
- 旧順序: `stop → rmi(旧イメージ削除) → build` → ビルド失敗でコンテナもイメージも消失
- 新順序: `build → stop → rm → up → image prune -f(dangling のみ)` → ビルド失敗時は旧コンテナ維持

## 根本原因

2026-05-13 に `--frontend-only` を実行した際、`docker rmi -f` で旧イメージを削除してからビルドを実行する設計になっていた。ビルドが何らかの理由で失敗した場合、コンテナも削除済み・イメージも削除済みの状態になり、起動不可になる。

## 変更内容

`scripts/deploy_production.sh` の `--frontend-only` ブランチを修正:
- ビルドを最初に実行（コンテナを停止する前）
- ビルド成功後にコンテナ停止・削除・新コンテナ起動
- 旧イメージは `docker image prune -f`（dangling タグなしイメージのみ）で安全に削除
- `docs/ops/03_deploy_procedures.md` にビルド先行方式の説明を追記

## Test plan

- [ ] `deploy_production.sh --frontend-only` を staging で実行し正常動作確認（HUMAN-REVIEW-REQUIRED）
- [ ] ビルド失敗シミュレーション: ビルドが失敗した場合に旧コンテナが維持されることを確認

Closes Asana GID 1214762107679590

🤖 Generated with [Claude Code](https://claude.com/claude-code)