### PR TITLE
fix(frontend): add NODE_OPTIONS to Dockerfile build stage (Next.js OOM fix)

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -267,6 +267,8 @@ services:
         NEXT_PUBLIC_VAPID_PUBLIC_KEY: ${NEXT_PUBLIC_VAPID_PUBLIC_KEY:-}
         NEXT_PUBLIC_LIFF_ID: ${NEXT_PUBLIC_LIFF_ID:-}
         NEXT_PUBLIC_PRIVY_APP_ID: ${NEXT_PUBLIC_PRIVY_APP_ID:-}
+        # Next.js ビルド OOM 対策 (CLAUDE.md §2026-05-19 GID 1214828243363427)
+        NODE_BUILD_MAX_OLD_SPACE_SIZE: ${NODE_BUILD_MAX_OLD_SPACE_SIZE:-4096}
     environment:
       NEXT_PUBLIC_BACKEND_BASE_URL: ${NEXT_PUBLIC_BACKEND_BASE_URL:-https://api.ultra-auto-trade.com}
       # SSR (Next.js サーバー側) は内部 nginx 経由で backend に到達する。

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -246,6 +246,10 @@ services:
         NEXT_PUBLIC_VAPID_PUBLIC_KEY: ${NEXT_PUBLIC_VAPID_PUBLIC_KEY:-}
         NEXT_PUBLIC_LIFF_ID: ${NEXT_PUBLIC_LIFF_ID:-}
         NEXT_PUBLIC_PRIVY_APP_ID: ${NEXT_PUBLIC_PRIVY_APP_ID:-}
+        # Next.js ビルド OOM 対策 (CLAUDE.md §2026-05-19 GID 1214828243363427)
+        # staging-new は 7.6GB RAM / swap なし → 4096MB が安全下限。
+        # 実ビルドログでピーク確認後に値を調整すること。
+        NODE_BUILD_MAX_OLD_SPACE_SIZE: ${NODE_BUILD_MAX_OLD_SPACE_SIZE:-4096}
     environment:
       NEXT_PUBLIC_BACKEND_BASE_URL: ${NEXT_PUBLIC_BACKEND_BASE_URL:-https://api-staging.ultra-auto-trade.com}
       # SSR は Docker ネットワーク内の nginx (内部ポート 8080) 経由で backend に到達する。

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -50,6 +50,13 @@ ENV NEXT_PUBLIC_PRIVY_APP_ID=${NEXT_PUBLIC_PRIVY_APP_ID}
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+# NODE_OPTIONS: Next.js build の OOM 対策 (CLAUDE.md §2026-05-19 GID 1214828243363427)
+# docker-compose.staging.yml build.args で NODE_BUILD_MAX_OLD_SPACE_SIZE をオーバーライド可能。
+# 実際のピークメモリは staging で `docker stats` → `npm run build` 実行後に確認すること。
+# 推測での値変更は禁止 (実ビルドログでピーク確認後に設定)。
+ARG NODE_BUILD_MAX_OLD_SPACE_SIZE=4096
+ENV NODE_OPTIONS="--max-old-space-size=${NODE_BUILD_MAX_OLD_SPACE_SIZE}"
+
 # Ensure standalone output is enabled
 RUN if ! grep -q "output.*standalone" next.config.* 2>/dev/null; then \
   echo "/** @type {import('next').NextConfig} */" > next.config.mjs.bak && \


### PR DESCRIPTION
## Summary

- `frontend/Dockerfile` builder stage に `NODE_BUILD_MAX_OLD_SPACE_SIZE` ARG を追加
- `NODE_OPTIONS=--max-old-space-size=${NODE_BUILD_MAX_OLD_SPACE_SIZE}` で Next.js ビルド OOM を防止
- `docker-compose.staging.yml` / `docker-compose.production.yml` に `NODE_BUILD_MAX_OLD_SPACE_SIZE` build arg 追加（`.env` でオーバーライド可能）

## 背景

GID 1214828243363427: staging auto-deploy で Next.js ビルドが OOM (signal: killed) で失敗。本 PR はコード変更部分のみ実装し、DoD の staging 実機確認は HUMAN-REVIEW-REQUIRED。

## 設計

```dockerfile
# Stage 2: builder
ARG NODE_BUILD_MAX_OLD_SPACE_SIZE=4096
ENV NODE_OPTIONS="--max-old-space-size=${NODE_BUILD_MAX_OLD_SPACE_SIZE}"
RUN npm run build
```

- `runner` ステージ (別 `FROM`) には `NODE_OPTIONS` が継承されない → runtime 影響なし
- デフォルト 4096MB (4GB)。staging-new が 7.6GB RAM なので安全マージンあり
- `.env.staging-new` に `NODE_BUILD_MAX_OLD_SPACE_SIZE=6144` 等で調整可能

## 注意事項

- 実際のピーク確認なしでの値変更禁止 (CLAUDE.md §2026-05-19)
- staging で `docker stats` + ビルドログのピーク確認後に値を微調整すること

## Test plan

- [ ] staging で `./scripts/deploy_staging.sh --frontend-only` を実行し OOM なしで成功する（3 回連続）
- [ ] production の既存ビルドに影響がないことを確認

Closes Asana GID 1214828243363427

🤖 Generated with [Claude Code](https://claude.com/claude-code)