### PR TITLE
fix(ai): v4 prompt agent_signals KeyError 修正 (PR #302 フォロー)

### DIFF
--- a/backend/app/ai/service.py
+++ b/backend/app/ai/service.py
@@ -304,8 +304,8 @@ class AIService:
         if market_context is not None:
             agent_ctx = run_all_agents(market_context)
 
-        # Build user content — v3 injects agent_signals into the template itself
-        if version == "v3":
+        # Build user content — v3/v4 inject agent_signals into the template itself
+        if version in ("v3", "v4"):
             agent_signals_text = (
                 agent_ctx.to_decision_prompt()
                 if agent_ctx is not None

--- a/backend/tests/test_ai_service.py
+++ b/backend/tests/test_ai_service.py
@@ -117,3 +117,47 @@ def test_build_rag_prompt_v3_without_market_context():
     assert isinstance(user_content, str)
     assert "No agent signals available" in user_content
     assert "test chunk" in user_content
+
+
+def test_build_rag_prompt_v4_without_market_context():
+    """v4 テンプレートで market_context が None の場合に KeyError が起きないこと。
+
+    PR #302 不完全修正のリグレッション防止: _V4_USER_TEMPLATE は {agent_signals} を
+    含むが service.py の分岐が version == "v3" のみだと v4 で KeyError が発生する。
+    """
+    service = AIService()
+    rag_context = RAGContext(chunks=["test chunk"], query="test query", source_count=1)
+
+    system_prompt, user_content = service._build_rag_prompt(
+        query="test query",
+        rag_context=rag_context,
+        version="v4",
+        market_context=None,
+    )
+    assert isinstance(system_prompt, str)
+    assert isinstance(user_content, str)
+    assert "No agent signals available" in user_content
+    assert "test chunk" in user_content
+
+
+def test_build_rag_prompt_v4_with_market_context():
+    """v4 テンプレートで market_context がある場合に agent_signals が展開されること。"""
+    from decimal import Decimal
+
+    from app.data_feeds.context import MarketContext
+
+    service = AIService()
+    rag_context = RAGContext(chunks=["btc context"], query="buy or sell?", source_count=1)
+    market_ctx = MarketContext(health_factor=Decimal("1.9"), aave_utilization_rate=Decimal("65.0"))
+
+    system_prompt, user_content = service._build_rag_prompt(
+        query="buy or sell?",
+        rag_context=rag_context,
+        version="v4",
+        market_context=market_ctx,
+    )
+    assert isinstance(system_prompt, str)
+    assert isinstance(user_content, str)
+    assert "btc context" in user_content
+    # agent_signals プレースホルダーが未展開のまま残っていないこと
+    assert "{agent_signals}" not in user_content


### PR DESCRIPTION
## 問題

PR #302 (`fix/ai-v4-prompt-agent-signals-keyerror`) で AI v4 KeyError を修正済みとされていたが、`_V4_USER_TEMPLATE` に `{agent_signals}` が含まれているにもかかわらず `service.py` の分岐条件が `version == "v3"` のままだったため、v4 呼び出し時に `KeyError: 'agent_signals'` が再現していた。

## 修正

`service.py:308` の条件を `version == "v3"` から `version in ("v3", "v4")` に変更。
v4 でも agent_signals を生成してテンプレートに渡すようにした。

## 検証

- `_V4_USER_TEMPLATE.format(agent_signals=..., context=..., query=...)` — OK ✅
- 旧コード（agent_signals なし）で KeyError 再現確認 ✅
- AI 関連 pytest 724 passed ✅
- `ruff check` / `ruff format --check` — OK ✅

## 影響範囲

`backend/app/ai/service.py` 1行変更のみ（`version == "v3"` → `version in ("v3", "v4")`）。
v1/v2 の else 分岐は変更なし。

## 前提

staging 復旧後に `AI_PROMPT_VERSION=v4` で動作確認予定。PR #302 の不完全修正を完全解消。

🤖 Generated with [Claude Code](https://claude.com/claude-code)