### PR TITLE
fix(ops): P0-2 loki driver → json-file 全切替（cascade 防止・S3）

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -24,9 +24,9 @@ version: "3.9"
 # 環境変数: .env.production  (DATABASE_URL をフルURLで定義すること)
 # ============================================================
 #
-# NOTE: The Loki Docker logging driver must be installed on the host before starting this stack:
-#   docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
-# Verify installation with: docker plugin ls
+# NOTE: Loki Docker logging driver plugin is NO LONGER REQUIRED (P0-2 2026-05-21).
+# All services now use json-file logging. Logs are forwarded to Loki via promtail
+# (docker_sd_configs + docker-files scrape). No host plugin installation needed.
 
 volumes:
   ultra-state:
@@ -114,14 +114,13 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。ログ収集は promtail が
+    # docker_sd_configs (Docker socket) + docker-files (json.log) 二重経路で担当。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=postgres,env=production"
+        max-size: "10m"
+        max-file: "3"
 
   # ===== Blue/Green Backend =====
   # 両者は build / env / volume が同一。container_name と公開ポートのみ異なる。
@@ -166,14 +165,12 @@ services:
     restart: always
     networks:
       - production-net
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。promtail 経由で Loki 収集継続。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=backend-blue,env=production"
+        max-size: "10m"
+        max-file: "3"
 
   backend-green:
     container_name: ultra-autotrade-backend-green-production
@@ -205,14 +202,12 @@ services:
     restart: always
     networks:
       - production-net
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。promtail 経由で Loki 収集継続。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=backend-green,env=production"
+        max-size: "10m"
+        max-file: "3"
 
   # ===== Reverse Proxy =====
   # nginx -s reload は POSIX 仕様で既存接続を引き継ぐため、ゼロダウンタイム保証。
@@ -232,14 +227,12 @@ services:
     restart: always
     networks:
       - production-net
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。promtail 経由で Loki 収集継続。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=nginx,env=production"
+        max-size: "10m"
+        max-file: "3"
 
   cloudflared:
     image: cloudflare/cloudflared:latest
@@ -295,11 +288,9 @@ services:
     restart: always
     networks:
       - production-net
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。promtail 経由で Loki 収集継続。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=frontend,env=production"
+        max-size: "10m"
+        max-file: "3"

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -25,9 +25,9 @@ version: "3.9"
 # COMPOSE_PROJECT_NAME: ultra-autotrade-staging  (.env.staging-new に定義)
 # ============================================================
 #
-# NOTE: The Loki Docker logging driver must be installed on the host before starting this stack:
-#   docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
-# Verify installation with: docker plugin ls
+# NOTE: Loki Docker logging driver plugin is NO LONGER REQUIRED (P0-2 2026-05-21).
+# All services now use json-file logging. Logs are forwarded to Loki via promtail
+# (docker_sd_configs + docker-files scrape). No host plugin installation needed.
 
 volumes:
   postgres-data-staging-new:
@@ -115,14 +115,13 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。ログ収集は promtail が
+    # docker_sd_configs (Docker socket) + docker-files (json.log) 二重経路で担当。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=postgres,env=staging"
+        max-size: "10m"
+        max-file: "3"
 
   # ===== Blue/Green Backend =====
   # active 側のみ nginx の upstream.conf に登録される。
@@ -161,14 +160,12 @@ services:
     restart: always
     networks:
       - staging-net
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。promtail 経由で Loki 収集継続。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=backend-blue,env=staging"
+        max-size: "10m"
+        max-file: "3"
 
   backend-green:
     container_name: ultra-autotrade-backend-green-staging-new
@@ -202,14 +199,12 @@ services:
     restart: always
     networks:
       - staging-net
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。promtail 経由で Loki 収集継続。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=backend-green,env=staging"
+        max-size: "10m"
+        max-file: "3"
 
   # ===== Reverse Proxy =====
   # production の :8080 と区別するため staging は 127.0.0.1:8082 にバインド。
@@ -228,14 +223,12 @@ services:
     restart: always
     networks:
       - staging-net
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。promtail 経由で Loki 収集継続。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=nginx,env=staging"
+        max-size: "10m"
+        max-file: "3"
 
   frontend:
     container_name: ultra-autotrade-frontend-staging-new
@@ -274,11 +267,9 @@ services:
     restart: always
     networks:
       - staging-net
+    # P0-2 (2026-05-21 loki cascade fix): json-file に切替。promtail 経由で Loki 収集継続。
     logging:
-      driver: loki
+      driver: "json-file"
       options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-timeout: "10s"
-        loki-external-labels: "service=frontend,env=staging"
+        max-size: "10m"
+        max-file: "3"


### PR DESCRIPTION
## 背景 (5/17 Loki SPOF postmortem / Phase1 開始ブロッカー)
postgres / backend-blue / backend-green / nginx / frontend の5サービスが `logging.driver: loki` のままで、loki 障害時に道連れ（cascade）。json-file に切替し promtail で吸い上げる。

## 変更 (production / staging 両方・compose のみ)
5サービスの logging を `json-file`（max-size:10m / max-file:3）に変更。loki/promtail/cloudflared は既に json-file 済。

## promtail 整合
config 修正不要。`docker/promtail/promtail-config.yaml` は docker_sd_configs + `/var/lib/docker/containers/*/*-json.log` 直 scrape の二重経路で json-file を確実に拾う（S3 調査済）。

## 検証 (dev VPS)
- YAML: production/staging 両方 `yaml.safe_load` OK
- `grep loki driver残存` = 0（両ファイル）

## 連携テスト（本番手順・小林さん）
1. `docker compose -f docker-compose.production.yml restart` で全サービス起動継続
2. `docker stop ultra-autotrade-loki-production` → 他4サービス生存（cascade しない）確認
3. `curl http://127.0.0.1:8000/health` API 応答（nginx 経由）

## ⚠️ Tier S 本番 compose
claude.ai レビュー必須・**本番 deploy は HUMAN-REVIEW-REQUIRED**（driver 変更は restart で反映、再ビルド不要）。

注: 当初 S3 エージェントが既マージ済 #350 ブランチに追加コミットして PR #358 を作ったため、driver 変更のみを main から cherry-pick した本クリーン PR で置換。#358 は close。

🤖 Generated with [Claude Code](https://claude.com/claude-code)