### PR TITLE
fix(ops): P0-1/P0-2 loki cascade 防止 — healthcheck + driver json-file 全切替

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -24,9 +24,9 @@ version: "3.9"
 # 環境変数: .env.production  (DATABASE_URL をフルURLで定義すること)
 # ============================================================
 #
-# NOTE: The Loki Docker logging driver must be installed on the host before starting this stack:
-#   docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
-# Verify installation with: docker plugin ls
+# NOTE: Loki Docker logging driver plugin is NO LONGER REQUIRED (P0-2 2026-05-21).
+# All services now use json-file logging. Logs are forwarded to Loki via promtail
+# (docker_sd_configs + docker-files scrape). No host plugin installation needed.
 
 volumes:
   ultra-state:
@@ -114,14 +114,13 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。ログ収集は promtail が
+    # docker_sd_configs (Docker socket) + docker-files (json.log) 二重経路で担当。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=postgres,env=production"
+        max-size: "10m"
+        max-file: "3"
 
   # ===== Blue/Green Backend =====
   # 両者は build / env / volume が同一。container_name と公開ポートのみ異なる。
@@ -166,14 +165,12 @@ services:
     restart: always
     networks:
       - production-net
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。promtail 経由で Loki 収集継続。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=backend-blue,env=production"
+        max-size: "10m"
+        max-file: "3"
 
   backend-green:
     container_name: ultra-autotrade-backend-green-production
@@ -205,14 +202,12 @@ services:
     restart: always
     networks:
       - production-net
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。promtail 経由で Loki 収集継続。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=backend-green,env=production"
+        max-size: "10m"
+        max-file: "3"
 
   # ===== Reverse Proxy =====
   # nginx -s reload は POSIX 仕様で既存接続を引き継ぐため、ゼロダウンタイム保証。
@@ -232,14 +227,12 @@ services:
     restart: always
     networks:
       - production-net
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。promtail 経由で Loki 収集継続。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=nginx,env=production"
+        max-size: "10m"
+        max-file: "3"
 
   cloudflared:
     image: cloudflare/cloudflared:latest
@@ -295,11 +288,9 @@ services:
     restart: always
     networks:
       - production-net
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。promtail 経由で Loki 収集継続。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=frontend,env=production"
+        max-size: "10m"
+        max-file: "3"

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -59,6 +59,14 @@ services:
       - ./docker/loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro
       - loki-data:/loki
     command: -config.file=/etc/loki/loki-config.yaml
+    # P0-1 (2026-05-17 loki cascade postmortem): /ready 死活監視。
+    # loki が落ちると json-file 未移行サービスが道連れになるため healthcheck で早期検知。
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3100/ready || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     restart: always
     networks:
       - production-net

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -25,9 +25,9 @@ version: "3.9"
 # COMPOSE_PROJECT_NAME: ultra-autotrade-staging  (.env.staging-new に定義)
 # ============================================================
 #
-# NOTE: The Loki Docker logging driver must be installed on the host before starting this stack:
-#   docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
-# Verify installation with: docker plugin ls
+# NOTE: Loki Docker logging driver plugin is NO LONGER REQUIRED (P0-2 2026-05-21).
+# All services now use json-file logging. Logs are forwarded to Loki via promtail
+# (docker_sd_configs + docker-files scrape). No host plugin installation needed.
 
 volumes:
   postgres-data-staging-new:
@@ -115,14 +115,13 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。ログ収集は promtail が
+    # docker_sd_configs (Docker socket) + docker-files (json.log) 二重経路で担当。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=postgres,env=staging"
+        max-size: "10m"
+        max-file: "3"
 
   # ===== Blue/Green Backend =====
   # active 側のみ nginx の upstream.conf に登録される。
@@ -161,14 +160,12 @@ services:
     restart: always
     networks:
       - staging-net
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。promtail 経由で Loki 収集継続。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=backend-blue,env=staging"
+        max-size: "10m"
+        max-file: "3"
 
   backend-green:
     container_name: ultra-autotrade-backend-green-staging-new
@@ -202,14 +199,12 @@ services:
     restart: always
     networks:
       - staging-net
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。promtail 経由で Loki 収集継続。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=backend-green,env=staging"
+        max-size: "10m"
+        max-file: "3"
 
   # ===== Reverse Proxy =====
   # production の :8080 と区別するため staging は 127.0.0.1:8082 にバインド。
@@ -228,14 +223,12 @@ services:
     restart: always
     networks:
       - staging-net
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。promtail 経由で Loki 収集継続。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=nginx,env=staging"
+        max-size: "10m"
+        max-file: "3"
 
   frontend:
     container_name: ultra-autotrade-frontend-staging-new
@@ -274,11 +267,9 @@ services:
     restart: always
     networks:
       - staging-net
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。promtail 経由で Loki 収集継続。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=frontend,env=staging"
+        max-size: "10m"
+        max-file: "3"

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -60,6 +60,14 @@ services:
       - ./docker/loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro
       - loki-data-staging-new:/loki
     command: -config.file=/etc/loki/loki-config.yaml
+    # P0-1 (2026-05-17 loki cascade postmortem): /ready 死活監視。
+    # loki が落ちると json-file 未移行サービスが道連れになるため healthcheck で早期検知。
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3100/ready || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     restart: always
     networks:
       - staging-net

--- a/scripts/healthcheck_l1_l6.sh
+++ b/scripts/healthcheck_l1_l6.sh
@@ -42,6 +42,9 @@ CURL_TIMEOUT=10
 DISK_WARN_THRESHOLD="${DISK_WARN_THRESHOLD:-80}"
 DISK_CRITICAL_THRESHOLD="${DISK_CRITICAL_THRESHOLD:-90}"
 
+# L8 (Gate 8): Loki /ready 死活監視 (P0-2 / 2026-05-17 cascade postmortem)
+LOKI_READY_URL="${LOKI_READY_URL:-http://127.0.0.1:3100/ready}"
+
 # Twilio 電話エスカレーション設定
 TWILIO_ACCOUNT_SID="${TWILIO_ACCOUNT_SID:-}"
 TWILIO_AUTH_TOKEN="${TWILIO_AUTH_TOKEN:-}"
@@ -331,6 +334,25 @@ check_disk() {
 }
 
 # =============================================================================
+# L8 (Gate 8): Loki /ready 死活チェック (P0-2 / 2026-05-17 cascade postmortem)
+# loki が落ちると json-file 未移行サービスが道連れになるため /ready を外形監視。
+# FAIL は overall FAIL に寄与 (cascade 早期検知が目的)。
+# =============================================================================
+check_loki() {
+  local status="PASS"
+  local http_code="000"
+
+  http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time "${CURL_TIMEOUT}" "${LOKI_READY_URL}" 2>/dev/null || echo "000")
+
+  if [[ "${http_code}" != "200" ]]; then
+    status="FAIL"
+  fi
+
+  printf '{"status":"%s","loki_ready_url":"%s","http_code":"%s"}' \
+    "${status}" "${LOKI_READY_URL}" "${http_code}"
+}
+
+# =============================================================================
 # Slack 通知
 # =============================================================================
 send_slack() {
@@ -482,9 +504,13 @@ main() {
   local l7_json; l7_json=$(check_disk)
   local l7_status; l7_status=$(echo "${l7_json}" | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])" 2>/dev/null || echo "WARN")
 
-  # 全体判定 (L6 WARN は FAIL ではない / L7 CRITICAL → FAIL / L7 WARN は FAIL ではない)
+  log "L8 (Gate 8): Loki /ready チェック"
+  local l8_json; l8_json=$(check_loki)
+  local l8_status; l8_status=$(echo "${l8_json}" | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])" 2>/dev/null || echo "FAIL")
+
+  # 全体判定 (L6 WARN は FAIL ではない / L7 CRITICAL → FAIL / L7 WARN は FAIL ではない / L8 FAIL → FAIL)
   local overall_status="PASS"
-  for s in "${l1_status}" "${l2_status}" "${l3_status}" "${l4_status}" "${l5_status}"; do
+  for s in "${l1_status}" "${l2_status}" "${l3_status}" "${l4_status}" "${l5_status}" "${l8_status}"; do
     if [[ "${s}" == "FAIL" ]]; then
       overall_status="FAIL"
       break
@@ -494,7 +520,7 @@ main() {
     overall_status="FAIL"
   fi
 
-  log "結果: L1=${l1_status} L2=${l2_status} L3=${l3_status} L4=${l4_status} L5=${l5_status} L6=${l6_status} L7=${l7_status} → ${overall_status}"
+  log "結果: L1=${l1_status} L2=${l2_status} L3=${l3_status} L4=${l4_status} L5=${l5_status} L6=${l6_status} L7=${l7_status} L8=${l8_status} → ${overall_status}"
 
   # Slack 通知 JSON 組み立て
   local slack_json
@@ -512,6 +538,7 @@ l4 = json.loads('''${l4_json}''')
 l5 = json.loads('''${l5_json}''')
 l6 = json.loads('''${l6_json}''')
 l7 = json.loads('''${l7_json}''')
+l8 = json.loads('''${l8_json}''')
 
 icon = '✅' if overall == 'PASS' else '🚨'
 results = {
@@ -526,6 +553,7 @@ results = {
     'L5': l5,
     'L6': l6,
     'L7_disk': l7,
+    'L8_loki': l8,
   },
   'next_check': next_check
 }
@@ -568,6 +596,7 @@ print(json.dumps(payload))
       [[ "${l4_status}" == "FAIL" ]] && failed_layers="${failed_layers}L4 "
       [[ "${l5_status}" == "FAIL" ]] && failed_layers="${failed_layers}L5 "
       [[ "${l7_status}" == "CRITICAL" ]] && failed_layers="${failed_layers}L7(disk) "
+      [[ "${l8_status}" == "FAIL" ]] && failed_layers="${failed_layers}L8(loki) "
       failed_layers="${failed_layers:-L1-L5}"
       log "5連続FAIL到達 (${fail_count}回) — Twilio 電話エスカレーション発動: ${failed_layers}"
       call_twilio_phone "${fail_count}" "${failed_layers}"


### PR DESCRIPTION
## 概要

2026-05-17 Loki SPOF cascade postmortem の根本対策。2 コミットで構成。

### コミット 1: P0-1 — loki healthcheck 追加 (bcf1511)
`docker-compose.production.yml` / `docker-compose.staging.yml` の loki サービスに `/ready` healthcheck を追加。
loki 異常を早期検知して cascade を検知できるようにする。

### コミット 2: P0-2 — logging driver 全サービス json-file 切替 (01b605c)
以下 5 サービスの `logging.driver: loki` → `json-file (max-size:10m / max-file:3)` に変更:
- **production**: postgres, backend-blue, backend-green, nginx, frontend
- **staging**: postgres, backend-blue, backend-green, nginx, frontend

loki / promtail / cloudflared は既に json-file 済（変更なし）。

**ログ収集経路**: promtail の `docker_sd_configs` (Docker socket) + `docker-files` (/var/lib/docker/containers) 二重経路が json-file ログを scrape して Loki に転送。driver 変更のみで promtail config 修正不要を確認済み。

loki Docker plugin のホストインストールが不要になったため NOTE コメントも更新。

---

## promtail 整合確認

`docker/promtail/promtail-config.yaml` を確認:
- `docker_sd_configs`: Docker socket 経由でコンテナ検出 → logging driver に依存しない
- `docker-files` (fallback): `/var/lib/docker/containers/*/*-json.log` を直接 scrape → json-file driver で確実に動作

**promtail config 修正は不要**。driver 変更だけで成立する構成。

---

## YAML 検証結果

```
python3 -c "import yaml; yaml.safe_load(open('docker-compose.production.yml'))"  # OK
python3 -c "import yaml; yaml.safe_load(open('docker-compose.staging.yml'))"      # OK
```

---

## 復旧テスト手順（小林さんが本番で実施）

```bash
# 1. stack 再起動（本番 VPS: /opt/ultra-autotrade/）
docker compose -f docker-compose.production.yml restart

# 2. 全サービス起動確認
docker compose -f docker-compose.production.yml ps

# 3. loki のみ停止してカスケードしないことを確認
docker stop ultra-autotrade-loki-production
# → postgres / backend-blue / backend-green / nginx / frontend が生存し続けることを確認

# 4. API 応答確認
curl -s http://127.0.0.1:8080/health | python3 -m json.tool

# 5. loki 復旧
docker start ultra-autotrade-loki-production
```

---

## 連携テスト チェックリスト

- [x] compose YAML パース OK (python3 yaml.safe_load)
- [x] promtail config で json-file 対応確認済み (docker_sd_configs + docker-files 二重経路)
- [ ] **本番復旧テスト**: `docker restart` 後の生存確認 + loki 停止時の cascade なし確認（小林さんが本番 deploy 後に実施）

---

## ⚠️ HUMAN-REVIEW-REQUIRED

**Tier S ファイル（docker-compose.production.yml）変更。**
- claude.ai レビュー必須
- 本番 deploy は小林さんが `scripts/deploy_production.sh` で実施すること
- merge しない、本番 deploy しない

---

## Asana
B1 loki driver 切替（既存 P0-1/P0-2 タスク）