### PR TITLE
fix(healthcheck): HEALTH_URL_INTERNAL 既定を nginx:8000 へ変更（Blue/Green 非依存）+ CLAUDE.md 誤記訂正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -520,7 +520,7 @@ tmux attach -t phase-<X>
 
 - **コンテナ名**: production は `*-production` suffix（2026-04-24 container_name 衝突インシデント後にリネーム済み）
 - **staging**: Shadow Mode専用（`AI_SHADOW_MODE=true` / `REBALANCE_SHADOW_MODE=true`）、Base Sepolia、port 3001/8082(nginx経由)/5433（注: 旧8001は廃止。`curl http://127.0.0.1:8082/health` で確認）
-- **production**: 実資金・実トレード、Base Mainnet、port 3000/8010(nginx経由)/5432
+- **production**: 実資金・実トレード、Base Mainnet、port 3000/8000(nginx host port)/8080(nginx container)/5432（8010=backend-blue直ポート、8011=backend-green直ポート、nginx経由=8000→8080→active backend）
 
 ---
 

--- a/scripts/healthcheck_l1_l6.sh
+++ b/scripts/healthcheck_l1_l6.sh
@@ -29,7 +29,12 @@ set -uo pipefail
 SCRIPT_NAME="healthcheck_l1_l6"
 ENV_FILE="${ENV_FILE:-/opt/ultra-autotrade/.env.production}"
 
-HEALTH_URL_INTERNAL="${HEALTH_URL_INTERNAL:-http://127.0.0.1:8010/health}"
+# nginx 経由 (host:8000 → nginx container:8080 → active backend)
+# nginx が active color (blue:8010 / green:8011) へルーティングするため、
+# この URL は Blue/Green color に依存せず常に active backend の /health に到達する。
+# docker-compose.production.yml: ports "8000:8080" (host→nginx container)
+# 旧値 http://127.0.0.1:8010/health は backend-blue 直ポート = Blue/Green 非依存 NG
+HEALTH_URL_INTERNAL="${HEALTH_URL_INTERNAL:-http://127.0.0.1:8000/health}"
 HEALTH_URL_EXTERNAL="${HEALTH_URL_EXTERNAL:-https://api.ultra-auto-trade.com/health}"
 POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-ultra-autotrade-postgres-production}"
 DB_USER="${DB_USER:-ultra}"


### PR DESCRIPTION
## 概要

2026-05-21 healthcheck deploy で L1+L2 が誤 FAIL した真因を修正する。

**真因**: `HEALTH_URL_INTERNAL` の既定値 `http://127.0.0.1:8010/health` が backend-blue 直ポート固定のため、active=green(:8011) 時に到達不可 → L1/L2 が誤 FAIL。

**修正**: 既定値を `http://127.0.0.1:8000/health`（nginx host port）へ変更。nginx が `upstream.production.conf` で active color へ常時ルーティングするため、**これだけで Blue/Green color 非依存**になる。

## ポート構造（実態）

| ポート | 用途 |
|---|---|
| `127.0.0.1:8000` → nginx container:8080 | **nginx host port（外部・healthcheck 用）** |
| `127.0.0.1:8080` → nginx container:8080 | nginx 別名 host port |
| `127.0.0.1:8010` → backend-blue:8000 | backend-blue 直ポート |
| `127.0.0.1:8011` → backend-green:8000 | backend-green 直ポート |

nginx → active backend は `docker/nginx/upstream.production.conf` の単一行書き換えで制御。

## 変更ファイル

1. **`scripts/healthcheck_l1_l6.sh`**
   - `HEALTH_URL_INTERNAL` 既定値: `http://127.0.0.1:8010/health` → `http://127.0.0.1:8000/health`
   - コメントで「nginx 経由 = active color 非依存」と port 構造を明記

2. **`CLAUDE.md`**
   - `port 3000/8010(nginx経由)/5432` → `port 3000/8000(nginx host port)/8080(nginx container)/5432（8010=backend-blue直、8011=backend-green直、nginx経由=8000→8080→active backend）`

## 連携テスト

- [x] `bash -n scripts/healthcheck_l1_l6.sh` → OK
- [x] `shellcheck -S error scripts/healthcheck_l1_l6.sh` → OK
- [ ] **本番確認手順**（本 PR merge + git pull 後）: active=green の状態で `HEALTH_URL_INTERNAL=http://127.0.0.1:8000/health ./scripts/healthcheck_l1_l6.sh DRY_RUN=true` を実行し L1 `internal_health=200` を確認。dev VPS は backend 不在のため実 200 取得不可（本番のみ検証可）。

## 本番 cron 簡素化

本 PR 反映後、**本番 cron の `HEALTH_URL_INTERNAL=8000` env override が不要**になる（小林さんが cron をクリーンアップ可能）。

## 競合 PR 確認

- **#359** (`fix/loki-driver-jsonfile-clean-20260521`): `docker-compose.production.yml` / `docker-compose.staging.yml` のみ変更 → `healthcheck_l1_l6.sh` / `CLAUDE.md` とは**競合なし**
- **#350** (`0d21cd6` merged): 本 PR のベース → 競合なし

## Asana

Closes Asana 1214991350677806

---

⚠️ **Tier S（CLAUDE.md 変更含む）— claude.ai レビュー必須。merge しない。本番 deploy は `git pull` で反映（HUMAN-REVIEW）。**