### PR TITLE
fix(ops): loki ring 半死 自動復旧 watchdog (RC-1 再発防止)

### DIFF
--- a/scripts/loki_watchdog.sh
+++ b/scripts/loki_watchdog.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# scripts/loki_watchdog.sh — Loki /ready 半死 (empty ring) 自動復旧 watchdog
+#
+# 背景 (RC-1 / docs/postmortems/2026-05-17_loki_postgres_cascade.md):
+#   Loki 2.9.0 single-binary は ingester ring 未登録で `empty ring` 半死状態に陥ることがある
+#   (/ready 503 / push 500)。inmemory ring + 127.0.0.1 + replication_factor=1 は標準構成であり
+#   config 修正では根治しない既知の ring-init 不安定性。2026-05-17 / 2026-05-21 に発生。
+#   #350 で healthcheck (検知) は入ったが、`restart: always` は unhealthy では再起動しないため
+#   「検知できても自動復旧しない」穴が残っていた。本 watchdog がその穴を埋める:
+#   /ready != 200 を検知したら loki を force-recreate し ingester を ring に再登録させる。
+#
+# cron 例 (本番 VPS / ultra):
+#   */3 * * * * /opt/ultra-autotrade/scripts/loki_watchdog.sh >> /opt/ultra-autotrade/logs/loki_watchdog.log 2>&1
+#
+# 設計上の安全装置:
+#   - COOLDOWN_SEC で recreate 連打を防止 (flap 時の暴走回避)
+#   - 検知/復旧の各段階で Slack 通知
+#   - recreate は --no-deps で loki 単体のみ (他サービス巻き込み回避)
+
+set -uo pipefail
+
+LOKI_READY_URL="${LOKI_READY_URL:-http://127.0.0.1:3100/ready}"
+COMPOSE_FILE="${COMPOSE_FILE:-/opt/ultra-autotrade/docker-compose.production.yml}"
+ENV_FILE="${ENV_FILE:-/opt/ultra-autotrade/.env.production}"
+LOKI_SERVICE="${LOKI_SERVICE:-loki}"
+DC="${DC:-docker compose}"
+CURL_TIMEOUT="${CURL_TIMEOUT:-5}"
+COOLDOWN_SEC="${COOLDOWN_SEC:-600}"  # 10分: recreate 連打防止
+RECREATE_WAIT_SEC="${RECREATE_WAIT_SEC:-15}"
+LAST_RECREATE_FILE="${LAST_RECREATE_FILE:-${TMPDIR:-/tmp}/.loki_watchdog_last_recreate}"
+
+timestamp_utc() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+log() { echo "$(timestamp_utc) [loki_watchdog] $*"; }
+
+# Slack Webhook 解決 (.env.production から)
+if [[ -z "${SLACK_WEBHOOK_URL:-}" ]] && [[ -f "${ENV_FILE}" ]]; then
+  SLACK_WEBHOOK_URL=$(grep "^SLACK_WEBHOOK_URL=" "${ENV_FILE}" | cut -d= -f2- | tr -d '"' || true)
+fi
+
+notify() {
+  [[ -z "${SLACK_WEBHOOK_URL:-}" ]] && return 0
+  curl -sf -X POST "${SLACK_WEBHOOK_URL}" \
+    -H "Content-Type: application/json" \
+    -d "{\"text\": \"$1\"}" >/dev/null 2>&1 || log "Slack 通知送信失敗"
+}
+
+check_ready() {
+  curl -s -o /dev/null -w "%{http_code}" --max-time "${CURL_TIMEOUT}" "${LOKI_READY_URL}" 2>/dev/null || echo "000"
+}
+
+main() {
+  local code
+  code=$(check_ready)
+
+  if [[ "${code}" == "200" ]]; then
+    log "loki /ready=200 OK"
+    return 0
+  fi
+
+  log "loki /ready=${code} — 半死 (empty ring) 検知"
+
+  # cooldown チェック (recreate 連打防止)
+  local now last elapsed
+  now=$(date +%s)
+  if [[ -f "${LAST_RECREATE_FILE}" ]]; then
+    last=$(cat "${LAST_RECREATE_FILE}" 2>/dev/null || echo "0")
+    elapsed=$(( now - last ))
+    if (( elapsed < COOLDOWN_SEC )); then
+      log "cooldown 中 (前回 recreate から ${elapsed}s < ${COOLDOWN_SEC}s) — recreate スキップ"
+      notify ":warning: [loki_watchdog] loki /ready=${code} だが cooldown 中 (${elapsed}s)。連続発生のため手動調査推奨"
+      return 1
+    fi
+  fi
+
+  log "loki を force-recreate (ingester ring 再登録)"
+  notify ":rotating_light: [loki_watchdog] loki /ready=${code} 検知 → force-recreate 実行 (RC-1 empty ring 自動復旧)"
+
+  if ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" up -d --no-deps --force-recreate "${LOKI_SERVICE}" >/dev/null 2>&1; then
+    echo "${now}" > "${LAST_RECREATE_FILE}" 2>/dev/null || true
+    sleep "${RECREATE_WAIT_SEC}"
+    local newcode
+    newcode=$(check_ready)
+    log "recreate 後 /ready=${newcode}"
+    if [[ "${newcode}" == "200" ]]; then
+      notify ":white_check_mark: [loki_watchdog] loki recreate 成功、/ready=200 復旧"
+      return 0
+    fi
+    notify ":x: [loki_watchdog] loki recreate 後も /ready=${newcode}。手動調査が必要"
+    return 1
+  fi
+
+  log "docker compose recreate 失敗"
+  notify ":x: [loki_watchdog] loki recreate コマンド失敗。手動対応が必要"
+  return 1
+}
+
+main "$@"


### PR DESCRIPTION
## 背景 (RC-1 再発)
`docs/postmortems/2026-05-17_loki_postgres_cascade.md` の **RC-1** が **2026-05-21 に再発**。Loki 2.9.0 single-binary が ingester ring 未登録で **`empty ring` 半死状態** (`/ready` 503 / push 500) に陥った。今朝の healthcheck deploy で **L8=FAIL** として検知。

- config (inmemory / 127.0.0.1 / replication_factor=1) は標準構成で、postmortem が config 修正を意図的に回避した既知の ring-init 不安定性
- 5/17 の復旧は無関係 Lane の compose recreate による **偶発回復**。postmortem は「偶発回復を対処済みと扱うな、検知手段を入れねば次も2日放置」と警告
- #350 で **検知** (healthcheck → L8) は実現。だが `restart: always` は **unhealthy では再起動しない** → 「検知できても自動復旧しない」穴が残存

## 本 PR (穴を埋める)
`scripts/loki_watchdog.sh` 新規追加:
- `/ready != 200` 検知時に `docker compose ... up -d --no-deps --force-recreate loki` で ingester を ring 再登録
- COOLDOWN_SEC (既定10分) で recreate 連打防止
- 検知/復旧/失敗の各段階で Slack 通知
- 全パラメータ env override 可能

cron 例 (本番 / ultra): `*/3 * * * * /opt/ultra-autotrade/scripts/loki_watchdog.sh >> /opt/ultra-autotrade/logs/loki_watchdog.log 2>&1`

## 検証 (dev VPS)
- `bash -n` OK / `shellcheck -S error` clean
- compose 実行形式は deploy_production.sh (L427-428) と同形を踏襲

## ⚠️ Tier S レビュー事項 (本番 auto-remediation)
- これは **production の自動再作成 (auto-remediation)**。loki recreate 中の短時間ログ送出断 (cascade リスク) vs 2日放置 のトレードオフを承認いただきたい
- docker.sock をコンテナに渡す autoheal 方式は**採らず**、host-level cron (ultra) 方式 = 攻撃面を増やさない選択
- **本日 deploy せず・cron 登録は承認後**。merge は claude.ai 判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)