### PR TITLE
feat(infra): env drift check + daily CI + horizontal propagation checklist

### DIFF
--- a/.github/workflows/drift_check.yml
+++ b/.github/workflows/drift_check.yml
@@ -1,0 +1,64 @@
+name: Environment Drift Check
+
+on:
+  schedule:
+    # 毎日 02:00 JST (= 17:00 UTC 前日)
+    - cron: '0 17 * * *'
+  workflow_dispatch:
+    inputs:
+      slack_notify:
+        description: 'Slack 通知を送る (差異・警告時)'
+        required: false
+        default: 'true'
+        type: boolean
+
+jobs:
+  drift-check:
+    name: 環境間 drift 検知
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: drift check 実行
+        id: drift
+        run: |
+          bash scripts/env_drift_check.sh 2>&1 | tee /tmp/drift_output.txt
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      - name: 結果をジョブサマリに出力
+        run: |
+          echo "## 環境間 drift チェック結果" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/drift_output.txt >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Slack 通知 (drift または警告あり)
+        if: >
+          (steps.drift.outputs.exit_code != '0' ||
+           contains(steps.drift.outputs.drift_output, '⚠️')) &&
+          (github.event_name == 'schedule' ||
+           (github.event_name == 'workflow_dispatch' && inputs.slack_notify == 'true'))
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          DRIFT_OUTPUT=$(cat /tmp/drift_output.txt)
+          SUMMARY=$(echo "${DRIFT_OUTPUT}" | tail -20)
+          STATUS=$([ "${{ steps.drift.outputs.exit_code }}" = "0" ] && echo "⚠️ 警告あり" || echo "❌ DRIFT 検出")
+
+          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+              --arg status "${STATUS}" \
+              --arg summary "${SUMMARY}" \
+              --arg run_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+              '{
+                "text": ("*[env_drift_check] " + $status + "*\n```\n" + $summary + "\n```\n\n参照: docs/51_horizontal_propagation_checklist.md\n詳細: " + $run_url)
+              }'
+            )"
+
+      - name: drift 検出時はジョブ失敗にする
+        if: steps.drift.outputs.exit_code != '0'
+        run: exit 1

--- a/docs/51_horizontal_propagation_checklist.md
+++ b/docs/51_horizontal_propagation_checklist.md
@@ -1,0 +1,109 @@
+# 同型バグ 水平展開チェックリスト
+
+> 生成: 2026-05-19 / 背景: 2026-05-01 production hotfix (PR #163) が staging に横展開されず、
+> 2026-05-09 に同型 502 が 12 日遅延検出された (postmortem: docs/postmortems/2026-05-09_staging_api_502.md)。
+> production hotfix PR をマージ・クローズする前に必ず本チェックリストを完了する。
+
+---
+
+## 対象シナリオ
+
+本チェックリストは以下のいずれかに該当する変更で実行する:
+
+- **インフラ変更**: nginx port・cloudflared ingress・docker-compose ports・upstream.conf 変更
+- **セキュリティ修正**: 認証・CORS・CSP・env ファイルに関わる修正
+- **バックエンド API パス変更**: エンドポイントパス・バージョンプレフィックス変更
+- **production hotfix**: staging で発生していない問題を production のみで修正した場合
+
+---
+
+## チェックリスト (PR close 前に完了)
+
+### A. 同型リスク確認
+
+- [ ] **対称環境確認**: この修正は production にのみ適用した。staging で同型問題が発生していないかを確認したか
+  - 確認方法: `bash scripts/env_drift_check.sh` を実行し警告・差異なしを確認
+  - staging に同型問題が存在する場合: **A-2 以降を続行する**
+  - staging に同型問題がない場合: **B に進む**
+
+- [ ] **A-2 staging 修正 PR 起票**: staging 向けの hotfix PR を作成したか（同日中）
+  - PR description に「production #NNN の staging 水平展開」と明記する
+  - Asana タスクを作成して本 PR に紐付ける
+
+- [ ] **A-3 水平展開完了確認**: staging 修正 PR がマージされたか（当週中）
+  - production PR の description に「staging 水平展開: PR #NNN マージ済」を記載する
+
+### B. インフラ変更時の追加確認
+
+インフラ変更（nginx/cloudflared/compose/upstream）が含まれる場合のみ実行:
+
+- [ ] **B-1 drift check 実行**: `bash scripts/env_drift_check.sh` が 0 件 drift でパスするか確認
+- [ ] **B-2 port 一覧確認**: 変更した port を参照している全箇所を更新したか
+
+  | 変更内容 | 確認が必要な箇所 |
+  |---|---|
+  | nginx 公開 port 変更 | cloudflared config.yml / Dashboard ingress / docs |
+  | cloudflared ingress port 変更 | nginx compose ports / 外形 healthcheck |
+  | backend 内部 port 変更 | nginx upstream.conf / deploy_production.sh |
+  | frontend port 変更 | cloudflared config.yml / nginx location |
+
+- [ ] **B-3 staging への追従**: 同じ変更を staging compose / upstream.conf に反映したか
+
+### C. デプロイ後確認
+
+- [ ] **Gate 8 外形確認**: 変更後に外形 `/health` を 5 回連続確認
+
+  ```bash
+  # production
+  for i in 1 2 3 4 5; do
+    curl -sf -o /dev/null -w "[%{http_code}] " https://api.ultra-auto-trade.com/health
+    sleep 2
+  done; echo
+
+  # staging (CF Access トークン使用)
+  for i in 1 2 3 4 5; do
+    curl -sf -o /dev/null -w "[%{http_code}] " \
+      -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+      -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
+      https://api-staging.ultra-auto-trade.com/health
+    sleep 2
+  done; echo
+  ```
+
+---
+
+## drift check スクリプト実行
+
+```bash
+# 手動実行（差異確認のみ）
+bash scripts/env_drift_check.sh
+
+# Slack 通知付き（CI から呼ぶ際）
+bash scripts/env_drift_check.sh --slack
+
+# 差異ありのみ出力
+bash scripts/env_drift_check.sh --quiet
+```
+
+自動実行: `.github/workflows/drift_check.yml` が毎日 02:00 JST に実行する。
+
+---
+
+## よくある drift パターン
+
+| パターン | 発生条件 | 影響 |
+|---|---|---|
+| cloudflared ingress port 古い | nginx port 変更後に Dashboard 更新漏れ | 502 (外部経路断絶) |
+| upstream.conf 旧形式残存 | `set $backend` への移行漏れ | nginx 再起動後に IP 固着 502 |
+| staging compose port 古い | production port 変更後の横展開漏れ | staging port 衝突・502 |
+| env ファイル drift | `sed -i` 一括更新で両環境が同値に | 環境分離崩壊 (セキュリティ違反) |
+
+---
+
+## 参照
+
+- `scripts/env_drift_check.sh` — 自動 drift 検知スクリプト
+- `.github/workflows/drift_check.yml` — 毎日 02:00 JST 自動実行
+- `docs/postmortems/2026-05-09_staging_api_502.md` — cloudflared ingress port mismatch 12 日遅延検出 RCA
+- `docs/postmortems/2026-05-12_nginx_upstream_ip_pin.md` — nginx upstream IP 固着 RCA
+- `CLAUDE.md §2026-05-09追加` — インフラ変更チェックリスト 鉄則 4

--- a/scripts/env_drift_check.sh
+++ b/scripts/env_drift_check.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# =============================================================================
+# env_drift_check.sh — 環境間設定 drift 検知スクリプト
+#
+# 背景:
+#   2026-05-01 production cloudflared ingress 修正後、staging への水平展開漏れで
+#   2026-05-09 に同型 502 が 12 日遅延検出された (postmortem: docs/postmortems/2026-05-09_staging_api_502.md)。
+#   production hotfix が staging に横展開されているかを自動検知するために作成。
+#
+# チェック内容:
+#   1. cloudflared config.yml の ingress port vs compose nginx 公開 port
+#   2. nginx upstream.conf のバックエンドポート vs compose backend 内部ポート
+#   3. production compose と staging compose の nginx 公開ポート比較
+#   4. staging cloudflared config ファイルが存在する場合の ingress port 一致
+#
+# 使用方法:
+#   bash scripts/env_drift_check.sh
+#   bash scripts/env_drift_check.sh --slack  # Slack通知付き
+#   bash scripts/env_drift_check.sh --quiet  # 差異ありのみ出力
+#
+# 終了コード:
+#   0: drift なし (全チェック通過)
+#   1: drift 検出 (要確認)
+#   2: チェックエラー (ファイル不存在等)
+# =============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# ─── オプション解析 ───────────────────────────────────────────────────
+SLACK_NOTIFY=false
+QUIET=false
+for arg in "$@"; do
+  case "$arg" in
+    --slack) SLACK_NOTIFY=true ;;
+    --quiet) QUIET=true ;;
+  esac
+done
+
+# ─── 設定ファイルパス ─────────────────────────────────────────────────
+COMPOSE_PROD="${PROJECT_ROOT}/docker-compose.production.yml"
+COMPOSE_STAGING="${PROJECT_ROOT}/docker-compose.staging.yml"
+CF_CONFIG="${PROJECT_ROOT}/config/cloudflared/config.yml"
+CF_CONFIG_STAGING="${PROJECT_ROOT}/config/cloudflared/config.staging.yml"
+UPSTREAM_PROD="${PROJECT_ROOT}/docker/nginx/upstream.production.conf"
+UPSTREAM_STAGING="${PROJECT_ROOT}/docker/nginx/upstream.staging.conf"
+
+# ─── 出力ヘルパー ────────────────────────────────────────────────────
+log()      { echo "[drift-check] $*"; }
+ok()       { echo "  ✅ $*"; }
+warn()     { echo "  ⚠️  $*"; WARNINGS+=("$*"); }
+fail()     { echo "  ❌ $*"; DRIFT+=("$*"); }
+skip()     { "${QUIET}" || echo "  ⬜ $*"; }
+
+DRIFT=()
+WARNINGS=()
+
+# ─── ヘルパー関数 ────────────────────────────────────────────────────
+
+# compose ファイルから nginx サービスの全公開ホストポートをスペース区切りで取得
+# "8000:8080" → 8000、"127.0.0.1:8082:8080" → 8082
+get_nginx_host_ports() {
+  local compose_file="$1"
+  # nginx サービスの ports ブロックから全ホストポートを抽出
+  awk '
+    /^  nginx:/{in_nginx=1; next}
+    in_nginx && /^  [a-z]/ && !/^  nginx:/{in_nginx=0}
+    in_nginx && /^\s+- /{
+      line=$0
+      # "IP:HOST_PORT:CONTAINER_PORT" or "HOST_PORT:CONTAINER_PORT"
+      if (match(line, /[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:([0-9]+):[0-9]+/, arr)) {
+        print arr[1]
+      } else if (match(line, /"?([0-9]+):[0-9]+"?/, arr)) {
+        print arr[1]
+      }
+    }
+  ' "${compose_file}" 2>/dev/null
+}
+
+# 後方互換: 最初のポートのみ取得
+get_nginx_host_port() {
+  get_nginx_host_ports "$1" | head -1
+}
+
+# compose ファイルから backend-blue サービスの uvicorn 内部ポートを取得
+# command: の "--port 8000" から抽出
+get_backend_internal_port() {
+  local compose_file="$1"
+  # command ブロック内の --port N を探す（複数行 YAML の > 形式に対応）
+  awk '
+    /^  backend-blue:/{in_service=1}
+    in_service && /^  [a-z]/ && !/^  backend-blue:/{in_service=0}
+    in_service && /--port/{
+      match($0, /--port[[:space:]]+([0-9]+)/, arr)
+      if (arr[1] != "") { print arr[1]; exit }
+    }
+  ' "${compose_file}" 2>/dev/null | head -1
+}
+
+# cloudflared config.yml から特定 hostname の service port を取得
+get_cf_ingress_port() {
+  local config_file="$1"
+  local hostname="$2"
+  # hostname の直後の service 行からポート番号を抽出
+  awk -v host="${hostname}" '
+    /hostname:.*'"${hostname}"'/{found=1; next}
+    found && /service:/{
+      match($0, /localhost:([0-9]+)/, arr)
+      if (arr[1] != "") { print arr[1]; exit }
+      found=0
+    }
+    found && /hostname:/{found=0}
+  ' "${config_file}" 2>/dev/null | head -1
+}
+
+# nginx upstream.conf からバックエンドのポートを取得
+# "set $backend backend-blue:8000;" → 8000
+get_upstream_backend_port() {
+  local upstream_file="$1"
+  grep -E 'set \$backend backend-(blue|green):' "${upstream_file}" 2>/dev/null \
+    | grep -oE ':[0-9]+' | tr -d ':' | head -1
+}
+
+# ─── チェック 1: production cloudflared ingress port vs nginx 公開 port ───────
+log "=== Check 1: production cloudflared ingress port vs nginx ホストポート ==="
+
+if [[ ! -f "${CF_CONFIG}" ]]; then
+  warn "config/cloudflared/config.yml が存在しない（token 方式 = Dashboard 管理）。手動確認が必要。"
+  warn "  確認先: Cloudflare Dashboard → Tunnels → ultra-autotrade → Public Hostname"
+  warn "  確認内容: api.ultra-auto-trade.com の Service が http://localhost:<nginx_port> か"
+else
+  if [[ ! -f "${COMPOSE_PROD}" ]]; then
+    fail "docker-compose.production.yml が存在しない"
+  else
+    cf_api_port=$(get_cf_ingress_port "${CF_CONFIG}" "api.ultra-auto-trade.com")
+    nginx_prod_ports=$(get_nginx_host_ports "${COMPOSE_PROD}" | tr '\n' ' ')
+
+    if [[ -z "${cf_api_port}" ]]; then
+      warn "config.yml から api.ultra-auto-trade.com の ingress port を取得できなかった"
+    elif [[ -z "${nginx_prod_ports}" ]]; then
+      warn "docker-compose.production.yml から nginx ホストポートを取得できなかった"
+    elif echo "${nginx_prod_ports}" | grep -qw "${cf_api_port}"; then
+      ok "production cloudflared ingress port (${cf_api_port}) が nginx ホストポート (${nginx_prod_ports}) に含まれる"
+    else
+      fail "production cloudflared ingress port (${cf_api_port}) が nginx ホストポート (${nginx_prod_ports}) にない"
+      fail "  → Cloudflare Dashboard または config.yml の ingress を nginx の公開ポートに合わせる"
+    fi
+  fi
+fi
+
+echo ""
+
+# ─── チェック 2: staging cloudflared ingress port (config ファイルがある場合) ───
+log "=== Check 2: staging cloudflared ingress port vs nginx ホストポート ==="
+
+if [[ ! -f "${CF_CONFIG_STAGING}" ]]; then
+  warn "config/cloudflared/config.staging.yml が存在しない（token 方式 = Dashboard 管理）。手動確認が必要。"
+  if [[ -f "${COMPOSE_STAGING}" ]]; then
+    nginx_staging_port=$(get_nginx_host_port "${COMPOSE_STAGING}")
+    warn "  staging nginx ホストポート: ${nginx_staging_port:-不明}"
+    warn "  確認先: Cloudflare Dashboard → Tunnels → ultra-autotrade-staging → Public Hostname"
+    warn "  確認内容: api-staging.ultra-auto-trade.com の Service が http://localhost:${nginx_staging_port:-?} か"
+  fi
+else
+  if [[ ! -f "${COMPOSE_STAGING}" ]]; then
+    fail "docker-compose.staging.yml が存在しない"
+  else
+    cf_staging_port=$(get_cf_ingress_port "${CF_CONFIG_STAGING}" "api-staging.ultra-auto-trade.com")
+    nginx_staging_port=$(get_nginx_host_port "${COMPOSE_STAGING}")
+
+    if [[ -z "${cf_staging_port}" ]]; then
+      warn "config.staging.yml から api-staging の ingress port を取得できなかった"
+    elif [[ -z "${nginx_staging_port}" ]]; then
+      warn "docker-compose.staging.yml から nginx ホストポートを取得できなかった"
+    elif [[ "${cf_staging_port}" != "${nginx_staging_port}" ]]; then
+      fail "staging cloudflared ingress port (${cf_staging_port}) != nginx ホストポート (${nginx_staging_port})"
+      fail "  → config.staging.yml の ingress を localhost:${nginx_staging_port} に更新する"
+    else
+      ok "staging cloudflared ingress port (${cf_staging_port}) == nginx ホストポート (${nginx_staging_port})"
+    fi
+  fi
+fi
+
+echo ""
+
+# ─── チェック 3: nginx upstream backend port vs compose backend 内部ポート ───
+log "=== Check 3: nginx upstream バックエンドポート vs compose backend 内部ポート ==="
+
+for env in production staging; do
+  if [[ "${env}" == "production" ]]; then
+    compose_file="${COMPOSE_PROD}"
+    upstream_file="${UPSTREAM_PROD}"
+  else
+    compose_file="${COMPOSE_STAGING}"
+    upstream_file="${UPSTREAM_STAGING}"
+  fi
+
+  if [[ ! -f "${upstream_file}" ]]; then
+    warn "${env}: ${upstream_file} が存在しない"
+    continue
+  fi
+  if [[ ! -f "${compose_file}" ]]; then
+    warn "${env}: ${compose_file} が存在しない"
+    continue
+  fi
+
+  upstream_port=$(get_upstream_backend_port "${upstream_file}")
+  backend_internal_port=$(get_backend_internal_port "${compose_file}")
+
+  if [[ -z "${upstream_port}" ]]; then
+    warn "${env}: upstream.conf からバックエンドポートを取得できなかった"
+  elif [[ -z "${backend_internal_port}" ]]; then
+    warn "${env}: compose から backend-blue 内部ポートを取得できなかった"
+  elif [[ "${upstream_port}" != "${backend_internal_port}" ]]; then
+    fail "${env}: nginx upstream ポート (${upstream_port}) != backend 内部ポート (${backend_internal_port})"
+  else
+    ok "${env}: nginx upstream (${upstream_port}) == backend 内部ポート (${backend_internal_port})"
+  fi
+done
+
+echo ""
+
+# ─── チェック 4: production nginx ポートと staging nginx ポートの相対関係 ───
+log "=== Check 4: compose ファイル間の nginx ポート重複チェック ==="
+
+if [[ -f "${COMPOSE_PROD}" ]] && [[ -f "${COMPOSE_STAGING}" ]]; then
+  prod_nginx_port=$(get_nginx_host_port "${COMPOSE_PROD}")
+  staging_nginx_port=$(get_nginx_host_port "${COMPOSE_STAGING}")
+
+  if [[ -n "${prod_nginx_port}" ]] && [[ -n "${staging_nginx_port}" ]]; then
+    if [[ "${prod_nginx_port}" == "${staging_nginx_port}" ]]; then
+      fail "production nginx ポート (${prod_nginx_port}) と staging nginx ポート (${staging_nginx_port}) が同じ！ポート衝突リスク。"
+    else
+      ok "production nginx ポート (${prod_nginx_port}) != staging nginx ポート (${staging_nginx_port}) (衝突なし)"
+    fi
+  else
+    warn "一方または両方の compose から nginx ポートを取得できなかった (prod=${prod_nginx_port:-不明} / staging=${staging_nginx_port:-不明})"
+  fi
+fi
+
+echo ""
+
+# ─── チェック 5: horizontal propagation — production の hotfix が staging に展開されているか ───
+log "=== Check 5: upstream.conf の upstream 形式チェック (IP 固着バグ再発防止) ==="
+
+for env in production staging; do
+  if [[ "${env}" == "production" ]]; then
+    upstream_file="${UPSTREAM_PROD}"
+  else
+    upstream_file="${UPSTREAM_STAGING}"
+  fi
+
+  if [[ ! -f "${upstream_file}" ]]; then
+    skip "${env}: ${upstream_file} が存在しない"
+    continue
+  fi
+
+  # 旧形式: "server backend-blue:8000 ...;"  ← IP 固着バグ (nginx 起動時 1 回しか解決しない)
+  # 新形式: "set $backend backend-blue:8000;" ← 変数 + resolver で動的解決
+  if grep -qE '^[[:space:]]*server backend-(blue|green):' "${upstream_file}"; then
+    fail "${env}: upstream.conf が旧形式 (server backend-...) → IP 固着バグ。新形式 (set \$backend) に移行が必要。"
+    fail "  参照: docs/postmortems/2026-05-12_nginx_upstream_ip_pin.md"
+  elif grep -qE 'set \$backend backend-(blue|green):' "${upstream_file}"; then
+    ok "${env}: upstream.conf が新形式 (set \$backend backend-...) で IP 固着バグなし"
+  else
+    warn "${env}: upstream.conf の形式を判定できなかった (手動確認推奨)"
+  fi
+done
+
+echo ""
+
+# ─── 結果サマリ ──────────────────────────────────────────────────────
+echo "=== 結果サマリ ==="
+
+if [[ "${#WARNINGS[@]}" -gt 0 ]]; then
+  echo "⚠️  警告: ${#WARNINGS[@]} 件 (手動確認が必要)"
+  for w in "${WARNINGS[@]}"; do
+    echo "   - ${w}"
+  done
+fi
+
+if [[ "${#DRIFT[@]}" -eq 0 ]]; then
+  echo "✅ drift なし: 全チェック通過"
+  RESULT_STATUS="PASS"
+  EXIT_CODE=0
+else
+  echo "❌ drift 検出: ${#DRIFT[@]} 件"
+  for d in "${DRIFT[@]}"; do
+    echo "   - ${d}"
+  done
+  RESULT_STATUS="FAIL"
+  EXIT_CODE=1
+fi
+
+echo ""
+log "横展開チェックリスト: docs/51_horizontal_propagation_checklist.md を参照"
+
+# ─── Slack 通知 ───────────────────────────────────────────────────────
+if "${SLACK_NOTIFY}" && [[ "${RESULT_STATUS}" == "FAIL" || "${#WARNINGS[@]}" -gt 0 ]]; then
+  WEBHOOK="${SLACK_WEBHOOK_URL:-}"
+  if [[ -z "${WEBHOOK}" ]]; then
+    log "WARN: SLACK_WEBHOOK_URL が未設定のため Slack 通知をスキップ"
+  else
+    DRIFT_TEXT=$(printf '%s\n' "${DRIFT[@]:-}" | head -5)
+    WARN_TEXT=$(printf '%s\n' "${WARNINGS[@]:-}" | head -3)
+    MSG="*[env_drift_check] ${RESULT_STATUS}*\n\n"
+    if [[ "${#DRIFT[@]}" -gt 0 ]]; then
+      MSG+="❌ drift 検出 (${#DRIFT[@]} 件):\n\`\`\`${DRIFT_TEXT}\`\`\`\n"
+    fi
+    if [[ "${#WARNINGS[@]}" -gt 0 ]]; then
+      MSG+="⚠️  手動確認 (${#WARNINGS[@]} 件):\n\`\`\`${WARN_TEXT}\`\`\`\n"
+    fi
+    MSG+="\n参照: docs/51_horizontal_propagation_checklist.md"
+
+    curl -s -X POST "${WEBHOOK}" \
+      -H "Content-Type: application/json" \
+      -d "{\"text\": \"${MSG}\"}" > /dev/null 2>&1 || true
+  fi
+fi
+
+exit "${EXIT_CODE}"


### PR DESCRIPTION
## Summary

- `scripts/env_drift_check.sh`: 5チェックの自動 drift 検知スクリプト
- `.github/workflows/drift_check.yml`: 毎日 02:00 JST 自動実行 + Slack 通知
- `docs/51_horizontal_propagation_checklist.md`: production hotfix PR close 前の水平展開チェックリスト

## 背景

2026-05-01 PR #163 で production cloudflared ingress を修正したが、staging への横展開が漏れ、2026-05-09 に同型 502 が 12 日遅延検出された。

本 PR で以下を自動化:
1. cloudflared config.yml の ingress port が nginx compose 公開 port と一致するか
2. nginx upstream.conf のバックエンドポートが compose backend 内部ポートと一致するか  
3. staging/production の nginx port が重複していないか
4. upstream.conf が旧形式 (`server backend-...:`) でないか (IP 固着バグ再発防止)
5. staging cloudflared が token 方式の場合、手動確認ガイダンスを表示

## Test plan

- [x] `bash scripts/env_drift_check.sh` がローカルで PASS
- [x] 既存設定に対して誤検知なし
- [ ] GitHub Actions の drift_check.yml が正常実行できることを確認

Closes Asana GID 1214653790908175

🤖 Generated with [Claude Code](https://claude.com/claude-code)