### PR TITLE
docs: staging コンテナ構成を実機(7サービス・両backend)に訂正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -519,7 +519,7 @@ tmux attach -t phase-<X>
 | **staging** | staging/api-staging.ultra-auto-trade.com（Phase 4設定予定）| `docker-compose.staging.yml` | `.env.staging` | `scripts/deploy_staging.sh` |
 
 - **コンテナ名**: production は `*-production` suffix（2026-04-24 container_name 衝突インシデント後にリネーム済み）
-- **staging**: Shadow Mode専用（`AI_SHADOW_MODE=true` / `REBALANCE_SHADOW_MODE=true`）、Base Sepolia、port 3001/8082(nginx経由)/5433（注: 旧8001は廃止。`curl http://127.0.0.1:8082/health` で確認）
+- **staging**: Shadow Mode専用（`AI_SHADOW_MODE=true` / `REBALANCE_SHADOW_MODE=true`）、Base Sepolia、port 3001/8082(nginx経由)/5433（注: 旧8001は廃止。`curl http://127.0.0.1:8082/health` で確認）。`docker-compose.staging.yml` は `profiles:` 指定なし = `up -d` 既定で **7 サービス**（postgres / backend-blue / backend-green / nginx / frontend / loki / promtail）が全起動。nginx upstream は `docker/nginx/upstream.staging.conf` で `backend-blue:8000` に固定。旧記述「5コンテナ / green のみ」は B案リネーム期の名残であり現 compose と矛盾（2026-05-22 訂正）。
 - **production**: 実資金・実トレード、Base Mainnet、port 3000/8000(nginx host port)/8080(nginx container)/5432（8010=backend-blue直ポート、8011=backend-green直ポート、nginx経由=8000→8080→active backend）
 
 ---

--- a/docs/42_production_e2e_runbook.md
+++ b/docs/42_production_e2e_runbook.md
@@ -21,7 +21,7 @@
 | 環境 | compose ファイル | env ファイル | DB 名 | nginx active |
 |---|---|---|---|---|
 | production | `docker-compose.production.yml` | `.env.production` | `ultra_autotrade` | blue (port 8010) |
-| staging | `docker-compose.staging.yml` | `.env.staging-new` | `ultra_autotrade_staging` | green (port 8021) |
+| staging | `docker-compose.staging.yml` | `.env.staging-new` | `ultra_autotrade_staging` | blue (port 8020、`docker/nginx/upstream.staging.conf` で `backend-blue:8000` に固定) |
 | local | `docker-compose.local.yml` | `.env.local` | (任意) | - |
 
 **注意**:
@@ -33,15 +33,21 @@
 
 | サービス | production | staging |
 |---|---|---|
-| backend (active) | `ultra-autotrade-backend-blue-production` | `ultra-autotrade-backend-green-staging-new` |
+| backend-blue | `ultra-autotrade-backend-blue-production` | `ultra-autotrade-backend-blue-staging-new` |
+| backend-green | `ultra-autotrade-backend-green-production` | `ultra-autotrade-backend-green-staging-new` |
 | frontend | `ultra-autotrade-frontend-production` | `ultra-autotrade-frontend-staging-new` |
 | postgres | `ultra-autotrade-postgres-production` | `ultra-autotrade-postgres-staging-new` |
 | nginx | `ultra-autotrade-nginx-production` | `ultra-autotrade-nginx-staging-new` |
 | cloudflared | `ultra-autotrade-cloudflared-production` | (不在) |
 | promtail | `ultra-autotrade-promtail-production` | `ultra-autotrade-promtail-staging-new` |
-| loki | `ultra-autotrade-loki-production` | (不在) |
+| loki | `ultra-autotrade-loki-production` | `ultra-autotrade-loki-staging-new` |
 
-**重要**: 無印の `ultra-autotrade-backend-production` コンテナは**存在しない**。Blue/Green 移行後は **active 側コンテナ名** で操作する。
+> **2026-05-22 訂正**: 旧記述では staging active = `backend-green-staging-new` としていたが、
+> `docker/nginx/upstream.staging.conf` の実体は `set $backend backend-blue:8000;` であり
+> nginx upstream = blue が正しい。また compose に `profiles:` 指定はなく `up -d` 既定で
+> blue + green の**両方**が起動する（green 単独運用は既定では不可能）。
+
+**重要**: 無印の `ultra-autotrade-backend-production` / `ultra-autotrade-backend-staging-new` コンテナは**存在しない**。Blue/Green 移行後は blue/green コンテナ名で操作する。
 
 切替方法: `nginx.conf` の upstream を blue⇔green で書き換えて nginx reload。詳細は §5.
 

--- a/docs/ops/03_deploy_procedures.md
+++ b/docs/ops/03_deploy_procedures.md
@@ -9,18 +9,25 @@
 
 | 環境 | URL | compose file | env file | ポート |
 |------|-----|-------------|----------|--------|
-| **production** | app/api.ultra-auto-trade.com | `docker-compose.production.yml` | `.env.production` | frontend:3000 / backend:8000 / postgres:5432 |
-| **staging** | staging/api-staging.ultra-auto-trade.com | `docker-compose.staging.yml` | `.env.staging-new` | frontend:3001 / backend:8001 / postgres:5433 |
+| **production** | app/api.ultra-auto-trade.com | `docker-compose.production.yml` | `.env.production` | frontend:3000 / backend:8000(nginx経由) / postgres:5432 |
+| **staging** | staging/api-staging.ultra-auto-trade.com | `docker-compose.staging.yml` | `.env.staging-new` | frontend:3001 / nginx:8082(backend経由) / postgres:5433（旧 backend:8001 は廃止、nginx upstream = backend-blue:8000） |
 
 ---
 
-## コンテナ名一覧（2026-04-24 container_name 衝突修正後）
+## コンテナ名一覧（2026-04-24 container_name 衝突修正後 / 2026-05-22 Blue/Green 反映）
+
+> **2026-05-22 訂正**: staging compose (`docker-compose.staging.yml`) は `profiles:` 指定なし。
+> `up -d` 既定で **7 サービス全て**（postgres / backend-blue / backend-green / nginx / frontend / loki / promtail）が起動する。
+> 旧記述「backend 単体（backend-staging-new）/ 5コンテナ構成」は B案リネーム期の名残であり、現 compose と矛盾するため削除。
+> nginx upstream は `docker/nginx/upstream.staging.conf` の `set $backend backend-blue:8000;` で blue 固定。
 
 | サービス | production | staging |
 |---------|-----------|---------|
-| backend | `ultra-autotrade-backend-production` | `ultra-autotrade-backend-staging-new` |
+| backend-blue | `ultra-autotrade-backend-blue-production` | `ultra-autotrade-backend-blue-staging-new` |
+| backend-green | `ultra-autotrade-backend-green-production` | `ultra-autotrade-backend-green-staging-new` |
 | frontend | `ultra-autotrade-frontend-production` | `ultra-autotrade-frontend-staging-new` |
 | postgres | `ultra-autotrade-postgres-production` | `ultra-autotrade-postgres-staging-new` |
+| nginx | `ultra-autotrade-nginx-production` | `ultra-autotrade-nginx-staging-new` |
 | cloudflared | `ultra-autotrade-cloudflared-production` | (なし) |
 | loki | `ultra-autotrade-loki-production` | `ultra-autotrade-loki-staging-new` |
 | promtail | `ultra-autotrade-promtail-production` | `ultra-autotrade-promtail-staging-new` |
@@ -230,8 +237,8 @@ cd /opt/ultra-autotrade
 ./scripts/deploy_staging.sh --frontend-only   # フロントのみ
 ./scripts/deploy_staging.sh --backend-only    # バックエンドのみ
 
-# ヘルスチェック（staging ポート: 8001/3001）
-curl http://localhost:8001/health
+# ヘルスチェック（staging ポート: 8082/3001 / 旧8001は廃止）
+curl http://127.0.0.1:8082/health
 curl http://localhost:3001
 ```
 


### PR DESCRIPTION
## 背景

旧記述「staging = 5コンテナ / backend-green のみ / blue 不在」は B案リネーム期（2026-04-17）の名残であり、現在の `docker-compose.staging.yml` と矛盾している。

2026-05-21 soak で同一 tick に blue/green 各1件の重複 `ai_decisions` を確認（観測設計 #365 の「24 tick × 2 = 48/round」と一致）しており、両 backend が実際に起動していることが裏付けられた。

## 正しい事実（実機確定済）

- `docker-compose.staging.yml` は `profiles:` 指定なし → `up -d` 既定で **7 サービス全て**が起動
  - サービス: `postgres / backend-blue / backend-green / nginx / frontend / loki / promtail`
- nginx upstream は `docker/nginx/upstream.staging.conf` で `set $backend backend-blue:8000;` に固定（green 単独運用は既定では不可能）
- soak は両 backend 前提（2026-05-21 実機で 48 ai_decisions/round = 24 tick × blue/green 各1件）

## 訂正内容

### `CLAUDE.md`

- 環境定義の staging 行に 7 サービス構成・nginx upstream=blue を明記
- 旧「5コンテナ / green のみ」断定を「(2026-05-22 訂正)」として削除

### `docs/42_production_e2e_runbook.md`

- §1.1 環境一覧: nginx active = `green (port 8021)` → `blue (port 8020、upstream.staging.conf で固定)` に訂正
- §1.2 コンテナ名規則: 旧 `backend (active) = backend-green-staging-new` を削除し、blue/green 両行に展開
- loki-staging-new の `(不在)` 誤記を `loki-staging-new` に訂正（compose に定義あり）

### `docs/ops/03_deploy_procedures.md`

- 環境一覧: staging port `backend:8001` → `nginx:8082` に訂正（旧8001廃止）
- コンテナ名表: 旧 `backend 単体` を blue/green 両行・nginx 行追加に更新
- ヘルスチェック: `localhost:8001` → `127.0.0.1:8082` に訂正

## 変更スコープ

- 変更は **md ファイルのみ**（コード・設定・compose ファイル変更なし）
- Asana: 1215036378326731

🤖 Generated with [Claude Code](https://claude.com/claude-code)