### PR TITLE
fix(ops): cloudflare audit polling SC2259 機能バグ修正 (heredoc が pipe 入力上書き)

### DIFF
--- a/scripts/cloudflare_audit_log_polling.sh
+++ b/scripts/cloudflare_audit_log_polling.sh
@@ -101,10 +101,13 @@ fi
 
 # ─── 監視対象アクション判定 ───────────────────────────────────────────
 # Tunnel 関連 / DNS 関連 / Firewall ルール変更のみフィルタ
-INTERESTING_ENTRIES=$(echo "${RESPONSE}" | python3 - <<'PYEOF'
-import sys, json
+INTERESTING_ENTRIES=$(RESPONSE="${RESPONSE}" python3 <<'PYEOF'
+import json
+import os
 
-data = json.load(sys.stdin)
+# 注: python3 を `- <<EOF` で起動すると heredoc が stdin を占有し、
+# `echo | ` の pipe 入力は上書きされ届かない (SC2259)。データは env var で渡す。
+data = json.loads(os.environ["RESPONSE"])
 result = data.get("result", [])
 
 WATCH_RESOURCE_TYPES = {
@@ -162,10 +165,12 @@ fi
 # ─── 変更検知 → Slack 通知 ────────────────────────────────────────────
 SLACK_TEXT="*[cloudflare-audit] Dashboard 変更を検知 (${ENTRY_COUNT} 件)*\n\n"
 
-ENTRIES_SUMMARY=$(echo "${INTERESTING_ENTRIES}" | python3 - <<'PYEOF'
-import sys, json
+ENTRIES_SUMMARY=$(INTERESTING_ENTRIES="${INTERESTING_ENTRIES}" python3 <<'PYEOF'
+import json
+import os
 
-entries = json.load(sys.stdin)
+# SC2259 回避: stdin は heredoc 専用。データは env var 経由で渡す。
+entries = json.loads(os.environ["INTERESTING_ENTRIES"])
 lines = []
 for e in entries[:10]:  # 最大 10 件表示
     when = e.get("when", "")[:16]  # YYYY-MM-DDTHH:MM


### PR DESCRIPTION
## 背景
`check-env-separation` job の shellcheck (severity:error) が `scripts/cloudflare_audit_log_polling.sh` の **SC2259** を検出し、全 PR の merge-check をブロックしていた (PR #350 等)。

## 真因 (実バグ)
```bash
VAR=$(echo "${INPUT}" | python3 - <<'PYEOF' ... PYEOF)
```
`python3 - <<EOF` は heredoc を stdin として program を読み込むため、`echo | ` の pipe 入力が**上書きされ python に届かない**。内部の `json.load(sys.stdin)` は EOF を読み JSONDecodeError → `2>/dev/null || echo 0` フォールバックで **ENTRY_COUNT が常に 0** → 監視が**常に「変更なし」を返す**。Cloudflare Dashboard 変更検知が 2026-05-19 (#adffb59) 以降機能していなかった。

## 修正
データを**環境変数経由**で渡す (stdin は heredoc 専用に空ける)。104行・165行の2箇所:
```bash
VAR=$(INPUT="${INPUT}" python3 <<'PYEOF'
import json, os
data = json.loads(os.environ["INPUT"])
```
- `echo | python3 -c` 形式 (95/97/151行) は SC2259 対象外のため変更なし

## 検証 (dev VPS)
- `bash -n` 構文 OK
- `python3 - <<` パターン残存なし (SC2259 解消)
- 機能テスト: env var 経由でサンプル RESPONSE を渡し、`json.loads` で正常 parse 確認 (1 entry, action=create)

本日 deploy せず。cron 変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)