### PR TITLE
feat(fees): F-7 月次手数料バッチ finalize_month 実装

### DIFF
--- a/backend/app/api/v1/fees.py
+++ b/backend/app/api/v1/fees.py
@@ -32,9 +32,8 @@
 from __future__ import annotations
 
 import logging
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from decimal import Decimal
-from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, Field
@@ -46,6 +45,7 @@ from app.auth.models import InvestmentTier, RiskMode, User
 from app.billing.v10_models import FeeConfigV10, FeeTransaction
 from app.database import get_db
 from app.fees import FeeCalculationInput, FeeCalculator
+from app.portfolio.models import PortfolioSnapshot
 
 logger = logging.getLogger(__name__)
 
@@ -176,6 +176,20 @@ class UataIncomeResponse(BaseModel):
     uata_income_total: str  # subscription + fee + yield_excess - affiliate
 
 
+class FinalizeMonthResponse(BaseModel):
+    """月次 finalize バッチの実行結果サマリ (F-7)。"""
+
+    calculation_month: date
+    usd_jpy_rate: str
+    dry_run: bool
+    users_processed: int
+    users_skipped_no_snapshot: int
+    users_skipped_already_finalized: int
+    total_fee_jpy: str
+    total_subscription_jpy: str
+    total_user_takehome_jpy: str
+
+
 # ===========================================================================
 # Helpers
 # ===========================================================================
@@ -203,6 +217,174 @@ def _decimal_str(value: Decimal | int | float | None) -> str:
     if value is None:
         return "0"
     return str(value if isinstance(value, Decimal) else Decimal(str(value)))
+
+
+def _next_month_start(d: date) -> date:
+    if d.month == 12:
+        return date(d.year + 1, 1, 1)
+    return date(d.year, d.month + 1, 1)
+
+
+def finalize_month_core(
+    db: Session,
+    config: FeeConfigV10,
+    month_start: date,
+    usd_jpy_rate: Decimal,
+    *,
+    dry_run: bool = False,
+) -> FinalizeMonthResponse:
+    """月次手数料バッチのコアロジック (API endpoint / 定期実行タスク 共通)。
+
+    各ユーザーの portfolio_snapshots から月次損益を算出し、
+    FeeCalculator で手数料を計算して fee_transactions に書き込む。
+    dry_run=True の場合は計算のみ行い DB 書込はしない。
+    expense_jpy は F-9 で実費マークアップを実装するまで 0 とする。
+    """
+    next_month = _next_month_start(month_start)
+    dt_from = datetime(month_start.year, month_start.month, 1, tzinfo=timezone.utc)
+    dt_to = datetime(next_month.year, next_month.month, 1, tzinfo=timezone.utc)
+
+    calculator = FeeCalculator(config)
+    active_users = db.execute(select(User).where(User.is_active.is_(True))).scalars().all()
+
+    processed = 0
+    skipped_no_snapshot = 0
+    skipped_finalized = 0
+    total_fee = Decimal("0")
+    total_sub = Decimal("0")
+    total_takehome = Decimal("0")
+
+    for user in active_users:
+        first_snap = db.scalar(
+            select(PortfolioSnapshot)
+            .where(PortfolioSnapshot.user_id == user.id)
+            .where(PortfolioSnapshot.recorded_at >= dt_from)
+            .where(PortfolioSnapshot.recorded_at < dt_to)
+            .order_by(PortfolioSnapshot.recorded_at.asc())
+            .limit(1)
+        )
+        if first_snap is None:
+            skipped_no_snapshot += 1
+            continue
+
+        last_snap = db.scalar(
+            select(PortfolioSnapshot)
+            .where(PortfolioSnapshot.user_id == user.id)
+            .where(PortfolioSnapshot.recorded_at >= dt_from)
+            .where(PortfolioSnapshot.recorded_at < dt_to)
+            .order_by(PortfolioSnapshot.recorded_at.desc())
+            .limit(1)
+        )
+        assert last_snap is not None  # noqa: S101
+
+        existing = db.scalar(
+            select(FeeTransaction)
+            .where(FeeTransaction.user_id == user.id)
+            .where(FeeTransaction.calculation_month == month_start)
+        )
+        if existing is not None and existing.finalized_at is not None:
+            skipped_finalized += 1
+            continue
+
+        deposit_jpy = (last_snap.total_supply_usd * usd_jpy_rate).quantize(Decimal("1"))
+        gross_profit_jpy = (
+            (last_snap.total_supply_usd - first_snap.total_supply_usd) * usd_jpy_rate
+        ).quantize(Decimal("1"))
+
+        user_tier = InvestmentTier(user.tier) if user.tier else InvestmentTier.LOWER
+        user_risk_mode = RiskMode(user.risk_mode) if user.risk_mode else RiskMode.CONSERVATIVE
+
+        user_created_date = user.created_at.date() if user.created_at else None
+        is_first_month = (
+            user_created_date is not None and month_start <= user_created_date < next_month
+        )
+
+        payload = FeeCalculationInput(
+            user_id=user.id,
+            calculation_month=month_start,
+            deposit_jpy=deposit_jpy,
+            gross_profit_jpy=gross_profit_jpy,
+            expense_jpy=Decimal("0"),  # F-9 で実費マークアップ実装予定
+            user_tier=user_tier,
+            user_risk_mode=user_risk_mode,
+            affiliate_id=user.invited_by,
+            is_first_month=is_first_month,
+        )
+
+        result = calculator.calculate_monthly(payload)
+
+        if not dry_run:
+            if existing is None:
+                db.add(
+                    FeeTransaction(
+                        user_id=result.user_id,
+                        calculation_month=result.calculation_month,
+                        tier=result.tier,
+                        risk_mode=result.risk_mode,
+                        deposit_amount_jpy=result.deposit_jpy,
+                        gross_profit_jpy=result.gross_profit_jpy,
+                        expense_jpy=result.expense_jpy,
+                        net_profit_jpy=result.net_profit_jpy,
+                        fee_rate_applied=result.fee_rate_applied,
+                        fee_amount_jpy=result.fee_amount_jpy,
+                        subscription_rate_applied=result.subscription_rate_applied,
+                        subscription_amount_jpy=result.subscription_amount_jpy,
+                        subscription_protected=result.subscription_protected,
+                        monthly_yield_cap_applied=result.monthly_yield_cap_applied,
+                        yield_excess_to_uata_jpy=result.yield_excess_to_uata_jpy,
+                        user_takehome_jpy=result.user_takehome_jpy,
+                        affiliate_id=result.affiliate_id,
+                        affiliate_amount_jpy=result.affiliate_amount_jpy,
+                    )
+                )
+            else:
+                existing.tier = result.tier
+                existing.risk_mode = result.risk_mode
+                existing.deposit_amount_jpy = result.deposit_jpy
+                existing.gross_profit_jpy = result.gross_profit_jpy
+                existing.expense_jpy = result.expense_jpy
+                existing.net_profit_jpy = result.net_profit_jpy
+                existing.fee_rate_applied = result.fee_rate_applied
+                existing.fee_amount_jpy = result.fee_amount_jpy
+                existing.subscription_rate_applied = result.subscription_rate_applied
+                existing.subscription_amount_jpy = result.subscription_amount_jpy
+                existing.subscription_protected = result.subscription_protected
+                existing.monthly_yield_cap_applied = result.monthly_yield_cap_applied
+                existing.yield_excess_to_uata_jpy = result.yield_excess_to_uata_jpy
+                existing.user_takehome_jpy = result.user_takehome_jpy
+                existing.affiliate_id = result.affiliate_id
+                existing.affiliate_amount_jpy = result.affiliate_amount_jpy
+
+        total_fee += result.fee_amount_jpy
+        total_sub += result.subscription_amount_jpy
+        total_takehome += result.user_takehome_jpy
+        processed += 1
+
+    if not dry_run:
+        db.commit()
+
+    logger.info(
+        "finalize_month: month=%s processed=%d skipped_no_snap=%d skipped_finalized=%d"
+        " total_fee=%s dry_run=%s",
+        month_start,
+        processed,
+        skipped_no_snapshot,
+        skipped_finalized,
+        total_fee,
+        dry_run,
+    )
+
+    return FinalizeMonthResponse(
+        calculation_month=month_start,
+        usd_jpy_rate=str(usd_jpy_rate),
+        dry_run=dry_run,
+        users_processed=processed,
+        users_skipped_no_snapshot=skipped_no_snapshot,
+        users_skipped_already_finalized=skipped_finalized,
+        total_fee_jpy=str(total_fee),
+        total_subscription_jpy=str(total_sub),
+        total_user_takehome_jpy=str(total_takehome),
+    )
 
 
 # ===========================================================================
@@ -400,19 +582,32 @@ def list_all_users_fees(
 
 @router.post(
     "/finalize-month",
-    summary="月次 finalize (F-7 で本実装、現状スケルトン)",
+    response_model=FinalizeMonthResponse,
+    summary="月次 finalize バッチ実行 (F-7 / Asana 1214120401388139)",
     dependencies=[Depends(require_admin)],
 )
-def finalize_month(month: date) -> dict[str, Any]:
-    """F-7 (1214120401388139) で本実装予定。本タスクでは 501 を返すスケルトン。"""
-    raise HTTPException(
-        status_code=status.HTTP_501_NOT_IMPLEMENTED,
-        detail=(
-            "Not yet implemented. Will be implemented in F-7 "
-            "(Asana 1214120401388139). Requested month: "
-            f"{month.isoformat()}"
-        ),
-    )
+def finalize_month(
+    month: date,
+    usd_jpy_rate: Decimal = Query(
+        default=Decimal("150"),
+        gt=0,
+        description="USD/JPY 換算レート (デフォルト 150)",
+    ),
+    dry_run: bool = Query(
+        default=False,
+        description="True の場合は計算のみ行い DB 書込をしない",
+    ),
+    db: Session = Depends(get_db),
+    config: FeeConfigV10 = Depends(_get_active_fee_config),
+) -> FinalizeMonthResponse:
+    """各ユーザーの portfolio_snapshots から月次損益を算出し fee_transactions に書き込む。
+
+    - month: 対象月の月初日 (例: 2026-05-01)
+    - usd_jpy_rate: 計算に使う USD/JPY レート (省略時 150)
+    - dry_run: True の場合は DB 書込なしで結果のみ返す
+    - expense_jpy は F-9 実装まで 0 として計算する
+    """
+    return finalize_month_core(db, config, month.replace(day=1), usd_jpy_rate, dry_run=dry_run)
 
 
 @router.get(

--- a/backend/app/automation/scheduled_tasks.py
+++ b/backend/app/automation/scheduled_tasks.py
@@ -20,7 +20,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, time, timedelta
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
 from typing import Callable, Optional
 from zoneinfo import ZoneInfo
 
@@ -37,6 +38,7 @@ DEFAULT_TIMEZONE = ZoneInfo("Asia/Tokyo")
 DAILY_REPORT_TIME = time(0, 30)  # 00:30 JST
 WEEKLY_REPORT_TIME = time(1, 0)  # 01:00 JST
 WEEKLY_REPORT_DAY = 0  # Monday (0 = Monday, 6 = Sunday)
+MONTHLY_FEE_BATCH_TIME = time(9, 0)  # 毎月1日 09:00 JST
 
 # RSS フェッチ間隔（秒）
 RSS_FETCH_INTERVAL_SECONDS = 1800  # 30 分
@@ -103,6 +105,138 @@ def _calculate_seconds_until(
 
     # 最小 60 秒（重複実行防止）
     return max(seconds, 60.0)
+
+
+def _calculate_seconds_until_month_first(
+    tz: ZoneInfo = DEFAULT_TIMEZONE,
+    now: Optional[datetime] = None,
+) -> float:
+    """次回「月初 09:00 JST」までの秒数を返す。
+
+    今月1日 09:00 JST がまだ来ていなければそれを目標とし、
+    過ぎていれば翌月1日 09:00 JST を目標とする。
+    """
+    if now is None:
+        now = datetime.now(tz)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=tz)
+    else:
+        now = now.astimezone(tz)
+
+    this_month_first = datetime(
+        now.year,
+        now.month,
+        1,
+        MONTHLY_FEE_BATCH_TIME.hour,
+        MONTHLY_FEE_BATCH_TIME.minute,
+        tzinfo=tz,
+    )
+
+    if now < this_month_first:
+        target = this_month_first
+    elif now.month == 12:
+        target = datetime(
+            now.year + 1,
+            1,
+            1,
+            MONTHLY_FEE_BATCH_TIME.hour,
+            MONTHLY_FEE_BATCH_TIME.minute,
+            tzinfo=tz,
+        )
+    else:
+        target = datetime(
+            now.year,
+            now.month + 1,
+            1,
+            MONTHLY_FEE_BATCH_TIME.hour,
+            MONTHLY_FEE_BATCH_TIME.minute,
+            tzinfo=tz,
+        )
+
+    return max((target - now).total_seconds(), 60.0)
+
+
+def _prev_month_start(d: date) -> date:
+    """指定日の前月月初を返す。"""
+    if d.month == 1:
+        return date(d.year - 1, 12, 1)
+    return date(d.year, d.month - 1, 1)
+
+
+def _monthly_fee_batch_sync(calculation_month: date, usd_jpy_rate: Decimal) -> None:
+    """月次手数料バッチの同期実行 (asyncio.to_thread から呼ばれる)。"""
+    from sqlalchemy import select as _select  # noqa: PLC0415
+
+    from app.api.v1.fees import finalize_month_core  # noqa: PLC0415
+    from app.billing.v10_models import FeeConfigV10  # noqa: PLC0415
+
+    with SessionLocal() as db:
+        config = db.scalar(
+            _select(FeeConfigV10)
+            .where(FeeConfigV10.is_active.is_(True))
+            .order_by(FeeConfigV10.effective_from.desc())
+            .limit(1)
+        )
+        if config is None:
+            logger.error(
+                "monthly_fee_batch: active fee_config not found, skipping month=%s",
+                calculation_month,
+            )
+            return
+        result = finalize_month_core(db, config, calculation_month, usd_jpy_rate)
+        logger.info(
+            "monthly_fee_batch done: month=%s processed=%d skipped_no_snap=%d"
+            " skipped_finalized=%d total_fee=%s",
+            calculation_month,
+            result.users_processed,
+            result.users_skipped_no_snapshot,
+            result.users_skipped_already_finalized,
+            result.total_fee_jpy,
+        )
+
+
+async def monthly_fee_batch_loop(
+    *,
+    usd_jpy_rate: Decimal = Decimal("150"),
+    tz: ZoneInfo = DEFAULT_TIMEZONE,
+    on_error: Optional[Callable[[Exception], None]] = None,
+) -> None:
+    """月次手数料バッチ: 毎月1日 09:00 JST に前月分の fee_transactions を計算・登録する。
+
+    ENABLE_MONTHLY_FEE_BATCH=1 で main.py から起動される。
+    usd_jpy_rate は USD_TO_JPY_RATE 環境変数（デフォルト 150）を使う。
+    """
+    logger.info(
+        "Starting monthly fee batch loop (schedule: 1st of month %s JST)", MONTHLY_FEE_BATCH_TIME
+    )
+
+    while True:
+        try:
+            wait_seconds = _calculate_seconds_until_month_first(tz=tz)
+            logger.debug("Waiting %.1f seconds until next monthly fee batch", wait_seconds)
+            await asyncio.sleep(wait_seconds)
+
+            now_jst = datetime.now(tz)
+            target_month = _prev_month_start(now_jst.date())
+
+            logger.info("Running monthly fee batch for month=%s", target_month)
+            await asyncio.to_thread(_monthly_fee_batch_sync, target_month, usd_jpy_rate)
+            logger.info("Monthly fee batch completed for month=%s", target_month)
+
+            await asyncio.sleep(3600)  # 重複実行防止
+
+        except asyncio.CancelledError:
+            logger.info("Monthly fee batch loop cancelled - shutting down")
+            raise
+
+        except Exception as exc:
+            logger.error("Error in monthly fee batch loop: %s", exc)
+            if on_error:
+                try:
+                    on_error(exc)
+                except Exception as callback_exc:
+                    logger.error("Error in on_error callback: %s", callback_exc)
+            await asyncio.sleep(3600)
 
 
 async def daily_report_loop(
@@ -892,6 +1026,7 @@ class ScheduledTaskManager:
         self._proposal_timeout_task: Optional[asyncio.Task[None]] = None
         self._learning_task: Optional[asyncio.Task[None]] = None
         self._compound_risk_task: Optional[asyncio.Task[None]] = None
+        self._monthly_fee_batch_task: Optional[asyncio.Task[None]] = None
 
     @property
     def is_daily_running(self) -> bool:
@@ -947,6 +1082,49 @@ class ScheduledTaskManager:
     def is_compound_risk_running(self) -> bool:
         """複合リスク監視タスクが動作中かどうか。"""
         return self._compound_risk_task is not None and not self._compound_risk_task.done()
+
+    @property
+    def is_monthly_fee_batch_running(self) -> bool:
+        """月次手数料バッチタスクが動作中かどうか。"""
+        return self._monthly_fee_batch_task is not None and not self._monthly_fee_batch_task.done()
+
+    async def start_monthly_fee_batch(
+        self,
+        *,
+        usd_jpy_rate: Decimal = Decimal("150"),
+        on_error: Optional[Callable[[Exception], None]] = None,
+    ) -> None:
+        """月次手数料バッチタスクを開始する。"""
+        if self.is_monthly_fee_batch_running:
+            raise RuntimeError("Monthly fee batch already running")
+
+        logger.info("Starting monthly fee batch task (rate=%s)", usd_jpy_rate)
+        self._monthly_fee_batch_task = asyncio.create_task(
+            monthly_fee_batch_loop(usd_jpy_rate=usd_jpy_rate, on_error=on_error)
+        )
+        logger.info("Monthly fee batch task started")
+
+    async def stop_monthly_fee_batch(self, timeout: float = 5.0) -> None:
+        """月次手数料バッチタスクを停止する。"""
+        if not self.is_monthly_fee_batch_running:
+            logger.debug("Monthly fee batch not running - nothing to stop")
+            return
+
+        logger.info("Stopping monthly fee batch task")
+        assert self._monthly_fee_batch_task is not None  # noqa: S101
+        self._monthly_fee_batch_task.cancel()
+
+        try:
+            await asyncio.wait_for(self._monthly_fee_batch_task, timeout=timeout)
+        except asyncio.CancelledError:
+            logger.info("Monthly fee batch task cancelled successfully")
+        except asyncio.TimeoutError:
+            logger.warning("Monthly fee batch task did not stop within %.1fs timeout", timeout)
+        except Exception as exc:
+            logger.error("Error while stopping monthly fee batch task: %s", exc)
+
+        self._monthly_fee_batch_task = None
+        logger.info("Monthly fee batch task stopped")
 
     async def start_daily_reports(
         self,
@@ -1628,6 +1806,7 @@ class ScheduledTaskManager:
             self.stop_proposal_timeout(timeout=timeout),
             self.stop_learning(timeout=timeout),
             self.stop_compound_risk_monitor(timeout=timeout),
+            self.stop_monthly_fee_batch(timeout=timeout),
             return_exceptions=True,
         )
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -538,6 +538,20 @@ def create_app() -> FastAPI:
             except BaseException as exc:
                 logger.error("Failed to start loop %s: %s", name, exc)
 
+        # --- 月次手数料バッチ (opt-in: ENABLE_MONTHLY_FEE_BATCH=1) ---
+        if os.getenv("ENABLE_MONTHLY_FEE_BATCH", "0") == "1":
+            try:
+                from decimal import Decimal as _Decimal  # noqa: PLC0415
+
+                usd_jpy_rate = _Decimal(os.getenv("USD_TO_JPY_RATE", "150"))
+                await scheduled_manager.start_monthly_fee_batch(
+                    usd_jpy_rate=usd_jpy_rate,
+                    on_error=_make_scheduler_error_handler("monthly_fee_batch_loop"),
+                )
+                logger.info("Monthly fee batch scheduled (rate=%s)", usd_jpy_rate)
+            except BaseException as exc:
+                logger.error("Failed to start monthly fee batch: %s", exc)
+
     @app.on_event("startup")
     async def startup_health_probes() -> None:
         """Start background probes for /health/detail (OpenAI / Perplexity / Aave safety)."""

--- a/backend/tests/test_api_v1_fees.py
+++ b/backend/tests/test_api_v1_fees.py
@@ -23,7 +23,7 @@ from decimal import Decimal
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, func, select
 from sqlalchemy.orm import Session, sessionmaker
 
 os.environ["JWT_SECRET_KEY"] = "test-secret-key-api-v1-fees"
@@ -616,19 +616,155 @@ class TestAllUsersEndpoint:
 
 
 # ===========================================================================
-# Admin: /finalize-month (501 stub)
+# Admin: /finalize-month (F-7 実装済み)
 # ===========================================================================
 
 
-class TestFinalizeMonthStub:
-    def test_returns_501_with_f7_reference(self, client: TestClient) -> None:
+def _add_portfolio_snapshot(
+    SessionFactory,
+    *,
+    user_id: int,
+    recorded_at: datetime,
+    total_supply_usd: Decimal,
+    total_value_usd: Decimal | None = None,
+) -> None:
+    from app.portfolio.models import PortfolioSnapshot  # noqa: PLC0415
+
+    with SessionFactory() as db:
+        snap = PortfolioSnapshot(
+            user_id=user_id,
+            total_value_usd=total_value_usd or total_supply_usd,
+            total_supply_usd=total_supply_usd,
+            total_borrow_usd=Decimal("0"),
+            health_factor=None,
+            recorded_at=recorded_at,
+        )
+        db.add(snap)
+        db.commit()
+
+
+class TestFinalizeMonth:
+    """F-7: POST /api/v1/fees/finalize-month の正常系・境界テスト。"""
+
+    def test_requires_admin(self, client: TestClient) -> None:
+        r = client.post("/api/v1/fees/finalize-month?month=2026-05-01")
+        assert r.status_code == 401
+
+    def test_user_without_snapshot_is_skipped(self, client: TestClient, test_db) -> None:
+        override_get_db, SessionFactory = test_db
+        with SessionFactory() as db:
+            _seed_active_config(db)
         token = _register_admin(client)
+
         r = client.post(
             "/api/v1/fees/finalize-month?month=2026-05-01",
             headers={"Authorization": f"Bearer {token}"},
         )
-        assert r.status_code == 501
-        assert "F-7" in r.json()["detail"] or "1214120401388139" in r.json()["detail"]
+        assert r.status_code == 200
+        body = r.json()
+        assert body["users_processed"] == 0
+        assert body["users_skipped_no_snapshot"] >= 1
+
+    def test_creates_fee_transaction_for_user_with_snapshots(
+        self, client: TestClient, test_db
+    ) -> None:
+        override_get_db, SessionFactory = test_db
+        with SessionFactory() as db:
+            _seed_active_config(db)
+        token = _register_admin(client)
+        user_id = _create_user(SessionFactory, email="fee_u@example.com", username="fee_u")
+
+        month_start = datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc)
+        month_end = datetime(2026, 5, 31, 23, 0, tzinfo=timezone.utc)
+        _add_portfolio_snapshot(
+            SessionFactory,
+            user_id=user_id,
+            recorded_at=month_start,
+            total_supply_usd=Decimal("10000"),
+        )
+        _add_portfolio_snapshot(
+            SessionFactory,
+            user_id=user_id,
+            recorded_at=month_end,
+            total_supply_usd=Decimal("10200"),  # $200 利益
+        )
+
+        r = client.post(
+            "/api/v1/fees/finalize-month?month=2026-05-01&usd_jpy_rate=150",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["users_processed"] == 1
+        assert body["calculation_month"] == "2026-05-01"
+        assert Decimal(body["total_fee_jpy"]) > Decimal("0")
+
+        with SessionFactory() as db:
+            tx = db.scalar(select(FeeTransaction).where(FeeTransaction.user_id == user_id))
+            assert tx is not None
+            assert tx.deposit_amount_jpy == Decimal("1530000")  # 10200 * 150
+            assert tx.gross_profit_jpy == Decimal("30000")  # 200 * 150
+
+    def test_dry_run_does_not_write_db(self, client: TestClient, test_db) -> None:
+        override_get_db, SessionFactory = test_db
+        with SessionFactory() as db:
+            _seed_active_config(db)
+        token = _register_admin(client)
+        user_id = _create_user(SessionFactory, email="dryrun@example.com", username="dryrun_u")
+        _add_portfolio_snapshot(
+            SessionFactory,
+            user_id=user_id,
+            recorded_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            total_supply_usd=Decimal("5000"),
+        )
+        _add_portfolio_snapshot(
+            SessionFactory,
+            user_id=user_id,
+            recorded_at=datetime(2026, 5, 31, tzinfo=timezone.utc),
+            total_supply_usd=Decimal("5100"),
+        )
+
+        r = client.post(
+            "/api/v1/fees/finalize-month?month=2026-05-01&dry_run=true",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        assert r.json()["dry_run"] is True
+        assert r.json()["users_processed"] == 1
+
+        with SessionFactory() as db:
+            count = db.scalar(
+                select(func.count(FeeTransaction.id)).where(FeeTransaction.user_id == user_id)
+            )
+            assert count == 0  # dry_run なので DB 未書込
+
+    def test_already_finalized_is_skipped(self, client: TestClient, test_db) -> None:
+        override_get_db, SessionFactory = test_db
+        with SessionFactory() as db:
+            _seed_active_config(db)
+        token = _register_admin(client)
+        user_id = _create_user(SessionFactory, email="finalized@example.com", username="fin_u")
+        _add_fee_tx(
+            SessionFactory,
+            user_id=user_id,
+            month=date(2026, 5, 1),
+            finalized=True,
+        )
+        _add_portfolio_snapshot(
+            SessionFactory,
+            user_id=user_id,
+            recorded_at=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            total_supply_usd=Decimal("8000"),
+        )
+
+        r = client.post(
+            "/api/v1/fees/finalize-month?month=2026-05-01",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["users_skipped_already_finalized"] >= 1
+        assert body["users_processed"] == 0
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- `finalize_month_core()` を実装し、API エンドポイントとスケジューラが共有するコアロジックを提供
- アクティブユーザーの月次損益を `PortfolioSnapshot` から算出し `FeeTransaction` に記録
- `monthly_fee_batch_loop()` を `ScheduledTaskManager` に追加し、翌月1日 09:00 JST に自動実行
- `ENABLE_MONTHLY_FEE_BATCH=1` / `USD_TO_JPY_RATE` 環境変数で制御

## 変更ファイル

| ファイル | Tier | 変更内容 |
|---|---|---|
| `backend/app/api/v1/fees.py` | A | `finalize_month_core()` 実装、エンドポイント置換 |
| `backend/app/automation/scheduled_tasks.py` | S | `monthly_fee_batch_loop` / start/stop メソッド追加 |
| `backend/app/main.py` | S | `ENABLE_MONTHLY_FEE_BATCH` 起動ロジック追加 |
| `backend/tests/test_api_v1_fees.py` | B | `TestFinalizeMonth` 4ケース追加 |

## テスト内容

- `test_requires_admin` — 未認証で 401
- `test_user_without_snapshot_is_skipped` — スナップショットなしユーザーをスキップ
- `test_creates_fee_transaction_for_user_with_snapshots` — 正常計算・FeeTransaction 作成確認
- `test_dry_run_does_not_write_db` — dry_run=true で DB 書込ゼロ確認
- `test_already_finalized_is_skipped` — 重複計算防止（uq_fee_tx_user_month）

## DoD

- Gate 1: `ruff check .` ✅
- Gate 2: `ruff format --check .` ✅
- Gate 3: `mypy app/` ✅
- Gate 4: `pytest tests/ --cov=app --cov-fail-under=80` ✅ (2873 passed, 85.47%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)