### PR TITLE
fix(frontend): main の next.config を output:standalone に戻す (VPS build 修復)

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,9 +1,8 @@
 /** @type {import('next').NextConfig} */
-// demo/frontend-static: Cloudflare Pages 向け static export 設定。
-// - output: 'export' で out/ に静的書出
-// - images.unoptimized: true で next/image の SSR 最適化を無効化
-// - headers() は static export で無効のため public/_headers に移行 (CSP/XFO/XCTO)
-// 本番 (output: 'standalone') は main branch の next.config.js を使用。
+// main branch (VPS/Docker 本番): output: 'standalone' で .next/standalone を生成し
+// node server として配信。Dockerfile runner 段が COPY --from=builder /app/.next/standalone/ /app/ で参照する。
+// output: 'export' (Cloudflare Pages 向け静的書出) は demo/frontend-static ブランチ専用。
+// main には export を置かない。
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_BASE_URL || '';
 // CSP は public/_headers で配信される。本変数は cspConnectSrc 派生で参照されないが、
 // 既存 import 依存性を破壊しないため定義のみ残す。
@@ -31,7 +30,7 @@ const nextConfig = {
   compiler: {
     removeConsole: process.env.NODE_ENV === 'production' ? { exclude: ['error', 'warn'] } : false,
   },
-  output: 'export',
+  output: 'standalone',
   images: { unoptimized: true },
   typescript: { ignoreBuildErrors: true },
   eslint: { ignoreDuringBuilds: true },


### PR DESCRIPTION
## 背景

PR #335「feat(demo): Cloudflare Pages static export 対応」で `demo/frontend-static` ブランチ用の設定 `output: 'export'` が **main に誤って混入**した。

`output: 'export'` モードでは `.next/standalone/` ディレクトリが生成されないため、VPS 用 Dockerfile の runner 段:

```dockerfile
COPY --from=builder /app/.next/standalone/ /app/
```

が "not found" で失敗し、frontend Docker image がビルドできない状態になっていた。

## 修正内容

`frontend/next.config.js` の変更のみ（他設定は一切変更なし）:

- `output: 'export'` → `output: 'standalone'`（L34相当）
- 冒頭コメント（L2-6）を実態に合わせ整理:
  - main branch = `output: 'standalone'`（VPS/Docker, `.next/standalone` を node server で配信）
  - `output: 'export'`（静的・CF Pages 用）は `demo/frontend-static` ブランチ専用である旨を明記

## 確認事項

- `frontend/next.config.js` **のみ** の変更（`git diff` で確認済）
- `next.config.mjs` / `next.config.ts` は存在せず `next.config.js` 1本のみ（競合なし）
- `grep -nE "output\s*:" frontend/next.config.js` で `standalone` のみを確認済

## スコープ外

Dockerfile の standalone 検出 grep がコメント行に反応する脆さは別途 follow-up 対応予定。今回は根本原因（実 `output` 行が `standalone` になる）の修正のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)