### PR TITLE
fix(db): user_settings テーブル CREATE TABLE 追加 (main.py import 欠落修正)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -78,6 +78,9 @@ from app.reports.router import router as reports_router
 from app.rss.router import router as rss_router
 from app.transactions.router import admin_router as admin_transactions_router
 from app.transactions.router import router as transactions_router
+from app.users.models import (
+    UserSettings,  # noqa: F401 — ensure table registered with Base.metadata
+)
 from app.users.router import router as users_router
 from app.users.settings_router import router as user_settings_router
 from app.webhook.router import router as webhook_router

--- a/backend/app/users/models.py
+++ b/backend/app/users/models.py
@@ -1,6 +1,28 @@
 # Copyright (c) Ultra AutoTrade. All rights reserved.
 # backend/app/users/models.py
-"""ユーザー設定モデル定義。"""
+"""ユーザー設定モデル定義。
+
+本モジュールは main.py から `from app.users.models import UserSettings  # noqa: F401`
+でインポートされ、Base.metadata.create_all() 時にテーブルが自動作成される。
+Alembic 不使用プロジェクトのため、下記 SQL は手動実行が必要なバックアップとして保持する。
+
+手動 CREATE TABLE SQL (新規環境・DB 再構築時):
+    CREATE TABLE IF NOT EXISTS user_settings (
+        id              SERIAL PRIMARY KEY,
+        user_id         INTEGER NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+        notification_email      VARCHAR(255),
+        notification_frequency  VARCHAR(20)  NOT NULL DEFAULT 'important',
+        max_single_trade_usd    NUMERIC(20,2),
+        max_daily_trade_usd     NUMERIC(20,2),
+        risk_mode       VARCHAR(20)  NOT NULL DEFAULT 'conservative',
+        dark_mode       BOOLEAN      NOT NULL DEFAULT TRUE,
+        language        VARCHAR(10)  NOT NULL DEFAULT 'ja',
+        two_factor_enabled BOOLEAN  NOT NULL DEFAULT FALSE,
+        created_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+        updated_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+    );
+    CREATE INDEX IF NOT EXISTS ix_user_settings_user_id ON user_settings (user_id);
+"""
 
 from datetime import datetime, timezone
 from decimal import Decimal

--- a/docs/internal/pr_323_review_20260521.md
+++ b/docs/internal/pr_323_review_20260521.md
@@ -1,0 +1,159 @@
+# PR #323 事前設計レビュー — ai_judgment_scheduler 動的 proposal 金額化
+
+> 作成: 2026-05-20 night-mode / Asana GID: 1214961595649705
+> ブランチ: `feat/dynamic-proposal-amount-p0x1`
+> レビュー対象: backend/app/automation/ai_judgment_scheduler.py (+ 2テストファイル)
+> 実装担当: 明朝 小林さんレビュー後 merge 判断
+
+---
+
+## 変更サマリー
+
+### 削除
+
+```python
+# 固定値 (硬直的だった)
+_PROPOSAL_AMOUNT = Decimal("1000")
+_PROPOSAL_AMOUNT_USD = Decimal("1000.00")
+```
+
+### 追加
+
+```python
+# 環境変数で上書き可能な動的パラメータ
+_PROPOSAL_RATIO = Decimal(os.getenv("PROPOSAL_AMOUNT_RATIO", "0.10"))   # 10%
+_PROPOSAL_AMOUNT_MIN_USD = Decimal(os.getenv("PROPOSAL_AMOUNT_MIN_USD", "50"))
+_PROPOSAL_AMOUNT_MAX_USD = Decimal(os.getenv("PROPOSAL_AMOUNT_MAX_USD", "2000"))
+
+def _resolve_proposal_amount(db: Session, user_id: int) -> Decimal:
+    """fund_allocations 合計 × RATIO。active なし → Decimal("0") → skip。"""
+    ...
+```
+
+### 変更ファイル数
+
+| ファイル | 変更行数 | 種別 |
+|---|---|---|
+| `backend/app/automation/ai_judgment_scheduler.py` | +78 / -7 | Tier S |
+| `backend/tests/automation/test_proposals_notification.py` | +60 / -3 | Tier B |
+| `backend/tests/test_ai_judgment_scheduler.py` | +40 / -3 | Tier B |
+
+---
+
+## 動的計算 logic 正当性チェック
+
+### ロジック
+
+```
+提案金額 = clamp(
+    allocated_amount_usd × 10%,
+    min=$50,
+    max=$2,000
+)
+```
+
+### 山本さん (user_id=11) 実証
+
+- fund_allocations: $4,600 (active, tester_user_id=11)
+- 計算: $4,600 × 10% = $460
+- actual proposal #11 (created 2026-05-20 17:26): amount_usd = $460 ✅
+
+### エッジケース処理
+
+| ケース | 挙動 | 評価 |
+|---|---|---|
+| active な fund_allocations なし | Decimal("0") → proposal skip | ✅ 安全側 |
+| allocated × 10% < $50 | $50 にクランプ | ✅ |
+| allocated × 10% > $2,000 | $2,000 にクランプ | ✅ |
+| DB クエリ例外 | 例外が上位に伝播 (未 try/except) | ⚠️ 要確認 (下記) |
+
+### ⚠️ 懸念: `_resolve_proposal_amount` の例外伝播
+
+`_resolve_proposal_amount()` 内に try/except がないため、DBクエリ失敗時は
+呼び出し元 `_create_proposals_for_users()` まで例外が伝播する。
+`_create_proposals_for_users()` でのハンドリング状況を要確認。
+
+```bash
+# 確認コマンド
+grep -A 20 "def _create_proposals_for_users" backend/app/automation/ai_judgment_scheduler.py
+```
+
+---
+
+## テストカバレッジ評価
+
+### 追加テスト
+
+`test_ai_judgment_scheduler.py` に `_add_fund_allocation()` ヘルパーが追加され、
+`test_run_job_buy_creates_proposals` / `test_run_job_sell_creates_withdraw_proposals`
+が動的金額で動くことを確認。
+
+```python
+# _add_fund_allocation() のデフォルト想定
+# allocated_amount_usd = $10,000 → $10,000 × 10% = $1,000
+# テストの assert: p.amount == Decimal("1000") ← 整合している
+```
+
+### カバレッジが薄い箇所
+
+| ケース | テストあり | 優先度 |
+|---|---|---|
+| active allocations なし → skip | ✅ (notifications テスト) | ✅ |
+| 複数 active allocations の合計 | ❓ | P2 |
+| min/max クランプ境界値 | ❓ | P1 |
+| DB クエリ例外時の挙動 | ❌ | P1 (上記懸念に対応) |
+
+---
+
+## 本番との整合性確認 (2026-05-20 実機確認済み)
+
+```sql
+-- fund_allocations 実スキーマ (本番 DB 確認)
+-- カラム: id, partner_id, tester_name, allocated_amount_usd, status,
+--         allocated_at, withdrawn_at, notes, created_at, updated_at, tester_user_id
+-- ※ user_id カラムは存在しない。正しいカラム名は tester_user_id
+
+-- PR #323 のクエリ: FundAllocation.tester_user_id == user_id ✅ (正しい)
+```
+
+---
+
+## Gate 1-3 (verify.sh) 状態
+
+PR #323 ブランチでの verify.sh 実行状況は未確認。  
+朝レビュー前に以下を確認すること:
+
+```bash
+git checkout feat/dynamic-proposal-amount-p0x1
+cd backend && source .venv/bin/activate
+cd /opt/ultra-autotrade/main && ./scripts/verify.sh
+```
+
+---
+
+## 残作業リスト (朝レビュー前)
+
+| # | 内容 | 担当 | 期限 |
+|---|---|---|---|
+| 1 | `_create_proposals_for_users()` の例外ハンドリング確認 | 小林さん / Lane | 朝レビュー前 |
+| 2 | min/max クランプ境界値テスト追加 | Lane | 朝 |
+| 3 | verify.sh 全通過確認 | Lane | 朝 |
+| 4 | Gate 4: Playwright E2E (proposal 作成フロー) | 朝 | staging で確認 |
+
+---
+
+## 推奨: 5/21 前倒しシナリオ
+
+| 条件 | アクション |
+|---|---|
+| verify.sh 全通過 + 例外ハンドリング OK | 朝一で merge → production deploy (小林さん専権) |
+| 例外ハンドリング修正が必要 | Lane で修正 → verify.sh 再実行 → merge |
+| Gate 4 (E2E) に時間がかかる | merge 後 staging E2E を別 Lane で並行実施 |
+
+---
+
+## 参照
+
+- Asana GID: 1214961595649705 (ai_judgment_scheduler 動的化 PR 準備)
+- fund_allocations 実スキーマ: `docs/ops/02_db_tables.md` 要更新 (tester_user_id)
+- 実機検証: 2026-05-20 17:26 WITHDRAW proposals #10/#11 の調査で一致確認


### PR DESCRIPTION
## 問題

`backend/app/users/models.py` に `UserSettings` クラス (`__tablename__ = "user_settings"`) が
定義されていたが、`main.py` にインポートされていなかったため `Base.metadata.create_all()` が
テーブルを作成しなかった。本番 DB に `user_settings` テーブルが存在せず起動時警告が発生。

## 真因

Alembic は使用しないプロジェクト（`migrations/versions/` 不在）。テーブルは `create_all()` で
自動生成される設計だが、`UserSettings` が `Base.metadata` に登録されていなかった。

## 修正内容

1. `backend/app/main.py`: `NotificationLog` と同様のパターンで `# noqa: F401` import 追加
2. `backend/app/users/models.py`: 手動 CREATE TABLE SQL をコメントとして追記（バックアップ用）
3. `docs/internal/pr_323_review_20260521.md`: PR #323 朝レビュー用設計書を合わせてコミット

## 本番への適用手順

次回 `deploy_production.sh` 実行時に `init_db()` → `create_all()` が自動でテーブルを作成する。
手動実行は不要（緊急時は `models.py` コメント内の SQL を直接実行可能）。

## Test plan

- [x] `ruff check` / `ruff format --check` 通過
- [x] `mypy backend/app/users/models.py` 通過
- [x] `python -c "from app.users.models import UserSettings"` 動作確認
- [ ] 本番 deploy 後に `\dt user_settings` で存在確認（小林さん専権）

🤖 Generated with [Claude Code](https://claude.com/claude-code)