### PR TITLE
fix(ops): staging 全サービスに mem_limit 付与 (OOM 再発防止)

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -69,6 +69,9 @@ services:
       retries: 3
       start_period: 30s
     restart: always
+    # 2026-05-22 OOM対策: runtime メモリ上限 (build とは別、Next build は host swap 利用)
+    mem_limit: 384m
+    memswap_limit: 384m
     networks:
       - staging-net
     logging:
@@ -88,6 +91,9 @@ services:
     depends_on:
       - loki
     restart: always
+    # 2026-05-22 OOM対策: runtime メモリ上限 (build とは別、Next build は host swap 利用)
+    mem_limit: 128m
+    memswap_limit: 128m
     networks:
       - staging-net
     logging:
@@ -108,6 +114,9 @@ services:
     volumes:
       - postgres-data-staging-new:/var/lib/postgresql/data
     restart: always
+    # 2026-05-22 OOM対策: runtime メモリ上限 (build とは別、Next build は host swap 利用)
+    mem_limit: 512m
+    memswap_limit: 512m
     networks:
       - staging-net
     healthcheck:
@@ -221,6 +230,9 @@ services:
     depends_on:
       - backend-blue
     restart: always
+    # 2026-05-22 OOM対策: runtime メモリ上限 (build とは別、Next build は host swap 利用)
+    mem_limit: 64m
+    memswap_limit: 64m
     networks:
       - staging-net
     # P0-2 (2026-05-21 loki cascade fix): json-file に切替。promtail 経由で Loki 収集継続。
@@ -265,6 +277,9 @@ services:
     depends_on:
       - nginx
     restart: always
+    # 2026-05-22 OOM対策: runtime メモリ上限 (build とは別、Next build は host swap 利用)
+    mem_limit: 512m
+    memswap_limit: 512m
     networks:
       - staging-net
     # P0-2 (2026-05-21 loki cascade fix): json-file に切替。promtail 経由で Loki 収集継続。


### PR DESCRIPTION
## 背景 / Incident

2026-05-22、staging stack が OOM で全滅。ホストは 7.6GB RAM・swap なし。
frontend の Next.js build が大量メモリを消費し、他サービスが巻き添えで落ちた。

## 変更内容

`docker-compose.staging.yml` の残り 5 サービスに `mem_limit` / `memswap_limit` を追加し、  
単一サービスの暴走が stack 全体を道連れにするのを防ぐ。

| サービス | mem_limit | memswap_limit |
|---|---|---|
| postgres | 512m | 512m |
| loki | 384m | 384m |
| promtail | 128m | 128m |
| nginx | 64m | 64m |
| frontend | 512m | 512m |

**backend-blue / backend-green は既存の `mem_limit: ${BACKEND_MEM_LIMIT:-768m}` を据置。変更なし。**

`memswap_limit = mem_limit` とすることで、コンテナに swap を使わせず予測可能に OOM させる（既存 backend と同方針）。  
Next.js build は host プロセスであるため、`mem_limit` の影響を受けない（build OOM とは別レイヤの防御）。

## 本番反映について

本変更は staging 専用ファイル (`docker-compose.staging.yml`) のみ。  
**本番反映は Mac で本 PR を merge → prod VPS で `git pull` して適用すること。本 PR はそこで停止。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)