### PR TITLE
feat(fees): F-9 expense_jpy を完了トレード件数 × 固定単価で実費算出

### DIFF
--- a/backend/app/api/v1/fees.py
+++ b/backend/app/api/v1/fees.py
@@ -32,6 +32,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from datetime import date, datetime, timezone
 from decimal import Decimal
 
@@ -46,6 +47,7 @@ from app.billing.v10_models import FeeConfigV10, FeeTransaction
 from app.database import get_db
 from app.fees import FeeCalculationInput, FeeCalculator
 from app.portfolio.models import PortfolioSnapshot
+from app.transactions.models import Transaction
 
 logger = logging.getLogger(__name__)
 
@@ -238,7 +240,7 @@ def finalize_month_core(
     各ユーザーの portfolio_snapshots から月次損益を算出し、
     FeeCalculator で手数料を計算して fee_transactions に書き込む。
     dry_run=True の場合は計算のみ行い DB 書込はしない。
-    expense_jpy は F-9 で実費マークアップを実装するまで 0 とする。
+    expense_jpy は当月の完了トレード件数 × TRADE_FIXED_COST_USD × usd_jpy_rate で算出 (F-9)。
     """
     next_month = _next_month_start(month_start)
     dt_from = datetime(month_start.year, month_start.month, 1, tzinfo=timezone.utc)
@@ -299,12 +301,27 @@ def finalize_month_core(
             user_created_date is not None and month_start <= user_created_date < next_month
         )
 
+        fixed_cost_usd = Decimal(os.getenv("TRADE_FIXED_COST_USD", "0.27"))
+        trade_count = (
+            db.scalar(
+                select(func.count(Transaction.id)).where(
+                    Transaction.user_id == user.id,
+                    Transaction.status == "completed",
+                    Transaction.is_dry_run.is_(False),
+                    Transaction.created_at >= dt_from,
+                    Transaction.created_at < dt_to,
+                )
+            )
+            or 0
+        )
+        expense_jpy = (fixed_cost_usd * trade_count * usd_jpy_rate).quantize(Decimal("1"))
+
         payload = FeeCalculationInput(
             user_id=user.id,
             calculation_month=month_start,
             deposit_jpy=deposit_jpy,
             gross_profit_jpy=gross_profit_jpy,
-            expense_jpy=Decimal("0"),  # F-9 で実費マークアップ実装予定
+            expense_jpy=expense_jpy,
             user_tier=user_tier,
             user_risk_mode=user_risk_mode,
             affiliate_id=user.invited_by,
@@ -605,7 +622,7 @@ def finalize_month(
     - month: 対象月の月初日 (例: 2026-05-01)
     - usd_jpy_rate: 計算に使う USD/JPY レート (省略時 150)
     - dry_run: True の場合は DB 書込なしで結果のみ返す
-    - expense_jpy は F-9 実装まで 0 として計算する
+    - expense_jpy: 当月の完了トレード件数 × TRADE_FIXED_COST_USD × usd_jpy_rate (F-9)
     """
     return finalize_month_core(db, config, month.replace(day=1), usd_jpy_rate, dry_run=dry_run)
 

--- a/backend/tests/test_api_v1_fees.py
+++ b/backend/tests/test_api_v1_fees.py
@@ -643,6 +643,34 @@ def _add_portfolio_snapshot(
         db.commit()
 
 
+def _add_transaction(
+    SessionFactory,
+    *,
+    user_id: int,
+    created_at: datetime,
+    status: str = "completed",
+    is_dry_run: bool = False,
+    operation: str = "deposit",
+    amount_usd: Decimal = Decimal("100"),
+) -> None:
+    from app.transactions.models import Transaction  # noqa: PLC0415
+
+    with SessionFactory() as db:
+        txn = Transaction(
+            user_id=user_id,
+            operation=operation,
+            asset="USDC",
+            amount=amount_usd,
+            amount_usd=amount_usd,
+            chain="polygon",
+            status=status,
+            is_dry_run=is_dry_run,
+            created_at=created_at,
+        )
+        db.add(txn)
+        db.commit()
+
+
 class TestFinalizeMonth:
     """F-7: POST /api/v1/fees/finalize-month の正常系・境界テスト。"""
 
@@ -737,6 +765,55 @@ class TestFinalizeMonth:
                 select(func.count(FeeTransaction.id)).where(FeeTransaction.user_id == user_id)
             )
             assert count == 0  # dry_run なので DB 未書込
+
+    def test_expense_jpy_calculated_from_completed_trades(
+        self, client: TestClient, test_db
+    ) -> None:
+        """F-9: 完了トレード件数 × TRADE_FIXED_COST_USD × usd_jpy_rate が expense_jpy に反映される。"""
+        override_get_db, SessionFactory = test_db
+        with SessionFactory() as db:
+            _seed_active_config(db)
+        token = _register_admin(client)
+        user_id = _create_user(SessionFactory, email="exp@example.com", username="exp_u")
+
+        month_dt = datetime(2026, 5, 15, tzinfo=timezone.utc)
+        _add_portfolio_snapshot(
+            SessionFactory,
+            user_id=user_id,
+            recorded_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            total_supply_usd=Decimal("10000"),
+        )
+        _add_portfolio_snapshot(
+            SessionFactory,
+            user_id=user_id,
+            recorded_at=datetime(2026, 5, 31, tzinfo=timezone.utc),
+            total_supply_usd=Decimal("10200"),
+        )
+        # 完了トレード 2 件
+        _add_transaction(SessionFactory, user_id=user_id, created_at=month_dt)
+        _add_transaction(SessionFactory, user_id=user_id, created_at=month_dt)
+        # 除外: dry_run / pending / 別月
+        _add_transaction(SessionFactory, user_id=user_id, created_at=month_dt, is_dry_run=True)
+        _add_transaction(SessionFactory, user_id=user_id, created_at=month_dt, status="pending")
+        _add_transaction(
+            SessionFactory,
+            user_id=user_id,
+            created_at=datetime(2026, 4, 30, tzinfo=timezone.utc),
+        )
+
+        os.environ["TRADE_FIXED_COST_USD"] = "0.27"
+        r = client.post(
+            "/api/v1/fees/finalize-month?month=2026-05-01&usd_jpy_rate=150",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        assert r.json()["users_processed"] == 1
+
+        with SessionFactory() as db:
+            tx = db.scalar(select(FeeTransaction).where(FeeTransaction.user_id == user_id))
+            assert tx is not None
+            # 2 trades × $0.27 × 150 = 81 JPY (ROUND_DOWN)
+            assert tx.expense_jpy == Decimal("81")
 
     def test_already_finalized_is_skipped(self, client: TestClient, test_db) -> None:
         override_get_db, SessionFactory = test_db


### PR DESCRIPTION
## Summary

- `finalize_month_core()` の `expense_jpy=Decimal("0")` 固定を廃止し、実費計算に置き換え
- 当月の完了（status=completed）・非 dry_run の Transaction を集計し `TRADE_FIXED_COST_USD × 件数 × usd_jpy_rate` で算出
- `Transaction` モデルを `fees.py` に import 追加

## 変更ファイル

| ファイル | Tier | 変更内容 |
|---|---|---|
| `backend/app/api/v1/fees.py` | A | Transaction import 追加、expense_jpy 実費算出ロジック実装 |
| `backend/tests/test_api_v1_fees.py` | B | `_add_transaction` ヘルパー追加、`test_expense_jpy_calculated_from_completed_trades` 追加 |

## 算出ロジック

```
expense_jpy = TRADE_FIXED_COST_USD × 完了トレード件数 × usd_jpy_rate
# 例: $0.27 × 2件 × 150 = 81円
```

除外条件: `is_dry_run=True` / `status != "completed"` / 当月範囲外

## DoD

- Gate 1: `ruff check .` ✅
- Gate 2: `ruff format --check .` ✅
- Gate 3: `mypy app/` ✅
- Gate 4: `pytest tests/ --cov=app --cov-fail-under=80` ✅ (2874 passed, 85.47%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)