### PR TITLE
fix(ops): Slack flood 解消 — staging-watchdog cooldown + Lane通知 unknown ガード

### DIFF
--- a/.claude/hooks/send-lane-completion.sh
+++ b/.claude/hooks/send-lane-completion.sh
@@ -32,6 +32,14 @@ FILES_COUNT="${6:-}"
 TIER="${7:-}"
 NEXT_ACTION="${8:-}"
 
+# Stop hook として無引数で呼ばれた場合 (lane/phase/status が全て unknown) は通知しない。
+# settings.json の Stop イベント登録では positional 引数が渡らず "unknown" 連発で
+# Slack が flood する (2026-05-21 night-mode で背景エージェント Stop 多発時に顕在化)。
+# 明示的に lane 等を指定した正規呼び出し (Agent Teams lane 完了通知) のみ通知する。
+if [[ "${LANE}" == "unknown" && "${PHASE}" == "unknown" && "${STATUS}" == "unknown" ]]; then
+  exit 0
+fi
+
 # 数値フィールドを jq --argjson 用に整形 (空 → null, 数値 → そのまま, 非数値 → null)
 to_jsonnum() {
   local v="$1"

--- a/scripts/staging-watchdog.sh
+++ b/scripts/staging-watchdog.sh
@@ -7,15 +7,21 @@
 # 真因: deploy_production.sh の down --remove-orphans が staging-new を道連れ削除していた
 # 根本修正: deploy_production.sh から --remove-orphans を除去 (fix/staging-orphan-protection-20260520)
 # 本スクリプト: defense-in-depth として staging 停止時に自動 up -d する
+#
+# 2026-05-21 追加: Slack flood 抑制 (COOLDOWN)。staging が継続的に down かつ復旧が定着しない場合、
+# 従来は 5 分毎に「停止を検知」を Slack へ連発していた。COOLDOWN_SEC 内は復旧は試みるが
+# 通知は抑制し、復旧 or cooldown 経過時のみ通知する。
 
-set -euo pipefail
+set -uo pipefail
 
-COMPOSE_DIR="/opt/ultra-autotrade"
-COMPOSE_FILE="docker-compose.staging.yml"
-ENV_FILE=".env.staging-new"
-SENTINEL_CONTAINER="ultra-autotrade-postgres-staging-new"
+COMPOSE_DIR="${COMPOSE_DIR:-/opt/ultra-autotrade}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.staging.yml}"
+ENV_FILE="${ENV_FILE:-.env.staging-new}"
+SENTINEL_CONTAINER="${SENTINEL_CONTAINER:-ultra-autotrade-postgres-staging-new}"
+WEBHOOK_FILE="${WEBHOOK_FILE:-${COMPOSE_DIR}/.env.production}"
+COOLDOWN_SEC="${COOLDOWN_SEC:-1800}"  # 30分: down 継続時の通知連発抑制
+STATE_FILE="${STATE_FILE:-${TMPDIR:-/tmp}/.staging_watchdog_alert}"
 LOG_PREFIX="[staging-watchdog] $(date '+%Y-%m-%dT%H:%M:%S')"
-WEBHOOK_FILE="${COMPOSE_DIR}/.env.production"
 
 notify_slack() {
   local msg="$1"
@@ -33,16 +39,36 @@ is_staging_alive() {
   docker ps --filter "name=${SENTINEL_CONTAINER}" --filter "status=running" -q | grep -q .
 }
 
+# ---- 正常時: 直前に alert を出していたら復旧通知して state クリア ----
 if is_staging_alive; then
-  echo "${LOG_PREFIX} staging healthy (${SENTINEL_CONTAINER} running)"
+  if [[ -f "${STATE_FILE}" ]]; then
+    echo "${LOG_PREFIX} RECOVERED: staging stack restored (alert state クリア)"
+    notify_slack "✅ [staging-watchdog] staging stack 復旧確認 (${SENTINEL_CONTAINER} running)。"
+    rm -f "${STATE_FILE}" 2>/dev/null || true
+  else
+    echo "${LOG_PREFIX} staging healthy (${SENTINEL_CONTAINER} running)"
+  fi
   exit 0
 fi
 
-echo "${LOG_PREFIX} WARN: staging stack down — starting auto-recovery"
-notify_slack "⚠️ [staging-watchdog] staging stack 停止を検知。自動復旧を開始します。"
+# ---- 異常時: cooldown 判定 (通知抑制。復旧自体は毎回試みる) ----
+now=$(date +%s)
+should_notify=1
+if [[ -f "${STATE_FILE}" ]]; then
+  last=$(cat "${STATE_FILE}" 2>/dev/null || echo "0")
+  if (( now - last < COOLDOWN_SEC )); then
+    should_notify=0
+  fi
+fi
 
-cd "${COMPOSE_DIR}"
-docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" up -d 2>&1
+echo "${LOG_PREFIX} WARN: staging stack down — starting auto-recovery (notify=${should_notify})"
+if [[ "${should_notify}" == "1" ]]; then
+  notify_slack "⚠️ [staging-watchdog] staging stack 停止を検知。自動復旧を開始します。(以後 ${COOLDOWN_SEC}s は通知抑制)"
+  echo "${now}" > "${STATE_FILE}" 2>/dev/null || true
+fi
+
+cd "${COMPOSE_DIR}" || { echo "${LOG_PREFIX} ERROR: cd ${COMPOSE_DIR} 失敗"; exit 1; }
+docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" up -d 2>&1 || true
 
 # 15秒待って確認
 sleep 15
@@ -50,8 +76,12 @@ sleep 15
 if is_staging_alive; then
   echo "${LOG_PREFIX} RECOVERED: staging stack restored"
   notify_slack "✅ [staging-watchdog] staging stack 自動復旧完了。"
+  rm -f "${STATE_FILE}" 2>/dev/null || true
 else
   echo "${LOG_PREFIX} ERROR: staging stack recovery FAILED"
-  notify_slack "❌ [staging-watchdog] staging stack 自動復旧失敗。手動対応が必要です。"
+  # 復旧失敗通知も should_notify のときのみ (連発防止)。
+  if [[ "${should_notify}" == "1" ]]; then
+    notify_slack "❌ [staging-watchdog] staging stack 自動復旧失敗。手動対応が必要です。(以後 ${COOLDOWN_SEC}s は通知抑制 — 継続 down 中)"
+  fi
   exit 1
 fi


### PR DESCRIPTION
## 背景 (2026-05-21 night-mode で Slack #ultra-auto-project がパンク)
`*/5` 分毎に2系統のメッセージが連発:
1. `[staging-watchdog] staging stack 停止を検知。自動復旧を開始します。`
2. `Lane: unknown Phase: unknown Status: unknown`

## 真因 (dev VPS 実コード解析)
1. **staging-watchdog.sh**: sentinel `ultra-autotrade-postgres-staging-new` は compose の container_name と**一致**（誤検知ではない）= staging postgres が**実際に down** かつ `up -d` 復旧が定着していない。通知 cooldown が無く毎サイクル「停止を検知」連発。さらに `set -e` 下で `up -d` 失敗時に復旧確認前に exit する潜在バグ。
2. **send-lane-completion.sh**: settings.json の **Stop hook**（matcher `.*`）として登録。Stop イベントは positional 引数を渡さないため `LANE/PHASE/STATUS` が常に `unknown`。night-mode の背景エージェント Stop 多発で `unknown` 連発。

## 修正
1. **staging-watchdog.sh**: `COOLDOWN_SEC`(既定30分) + state-file で down 継続時の通知を抑制（**復旧は毎サイクル試行継続**、復旧 or cooldown 経過時のみ通知）。`up -d ... || true` + `cd || exit` で set -e 落ち修正。全パラメータ env override 化。
2. **send-lane-completion.sh**: lane/phase/status が全て `unknown` の場合は通知 skip するガード追加（正規の Agent Teams lane 完了通知は引数ありなので通知継続）。

## 検証 (dev VPS)
- `bash -n` 両方 OK / `shellcheck -S error` 両方 clean
- hook ガード: 無引数 DRY_RUN で exit 0（通知されないこと確認）
- **live hook (dev VPS) は即時反映済** → 以降の背景エージェント Stop での `unknown` flood は停止済

## ⚠️ 残: staging postgres 実 down の根本原因
本 PR は flood 抑制 + recovery 堅牢化。**staging postgres が「なぜ up -d で復旧定着しないか」(crash-loop / volume / disk / port) は本番 SSH ログ調査が必要 = HUMAN-REVIEW-REQUIRED**。診断コマンドは本 PR コメント参照。

merge は claude.ai 判断（hook ガードだけでも先行 merge 推奨＝flood 恒久停止）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)