### PR TITLE
fix(ai): SELL-spam — SELL/BUY requires Indicator AND Macro both >=70% (not single agent)

### DIFF
--- a/backend/app/ai/agents.py
+++ b/backend/app/ai/agents.py
@@ -135,6 +135,49 @@ class MultiAgentContext(BaseModel):
             return 50
         return int(sum(s.confidence for s in signals) / len(signals))
 
+    # ------------------------------------------------------------------
+    # SELL/BUY AND-condition guard (v4/v5 rule engine, 2026-05-21)
+    # ------------------------------------------------------------------
+
+    #: Minimum confidence required for either core agent to qualify as directional.
+    _DIRECTIONAL_THRESHOLD: int = 70
+
+    def indicator_and_macro_agree_bearish(self) -> bool:
+        """Return True only when BOTH Indicator AND Macro agents are BEARISH >= threshold.
+
+        Purpose: prevent a single continuously-BEARISH Macro Agent from triggering
+        repeated SELL signals (root cause of the SELL-spam issue on v4 prompts).
+
+        Evaluated by the Python rule engine BEFORE the LLM call so the guard is
+        deterministic and cannot be overridden by the LLM's prompt interpretation.
+        """
+        ind = self.indicator_signal
+        mac = self.macro_signal
+        if ind is None or mac is None:
+            return False
+        return (
+            ind.bias == Bias.BEARISH
+            and ind.confidence >= self._DIRECTIONAL_THRESHOLD
+            and mac.bias == Bias.BEARISH
+            and mac.confidence >= self._DIRECTIONAL_THRESHOLD
+        )
+
+    def indicator_and_macro_agree_bullish(self) -> bool:
+        """Return True only when BOTH Indicator AND Macro agents are BULLISH >= threshold.
+
+        Symmetric guard to prevent single-agent BULLISH from triggering BUY.
+        """
+        ind = self.indicator_signal
+        mac = self.macro_signal
+        if ind is None or mac is None:
+            return False
+        return (
+            ind.bias == Bias.BULLISH
+            and ind.confidence >= self._DIRECTIONAL_THRESHOLD
+            and mac.bias == Bias.BULLISH
+            and mac.confidence >= self._DIRECTIONAL_THRESHOLD
+        )
+
 
 # ============================================================
 # Specialist Agents (pure functions — no side effects)

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -101,11 +101,11 @@ Decision rules:
 - Weight: Risk Agent 40%, Indicator 25%, Macro 20%, Pattern 15%
 
 Respond in JSON format ONLY:
-{
+{{
     "action": "BUY" | "SELL" | "HOLD",
     "confidence": 0-100,
     "reason": "Brief explanation referencing agent signals"
-}"""
+}}"""
 
 _V3_USER_TEMPLATE = """## Specialist Agent Reports:
 {agent_signals}
@@ -122,6 +122,10 @@ Synthesize the agent reports and provide your final judgment in JSON format only
 # v4: HOLD bias 解消版 — 中庸 confidence でも方向シグナルがあれば BUY/SELL 許可
 # agents disagree → default to HOLD (v3 ルール) を廃止し、多数派方向に従う
 # リスク guard (compound risk→HOLD, HF<1.6→保守) は維持
+# NOTE: v4 の元 SELL ルール「Indicator or Macro BEARISH ≥70%」は単一エージェント発火を
+# 許してしまい Macro Agent 継続 BEARISH で SELL 連発を引き起こした (SELL-spam 問題)。
+# 2026-05-21 に AND 条件へ修正。Python rule engine (service.py Guard 2) と二重防衛。
+# 新規利用は v5 を推奨。v4 は後方互換のため保持。
 _V4_SYSTEM = """You are the Decision Agent of Ultra AutoTrade, a DeFi robo-advisor.
 
 You receive analysis from 4 specialist agents:
@@ -132,22 +136,22 @@ You receive analysis from 4 specialist agents:
 
 Your job: Synthesize all agent signals into a SINGLE final judgment.
 
-Decision rules (v4 — reduced HOLD bias):
+Decision rules (v4 — AND-condition for directional trades):
 - HARD STOP (always HOLD): Risk Agent detects COMPOUND RISK, or HF < 1.6
-- SELL: Indicator or Macro Agent reports BEARISH with confidence >= 70%
-- BUY: 2+ agents lean BULLISH, OR a single agent reports BULLISH with confidence >= 65%
-- HOLD: Use HOLD only when no single agent has confidence >= 65% AND no majority direction exists
-- Disagreement does NOT automatically mean HOLD — if 2+ agents agree on a direction, act on it
-- Moderate confidence (45–65) with a clear directional signal warrants BUY or SELL, not HOLD
+- SELL: BOTH Indicator AND Macro Agent report BEARISH with confidence >= 70%
+- BUY: BOTH Indicator AND Macro Agent report BULLISH with confidence >= 70%
+- HOLD: Use HOLD when agents disagree, when only one agent is directional,
+  or when confidence < 70% for either Indicator or Macro
+- Single-agent BEARISH/BULLISH alone is NOT sufficient for SELL/BUY
 
 Weight for confidence calculation: Risk Agent 40%, Indicator 25%, Macro 20%, Pattern 15%
 
 Respond in JSON format ONLY:
-{
+{{
     "action": "BUY" | "SELL" | "HOLD",
     "confidence": 0-100,
     "reason": "Brief explanation referencing agent signals"
-}"""
+}}"""
 
 _V4_USER_TEMPLATE = """## Specialist Agent Reports:
 {agent_signals}
@@ -159,6 +163,58 @@ _V4_USER_TEMPLATE = """## Specialist Agent Reports:
 {query}
 
 Synthesize the agent reports and provide your final judgment in JSON format only."""
+
+
+# v5: AND-condition 明文化版 — SELL/BUY は Indicator AND Macro 両方が同方向 ≥70% のみ
+# v4 SELL-spam 問題の根本対策。Python 側 rule engine と組み合わせて二重防衛。
+# Rationale: Macro Agent は macro news に引っ張られて継続 BEARISH になりやすい。
+# Indicator Agent (on-chain HF/utilization) との AND を要求することで
+# on-chain 実態と乖離した経済環境シグナルだけで SELL 連発するのを防ぐ。
+_V5_SYSTEM = """You are the Decision Agent of Ultra AutoTrade, a DeFi robo-advisor.
+
+You receive analysis from 4 specialist agents:
+1. Indicator Agent — Aave on-chain metrics (HF, utilization, APY)
+2. Pattern Agent — behavioral analysis (recent decision patterns, win rate)
+3. Risk Agent — composite risk (geopolitical, stablecoin, compound risks)
+4. Macro Agent — macro-economic environment (FED policy, news sentiment)
+
+Your job: Synthesize all agent signals into a SINGLE final judgment.
+
+Decision rules (v5 — AND-condition for directional trades):
+- HARD STOP (always HOLD): Risk Agent detects COMPOUND RISK, or HF < 1.6
+- SELL: BOTH Indicator Agent AND Macro Agent must independently report BEARISH
+  with confidence >= 70%. A single BEARISH agent alone is NOT sufficient for SELL.
+- BUY: BOTH Indicator Agent AND Macro Agent must independently report BULLISH
+  with confidence >= 70%. A single BULLISH agent alone is NOT sufficient for BUY.
+- HOLD: Use HOLD whenever agents disagree, when only one agent is directional,
+  or when confidence < 70% for either core agent (Indicator or Macro).
+- Pattern Agent and Risk Agent are supporting signals — they inform confidence
+  calculation but cannot alone trigger SELL or BUY.
+
+Rationale: Requiring both Indicator (on-chain reality) and Macro (economic
+environment) to align prevents a single stuck-BEARISH macro feed from causing
+repeated SELL signals in stable on-chain conditions.
+
+Weight for confidence calculation: Risk Agent 40%, Indicator 25%, Macro 20%, Pattern 15%
+
+Respond in JSON format ONLY:
+{{
+    "action": "BUY" | "SELL" | "HOLD",
+    "confidence": 0-100,
+    "reason": "Brief explanation referencing which agents agreed and their confidence"
+}}"""
+
+_V5_USER_TEMPLATE = """## Specialist Agent Reports:
+{agent_signals}
+
+## Retrieved Context (from Knowledge Hub):
+{context}
+
+## Analysis Request:
+{query}
+
+Synthesize the agent reports and provide your final judgment in JSON format only.
+Remember: SELL requires BOTH Indicator AND Macro BEARISH >=70%. BUY requires BOTH BULLISH >=70%."""
 
 
 PROMPT_REGISTRY: Dict[str, PromptTemplate] = {
@@ -182,9 +238,15 @@ PROMPT_REGISTRY: Dict[str, PromptTemplate] = {
     ),
     "v4": PromptTemplate(
         version="v4",
-        description="HOLD bias 解消版 — 中庸 confidence でも方向シグナルがあれば BUY/SELL 許可",
+        description="AND-condition 版 (SELL-spam 修正済) — 新規利用は v5 推奨",
         system_prompt=_V4_SYSTEM,
         user_template=_V4_USER_TEMPLATE,
+    ),
+    "v5": PromptTemplate(
+        version="v5",
+        description="AND-condition 明文化版 — SELL/BUY は Indicator AND Macro 両方が同方向 >=70% のみ",
+        system_prompt=_V5_SYSTEM,
+        user_template=_V5_USER_TEMPLATE,
     ),
 }
 

--- a/backend/app/ai/service.py
+++ b/backend/app/ai/service.py
@@ -226,10 +226,13 @@ class AIService:
         """
         ai_settings = settings or get_ai_settings()
         version = ai_settings.prompt_version
+        # AND-condition flag: set True if agents disagree and v4/v5 guard applies
+        _and_condition_failed = False
 
-        # Rule engine: COMPOUND RISK → force HOLD before LLM call
+        # Rule engine: pre-LLM checks (deterministic, cannot be overridden by LLM)
         if market_context is not None:
             agent_ctx_check = run_all_agents(market_context)
+            # Guard 1: COMPOUND RISK → force HOLD
             if agent_ctx_check.has_compound_risk():
                 logger.warning("COMPOUND RISK detected by Risk Agent. Forcing HOLD.")
                 compound_decision = LLMDecision(
@@ -247,6 +250,20 @@ class AIService:
                     final_confidence=95,
                     final_reason="COMPOUND RISK detected. Rule engine forced HOLD before LLM call.",
                 )
+            # Guard 2: AND-condition for v4/v5 — SELL/BUY needs both Indicator AND Macro >=70%
+            if version in ("v4", "v5") and not (
+                agent_ctx_check.indicator_and_macro_agree_bearish()
+                or agent_ctx_check.indicator_and_macro_agree_bullish()
+            ):
+                _and_condition_failed = True
+                logger.debug(
+                    "AND-condition not met: Indicator=%s/%s Macro=%s/%s. "
+                    "Post-LLM clamping enabled.",
+                    getattr(agent_ctx_check.indicator_signal, "bias", "N/A"),
+                    getattr(agent_ctx_check.indicator_signal, "confidence", 0),
+                    getattr(agent_ctx_check.macro_signal, "bias", "N/A"),
+                    getattr(agent_ctx_check.macro_signal, "confidence", 0),
+                )
 
         system_prompt, user_content = self._build_rag_prompt(
             query, rag_context, version, market_context, cognitive_state
@@ -261,6 +278,36 @@ class AIService:
             secondary = self._call_openai(system_prompt, user_content, ai_settings, version)
 
         result = self._cross_validate(primary, secondary)
+
+        # Post-LLM: enforce AND-condition guard (v4/v5) — clamp SELL/BUY to HOLD
+        # when Indicator and Macro did not both agree on direction >=70%.
+        if _and_condition_failed and result.final_action in (TradeAction.SELL, TradeAction.BUY):
+            logger.warning(
+                "AND-condition guard: %s → HOLD (Indicator+Macro not both >=70%%). conf=%s",
+                result.final_action.value,
+                result.final_confidence,
+            )
+            _clamp_reason = (
+                f"AND-condition not met: LLM proposed {result.final_action.value} but "
+                "Indicator and Macro agents did not both agree >=70%. "
+                f"Original: {result.final_reason}"
+            )
+            _clamped = LLMDecision(
+                provider=LLMProvider.RULE_BASED,
+                action=TradeAction.HOLD,
+                confidence=min(result.final_confidence, 45),
+                reason=_clamp_reason,
+                prompt_version=version,
+            )
+            result = CrossValidationResult(
+                primary=_clamped,
+                secondary=result.secondary,
+                agreed=result.agreed,
+                final_action=TradeAction.HOLD,
+                final_confidence=_clamped.confidence,
+                final_reason=_clamp_reason,
+                prompt_version=version,
+            )
 
         # Shadow Mode: record judgment and attach shadow_mode flag before returning.
         # Caller should skip actual trade execution when shadow_mode=True.
@@ -305,7 +352,7 @@ class AIService:
             agent_ctx = run_all_agents(market_context)
 
         # Build user content — v3/v4 inject agent_signals into the template itself
-        if version in ("v3", "v4"):
+        if version in ("v3", "v4", "v5"):
             agent_signals_text = (
                 agent_ctx.to_decision_prompt()
                 if agent_ctx is not None

--- a/backend/tests/test_ai_judge.py
+++ b/backend/tests/test_ai_judge.py
@@ -490,10 +490,12 @@ class TestPromptVersioning:
 
         tmpl = get_prompt_template("v4")
         assert tmpl.version == "v4"
-        assert "HOLD bias" in tmpl.description
+        # v4 description updated to reflect AND-condition fix (2026-05-21)
+        assert "v4" in tmpl.description or "AND-condition" in tmpl.description
         assert "COMPOUND RISK" in tmpl.system_prompt
         assert "HF < 1.6" in tmpl.system_prompt
-        assert "Disagreement" in tmpl.system_prompt
+        # v4 SELL rule now requires AND (not OR) — verify AND-condition present
+        assert "AND" in tmpl.system_prompt
         assert "{agent_signals}" in tmpl.user_template
         assert "{context}" in tmpl.user_template
         assert "{query}" in tmpl.user_template
@@ -503,8 +505,11 @@ class TestPromptVersioning:
 
         tmpl = get_prompt_template("v4")
         assert "迷ったら HOLD" not in tmpl.system_prompt
-        assert "Disagreement" in tmpl.system_prompt
-        assert "does NOT automatically mean HOLD" in tmpl.system_prompt
+        # v4 was updated (2026-05-21) to AND-condition: SELL needs BOTH Indicator AND Macro >=70%
+        # Old: "Disagreement does NOT automatically mean HOLD" (HOLD bias 解消 intent)
+        # New: AND-condition — single-agent BEARISH alone is NOT sufficient for SELL
+        assert "SELL" in tmpl.system_prompt
+        assert "AND" in tmpl.system_prompt
 
     def test_build_prompt_content_v4_receives_agent_signals(self):
         """v4 prompt の _build_prompt_content が agent_signals を受け取る回帰テスト。

--- a/backend/tests/test_ai_sell_and_condition.py
+++ b/backend/tests/test_ai_sell_and_condition.py
@@ -1,0 +1,515 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""
+Tests for the SELL/BUY AND-condition fix (fix/ai-sell-and-condition-20260521).
+
+Root cause: v4 prompt allowed a single BEARISH agent (Indicator OR Macro) with
+confidence ≥70% to trigger SELL, causing Macro Agent's continuous BEARISH to
+fire repeated SELL signals.
+
+Fix: Both Indicator AND Macro must independently agree on the same direction
+≥70% (AND-condition). Enforced at the Python rule engine level (service.py
+Guard 2) and documented in the v4/v5 prompts.
+
+These tests are deterministic — no LLM calls are made.
+"""
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from app.ai.agents import (
+    AgentSignal,
+    Bias,
+    MultiAgentContext,
+)
+from app.ai.prompts import PROMPT_REGISTRY, get_prompt_template
+from app.ai.schemas import (
+    CrossValidationResult,
+    LLMDecision,
+    LLMProvider,
+    RAGContext,
+    TradeAction,
+)
+from app.ai.service import AIService
+from app.data_feeds.context import build_market_context
+from app.data_feeds.finance_feed import FinanceFeedResult
+from app.data_feeds.geopolitical import GeoRiskResult
+from app.data_feeds.news_feed import NewsFeedResult
+
+# ---------------------------------------------------------------------------
+# Helper builders
+# ---------------------------------------------------------------------------
+
+
+def _make_agent_signal(
+    name: str,
+    bias: Bias,
+    confidence: int,
+    reasoning: str = "",
+) -> AgentSignal:
+    return AgentSignal(
+        agent_name=name,
+        bias=bias,
+        confidence=confidence,
+        reasoning=reasoning or f"{bias.value} signal",
+    )
+
+
+def _make_cross_result(
+    action: TradeAction, confidence: int = 75, version: str = "v5"
+) -> CrossValidationResult:
+    decision = LLMDecision(
+        provider=LLMProvider.CLAUDE,
+        action=action,
+        confidence=confidence,
+        reason=f"LLM proposed {action.value}",
+        prompt_version=version,
+    )
+    return CrossValidationResult(
+        primary=decision,
+        secondary=None,
+        agreed=True,
+        final_action=action,
+        final_confidence=confidence,
+        final_reason=decision.reason,
+        prompt_version=version,
+    )
+
+
+def _make_rag_context() -> RAGContext:
+    return RAGContext(chunks=["(no context)"], query="market update", source_count=0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: MultiAgentContext AND-condition methods
+# ---------------------------------------------------------------------------
+
+
+class TestIndicatorAndMacroAgreeBearish:
+    """Unit tests for MultiAgentContext.indicator_and_macro_agree_bearish()."""
+
+    def test_both_bearish_high_confidence_returns_true(self) -> None:
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.BEARISH, 75),
+            macro_signal=_make_agent_signal("Macro", Bias.BEARISH, 80),
+        )
+        assert mac.indicator_and_macro_agree_bearish() is True
+
+    def test_only_macro_bearish_returns_false(self) -> None:
+        """Root cause scenario: only Macro is BEARISH — must NOT trigger SELL."""
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.NEUTRAL, 50),
+            macro_signal=_make_agent_signal("Macro", Bias.BEARISH, 80),
+        )
+        assert mac.indicator_and_macro_agree_bearish() is False
+
+    def test_only_indicator_bearish_returns_false(self) -> None:
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.BEARISH, 75),
+            macro_signal=_make_agent_signal("Macro", Bias.NEUTRAL, 50),
+        )
+        assert mac.indicator_and_macro_agree_bearish() is False
+
+    def test_both_bearish_but_low_confidence_returns_false(self) -> None:
+        """Confidence must be ≥70 for both."""
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.BEARISH, 65),
+            macro_signal=_make_agent_signal("Macro", Bias.BEARISH, 65),
+        )
+        assert mac.indicator_and_macro_agree_bearish() is False
+
+    def test_macro_low_confidence_blocks_condition(self) -> None:
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.BEARISH, 80),
+            macro_signal=_make_agent_signal("Macro", Bias.BEARISH, 60),
+        )
+        assert mac.indicator_and_macro_agree_bearish() is False
+
+    def test_indicator_missing_returns_false(self) -> None:
+        mac = MultiAgentContext(
+            macro_signal=_make_agent_signal("Macro", Bias.BEARISH, 80),
+        )
+        assert mac.indicator_and_macro_agree_bearish() is False
+
+    def test_macro_missing_returns_false(self) -> None:
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.BEARISH, 80),
+        )
+        assert mac.indicator_and_macro_agree_bearish() is False
+
+    def test_both_bearish_at_threshold_returns_true(self) -> None:
+        """Exactly 70 confidence should satisfy the condition."""
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.BEARISH, 70),
+            macro_signal=_make_agent_signal("Macro", Bias.BEARISH, 70),
+        )
+        assert mac.indicator_and_macro_agree_bearish() is True
+
+    def test_both_bullish_does_not_satisfy_bearish(self) -> None:
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.BULLISH, 75),
+            macro_signal=_make_agent_signal("Macro", Bias.BULLISH, 75),
+        )
+        assert mac.indicator_and_macro_agree_bearish() is False
+
+
+class TestIndicatorAndMacroAgreeBullish:
+    """Unit tests for MultiAgentContext.indicator_and_macro_agree_bullish()."""
+
+    def test_both_bullish_high_confidence_returns_true(self) -> None:
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.BULLISH, 75),
+            macro_signal=_make_agent_signal("Macro", Bias.BULLISH, 80),
+        )
+        assert mac.indicator_and_macro_agree_bullish() is True
+
+    def test_only_macro_bullish_returns_false(self) -> None:
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.NEUTRAL, 50),
+            macro_signal=_make_agent_signal("Macro", Bias.BULLISH, 80),
+        )
+        assert mac.indicator_and_macro_agree_bullish() is False
+
+    def test_only_indicator_bullish_returns_false(self) -> None:
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.BULLISH, 75),
+            macro_signal=_make_agent_signal("Macro", Bias.NEUTRAL, 50),
+        )
+        assert mac.indicator_and_macro_agree_bullish() is False
+
+    def test_both_bullish_but_low_confidence_returns_false(self) -> None:
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.BULLISH, 65),
+            macro_signal=_make_agent_signal("Macro", Bias.BULLISH, 65),
+        )
+        assert mac.indicator_and_macro_agree_bullish() is False
+
+    def test_both_bearish_does_not_satisfy_bullish(self) -> None:
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.BEARISH, 75),
+            macro_signal=_make_agent_signal("Macro", Bias.BEARISH, 75),
+        )
+        assert mac.indicator_and_macro_agree_bullish() is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: service.py AND-condition guard (post-LLM clamping)
+# ---------------------------------------------------------------------------
+
+
+class TestJudgeWithRagAndConditionGuard:
+    """Integration tests for the AND-condition guard in judge_with_rag.
+
+    These tests mock the LLM calls and verify that the rule engine
+    correctly clamps SELL/BUY to HOLD when the AND-condition is not met.
+    """
+
+    def _make_service(self) -> AIService:
+        return AIService()
+
+    def _make_settings(self, version: str = "v5") -> MagicMock:
+        settings = MagicMock()
+        settings.prompt_version = version
+        settings.anthropic_api_key = "fake-key"
+        settings.openai_api_key = None
+        settings.cross_validation_enabled = False
+        settings.shadow_mode = False
+        settings.claude_model = "claude-opus-4-5"
+        return settings
+
+    def test_sell_blocked_when_only_macro_bearish(self) -> None:
+        """
+        Root cause scenario: LLM proposes SELL because Macro is BEARISH ≥70%.
+        AND-condition guard must clamp result to HOLD when Indicator is not BEARISH.
+        """
+        svc = self._make_service()
+        settings = self._make_settings(version="v5")
+
+        # Macro BEARISH 80%, Indicator NEUTRAL — AND-condition NOT met
+        fin = FinanceFeedResult(fed_stance="hawkish")
+        news = NewsFeedResult(sentiment="negative", summary="Rate hike fears")
+        ctx = build_market_context(
+            health_factor=Decimal("2.2"),  # Indicator will be BULLISH (high HF)
+            finance=fin,
+            news=news,
+        )
+
+        with patch.object(
+            svc, "_call_claude", return_value=_make_cross_result(TradeAction.SELL, 75).primary
+        ):
+            result = svc.judge_with_rag(
+                query="market update",
+                rag_context=_make_rag_context(),
+                market_context=ctx,
+                settings=settings,
+            )
+
+        assert result.final_action == TradeAction.HOLD, (
+            "SELL must be blocked when only Macro is BEARISH (AND-condition not met)"
+        )
+        assert "AND-condition" in result.final_reason
+
+    def test_sell_allowed_when_both_indicator_and_macro_bearish(self) -> None:
+        """
+        SELL is permitted when BOTH Indicator (low HF) AND Macro (hawkish + negative)
+        are BEARISH ≥70%.
+        """
+        svc = self._make_service()
+        settings = self._make_settings(version="v5")
+
+        # Indicator BEARISH: low HF (1.45) + high utilization → score well below 35
+        # Macro BEARISH: hawkish FED + negative news
+        fin = FinanceFeedResult(
+            fed_stance="hawkish",
+            macro_summary="FED raises rates aggressively",
+        )
+        news = NewsFeedResult(
+            sentiment="negative",
+            summary="Market crash fears amid rate hikes",
+        )
+        ctx = build_market_context(
+            health_factor=Decimal("1.45"),  # critically low → BEARISH, high confidence
+            aave_utilization_rate=Decimal("92"),
+            finance=fin,
+            news=news,
+        )
+
+        with patch.object(
+            svc, "_call_claude", return_value=_make_cross_result(TradeAction.SELL, 78).primary
+        ):
+            result = svc.judge_with_rag(
+                query="market update",
+                rag_context=_make_rag_context(),
+                market_context=ctx,
+                settings=settings,
+            )
+
+        # Both agents are BEARISH — AND-condition met — SELL should pass through
+        assert result.final_action == TradeAction.SELL, (
+            "SELL must be allowed when both Indicator AND Macro are BEARISH ≥70%"
+        )
+
+    def test_buy_blocked_when_only_macro_bullish(self) -> None:
+        """BUY blocked when only Macro is BULLISH (Indicator is NEUTRAL/BEARISH)."""
+        svc = self._make_service()
+        settings = self._make_settings(version="v5")
+
+        fin = FinanceFeedResult(fed_stance="dovish")
+        news = NewsFeedResult(sentiment="positive", summary="FED cuts rates")
+        # Indicator BEARISH: low HF
+        ctx = build_market_context(
+            health_factor=Decimal("1.45"),
+            finance=fin,
+            news=news,
+        )
+
+        with patch.object(
+            svc, "_call_claude", return_value=_make_cross_result(TradeAction.BUY, 72).primary
+        ):
+            result = svc.judge_with_rag(
+                query="market update",
+                rag_context=_make_rag_context(),
+                market_context=ctx,
+                settings=settings,
+            )
+
+        assert result.final_action == TradeAction.HOLD, (
+            "BUY must be blocked when only Macro is BULLISH (Indicator is BEARISH)"
+        )
+
+    def test_buy_allowed_when_both_indicator_and_macro_bullish(self) -> None:
+        """BUY permitted when BOTH Indicator AND Macro are BULLISH ≥70%."""
+        svc = self._make_service()
+        settings = self._make_settings(version="v5")
+
+        fin = FinanceFeedResult(fed_stance="dovish", stablecoin_risk="low")
+        news = NewsFeedResult(sentiment="positive", summary="ETH bull run confirmed")
+        geo = GeoRiskResult(geo_risk_score=15, summary="Stable environment")
+        # Indicator BULLISH: high HF, low utilization, good APY
+        ctx = build_market_context(
+            health_factor=Decimal("2.8"),
+            aave_utilization_rate=Decimal("30"),
+            aave_supply_apy=Decimal("7.0"),
+            finance=fin,
+            news=news,
+            geo_risk=geo,
+        )
+
+        with patch.object(
+            svc, "_call_claude", return_value=_make_cross_result(TradeAction.BUY, 80).primary
+        ):
+            result = svc.judge_with_rag(
+                query="market update",
+                rag_context=_make_rag_context(),
+                market_context=ctx,
+                settings=settings,
+            )
+
+        assert result.final_action == TradeAction.BUY, (
+            "BUY must be allowed when both Indicator AND Macro are BULLISH ≥70%"
+        )
+
+    def test_hold_passes_through_regardless_of_and_condition(self) -> None:
+        """HOLD from LLM is never blocked — AND-condition only affects SELL/BUY."""
+        svc = self._make_service()
+        settings = self._make_settings(version="v5")
+
+        ctx = build_market_context()  # minimal context
+
+        with patch.object(
+            svc, "_call_claude", return_value=_make_cross_result(TradeAction.HOLD, 55).primary
+        ):
+            result = svc.judge_with_rag(
+                query="market update",
+                rag_context=_make_rag_context(),
+                market_context=ctx,
+                settings=settings,
+            )
+
+        assert result.final_action == TradeAction.HOLD
+
+    def test_and_condition_not_applied_for_v3(self) -> None:
+        """AND-condition guard is v4/v5 only — v3 SELL should pass through unchanged."""
+        svc = self._make_service()
+        settings = self._make_settings(version="v3")
+
+        # Macro BEARISH, Indicator NEUTRAL — same as root cause scenario
+        fin = FinanceFeedResult(fed_stance="hawkish")
+        news = NewsFeedResult(sentiment="negative", summary="Rate hike fears")
+        ctx = build_market_context(
+            health_factor=Decimal("2.2"),
+            finance=fin,
+            news=news,
+        )
+
+        with patch.object(
+            svc,
+            "_call_claude",
+            return_value=_make_cross_result(TradeAction.SELL, 72, version="v3").primary,
+        ):
+            result = svc.judge_with_rag(
+                query="market update",
+                rag_context=_make_rag_context(),
+                market_context=ctx,
+                settings=settings,
+            )
+
+        # v3 does not apply AND-condition guard — LLM result passes through
+        assert result.final_action == TradeAction.SELL, (
+            "v3 should not have AND-condition guard applied"
+        )
+
+    def test_no_market_context_skips_and_guard(self) -> None:
+        """Without market_context, AND-condition guard is skipped."""
+        svc = self._make_service()
+        settings = self._make_settings(version="v5")
+
+        with patch.object(
+            svc, "_call_claude", return_value=_make_cross_result(TradeAction.SELL, 75).primary
+        ):
+            result = svc.judge_with_rag(
+                query="market update",
+                rag_context=_make_rag_context(),
+                market_context=None,  # No market context
+                settings=settings,
+            )
+
+        # With no market context, no pre-LLM guard runs — LLM result passes through
+        assert result.final_action == TradeAction.SELL
+
+
+# ---------------------------------------------------------------------------
+# Tests: JSON Schema / parse-fail→HOLD safety (CLAUDE.md security rule 10)
+# ---------------------------------------------------------------------------
+
+
+class TestParseFailureSafetyUnchanged:
+    """Verify that the existing parse-fail→HOLD safety is not broken by the fix."""
+
+    def test_parse_failure_still_returns_hold(self) -> None:
+        svc = AIService()
+        from app.ai.schemas import LLMProvider
+
+        result = svc._parse_llm_response("invalid json {{", LLMProvider.CLAUDE)
+        assert result.action == TradeAction.HOLD
+
+    def test_invalid_action_string_still_returns_hold(self) -> None:
+        import json
+
+        svc = AIService()
+        from app.ai.schemas import LLMProvider
+
+        raw = json.dumps({"action": "MAYBE", "confidence": 70, "reason": "test"})
+        result = svc._parse_llm_response(raw, LLMProvider.CLAUDE)
+        assert result.action == TradeAction.HOLD
+
+    def test_low_confidence_llm_response_still_returns_hold(self) -> None:
+        """_apply_safety_guards: confidence < 40 → HOLD (unchanged behavior)."""
+        from datetime import datetime, timezone
+
+        svc = AIService()
+        from app.ai.schemas import AIAnalysisResult
+
+        result = svc._apply_safety_guards(
+            AIAnalysisResult(
+                id="x",
+                url="https://x.com",
+                action=TradeAction.SELL,
+                confidence=30,  # below 40 threshold
+                sentiment="negative",
+                reason="weak signal",
+                timestamp=datetime.now(timezone.utc),
+            )
+        )
+        assert result.action == TradeAction.HOLD
+
+
+# ---------------------------------------------------------------------------
+# Tests: Prompt registry — v4 AND-condition text, v5 existence
+# ---------------------------------------------------------------------------
+
+
+class TestPromptRegistry:
+    def test_v5_prompt_exists(self) -> None:
+        assert "v5" in PROMPT_REGISTRY
+
+    def test_v5_prompt_contains_and_condition_language(self) -> None:
+        v5 = get_prompt_template("v5")
+        assert "AND" in v5.system_prompt
+        assert (
+            "Indicator Agent AND Macro Agent" in v5.system_prompt
+            or "Indicator AND Macro" in v5.system_prompt
+        )
+
+    def test_v5_prompt_explicitly_blocks_single_agent_sell(self) -> None:
+        v5 = get_prompt_template("v5")
+        assert "single" in v5.system_prompt.lower() or "alone" in v5.system_prompt.lower()
+
+    def test_v4_prompt_updated_to_and_condition(self) -> None:
+        """v4 prompt SELL rule must now require AND, not OR for directional trades."""
+        v4 = get_prompt_template("v4")
+        # The SELL decision rule must require BOTH (AND), not single agent (OR)
+        assert "SELL: BOTH" in v4.system_prompt or (
+            "SELL" in v4.system_prompt and "AND" in v4.system_prompt
+        )
+        # Confirm "Indicator or Macro" does not appear as the SELL trigger rule
+        # (it may still appear in comments or HOLD rule, so check the SELL line specifically)
+        sell_lines = [
+            line for line in v4.system_prompt.split("\n") if line.strip().startswith("- SELL:")
+        ]
+        assert sell_lines, "v4 must have a SELL rule line"
+        assert "or Macro" not in sell_lines[0], f"v4 SELL rule must not use OR: {sell_lines[0]}"
+
+    def test_v5_user_template_has_reminder(self) -> None:
+        v5 = get_prompt_template("v5")
+        assert "SELL requires" in v5.user_template or "BUY requires" in v5.user_template
+
+    def test_all_prior_versions_still_exist(self) -> None:
+        for version in ("v1", "v2", "v3", "v4"):
+            assert version in PROMPT_REGISTRY, f"Version {version} must still exist"
+
+    def test_list_versions_includes_v5(self) -> None:
+        from app.ai.prompts import list_versions
+
+        versions = list_versions()
+        assert "v5" in versions


### PR DESCRIPTION
## Summary

- **Root cause**: v4 prompt SELL rule `Indicator OR Macro BEARISH >=70%` allowed a continuously-BEARISH Macro Agent to trigger repeated SELL signals unilaterally, even when on-chain HF/utilization (Indicator Agent) was healthy.
- **Fix (案a — AND-condition)**: SELL/BUY now requires **BOTH** Indicator AND Macro agents to independently report the same direction >=70% confidence. Enforced at the Python rule engine level (not just prompt text) in `service.py` Guard 2, so it cannot be overridden by LLM interpretation.
- **v5 prompt added**: explicit AND-condition rationale baked into both prompt text and user template reminder.

## Files changed

| File | Change |
|---|---|
| `backend/app/ai/agents.py` | Add `indicator_and_macro_agree_bearish/bullish()` methods to `MultiAgentContext` |
| `backend/app/ai/service.py` | Add Guard 2 (AND-condition check) pre-LLM + post-LLM clamping; add v5 to prompt routing |
| `backend/app/ai/prompts.py` | Fix v4 SELL rule (OR → AND); add v5 prompt with AND-condition rationale |
| `backend/tests/test_ai_sell_and_condition.py` | **31 new deterministic tests** (no LLM calls) |
| `backend/tests/test_ai_judge.py` | Update 2 tests to reflect updated v4 AND-condition language |

## 連携テスト結果

- [x] `pytest tests/test_ai_sell_and_condition.py` — 31/31 pass (new tests)
- [x] `pytest tests/` — 2901 passed, 0 failed, coverage 85.55% (>80%)
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — All formatted
- [x] `mypy app/` — no issues found in 241 source files
- [x] frontend build OK — N/A (no frontend changes)
- [x] browser console / Playwright — N/A (no UI changes; AI logic change only)
- [ ] staging `/partner/proposals` E2E — HUMAN/staging に委ねる (実 scheduler 実行依存)

## AI 判定ロジック変更の詳細

### Before (v4 旧ルール — SELL-spam の根本原因)
```
SELL: Indicator OR Macro Agent reports BEARISH with confidence >= 70%
```
→ Macro Agent が継続 BEARISH でいるだけで SELL 連発

### After (v4/v5 新ルール — AND-condition)
```
SELL: BOTH Indicator AND Macro Agent report BEARISH with confidence >= 70%
```
→ on-chain 実態 (Indicator) と経済環境 (Macro) が一致した場合のみ SELL

### Python rule engine (service.py Guard 2) による二重防衛
プロンプト文言だけでなく、LLM 呼出前に Python で AND-condition を検証。
LLM が AND-condition 未達成の市場データで SELL/BUY を提案した場合も HOLD にクランプ。

### 既存安全装置は壊していない
- JSON parse failure → HOLD (CLAUDE.md security rule 10) — 変更なし
- confidence < 40 → HOLD (_apply_safety_guards) — 変更なし  
- COMPOUND RISK → force HOLD (Guard 1) — 変更なし

## ⚠️ レビュー必須事項

**AI 判定ロジック変更のため、claude.ai レビュー必須。本番 deploy は HUMAN-REVIEW-REQUIRED。**

claude.ai がレビューすべき点:
1. AND-condition の閾値 (70%) が適切か — 厳しすぎると BUY/SELL が全く出なくなる可能性
2. v4 を使っている既存設定ファイルへの影響確認 (`.env.*` の `PROMPT_VERSION=v4` 設定)
3. Macro Agent の confidence 計算ロジックが >=70% に達しやすい構造かの確認
4. v5 への移行タイミング (v4 を使い続けるか v5 に切り替えるか)

Closes Asana 1214894640997788

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
## ⚠️ claude.ai レビュー結果（2026-05-21）— 条件付き GO
**本番反映前に staging 24h 観測必須:**
- staging で 24h 観測し、**BUY/SELL が 0件**（AND 条件が厳しすぎて取引が全く出ない）なら **AND 閾値を 70% → 65% に再調整**してから本番反映
- AND 化 + 山本さん require_approval の**二重防御**により本番反映自体は安全（誤 SELL が出ても自動執行されない）
- 観測指標: staging の ai_decisions で BUY/SELL/HOLD の比率、AND 成立回数、Macro/Indicator の confidence 分布
