### PR TITLE
fix(aave): P3-3 Aave active chain default を Base に固定 + RPC 未設定 chain スキップガード

### DIFF
--- a/backend/app/aave/chains.py
+++ b/backend/app/aave/chains.py
@@ -151,13 +151,16 @@ def get_active_chains() -> list[AaveChainConfig]:
     """
     環境変数 AAVE_ACTIVE_CHAINS からアクティブなチェーン一覧を取得する。
 
-    カンマ区切りで複数チェーンを指定可能（例: "arbitrum,optimism"）。
-    未設定の場合は "arbitrum" をデフォルトとする。
+    カンマ区切りで複数チェーンを指定可能（例: "base,optimism"）。
+    未設定の場合は "base" をデフォルトとする（本番は Base Mainnet 運用）。
+
+    NOTE: 旧デフォルト "arbitrum" から "base" に変更（2026-05-21）。
+    AAVE_RPC_URL_ARBITRUM が未設定の本番環境で ValueError が発生していた根本原因。
 
     :return: アクティブなチェーンの AaveChainConfig リスト
     :raises ValueError: 未知のチェーン名が含まれる場合
     """
-    raw = os.getenv("AAVE_ACTIVE_CHAINS", "arbitrum")
+    raw = os.getenv("AAVE_ACTIVE_CHAINS", "base")
     chain_names = [name.strip() for name in raw.split(",") if name.strip()]
     return [get_chain_config(name) for name in chain_names]
 

--- a/backend/app/aave/client.py
+++ b/backend/app/aave/client.py
@@ -1045,8 +1045,10 @@ def make_multi_chain_clients(
     """
     AAVE_ACTIVE_CHAINS の全チェーンに対してクライアントを生成する。
 
+    RPC URL 未設定のチェーンは警告ログを出力してスキップする（ValueError で起動失敗しない）。
+
     :param client_type: "dummy" | "web3"。未指定時は AAVE_CLIENT_TYPE env var を参照。
-    :returns: chain_name -> AaveClientBase のマッピング
+    :returns: chain_name -> AaveClientBase のマッピング（RPC 未設定チェーンは含まれない）
     """
     from .chains import get_active_chains
 
@@ -1057,10 +1059,18 @@ def make_multi_chain_clients(
             client_type = "web3" if env == "staging" else "dummy"
 
     active_chains = get_active_chains()
-    return {
-        chain.chain_name: make_aave_client(
+    result: dict[str, AaveClientBase] = {}
+    for chain in active_chains:
+        # web3 モードでは RPC 未設定チェーンをスキップ（本番は AAVE_ACTIVE_CHAINS=base のみ想定）
+        if client_type == "web3" and not os.getenv(chain.rpc_url_env_var):
+            logger.warning(
+                "Skipping chain %r: RPC URL env var %r is not set",
+                chain.chain_name,
+                chain.rpc_url_env_var,
+            )
+            continue
+        result[chain.chain_name] = make_aave_client(
             client_type=client_type,
             chain_name=chain.chain_name,
         )
-        for chain in active_chains
-    }
+    return result

--- a/backend/app/aave/router.py
+++ b/backend/app/aave/router.py
@@ -55,9 +55,12 @@ def rebalance(
     """
     BUY/SELL/HOLD に応じて deposit / withdraw / NOOP を実行する。
 
-    chain_name 未指定時はプライマリチェーン（arbitrum）を使用する。
+    chain_name 未指定時は AAVE_ACTIVE_CHAINS の先頭チェーンを使用する（本番: base）。
     """
-    chain = body.chain_name or "arbitrum"
+    import os  # noqa: PLC0415
+
+    default_chain = os.getenv("AAVE_ACTIVE_CHAINS", "base").split(",")[0].strip()
+    chain = body.chain_name or default_chain
     try:
         result = multi_service.execute_rebalance(
             chain_name=chain,

--- a/backend/app/aave/schemas.py
+++ b/backend/app/aave/schemas.py
@@ -142,7 +142,7 @@ class AaveRebalanceRequest(BaseModel):
     )
     chain_name: Optional[str] = Field(
         None,
-        description="対象チェーン名。未指定時はプライマリチェーン（arbitrum）を使用する。",
+        description="対象チェーン名。未指定時は AAVE_ACTIVE_CHAINS の先頭チェーン（本番デフォルト: base）を使用する。",
     )
 
 

--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -53,8 +53,12 @@ def _expire_old_proposals(db: Session, user_id: int) -> None:
 
 
 def _get_primary_chain() -> str:
-    """AAVE_ACTIVE_CHAINS の先頭チェーンを返す。未設定時は arbitrum_sepolia。"""
-    raw = os.getenv("AAVE_ACTIVE_CHAINS", "arbitrum_sepolia")
+    """AAVE_ACTIVE_CHAINS の先頭チェーンを返す。未設定時は "base"（本番は Base Mainnet 運用）。
+
+    NOTE: 旧デフォルト "arbitrum_sepolia" から "base" に変更（2026-05-21）。
+    chains.py の get_active_chains() のデフォルトと統一する。
+    """
+    raw = os.getenv("AAVE_ACTIVE_CHAINS", "base")
     return raw.split(",")[0].strip()
 
 

--- a/backend/tests/test_aave_chains.py
+++ b/backend/tests/test_aave_chains.py
@@ -116,14 +116,18 @@ class TestGetActiveChains:
             get_active_chains()
 
     @patch.dict("os.environ", {}, clear=False)
-    def test_env_not_set_defaults_to_arbitrum(self) -> None:
-        """AAVE_ACTIVE_CHAINS 未設定時は arbitrum をデフォルトとする。"""
+    def test_env_not_set_defaults_to_base(self) -> None:
+        """AAVE_ACTIVE_CHAINS 未設定時は base をデフォルトとする（本番は Base Mainnet 運用）。
+
+        2026-05-21 変更: 旧デフォルト "arbitrum" → "base"。
+        AAVE_RPC_URL_ARBITRUM 未設定の本番環境で ValueError が発生していた根本対策。
+        """
         import os
 
         os.environ.pop("AAVE_ACTIVE_CHAINS", None)
         chains = get_active_chains()
         assert len(chains) == 1
-        assert chains[0].chain_name == "arbitrum"
+        assert chains[0].chain_name == "base"
 
 
 class TestGetRpcUrlForChain:
@@ -138,3 +142,117 @@ class TestGetRpcUrlForChain:
         with patch.dict("os.environ", {}, clear=True):
             with pytest.raises(ValueError, match="RPC URL"):
                 get_rpc_url_for_chain(config)
+
+    def test_base_rpc_url_from_env(self) -> None:
+        """本番環境想定: AAVE_RPC_URL_BASE が設定されていれば base RPC URL を返す。"""
+        config = get_chain_config("base")
+        with patch.dict("os.environ", {"AAVE_RPC_URL_BASE": "https://base-rpc.example.com"}):
+            url = get_rpc_url_for_chain(config)
+            assert url == "https://base-rpc.example.com"
+
+    def test_arbitrum_rpc_not_set_raises(self) -> None:
+        """AAVE_RPC_URL_ARBITRUM 未設定時は ValueError（本番インシデント P0 の再現テスト）。"""
+        config = get_chain_config("arbitrum")
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="AAVE_RPC_URL_ARBITRUM"):
+                get_rpc_url_for_chain(config)
+
+
+class TestMakeMultiChainClientsRpcGuard:
+    """make_multi_chain_clients の RPC 未設定チェーンスキップ動作を検証する。
+
+    P0 GID 1214993061793196: AAVE_ACTIVE_CHAINS に arbitrum が含まれ
+    AAVE_RPC_URL_ARBITRUM が未設定の場合、起動 ValueError を防ぐためスキップする。
+    """
+
+    def test_skips_chain_without_rpc_in_web3_mode(self) -> None:
+        """web3 モードで RPC 未設定チェーンはスキップされ、結果に含まれない。"""
+        from unittest.mock import patch
+
+        from app.aave.client import make_multi_chain_clients
+
+        # AAVE_ACTIVE_CHAINS=arbitrum, RPC 未設定 → arbitrum はスキップ
+        with patch.dict(
+            "os.environ",
+            {"AAVE_ACTIVE_CHAINS": "arbitrum", "AAVE_CLIENT_TYPE": "web3"},
+            clear=False,
+        ):
+            # AAVE_RPC_URL_ARBITRUM を確実に未設定にする
+            import os
+
+            os.environ.pop("AAVE_RPC_URL_ARBITRUM", None)
+            clients = make_multi_chain_clients(client_type="web3")
+            # RPC 未設定 → スキップ → 空
+            assert "arbitrum" not in clients
+
+    def test_includes_chain_with_rpc_set_in_web3_mode(self) -> None:
+        """web3 モードで RPC 設定済みチェーンは結果に含まれる。"""
+        from unittest.mock import MagicMock, patch
+
+        from app.aave.client import make_multi_chain_clients
+
+        with patch.dict(
+            "os.environ",
+            {
+                "AAVE_ACTIVE_CHAINS": "base",
+                "AAVE_RPC_URL_BASE": "https://base-rpc.example.com",
+                "AAVE_CLIENT_TYPE": "web3",
+            },
+            clear=False,
+        ):
+            with patch("app.aave.client.make_aave_client") as mock_factory:
+                mock_factory.return_value = MagicMock()
+                clients = make_multi_chain_clients(client_type="web3")
+                assert "base" in clients
+
+    def test_dummy_mode_includes_all_chains_regardless_of_rpc(self) -> None:
+        """dummy モードでは RPC 未設定でもスキップしない（テスト環境で動くため）。"""
+        import os
+        from unittest.mock import MagicMock, patch
+
+        from app.aave.client import make_multi_chain_clients
+
+        os.environ.pop("AAVE_RPC_URL_ARBITRUM", None)
+
+        with patch.dict(
+            "os.environ",
+            {"AAVE_ACTIVE_CHAINS": "arbitrum"},
+            clear=False,
+        ):
+            with patch("app.aave.client.make_aave_client") as mock_factory:
+                mock_factory.return_value = MagicMock()
+                clients = make_multi_chain_clients(client_type="dummy")
+                assert "arbitrum" in clients
+
+
+class TestGetPrimaryChainDefault:
+    """proposals/router.py の _get_primary_chain() のデフォルト挙動を検証する。
+
+    P0 GID 1214993061793196: 旧デフォルト "arbitrum_sepolia" / "arbitrum" → "base" に統一。
+    """
+
+    def test_default_chain_is_base_when_env_not_set(self) -> None:
+        """AAVE_ACTIVE_CHAINS 未設定時は "base" が返る。"""
+        import os
+
+        from app.proposals.router import _get_primary_chain
+
+        os.environ.pop("AAVE_ACTIVE_CHAINS", None)
+        chain = _get_primary_chain()
+        assert chain == "base"
+
+    def test_returns_first_chain_from_env(self) -> None:
+        """AAVE_ACTIVE_CHAINS=base,arbitrum → "base" が返る（先頭チェーン）。"""
+        with patch.dict("os.environ", {"AAVE_ACTIVE_CHAINS": "base,arbitrum"}):
+            from app.proposals.router import _get_primary_chain
+
+            chain = _get_primary_chain()
+            assert chain == "base"
+
+    def test_base_only_env_returns_base(self) -> None:
+        """本番環境想定: AAVE_ACTIVE_CHAINS=base → "base" が返る。"""
+        with patch.dict("os.environ", {"AAVE_ACTIVE_CHAINS": "base"}):
+            from app.proposals.router import _get_primary_chain
+
+            chain = _get_primary_chain()
+            assert chain == "base"

--- a/backend/tests/test_aave_router.py
+++ b/backend/tests/test_aave_router.py
@@ -138,8 +138,9 @@ def test_aave_rebalance_buy_returns_200() -> None:
     assert data["result"]["operation"] == "DEPOSIT"
     assert data["result"]["status"] == "success"
     assert service.calls  # at least 1 call
-    # Default chain should be arbitrum
-    assert service.calls[0][0] == "arbitrum"
+    # Default chain should be base (P3-3: 旧 arbitrum default が Base 専用本番で
+    # AAVE_RPC_URL_ARBITRUM ValueError を起こした bug を修正し base に統一)
+    assert service.calls[0][0] == "base"
 
 
 def test_aave_rebalance_validation_error_for_negative_amount() -> None:


### PR DESCRIPTION
## 概要 / P0 GID 1214993061793196

proposal #1 が Arbitrum(42161) 向け execution を試行し `AAVE_RPC_URL_ARBITRUM` 未設定で `ValueError` が発生した P0 の根本修正。

## 真因 (Arbitrum が選ばれた理由)

コード上で **3 箇所** が `AAVE_ACTIVE_CHAINS` 未設定時のデフォルトを `"arbitrum"` または `"arbitrum_sepolia"` にハードコードしていた。本番環境は `AAVE_RPC_URL_BASE` のみ設定されており `AAVE_ACTIVE_CHAINS` は未設定 → すべてのコードパスが Arbitrum を試行 → RPC URL 未設定で ValueError。

| 場所 | 旧デフォルト | 新デフォルト |
|---|---|---|
| `backend/app/aave/chains.py` `get_active_chains()` | `"arbitrum"` | `"base"` |
| `backend/app/proposals/router.py` `_get_primary_chain()` | `"arbitrum_sepolia"` | `"base"` |
| `backend/app/aave/router.py` `rebalance()` | ハードコード `"arbitrum"` | `AAVE_ACTIVE_CHAINS` 先頭 |

## 変更内容

1. **chains.py** `get_active_chains()`: デフォルト `"arbitrum"` → `"base"`
2. **proposals/router.py** `_get_primary_chain()`: デフォルト `"arbitrum_sepolia"` → `"base"` かつ chains.py と統一
3. **aave/router.py** `rebalance()`: ハードコード fallback `"arbitrum"` を廃止 → `AAVE_ACTIVE_CHAINS` 先頭を動的取得
4. **aave/client.py** `make_multi_chain_clients()`: `web3` モードで RPC 未設定 chain を **skip + warning ログ**（防衛ガード — 将来 `AAVE_ACTIVE_CHAINS` に複数 chain が入っても起動失敗しない）
5. **aave/schemas.py**: description の `"arbitrum"` 言及を修正

## テスト結果

- `tests/test_aave_chains.py`: 25 tests pass（デフォルト base 検証 / RPC 未設定 Arbitrum スキップ / `_get_primary_chain` デフォルト確認）
- `ruff check . && ruff format --check .`: All checks passed
- `mypy app/`: Success: no issues found in 241 source files
- `pytest tests/test_aave_chains.py tests/test_aave_multi_chain_service.py tests/test_proposals_api.py tests/test_proposal_execute_failure.py`: 54 passed

## 本番確認コマンド (HUMAN-REVIEW 後)

```bash
# staging / production VPS で確認
grep -E "AAVE_ACTIVE_CHAINS|AAVE_RPC_URL" .env.production
# AAVE_ACTIVE_CHAINS が未設定でも AAVE_RPC_URL_BASE=... が設定されていれば base で動く
```

## Gate

- [x] Gate 1-3: verify.sh 相当 (ruff / mypy / pytest) pass
- [ ] Gate 4: E2E — Aave execution path は本番 RPC 依存のため staging 実機で要確認
- [ ] Gate 7: chrome 確認 — UI 変更なし、n/a

⚠️ **Tier S 金融。本番 deploy は HUMAN-REVIEW 必須。merge しない。**

Closes P0 GID 1214993061793196