### PR TITLE
fix(frontend): copy-trading/trade の PrivyProvider 二重ネスト除去 (prerender失敗修正)

### DIFF
--- a/frontend/app/(user)/copy-trading/page.tsx
+++ b/frontend/app/(user)/copy-trading/page.tsx
@@ -7,7 +7,6 @@ import { useState, useEffect, useCallback } from 'react'
 
 import { TrendingUp, RefreshCw } from 'lucide-react'
 import { useAuth } from '@/lib/auth'
-import { UserProviders } from '@/components/user/UserProviders'
 import AuthGuard from '@/components/AuthGuard'
 import { CopyTradingCard } from '@/components/user/CopyTradingCard'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -151,10 +150,8 @@ function CopyTradingPage() {
 
 export default function CopyTradingPageWrapper() {
   return (
-    <UserProviders>
-      <AuthGuard>
-        <CopyTradingPage />
-      </AuthGuard>
-    </UserProviders>
+    <AuthGuard>
+      <CopyTradingPage />
+    </AuthGuard>
   )
 }

--- a/frontend/app/(user)/trade/page.tsx
+++ b/frontend/app/(user)/trade/page.tsx
@@ -11,7 +11,6 @@ import { Badge } from '@/components/ui/badge'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import AuthGuard from '@/components/AuthGuard'
 import { useAuth } from '@/lib/auth'
-import { UserProviders } from '@/components/user/UserProviders'
 import { postJson, getJson } from '@/lib/api/http'
 
 type TradeAction = 'BUY' | 'SELL'
@@ -333,10 +332,8 @@ function TradePage() {
 
 export default function TradeApprovalPage() {
   return (
-    <UserProviders>
-      <AuthGuard>
-        <TradePage />
-      </AuthGuard>
-    </UserProviders>
+    <AuthGuard>
+      <TradePage />
+    </AuthGuard>
   )
 }


### PR DESCRIPTION
## 原因

`(user)/layout.tsx` が `<UserProviders>` (内部に `<PrivyProvider>`) で children 全体を既に包んでいるにも関わらず、以下の2ページが default export wrapper で再度 `<UserProviders>` で巻いていた。

- `frontend/app/(user)/copy-trading/page.tsx` — `CopyTradingPageWrapper`
- `frontend/app/(user)/trade/page.tsx` — `TradeApprovalPage`

この二重ネストにより Next.js build の prerender フェーズで `Error: Multiple PrivyProvider instances found` が発生し、`/copy-trading` `/trade` の静的 export が失敗、`next build` が exit 1 で終了していた。

## 修正内容

**外科的1点修正**: 各ページの default export wrapper から冗長な `<UserProviders>...</UserProviders>` ラッパーを除去し、未使用になった `import { UserProviders }` を削除。

```diff
// copy-trading/page.tsx
-import { UserProviders } from '@/components/user/UserProviders'
 export default function CopyTradingPageWrapper() {
-  return <UserProviders><AuthGuard><CopyTradingPage /></AuthGuard></UserProviders>
+  return <AuthGuard><CopyTradingPage /></AuthGuard>
}

// trade/page.tsx
-import { UserProviders } from '@/components/user/UserProviders'
 export default function TradeApprovalPage() {
-  return <UserProviders><AuthGuard><TradePage /></AuthGuard></UserProviders>
+  return <AuthGuard><TradePage /></AuthGuard>
}
```

`(user)` ツリー全体を `grep -rn 'UserProviders' frontend/app/(user)/` で網羅チェック済み。修正後は `(user)/layout.tsx` の1箇所のみが `UserProviders` を供給する状態。`copy-trading/layout.tsx` は `NextIntlClientProvider` のみで `UserProviders` は使用していないことも確認済み。

## 検証

- `git diff` 目視: 変更は上記2ファイル・ラッパー除去と未使用 import 削除のみ ✅
- `npx tsc --noEmit`: dev VPS に node_modules が展開されていないため実行不可 (tsc バイナリなし)。Mac 側で merge 後に `next build` フルチェックで確認をお願いします。
- **full `npm run build` は実行していない** (dev VPS のメモリ保護のため)。

## 本番反映手順

Mac で merge → prod VPS で `git pull` → `docker compose up -d frontend` (または該当サービスのみ re-up)。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)