### PR TITLE
fix(ai): ai_decisions に prompt_version カラム追加 (v3/v4 切替の監査性確保)

### DIFF
--- a/backend/app/ai/decisions_router.py
+++ b/backend/app/ai/decisions_router.py
@@ -112,6 +112,7 @@ def create_decision(
         secondary_confidence=request.secondary_confidence,
         agreed=request.agreed,
         rag_context_json=request.rag_context_json,
+        prompt_version=request.prompt_version,
     )
     db.add(decision)
     db.commit()

--- a/backend/app/ai/decisions_schemas.py
+++ b/backend/app/ai/decisions_schemas.py
@@ -22,6 +22,7 @@ class AIDecisionCreate(BaseModel):
     secondary_confidence: Optional[int] = None
     agreed: bool = False
     rag_context_json: Optional[Any] = None
+    prompt_version: Optional[str] = "v1"
 
 
 class AIDecisionResponse(BaseModel):
@@ -41,6 +42,7 @@ class AIDecisionResponse(BaseModel):
     secondary_confidence: Optional[int]
     agreed: bool
     rag_context_json: Optional[Any]
+    prompt_version: Optional[str]
     created_at: datetime
 
 

--- a/backend/app/ai/models.py
+++ b/backend/app/ai/models.py
@@ -30,6 +30,8 @@ class AIDecision(Base):
     secondary_confidence: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     agreed: Mapped[bool] = mapped_column(Boolean, default=False)
     rag_context_json: Mapped[Optional[Any]] = mapped_column(JSON, nullable=True)
+    # ALTER TABLE ai_decisions ADD COLUMN IF NOT EXISTS prompt_version VARCHAR(10) DEFAULT 'v1';
+    prompt_version: Mapped[Optional[str]] = mapped_column(String(10), nullable=True, default="v1")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),

--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -161,6 +161,7 @@ def save_ai_decision(
         secondary_confidence=result.secondary.confidence if result.secondary else None,
         agreed=result.agreed,
         rag_context_json=rag_context.model_dump() if rag_context else None,
+        prompt_version=result.primary.prompt_version,
     )
     db.add(decision)
     db.flush()  # id を確定させる


### PR DESCRIPTION
## 概要

ai_decisions テーブルに prompt_version VARCHAR(10) DEFAULT 'v1' カラムを追加。v3/v4 prompt 切替の監査性確保。

## 変更内容
- backend/app/ai/models.py: prompt_version カラム追加
- backend/app/automation/ai_judgment_scheduler.py: prompt_version 記録
- backend/app/ai/router.py: prompt_version 返却

## DB migration
- 本番 ALTER TABLE 完了済
- staging ALTER TABLE 実行待ち (staging stack 復旧後)

## テスト
- ruff / mypy / pytest 739 passed

## Tier S 判定
- DB schema 変更 (migration あり)
- 本番反映後 v4 監査 SQL の前提