### PR TITLE
P0-4: emergency stop E2E test plan + shell skeleton

### DIFF
--- a/docs/internal/emergency_stop_e2e_test_plan.md
+++ b/docs/internal/emergency_stop_e2e_test_plan.md
@@ -1,0 +1,382 @@
+# 緊急停止 E2E テスト計画 (P0-4)
+
+**バージョン:** 0.1 (Draft)
+**起票日:** 2026-05-23
+**担当:** Ultra AutoTrade 運用チーム / Claude Code
+**関連 Asana:** P0-4 (緊急停止 E2E)
+**関連 doc:** [`docs/33_emergency_stop_governance.md`](../33_emergency_stop_governance.md)
+
+---
+
+## 0. 本 doc の目的・スコープ
+
+緊急停止 (emergency_stop) の挙動を E2E でテストする計画を 4 シナリオに分けて定義する。
+本 PR では **実機実行は行わない**。staging での実行は別チケットで行う。
+
+本 doc に含まれる:
+- 4 シナリオの前提条件・手順・期待結果・失敗時調査ポイント
+- staging を想定した curl / psql / docker コマンド
+- scheduler フラグ逆転 (memory: `disable-scheduler-flag-inverted`) への注意喚起
+- prod は dev から SSH 不可 (memory: `prod-steps-not-done-until-verified`) のため手動実行が必要な旨
+
+本 doc に含まれないもの:
+- 実 endpoint の最終 URL (TODO で記載)
+- 実機 (staging/prod) 実行ログ
+- merge 可否判断 (claude.ai + 小林さんの最終承認に従う)
+
+---
+
+## 1. 共通前提
+
+### 1-1. 環境
+
+| 項目 | staging | production |
+|------|---------|-----------|
+| backend URL | `https://staging.api.ultra-autotrade.example.com` (TODO 確定) | `https://api.ultra-autotrade.example.com` (TODO 確定) |
+| DB | staging Postgres | production Postgres |
+| scheduler フラグ | **ENABLED + shadow mode** | **DISABLED** |
+| 実行可否 | 本 doc 手順で実行可 | dev から SSH 不可・**手動実行必須** |
+
+### 1-2. ⚠️ scheduler フラグ逆転に関する注意
+
+memory `disable-scheduler-flag-inverted` 参照。
+
+- staging: `DISABLE_SCHEDULER=false` (ON) + `AI_JUDGMENT_SHADOW_MODE=true` で常時動作
+- production: `DISABLE_SCHEDULER=true` (OFF) で停止
+- soak テスト中にこのフラグを取り違えると `ai_decisions` 0 件で評価不成立になる
+- 本 E2E でも staging で scheduler が動いている前提で手順を組む
+
+### 1-3. ⚠️ production 実行の制約
+
+memory `prod-steps-not-done-until-verified` 参照。
+
+- dev 環境から prod へ SSH は不可
+- prod でのテストは運用担当が手動で実行する
+- 本 doc は staging のみ自動化対象。prod での実機出力で裏取りが取れるまで「完了」と書かない
+
+### 1-4. 必要権限・トークン
+
+- ADMIN ロールの API トークン (発動・解除両方)
+- PARTNER ロールの API トークン (発動のみ・解除不可の検証用)
+- staging Postgres への直接アクセス (psql)
+- staging backend container への docker exec / docker logs 権限
+
+### 1-5. 前提コード参照 (本 PR では変更しない)
+
+- `backend/app/automation/automation_router.py` — `POST /automation/emergency-stop`
+- `backend/app/automation/monitoring_service.py` — `activate_emergency_stop()` / `record_health_factor()`
+- `backend/state.json` — 永続化先 (デプロイ環境ごとに path 異なる)
+
+---
+
+## 2. シナリオA: 手動発動
+
+### 2-1. 概要
+
+operator が API (将来的には UI) から emergency_stop を ON にする。
+
+### 2-2. 前提条件
+
+- staging backend が正常稼働
+- `is_trading_paused=false` (停止していない状態から開始)
+- 進行中の tx がなければベスト (あっても完走するはず)
+- ADMIN トークンを取得済み
+
+### 2-3. 手順
+
+```bash
+# Step 1: 事前状態確認
+curl -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
+  https://staging.api.ultra-autotrade.example.com/automation/status
+# 期待: is_trading_paused=false
+
+# Step 2: 緊急停止発動
+curl -X POST \
+  -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"reason":"e2e scenario A manual"}' \
+  https://staging.api.ultra-autotrade.example.com/automation/emergency-stop
+
+# Step 3: 発動後の状態確認
+curl -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
+  https://staging.api.ultra-autotrade.example.com/automation/status
+
+# Step 4: state.json 確認
+docker exec <staging-backend-container> cat /app/backend/state.json
+
+# Step 5: 新規 proposal を投げて 503 を確認
+curl -X POST \
+  -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"text":"test news"}' \
+  https://staging.api.ultra-autotrade.example.com/automation/process-news
+
+# Step 6: ai_decisions テーブルで reject が記録されているか確認
+psql $STAGING_DB_URL -c \
+  "SELECT id, decision, created_at FROM ai_decisions ORDER BY created_at DESC LIMIT 5;"
+```
+
+### 2-4. 期待結果
+
+| ステップ | 期待 |
+|---------|------|
+| Step 2 | HTTP 200, `{"status":"stopped",...}` |
+| Step 3 | `is_trading_paused=true`, `mode=HARD_STOP` |
+| Step 4 | `emergency_stop=true`, `reason` に "Manual emergency stop by user" |
+| Step 5 | HTTP 503 |
+| Step 6 | 該当 proposal が `decision=reject` または同等で記録 |
+
+### 2-5. 失敗時の調査ポイント
+
+- HTTP 200 が返らない → トークン権限、CSRF、router 登録 (`automation_router.py`)
+- state.json が更新されない → `MonitoringService.activate_emergency_stop()` のログ
+- 503 が返らない → `is_trading_allowed()` の呼び出し点 (`backend/app/automation/router.py` 周辺)
+- ai_decisions に何も記録されない → scheduler フラグ逆転を疑う (memory 参照)
+
+### 2-6. 後始末
+
+シナリオ C を続けて実行するか、ADMIN 経由で resume を呼ぶこと。
+
+---
+
+## 3. シナリオB: HF < 1.6 で自動発動
+
+### 3-1. 概要
+
+HealthFactor 監視が 1.6 を切ったタイミングで emergency_stop が自動 ON になる。
+
+### 3-2. 前提条件
+
+- staging backend が正常稼働
+- emergency_stop は OFF からスタート
+- HF を意図的に下げる手段がある (テスト用 mock endpoint or staging Aave fork)
+- `MonitoringService.record_health_factor()` が呼ばれる経路が活きている
+
+### 3-3. 手順
+
+```bash
+# Step 1: 事前 HF と emergency_stop 状態の確認
+curl -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
+  https://staging.api.ultra-autotrade.example.com/aave/status
+curl -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
+  https://staging.api.ultra-autotrade.example.com/automation/status
+
+# Step 2: HF を 1.6 未満に下げる
+# TODO: staging で HF を下げる手段を確定する
+#   案 A: Aave testnet で borrow を増やす
+#   案 B: mock endpoint で `record_health_factor(1.45)` を直接呼ぶ
+#   案 C: staging 専用の admin endpoint (要追加実装)
+
+# Step 3: 発動を待つ (監視周期 = 5〜30 秒想定、TODO で確定)
+sleep 30
+
+# Step 4: state.json と Slack 通知確認
+docker exec <staging-backend-container> cat /app/backend/state.json
+# staging Slack #alerts-staging チャンネルを目視確認
+
+# Step 5: ログ確認
+docker logs <staging-backend-container> 2>&1 | grep -i "emergency" | tail -20
+```
+
+### 3-4. 期待結果
+
+| ステップ | 期待 |
+|---------|------|
+| Step 4 | `emergency_stop=true`, `health_factor` が 1.6 未満の値, `reason` に "health factor X.XX below emergency threshold 1.6" |
+| Step 4 | Slack に `🚨 緊急停止が発動されました` が投稿 (severity=EMERGENCY) |
+| Step 5 | ログに `EMERGENCY: Emergency stop activated: health factor ...` |
+
+### 3-5. 失敗時の調査ポイント
+
+- HF を下げてもフラグが立たない → 監視周期、`record_health_factor()` 呼び出しタイミング
+- 立つが Slack が来ない → `CompositeNotificationService` の設定、Slack token
+- ログに何も出ない → ログレベル、stdout buffering
+
+### 3-6. 後始末
+
+シナリオ C で解除する。
+
+---
+
+## 4. シナリオC: 解除フロー (cooldown 含む)
+
+### 4-1. 概要
+
+operator が解除 → HF 回復確認 → ENABLE 経路で復旧。cooldown 期間中の再発動防止を含む。
+
+### 4-2. 前提条件
+
+- emergency_stop が ON の状態 (シナリオ A or B の後)
+- ADMIN トークン (PARTNER では解除不可)
+- HF が 1.8 以上に回復済み
+
+### 4-3. 手順
+
+```bash
+# Step 1: HF 回復確認
+curl -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
+  https://staging.api.ultra-autotrade.example.com/aave/status
+# 期待: health_factor >= 1.8
+
+# Step 2: PARTNER で解除を試みる (失敗確認)
+curl -X POST \
+  -H "Authorization: Bearer $STAGING_PARTNER_TOKEN" \
+  https://staging.api.ultra-autotrade.example.com/automation/emergency-stop/resume
+# 期待: HTTP 403
+
+# Step 3: ADMIN で解除
+curl -X POST \
+  -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
+  https://staging.api.ultra-autotrade.example.com/automation/emergency-stop/resume
+
+# Step 4: 状態確認
+curl -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
+  https://staging.api.ultra-autotrade.example.com/automation/status
+
+# Step 5: state.json 確認
+docker exec <staging-backend-container> cat /app/backend/state.json
+
+# Step 6: cooldown 期間中の挙動確認 (実装ある場合)
+# TODO: cooldown 仕様の確定後に手順詳細化
+# 期待: 解除直後でも自動取引は ENABLE するが、N 分間は再発動閾値が緩い
+
+# Step 7: 自動取引の再開確認
+curl -X POST \
+  -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"text":"test news after resume"}' \
+  https://staging.api.ultra-autotrade.example.com/automation/process-news
+# 期待: HTTP 200, 503 ではない
+```
+
+### 4-4. 期待結果
+
+| ステップ | 期待 |
+|---------|------|
+| Step 2 | HTTP 403 (PARTNER は解除不可) |
+| Step 3 | HTTP 200 |
+| Step 4 | `is_trading_paused=false` |
+| Step 5 | `emergency_stop=false`, `mode!=HARD_STOP` |
+| Step 7 | HTTP 200 で proposal 受理 |
+
+### 4-5. 失敗時の調査ポイント
+
+- PARTNER が解除できてしまう → ロール制御 (`require_admin`)
+- ADMIN でも 403 → トークン有効期限、ロール割当
+- 解除後も 503 → `clear_emergency_stop()` の OR 条件、別フラグが残っている
+- cooldown が効いていない → 仕様未実装の可能性
+
+### 4-6. 後始末
+
+state.json と Slack 通知 (`✅ 緊急停止が解除されました`) を確認。
+
+---
+
+## 5. シナリオD: state.json 永続 (再起動時)
+
+### 5-1. 概要
+
+emergency_stop=true の状態で backend container を再起動しても状態が維持される。
+
+### 5-2. 前提条件
+
+- emergency_stop が ON の状態 (シナリオ A or B の後)
+- staging backend container の再起動権限
+- state.json が永続 volume にマウントされていることを確認済み
+
+### 5-3. 手順
+
+```bash
+# Step 1: 事前確認
+docker exec <staging-backend-container> cat /app/backend/state.json
+# 期待: emergency_stop=true
+
+# Step 2: container 再起動
+docker restart <staging-backend-container>
+
+# Step 3: 起動完了を待つ
+sleep 20
+until curl -sf https://staging.api.ultra-autotrade.example.com/health > /dev/null; do
+  sleep 2
+done
+
+# Step 4: 再起動後の state.json 確認
+docker exec <staging-backend-container> cat /app/backend/state.json
+# 期待: emergency_stop=true が維持されている
+
+# Step 5: API 経由で状態確認
+curl -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
+  https://staging.api.ultra-autotrade.example.com/automation/status
+# 期待: is_trading_paused=true
+
+# Step 6: 新規 proposal が 503 になることを確認
+curl -X POST \
+  -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"text":"test news after restart"}' \
+  https://staging.api.ultra-autotrade.example.com/automation/process-news
+# 期待: HTTP 503
+
+# Step 7: ログで復元メッセージを確認
+docker logs <staging-backend-container> 2>&1 | grep -i "state.json\|emergency_stop" | head -20
+```
+
+### 5-4. 期待結果
+
+| ステップ | 期待 |
+|---------|------|
+| Step 4 | state.json が再起動前と同じ内容 |
+| Step 5 | `is_trading_paused=true` |
+| Step 6 | HTTP 503 |
+| Step 7 | 起動時に state.json から復元したログが出力 |
+
+### 5-5. 失敗時の調査ポイント
+
+- state.json が空になる → volume マウント、permission
+- 内容は残るが flag が効かない → 起動時 load ロジック
+- ログに復元メッセージが出ない → ログレベル
+
+### 5-6. 後始末
+
+シナリオ C で解除する。
+
+---
+
+## 6. 実行順序の推奨
+
+```
+[A 手動発動] → [C 解除] → 状態リセット
+[B HF 自動] → [D 再起動] → [C 解除] → 状態リセット
+```
+
+A と B は独立。C は A/B の後始末を兼ねる。D は B の後に流すと自然。
+
+---
+
+## 7. production での扱い
+
+- dev 環境から prod へ SSH 不可 (memory: `prod-steps-not-done-until-verified`)
+- prod での全シナリオ実行は **運用担当による手動実行** が必須
+- 本 doc の手順を運用担当に共有し、実機出力で裏取りを取るまで「完了」と書かない
+- prod では特に **シナリオ A の手動発動だけドリル** を四半期に 1 回行うことを推奨 (案・別チケット)
+
+---
+
+## 8. TODO (本 PR 後)
+
+- [ ] staging backend URL の確定
+- [ ] HF を staging で意図的に下げる手段の確定 (案 A/B/C のいずれか)
+- [ ] cooldown 仕様の確定と手順反映
+- [ ] `scripts/test_emergency_stop_e2e.sh` の実 endpoint 埋め
+- [ ] CI への組込検討 (nightly staging E2E)
+- [ ] prod 用 runbook 化 (運用担当へ引き渡し)
+
+---
+
+## 9. 参考
+
+- [`docs/33_emergency_stop_governance.md`](../33_emergency_stop_governance.md)
+- `backend/app/automation/automation_router.py`
+- `backend/app/automation/monitoring_service.py`
+- memory: `disable-scheduler-flag-inverted`
+- memory: `prod-steps-not-done-until-verified`

--- a/docs/internal/emergency_stop_e2e_test_plan.md
+++ b/docs/internal/emergency_stop_e2e_test_plan.md
@@ -1,6 +1,6 @@
 # 緊急停止 E2E テスト計画 (P0-4)
 
-**バージョン:** 0.1 (Draft)
+**バージョン:** 0.2 (実 endpoint 反映)
 **起票日:** 2026-05-23
 **担当:** Ultra AutoTrade 運用チーム / Claude Code
 **関連 Asana:** P0-4 (緊急停止 E2E)
@@ -15,12 +15,12 @@
 
 本 doc に含まれる:
 - 4 シナリオの前提条件・手順・期待結果・失敗時調査ポイント
-- staging を想定した curl / psql / docker コマンド
+- 実 endpoint / state.json path / 期待 HTTP コードを反映
+- staging を想定した curl / psql / docker compose コマンド
 - scheduler フラグ逆転 (memory: `disable-scheduler-flag-inverted`) への注意喚起
 - prod は dev から SSH 不可 (memory: `prod-steps-not-done-until-verified`) のため手動実行が必要な旨
 
 本 doc に含まれないもの:
-- 実 endpoint の最終 URL (TODO で記載)
 - 実機 (staging/prod) 実行ログ
 - merge 可否判断 (claude.ai + 小林さんの最終承認に従う)
 
@@ -32,12 +32,30 @@
 
 | 項目 | staging | production |
 |------|---------|-----------|
-| backend URL | `https://staging.api.ultra-autotrade.example.com` (TODO 確定) | `https://api.ultra-autotrade.example.com` (TODO 確定) |
-| DB | staging Postgres | production Postgres |
+| backend URL | `https://api-staging.ultra-auto-trade.com` | `https://api.ultra-auto-trade.com` (TODO 確定) |
+| compose file | `docker-compose.staging.yml` | `docker-compose.production.yml` |
+| backend container | `ultra-autotrade-backend-blue-staging-new` / `-green-` | `-prod-*` |
+| postgres container | `ultra-autotrade-postgres-staging-new` (user: `ultra` / db: `ultra_autotrade_staging`) | prod compose 参照 |
+| state.json path | `/var/run/ultra/state.json` (volume `ultra-state-staging-new`) | 同 path |
 | scheduler フラグ | **ENABLED + shadow mode** | **DISABLED** |
 | 実行可否 | 本 doc 手順で実行可 | dev から SSH 不可・**手動実行必須** |
 
-### 1-2. ⚠️ scheduler フラグ逆転に関する注意
+### 1-2. 実 endpoint 一覧
+
+| Method | Path | Auth | Source |
+|--------|------|------|--------|
+| POST | `/api/automation/emergency-stop` | Bearer, `require_partner` (Partner+) | `backend/app/api/automation_dashboard.py:168` |
+| POST | `/api/automation/emergency-stop/resume` | Bearer, `require_admin` | `backend/app/api/automation_dashboard.py:187` |
+| GET  | `/api/automation/status` | Bearer, `require_viewer` | `backend/app/api/automation_dashboard.py:83` |
+| GET  | `/api/aave/status` | (router 参照) | `backend/app/aave/router.py` |
+| POST | `/automation/emergency-stop` (legacy) | Bearer, `require_active_user`, no body | `backend/app/automation/automation_router.py:168` |
+| POST | `/automation/process-news` | `X-Internal-Token` header | `backend/app/automation/automation_router.py:63` |
+
+本テストでは **`/api/automation/*` (dashboard router) を主系** として使用する。
+legacy の `/automation/emergency-stop` (require_active_user) は誰でも発動できてしまうため
+シナリオ A の冗長確認には使わない。
+
+### 1-3. ⚠️ scheduler フラグ逆転に関する注意
 
 memory `disable-scheduler-flag-inverted` 参照。
 
@@ -46,7 +64,7 @@ memory `disable-scheduler-flag-inverted` 参照。
 - soak テスト中にこのフラグを取り違えると `ai_decisions` 0 件で評価不成立になる
 - 本 E2E でも staging で scheduler が動いている前提で手順を組む
 
-### 1-3. ⚠️ production 実行の制約
+### 1-4. ⚠️ production 実行の制約
 
 memory `prod-steps-not-done-until-verified` 参照。
 
@@ -54,18 +72,43 @@ memory `prod-steps-not-done-until-verified` 参照。
 - prod でのテストは運用担当が手動で実行する
 - 本 doc は staging のみ自動化対象。prod での実機出力で裏取りが取れるまで「完了」と書かない
 
-### 1-4. 必要権限・トークン
+### 1-5. 必要権限・トークン
 
-- ADMIN ロールの API トークン (発動・解除両方)
-- PARTNER ロールの API トークン (発動のみ・解除不可の検証用)
-- staging Postgres への直接アクセス (psql)
-- staging backend container への docker exec / docker logs 権限
+- ADMIN ロールの Bearer API トークン (`STAGING_ADMIN_TOKEN`) — 発動・解除両方
+- PARTNER ロールの Bearer API トークン (`STAGING_PARTNER_TOKEN`) — 解除不可の検証用
+- `INTERNAL_API_TOKEN` 環境変数の値 (`STAGING_INTERNAL_TOKEN`) — `/automation/process-news` 用
+- staging postgres への `docker compose exec` 権限
+- staging backend container への `docker compose exec` / `docker compose logs` 権限
 
-### 1-5. 前提コード参照 (本 PR では変更しない)
+### 1-6. 前提コード参照 (本 PR では変更しない)
 
-- `backend/app/automation/automation_router.py` — `POST /automation/emergency-stop`
-- `backend/app/automation/monitoring_service.py` — `activate_emergency_stop()` / `record_health_factor()`
-- `backend/state.json` — 永続化先 (デプロイ環境ごとに path 異なる)
+- `backend/app/api/automation_dashboard.py` — `/api/automation/emergency-stop[/resume]`
+- `backend/app/automation/automation_router.py` — `/automation/emergency-stop`, `/automation/process-news`
+- `backend/app/automation/monitoring_service.py` — `activate_emergency_stop()` / `clear_emergency_stop()` / `record_health_factor()` / `_restore_emergency_state()`
+- `backend/app/automation/workflow.py:330` — `is_trading_allowed()` 否定で全件 HOLD する rule_engine_pre_check
+- `backend/app/aave/state_manager.py` — state.json の atomic write / parse error 時 fail-closed
+- `backend/app/aave/schemas.py:39` — `AaveSystemState` スキーマ
+
+### 1-7. state.json 構造 (vault: AaveSystemState)
+
+`backend/app/aave/schemas.py:39` より:
+
+```json
+{
+  "emergency_stop": true,
+  "mode": "hard_stop",
+  "health_factor": "1.45",
+  "last_update": "2026-05-23T12:34:56+00:00",
+  "reason": "health factor 1.45 below emergency threshold 1.6",
+  "circuit_closed": true,
+  "stale_threshold_seconds": 300
+}
+```
+
+- `mode` enum: `normal` / `safe_mode` / `hard_stop` (`AaveOperationMode`)
+- `health_factor` は文字列 (Decimal serialized) — `null` の場合はポジションなし
+- `circuit_closed`: `false` の場合は Circuit Breaker 開放で全停止
+- atomic write は `state_manager.py:save_system_state` を経由 (NamedTemporaryFile + os.replace)
 
 ---
 
@@ -74,64 +117,77 @@ memory `prod-steps-not-done-until-verified` 参照。
 ### 2-1. 概要
 
 operator が API (将来的には UI) から emergency_stop を ON にする。
+本テストでは PARTNER 権限以上で発動できる `/api/automation/emergency-stop` を使用。
 
 ### 2-2. 前提条件
 
-- staging backend が正常稼働
-- `is_trading_paused=false` (停止していない状態から開始)
-- 進行中の tx がなければベスト (あっても完走するはず)
-- ADMIN トークンを取得済み
+- staging backend が正常稼働 (`/api/automation/status` が 200)
+- `is_trading_paused=false` から開始
+- 進行中の tx がなければベスト
+- ADMIN Bearer トークンを取得済み
 
-### 2-3. 手順
+### 2-3. 手順 (script: `scenario_a`)
 
 ```bash
 # Step 1: 事前状態確認
 curl -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
-  https://staging.api.ultra-autotrade.example.com/automation/status
-# 期待: is_trading_paused=false
+  https://api-staging.ultra-auto-trade.com/api/automation/status
+# 期待: HTTP 200, .is_trading_paused == false
 
-# Step 2: 緊急停止発動
+# Step 2: 緊急停止発動 (Partner+ 権限)
 curl -X POST \
   -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"reason":"e2e scenario A manual"}' \
-  https://staging.api.ultra-autotrade.example.com/automation/emergency-stop
+  https://api-staging.ultra-auto-trade.com/api/automation/emergency-stop
+# 期待: HTTP 200, .status == "stopped"
 
 # Step 3: 発動後の状態確認
 curl -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
-  https://staging.api.ultra-autotrade.example.com/automation/status
+  https://api-staging.ultra-auto-trade.com/api/automation/status
+# 期待: .is_trading_paused == true
 
 # Step 4: state.json 確認
-docker exec <staging-backend-container> cat /app/backend/state.json
+docker compose -f docker-compose.staging.yml exec -T backend-blue \
+  cat /var/run/ultra/state.json
+# 期待: .emergency_stop == true, .mode == "hard_stop"
 
-# Step 5: 新規 proposal を投げて 503 を確認
+# Step 5: process-news で全件 HOLD を確認 (HTTP 200 だが skipped == fetched)
 curl -X POST \
-  -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
+  -H "X-Internal-Token: $STAGING_INTERNAL_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"text":"test news"}' \
-  https://staging.api.ultra-autotrade.example.com/automation/process-news
+  -d '{}' \
+  'https://api-staging.ultra-auto-trade.com/automation/process-news?dry_run=true'
+# 期待: HTTP 200, .octobot_skipped_count == .fetched_count
+# 注: 元の skeleton にあった「503」は workflow.py の実装と合わない (rule_engine_pre_check が HOLD する)。
 
-# Step 6: ai_decisions テーブルで reject が記録されているか確認
-psql $STAGING_DB_URL -c \
-  "SELECT id, decision, created_at FROM ai_decisions ORDER BY created_at DESC LIMIT 5;"
+# Step 6: ai_decisions の最近の記録を確認
+docker compose -f docker-compose.staging.yml exec -T postgres \
+  psql -U ultra -d ultra_autotrade_staging -c \
+  "SELECT id, action, confidence, primary_provider, created_at FROM ai_decisions ORDER BY created_at DESC LIMIT 5;"
 ```
 
 ### 2-4. 期待結果
 
 | ステップ | 期待 |
 |---------|------|
-| Step 2 | HTTP 200, `{"status":"stopped",...}` |
-| Step 3 | `is_trading_paused=true`, `mode=HARD_STOP` |
-| Step 4 | `emergency_stop=true`, `reason` に "Manual emergency stop by user" |
-| Step 5 | HTTP 503 |
-| Step 6 | 該当 proposal が `decision=reject` または同等で記録 |
+| Step 2 | HTTP 200, `{"status":"stopped","message":...}` |
+| Step 3 | `is_trading_paused=true` |
+| Step 4 | `emergency_stop=true`, `mode=hard_stop`, `reason` に `Manual emergency stop ... (user_id=...)` |
+| Step 5 | HTTP 200, `octobot_skipped_count == fetched_count` (`hold_count` で計上される) |
+| Step 6 | rule_engine は LLM 呼出し前にブロックするため新規 ai_decisions は通常追加されない (既存件のみ) |
 
 ### 2-5. 失敗時の調査ポイント
 
-- HTTP 200 が返らない → トークン権限、CSRF、router 登録 (`automation_router.py`)
-- state.json が更新されない → `MonitoringService.activate_emergency_stop()` のログ
-- 503 が返らない → `is_trading_allowed()` の呼び出し点 (`backend/app/automation/router.py` 周辺)
-- ai_decisions に何も記録されない → scheduler フラグ逆転を疑う (memory 参照)
+- HTTP 200 が返らない → トークン権限 (`require_partner`), router 登録 (`backend/app/main.py:249`)
+- state.json が更新されない → `MonitoringService.activate_emergency_stop()` の `_sync_state_file` ログ
+- process-news が trade してしまう → `workflow.py:330 is_trading_allowed()`, `monitoring_service._trading_paused` の値
+- ai_decisions に何も記録されない → 元々 pending が 0、または scheduler フラグ逆転 (memory 参照)
+
+**ログ場所:**
+- backend container stdout: `docker compose -f docker-compose.staging.yml logs backend-blue`
+- 永続ログ volume: `ultra-log-staging-new` (`/var/log/ultra-autotrade`)
+- Loki: promtail 経由で集約 (`docker-compose.staging.yml:53 loki`)
 
 ### 2-6. 後始末
 
@@ -145,52 +201,77 @@ psql $STAGING_DB_URL -c \
 
 HealthFactor 監視が 1.6 を切ったタイミングで emergency_stop が自動 ON になる。
 
+実 Aave testnet の HF を意図的に下げるのは非現実的なので、**2 経路** を定義:
+
+- **B-1 (実装済み)**: state.json を手動で `emergency_stop=true / health_factor=1.45` に書き換え、
+  backend を restart して `_restore_emergency_state()` が拾うことを確認する。
+  → これは「永続化と起動時復元の経路」をカバーし、シナリオ D と一部重複するが、
+  HF<1.6 のシナリオを構造的に再現できる唯一の安全な手段。
+- **B-2 (未実装・案)**: staging 専用の admin endpoint を追加し、
+  `MonitoringService.record_health_factor(Decimal("1.45"))` を直接呼ぶ。
+  これで監視ループ経由の自動発動を再現できる。
+  → 本 PR では実装しない。実装する場合は `backend/app/api/automation_dashboard.py` に
+  `@router.post("/_test/inject-hf")` を追加し、staging 環境変数で gating する。
+
 ### 3-2. 前提条件
 
-- staging backend が正常稼働
+- staging backend が稼働
 - emergency_stop は OFF からスタート
-- HF を意図的に下げる手段がある (テスト用 mock endpoint or staging Aave fork)
-- `MonitoringService.record_health_factor()` が呼ばれる経路が活きている
+- backend container を再起動できる権限
 
-### 3-3. 手順
+### 3-3. 手順 (script: `scenario_b`, B-1 経路)
 
 ```bash
-# Step 1: 事前 HF と emergency_stop 状態の確認
+# Step 1: 事前状態確認
 curl -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
-  https://staging.api.ultra-autotrade.example.com/aave/status
+  https://api-staging.ultra-auto-trade.com/api/aave/status
 curl -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
-  https://staging.api.ultra-autotrade.example.com/automation/status
+  https://api-staging.ultra-auto-trade.com/api/automation/status
 
-# Step 2: HF を 1.6 未満に下げる
-# TODO: staging で HF を下げる手段を確定する
-#   案 A: Aave testnet で borrow を増やす
-#   案 B: mock endpoint で `record_health_factor(1.45)` を直接呼ぶ
-#   案 C: staging 専用の admin endpoint (要追加実装)
+# Step 2: state.json をバックアップして HF=1.45 に書き換え
+docker compose -f docker-compose.staging.yml exec -T backend-blue \
+  cat /var/run/ultra/state.json > /tmp/state.before.json
 
-# Step 3: 発動を待つ (監視周期 = 5〜30 秒想定、TODO で確定)
-sleep 30
+jq '.emergency_stop=true | .mode="hard_stop" | .health_factor="1.45"
+    | .reason="e2e scenario B: HF 1.45 below emergency threshold 1.6 (synthetic)"
+    | .last_update=(now | strftime("%Y-%m-%dT%H:%M:%SZ"))' \
+    /tmp/state.before.json > /tmp/state.after.json
 
-# Step 4: state.json と Slack 通知確認
-docker exec <staging-backend-container> cat /app/backend/state.json
-# staging Slack #alerts-staging チャンネルを目視確認
+cat /tmp/state.after.json | docker compose -f docker-compose.staging.yml exec -T backend-blue \
+  sh -c 'cat > /var/run/ultra/state.json.new && mv /var/run/ultra/state.json.new /var/run/ultra/state.json'
 
-# Step 5: ログ確認
-docker logs <staging-backend-container> 2>&1 | grep -i "emergency" | tail -20
+# Step 3: backend restart で _restore_emergency_state() を発火
+docker compose -f docker-compose.staging.yml restart backend-blue
+
+# Step 4: 起動完了を待つ
+until curl -sf -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
+  https://api-staging.ultra-auto-trade.com/api/automation/status > /dev/null; do sleep 2; done
+
+# Step 5: state.json と is_trading_paused を確認
+docker compose -f docker-compose.staging.yml exec -T backend-blue \
+  cat /var/run/ultra/state.json
+
+# Step 6: ログで復元メッセージを確認
+docker compose -f docker-compose.staging.yml logs --tail=120 backend-blue 2>&1 \
+  | grep -i "Restored emergency_stop"
 ```
 
 ### 3-4. 期待結果
 
 | ステップ | 期待 |
 |---------|------|
-| Step 4 | `emergency_stop=true`, `health_factor` が 1.6 未満の値, `reason` に "health factor X.XX below emergency threshold 1.6" |
-| Step 4 | Slack に `🚨 緊急停止が発動されました` が投稿 (severity=EMERGENCY) |
-| Step 5 | ログに `EMERGENCY: Emergency stop activated: health factor ...` |
+| Step 5 | state.json の `emergency_stop=true` / `mode=hard_stop` が維持、`/api/automation/status` で `is_trading_paused=true` |
+| Step 6 | `Restored emergency_stop=True from state.json (reason=...)` のログが出力される (`monitoring_service.py:173`) |
 
 ### 3-5. 失敗時の調査ポイント
 
-- HF を下げてもフラグが立たない → 監視周期、`record_health_factor()` 呼び出しタイミング
-- 立つが Slack が来ない → `CompositeNotificationService` の設定、Slack token
-- ログに何も出ない → ログレベル、stdout buffering
+- restart 後 emergency_stop=false になる → `monitoring_service._restore_emergency_state()` の例外ログ (`Failed to restore emergency state from file`)
+- state.json が読めない (parse error) → `state_manager.py:76` で fail-closed (`mode=HARD_STOP` の初期値で復帰)
+- B-2 経路 (HF を直接記録) が必要な場合 → staging-only inject endpoint の追加を検討
+
+**ログ場所:**
+- 起動時の復元ログ: `docker compose logs backend-blue | grep "Restored emergency_stop"`
+- state.json parse error: `state_manager.py:76` `"state.json parse error - fail-closed for safety"` で grep
 
 ### 3-6. 後始末
 
@@ -198,75 +279,101 @@ docker logs <staging-backend-container> 2>&1 | grep -i "emergency" | tail -20
 
 ---
 
-## 4. シナリオC: 解除フロー (cooldown 含む)
+## 4. シナリオC: 解除フロー (PARTNER 不可・cooldown 含む)
 
 ### 4-1. 概要
 
-operator が解除 → HF 回復確認 → ENABLE 経路で復旧。cooldown 期間中の再発動防止を含む。
+operator が解除 → HF 回復確認 → ENABLE 経路で復旧。PARTNER は解除不可。
 
-### 4-2. 前提条件
+### 4-2. cooldown 仕様の現状
+
+`git grep cooldown backend/app/automation/` を確認した結果、**emergency_stop 専用の cooldown は存在しない**。
+関連は以下:
+
+- `AAVE_TRADE_COOLDOWN_SECONDS` (`backend/app/aave/config.py:117`, default=600s) — Aave 操作間隔の throttle。emergency と直交。
+- `REBALANCE_COOLDOWN_SECONDS` (`backend/app/aave/rebalance_config.py:154`) — rebalance 間隔。
+- 監視ループ間隔: `DEFAULT_MONITORING_INTERVAL_SECONDS=60` (`backend/app/automation/background_tasks.py:27`) — HF を 60s 周期で再評価し、危険域なら再度 HARD_STOP になる。
+
+本テストでは「resume 後 N 秒待って自動再トリガーが起きないこと」(= HF が健康な場合の挙動) を `COOLDOWN_SECONDS` env で待機して確認する (default 30s)。
+
+### 4-3. 前提条件
 
 - emergency_stop が ON の状態 (シナリオ A or B の後)
 - ADMIN トークン (PARTNER では解除不可)
-- HF が 1.8 以上に回復済み
+- HF が 1.8 以上に回復済み (B-1 経路では state.json を書き換えたままなので、resume 後に
+  監視ループが実 HF=1.8+ を取得して上書きする)
 
-### 4-3. 手順
+### 4-4. 手順 (script: `scenario_c`)
 
 ```bash
 # Step 1: HF 回復確認
 curl -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
-  https://staging.api.ultra-autotrade.example.com/aave/status
-# 期待: health_factor >= 1.8
+  https://api-staging.ultra-auto-trade.com/api/aave/status
 
 # Step 2: PARTNER で解除を試みる (失敗確認)
 curl -X POST \
   -H "Authorization: Bearer $STAGING_PARTNER_TOKEN" \
-  https://staging.api.ultra-autotrade.example.com/automation/emergency-stop/resume
-# 期待: HTTP 403
+  -H "Content-Type: application/json" \
+  -d '{}' \
+  https://api-staging.ultra-auto-trade.com/api/automation/emergency-stop/resume
+# 期待: HTTP 403, "Admin access required"
 
 # Step 3: ADMIN で解除
 curl -X POST \
   -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
-  https://staging.api.ultra-autotrade.example.com/automation/emergency-stop/resume
+  -H "Content-Type: application/json" \
+  -d '{}' \
+  https://api-staging.ultra-auto-trade.com/api/automation/emergency-stop/resume
+# 期待: HTTP 200, .status == "resumed"
 
 # Step 4: 状態確認
 curl -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
-  https://staging.api.ultra-autotrade.example.com/automation/status
+  https://api-staging.ultra-auto-trade.com/api/automation/status
+# 期待: .is_trading_paused == false
 
 # Step 5: state.json 確認
-docker exec <staging-backend-container> cat /app/backend/state.json
+docker compose -f docker-compose.staging.yml exec -T backend-blue \
+  cat /var/run/ultra/state.json
+# 期待: .emergency_stop == false
 
-# Step 6: cooldown 期間中の挙動確認 (実装ある場合)
-# TODO: cooldown 仕様の確定後に手順詳細化
-# 期待: 解除直後でも自動取引は ENABLE するが、N 分間は再発動閾値が緩い
+# Step 6: cooldown 期間中の挙動確認 (30s 待って二重トリガー無し)
+sleep 30
+curl -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
+  https://api-staging.ultra-auto-trade.com/api/automation/status
+# 期待: .is_trading_paused == false (HF が健康なら再発動しない)
 
-# Step 7: 自動取引の再開確認
+# Step 7: process-news が正常実行されることを確認
 curl -X POST \
-  -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
+  -H "X-Internal-Token: $STAGING_INTERNAL_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"text":"test news after resume"}' \
-  https://staging.api.ultra-autotrade.example.com/automation/process-news
-# 期待: HTTP 200, 503 ではない
+  -d '{}' \
+  'https://api-staging.ultra-auto-trade.com/automation/process-news?dry_run=true'
+# 期待: HTTP 200
 ```
 
-### 4-4. 期待結果
+### 4-5. 期待結果
 
 | ステップ | 期待 |
 |---------|------|
-| Step 2 | HTTP 403 (PARTNER は解除不可) |
-| Step 3 | HTTP 200 |
+| Step 2 | HTTP 403 (PARTNER は `/emergency-stop/resume` 不可) |
+| Step 3 | HTTP 200, `.status == "resumed"` |
 | Step 4 | `is_trading_paused=false` |
-| Step 5 | `emergency_stop=false`, `mode!=HARD_STOP` |
+| Step 5 | `emergency_stop=false`, `mode in {normal, safe_mode, hard_stop}` (HF 次第) |
+| Step 6 | 30s 後も resumed のまま (HF が 1.6 以上) |
 | Step 7 | HTTP 200 で proposal 受理 |
 
-### 4-5. 失敗時の調査ポイント
+### 4-6. 失敗時の調査ポイント
 
-- PARTNER が解除できてしまう → ロール制御 (`require_admin`)
-- ADMIN でも 403 → トークン有効期限、ロール割当
-- 解除後も 503 → `clear_emergency_stop()` の OR 条件、別フラグが残っている
-- cooldown が効いていない → 仕様未実装の可能性
+- PARTNER が解除できてしまう → `automation_dashboard.py:190` が `require_admin` であることを再確認
+- ADMIN でも 403 → トークン有効期限、ロール割当 (`auth.models.User.role`)
+- 解除後も 503 / HOLD が続く → `clear_emergency_stop()` の OR 条件 (`monitoring_service.py:243` 既存 emergency_stop=True 維持の挙動)。HF が 1.6 未満なら HARD_STOP は維持される (emergency_stop は False)。
+- cooldown が効いていない → emergency 専用 cooldown は無い。HF を再確認。
 
-### 4-6. 後始末
+**ログ場所:**
+- resume ログ: `docker compose logs backend-blue | grep "Cleared emergency stop"`
+- HF 再評価: `grep "HF_BELOW_EMERGENCY\|record_health_factor"` for ongoing checks
+
+### 4-7. 後始末
 
 state.json と Slack 通知 (`✅ 緊急停止が解除されました`) を確認。
 
@@ -277,64 +384,78 @@ state.json と Slack 通知 (`✅ 緊急停止が解除されました`) を確�
 ### 5-1. 概要
 
 emergency_stop=true の状態で backend container を再起動しても状態が維持される。
+`_restore_emergency_state()` (`monitoring_service.py:168`) の動作確認。
 
 ### 5-2. 前提条件
 
-- emergency_stop が ON の状態 (シナリオ A or B の後)
-- staging backend container の再起動権限
-- state.json が永続 volume にマウントされていることを確認済み
+- emergency_stop を ON にしてから開始 (script では Step 0 で発動)
+- staging backend container の `docker compose restart` 権限
+- state.json が `ultra-state-staging-new` volume にマウントされていることを確認済み (`docker-compose.staging.yml:167`)
 
-### 5-3. 手順
+### 5-3. 手順 (script: `scenario_d`)
 
 ```bash
-# Step 1: 事前確認
-docker exec <staging-backend-container> cat /app/backend/state.json
-# 期待: emergency_stop=true
-
-# Step 2: container 再起動
-docker restart <staging-backend-container>
-
-# Step 3: 起動完了を待つ
-sleep 20
-until curl -sf https://staging.api.ultra-autotrade.example.com/health > /dev/null; do
-  sleep 2
-done
-
-# Step 4: 再起動後の state.json 確認
-docker exec <staging-backend-container> cat /app/backend/state.json
-# 期待: emergency_stop=true が維持されている
-
-# Step 5: API 経由で状態確認
-curl -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
-  https://staging.api.ultra-autotrade.example.com/automation/status
-# 期待: is_trading_paused=true
-
-# Step 6: 新規 proposal が 503 になることを確認
+# Step 0: 緊急停止発動 (前提)
 curl -X POST \
   -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"text":"test news after restart"}' \
-  https://staging.api.ultra-autotrade.example.com/automation/process-news
-# 期待: HTTP 503
+  -d '{"reason":"e2e scenario D precondition"}' \
+  https://api-staging.ultra-auto-trade.com/api/automation/emergency-stop
 
-# Step 7: ログで復元メッセージを確認
-docker logs <staging-backend-container> 2>&1 | grep -i "state.json\|emergency_stop" | head -20
+# Step 1: 事前 state.json
+docker compose -f docker-compose.staging.yml exec -T backend-blue \
+  cat /var/run/ultra/state.json
+# 期待: .emergency_stop == true
+
+# Step 2: container 再起動
+docker compose -f docker-compose.staging.yml restart backend-blue
+
+# Step 3: 起動完了を待つ
+until curl -sf -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
+  https://api-staging.ultra-auto-trade.com/api/automation/status > /dev/null; do sleep 2; done
+
+# Step 4: 再起動後の state.json
+docker compose -f docker-compose.staging.yml exec -T backend-blue \
+  cat /var/run/ultra/state.json
+# 期待: .emergency_stop == true (維持)
+
+# Step 5: API 経由で確認
+curl -H "Authorization: Bearer $STAGING_ADMIN_TOKEN" \
+  https://api-staging.ultra-auto-trade.com/api/automation/status
+# 期待: .is_trading_paused == true
+
+# Step 6: process-news が引き続き全件 skipped
+curl -X POST \
+  -H "X-Internal-Token: $STAGING_INTERNAL_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{}' \
+  'https://api-staging.ultra-auto-trade.com/automation/process-news?dry_run=true'
+# 期待: HTTP 200, octobot_skipped_count == fetched_count
+
+# Step 7: 復元ログ確認
+docker compose -f docker-compose.staging.yml logs --tail=120 backend-blue 2>&1 \
+  | grep -i "Restored emergency_stop\|state.json"
 ```
 
 ### 5-4. 期待結果
 
 | ステップ | 期待 |
 |---------|------|
-| Step 4 | state.json が再起動前と同じ内容 |
+| Step 4 | state.json が再起動前と同じ内容 (`emergency_stop=true`) |
 | Step 5 | `is_trading_paused=true` |
-| Step 6 | HTTP 503 |
-| Step 7 | 起動時に state.json から復元したログが出力 |
+| Step 6 | HTTP 200, 全件 skipped |
+| Step 7 | `Restored emergency_stop=True from state.json (reason=...)` のログ (`monitoring_service.py:173`) |
 
 ### 5-5. 失敗時の調査ポイント
 
-- state.json が空になる → volume マウント、permission
-- 内容は残るが flag が効かない → 起動時 load ロジック
-- ログに復元メッセージが出ない → ログレベル
+- state.json が空になる → volume マウント (`ultra-state-staging-new` が backend-blue/green 両方に rw でマウントされているか)
+- 内容は残るが flag が効かない → 起動時 `_restore_emergency_state` のログ。例外で fail-open になっていないか
+- ログに復元メッセージが出ない → ログレベル、stdout buffering。`compose logs backend-blue` で全件取得して `Restored` で grep
+
+**ログ場所:**
+- 復元ログ: `docker compose logs backend-blue 2>&1 | grep -i "Restored emergency_stop"`
+- volume 状態: `docker volume inspect ultra-state-staging-new`
+- state.json 直接読取: `dc_exec_backend cat /var/run/ultra/state.json` (本スクリプトの `read_state_json` 関数)
 
 ### 5-6. 後始末
 
@@ -346,10 +467,12 @@ docker logs <staging-backend-container> 2>&1 | grep -i "state.json\|emergency_st
 
 ```
 [A 手動発動] → [C 解除] → 状態リセット
-[B HF 自動] → [D 再起動] → [C 解除] → 状態リセット
+[B HF 自動 (B-1 path)] → [D 再起動] → [C 解除] → 状態リセット
 ```
 
 A と B は独立。C は A/B の後始末を兼ねる。D は B の後に流すと自然。
+
+スクリプトの `all` モードはこの順序を踏襲する。
 
 ---
 
@@ -364,19 +487,21 @@ A と B は独立。C は A/B の後始末を兼ねる。D は B の後に流す
 
 ## 8. TODO (本 PR 後)
 
-- [ ] staging backend URL の確定
-- [ ] HF を staging で意図的に下げる手段の確定 (案 A/B/C のいずれか)
-- [ ] cooldown 仕様の確定と手順反映
-- [ ] `scripts/test_emergency_stop_e2e.sh` の実 endpoint 埋め
-- [ ] CI への組込検討 (nightly staging E2E)
+- [ ] B-2 経路 (`_test/inject-hf` admin endpoint) の追加検討 — staging 限定 gating 必須
+- [ ] CI への組込検討 (nightly staging E2E、Slack 通知の自動判定)
 - [ ] prod 用 runbook 化 (運用担当へ引き渡し)
+- [ ] PARTNER ロールで `/api/automation/emergency-stop` (発動) は 200 が返る (Partner+) ことの positive 確認ケース追加
+- [ ] Slack 通知の自動 assertion (現状はログ目視)
 
 ---
 
 ## 9. 参考
 
 - [`docs/33_emergency_stop_governance.md`](../33_emergency_stop_governance.md)
-- `backend/app/automation/automation_router.py`
+- `backend/app/api/automation_dashboard.py` (主系 endpoint)
+- `backend/app/automation/automation_router.py` (legacy / process-news)
 - `backend/app/automation/monitoring_service.py`
+- `backend/app/aave/state_manager.py` / `backend/app/aave/schemas.py:39`
+- `docker-compose.staging.yml` (container 名 / volume / port)
 - memory: `disable-scheduler-flag-inverted`
 - memory: `prod-steps-not-done-until-verified`

--- a/scripts/test_emergency_stop_e2e.sh
+++ b/scripts/test_emergency_stop_e2e.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# E2E test skeleton for emergency stop (staging only).
+#
+# Usage:
+#   bash scripts/test_emergency_stop_e2e.sh [scenario_a|scenario_b|scenario_c|scenario_d|all]
+#
+# Environment (export before running):
+#   STAGING_BACKEND_URL       e.g. https://staging.api.ultra-autotrade.example.com (TODO confirm)
+#   STAGING_ADMIN_TOKEN       ADMIN role API token
+#   STAGING_PARTNER_TOKEN     PARTNER role API token (for negative test in scenario C)
+#   STAGING_DB_URL            psql connection string (postgres://...)
+#   STAGING_BACKEND_CONTAINER docker container name of staging backend
+#
+# Notes:
+#   - production 環境では実行しない (dev から prod SSH 不可)
+#   - 本スクリプトは雛形であり、実 endpoint / HF 操作手段は TODO のまま
+#   - scheduler フラグ取り違えに注意: staging=ON+shadow / prod=OFF
+#
+# Related:
+#   docs/internal/emergency_stop_e2e_test_plan.md
+#   docs/33_emergency_stop_governance.md
+
+set -euo pipefail
+
+# ------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------
+SCENARIO="${1:-all}"
+
+BACKEND_URL="${STAGING_BACKEND_URL:-}"
+ADMIN_TOKEN="${STAGING_ADMIN_TOKEN:-}"
+PARTNER_TOKEN="${STAGING_PARTNER_TOKEN:-}"
+DB_URL="${STAGING_DB_URL:-}"
+BACKEND_CONTAINER="${STAGING_BACKEND_CONTAINER:-staging-backend}"
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+log() {
+  printf '[%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*"
+}
+
+die() {
+  log "ERROR: $*"
+  exit 1
+}
+
+require_env() {
+  local missing=0
+  for var in "$@"; do
+    if [[ -z "${!var:-}" ]]; then
+      log "missing required env: $var"
+      missing=1
+    fi
+  done
+  if [[ "$missing" -ne 0 ]]; then
+    die "set required env vars before running"
+  fi
+}
+
+guard_not_prod() {
+  # Refuse to run if the URL looks like production.
+  if [[ "$BACKEND_URL" == *"api.ultra-autotrade.example.com"* ]] \
+     && [[ "$BACKEND_URL" != *"staging"* ]]; then
+    die "production URL detected; this script is staging only"
+  fi
+}
+
+api_get() {
+  local path="$1"
+  curl -sS -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+    "${BACKEND_URL}${path}"
+}
+
+api_post_admin() {
+  local path="$1"
+  local body="${2:-{}}"
+  curl -sS -X POST \
+    -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$body" \
+    "${BACKEND_URL}${path}"
+}
+
+api_post_partner() {
+  local path="$1"
+  local body="${2:-{}}"
+  curl -sS -X POST \
+    -H "Authorization: Bearer ${PARTNER_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$body" \
+    -w '\nHTTP_CODE:%{http_code}\n' \
+    "${BACKEND_URL}${path}"
+}
+
+read_state_json() {
+  docker exec "${BACKEND_CONTAINER}" cat /app/backend/state.json
+}
+
+# ------------------------------------------------------------------
+# Scenarios
+# ------------------------------------------------------------------
+
+# Scenario A: manual activation via API
+scenario_a() {
+  log "=== Scenario A: manual emergency stop ==="
+  require_env STAGING_BACKEND_URL STAGING_ADMIN_TOKEN STAGING_BACKEND_CONTAINER
+
+  log "Step 1: pre-state"
+  api_get "/automation/status"
+
+  log "Step 2: activate emergency stop"
+  api_post_admin "/automation/emergency-stop" '{"reason":"e2e scenario A manual"}'
+
+  log "Step 3: post-state"
+  api_get "/automation/status"
+
+  log "Step 4: state.json"
+  read_state_json
+
+  log "Step 5: process-news should return 503"
+  curl -sS -X POST \
+    -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d '{"text":"test news scenario A"}' \
+    -w '\nHTTP_CODE:%{http_code}\n' \
+    "${BACKEND_URL}/automation/process-news" || true
+
+  log "Step 6: ai_decisions tail"
+  if [[ -n "$DB_URL" ]]; then
+    psql "$DB_URL" -c \
+      "SELECT id, decision, created_at FROM ai_decisions ORDER BY created_at DESC LIMIT 5;"
+  else
+    log "STAGING_DB_URL not set; skipping psql"
+  fi
+
+  log "Scenario A done"
+}
+
+# Scenario B: automatic activation when HF < 1.6
+scenario_b() {
+  log "=== Scenario B: HF < 1.6 auto activation ==="
+  require_env STAGING_BACKEND_URL STAGING_ADMIN_TOKEN STAGING_BACKEND_CONTAINER
+
+  log "Step 1: pre-state"
+  api_get "/aave/status"
+  api_get "/automation/status"
+
+  log "Step 2: lower HF (TODO: confirm method)"
+  # TODO: pick one of
+  #   - Aave testnet borrow を増やす
+  #   - mock endpoint で record_health_factor(1.45)
+  #   - staging 専用 admin endpoint
+  log "PLACEHOLDER: HF lowering step not yet implemented"
+
+  log "Step 3: wait for monitoring cycle"
+  sleep 30
+
+  log "Step 4: state.json"
+  read_state_json
+
+  log "Step 5: emergency log tail"
+  docker logs "${BACKEND_CONTAINER}" 2>&1 | grep -i "emergency" | tail -20 || true
+
+  log "Scenario B done"
+}
+
+# Scenario C: resume flow including PARTNER negative test and cooldown
+scenario_c() {
+  log "=== Scenario C: resume flow ==="
+  require_env STAGING_BACKEND_URL STAGING_ADMIN_TOKEN STAGING_PARTNER_TOKEN STAGING_BACKEND_CONTAINER
+
+  log "Step 1: HF recovery check"
+  api_get "/aave/status"
+
+  log "Step 2: PARTNER resume (expect 403)"
+  api_post_partner "/automation/emergency-stop/resume" || true
+
+  log "Step 3: ADMIN resume"
+  api_post_admin "/automation/emergency-stop/resume"
+
+  log "Step 4: post-state"
+  api_get "/automation/status"
+
+  log "Step 5: state.json"
+  read_state_json
+
+  log "Step 6: cooldown behaviour (TODO: spec)"
+  log "PLACEHOLDER: cooldown verification not yet implemented"
+
+  log "Step 7: process-news should succeed"
+  curl -sS -X POST \
+    -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d '{"text":"test news scenario C"}' \
+    -w '\nHTTP_CODE:%{http_code}\n' \
+    "${BACKEND_URL}/automation/process-news" || true
+
+  log "Scenario C done"
+}
+
+# Scenario D: state.json persistence across restart
+scenario_d() {
+  log "=== Scenario D: state.json persistence ==="
+  require_env STAGING_BACKEND_URL STAGING_ADMIN_TOKEN STAGING_BACKEND_CONTAINER
+
+  log "Step 1: pre-restart state.json"
+  read_state_json
+
+  log "Step 2: restart container"
+  docker restart "${BACKEND_CONTAINER}"
+
+  log "Step 3: wait for health endpoint"
+  local tries=0
+  until curl -sf "${BACKEND_URL}/health" > /dev/null; do
+    tries=$((tries + 1))
+    if [[ "$tries" -gt 30 ]]; then
+      die "backend did not come back within 60s"
+    fi
+    sleep 2
+  done
+
+  log "Step 4: post-restart state.json"
+  read_state_json
+
+  log "Step 5: automation status"
+  api_get "/automation/status"
+
+  log "Step 6: process-news should still 503"
+  curl -sS -X POST \
+    -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d '{"text":"test news scenario D"}' \
+    -w '\nHTTP_CODE:%{http_code}\n' \
+    "${BACKEND_URL}/automation/process-news" || true
+
+  log "Step 7: restore log tail"
+  docker logs "${BACKEND_CONTAINER}" 2>&1 \
+    | grep -i "state.json\|emergency_stop" \
+    | head -20 || true
+
+  log "Scenario D done"
+}
+
+# ------------------------------------------------------------------
+# Dispatch
+# ------------------------------------------------------------------
+main() {
+  if [[ -n "$BACKEND_URL" ]]; then
+    guard_not_prod
+  fi
+
+  case "$SCENARIO" in
+    scenario_a) scenario_a ;;
+    scenario_b) scenario_b ;;
+    scenario_c) scenario_c ;;
+    scenario_d) scenario_d ;;
+    all)
+      scenario_a
+      scenario_c  # cleanup after A
+      scenario_b
+      scenario_d
+      scenario_c  # final cleanup
+      ;;
+    *)
+      die "unknown scenario: ${SCENARIO} (use scenario_a|scenario_b|scenario_c|scenario_d|all)"
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/test_emergency_stop_e2e.sh
+++ b/scripts/test_emergency_stop_e2e.sh
@@ -1,26 +1,45 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
 #
-# E2E test skeleton for emergency stop (staging only).
+# E2E test script for emergency stop (staging only).
 #
 # Usage:
 #   bash scripts/test_emergency_stop_e2e.sh [scenario_a|scenario_b|scenario_c|scenario_d|all]
 #
 # Environment (export before running):
-#   STAGING_BACKEND_URL       e.g. https://staging.api.ultra-autotrade.example.com (TODO confirm)
-#   STAGING_ADMIN_TOKEN       ADMIN role API token
-#   STAGING_PARTNER_TOKEN     PARTNER role API token (for negative test in scenario C)
-#   STAGING_DB_URL            psql connection string (postgres://...)
-#   STAGING_BACKEND_CONTAINER docker container name of staging backend
+#   STAGING_BACKEND_URL       e.g. https://api-staging.ultra-auto-trade.com
+#                              (default fallback to internal nginx http://127.0.0.1:8082)
+#   STAGING_ADMIN_TOKEN       ADMIN role Bearer token
+#   STAGING_PARTNER_TOKEN     PARTNER role Bearer token (for negative test in scenario C)
+#   STAGING_INTERNAL_TOKEN    INTERNAL_API_TOKEN value (for /automation/process-news)
+#   STAGING_COMPOSE_FILE      docker-compose file (default: docker-compose.staging.yml)
+#   STAGING_BACKEND_SERVICE   compose service name of active backend (default: backend-blue)
+#   STAGING_DB_SERVICE        compose service name of postgres (default: postgres)
+#   STAGING_DB_USER           postgres user (default: ultra)
+#   STAGING_DB_NAME           postgres db (default: ultra_autotrade_staging)
+#   COOLDOWN_SECONDS          cooldown wait between activate -> resume probes (default: 30)
+#   MONITORING_INTERVAL_SECONDS  HF monitoring loop interval (default: 60, source: backend/app/automation/background_tasks.py)
 #
 # Notes:
 #   - production 環境では実行しない (dev から prod SSH 不可)
-#   - 本スクリプトは雛形であり、実 endpoint / HF 操作手段は TODO のまま
+#   - 実 endpoint:
+#       * POST /api/automation/emergency-stop         (Bearer, PARTNER+)        [require_partner]
+#       * POST /api/automation/emergency-stop/resume  (Bearer, ADMIN)            [require_admin]
+#       * GET  /api/automation/status                                            [require_viewer]
+#       * GET  /api/aave/status
+#       * POST /automation/process-news               (X-Internal-Token)         [verify_internal_token]
+#   - state.json は /var/run/ultra/state.json (volume: ultra-state-staging-new)
 #   - scheduler フラグ取り違えに注意: staging=ON+shadow / prod=OFF
+#   - process-news は emergency_stop=true の時 HTTP 200 を返すが
+#     octobot_skipped_count == fetched_count となる (workflow rule_engine が HOLD する仕様)
 #
 # Related:
 #   docs/internal/emergency_stop_e2e_test_plan.md
 #   docs/33_emergency_stop_governance.md
+#   backend/app/automation/automation_router.py
+#   backend/app/api/automation_dashboard.py
+#   backend/app/automation/monitoring_service.py
+#   backend/app/aave/state_manager.py
 
 set -euo pipefail
 
@@ -29,11 +48,24 @@ set -euo pipefail
 # ------------------------------------------------------------------
 SCENARIO="${1:-all}"
 
-BACKEND_URL="${STAGING_BACKEND_URL:-}"
+BACKEND_URL="${STAGING_BACKEND_URL:-https://api-staging.ultra-auto-trade.com}"
 ADMIN_TOKEN="${STAGING_ADMIN_TOKEN:-}"
 PARTNER_TOKEN="${STAGING_PARTNER_TOKEN:-}"
-DB_URL="${STAGING_DB_URL:-}"
-BACKEND_CONTAINER="${STAGING_BACKEND_CONTAINER:-staging-backend}"
+INTERNAL_TOKEN="${STAGING_INTERNAL_TOKEN:-}"
+COMPOSE_FILE="${STAGING_COMPOSE_FILE:-docker-compose.staging.yml}"
+BACKEND_SERVICE="${STAGING_BACKEND_SERVICE:-backend-blue}"
+DB_SERVICE="${STAGING_DB_SERVICE:-postgres}"
+DB_USER="${STAGING_DB_USER:-ultra}"
+DB_NAME="${STAGING_DB_NAME:-ultra_autotrade_staging}"
+COOLDOWN_SECONDS="${COOLDOWN_SECONDS:-30}"
+MONITORING_INTERVAL_SECONDS="${MONITORING_INTERVAL_SECONDS:-60}"
+
+# Path of state.json inside backend container (matches AAVE_STATE_FILE_PATH default).
+STATE_JSON_PATH="/var/run/ultra/state.json"
+
+# Temporary working directory for response bodies (auto-cleanup on exit).
+TMP_DIR="$(mktemp -d -t emerstop-e2e.XXXXXX)"
+trap 'rm -rf "$TMP_DIR"' EXIT
 
 # ------------------------------------------------------------------
 # Helpers
@@ -49,6 +81,7 @@ die() {
 
 require_env() {
   local missing=0
+  local var
   for var in "$@"; do
     if [[ -z "${!var:-}" ]]; then
       log "missing required env: $var"
@@ -61,23 +94,44 @@ require_env() {
 }
 
 guard_not_prod() {
-  # Refuse to run if the URL looks like production.
-  if [[ "$BACKEND_URL" == *"api.ultra-autotrade.example.com"* ]] \
-     && [[ "$BACKEND_URL" != *"staging"* ]]; then
-    die "production URL detected; this script is staging only"
-  fi
+  # Refuse to run if the URL looks like production (not staging).
+  case "$BACKEND_URL" in
+    *staging*) ;;
+    *127.0.0.1*|*localhost*) ;;
+    *)
+      die "non-staging URL detected: $BACKEND_URL — this script is staging only"
+      ;;
+  esac
 }
 
-api_get() {
+compose() {
+  docker compose -f "$COMPOSE_FILE" "$@"
+}
+
+dc_exec_backend() {
+  compose exec -T "$BACKEND_SERVICE" "$@"
+}
+
+dc_exec_db() {
+  # psql in compose-managed postgres container.
+  compose exec -T -e PGPASSWORD="${POSTGRES_PASSWORD:-}" "$DB_SERVICE" \
+    psql -U "$DB_USER" -d "$DB_NAME" "$@"
+}
+
+# curl wrappers — write body to $1, return HTTP code on stdout.
+api_get_admin() {
   local path="$1"
-  curl -sS -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  local out="$2"
+  curl -sS -o "$out" -w '%{http_code}' \
+    -H "Authorization: Bearer ${ADMIN_TOKEN}" \
     "${BACKEND_URL}${path}"
 }
 
 api_post_admin() {
   local path="$1"
-  local body="${2:-{}}"
-  curl -sS -X POST \
+  local body="${2:-{\}}"
+  local out="$3"
+  curl -sS -o "$out" -w '%{http_code}' -X POST \
     -H "Authorization: Bearer ${ADMIN_TOKEN}" \
     -H "Content-Type: application/json" \
     -d "$body" \
@@ -86,135 +140,267 @@ api_post_admin() {
 
 api_post_partner() {
   local path="$1"
-  local body="${2:-{}}"
-  curl -sS -X POST \
+  local body="${2:-{\}}"
+  local out="$3"
+  curl -sS -o "$out" -w '%{http_code}' -X POST \
     -H "Authorization: Bearer ${PARTNER_TOKEN}" \
     -H "Content-Type: application/json" \
     -d "$body" \
-    -w '\nHTTP_CODE:%{http_code}\n' \
+    "${BACKEND_URL}${path}"
+}
+
+api_post_internal() {
+  local path="$1"
+  local body="${2:-{\}}"
+  local out="$3"
+  curl -sS -o "$out" -w '%{http_code}' -X POST \
+    -H "X-Internal-Token: ${INTERNAL_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$body" \
     "${BACKEND_URL}${path}"
 }
 
 read_state_json() {
-  docker exec "${BACKEND_CONTAINER}" cat /app/backend/state.json
+  dc_exec_backend cat "$STATE_JSON_PATH"
+}
+
+assert_jq_eq() {
+  # assert_jq_eq <file> <jq-expr> <expected> <label>
+  local file="$1" expr="$2" expected="$3" label="$4"
+  local actual
+  actual="$(jq -r "$expr" "$file")"
+  if [[ "$actual" != "$expected" ]]; then
+    log "FAIL: $label — expected '$expected', got '$actual'"
+    log "--- response body ---"
+    cat "$file" || true
+    log "--- end body ---"
+    die "assertion failed: $label"
+  fi
+  log "OK: $label = $actual"
+}
+
+assert_http_code() {
+  # assert_http_code <actual> <expected> <label>
+  local actual="$1" expected="$2" label="$3"
+  if [[ "$actual" != "$expected" ]]; then
+    die "FAIL: $label — expected HTTP $expected, got $actual"
+  fi
+  log "OK: $label HTTP $actual"
 }
 
 # ------------------------------------------------------------------
 # Scenarios
 # ------------------------------------------------------------------
 
-# Scenario A: manual activation via API
+# Scenario A: manual activation via API (ADMIN).
 scenario_a() {
-  log "=== Scenario A: manual emergency stop ==="
-  require_env STAGING_BACKEND_URL STAGING_ADMIN_TOKEN STAGING_BACKEND_CONTAINER
+  log "=== Scenario A: manual emergency stop (ADMIN) ==="
+  require_env STAGING_BACKEND_URL STAGING_ADMIN_TOKEN
 
-  log "Step 1: pre-state"
-  api_get "/automation/status"
+  local resp="$TMP_DIR/resp.json"
+  local code
 
-  log "Step 2: activate emergency stop"
-  api_post_admin "/automation/emergency-stop" '{"reason":"e2e scenario A manual"}'
+  log "Step 1: pre-state — GET /api/automation/status"
+  code="$(api_get_admin "/api/automation/status" "$resp")"
+  assert_http_code "$code" "200" "pre-status"
+  assert_jq_eq "$resp" '.is_trading_paused' "false" "pre is_trading_paused=false"
 
-  log "Step 3: post-state"
-  api_get "/automation/status"
+  log "Step 2: POST /api/automation/emergency-stop"
+  code="$(api_post_admin "/api/automation/emergency-stop" \
+    '{"reason":"e2e scenario A manual"}' "$resp")"
+  assert_http_code "$code" "200" "emergency-stop activate"
+  assert_jq_eq "$resp" '.status' "stopped" "activate response status"
 
-  log "Step 4: state.json"
-  read_state_json
+  log "Step 3: post-state — GET /api/automation/status"
+  code="$(api_get_admin "/api/automation/status" "$resp")"
+  assert_http_code "$code" "200" "post-status"
+  assert_jq_eq "$resp" '.is_trading_paused' "true" "post is_trading_paused=true"
 
-  log "Step 5: process-news should return 503"
-  curl -sS -X POST \
-    -H "Authorization: Bearer ${ADMIN_TOKEN}" \
-    -H "Content-Type: application/json" \
-    -d '{"text":"test news scenario A"}' \
-    -w '\nHTTP_CODE:%{http_code}\n' \
-    "${BACKEND_URL}/automation/process-news" || true
+  log "Step 4: state.json snapshot"
+  read_state_json | tee "$TMP_DIR/state.json"
+  assert_jq_eq "$TMP_DIR/state.json" '.emergency_stop' "true" "state.json emergency_stop=true"
+  assert_jq_eq "$TMP_DIR/state.json" '.mode' "hard_stop" "state.json mode=hard_stop"
 
-  log "Step 6: ai_decisions tail"
-  if [[ -n "$DB_URL" ]]; then
-    psql "$DB_URL" -c \
-      "SELECT id, decision, created_at FROM ai_decisions ORDER BY created_at DESC LIMIT 5;"
+  log "Step 5: process-news should NOT trade (octobot_skipped_count == fetched_count)"
+  if [[ -n "$INTERNAL_TOKEN" ]]; then
+    code="$(api_post_internal \
+      "/automation/process-news?dry_run=true" \
+      '{}' "$resp")"
+    log "process-news HTTP $code"
+    cat "$resp" || true
+    # process-news は 200 を返すが、emergency_stop=true の時は workflow.py の
+    # rule_engine_pre_check が "emergency_stop" 判定で全件 HOLD する。
+    if [[ "$code" == "200" ]]; then
+      local fetched skipped
+      fetched="$(jq -r '.fetched_count' "$resp")"
+      skipped="$(jq -r '.octobot_skipped_count' "$resp")"
+      log "fetched=$fetched, skipped=$skipped"
+      if [[ "$fetched" -gt 0 ]] && [[ "$skipped" != "$fetched" ]]; then
+        die "FAIL: emergency_stop active but trades not all skipped (fetched=$fetched skipped=$skipped)"
+      fi
+      log "OK: workflow correctly skipped/held all pending items"
+    fi
   else
-    log "STAGING_DB_URL not set; skipping psql"
+    log "STAGING_INTERNAL_TOKEN not set; skipping process-news probe"
   fi
+
+  log "Step 6: ai_decisions tail (psql)"
+  dc_exec_db -c \
+    "SELECT id, action, confidence, primary_provider, created_at FROM ai_decisions ORDER BY created_at DESC LIMIT 5;" \
+    || log "WARN: psql query failed (DB unreachable?)"
+
+  log "Step 7: emergency activation log tail"
+  compose logs --tail=80 "$BACKEND_SERVICE" 2>&1 \
+    | grep -iE "emergency_stop|HF_BELOW_EMERGENCY|activate_emergency_stop" \
+    | tail -10 || true
 
   log "Scenario A done"
 }
 
-# Scenario B: automatic activation when HF < 1.6
+# Scenario B: automatic activation when HF < 1.6.
+# staging で実 Aave の HF を意図的に下げるのは非現実的なので、2 経路を試す。
+#
+#   B-1: state.json を手動で書き換え → 起動時 _restore_emergency_state でフラグ復元
+#   B-2: API モック呼出 (まだ未実装) — 案として記載のみ、実装時は staging admin endpoint を追加。
 scenario_b() {
-  log "=== Scenario B: HF < 1.6 auto activation ==="
-  require_env STAGING_BACKEND_URL STAGING_ADMIN_TOKEN STAGING_BACKEND_CONTAINER
+  log "=== Scenario B: HF < 1.6 auto activation (state.json 手動書き換え経路) ==="
+  require_env STAGING_BACKEND_URL STAGING_ADMIN_TOKEN
+
+  local resp="$TMP_DIR/resp.json"
+  local code
 
   log "Step 1: pre-state"
-  api_get "/aave/status"
-  api_get "/automation/status"
+  code="$(api_get_admin "/api/aave/status" "$resp")"
+  log "GET /api/aave/status HTTP $code"
+  cat "$resp" || true
+  code="$(api_get_admin "/api/automation/status" "$resp")"
+  assert_http_code "$code" "200" "automation/status"
 
-  log "Step 2: lower HF (TODO: confirm method)"
-  # TODO: pick one of
-  #   - Aave testnet borrow を増やす
-  #   - mock endpoint で record_health_factor(1.45)
-  #   - staging 専用 admin endpoint
-  log "PLACEHOLDER: HF lowering step not yet implemented"
+  log "Step 2 (B-1): backup current state.json, then overwrite with HF=1.45"
+  read_state_json > "$TMP_DIR/state.before.json"
+  log "--- state.before.json ---"; cat "$TMP_DIR/state.before.json"; log "---"
+  # Build the new state JSON (preserve unrelated fields, override emergency_stop / mode / HF / reason).
+  jq '
+    .emergency_stop = true
+    | .mode = "hard_stop"
+    | .health_factor = "1.45"
+    | .reason = "e2e scenario B: HF 1.45 below emergency threshold 1.6 (synthetic)"
+    | .last_update = (now | strftime("%Y-%m-%dT%H:%M:%SZ"))
+  ' "$TMP_DIR/state.before.json" > "$TMP_DIR/state.after.json"
 
-  log "Step 3: wait for monitoring cycle"
-  sleep 30
+  # Write atomically inside the backend container.
+  dc_exec_backend sh -c "cat > ${STATE_JSON_PATH}.new && mv ${STATE_JSON_PATH}.new ${STATE_JSON_PATH}" \
+    < "$TMP_DIR/state.after.json"
 
-  log "Step 4: state.json"
-  read_state_json
+  log "Step 3: restart backend so monitoring_service._restore_emergency_state() picks it up"
+  compose restart "$BACKEND_SERVICE"
 
-  log "Step 5: emergency log tail"
-  docker logs "${BACKEND_CONTAINER}" 2>&1 | grep -i "emergency" | tail -20 || true
+  log "Step 4: wait for /api/automation/status to come back"
+  local tries=0
+  until code="$(api_get_admin "/api/automation/status" "$resp")" && [[ "$code" == "200" ]]; do
+    tries=$((tries + 1))
+    if [[ "$tries" -gt 30 ]]; then
+      die "backend did not come back within 60s"
+    fi
+    sleep 2
+  done
 
-  log "Scenario B done"
+  log "Step 5: assert state restored"
+  assert_jq_eq "$resp" '.is_trading_paused' "true" "after-restart is_trading_paused=true"
+  read_state_json | tee "$TMP_DIR/state.after_restart.json"
+  assert_jq_eq "$TMP_DIR/state.after_restart.json" '.emergency_stop' "true" "state.json emergency_stop=true persisted"
+
+  log "Step 6: emergency restore log tail (expect 'Restored emergency_stop=True from state.json')"
+  compose logs --tail=120 "$BACKEND_SERVICE" 2>&1 \
+    | grep -iE "Restored emergency_stop|emergency|state.json" \
+    | tail -15 || true
+
+  log "Step 7 (B-2 NOTE): API mock route for record_health_factor() is not exposed."
+  log "  To exercise the live monitoring loop, add a staging-only admin endpoint that calls"
+  log "  monitoring_service.record_health_factor(Decimal('1.45')) and re-run this scenario."
+  log "  Monitoring loop interval = ${MONITORING_INTERVAL_SECONDS}s (backend/app/automation/background_tasks.py)"
+
+  log "Scenario B done (B-1 path only; B-2 requires future endpoint)"
 }
 
-# Scenario C: resume flow including PARTNER negative test and cooldown
+# Scenario C: resume flow including PARTNER negative test and cooldown.
 scenario_c() {
-  log "=== Scenario C: resume flow ==="
-  require_env STAGING_BACKEND_URL STAGING_ADMIN_TOKEN STAGING_PARTNER_TOKEN STAGING_BACKEND_CONTAINER
+  log "=== Scenario C: resume flow (PARTNER 403 + ADMIN resume + cooldown) ==="
+  require_env STAGING_BACKEND_URL STAGING_ADMIN_TOKEN STAGING_PARTNER_TOKEN
+
+  local resp="$TMP_DIR/resp.json"
+  local code
 
   log "Step 1: HF recovery check"
-  api_get "/aave/status"
+  code="$(api_get_admin "/api/aave/status" "$resp")"
+  log "GET /api/aave/status HTTP $code"
+  cat "$resp" || true
 
   log "Step 2: PARTNER resume (expect 403)"
-  api_post_partner "/automation/emergency-stop/resume" || true
+  code="$(api_post_partner "/api/automation/emergency-stop/resume" '{}' "$resp")"
+  assert_http_code "$code" "403" "PARTNER resume should be forbidden"
 
   log "Step 3: ADMIN resume"
-  api_post_admin "/automation/emergency-stop/resume"
+  code="$(api_post_admin "/api/automation/emergency-stop/resume" '{}' "$resp")"
+  assert_http_code "$code" "200" "ADMIN resume"
+  assert_jq_eq "$resp" '.status' "resumed" "resume response status"
 
   log "Step 4: post-state"
-  api_get "/automation/status"
+  code="$(api_get_admin "/api/automation/status" "$resp")"
+  assert_http_code "$code" "200" "post-resume status"
+  assert_jq_eq "$resp" '.is_trading_paused' "false" "after-resume is_trading_paused=false"
 
-  log "Step 5: state.json"
-  read_state_json
+  log "Step 5: state.json after resume"
+  read_state_json | tee "$TMP_DIR/state.resumed.json"
+  assert_jq_eq "$TMP_DIR/state.resumed.json" '.emergency_stop' "false" "state.json emergency_stop=false"
 
-  log "Step 6: cooldown behaviour (TODO: spec)"
-  log "PLACEHOLDER: cooldown verification not yet implemented"
+  log "Step 6: cooldown behaviour"
+  log "  NOTE: there is no dedicated 'emergency_stop cooldown'. The closest spec is:"
+  log "    - HF < ${MONITORING_INTERVAL_SECONDS}s で再評価 → 危険域なら HARD_STOP に戻る (monitoring_service.record_health_factor)"
+  log "    - AAVE_TRADE_COOLDOWN_SECONDS は trade 間隔の throttle, emergency と直交"
+  log "  → resume 後 COOLDOWN_SECONDS=${COOLDOWN_SECONDS}s 待って二重トリガー無しを確認"
+  sleep "$COOLDOWN_SECONDS"
+  code="$(api_get_admin "/api/automation/status" "$resp")"
+  assert_jq_eq "$resp" '.is_trading_paused' "false" "cooldown still resumed (HF should be healthy)"
 
-  log "Step 7: process-news should succeed"
-  curl -sS -X POST \
-    -H "Authorization: Bearer ${ADMIN_TOKEN}" \
-    -H "Content-Type: application/json" \
-    -d '{"text":"test news scenario C"}' \
-    -w '\nHTTP_CODE:%{http_code}\n' \
-    "${BACKEND_URL}/automation/process-news" || true
+  log "Step 7: process-news should succeed (no rule_engine block)"
+  if [[ -n "$INTERNAL_TOKEN" ]]; then
+    code="$(api_post_internal \
+      "/automation/process-news?dry_run=true" \
+      '{}' "$resp")"
+    log "process-news HTTP $code"
+    cat "$resp" || true
+    assert_http_code "$code" "200" "process-news after resume"
+  else
+    log "STAGING_INTERNAL_TOKEN not set; skipping process-news probe"
+  fi
 
   log "Scenario C done"
 }
 
-# Scenario D: state.json persistence across restart
+# Scenario D: state.json persistence across restart.
 scenario_d() {
-  log "=== Scenario D: state.json persistence ==="
-  require_env STAGING_BACKEND_URL STAGING_ADMIN_TOKEN STAGING_BACKEND_CONTAINER
+  log "=== Scenario D: state.json persistence across restart ==="
+  require_env STAGING_BACKEND_URL STAGING_ADMIN_TOKEN
+
+  local resp="$TMP_DIR/resp.json"
+  local code
+
+  log "Step 0: activate emergency stop (precondition)"
+  code="$(api_post_admin "/api/automation/emergency-stop" \
+    '{"reason":"e2e scenario D precondition"}' "$resp")"
+  assert_http_code "$code" "200" "pre-restart activate"
 
   log "Step 1: pre-restart state.json"
-  read_state_json
+  read_state_json | tee "$TMP_DIR/state.pre_restart.json"
+  assert_jq_eq "$TMP_DIR/state.pre_restart.json" '.emergency_stop' "true" "pre-restart emergency_stop=true"
 
-  log "Step 2: restart container"
-  docker restart "${BACKEND_CONTAINER}"
+  log "Step 2: docker compose restart $BACKEND_SERVICE"
+  compose restart "$BACKEND_SERVICE"
 
-  log "Step 3: wait for health endpoint"
+  log "Step 3: wait for /api/automation/status (max 60s)"
   local tries=0
-  until curl -sf "${BACKEND_URL}/health" > /dev/null; do
+  until code="$(api_get_admin "/api/automation/status" "$resp")" && [[ "$code" == "200" ]]; do
     tries=$((tries + 1))
     if [[ "$tries" -gt 30 ]]; then
       die "backend did not come back within 60s"
@@ -223,25 +409,37 @@ scenario_d() {
   done
 
   log "Step 4: post-restart state.json"
-  read_state_json
+  read_state_json | tee "$TMP_DIR/state.post_restart.json"
+  assert_jq_eq "$TMP_DIR/state.post_restart.json" '.emergency_stop' "true" "post-restart emergency_stop=true persisted"
 
   log "Step 5: automation status"
-  api_get "/automation/status"
+  assert_jq_eq "$resp" '.is_trading_paused' "true" "post-restart is_trading_paused=true"
 
-  log "Step 6: process-news should still 503"
-  curl -sS -X POST \
-    -H "Authorization: Bearer ${ADMIN_TOKEN}" \
-    -H "Content-Type: application/json" \
-    -d '{"text":"test news scenario D"}' \
-    -w '\nHTTP_CODE:%{http_code}\n' \
-    "${BACKEND_URL}/automation/process-news" || true
+  log "Step 6: process-news should still be blocked (skipped == fetched)"
+  if [[ -n "$INTERNAL_TOKEN" ]]; then
+    code="$(api_post_internal \
+      "/automation/process-news?dry_run=true" \
+      '{}' "$resp")"
+    log "process-news HTTP $code"
+    cat "$resp" || true
+    if [[ "$code" == "200" ]]; then
+      local fetched skipped
+      fetched="$(jq -r '.fetched_count' "$resp")"
+      skipped="$(jq -r '.octobot_skipped_count' "$resp")"
+      if [[ "$fetched" -gt 0 ]] && [[ "$skipped" != "$fetched" ]]; then
+        die "FAIL: post-restart trades not all skipped"
+      fi
+    fi
+  else
+    log "STAGING_INTERNAL_TOKEN not set; skipping process-news probe"
+  fi
 
-  log "Step 7: restore log tail"
-  docker logs "${BACKEND_CONTAINER}" 2>&1 \
-    | grep -i "state.json\|emergency_stop" \
-    | head -20 || true
+  log "Step 7: restore log tail (expect 'Restored emergency_stop=True from state.json')"
+  compose logs --tail=120 "$BACKEND_SERVICE" 2>&1 \
+    | grep -iE "Restored emergency_stop|state.json|emergency_stop" \
+    | tail -20 || true
 
-  log "Scenario D done"
+  log "Scenario D done — cleanup with scenario_c"
 }
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## 概要
Asana タスク: P0-4 (緊急停止 E2E)

緊急停止の 4 シナリオを E2E でテストする計画 + staging 用 shell 雛形。本 PR では実機実行しない。

## 変更ファイル
```
 docs/internal/emergency_stop_e2e_test_plan.md | 382 ++++++++++++++++++++++++++
 scripts/test_emergency_stop_e2e.sh            | 273 ++++++++++++++++++
 2 files changed, 655 insertions(+)
```

## シナリオ一覧
- A: 手動発動
- B: HF<1.6 自動発動
- C: 解除(cooldown 含む)
- D: state.json 永続

## 検証
- `bash -n scripts/test_emergency_stop_e2e.sh`
  ```
  SYNTAX_OK
  ```
- doc 行数 (`wc -l docs/internal/emergency_stop_e2e_test_plan.md`)
  ```
  382 docs/internal/emergency_stop_e2e_test_plan.md
  ```

## 依存・注意
- Tier-S 不触 (backend/app/main.py / ai_judgment_scheduler.py / aave/client.py / 過去 alembic)
- prod は dev から SSH 不可 (memory: prod-steps-not-done-until-verified)
- scheduler フラグの逆転に注意 (memory: disable-scheduler-flag-inverted) — staging=ON+shadow / prod=OFF
- merge 禁止 (最終承認は claude.ai + 小林さん)
- 実機実行は別チケット

🤖 Generated with [Claude Code](https://claude.com/claude-code)