### PR TITLE
fix(docs/launch): Lane 1 起動方式を Agent View に修正

### DIFF
--- a/docs/launch/lanes/lane1_chaos_test.md
+++ b/docs/launch/lanes/lane1_chaos_test.md
@@ -117,7 +117,7 @@ fi
 # 結果を docs/launch/chaos_test_results/2026-MM-DD_run_N.md に記録
 ```
 
-**3 日連続実行は cron 化せず、各日 22:00 に手動 (Lane で `claude --bg`) で kick**。理由: chaos test の最中に他 Lane が staging を触ると干渉する。
+**3 日連続実行は cron 化せず、各日 22:00 に手動で Agent View (`claude agents` 起動 → 該当 Lane 行を選択 → `/bg` で背景投入) で kick**。理由: chaos test の最中に他 Lane が staging を触ると干渉する。
 
 ### Step 4: pytest chaos suite (60 min)
 


### PR DESCRIPTION
## Summary

PR #325 レビュー指摘対応。**lane1_chaos_test.md L120 の 1 行のみ**修正。

## 変更内容

```diff
- **3 日連続実行は cron 化せず、各日 22:00 に手動 (Lane で `claude --bg`) で kick**。
+ **3 日連続実行は cron 化せず、各日 22:00 に手動で Agent View (`claude agents` 起動 → 該当 Lane 行を選択 → `/bg` で背景投入) で kick**。
```

## 修正範囲の確認結果

| ファイル | `claude --bg` 言及 | 修正 |
|---|---|---|
| lane1_chaos_test.md L120 | あり | ✅ 本 PR で修正 |
| lane2_approval_rate.md | 無し | — |
| lane3_sales_ops.md | 無し | — |
| lane4_mori_dm.md | 無し | — |

`grep -rn "claude --bg\|--bg" docs/launch/lanes/` で確認。lane2-4 には起動コマンドの直接記述がないため、本 PR は lane1 単独修正。

## CLAUDE.md 参照

`§「Claude Code Agent View 運用」` (2026-05-12 追加) に準拠:
- 起動: `claude agents` (新規) or ← (既存セッション内)
- 背景投入: 該当 Lane 行を選択 → `/bg` (既存) or `claude --bg "<prompt>"` (新規)
- Tier B 並列 (3-5 レーン) は Agent View に統一

## Tier

**B** (`docs/launch/lanes/` 配下、軽微 1 行修正)。auto-merge OK。

## Test plan

- [x] `claude --bg` の出現を全 Lane 指示書から grep で確認 (lane1 L120 のみ該当)
- [x] 修正後の文言で起動手順が再現可能か文字列確認
- [ ] merge 後の Lane 4 (森先生 DM、5/22 deadline) を Agent View 経由で起動して動作確認

## 関連

- PR #325 (merge 済) — 元 Lane 指示書
- PR #324 — roadmap_to_launch.md skeleton
- handoff: https://mooores.slack.com/archives/C0ACS09FMGC/p1779245661503999

🤖 Generated with [Claude Code](https://claude.com/claude-code)