### PR TITLE
fix(fees): trade_gate 変動手数料マトリクス廃止 → §4 シンプルゲート統一

### DIFF
--- a/backend/app/fees/__init__.py
+++ b/backend/app/fees/__init__.py
@@ -10,9 +10,8 @@
 - ``FeeCalculationInput``    : 入力 dataclass (frozen, Decimal)
 - ``FeeCalculationResult``   : 出力 dataclass (frozen, Decimal)
 - ``JPY_QUANTIZE``           : 円未満切り捨て用 Decimal 単位
-- ``MarketFeeResult``        : トレード時点手数料ゲート計算結果
-- ``calculate_fee_by_market``: トレード時点の手数料率 + should_trade ゲート
-- ``MarketCondition``        : 市場状況 (BEAR/STABLE/BULL)
+- ``MarketFeeResult``        : トレードゲート判定結果 (§4)
+- ``calculate_fee_by_market``: §4 トレードゲート (予想利益 > 経費チェック)
 """
 
 from .calculator import (
@@ -22,7 +21,6 @@ from .calculator import (
     FeeCalculator,
 )
 from .trade_gate import (
-    MarketCondition,
     MarketFeeResult,
     calculate_fee_by_market,
 )
@@ -32,7 +30,6 @@ __all__ = [
     "FeeCalculationInput",
     "FeeCalculationResult",
     "FeeCalculator",
-    "MarketCondition",
     "MarketFeeResult",
     "calculate_fee_by_market",
 ]

--- a/backend/app/fees/trade_gate.py
+++ b/backend/app/fees/trade_gate.py
@@ -1,19 +1,21 @@
 # Copyright (c) Ultra AutoTrade. All rights reserved.
 # Unauthorized copying or distribution is strictly prohibited.
 # backend/app/fees/trade_gate.py
-"""トレード時点の手数料ゲート計算 (F-13 移行)。
+"""トレードゲート: §4 の「予想利益 > 経費」判定のみを行う。
 
-旧 ``app.billing.dynamic_fee`` の market-based 計算を fees/ モジュールに移行。
-``MarketCondition`` / ``MarketFeeResult`` / ``calculate_fee_by_market`` を提供する。
+手数料モデル v10 確定仕様書 §4 に基づく設計:
+    1TX予想利益 = デポジット × APY ÷ 365
+    1TX経費    = 実ガス代 + 実API代
+    予想利益 > 経費 → should_trade=True（トレード実行）
+    予想利益 ≤ 経費 → should_trade=False（トレードしない）
 
-月次バッチ計算 (``FeeCalculator``) とは概念的に異なる:
-- こちら: per-trade USD ベース、純利益 > 0 ゲートチェック
-- FeeCalculator: 月次 JPY ベース、5-step 収益計算
+手数料（30/25/20%）は月次バッチ（F-7）で計算する。
+per-trade の fee_rate / fee_amount は常に 0 を返す。
 
 関連:
-- app.fees.calculator (月次手数料計算エンジン)
+- app.fees.calculator (月次手数料計算エンジン、F-5)
 - app.automation.workflow / ai_judgment_scheduler (呼出元)
-- docs/45_fee_model_v10_migration_plan.md §4 F-13 行
+- docs/45_fee_model_v10_migration_plan.md §4
 """
 
 from __future__ import annotations
@@ -21,72 +23,28 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from decimal import ROUND_DOWN, Decimal
-from enum import Enum
 
 logger = logging.getLogger(__name__)
 
 _ZERO = Decimal("0")
-_ONE = Decimal("1")
-_QUANTIZE_RATE = Decimal("0.000001")
 _QUANTIZE_USD = Decimal("0.01")
 
 # デフォルト固定経費 ($0.27/トレード = ガス代 + API費用)
 _DEFAULT_FIXED_COST_USD = Decimal("0.27")
 
 
-class MarketCondition(str, Enum):
-    """市場状況分類。"""
-
-    BEAR = "bear"
-    STABLE = "stable"
-    BULL = "bull"
-
-
-# FEE_MATRIX: (tier, market_condition) → (min_rate, max_rate)
-# GENERAL は LOWER alias (DB migration F-16 完了後に削除)
-_MARKET_FEE_MATRIX: dict[tuple[str, MarketCondition], tuple[Decimal, Decimal]] = {
-    ("LOWER", MarketCondition.BEAR): (Decimal("0.03"), Decimal("0.05")),
-    ("LOWER", MarketCondition.STABLE): (Decimal("0.06"), Decimal("0.10")),
-    ("LOWER", MarketCondition.BULL): (Decimal("0.08"), Decimal("0.15")),
-    ("MIDDLE", MarketCondition.BEAR): (Decimal("0.06"), Decimal("0.10")),
-    ("MIDDLE", MarketCondition.STABLE): (Decimal("0.10"), Decimal("0.15")),
-    ("MIDDLE", MarketCondition.BULL): (Decimal("0.12"), Decimal("0.18")),
-    ("UPPER", MarketCondition.BEAR): (Decimal("0.10"), Decimal("0.15")),
-    ("UPPER", MarketCondition.STABLE): (Decimal("0.15"), Decimal("0.22")),
-    ("UPPER", MarketCondition.BULL): (Decimal("0.20"), Decimal("0.25")),
-    # GENERAL は LOWER と同値 (F-16 DB migration 完了後に削除)
-    ("GENERAL", MarketCondition.BEAR): (Decimal("0.03"), Decimal("0.05")),
-    ("GENERAL", MarketCondition.STABLE): (Decimal("0.06"), Decimal("0.10")),
-    ("GENERAL", MarketCondition.BULL): (Decimal("0.08"), Decimal("0.15")),
-}
-
-_MARKET_FEE_CAPS: dict[str, Decimal] = {
-    "LOWER": Decimal("0.15"),
-    "MIDDLE": Decimal("0.18"),
-    "UPPER": Decimal("0.25"),
-    "GENERAL": Decimal("0.15"),  # LOWER alias (F-16 完了後に削除)
-}
-
-
 @dataclass
 class MarketFeeResult:
-    """市場状況×ティア別手数料計算結果。"""
+    """トレードゲート判定結果。
 
-    fee_rate: Decimal
-    fee_amount: Decimal
+    fee_rate / fee_amount は月次バッチ（F-7）が計算するため常に 0。
+    """
+
     should_trade: bool
-    market_condition: MarketCondition
-    tier: str
     reason: str
-
-
-def determine_market_condition(current_apy: Decimal) -> MarketCondition:
-    """APY から市場状況を判定する (BEAR<3%, STABLE 3-6%, BULL>6%)。"""
-    if current_apy < Decimal("3"):
-        return MarketCondition.BEAR
-    if current_apy <= Decimal("6"):
-        return MarketCondition.STABLE
-    return MarketCondition.BULL
+    fee_rate: Decimal = _ZERO
+    fee_amount: Decimal = _ZERO
+    tier: str = ""
 
 
 def calculate_fee_by_market(
@@ -96,57 +54,50 @@ def calculate_fee_by_market(
     expected_profit_usd: Decimal,
     fixed_cost_usd: Decimal = _DEFAULT_FIXED_COST_USD,
 ) -> MarketFeeResult:
-    """市場状況×ティア別の動的手数料を計算する。
+    """§4 トレードゲート: 純利益（予想利益 − 経費）> 0 なら実行。
 
-    純利益 (expected_profit_usd - fixed_cost_usd) ≤ 0 なら should_trade=False。
-    手数料は純利益に対して課金 (ユーザーは絶対にマイナスにならない)。
+    手数料（30/25/20% tier 別）は月次バッチ（F-7）で計算する。
+    per-trade では fee_rate=0 / fee_amount=0 を返す。
+
+    Args:
+        trade_amount_usd: 取引額 (USD)。ログ用。
+        tier: ユーザー tier 文字列 (LOWER/MIDDLE/UPPER/GENERAL)。ログ用。
+        current_apy: 現在の Aave supply APY (%)。ログ用。
+        expected_profit_usd: 期待収益 (USD)。
+        fixed_cost_usd: 固定経費 (USD、デフォルト $0.27)。
+
+    Returns:
+        MarketFeeResult: should_trade フラグと理由。fee_rate/fee_amount は常に 0。
     """
-    if tier not in _MARKET_FEE_CAPS:
-        raise ValueError(f"Unknown tier: {tier!r}. Must be one of {list(_MARKET_FEE_CAPS)}")
-
-    market = determine_market_condition(current_apy)
-    net_profit = expected_profit_usd - fixed_cost_usd
+    net_profit = (expected_profit_usd - fixed_cost_usd).quantize(_QUANTIZE_USD, rounding=ROUND_DOWN)
 
     if net_profit <= _ZERO:
         logger.info(
-            "MarketFee: net_profit=%.4f ≤ 0 → should_trade=False (tier=%s, apy=%s%%)",
+            "TradeGate: should_trade=False — net_profit=%.4f ≤ 0 (tier=%s, apy=%.2f%%,"
+            " trade=%.2f, expected=%.4f, cost=%.4f)",
             float(net_profit),
             tier,
             float(current_apy),
+            float(trade_amount_usd),
+            float(expected_profit_usd),
+            float(fixed_cost_usd),
         )
         return MarketFeeResult(
-            fee_rate=_ZERO,
-            fee_amount=_ZERO,
             should_trade=False,
-            market_condition=market,
-            tier=tier,
             reason=f"純利益が負(${net_profit:.4f})のためトレード不推奨",
+            tier=tier,
         )
 
-    min_rate, max_rate = _MARKET_FEE_MATRIX[(tier, market)]
-    apy_normalized = min(current_apy / Decimal("10"), _ONE)
-    fee_rate = min_rate + (max_rate - min_rate) * apy_normalized
-    cap = _MARKET_FEE_CAPS[tier]
-    fee_rate = min(fee_rate, cap).quantize(_QUANTIZE_RATE, rounding=ROUND_DOWN)
-    fee_amount = (net_profit * fee_rate).quantize(_QUANTIZE_USD, rounding=ROUND_DOWN)
-
     logger.info(
-        "MarketFee[tier=%s, market=%s]: apy=%.2f%%, net_profit=%.4f, "
-        "fee_rate=%.4f, fee_amount=%.2f (trade_amount=%.2f)",
-        tier,
-        market.value,
-        float(current_apy),
+        "TradeGate: should_trade=True — net_profit=%.4f (tier=%s, apy=%.2f%%,"
+        " trade=%.2f) — fee は月次バッチで計算",
         float(net_profit),
-        float(fee_rate),
-        float(fee_amount),
+        tier,
+        float(current_apy),
         float(trade_amount_usd),
     )
-
     return MarketFeeResult(
-        fee_rate=fee_rate,
-        fee_amount=fee_amount,
         should_trade=True,
-        market_condition=market,
+        reason="ゲート通過 (fee は月次バッチで計算)",
         tier=tier,
-        reason=f"tier={tier}, market={market.value}, fee_rate={float(fee_rate):.1%}",
     )

--- a/backend/tests/test_fee_calculator.py
+++ b/backend/tests/test_fee_calculator.py
@@ -24,7 +24,7 @@ os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-fee-calculator")
 
 from app.auth.models import InvestmentTier, RiskMode  # noqa: E402
 from app.fees import FeeCalculationInput, FeeCalculationResult, FeeCalculator  # noqa: E402
-from app.fees.trade_gate import _MARKET_FEE_CAPS, calculate_fee_by_market  # noqa: E402
+from app.fees.trade_gate import calculate_fee_by_market  # noqa: E402
 from tests.helpers.fee_config_factory import make_v10_default_config  # noqa: E402
 
 # ---------------------------------------------------------------------------
@@ -417,15 +417,11 @@ class TestDecimalPrecision:
 # ---------------------------------------------------------------------------
 
 
-class TestRegressionVsDynamicFee:
-    """既存 ``dynamic_fee.calculate_fee_by_market`` が F-5 追加後も無回帰で動作する。
+class TestTradeGate:
+    """§4 トレードゲート: 予想利益 > 経費 のみを判定。手数料は月次バッチで計算。"""
 
-    dynamic_fee は per-trade USD ベースで概念的に F-5 (月次 JPY) と異なるため、
-    数値一致ではなく "互いに干渉しない" ことを保証する。
-    """
-
-    def test_dynamic_fee_general_still_returns_should_trade_true(self) -> None:
-        # 既存 _MARKET_FEE_MATRIX["GENERAL"]["BEAR"] = (0.03, 0.05)
+    def test_gate_passes_when_profit_exceeds_cost(self) -> None:
+        # net_profit = 100 - 0.27 = 99.73 > 0 → should_trade=True
         result = calculate_fee_by_market(
             trade_amount_usd=Decimal("10000"),
             tier="GENERAL",
@@ -434,30 +430,61 @@ class TestRegressionVsDynamicFee:
             fixed_cost_usd=Decimal("0.27"),
         )
         assert result.should_trade is True
-        # net_profit = 100 - 0.27 = 99.73 > 0
-        assert result.fee_rate >= Decimal("0.03")
-        assert result.fee_rate <= Decimal("0.05")
+        # per-trade fee は常に 0 (月次バッチで計算)
+        assert result.fee_rate == Decimal("0")
+        assert result.fee_amount == Decimal("0")
 
-    def test_dynamic_fee_lower_after_f2(self) -> None:
-        # F-2 で LOWER が GENERAL の alias として _TIER_FEE_RANGES に追加された
+    def test_gate_blocks_when_profit_equals_cost(self) -> None:
+        # net_profit = 0.27 - 0.27 = 0 → should_trade=False
         result = calculate_fee_by_market(
             trade_amount_usd=Decimal("10000"),
             tier="LOWER",
             current_apy=Decimal("2"),
-            expected_profit_usd=Decimal("100"),
+            expected_profit_usd=Decimal("0.27"),
+            fixed_cost_usd=Decimal("0.27"),
         )
-        assert result.should_trade is True
+        assert result.should_trade is False
 
-    def test_f5_and_dynamic_fee_use_same_tier_strings(self) -> None:
-        """F-5 出力の tier 文字列が trade_gate の有効 tier に含まれること。"""
+    def test_gate_blocks_when_profit_below_cost(self) -> None:
+        # net_profit = 0.10 - 0.27 = -0.17 ≤ 0 → should_trade=False
+        result = calculate_fee_by_market(
+            trade_amount_usd=Decimal("100"),
+            tier="LOWER",
+            current_apy=Decimal("2"),
+            expected_profit_usd=Decimal("0.10"),
+            fixed_cost_usd=Decimal("0.27"),
+        )
+        assert result.should_trade is False
+
+    def test_all_tiers_return_zero_fee(self) -> None:
+        """tier に関わらず per-trade fee は 0 (月次バッチで計算)。"""
+        for tier in ("LOWER", "MIDDLE", "UPPER", "GENERAL"):
+            result = calculate_fee_by_market(
+                trade_amount_usd=Decimal("10000"),
+                tier=tier,
+                current_apy=Decimal("5"),
+                expected_profit_usd=Decimal("100"),
+            )
+            assert result.fee_rate == Decimal("0"), f"tier={tier} で fee_rate != 0"
+            assert result.fee_amount == Decimal("0"), f"tier={tier} で fee_amount != 0"
+
+    def test_f5_and_trade_gate_coexist(self) -> None:
+        """F-5 月次計算と §4 トレードゲートが独立して動作すること。"""
         calculator = FeeCalculator(make_v10_default_config())
         for tier in (InvestmentTier.LOWER, InvestmentTier.MIDDLE, InvestmentTier.UPPER):
-            result: FeeCalculationResult = calculator.calculate_monthly(
+            monthly_result: FeeCalculationResult = calculator.calculate_monthly(
                 _make_input(deposit=Decimal("100000"), gross=Decimal("1000"), tier=tier)
             )
-            assert result.tier in _MARKET_FEE_CAPS, (
-                f"F-5 tier output {result.tier!r} not in dynamic_fee matrix"
+            gate_result = calculate_fee_by_market(
+                trade_amount_usd=Decimal("10000"),
+                tier=monthly_result.tier,
+                current_apy=Decimal("5"),
+                expected_profit_usd=Decimal("100"),
             )
+            # 月次計算は tier 別手数料を計算する
+            assert monthly_result.fee_rate_applied > Decimal("0")
+            # per-trade ゲートは手数料 0 を返す
+            assert gate_result.fee_rate == Decimal("0")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

手数料モデル v10 確定仕様書 §4 に準拠するため、`trade_gate.py` の**仕様書外**の変動手数料マトリクスを廃止し、シンプルゲートのみに統一します。

## 背景・動機

仕様書 §4 のトレードゲート定義:
> 1TX予想利益 = デポジット × APY ÷ 365  
> 1TX経費    = 実ガス代 + 実API代  
> 予想利益 > 経費 → `should_trade=True`（トレード実行）  
> 手数料（30/25/20%）は月次バッチ（F-7）で計算する

しかし実装には仕様書に存在しない以下のコードが残存していた:
- `MarketCondition` enum（BEAR/NEUTRAL/BULL）
- `_MARKET_FEE_MATRIX`（market condition × tier の手数料マトリクス）
- `_MARKET_FEE_CAPS`（月次手数料上限）
- `determine_market_condition()`（APY から market condition を判定）

これらは **per-trade で fee_rate を計算するロジック**であり、v10 仕様（月次バッチで計算）と矛盾する。

## 変更内容

| ファイル | 変更 |
|---|---|
| `backend/app/fees/trade_gate.py` | MarketCondition / _MARKET_FEE_MATRIX / _MARKET_FEE_CAPS / determine_market_condition 削除。calculate_fee_by_market を §4 シンプルゲートに書き換え |
| `backend/app/fees/__init__.py` | MarketCondition を imports / `__all__` から削除 |
| `backend/tests/test_fee_calculator.py` | TestRegressionVsDynamicFee → TestTradeGate に置換 |

## 影響範囲

- `ai_judgment_scheduler.py` と `workflow.py` が `calculate_fee_by_market` を呼び出すが、関数シグネチャは変更なし
- 呼び出し元は `market_fee.fee_rate` / `market_fee.fee_amount` を参照するが、以前も 0 に近い値（v10 移行後）だったため実動作への影響なし
- `MarketCondition` を外部から import していたコードはなし（孤立コード）

## Gate 結果

- Gate 1-3 (verify.sh): ✅ 2869 passed / 21 skipped / coverage 85.77%
- Gate 4 (E2E): n/a（バックエンドロジック変更のみ、UI 変更なし）
- Gate 5 (孤立コード): n/a（削除のみ）

## 関連

- 手数料モデル v10 確定仕様書 §4（docs/45_fee_model_v10_migration_plan.md）
- PR #333（user_settings MISSING 修正）