### PR TITLE
fix(compose): backend OOM対策 mem_limit 768m 追加 (Tier S)

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -135,6 +135,10 @@ services:
     environment:
       REBALANCE_SHADOW_MODE: "false"
       DEPLOY_SLOT: "blue"
+    # 2026-05-19: OOM対策。起動時 import (web3/anthropic/openai) + 8並列タスクで約300MB消費。
+    # 768m = 余裕をもった上限。memswap=mem と同値にしてスワップで延命せずフェイルファスト化。
+    mem_limit: ${BACKEND_MEM_LIMIT:-768m}
+    memswap_limit: ${BACKEND_MEM_LIMIT:-768m}
     ports:
       # 内部検証用 (deploy script が /health を直接ポーリング)。外部公開なし。
       - "127.0.0.1:8010:8000"
@@ -179,6 +183,8 @@ services:
     environment:
       REBALANCE_SHADOW_MODE: "false"
       DEPLOY_SLOT: "green"
+    mem_limit: ${BACKEND_MEM_LIMIT:-768m}
+    memswap_limit: ${BACKEND_MEM_LIMIT:-768m}
     ports:
       - "127.0.0.1:8011:8000"
     volumes:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -138,6 +138,8 @@ services:
       REBALANCE_SHADOW_MODE: "true"
       AI_SHADOW_MODE: "true"
       DEPLOY_SLOT: "blue"
+    mem_limit: ${BACKEND_MEM_LIMIT:-768m}
+    memswap_limit: ${BACKEND_MEM_LIMIT:-768m}
     ports:
       # 内部検証用 (deploy script が /health を直接ポーリング)。外部公開なし。
       - "127.0.0.1:8020:8000"
@@ -178,6 +180,8 @@ services:
       REBALANCE_SHADOW_MODE: "true"
       AI_SHADOW_MODE: "true"
       DEPLOY_SLOT: "green"
+    mem_limit: ${BACKEND_MEM_LIMIT:-768m}
+    memswap_limit: ${BACKEND_MEM_LIMIT:-768m}
     ports:
       - "127.0.0.1:8021:8000"
     volumes:


### PR DESCRIPTION
## Summary

- backend-blue / backend-green コンテナに `mem_limit: 768m` + `memswap_limit: 768m` を追加
- production + staging 両 compose ファイルを更新
- OOM キル時のスワップ延命を防ぎ、フェイルファスト化

## Background

2026-05-13 backend-blue が ExitCode 137 (OOMKilled) で 17 回 restart loop、16h で AI 判定が停止した。

### tracemalloc 調査結果 (2026-05-19)

| モジュール | import 時メモリ増加 |
|---|---|
| app.main (全体) | +96.6MB |
| web3 | +33.5MB |
| anthropic | +15.2MB |
| openai | +9.5MB |

起動時に 8 並列バックグラウンドタスク（geo-risk / news / finance / howl / learning / process_news / monitoring / scheduled_tasks）が同時初期化される。推定ピーク 300-500MB。

### メモリ上限設定

`mem_limit: 768m` = import 96MB + 起動スパイク ~300MB + 余裕 ~370MB

`${BACKEND_MEM_LIMIT:-768m}` で環境変数によるオーバーライドが可能（増やす方向のみ推奨）。

## ⚠️ Tier S 注意事項

- `docker-compose.production.yml` は Tier S (同時並列禁止 / 1日1PRまで)
- 本 PR は PR #316 (Next.js OOM fix) と同じファイルに触れるため、マージ順序注意
- **推奨順序: PR #316 → main merge → 本 PR merge**

## Test plan

- [ ] staging で `docker compose up -d backend-blue` 後 `docker stats` で 768m 以内を確認
- [ ] 起動完了 + `/health` 200 を確認 (30s 待機)
- [ ] OOM 時に SIGKILL (exit 137) で即終了することを確認 (スワップ延命なし)

Refs: Asana GID 1214762198268443 (backend-blue OOM root cause 調査)

🤖 Generated with [Claude Code](https://claude.com/claude-code)