### PR TITLE
fix(ai): prompt_version を ai_decisions DB に永続化

### DIFF
--- a/backend/app/ai/decisions_router.py
+++ b/backend/app/ai/decisions_router.py
@@ -112,6 +112,7 @@ def create_decision(
         secondary_confidence=request.secondary_confidence,
         agreed=request.agreed,
         rag_context_json=request.rag_context_json,
+        prompt_version=request.prompt_version,
     )
     db.add(decision)
     db.commit()

--- a/backend/app/ai/decisions_schemas.py
+++ b/backend/app/ai/decisions_schemas.py
@@ -22,6 +22,7 @@ class AIDecisionCreate(BaseModel):
     secondary_confidence: Optional[int] = None
     agreed: bool = False
     rag_context_json: Optional[Any] = None
+    prompt_version: Optional[str] = "v1"
 
 
 class AIDecisionResponse(BaseModel):
@@ -41,6 +42,7 @@ class AIDecisionResponse(BaseModel):
     secondary_confidence: Optional[int]
     agreed: bool
     rag_context_json: Optional[Any]
+    prompt_version: Optional[str]
     created_at: datetime
 
 

--- a/backend/app/ai/models.py
+++ b/backend/app/ai/models.py
@@ -30,6 +30,8 @@ class AIDecision(Base):
     secondary_confidence: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     agreed: Mapped[bool] = mapped_column(Boolean, default=False)
     rag_context_json: Mapped[Optional[Any]] = mapped_column(JSON, nullable=True)
+    # ALTER TABLE ai_decisions ADD COLUMN IF NOT EXISTS prompt_version VARCHAR(10) DEFAULT 'v1';
+    prompt_version: Mapped[Optional[str]] = mapped_column(String(10), nullable=True, default="v1")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),

--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -161,6 +161,7 @@ def save_ai_decision(
         secondary_confidence=result.secondary.confidence if result.secondary else None,
         agreed=result.agreed,
         rag_context_json=rag_context.model_dump() if rag_context else None,
+        prompt_version=result.primary.prompt_version,
     )
     db.add(decision)
     db.flush()  # id を確定させる


### PR DESCRIPTION
AI 判定時の prompt_version (v1/v2/v3/v4) が Pydantic schema にのみ存在し SQLAlchemy model および INSERT 時に欠落していたため DB に記録されていなかった。 v4 本番反映後の効果測定のために必要。

変更内容:
- models.py: prompt_version カラム追加 (VARCHAR(10), nullable, default='v1') ALTER TABLE: `ADD COLUMN IF NOT EXISTS prompt_version VARCHAR(10) DEFAULT 'v1'`
- decisions_schemas.py: AIDecisionCreate + AIDecisionResponse に prompt_version フィールド追加
- ai_judgment_scheduler.py: AIDecision(...) 生成時に prompt_version=result.primary.prompt_version 追加
- decisions_router.py: AIDecision(...) 生成時に prompt_version=request.prompt_version 追加

# 🔀 Pull Request Template

## 📝 このPRの目的
（何を実装 / 修正したかを明確に説明）

---

## 🔧 変更内容（概要）
- （主要な変更点を箇条書き）
- 
---

## 📁 変更したファイル
（例）
- backend/app/ai/analyzer.py
- docs/05_ai_judgement_rules.md

---

## 🧪 動作確認
- [ ] ローカルテスト済み
- [ ] フェーズ要件に沿っている
- [ ] .mdとコードの整合性チェック済み
- [ ] 破壊的変更なし

---

## 📘 関連Issue
例：Closes #23

---

## 📚 ドキュメント更新
- [ ] docs/*.md 更新済み  
- [ ] 変更内容が仕様書と一致している

---

## ⚠ 注意事項
- 要件変更が含まれていないこと
- フェーズ範囲外の作業をしていないこと
- 仕様書（.md）が最新と一致していること

---

## チェーン設定関連 (チェーン関連の PR のみ)

本 PR は **チェーン (mainnet/testnet) の切替** または **chain ID 設定** を含みますか?

- [ ] いいえ (チェーン設定の変更なし)
- [ ] はい — 以下のチェックを実施

チェーン関連 PR の場合は以下を確認:
- [ ] `grep -rn "Sepolia" frontend/` の出力をすべて確認・修正済み
- [ ] `.env.production` の `NEXT_PUBLIC_*` チェーン設定を本番値に更新済み
- [ ] `frontend/components/PrivyProvider.tsx` の chain config 確認済み
- [ ] post-deploy `curl <production URL> | grep -i "sepolia"` で出力ゼロ確認済み
- [ ] ブラウザで実機ランディング目視確認済み (スクリーンショット添付)

参照:
- docs/43_mainnet_wallet_switch_guide.md §2.5 (frontend 表示テキスト確認)
- 2026-05-02 インシデント: Asana GID 1214462619161978
