### PR TITLE
fix(ci): frontend/.npmrc — Cloudflare Pages ERESOLVE ビルド修正

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,10 @@
+; Cloudflare Pages の auto `npm clean-install --progress=false` step が
+; --legacy-peer-deps なしで実行されると @privy-io/react-auth と
+; @farcaster/mini-app-solana の peerOptional 競合で ERESOLVE fail になるため
+; project-wide で legacy-peer-deps=true を設定する。
+;
+; CLAUDE.md「Frontend ルール: package.json変更時は npm install --legacy-peer-deps」
+; と整合 (CI / Cloudflare Pages / 本番 Docker build 全てで同一動作になる)。
+;
+; 参照: demo/frontend-static ブランチの同ファイル (0264a80)
+legacy-peer-deps=true


### PR DESCRIPTION
## 問題

全 PR の Cloudflare Pages ビルドが "0秒 fail" していた。

**原因**: Cloudflare Pages が PR ビルド時に `npm clean-install --progress=false` を自動実行するが、`--legacy-peer-deps` フラグなしのため `@privy-io/react-auth@3.21.0` と `@farcaster/mini-app-solana` の `peerOptional` 競合で ERESOLVE エラーが発生。

## 修正

`frontend/.npmrc` に `legacy-peer-deps=true` を追加。

- demo ブランチ (`0264a80`) で同じ修正が済んでいたが、main への適用が漏れていた
- CLAUDE.md「Frontend ルール: `npm install --legacy-peer-deps`」と整合

## 影響

- 全 PR の Cloudflare Pages ビルドが通るようになる
- 本番 Docker build も同じ ERESOLVE リスクがあったが、Dockerfile で `npm install --legacy-peer-deps` を明示していたため影響なし

## Test plan

- [ ] この PR の Cloudflare Pages ビルドが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)