### PR TITLE
P0-6: learning data layer (user_actions + ai_decision_features) + Phase2 design §9

### DIFF
--- a/backend/alembic/versions/h8i9j0k1l2m3_add_user_actions_and_ai_decision_features.py
+++ b/backend/alembic/versions/h8i9j0k1l2m3_add_user_actions_and_ai_decision_features.py
@@ -1,0 +1,126 @@
+"""add_user_actions_and_ai_decision_features
+
+P0-6 (Hermes 受け入れ前提の学習データ層):
+  Hermes 学習に必要な「特徴量」と「ユーザ行動」を蓄積するための 2 表を追加する。
+
+  - user_actions:
+      manual UI / onboarding 経由でのユーザ click を supervised signal として
+      蓄積する。後段の学習データ抽出 (scripts/export_learning_data.py) で
+      ai_decisions と session/時刻で結合し、判定 → 行動の系列を学習データ化する。
+
+  - ai_decision_features:
+      ai_decisions と 1:1 で、判定時点のマーケット/ポートフォリオ特徴量を
+      正規化して保存する (prompt 入力の再現性を担保)。
+      ai_decisions.rag_context_json は既存のまま残し、本表は高頻度クエリ用に
+      分離する (docs/50_phase2_ai_optimizer_design.md §9 参照)。
+
+  既存資産との関係:
+    portfolio_snapshots (backend/app/portfolio/models.py:18) は変更しない。
+    ai_decisions (backend/app/ai/models.py:14) も変更しない。
+    本 migration は新規表 2 つの create_table のみで、既存表に touch しない。
+
+Revision ID: h8i9j0k1l2m3
+Revises: g7h8i9j0k1l2
+Create Date: 2026-05-23 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "h8i9j0k1l2m3"
+down_revision: Union[str, Sequence[str], None] = "g7h8i9j0k1l2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create user_actions and ai_decision_features tables."""
+    # ------------------------------------------------------------------
+    # user_actions: manual UI / onboarding click ログ (supervised signal)
+    # ------------------------------------------------------------------
+    op.create_table(
+        "user_actions",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "action_type",
+            sa.String(length=64),
+            nullable=False,
+            comment="e.g. manual_buy_click, manual_sell_click, onramp_completed",
+        ),
+        sa.Column(
+            "target_type",
+            sa.String(length=32),
+            nullable=True,
+            comment="e.g. proposal, asset",
+        ),
+        sa.Column("target_id", sa.String(length=128), nullable=True),
+        sa.Column(
+            "clicked_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("session_id", sa.String(length=128), nullable=True),
+        sa.Column("context_json", postgresql.JSONB(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_user_actions_user_clicked",
+        "user_actions",
+        ["user_id", "clicked_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_user_actions_action_type",
+        "user_actions",
+        ["action_type"],
+        unique=False,
+    )
+
+    # ------------------------------------------------------------------
+    # ai_decision_features: ai_decisions と 1:1 の特徴量保存
+    # ------------------------------------------------------------------
+    op.create_table(
+        "ai_decision_features",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("ai_decision_id", sa.Integer(), nullable=False),
+        sa.Column("portfolio_snapshot_id", sa.Integer(), nullable=True),
+        sa.Column("market_apy_supply", sa.Numeric(precision=10, scale=4), nullable=True),
+        sa.Column("market_apy_borrow", sa.Numeric(precision=10, scale=4), nullable=True),
+        sa.Column("health_factor", sa.Numeric(precision=10, scale=4), nullable=True),
+        sa.Column("gas_gwei", sa.Numeric(precision=20, scale=4), nullable=True),
+        sa.Column("price_usd", sa.Numeric(precision=20, scale=8), nullable=True),
+        sa.Column("prompt_features_json", postgresql.JSONB(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["ai_decision_id"], ["ai_decisions.id"]),
+        sa.ForeignKeyConstraint(["portfolio_snapshot_id"], ["portfolio_snapshots.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_ai_decision_features_decision",
+        "ai_decision_features",
+        ["ai_decision_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    """Drop the two learning-data tables."""
+    op.drop_index("uq_ai_decision_features_decision", table_name="ai_decision_features")
+    op.drop_table("ai_decision_features")
+    op.drop_index("ix_user_actions_action_type", table_name="user_actions")
+    op.drop_index("ix_user_actions_user_clicked", table_name="user_actions")
+    op.drop_table("user_actions")

--- a/backend/app/users/action_models.py
+++ b/backend/app/users/action_models.py
@@ -1,0 +1,181 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/app/users/action_models.py
+"""学習データ層 (Hermes 受け入れ前提) の SQLAlchemy モデル定義。
+
+P0-6 (docs/50_phase2_ai_optimizer_design.md §9):
+  Alembic migration `h8i9j0k1l2m3_add_user_actions_and_ai_decision_features.py`
+  で作成される 2 表 (user_actions / ai_decision_features) を ORM 経由で参照
+  できるようにするためのモデル定義。
+
+  - UserAction:
+      manual UI / onboarding 経由の click ログ (supervised signal)。
+      `user_actions` テーブル。
+  - AIDecisionFeatures:
+      `ai_decisions` と 1:1 で、判定時点の特徴量 (market_apy_supply 等) を
+      正規化保存する `ai_decision_features` テーブル。
+
+  既存 SQLAlchemy `Base` (backend/app/database.py:20) を共有する。
+  既存テーブル (users / ai_decisions / portfolio_snapshots) には touch しない:
+  ForeignKey 文字列参照のみで relationship は遅延解決する。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any, Optional
+
+from sqlalchemy import (
+    JSON,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+if TYPE_CHECKING:
+    # 循環参照防止のため runtime には import しない。relationship は文字列参照。
+    from app.ai.models import AIDecision
+    from app.auth.models import User
+    from app.portfolio.models import PortfolioSnapshot
+
+
+class UserAction(Base):
+    """ユーザ行動ログ (`user_actions`)。
+
+    manual UI / onboarding 経由のユーザ click を supervised signal として
+    蓄積する。`session_id` 一致もしくは `clicked_at` 近接時刻で
+    `ai_decisions` と結合する。
+
+    Attributes:
+        id: プライマリキー
+        user_id: ユーザ ID (users.id への FK)
+        action_type: 行動種別 (e.g. ``manual_buy_click`` / ``manual_sell_click``
+            / ``onramp_completed``)
+        target_type: 対象種別 (e.g. ``proposal`` / ``asset``)
+        target_id: 対象 ID (proposal_id / 資産シンボル等の任意文字列)
+        clicked_at: クリック時刻 (TZ 付き)
+        session_id: セッション識別子 (UI 側で発行)
+        context_json: 任意 context (JSONB)。PII を含めない運用ルール。
+    """
+
+    __tablename__ = "user_actions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id"),
+        nullable=False,
+        index=True,
+    )
+    action_type: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    target_type: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    target_id: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    clicked_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+        index=True,
+    )
+    session_id: Mapped[Optional[str]] = mapped_column(String(128), nullable=True, index=True)
+    # PostgreSQL では JSONB、SQLite では JSON にフォールバックする。
+    # 既存 models.py 群が generic JSON を多用しているのに合わせる。
+    context_json: Mapped[Optional[Any]] = mapped_column(JSON, nullable=True)
+
+    user: Mapped["User"] = relationship(
+        "User",
+        primaryjoin="UserAction.user_id == User.id",
+        foreign_keys=[user_id],
+        lazy="select",
+        viewonly=True,
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<UserAction(id={self.id}, user_id={self.user_id}, "
+            f"action_type={self.action_type!r}, clicked_at={self.clicked_at})>"
+        )
+
+
+class AIDecisionFeatures(Base):
+    """AI 判定特徴量 (`ai_decision_features`)。
+
+    `ai_decisions` と 1:1 (UNIQUE) で、判定時点のマーケット/ポートフォリオ
+    特徴量を正規化保存する。`ai_decisions.rag_context_json` は監査・人間
+    読解用に維持し、高頻度な学習クエリは本表で行う。
+
+    Attributes:
+        id: プライマリキー
+        ai_decision_id: `ai_decisions.id` への FK (UNIQUE)
+        portfolio_snapshot_id: `portfolio_snapshots.id` への FK (nullable)
+        market_apy_supply / market_apy_borrow: 判定時点の APY (%)
+        health_factor: 判定時点の HF
+        gas_gwei: 判定時点の Gas (gwei)
+        price_usd: 判定時点の主要資産価格 (USD)
+        prompt_features_json: 任意の追加特徴量 (PII フィルタ済み JSON)
+        created_at: 作成日時
+    """
+
+    __tablename__ = "ai_decision_features"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    ai_decision_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("ai_decisions.id"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    portfolio_snapshot_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("portfolio_snapshots.id"),
+        nullable=True,
+        index=True,
+    )
+    market_apy_supply: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(precision=10, scale=4), nullable=True
+    )
+    market_apy_borrow: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(precision=10, scale=4), nullable=True
+    )
+    health_factor: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(precision=10, scale=4), nullable=True
+    )
+    gas_gwei: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(precision=20, scale=4), nullable=True
+    )
+    price_usd: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(precision=20, scale=8), nullable=True
+    )
+    prompt_features_json: Mapped[Optional[Any]] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    decision: Mapped["AIDecision"] = relationship(
+        "AIDecision",
+        primaryjoin="AIDecisionFeatures.ai_decision_id == AIDecision.id",
+        foreign_keys=[ai_decision_id],
+        lazy="select",
+        viewonly=True,
+    )
+    snapshot: Mapped[Optional["PortfolioSnapshot"]] = relationship(
+        "PortfolioSnapshot",
+        primaryjoin="AIDecisionFeatures.portfolio_snapshot_id == PortfolioSnapshot.id",
+        foreign_keys=[portfolio_snapshot_id],
+        lazy="select",
+        viewonly=True,
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<AIDecisionFeatures(id={self.id}, "
+            f"ai_decision_id={self.ai_decision_id}, "
+            f"portfolio_snapshot_id={self.portfolio_snapshot_id})>"
+        )

--- a/docs/50_phase2_ai_optimizer_design.md
+++ b/docs/50_phase2_ai_optimizer_design.md
@@ -517,7 +517,40 @@ POST /api/optimizer/analyze (balanced, flag=on) → 200, allocation=[AAVE≥60%,
 ### 9.5 後続タスク
 
 - P5 (manual UI): `user_actions` への INSERT 経路を実装（POST endpoint）。
-- Hermes ローダ: `scripts/export_learning_data.py` の TODO（SQLAlchemy 抽出ロジック）を埋め、
-  JSONL を学習パイプラインに食わせる。
+- Hermes ローダ: `scripts/export_learning_data.py` の SQLAlchemy 抽出を本実装済み
+  （後段で feature ストアに食わせる）。
 - 個人情報の取り扱い: `context_json` / `prompt_features_json` に PII が混入しないよう、
   POST 側でホワイトリストフィルタを実装すること（本 PR の scope 外）。
+
+### 9.6 export スクリプトの使用例
+
+`scripts/export_learning_data.py` は SQLAlchemy 経由で 3 表 (+ user_actions サブクエリ) を
+結合し、1 ai_decision = 1 JSON レコードで JSONL/CSV を吐く。
+
+```bash
+# JSONL に書き出し (デフォルト)
+DATABASE_URL=postgresql://user:pass@db:5432/uata \
+  python scripts/export_learning_data.py \
+    --since 2026-05-01 \
+    --until 2026-05-23 \
+    --out /tmp/learning_dump_20260523.jsonl
+
+# CSV (ネストは JSON 文字列に flatten)
+python scripts/export_learning_data.py \
+  --since 2026-05-01 --until 2026-05-23 \
+  --out /tmp/learning_dump.csv --format csv \
+  --db-url postgresql://user:pass@host:5432/db
+
+# 上限を 50000 行に拡張 + user_actions の時刻窓を 60 分に拡張
+python scripts/export_learning_data.py \
+  --since 2026-05-01 --until 2026-05-23 \
+  --out /tmp/big.jsonl \
+  --limit 50000 \
+  --user-action-window-minutes 60
+```
+
+### 9.7 出力サンプル (JSONL 1 行)
+
+```json
+{"decision_id": 12345, "user_id": 7, "decided_at": "2026-05-10T12:34:56+00:00", "decision": {"query": "should I rebalance USDC?", "action": "HOLD", "confidence": 72, "reason": "HF margin is sufficient", "agreed": true, "prompt_version": "v1"}, "ai_response": {"primary_provider": "anthropic", "primary_action": "HOLD", "primary_confidence": 75, "secondary_provider": "openai", "secondary_action": "HOLD", "secondary_confidence": 70, "rag_context_json": {"docs": ["aave-hf-rule"]}}, "features": {"id": 9001, "ai_decision_id": 12345, "portfolio_snapshot_id": 4567, "market_apy_supply": 3.21, "market_apy_borrow": 5.47, "health_factor": 2.13, "gas_gwei": 12.5, "price_usd": 1.0001, "prompt_features_json": {"asset": "USDC"}}, "snapshot": {"id": 4567, "user_id": 7, "total_value_usd": 12345.67, "health_factor": 2.13}, "user_actions": [{"id": 333, "user_id": 7, "action_type": "manual_buy_click", "target_type": "proposal", "target_id": "p-2026-05-10-001", "clicked_at": "2026-05-10T12:40:01+00:00", "session_id": "sess-abc", "context_json": {"src": "dashboard"}}]}
+```

--- a/docs/50_phase2_ai_optimizer_design.md
+++ b/docs/50_phase2_ai_optimizer_design.md
@@ -441,3 +441,83 @@ POST /api/optimizer/analyze (balanced, flag=on) → 200, allocation=[AAVE≥60%,
 | `docs/13_security_design.md` | Health Factor 制約、セキュリティルール |
 | `docs/07_aave_operation_logic.md` | Aave 運用ロジック、HF 閾値 |
 | `docs/14_test_strategy.md` | テスト戦略、E2E 実行方法 |
+
+---
+
+## 9. 学習データ層（Hermes 受け入れ前提）
+
+**Asana**: P0-6
+**migration**: `backend/alembic/versions/h8i9j0k1l2m3_add_user_actions_and_ai_decision_features.py`
+**export 雛形**: `scripts/export_learning_data.py`
+
+### 9.1 目的
+
+将来 Hermes（社内学習モデル）に対し、AI 判定の **prompt 入力（特徴量）** と
+**ユーザの実際の行動（supervised signal）** を時系列で食わせるための蓄積基盤を準備する。
+既存資産（`portfolio_snapshots`, `ai_decisions.rag_context_json`）は維持し、再発明しない。
+
+### 9.2 表構成
+
+```
+            +-------------------------+      +-----------------------+
+            | portfolio_snapshots     |      | users                 |
+            | (既存・変更なし)        |      | (既存・変更なし)      |
+            | backend/app/portfolio/  |      | id, ...               |
+            |   models.py:18          |      +-----------+-----------+
+            +-----------+-------------+                  |
+                        ^                                |
+                        | N:1                            | 1:N
+                        |                                v
+            +-----------+-------------+      +-----------------------+
+            | ai_decisions            |      | user_actions          |
+            | (既存・変更なし)        |      | (新規)                |
+            | id, user_id, query,     |      | id, user_id,          |
+            |   action, confidence,   |      |   action_type,        |
+            |   rag_context_json, ... |      |   target_type/_id,    |
+            +-----------+-------------+      |   clicked_at,         |
+                        ^                    |   session_id,         |
+                        | 1:1 (unique)       |   context_json        |
+                        v                    +-----------------------+
+            +-------------------------+
+            | ai_decision_features    |
+            | (新規)                  |
+            | id, ai_decision_id,     |
+            |   portfolio_snapshot_id,|
+            |   market_apy_*,         |
+            |   health_factor,        |
+            |   gas_gwei, price_usd,  |
+            |   prompt_features_json  |
+            +-------------------------+
+```
+
+| 表 | 状態 | 役割 |
+|----|------|------|
+| `portfolio_snapshots` | 既存 | 30 分 / イベント駆動のポートフォリオ snapshot |
+| `ai_decisions` | 既存 | AI 判定の結果。`rag_context_json` は維持 |
+| `ai_decision_features` | **新規** | `ai_decisions` と 1:1。判定時点の特徴量を分離保存（prompt 入力の再現性） |
+| `user_actions` | **新規** | manual UI / onboarding の click ログ。supervised signal の供給源 |
+
+### 9.3 関係
+
+- `ai_decisions` ←(1:1, UNIQUE)— `ai_decision_features`
+- `ai_decisions` ←(N:1)— `portfolio_snapshots`（`ai_decision_features.portfolio_snapshot_id`）
+- `user_actions` は `(user_id, clicked_at)` のインデックスで時系列引きできる。
+  学習データ抽出時は `session_id` 一致もしくは `|clicked_at - ai_decision.created_at| < W`
+  の窓で `ai_decisions` と結合する。
+
+### 9.4 再発明しない設計判断
+
+| 課題 | 採用案 | 理由 |
+|------|--------|------|
+| 特徴量の保存先 | **`ai_decision_features` (新規) に分離** | `ai_decisions.rag_context_json` は監査・人間読解用に維持しつつ、高頻度な学習クエリは正規化された別表で引く |
+| ポートフォリオ snapshot | **既存 `portfolio_snapshots` を FK 参照** | 新規 snapshot 表を作らない。既存 30 分 / イベント駆動の蓄積を再利用 |
+| ユーザ行動の保存先 | **`user_actions` (新規) を単独表で導入** | `ai_decisions` への混入を避け、judgement なしの click（onramp 完了など）も同じ表で受ける |
+| JSON カラム | **`JSONB`** | 既存 `d4e5f6a7b8c9_fee_v10_tables.py` と同じ `postgresql.JSONB()` を踏襲 |
+
+### 9.5 後続タスク
+
+- P5 (manual UI): `user_actions` への INSERT 経路を実装（POST endpoint）。
+- Hermes ローダ: `scripts/export_learning_data.py` の TODO（SQLAlchemy 抽出ロジック）を埋め、
+  JSONL を学習パイプラインに食わせる。
+- 個人情報の取り扱い: `context_json` / `prompt_features_json` に PII が混入しないよう、
+  POST 側でホワイトリストフィルタを実装すること（本 PR の scope 外）。

--- a/scripts/export_learning_data.py
+++ b/scripts/export_learning_data.py
@@ -6,29 +6,59 @@ P0-6 (Hermes 受け入れ前提の学習データ層):
     同 session_id (もしくは同 user_id + 近接時刻) の user_actions を結合して
     1 JSONL レコードとして出力する。
 
-このスクリプトは骨格 (skeleton) のみ。実装本体は後続タスクで埋める。
-docs/50_phase2_ai_optimizer_design.md §9 (学習データ層) を設計の出典とする。
+設計の出典:
+    docs/50_phase2_ai_optimizer_design.md §9 (学習データ層)
 
 使い方:
+    # JSONL に書き出し
     python scripts/export_learning_data.py \\
         --since 2026-05-01 --until 2026-05-23 \\
         --out /tmp/learning_dump_20260523.jsonl
+
+    # CSV (フラット化) で書き出し
+    python scripts/export_learning_data.py \\
+        --since 2026-05-01 --until 2026-05-23 \\
+        --out /tmp/learning_dump_20260523.csv \\
+        --format csv
+
+    # DB URL を明示
+    python scripts/export_learning_data.py \\
+        --since 2026-05-01 --until 2026-05-23 \\
+        --out /tmp/out.jsonl \\
+        --db-url postgresql://user:pass@host:5432/db
+
+環境変数 ``DATABASE_URL`` が設定されていれば ``--db-url`` 省略可。
 """
 
 from __future__ import annotations
 
 import argparse
+import csv
 import json
+import os
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Iterator
+
+# repo root を import path に追加 (backend.app.* を参照するため)
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+_BACKEND_ROOT = _REPO_ROOT / "backend"
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+
+# user_actions と ai_decisions を時刻で結合する窓 (session_id 一致が無い場合に使用)
+DEFAULT_USER_ACTION_WINDOW = timedelta(minutes=30)
 
 
 def _parse_iso(value: str) -> datetime:
     """Parse an ISO-8601 date / datetime string into a tz-aware UTC datetime.
 
-    Accepts "YYYY-MM-DD" (treated as 00:00:00 UTC) and full ISO datetimes.
+    Accepts ``YYYY-MM-DD`` (treated as 00:00:00 UTC) and full ISO datetimes.
     """
     try:
         dt = datetime.fromisoformat(value)
@@ -43,7 +73,7 @@ def _parse_iso(value: str) -> datetime:
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Export learning data (ai_decisions + features + user_actions) as JSONL."
+        description="Export learning data (ai_decisions + features + user_actions) as JSONL/CSV."
     )
     parser.add_argument(
         "--since",
@@ -61,33 +91,214 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--out",
         type=Path,
         required=True,
-        help="Output JSONL path (will be created/overwritten).",
+        help="Output path (JSONL or CSV). Parent directory is created.",
+    )
+    parser.add_argument(
+        "--db-url",
+        type=str,
+        default=os.environ.get("DATABASE_URL", ""),
+        help="SQLAlchemy DB URL. Defaults to env DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=10000,
+        help="Maximum number of ai_decisions to export (default: 10000).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("jsonl", "csv"),
+        default="jsonl",
+        help="Output format (default: jsonl).",
+    )
+    parser.add_argument(
+        "--user-action-window-minutes",
+        type=int,
+        default=int(DEFAULT_USER_ACTION_WINDOW.total_seconds() / 60),
+        help=(
+            "Time window (minutes) for matching user_actions to ai_decisions "
+            "when session_id is missing (default: 30)."
+        ),
     )
     return parser.parse_args(argv)
 
 
-def iter_learning_records(since: datetime, until: datetime) -> Iterable[dict[str, Any]]:
+def _json_default(value: Any) -> Any:
+    """``json.dumps`` の default ハンドラ。Decimal / datetime を文字列化する。"""
+    if isinstance(value, Decimal):
+        # 学習側で float 化したいケースが多いので float に倒す。精度劣化が問題なら str に切替。
+        return float(value)
+    if isinstance(value, (datetime,)):
+        return value.isoformat()
+    return str(value)
+
+
+def _row_to_dict(row: Any) -> dict[str, Any]:
+    """SQLAlchemy ORM オブジェクト → dict 変換。``_sa_instance_state`` 等は除外。"""
+    if row is None:
+        return {}
+    result: dict[str, Any] = {}
+    # __table__.columns を参照すれば private 属性を踏まずに済む
+    table = getattr(row, "__table__", None)
+    if table is None:
+        # mappings() で取れた Row などはそのまま辞書化を試みる
+        try:
+            return dict(row)
+        except Exception:
+            return {}
+    for col in table.columns:
+        result[col.name] = getattr(row, col.name, None)
+    return result
+
+
+def iter_learning_records(
+    db_url: str,
+    since: datetime,
+    until: datetime,
+    limit: int,
+    user_action_window: timedelta,
+) -> Iterator[dict[str, Any]]:
     """Yield 1 dict per ai_decision in [since, until).
 
-    TODO: implement using SQLAlchemy session.
-        - SELECT ai_decisions WHERE created_at >= :since AND created_at < :until
-        - LEFT JOIN ai_decision_features ON ai_decision_id
-        - LEFT JOIN portfolio_snapshots ON portfolio_snapshot_id
-        - LEFT JOIN user_actions ON (user_id matches AND
-              (session_id = ai_decisions.session_id when present,
-               OR |clicked_at - decisions.created_at| < window))
-        - Yield: {
-            "ai_decision_id": ...,
-            "user_id": ...,
-            "created_at": ISO,
-            "query": ..., "action": ..., "confidence": ...,
-            "features": {...},                 # from ai_decision_features
-            "portfolio_snapshot": {...} | None,
-            "user_actions": [ {...}, ... ],    # 同 session/近接時刻
-          }
+    Returns an iterator so callers (JSONL / CSV writers) can stream.
+
+    Joins:
+      - ai_decisions (filter by created_at)
+      - LEFT JOIN ai_decision_features ON ai_decision_id
+      - LEFT JOIN portfolio_snapshots ON portfolio_snapshot_id
+      - sub-query: user_actions WHERE user_id matches AND
+            (session_id matches when present
+             OR |clicked_at - created_at| < user_action_window)
     """
-    # TODO: implement
-    return []
+    # 遅延 import: --help だけ呼ぶケースで sqlalchemy 不在でも動くようにする
+    try:
+        from sqlalchemy import and_, create_engine, or_, select
+        from sqlalchemy.exc import OperationalError, ProgrammingError
+        from sqlalchemy.orm import sessionmaker
+
+        from app.ai.models import AIDecision
+        from app.portfolio.models import PortfolioSnapshot
+        from app.users.action_models import AIDecisionFeatures, UserAction
+    except ImportError as exc:  # pragma: no cover - depends on runtime env
+        print(
+            f"ERROR: failed to import SQLAlchemy / models: {exc}\n"
+            f"       run from repo root with backend deps installed.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from exc
+
+    if not db_url:
+        print(
+            "ERROR: DB URL not given. Pass --db-url or set DATABASE_URL env var.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    engine = create_engine(db_url)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    try:
+        with SessionLocal() as session:
+            base_stmt = (
+                select(AIDecision, AIDecisionFeatures, PortfolioSnapshot)
+                .join(
+                    AIDecisionFeatures,
+                    AIDecisionFeatures.ai_decision_id == AIDecision.id,
+                    isouter=True,
+                )
+                .join(
+                    PortfolioSnapshot,
+                    PortfolioSnapshot.id == AIDecisionFeatures.portfolio_snapshot_id,
+                    isouter=True,
+                )
+                .where(AIDecision.created_at >= since)
+                .where(AIDecision.created_at < until)
+                .order_by(AIDecision.created_at.asc())
+                .limit(limit)
+            )
+
+            try:
+                # 件数を先に取って進捗 log に使う
+                rows = session.execute(base_stmt).all()
+            except (OperationalError, ProgrammingError) as exc:
+                print(
+                    "ERROR: failed to query ai_decisions / ai_decision_features.\n"
+                    "       Have the migrations been applied?\n"
+                    f"       (alembic upgrade head; see backend/alembic/versions/"
+                    f"h8i9j0k1l2m3_add_user_actions_and_ai_decision_features.py)\n"
+                    f"       Underlying error: {exc}",
+                    file=sys.stderr,
+                )
+                raise SystemExit(1) from exc
+
+            total = len(rows)
+            print(f"[export_learning_data] fetched {total} ai_decision row(s)", file=sys.stderr)
+
+            for idx, (decision, features, snapshot) in enumerate(rows, start=1):
+                # user_actions 取得 (per-decision クエリ。N+1 だが学習データ抽出は
+                # batch 用途で頻度低、可読性優先)
+                actions: list[dict[str, Any]] = []
+                try:
+                    if decision.user_id is not None:
+                        action_window_lo = decision.created_at - user_action_window
+                        action_window_hi = decision.created_at + user_action_window
+                        # session_id が ai_decisions 側に存在しないため、
+                        # 純粋に時間窓 + user_id でマッチする。
+                        # session_id 一致条件は user_actions.session_id が
+                        # 該当 decision の context と一致するロジックを将来追加可能。
+                        action_stmt = (
+                            select(UserAction)
+                            .where(UserAction.user_id == decision.user_id)
+                            .where(
+                                and_(
+                                    UserAction.clicked_at >= action_window_lo,
+                                    UserAction.clicked_at <= action_window_hi,
+                                )
+                            )
+                            .order_by(UserAction.clicked_at.asc())
+                        )
+                        for ua in session.execute(action_stmt).scalars():
+                            actions.append(_row_to_dict(ua))
+                except (OperationalError, ProgrammingError) as exc:
+                    print(
+                        "ERROR: failed to query user_actions. migrations applied?\n"
+                        f"       {exc}",
+                        file=sys.stderr,
+                    )
+                    raise SystemExit(1) from exc
+
+                record: dict[str, Any] = {
+                    "decision_id": decision.id,
+                    "user_id": decision.user_id,
+                    "decided_at": decision.created_at,
+                    "decision": {
+                        "query": decision.query,
+                        "action": decision.action,
+                        "confidence": decision.confidence,
+                        "reason": decision.reason,
+                        "agreed": bool(decision.agreed),
+                        "prompt_version": decision.prompt_version,
+                    },
+                    "ai_response": {
+                        "primary_provider": decision.primary_provider,
+                        "primary_action": decision.primary_action,
+                        "primary_confidence": decision.primary_confidence,
+                        "secondary_provider": decision.secondary_provider,
+                        "secondary_action": decision.secondary_action,
+                        "secondary_confidence": decision.secondary_confidence,
+                        "rag_context_json": decision.rag_context_json,
+                    },
+                    "features": _row_to_dict(features) if features is not None else None,
+                    "snapshot": _row_to_dict(snapshot) if snapshot is not None else None,
+                    "user_actions": actions,
+                }
+
+                if idx % 100 == 0 or idx == total:
+                    print(f"[{idx}/{total}] processed...", file=sys.stderr)
+
+                yield record
+    finally:
+        engine.dispose()
 
 
 def write_jsonl(records: Iterable[dict[str, Any]], out_path: Path) -> int:
@@ -96,21 +307,84 @@ def write_jsonl(records: Iterable[dict[str, Any]], out_path: Path) -> int:
     count = 0
     with out_path.open("w", encoding="utf-8") as fp:
         for rec in records:
-            fp.write(json.dumps(rec, ensure_ascii=False, default=str))
+            fp.write(json.dumps(rec, ensure_ascii=False, default=_json_default))
             fp.write("\n")
             count += 1
     return count
 
 
-def main() -> int:
-    args = parse_args()
+def _flatten_for_csv(rec: dict[str, Any]) -> dict[str, Any]:
+    """CSV 出力向けに JSON カラムを文字列化したフラット dict を返す。
+
+    ネストした dict / list は JSON 文字列に直して 1 列にする。
+    """
+    flat: dict[str, Any] = {}
+    for key, value in rec.items():
+        if isinstance(value, (dict, list)):
+            flat[key] = json.dumps(value, ensure_ascii=False, default=_json_default)
+        elif isinstance(value, Decimal):
+            flat[key] = float(value)
+        elif isinstance(value, datetime):
+            flat[key] = value.isoformat()
+        else:
+            flat[key] = value
+    return flat
+
+
+def write_csv(records: Iterable[dict[str, Any]], out_path: Path) -> int:
+    """Write records as CSV (nested dict/list -> JSON string). Returns row count."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    count = 0
+    # ストリームを 1 周しないとヘッダ確定できないので buffer する。
+    # --limit が default 10000 なのでメモリ的に許容。
+    buffered = [_flatten_for_csv(rec) for rec in records]
+    if not buffered:
+        # 空ファイルでも出力 (touch 相当)
+        out_path.write_text("", encoding="utf-8")
+        return 0
+
+    fieldnames: list[str] = []
+    seen: set[str] = set()
+    for row in buffered:
+        for key in row:
+            if key not in seen:
+                seen.add(key)
+                fieldnames.append(key)
+
+    with out_path.open("w", encoding="utf-8", newline="") as fp:
+        writer = csv.DictWriter(fp, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in buffered:
+            writer.writerow(row)
+            count += 1
+    return count
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
     if args.until <= args.since:
         print("ERROR: --until must be strictly greater than --since", file=sys.stderr)
         return 2
 
-    # TODO: bootstrap SQLAlchemy session from backend/app/database.py
-    records = iter_learning_records(args.since, args.until)
-    n = write_jsonl(records, args.out)
+    if args.limit <= 0:
+        print("ERROR: --limit must be > 0", file=sys.stderr)
+        return 2
+
+    window = timedelta(minutes=max(0, args.user_action_window_minutes))
+
+    records = iter_learning_records(
+        db_url=args.db_url,
+        since=args.since,
+        until=args.until,
+        limit=args.limit,
+        user_action_window=window,
+    )
+
+    if args.format == "csv":
+        n = write_csv(records, args.out)
+    else:
+        n = write_jsonl(records, args.out)
+
     print(f"wrote {n} record(s) to {args.out}")
     return 0
 

--- a/scripts/export_learning_data.py
+++ b/scripts/export_learning_data.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Export learning data (ai_decisions + features + same-session user_actions) as JSONL.
+
+P0-6 (Hermes 受け入れ前提の学習データ層):
+    1 行 = 1 ai_decision に対し、当該 decision の ai_decision_features と、
+    同 session_id (もしくは同 user_id + 近接時刻) の user_actions を結合して
+    1 JSONL レコードとして出力する。
+
+このスクリプトは骨格 (skeleton) のみ。実装本体は後続タスクで埋める。
+docs/50_phase2_ai_optimizer_design.md §9 (学習データ層) を設計の出典とする。
+
+使い方:
+    python scripts/export_learning_data.py \\
+        --since 2026-05-01 --until 2026-05-23 \\
+        --out /tmp/learning_dump_20260523.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+
+def _parse_iso(value: str) -> datetime:
+    """Parse an ISO-8601 date / datetime string into a tz-aware UTC datetime.
+
+    Accepts "YYYY-MM-DD" (treated as 00:00:00 UTC) and full ISO datetimes.
+    """
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"--since/--until must be ISO-8601 (YYYY-MM-DD or full datetime); got {value!r}"
+        ) from exc
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Export learning data (ai_decisions + features + user_actions) as JSONL."
+    )
+    parser.add_argument(
+        "--since",
+        type=_parse_iso,
+        required=True,
+        help="Inclusive lower bound on ai_decisions.created_at (ISO-8601).",
+    )
+    parser.add_argument(
+        "--until",
+        type=_parse_iso,
+        required=True,
+        help="Exclusive upper bound on ai_decisions.created_at (ISO-8601).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="Output JSONL path (will be created/overwritten).",
+    )
+    return parser.parse_args(argv)
+
+
+def iter_learning_records(since: datetime, until: datetime) -> Iterable[dict[str, Any]]:
+    """Yield 1 dict per ai_decision in [since, until).
+
+    TODO: implement using SQLAlchemy session.
+        - SELECT ai_decisions WHERE created_at >= :since AND created_at < :until
+        - LEFT JOIN ai_decision_features ON ai_decision_id
+        - LEFT JOIN portfolio_snapshots ON portfolio_snapshot_id
+        - LEFT JOIN user_actions ON (user_id matches AND
+              (session_id = ai_decisions.session_id when present,
+               OR |clicked_at - decisions.created_at| < window))
+        - Yield: {
+            "ai_decision_id": ...,
+            "user_id": ...,
+            "created_at": ISO,
+            "query": ..., "action": ..., "confidence": ...,
+            "features": {...},                 # from ai_decision_features
+            "portfolio_snapshot": {...} | None,
+            "user_actions": [ {...}, ... ],    # 同 session/近接時刻
+          }
+    """
+    # TODO: implement
+    return []
+
+
+def write_jsonl(records: Iterable[dict[str, Any]], out_path: Path) -> int:
+    """Write records as JSONL. Returns the number of records written."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    count = 0
+    with out_path.open("w", encoding="utf-8") as fp:
+        for rec in records:
+            fp.write(json.dumps(rec, ensure_ascii=False, default=str))
+            fp.write("\n")
+            count += 1
+    return count
+
+
+def main() -> int:
+    args = parse_args()
+    if args.until <= args.since:
+        print("ERROR: --until must be strictly greater than --since", file=sys.stderr)
+        return 2
+
+    # TODO: bootstrap SQLAlchemy session from backend/app/database.py
+    records = iter_learning_records(args.since, args.until)
+    n = write_jsonl(records, args.out)
+    print(f"wrote {n} record(s) to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 概要
Asana タスク: P0-6 (Hermes 受け入れ前提の学習データ層)

Hermes 学習に必要な特徴量と user 行動を蓄積する基盤。既存 portfolio_snapshots / ai_decisions を活かし、再発明せず features と user_actions の2表を新設。

## 変更ファイル
```
 ...m3_add_user_actions_and_ai_decision_features.py | 126 +++++++++++++++++++++
 docs/50_phase2_ai_optimizer_design.md              |  80 +++++++++++++
 scripts/export_learning_data.py                    | 119 +++++++++++++++++++
 3 files changed, 325 insertions(+)
```

## 既存資産マップ参照
- portfolio_snapshots: backend/app/portfolio/models.py:18 (既存・変更なし)
- ai_decisions: backend/app/ai/models.py:14 (既存・変更なし、rag_context_json は維持)
- docs/50_phase2_ai_optimizer_design.md: §9 追記のみ
- 既存 alembic 過去 revision: 変更なし

## migration dry-run 出力 (verbatim)
```
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Generating static SQL
INFO  [alembic.runtime.migration] Will assume transactional DDL.
BEGIN;

INFO  [alembic.runtime.migration] Running upgrade g7h8i9j0k1l2 -> h8i9j0k1l2m3, add_user_actions_and_ai_decision_features
-- Running upgrade g7h8i9j0k1l2 -> h8i9j0k1l2m3

CREATE TABLE user_actions (
    id SERIAL NOT NULL, 
    user_id INTEGER NOT NULL, 
    action_type VARCHAR(64) NOT NULL, 
    target_type VARCHAR(32), 
    target_id VARCHAR(128), 
    clicked_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
    session_id VARCHAR(128), 
    context_json JSONB, 
    PRIMARY KEY (id), 
    FOREIGN KEY(user_id) REFERENCES users (id)
);

COMMENT ON COLUMN user_actions.action_type IS 'e.g. manual_buy_click, manual_sell_click, onramp_completed';

COMMENT ON COLUMN user_actions.target_type IS 'e.g. proposal, asset';

CREATE INDEX ix_user_actions_user_clicked ON user_actions (user_id, clicked_at);

CREATE INDEX ix_user_actions_action_type ON user_actions (action_type);

CREATE TABLE ai_decision_features (
    id SERIAL NOT NULL, 
    ai_decision_id INTEGER NOT NULL, 
    portfolio_snapshot_id INTEGER, 
    market_apy_supply NUMERIC(10, 4), 
    market_apy_borrow NUMERIC(10, 4), 
    health_factor NUMERIC(10, 4), 
    gas_gwei NUMERIC(20, 4), 
    price_usd NUMERIC(20, 8), 
    prompt_features_json JSONB, 
    created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
    PRIMARY KEY (id), 
    FOREIGN KEY(ai_decision_id) REFERENCES ai_decisions (id), 
    FOREIGN KEY(portfolio_snapshot_id) REFERENCES portfolio_snapshots (id)
);

CREATE UNIQUE INDEX uq_ai_decision_features_decision ON ai_decision_features (ai_decision_id);

UPDATE alembic_version SET version_num='h8i9j0k1l2m3' WHERE alembic_version.version_num = 'g7h8i9j0k1l2';

COMMIT;
```

## 検証コマンド出力 (verbatim)
```
PY_COMPILE_OK (exit 0)
```

## ⚠️ 依存・注意
- Tier-S 不触(main.py, ai_judgment_scheduler.py, aave/client.py, 過去 alembic は変更なし)
- merge 禁止(最終承認は claude.ai + 小林さん)
- prod 不触(本 PR では migration 実行しない)
- 後続: P5 (manual UI) の user_actions POST 経路と連携
- 注: repo には既存の並行 head が 2 つ存在(`a7b8c9d0e1f2` と `g7h8i9j0k1l2`)。本 PR は指示通り `g7h8i9j0k1l2` の直上に積む。alembic merge は別 PR の責務

🤖 Generated with [Claude Code](https://claude.com/claude-code)