### PR TITLE
fix(lint): ruff format + --fix で main 赤化解消 (#347 follow-up)

### DIFF
--- a/backend/app/auth/models.py
+++ b/backend/app/auth/models.py
@@ -56,9 +56,9 @@ class UserRole(str, Enum):
 class InvestmentTier(str, Enum):
     """投資ティア。v10 (F-2 2026-04-25 〜): LOWER / MIDDLE / UPPER の 3 層
 
-      - LOWER:  〜1,000,000 円
-      - MIDDLE: 1,000,001 〜 10,000,000 円
-      - UPPER:  10,000,001 円 〜
+    - LOWER:  〜1,000,000 円
+    - MIDDLE: 1,000,001 〜 10,000,000 円
+    - UPPER:  10,000,001 円 〜
     """
 
     LOWER = "LOWER"

--- a/backend/app/fees/models.py
+++ b/backend/app/fees/models.py
@@ -166,9 +166,7 @@ class FeeTransaction(Base):
         default=lambda: datetime.now(timezone.utc),
         server_default=text("NOW()"),
     )
-    finalized_at: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    finalized_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
 
     __table_args__ = (
         CheckConstraint(

--- a/backend/scripts/detect_db_gaps.py
+++ b/backend/scripts/detect_db_gaps.py
@@ -21,8 +21,8 @@ from sqlalchemy import inspect as sa_inspect
 
 from app.ai.models import AIDecision  # noqa: F401
 from app.auth.models import User  # noqa: F401
-from app.fees.models import FeeConfigV10, FeeTransaction  # noqa: F401
 from app.database import Base, get_database_url
+from app.fees.models import FeeConfigV10, FeeTransaction  # noqa: F401
 from app.invitations.models import Invitation  # noqa: F401
 from app.knowledge.models import (  # noqa: F401
     KnowledgeChunk,

--- a/backend/scripts/seed_fee_config_v10.py
+++ b/backend/scripts/seed_fee_config_v10.py
@@ -43,8 +43,8 @@ from sqlalchemy import select  # noqa: E402
 from sqlalchemy.orm import Session  # noqa: E402
 
 from app.auth.models import RISK_MODE_SUBSCRIPTION_RATES, RiskMode  # noqa: E402
-from app.fees.models import FeeConfigV10  # noqa: E402
 from app.database import SessionLocal  # noqa: E402
+from app.fees.models import FeeConfigV10  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/backend/tests/test_api_v1_fees.py
+++ b/backend/tests/test_api_v1_fees.py
@@ -31,7 +31,7 @@ os.environ["JWT_ALGORITHM"] = "HS256"
 os.environ["JWT_ACCESS_TOKEN_EXPIRE_MINUTES"] = "30"
 os.environ["INITIAL_ADMIN_EMAIL"] = "fees_admin@example.com"
 
-from app.auth.models import InvestmentTier, RiskMode, User, UserRole  # noqa: E402
+from app.auth.models import InvestmentTier, RiskMode, UserRole  # noqa: E402
 from app.auth.schemas import UserCreateRequest  # noqa: E402
 from app.auth.service import AuthService  # noqa: E402
 from app.database import Base, get_db  # noqa: E402


### PR DESCRIPTION
## 背景
PR #347 (F-13 GENERAL 物理削除) merge 後、main CI が `Ruff format check` (ruff format --check .) で **赤化** していた (本日 00:37〜)。これにより全 open PR の merge-check (Lint job) がブロックされていた。

## 変更内容 (auto-fix のみ・ロジック変更なし)
- **ruff format**: `app/auth/models.py`, `app/fees/models.py`
- **I001 import 整列**: `scripts/detect_db_gaps.py`, `scripts/seed_fee_config_v10.py`
- **F401 未使用 import 削除**: `tests/test_api_v1_fees.py` (`app.auth.models.User`)

## 検証
- `ruff check .` → All checks passed
- `ruff format --check .` → 480 files already formatted
- 5 files changed, +7 −9 (整形・import のみ)

## 既知の残課題 (本PR対象外)
`check-env-separation` の shellcheck SC2259 (`scripts/cloudflare_audit_log_polling.sh`) は別の**機能バグ** (heredoc が pipe 入力を上書きし RESPONSE が python に渡らない)。別タスクで対応推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)