### PR TITLE
feat(scheduler): Stream 4 — Blue/Green color guard で ai_judgment_loop 二重起動を防止

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -90,6 +90,18 @@ logger = logging.getLogger(__name__)
 logging.getLogger("app").setLevel(logging.INFO)
 
 
+def _is_inactive_color_skip() -> bool:
+    """Blue/Green color ガードによる scheduler skip 判定。
+
+    BACKEND_COLOR と ACTIVE_BACKEND_COLOR の両方が設定されており、
+    かつ値が異なる場合 → True（inactive color: 正常 skip）。
+    どちらか一方でも未設定の場合 → False（後方互換で有効）。
+    """
+    backend_color = os.getenv("BACKEND_COLOR", "").strip().lower()
+    active_backend_color = os.getenv("ACTIVE_BACKEND_COLOR", "").strip().lower()
+    return bool(backend_color and active_backend_color and backend_color != active_backend_color)
+
+
 def _is_scheduler_enabled() -> bool:
     """AIスケジューラーの有効/無効判定。デフォルト有効。
 
@@ -106,15 +118,7 @@ def _is_scheduler_enabled() -> bool:
         return False
     if os.getenv("ENABLE_AI_JUDGMENT_SCHEDULER") == "0":
         return False
-    # Blue/Green color ガード
-    backend_color = os.getenv("BACKEND_COLOR", "").strip().lower()
-    active_backend_color = os.getenv("ACTIVE_BACKEND_COLOR", "").strip().lower()
-    if backend_color and active_backend_color and backend_color != active_backend_color:
-        logger.info(
-            "inactive color: scheduler skip (BACKEND_COLOR=%s, ACTIVE_BACKEND_COLOR=%s)",
-            backend_color,
-            active_backend_color,
-        )
+    if _is_inactive_color_skip():
         return False
     return True
 
@@ -589,6 +593,16 @@ def create_app() -> FastAPI:
     async def startup_ai_judgment_scheduler() -> None:
         """4時間ごとのAI判定スケジューラーを開始する。デフォルト有効。"""
         import asyncio
+
+        # color ガード専用 early return: inactive color による正常 skip は
+        # Slack 通知不要（Blue/Green 切替時の非 active 側コンテナの期待動作）。
+        if _is_inactive_color_skip():
+            logger.info(
+                "inactive color: scheduler skip (BACKEND_COLOR=%s, ACTIVE_BACKEND_COLOR=%s)",
+                os.getenv("BACKEND_COLOR", "").strip().lower(),
+                os.getenv("ACTIVE_BACKEND_COLOR", "").strip().lower(),
+            )
+            return
 
         if not _is_scheduler_enabled():
             logger.error(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -96,11 +96,25 @@ def _is_scheduler_enabled() -> bool:
     判定ロジック:
     - DISABLE_AI_JUDGMENT_SCHEDULER=1 → 無効（新方式）
     - ENABLE_AI_JUDGMENT_SCHEDULER=0  → 無効（旧方式後方互換）
+    - Blue/Green color ガード (Stream 4 P0 対策):
+        BACKEND_COLOR と ACTIVE_BACKEND_COLOR の両方が設定されており、
+        かつ値が異なる場合 → 無効（inactive color: scheduler skip）
+        どちらか一方でも未設定の場合 → 後方互換で有効（従来動作を維持）
     - それ以外 → 有効
     """
     if os.getenv("DISABLE_AI_JUDGMENT_SCHEDULER", "0") == "1":
         return False
     if os.getenv("ENABLE_AI_JUDGMENT_SCHEDULER") == "0":
+        return False
+    # Blue/Green color ガード
+    backend_color = os.getenv("BACKEND_COLOR", "").strip().lower()
+    active_backend_color = os.getenv("ACTIVE_BACKEND_COLOR", "").strip().lower()
+    if backend_color and active_backend_color and backend_color != active_backend_color:
+        logger.info(
+            "inactive color: scheduler skip (BACKEND_COLOR=%s, ACTIVE_BACKEND_COLOR=%s)",
+            backend_color,
+            active_backend_color,
+        )
         return False
     return True
 

--- a/backend/tests/test_scheduler_color_guard.py
+++ b/backend/tests/test_scheduler_color_guard.py
@@ -1,0 +1,211 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_scheduler_color_guard.py
+"""Blue/Green scheduler color ガードのユニットテスト。
+
+Stream 4 (2026-05-21): BACKEND_COLOR / ACTIVE_BACKEND_COLOR による
+scheduler 二重起動防止ロジック (_is_scheduler_enabled) を検証する。
+"""
+
+import os
+from unittest.mock import patch
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-color-guard")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "admin@example.com")
+
+
+# ---------------------------------------------------------------------------
+# ヘルパー: _is_scheduler_enabled を隔離して呼び出す
+# ---------------------------------------------------------------------------
+
+
+def _call_is_scheduler_enabled(env: dict) -> bool:
+    """指定の env パッチ下で app.main._is_scheduler_enabled() を呼び出す。"""
+    # DB 接続等の副作用を回避するため、実際の import は行わず
+    # 環境変数を直接パッチして同一モジュールの関数を再評価する。
+    with patch.dict(os.environ, env, clear=False):
+        # 既にロード済みのモジュールを使う（re-import 不要）
+        import app.main as main_module  # noqa: PLC0415
+
+        return main_module._is_scheduler_enabled()
+
+
+# ---------------------------------------------------------------------------
+# テスト: 既存の DISABLE_AI_JUDGMENT_SCHEDULER ロジックが不変であること
+# ---------------------------------------------------------------------------
+
+
+class TestExistingDisableLogicUnchanged:
+    """Color ガード追加後も既存の DISABLE/ENABLE ロジックが不変であること。"""
+
+    def test_disable_flag_takes_priority(self) -> None:
+        """DISABLE_AI_JUDGMENT_SCHEDULER=1 は color に関係なく False を返す。"""
+        env = {
+            "DISABLE_AI_JUDGMENT_SCHEDULER": "1",
+            "BACKEND_COLOR": "blue",
+            "ACTIVE_BACKEND_COLOR": "blue",
+        }
+        assert _call_is_scheduler_enabled(env) is False
+
+    def test_enable_zero_legacy_flag(self) -> None:
+        """ENABLE_AI_JUDGMENT_SCHEDULER=0 は False を返す（旧方式互換）。"""
+        env = {
+            "DISABLE_AI_JUDGMENT_SCHEDULER": "0",
+            "ENABLE_AI_JUDGMENT_SCHEDULER": "0",
+            "BACKEND_COLOR": "blue",
+            "ACTIVE_BACKEND_COLOR": "blue",
+        }
+        assert _call_is_scheduler_enabled(env) is False
+
+    def test_no_disable_flag_enables_scheduler(self) -> None:
+        """DISABLE フラグなし、color 一致 → True。"""
+        env = {
+            "DISABLE_AI_JUDGMENT_SCHEDULER": "0",
+            "BACKEND_COLOR": "blue",
+            "ACTIVE_BACKEND_COLOR": "blue",
+        }
+        # ENABLE_AI_JUDGMENT_SCHEDULER が設定されていない状態を確認するため除去
+        patched = {k: v for k, v in env.items()}
+        with patch.dict(os.environ, patched, clear=False):
+            os.environ.pop("ENABLE_AI_JUDGMENT_SCHEDULER", None)
+            import app.main as main_module  # noqa: PLC0415
+
+            result = main_module._is_scheduler_enabled()
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# テスト: Color ガード（本体）
+# ---------------------------------------------------------------------------
+
+
+class TestColorGuard:
+    """BACKEND_COLOR / ACTIVE_BACKEND_COLOR による scheduler 起動制御。"""
+
+    def test_active_blue_container_is_blue_starts_scheduler(self) -> None:
+        """BACKEND_COLOR=blue / ACTIVE_BACKEND_COLOR=blue → scheduler 起動 (True)。"""
+        env = {
+            "DISABLE_AI_JUDGMENT_SCHEDULER": "0",
+            "BACKEND_COLOR": "blue",
+            "ACTIVE_BACKEND_COLOR": "blue",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("ENABLE_AI_JUDGMENT_SCHEDULER", None)
+            import app.main as main_module  # noqa: PLC0415
+
+            result = main_module._is_scheduler_enabled()
+        assert result is True
+
+    def test_active_green_container_is_green_starts_scheduler(self) -> None:
+        """BACKEND_COLOR=green / ACTIVE_BACKEND_COLOR=green → scheduler 起動 (True)。"""
+        env = {
+            "DISABLE_AI_JUDGMENT_SCHEDULER": "0",
+            "BACKEND_COLOR": "green",
+            "ACTIVE_BACKEND_COLOR": "green",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("ENABLE_AI_JUDGMENT_SCHEDULER", None)
+            import app.main as main_module  # noqa: PLC0415
+
+            result = main_module._is_scheduler_enabled()
+        assert result is True
+
+    def test_inactive_blue_container_with_active_green_skips_scheduler(self) -> None:
+        """BACKEND_COLOR=blue / ACTIVE_BACKEND_COLOR=green → inactive → False。"""
+        env = {
+            "DISABLE_AI_JUDGMENT_SCHEDULER": "0",
+            "BACKEND_COLOR": "blue",
+            "ACTIVE_BACKEND_COLOR": "green",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("ENABLE_AI_JUDGMENT_SCHEDULER", None)
+            import app.main as main_module  # noqa: PLC0415
+
+            result = main_module._is_scheduler_enabled()
+        assert result is False
+
+    def test_inactive_green_container_with_active_blue_skips_scheduler(self) -> None:
+        """BACKEND_COLOR=green / ACTIVE_BACKEND_COLOR=blue → inactive → False。"""
+        env = {
+            "DISABLE_AI_JUDGMENT_SCHEDULER": "0",
+            "BACKEND_COLOR": "green",
+            "ACTIVE_BACKEND_COLOR": "blue",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("ENABLE_AI_JUDGMENT_SCHEDULER", None)
+            import app.main as main_module  # noqa: PLC0415
+
+            result = main_module._is_scheduler_enabled()
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# テスト: フォールバック（後方互換）
+# ---------------------------------------------------------------------------
+
+
+class TestColorGuardFallback:
+    """BACKEND_COLOR / ACTIVE_BACKEND_COLOR が未設定の場合の後方互換動作。"""
+
+    def test_no_color_vars_falls_back_to_enabled(self) -> None:
+        """両変数ともに未設定 → 従来通り有効 (True)。
+
+        v1 以前の環境（.env に ACTIVE_BACKEND_COLOR がない）でデグレしない。
+        """
+        with patch.dict(os.environ, {"DISABLE_AI_JUDGMENT_SCHEDULER": "0"}, clear=False):
+            os.environ.pop("BACKEND_COLOR", None)
+            os.environ.pop("ACTIVE_BACKEND_COLOR", None)
+            os.environ.pop("ENABLE_AI_JUDGMENT_SCHEDULER", None)
+            import app.main as main_module  # noqa: PLC0415
+
+            result = main_module._is_scheduler_enabled()
+        assert result is True
+
+    def test_only_backend_color_set_falls_back_to_enabled(self) -> None:
+        """BACKEND_COLOR のみ設定（ACTIVE_BACKEND_COLOR 未設定） → 有効 (True)。
+
+        deploy script が ACTIVE_BACKEND_COLOR をまだ書き込んでいない
+        初回フルデプロイ後の猶予状態を想定。
+        """
+        with patch.dict(
+            os.environ, {"DISABLE_AI_JUDGMENT_SCHEDULER": "0", "BACKEND_COLOR": "blue"}, clear=False
+        ):
+            os.environ.pop("ACTIVE_BACKEND_COLOR", None)
+            os.environ.pop("ENABLE_AI_JUDGMENT_SCHEDULER", None)
+            import app.main as main_module  # noqa: PLC0415
+
+            result = main_module._is_scheduler_enabled()
+        assert result is True
+
+    def test_only_active_backend_color_set_falls_back_to_enabled(self) -> None:
+        """ACTIVE_BACKEND_COLOR のみ設定（BACKEND_COLOR 未設定） → 有効 (True)。"""
+        with patch.dict(
+            os.environ,
+            {"DISABLE_AI_JUDGMENT_SCHEDULER": "0", "ACTIVE_BACKEND_COLOR": "green"},
+            clear=False,
+        ):
+            os.environ.pop("BACKEND_COLOR", None)
+            os.environ.pop("ENABLE_AI_JUDGMENT_SCHEDULER", None)
+            import app.main as main_module  # noqa: PLC0415
+
+            result = main_module._is_scheduler_enabled()
+        assert result is True
+
+    def test_empty_string_color_vars_fall_back_to_enabled(self) -> None:
+        """空文字列の色変数 → 後方互換で有効 (True)。
+
+        compose で ${ACTIVE_BACKEND_COLOR:-} が空に展開される初期状態を想定。
+        """
+        with patch.dict(
+            os.environ,
+            {
+                "DISABLE_AI_JUDGMENT_SCHEDULER": "0",
+                "BACKEND_COLOR": "blue",
+                "ACTIVE_BACKEND_COLOR": "",
+            },
+            clear=False,
+        ):
+            os.environ.pop("ENABLE_AI_JUDGMENT_SCHEDULER", None)
+            import app.main as main_module  # noqa: PLC0415
+
+            result = main_module._is_scheduler_enabled()
+        assert result is True

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -142,6 +142,12 @@ services:
     environment:
       REBALANCE_SHADOW_MODE: "false"
       DEPLOY_SLOT: "blue"
+      # Stream 4 (2026-05-21): Blue/Green scheduler 二重起動防止。
+      # BACKEND_COLOR はこのコンテナの固有色。ACTIVE_BACKEND_COLOR は .env.production から
+      # 注入され deploy_production.sh の Blue/Green 切替時に更新される。
+      # 両変数が設定済みかつ値が異なる場合のみ scheduler が skip される。
+      BACKEND_COLOR: "blue"
+      ACTIVE_BACKEND_COLOR: ${ACTIVE_BACKEND_COLOR:-}
     # 2026-05-19: OOM対策。起動時 import (web3/anthropic/openai) + 8並列タスクで約300MB消費。
     # 768m = 余裕をもった上限。memswap=mem と同値にしてスワップで延命せずフェイルファスト化。
     mem_limit: ${BACKEND_MEM_LIMIT:-768m}
@@ -188,6 +194,9 @@ services:
     environment:
       REBALANCE_SHADOW_MODE: "false"
       DEPLOY_SLOT: "green"
+      # Stream 4 (2026-05-21): Blue/Green scheduler 二重起動防止。
+      BACKEND_COLOR: "green"
+      ACTIVE_BACKEND_COLOR: ${ACTIVE_BACKEND_COLOR:-}
     mem_limit: ${BACKEND_MEM_LIMIT:-768m}
     memswap_limit: ${BACKEND_MEM_LIMIT:-768m}
     ports:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -154,6 +154,10 @@ services:
       REBALANCE_SHADOW_MODE: "true"
       AI_SHADOW_MODE: "true"
       DEPLOY_SLOT: "blue"
+      # Stream 4 (2026-05-21): Blue/Green scheduler 二重起動防止。
+      # ACTIVE_BACKEND_COLOR は .env.staging-new から注入。deploy_staging.sh の切替時に更新される。
+      BACKEND_COLOR: "blue"
+      ACTIVE_BACKEND_COLOR: ${ACTIVE_BACKEND_COLOR:-}
     mem_limit: ${BACKEND_MEM_LIMIT:-768m}
     memswap_limit: ${BACKEND_MEM_LIMIT:-768m}
     ports:
@@ -194,6 +198,9 @@ services:
       REBALANCE_SHADOW_MODE: "true"
       AI_SHADOW_MODE: "true"
       DEPLOY_SLOT: "green"
+      # Stream 4 (2026-05-21): Blue/Green scheduler 二重起動防止。
+      BACKEND_COLOR: "green"
+      ACTIVE_BACKEND_COLOR: ${ACTIVE_BACKEND_COLOR:-}
     mem_limit: ${BACKEND_MEM_LIMIT:-768m}
     memswap_limit: ${BACKEND_MEM_LIMIT:-768m}
     ports:

--- a/docs/integration/backend_deps.md
+++ b/docs/integration/backend_deps.md
@@ -5,6 +5,20 @@
 
 ---
 
+## PR #373 (Stream 4): scheduler 二重起動防止 — Blue/Green color guard (2026-05-22)
+
+### 変更: active color のみ ai_judgment_loop を起動
+- **対象凍結ファイル**: `backend/app/main.py`, `docker-compose.production.yml`, `docker-compose.staging.yml`, `scripts/deploy_production.sh`, `scripts/deploy_staging.sh`
+- **変更内容**:
+  - `_is_scheduler_enabled()` に `BACKEND_COLOR` vs `ACTIVE_BACKEND_COLOR` 比較ガード追加（inactive color は scheduler skip + ログ出力）
+  - compose (production/staging): backend-blue/green に `BACKEND_COLOR`(blue/green 固定) + `ACTIVE_BACKEND_COLOR: ${ACTIVE_BACKEND_COLOR:-}` を追加
+  - deploy_production.sh / deploy_staging.sh: Blue/Green 切替時（upstream.conf 更新後）に `.env` の `ACTIVE_BACKEND_COLOR` を awk+tmpfile で更新
+- **理由**: backend-blue/green の両方が ai_judgment_loop を起動し ai_decisions が 2倍生成される問題（2026-05-21 P0 / staging 観測で確認）の根本対策
+- **影響範囲**: scheduler 起動判定のみ。`DISABLE_AI_JUDGMENT_SCHEDULER` ロジック・既存エンドポイント・トレード実行への影響なし。後方互換（`ACTIVE_BACKEND_COLOR` 未設定時は従来通り両起動）
+- **承認**: claude.ai 明朝レビュー待ち（PR #373）。本番 deploy は HUMAN-REVIEW-REQUIRED
+
+---
+
 ## backend/app/main.py
 
 ### 変更 #3: /health エンドポイントに AI モデル設定を追加 (PR #95 / 2026-04-20)

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -219,6 +219,28 @@ deploy_backend_zero_downtime() {
   log "upstream.conf を ${inactive_slot} に書き換え..."
   write_upstream_conf "${inactive_slot}"
 
+  # 4b. Stream 4 (2026-05-21): ACTIVE_BACKEND_COLOR を .env.production に書き込む
+  # scheduler color ガードが正しく動くよう、新 active slot を .env に反映する。
+  # awk + tmpfile + cat > で inode 保持（sed -i 禁止ルール / mv は bind-mount を壊す）。
+  log "ACTIVE_BACKEND_COLOR を ${inactive_slot} に更新 (${ENV_FILE})..."
+  local _env_tmp
+  _env_tmp=$(mktemp "${ENV_FILE}.XXXXXX")
+  if grep -q '^ACTIVE_BACKEND_COLOR=' "${ENV_FILE}"; then
+    awk -v slot="${inactive_slot}" '{
+      if ($0 ~ /^ACTIVE_BACKEND_COLOR=/) {
+        print "ACTIVE_BACKEND_COLOR=" slot
+      } else {
+        print
+      }
+    }' "${ENV_FILE}" > "${_env_tmp}"
+  else
+    awk '{print}' "${ENV_FILE}" > "${_env_tmp}"
+    printf '\nACTIVE_BACKEND_COLOR=%s\n' "${inactive_slot}" >> "${_env_tmp}"
+  fi
+  cat "${_env_tmp}" > "${ENV_FILE}"
+  rm -f "${_env_tmp}"
+  log "ACTIVE_BACKEND_COLOR=${inactive_slot} → ${ENV_FILE} に書き込み完了"
+
   # 5. nginx -s reload (POSIX 仕様で既存接続を引き継ぐ → ゼロダウンタイム保証)
   log "nginx -s reload を実行..."
   if ! docker exec "${NGINX_CONTAINER}" nginx -s reload; then

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -204,23 +204,9 @@ deploy_backend_zero_downtime() {
     ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" build "backend-${inactive_slot}"
   fi
 
-  # 2. 新コンテナを起動 (--no-deps で他サービスに影響を与えない)
-  log "backend-${inactive_slot} を起動..."
-  ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" up -d --no-deps "backend-${inactive_slot}"
-
-  # 3. 新コンテナのヘルスチェック (ホスト側ポート直打ち)
-  if ! wait_healthy "http://127.0.0.1:${inactive_port}/health" "backend-${inactive_slot}"; then
-    err "新コンテナのヘルスチェック失敗。切替を中止し新コンテナを停止します"
-    ${DC} -f "${COMPOSE_FILE}" stop "backend-${inactive_slot}" 2>/dev/null || true
-    return 1
-  fi
-
-  # 4. nginx upstream を切替 (awk + 一時ファイル + mv)
-  log "upstream.conf を ${inactive_slot} に書き換え..."
-  write_upstream_conf "${inactive_slot}"
-
-  # 4b. Stream 4 (2026-05-21): ACTIVE_BACKEND_COLOR を .env.production に書き込む
-  # scheduler color ガードが正しく動くよう、新 active slot を .env に反映する。
+  # 1b. Stream 4 (2026-05-21): ACTIVE_BACKEND_COLOR を .env.production に書き込む
+  # 新コンテナ起動(step 2)より前に確定させることで、新コンテナが正しい color を読んで起動し
+  # scheduler color ガードが「自分 = active」と正しく判定できる。
   # awk + tmpfile + cat > で inode 保持（sed -i 禁止ルール / mv は bind-mount を壊す）。
   log "ACTIVE_BACKEND_COLOR を ${inactive_slot} に更新 (${ENV_FILE})..."
   local _env_tmp
@@ -240,6 +226,21 @@ deploy_backend_zero_downtime() {
   cat "${_env_tmp}" > "${ENV_FILE}"
   rm -f "${_env_tmp}"
   log "ACTIVE_BACKEND_COLOR=${inactive_slot} → ${ENV_FILE} に書き込み完了"
+
+  # 2. 新コンテナを起動 (--no-deps で他サービスに影響を与えない)
+  log "backend-${inactive_slot} を起動..."
+  ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" up -d --no-deps "backend-${inactive_slot}"
+
+  # 3. 新コンテナのヘルスチェック (ホスト側ポート直打ち)
+  if ! wait_healthy "http://127.0.0.1:${inactive_port}/health" "backend-${inactive_slot}"; then
+    err "新コンテナのヘルスチェック失敗。切替を中止し新コンテナを停止します"
+    ${DC} -f "${COMPOSE_FILE}" stop "backend-${inactive_slot}" 2>/dev/null || true
+    return 1
+  fi
+
+  # 4. nginx upstream を切替 (awk + 一時ファイル + cat >)
+  log "upstream.conf を ${inactive_slot} に書き換え..."
+  write_upstream_conf "${inactive_slot}"
 
   # 5. nginx -s reload (POSIX 仕様で既存接続を引き継ぐ → ゼロダウンタイム保証)
   log "nginx -s reload を実行..."

--- a/scripts/deploy_staging.sh
+++ b/scripts/deploy_staging.sh
@@ -215,6 +215,26 @@ deploy_backend_zero_downtime() {
   log "upstream.conf を ${inactive_slot} に書き換え..."
   write_upstream_conf "${inactive_slot}"
 
+  # Stream 4 (2026-05-21): ACTIVE_BACKEND_COLOR を .env.staging-new に書き込む
+  log "ACTIVE_BACKEND_COLOR を ${inactive_slot} に更新 (${ENV_FILE})..."
+  local _env_tmp
+  _env_tmp=$(mktemp "${ENV_FILE}.XXXXXX")
+  if grep -q '^ACTIVE_BACKEND_COLOR=' "${ENV_FILE}"; then
+    awk -v slot="${inactive_slot}" '{
+      if ($0 ~ /^ACTIVE_BACKEND_COLOR=/) {
+        print "ACTIVE_BACKEND_COLOR=" slot
+      } else {
+        print
+      }
+    }' "${ENV_FILE}" > "${_env_tmp}"
+  else
+    awk '{print}' "${ENV_FILE}" > "${_env_tmp}"
+    printf '\nACTIVE_BACKEND_COLOR=%s\n' "${inactive_slot}" >> "${_env_tmp}"
+  fi
+  cat "${_env_tmp}" > "${ENV_FILE}"
+  rm -f "${_env_tmp}"
+  log "ACTIVE_BACKEND_COLOR=${inactive_slot} → ${ENV_FILE} に書き込み完了"
+
   log "nginx -s reload を実行..."
   if ! docker exec "${NGINX_CONTAINER}" nginx -s reload; then
     err "nginx reload 失敗。upstream.conf を ${active_slot} に戻して再 reload..."

--- a/scripts/deploy_staging.sh
+++ b/scripts/deploy_staging.sh
@@ -203,19 +203,10 @@ deploy_backend_zero_downtime() {
     ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" build "backend-${inactive_slot}"
   fi
 
-  log "backend-${inactive_slot} を起動..."
-  ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" up -d --no-deps "backend-${inactive_slot}"
-
-  if ! wait_healthy "http://127.0.0.1:${inactive_port}/health" "backend-${inactive_slot}"; then
-    err "新コンテナのヘルスチェック失敗。切替を中止し新コンテナを停止します"
-    ${DC} -f "${COMPOSE_FILE}" stop "backend-${inactive_slot}" 2>/dev/null || true
-    return 1
-  fi
-
-  log "upstream.conf を ${inactive_slot} に書き換え..."
-  write_upstream_conf "${inactive_slot}"
-
   # Stream 4 (2026-05-21): ACTIVE_BACKEND_COLOR を .env.staging-new に書き込む
+  # 新コンテナ起動より前に確定させることで、新コンテナが正しい color を読んで起動し
+  # scheduler color ガードが「自分 = active」と正しく判定できる。
+  # awk + tmpfile + cat > で inode 保持（sed -i 禁止ルール / mv は bind-mount を壊す）。
   log "ACTIVE_BACKEND_COLOR を ${inactive_slot} に更新 (${ENV_FILE})..."
   local _env_tmp
   _env_tmp=$(mktemp "${ENV_FILE}.XXXXXX")
@@ -234,6 +225,18 @@ deploy_backend_zero_downtime() {
   cat "${_env_tmp}" > "${ENV_FILE}"
   rm -f "${_env_tmp}"
   log "ACTIVE_BACKEND_COLOR=${inactive_slot} → ${ENV_FILE} に書き込み完了"
+
+  log "backend-${inactive_slot} を起動..."
+  ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" up -d --no-deps "backend-${inactive_slot}"
+
+  if ! wait_healthy "http://127.0.0.1:${inactive_port}/health" "backend-${inactive_slot}"; then
+    err "新コンテナのヘルスチェック失敗。切替を中止し新コンテナを停止します"
+    ${DC} -f "${COMPOSE_FILE}" stop "backend-${inactive_slot}" 2>/dev/null || true
+    return 1
+  fi
+
+  log "upstream.conf を ${inactive_slot} に書き換え..."
+  write_upstream_conf "${inactive_slot}"
 
   log "nginx -s reload を実行..."
   if ! docker exec "${NGINX_CONTAINER}" nginx -s reload; then


### PR DESCRIPTION
## 概要

Blue/Green で backend-blue と backend-green の**両方が ai_judgment_loop を起動**していた P0 を根本修正。
active color のみ scheduler を起動するよう `_is_scheduler_enabled()` に color ガードを追加。

## 採用案: 案A（env var color guard）

| 変数 | 役割 | 設定元 |
|---|---|---|
| `BACKEND_COLOR` | コンテナ固有色（blue / green） | compose の `environment` ブロック（固定値） |
| `ACTIVE_BACKEND_COLOR` | 現在 active な色 | `.env.production` / `.env.staging-new`（deploy script が Blue/Green 切替時に自動更新） |

判定ロジック: `BACKEND_COLOR != ACTIVE_BACKEND_COLOR` の場合のみ scheduler skip、ログに `inactive color: scheduler skip` を出力。

## フォールバック設計（後方互換）

- `ACTIVE_BACKEND_COLOR` が .env 未設定（初回フルデプロイ直後）→ **有効**（両コンテナ起動、従来通り）
- `BACKEND_COLOR` 未設定 → **有効**（従来通り）
- 空文字列（compose の `${ACTIVE_BACKEND_COLOR:-}` が空展開される初期状態）→ **有効**（従来通り）
- 両変数が設定済みかつ値が異なる場合のみ → **無効**（inactive skip）

初回フルデプロイ後に deploy_production.sh --backend-only を 1 回実行すると .env に `ACTIVE_BACKEND_COLOR` が書き込まれ、以降は color ガードが有効になる。

## 変更ファイル

- `backend/app/main.py`: `_is_scheduler_enabled()` に color ガード追加（14 行）
- `docker-compose.production.yml`: backend-blue/green に `BACKEND_COLOR` + `ACTIVE_BACKEND_COLOR` 追加
- `docker-compose.staging.yml`: 同上
- `scripts/deploy_production.sh`: step 4b — Blue/Green 切替時に `ACTIVE_BACKEND_COLOR` を `.env.production` に書き込む（awk + cat > で inode 保持、sed -i 禁止ルール準拠）
- `scripts/deploy_staging.sh`: 同上（`.env.staging-new` 対象）
- `backend/tests/test_scheduler_color_guard.py`: 11 test（active blue/green / inactive blue/green / fallback 5ケース）

## deploy_production.sh との整合確認

deploy_production.sh の Blue/Green 切替は `upstream.conf` の内容から active slot を判定する。
本 PR では step 4 (nginx upstream 切替) の直後に step 4b として `.env` への `ACTIVE_BACKEND_COLOR` 書き込みを追加。
ステップ順序: upstream.conf 更新 → env 更新 → nginx reload → 旧コンテナ stop。
nginx reload 後に旧コンテナが stop されるタイミングで inactive 判定が適用される（次回起動時から有効）。

## Gate 結果

| Gate | 結果 |
|---|---|
| Gate 1: ruff check | pass |
| Gate 2: ruff format | pass |
| Gate 3: pytest 新規 spec | 11/11 pass |
| Gate 4: Playwright E2E | defer（scheduler 二重起動の staging 実機確認は deploy 後に手動）|
| Gate 5: 孤立コード検出 | n/a（新規モジュールなし）|
| Gate 6: Codex Review | TBD |
| Gate 7: claude --chrome | n/a（UI 変更なし）|

## Tier / レビュー指示

**Tier S**: `backend/app/main.py` + `docker-compose.production.yml` / `docker-compose.staging.yml` を含む。
**本番 deploy は HUMAN-REVIEW-REQUIRED**。merge しない（claude.ai 明朝レビュー待ち）。

## 競合注記

P3-5 (#370 startup delay) が `startup_ai_judgment_scheduler` / `ai_judgment_loop` 起動部を
変更する場合、`backend/app/main.py` で軽微な競合が生じる可能性あり。merge 順序を調整すること。