### PR TITLE
feat(fees): F-10 リスクモード UI Phase 1 制限表示

### DIFF
--- a/frontend/app/(user)/settings/_components/RiskSettingsCard.tsx
+++ b/frontend/app/(user)/settings/_components/RiskSettingsCard.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import { useState } from 'react'
+import { Lock } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -24,12 +25,37 @@ interface RiskSettingsCardProps {
   onMaxSingleTradeUsdChange: (value: number) => void
   maxDailyTradeUsd: number
   onMaxDailyTradeUsdChange: (value: number) => void
+  allowedModes?: RiskMode[]
 }
 
-const riskOptions: { mode: RiskMode; label: string; emoji: string; description: string; toastDescription: string }[] = [
-  { mode: 'conservative', label: '保守的', emoji: '🛡️', description: '安全重視、低リスク', toastDescription: 'ステーブルコインのみで安全に運用します' },
-  { mode: 'balanced', label: 'バランス', emoji: '⚖️', description: '標準設定', toastDescription: '安定性と収益のバランスを取って運用します' },
-  { mode: 'aggressive', label: '積極的', emoji: '🚀', description: '高リターン、高リスク', toastDescription: '高リターンを重視して積極的に運用します' },
+const riskOptions: {
+  mode: RiskMode
+  label: string
+  emoji: string
+  description: string
+  toastDescription: string
+}[] = [
+  {
+    mode: 'conservative',
+    label: '保守的',
+    emoji: '🛡️',
+    description: '安全重視、低リスク',
+    toastDescription: 'ステーブルコインのみで安全に運用します',
+  },
+  {
+    mode: 'balanced',
+    label: 'バランス',
+    emoji: '⚖️',
+    description: '標準設定',
+    toastDescription: '安定性と収益のバランスを取って運用します',
+  },
+  {
+    mode: 'aggressive',
+    label: '積極的',
+    emoji: '🚀',
+    description: '高リターン、高リスク',
+    toastDescription: '高リターンを重視して積極的に運用します',
+  },
 ]
 
 const modeActiveClass: Record<RiskMode, string> = {
@@ -45,11 +71,12 @@ export function RiskSettingsCard({
   onMaxSingleTradeUsdChange,
   maxDailyTradeUsd,
   onMaxDailyTradeUsdChange,
+  allowedModes = ['conservative'],
 }: RiskSettingsCardProps) {
   const [saving, setSaving] = useState(false)
 
   const handleRiskModeChange = async (mode: RiskMode) => {
-    if (saving || mode === riskMode) return
+    if (saving || mode === riskMode || !allowedModes.includes(mode)) return
     setSaving(true)
     try {
       await apiPut<RiskModeResponse>('/auth/risk-mode', { mode })
@@ -77,28 +104,54 @@ export function RiskSettingsCard({
           <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
             {riskOptions.map((opt) => {
               const isActive = riskMode === opt.mode
+              const isAllowed = allowedModes.includes(opt.mode)
+              const isDisabled = saving || !isAllowed
+
               return (
                 <button
                   key={opt.mode}
                   onClick={() => { void handleRiskModeChange(opt.mode) }}
-                  disabled={saving}
+                  disabled={isDisabled}
                   className={cn(
-                    'text-left rounded-lg border-2 p-3 transition-all disabled:opacity-60',
-                    isActive
+                    'text-left rounded-lg border-2 p-3 transition-all',
+                    isAllowed
+                      ? 'disabled:opacity-60'
+                      : 'cursor-not-allowed opacity-50',
+                    isActive && isAllowed
                       ? modeActiveClass[opt.mode]
-                      : 'border-zinc-700 bg-zinc-800/40 hover:border-zinc-600'
+                      : isAllowed
+                        ? 'border-zinc-700 bg-zinc-800/40 hover:border-zinc-600'
+                        : 'border-zinc-800 bg-zinc-900/40',
                   )}
                 >
                   <div className="flex items-center gap-1.5 mb-1">
-                    <span className="text-base">{opt.emoji}</span>
-                    <span className="text-sm font-semibold text-zinc-100">{opt.label}</span>
-                    {isActive && (
+                    {isAllowed ? (
+                      <span className="text-base">{opt.emoji}</span>
+                    ) : (
+                      <Lock className="w-4 h-4 text-zinc-600" />
+                    )}
+                    <span
+                      className={cn(
+                        'text-sm font-semibold',
+                        isAllowed ? 'text-zinc-100' : 'text-zinc-600',
+                      )}
+                    >
+                      {opt.label}
+                    </span>
+                    {isActive && isAllowed && (
                       <span className="ml-auto text-xs px-1.5 py-0.5 rounded bg-zinc-700 text-zinc-300">
                         現在
                       </span>
                     )}
+                    {!isAllowed && (
+                      <span className="ml-auto text-xs px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-600">
+                        Phase 2
+                      </span>
+                    )}
                   </div>
-                  <p className="text-xs text-zinc-400">{opt.description}</p>
+                  <p className={cn('text-xs', isAllowed ? 'text-zinc-400' : 'text-zinc-700')}>
+                    {isAllowed ? opt.description : 'Phase 2 で解禁予定'}
+                  </p>
                 </button>
               )
             })}

--- a/frontend/app/(user)/settings/page.tsx
+++ b/frontend/app/(user)/settings/page.tsx
@@ -23,6 +23,11 @@ type RiskMode = 'conservative' | 'balanced' | 'aggressive'
 type NotificationFrequency = 'all' | 'important' | 'emergency'
 type Language = 'ja' | 'en'
 
+interface RiskModeOption {
+  mode: RiskMode
+  allowed_in_phase_1: boolean
+}
+
 interface UserSettingsResponse {
   notification_email?: string
   notification_frequency?: NotificationFrequency
@@ -59,6 +64,7 @@ export default function SettingsPage() {
   const { address, chainId, disconnect } = useWallet()
   const [settings, setSettings] = useState<SettingsState>(DEFAULT_SETTINGS)
   const [isStopped, setIsStopped] = useState(false)
+  const [allowedModes, setAllowedModes] = useState<RiskMode[]>(['conservative'])
 
   // U-07: Load risk mode from GET /auth/risk-mode
   useEffect(() => {
@@ -66,6 +72,19 @@ export default function SettingsPage() {
     apiFetch<{ mode: RiskMode }>('/auth/risk-mode')
       .then((data) => setSettings((prev) => ({ ...prev, riskMode: data.mode })))
       .catch(() => {/* keep default on error */})
+  }, [token])
+
+  // F-10: Load allowed risk modes from GET /auth/risk-modes
+  useEffect(() => {
+    if (!token) return
+    apiFetch<{ modes: RiskModeOption[] }>('/auth/risk-modes')
+      .then((data) => {
+        const allowed = data.modes
+          .filter((m) => m.allowed_in_phase_1)
+          .map((m) => m.mode)
+        if (allowed.length > 0) setAllowedModes(allowed)
+      })
+      .catch(() => {/* keep default conservative */})
   }, [token])
 
   // Load user settings from GET /api/user/settings
@@ -155,6 +174,7 @@ export default function SettingsPage() {
           onMaxSingleTradeUsdChange={(value) => set('maxSingleTradeUsd', value)}
           maxDailyTradeUsd={settings.maxDailyTradeUsd}
           onMaxDailyTradeUsdChange={(value) => set('maxDailyTradeUsd', value)}
+          allowedModes={allowedModes}
         />
 
         {/* 3. 通知設定 — synced with PUT /api/user/settings */}


### PR DESCRIPTION
## Summary

- `RiskSettingsCard` に `allowedModes` prop を追加（デフォルト `['conservative']`）
- 非許可モード（balanced / aggressive）を Lock アイコン + "Phase 2" バッジ + グレーアウト + `cursor-not-allowed` で表示
- `settings/page.tsx` で `GET /auth/risk-modes` を呼び出し、`allowed_in_phase_1: true` のモードのみを抽出して渡す
- バックエンドの `PHASE_1_ALLOWED_RISK_MODES` と UI が同期した状態になる

## Test plan

- [ ] Gate 1-3: `ruff check / format` OK、`tsc --noEmit` 実コードエラー 0
- [ ] 設定画面でリスクモード選択: 保守的のみクリック可能、他は Lock + "Phase 2"
- [ ] API `/auth/risk-modes` が返す `allowed_in_phase_1` が変わった場合に UI が追従する

🤖 Generated with [Claude Code](https://claude.com/claude-code)