### PR TITLE
fix(scheduler): PR #323 follow-up — per-user exception handling + clamp boundary tests

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -234,80 +234,92 @@ def _create_proposals_for_users(
     count = 0
     for user in active_users:
         try:
-            if not _is_user_due_for_judgment(user, now):
-                logger.debug(
-                    "Skipping proposal for user %d (tier=%s, last_judgment_at=%s)",
-                    user.id,
-                    user.tier,
-                    user.last_judgment_at,
+            # per-user SAVEPOINT: 1ユーザーの DB エラー (SELECT 失敗等) で session が汚染され
+            # 後続ユーザー全員が fail する問題を防ぐ。例外時はこの savepoint のみ自動 rollback
+            # され、先行ユーザーの proposal は維持される。素朴な db.rollback() は単一 commit
+            # 設計下で全 user 分を破棄するため不可。最終 commit は呼び出し側で 1 回行う。
+            with db.begin_nested():
+                if not _is_user_due_for_judgment(user, now):
+                    logger.debug(
+                        "Skipping proposal for user %d (tier=%s, last_judgment_at=%s)",
+                        user.id,
+                        user.tier,
+                        user.last_judgment_at,
+                    )
+                    continue
+
+                # fund_allocations から per-user 提案金額を動的計算 (Decimal("0") = skip)
+                proposal_amount_usd = _resolve_proposal_amount(db, user.id)
+                if proposal_amount_usd <= Decimal("0"):
+                    # _resolve_proposal_amount 内で警告・Slack 通知済み
+                    continue
+
+                # 動的手数料計算: デフォルトAPY 4%（安定期）を使用
+                # 30日保有での予想利益 = amount × (APY/100) × (30/365)
+                _default_apy = Decimal("4")
+                _expected_profit = (
+                    proposal_amount_usd
+                    * _default_apy
+                    / Decimal("100")
+                    * Decimal("30")
+                    / Decimal("365")
                 )
-                continue
-
-            # fund_allocations から per-user 提案金額を動的計算 (Decimal("0") = skip)
-            proposal_amount_usd = _resolve_proposal_amount(db, user.id)
-            if proposal_amount_usd <= Decimal("0"):
-                # _resolve_proposal_amount 内で警告・Slack 通知済み
-                continue
-
-            # 動的手数料計算: デフォルトAPY 4%（安定期）を使用
-            # 30日保有での予想利益 = amount × (APY/100) × (30/365)
-            _default_apy = Decimal("4")
-            _expected_profit = (
-                proposal_amount_usd * _default_apy / Decimal("100") * Decimal("30") / Decimal("365")
-            )
-            market_fee = calculate_fee_by_market(
-                trade_amount_usd=proposal_amount_usd,
-                tier=normalize_tier(user.tier, user_id=user.id).value,
-                current_apy=_default_apy,
-                expected_profit_usd=_expected_profit,
-                fixed_cost_usd=fixed_cost,
-            )
-
-            if not market_fee.should_trade:
-                logger.info(
-                    "DynamicFee: should_trade=False for user %d — skipping proposal (%s)",
-                    user.id,
-                    market_fee.reason,
+                market_fee = calculate_fee_by_market(
+                    trade_amount_usd=proposal_amount_usd,
+                    tier=normalize_tier(user.tier, user_id=user.id).value,
+                    current_apy=_default_apy,
+                    expected_profit_usd=_expected_profit,
+                    fixed_cost_usd=fixed_cost,
                 )
-                continue
 
-            proposal = Proposal(
-                user_id=user.id,
-                ai_decision_id=decision.id,
-                operation=operation,
-                asset=_PROPOSAL_ASSET,
-                amount=proposal_amount_usd,
-                amount_usd=proposal_amount_usd,
-                reason=reason,
-                expires_at=expires_at,
-                fee_rate=market_fee.fee_rate,
-                fee_amount=market_fee.fee_amount,
-            )
-            db.add(proposal)
-            user.last_judgment_at = now
-            count += 1
+                if not market_fee.should_trade:
+                    logger.info(
+                        "DynamicFee: should_trade=False for user %d — skipping proposal (%s)",
+                        user.id,
+                        market_fee.reason,
+                    )
+                    continue
 
-            # ai_proposal_notification: best-effort（失敗しても Proposal 作成は継続）
-            try:
-                from app.notifications.factory import get_notification_service  # noqa: PLC0415
-                from app.notifications.templates import ai_proposal_notification  # noqa: PLC0415
-
-                _payload = ai_proposal_notification(
+                proposal = Proposal(
+                    user_id=user.id,
+                    ai_decision_id=decision.id,
                     operation=operation,
                     asset=_PROPOSAL_ASSET,
                     amount=proposal_amount_usd,
-                    confidence=result.final_confidence,
+                    amount_usd=proposal_amount_usd,
+                    reason=reason,
+                    expires_at=expires_at,
+                    fee_rate=market_fee.fee_rate,
+                    fee_amount=market_fee.fee_amount,
                 )
-                _payload.notification_message.user_id = user.id
-                get_notification_service().send(_payload.notification_message)
-            except Exception as _notif_exc:  # noqa: BLE001
-                logger.warning(
-                    "ai_proposal_notification failed for user %d (skipping): %s",
-                    user.id,
-                    _notif_exc,
-                )
+                db.add(proposal)
+                user.last_judgment_at = now
+                count += 1
+
+                # ai_proposal_notification: best-effort（失敗しても Proposal 作成は継続）
+                try:
+                    from app.notifications.factory import get_notification_service  # noqa: PLC0415
+                    from app.notifications.templates import (
+                        ai_proposal_notification,  # noqa: PLC0415
+                    )
+
+                    _payload = ai_proposal_notification(
+                        operation=operation,
+                        asset=_PROPOSAL_ASSET,
+                        amount=proposal_amount_usd,
+                        confidence=result.final_confidence,
+                    )
+                    _payload.notification_message.user_id = user.id
+                    get_notification_service().send(_payload.notification_message)
+                except Exception as _notif_exc:  # noqa: BLE001
+                    logger.warning(
+                        "ai_proposal_notification failed for user %d (skipping): %s",
+                        user.id,
+                        _notif_exc,
+                    )
         except Exception as _user_exc:  # noqa: BLE001
             # 1ユーザーの失敗が他のユーザーの提案生成を止めないようにする。
+            # savepoint は with ブロック脱出時に当該ユーザー分のみ自動 rollback 済。
             # DB クエリ例外 / 未想定エラーはここで捕捉し、ループ継続。
             logger.error(
                 "Proposal creation failed for user %d (skipping, continuing to next user): %s",

--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -233,77 +233,86 @@ def _create_proposals_for_users(
 
     count = 0
     for user in active_users:
-        if not _is_user_due_for_judgment(user, now):
-            logger.debug(
-                "Skipping proposal for user %d (tier=%s, last_judgment_at=%s)",
-                user.id,
-                user.tier,
-                user.last_judgment_at,
-            )
-            continue
-
-        # fund_allocations から per-user 提案金額を動的計算 (Decimal("0") = skip)
-        proposal_amount_usd = _resolve_proposal_amount(db, user.id)
-        if proposal_amount_usd <= Decimal("0"):
-            # _resolve_proposal_amount 内で警告・Slack 通知済み
-            continue
-
-        # 動的手数料計算: デフォルトAPY 4%（安定期）を使用
-        # 30日保有での予想利益 = amount × (APY/100) × (30/365)
-        _default_apy = Decimal("4")
-        _expected_profit = (
-            proposal_amount_usd * _default_apy / Decimal("100") * Decimal("30") / Decimal("365")
-        )
-        market_fee = calculate_fee_by_market(
-            trade_amount_usd=proposal_amount_usd,
-            tier=normalize_tier(user.tier, user_id=user.id).value,
-            current_apy=_default_apy,
-            expected_profit_usd=_expected_profit,
-            fixed_cost_usd=fixed_cost,
-        )
-
-        if not market_fee.should_trade:
-            logger.info(
-                "DynamicFee: should_trade=False for user %d — skipping proposal (%s)",
-                user.id,
-                market_fee.reason,
-            )
-            continue
-
-        proposal = Proposal(
-            user_id=user.id,
-            ai_decision_id=decision.id,
-            operation=operation,
-            asset=_PROPOSAL_ASSET,
-            amount=proposal_amount_usd,
-            amount_usd=proposal_amount_usd,
-            reason=reason,
-            expires_at=expires_at,
-            fee_rate=market_fee.fee_rate,
-            fee_amount=market_fee.fee_amount,
-        )
-        db.add(proposal)
-        user.last_judgment_at = now
-        count += 1
-
-        # ai_proposal_notification: best-effort（失敗しても Proposal 作成は継続）
         try:
-            from app.notifications.factory import get_notification_service  # noqa: PLC0415
-            from app.notifications.templates import ai_proposal_notification  # noqa: PLC0415
+            if not _is_user_due_for_judgment(user, now):
+                logger.debug(
+                    "Skipping proposal for user %d (tier=%s, last_judgment_at=%s)",
+                    user.id,
+                    user.tier,
+                    user.last_judgment_at,
+                )
+                continue
 
-            _payload = ai_proposal_notification(
+            # fund_allocations から per-user 提案金額を動的計算 (Decimal("0") = skip)
+            proposal_amount_usd = _resolve_proposal_amount(db, user.id)
+            if proposal_amount_usd <= Decimal("0"):
+                # _resolve_proposal_amount 内で警告・Slack 通知済み
+                continue
+
+            # 動的手数料計算: デフォルトAPY 4%（安定期）を使用
+            # 30日保有での予想利益 = amount × (APY/100) × (30/365)
+            _default_apy = Decimal("4")
+            _expected_profit = (
+                proposal_amount_usd * _default_apy / Decimal("100") * Decimal("30") / Decimal("365")
+            )
+            market_fee = calculate_fee_by_market(
+                trade_amount_usd=proposal_amount_usd,
+                tier=normalize_tier(user.tier, user_id=user.id).value,
+                current_apy=_default_apy,
+                expected_profit_usd=_expected_profit,
+                fixed_cost_usd=fixed_cost,
+            )
+
+            if not market_fee.should_trade:
+                logger.info(
+                    "DynamicFee: should_trade=False for user %d — skipping proposal (%s)",
+                    user.id,
+                    market_fee.reason,
+                )
+                continue
+
+            proposal = Proposal(
+                user_id=user.id,
+                ai_decision_id=decision.id,
                 operation=operation,
                 asset=_PROPOSAL_ASSET,
                 amount=proposal_amount_usd,
-                confidence=result.final_confidence,
+                amount_usd=proposal_amount_usd,
+                reason=reason,
+                expires_at=expires_at,
+                fee_rate=market_fee.fee_rate,
+                fee_amount=market_fee.fee_amount,
             )
-            _payload.notification_message.user_id = user.id
-            get_notification_service().send(_payload.notification_message)
-        except Exception as _notif_exc:  # noqa: BLE001
-            logger.warning(
-                "ai_proposal_notification failed for user %d (skipping): %s",
+            db.add(proposal)
+            user.last_judgment_at = now
+            count += 1
+
+            # ai_proposal_notification: best-effort（失敗しても Proposal 作成は継続）
+            try:
+                from app.notifications.factory import get_notification_service  # noqa: PLC0415
+                from app.notifications.templates import ai_proposal_notification  # noqa: PLC0415
+
+                _payload = ai_proposal_notification(
+                    operation=operation,
+                    asset=_PROPOSAL_ASSET,
+                    amount=proposal_amount_usd,
+                    confidence=result.final_confidence,
+                )
+                _payload.notification_message.user_id = user.id
+                get_notification_service().send(_payload.notification_message)
+            except Exception as _notif_exc:  # noqa: BLE001
+                logger.warning(
+                    "ai_proposal_notification failed for user %d (skipping): %s",
+                    user.id,
+                    _notif_exc,
+                )
+        except Exception as _user_exc:  # noqa: BLE001
+            # 1ユーザーの失敗が他のユーザーの提案生成を止めないようにする。
+            # DB クエリ例外 / 未想定エラーはここで捕捉し、ループ継続。
+            logger.error(
+                "Proposal creation failed for user %d (skipping, continuing to next user): %s",
                 user.id,
-                _notif_exc,
+                _user_exc,
             )
 
     return count

--- a/backend/tests/test_ai_judgment_scheduler.py
+++ b/backend/tests/test_ai_judgment_scheduler.py
@@ -941,3 +941,157 @@ def test_run_ai_judgment_job_passes_cognitive_state(db_session):
     assert passed_state is fake_state
     assert passed_state.consecutive_holds == 3
     assert passed_state.total_judgments == 10
+
+
+# ---------------------------------------------------------------------------
+# _resolve_proposal_amount: min/max クランプ境界値テスト (PR #323 follow-up P1)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_proposal_amount_clamps_to_min(db_session):
+    """allocated × 10% < $50 のとき、$50 にクランプされること。
+
+    境界値: $499 × 10% = $49.90 → $50 (min)
+    """
+    from app.automation.ai_judgment_scheduler import _resolve_proposal_amount  # noqa: PLC0415
+
+    user = _add_active_user(db_session, "clamp_min@example.com")
+    _add_fund_allocation(db_session, user, allocated_usd=Decimal("499"))
+    db_session.commit()
+
+    result = _resolve_proposal_amount(db_session, user.id)
+    assert result == Decimal("50"), f"expected $50 (min clamp) but got {result}"
+
+
+def test_resolve_proposal_amount_clamps_to_max(db_session):
+    """allocated × 10% > $2,000 のとき、$2,000 にクランプされること。
+
+    境界値: $20001 × 10% = $2000.10 → $2000 (max)
+    """
+    from app.automation.ai_judgment_scheduler import _resolve_proposal_amount  # noqa: PLC0415
+
+    user = _add_active_user(db_session, "clamp_max@example.com")
+    _add_fund_allocation(db_session, user, allocated_usd=Decimal("20001"))
+    db_session.commit()
+
+    result = _resolve_proposal_amount(db_session, user.id)
+    assert result == Decimal("2000"), f"expected $2000 (max clamp) but got {result}"
+
+
+def test_resolve_proposal_amount_exact_min_boundary(db_session):
+    """allocated × 10% = $50 ちょうどのとき、$50 が返ること（境界 = min の場合は min 返却）。
+
+    $500 × 10% = $50.00
+    """
+    from app.automation.ai_judgment_scheduler import _resolve_proposal_amount  # noqa: PLC0415
+
+    user = _add_active_user(db_session, "boundary_min@example.com")
+    _add_fund_allocation(db_session, user, allocated_usd=Decimal("500"))
+    db_session.commit()
+
+    result = _resolve_proposal_amount(db_session, user.id)
+    assert result == Decimal("50.00")
+
+
+def test_resolve_proposal_amount_exact_max_boundary(db_session):
+    """allocated × 10% = $2,000 ちょうどのとき、$2,000 が返ること（境界 = max の場合は max 返却）。
+
+    $20000 × 10% = $2000.00
+    """
+    from app.automation.ai_judgment_scheduler import _resolve_proposal_amount  # noqa: PLC0415
+
+    user = _add_active_user(db_session, "boundary_max@example.com")
+    _add_fund_allocation(db_session, user, allocated_usd=Decimal("20000"))
+    db_session.commit()
+
+    result = _resolve_proposal_amount(db_session, user.id)
+    assert result == Decimal("2000.00")
+
+
+def test_resolve_proposal_amount_yamamoto_san(db_session):
+    """山本さん想定値: $4,600 × 10% = $460 (クランプなし、実機確認済み)。"""
+    from app.automation.ai_judgment_scheduler import _resolve_proposal_amount  # noqa: PLC0415
+
+    user = _add_active_user(db_session, "yamamoto@example.com")
+    _add_fund_allocation(db_session, user, allocated_usd=Decimal("4600"))
+    db_session.commit()
+
+    result = _resolve_proposal_amount(db_session, user.id)
+    assert result == Decimal("460.00")
+
+
+def test_resolve_proposal_amount_multiple_allocations_summed(db_session):
+    """複数の active fund_allocations がある場合、合計値に比率を乗じること。
+
+    allocation1: $3,000, allocation2: $2,000 → sum=$5,000 × 10% = $500
+    """
+    from app.automation.ai_judgment_scheduler import _resolve_proposal_amount  # noqa: PLC0415
+
+    user = _add_active_user(db_session, "multi_alloc@example.com")
+    _add_fund_allocation(db_session, user, allocated_usd=Decimal("3000"))
+    _add_fund_allocation(db_session, user, allocated_usd=Decimal("2000"))
+    db_session.commit()
+
+    result = _resolve_proposal_amount(db_session, user.id)
+    assert result == Decimal("500.00")
+
+
+def test_create_proposals_db_error_one_user_does_not_stop_others(db_session):
+    """_resolve_proposal_amount が DB 例外を投げたとき、他ユーザーの処理が継続すること。
+
+    1ユーザーの例外が全体ループを止めないことを確認する（PR #323 follow-up P1）。
+    """
+    from unittest.mock import MagicMock  # noqa: PLC0415
+
+    from app.auth.constants import ExecutionPolicy  # noqa: PLC0415
+    from app.automation.ai_judgment_scheduler import _create_proposals_for_users  # noqa: PLC0415
+
+    user_ok = MagicMock()
+    user_ok.id = 1
+    user_ok.is_active = True
+    user_ok.execution_policy = ExecutionPolicy.REQUIRE_APPROVAL.value
+    user_ok.last_judgment_at = None
+    user_ok.tier = "LOWER"
+
+    user_fail = MagicMock()
+    user_fail.id = 2
+    user_fail.is_active = True
+    user_fail.execution_policy = ExecutionPolicy.REQUIRE_APPROVAL.value
+    user_fail.last_judgment_at = None
+    user_fail.tier = "LOWER"
+
+    decision = MagicMock()
+    decision.id = 99
+
+    cv_result = _make_cross_validation_result(TradeAction.BUY)
+
+    mock_db = MagicMock()
+    mock_db.scalars.return_value.all.return_value = [user_fail, user_ok]
+
+    call_count = 0
+
+    def resolve_side_effect(_db, user_id):
+        nonlocal call_count
+        call_count += 1
+        if user_id == user_fail.id:
+            raise RuntimeError("simulated DB error for user 2")
+        return Decimal("460")
+
+    with (
+        patch(
+            "app.automation.ai_judgment_scheduler._resolve_proposal_amount",
+            side_effect=resolve_side_effect,
+        ),
+        patch("app.fees.trade_gate.calculate_fee_by_market") as mock_fee,
+        patch("app.notifications.factory.get_notification_service"),
+    ):
+        mock_fee.return_value.should_trade = True
+        mock_fee.return_value.fee_rate = Decimal("0.05")
+        mock_fee.return_value.fee_amount = Decimal("23.00")
+
+        count = _create_proposals_for_users(mock_db, decision, cv_result)
+
+    # user_fail は例外でスキップ、user_ok は成功 → count=1
+    assert count == 1, f"Expected 1 proposal (user_ok only) but got {count}"
+    # _resolve_proposal_amount は両ユーザー分呼ばれていること
+    assert call_count == 2, f"Expected resolve called twice but got {call_count}"


### PR DESCRIPTION
## Summary

PR #323 (動的 proposal 金額化) の残課題対応。`docs/internal/pr_323_review_20260521.md` に記載された P1 課題を解消。

- **P1: `_create_proposals_for_users()` per-user 例外ハンドリング** — DB クエリ失敗時に 1 ユーザーの例外が他ユーザーの提案生成を停止していた問題を修正。ユーザーループ本体を `try/except BLE001` で囲み、例外は `logger.error` でロギングしてループ継続。
- **P1: min/max クランプ境界値テスト追加** — `$499×10%=$49.90→$50(min)`, `$20001×10%=$2000.10→$2000(max)`, 境界値 `$500×10%=$50`, `$20000×10%=$2000`, 山本さん実機値 `$4600×10%=$460` を網羅。
- **P2: 複数 allocation 合計テスト** — 複数の active fund_allocations が sum される経路を確認。

## 変更ファイル

| ファイル | 変更 | Tier |
|---|---|---|
| `backend/app/automation/ai_judgment_scheduler.py` | per-user try/except 追加 | Tier S |
| `backend/tests/test_ai_judgment_scheduler.py` | 境界値テスト 7 件追加 (33→40) | Tier B |

## Test plan

- [x] `pytest tests/test_ai_judgment_scheduler.py` — 40 passed
- [x] `pytest tests/automation/test_proposals_notification.py` — 15 passed
- [x] `ruff check .` + `ruff format --check .` — クリーン
- [ ] `pytest tests/ --cov=app --cov-fail-under=80` — 実行中 (全スイート 10 分)
- [ ] Gate 4: Playwright E2E (`/partner/dashboard` proposal 表示) — staging 環境依存のため HUMAN/staging に委ねる

## Asana

Closes GID: 1214961595649705 (ai_judgment_scheduler 動的化 PR #323 fix-up)

## レビュー依頼点

1. per-user `except Exception` の範囲が適切か (通知失敗の inner try/except と二重になっていないか確認済み — 内側は通知のみ、外側はユーザー全体)
2. DB session が例外後も valid な状態を保てるか (`db.rollback()` なし) — SQLAlchemy の autoflush 動作確認を推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)