### PR TITLE
P2-paymaster: ERC-20 Paymaster client + first-tx gas approval UI

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -111,9 +111,17 @@ NEXT_PUBLIC_BASE_MAINNET_RPC=https://base-mainnet.g.alchemy.com/v2/YOUR_KEY
 # Paymaster (ERC-20 / Base) — added 2026-05-23
 # 仕様原文では Paymaster は将来扱いだったが、Q3 reframe で MVP 格上げ
 # 実値は別管理 (1Password / Secrets Manager)
+#
+# 候補プロバイダ (EntryPoint v0.7 対応):
+#   - Pimlico   : https://api.pimlico.io/v2/base/rpc?apikey=...
+#   - Stackup   : https://api.stackup.sh/v1/paymaster/<key>
+#   - Alchemy   : https://base-mainnet.g.alchemy.com/v2/<key> (Account Kit)
+#   - Base公式  : https://paymaster.base.org/v1
 # =============================================================================
-NEXT_PUBLIC_PAYMASTER_URL=https://api.paymaster.example.com/v1
-NEXT_PUBLIC_PAYMASTER_API_KEY=DUMMY_REPLACE_ME
+NEXT_PUBLIC_PAYMASTER_URL=https://paymaster.base.org/v1
+NEXT_PUBLIC_PAYMASTER_API_KEY=REPLACE_WITH_REAL_KEY
+# ETH→USDC fallback 換算用 (Paymaster API 不通時のみ使用)
+NEXT_PUBLIC_ETH_USD_PRICE=3000
 
 # =============================================================================
 # Cloudflare

--- a/.env.production.example
+++ b/.env.production.example
@@ -108,6 +108,14 @@ NEXT_PUBLIC_DEFAULT_CHAIN_ID=8453
 NEXT_PUBLIC_BASE_MAINNET_RPC=https://base-mainnet.g.alchemy.com/v2/YOUR_KEY
 
 # =============================================================================
+# Paymaster (ERC-20 / Base) — added 2026-05-23
+# 仕様原文では Paymaster は将来扱いだったが、Q3 reframe で MVP 格上げ
+# 実値は別管理 (1Password / Secrets Manager)
+# =============================================================================
+NEXT_PUBLIC_PAYMASTER_URL=https://api.paymaster.example.com/v1
+NEXT_PUBLIC_PAYMASTER_API_KEY=DUMMY_REPLACE_ME
+
+# =============================================================================
 # Cloudflare
 # =============================================================================
 CLOUDFLARE_TUNNEL_TOKEN=

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -104,6 +104,14 @@ NEXT_PUBLIC_DEFAULT_CHAIN_ID=84532
 NEXT_PUBLIC_BASE_SEPOLIA_RPC=https://base-sepolia.g.alchemy.com/v2/YOUR_KEY
 
 # =============================================================================
+# Paymaster (ERC-20 / Base) — added 2026-05-23
+# 仕様原文では Paymaster は将来扱いだったが、Q3 reframe で MVP 格上げ
+# 実値は別管理 (1Password / Secrets Manager)
+# =============================================================================
+NEXT_PUBLIC_PAYMASTER_URL=https://api.paymaster.example.com/v1
+NEXT_PUBLIC_PAYMASTER_API_KEY=DUMMY_REPLACE_ME
+
+# =============================================================================
 # Cloudflare
 # CLOUDFLARE_TUNNEL_TOKEN は Phase 4 で staging 専用トンネルを作成後に設定
 # =============================================================================

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -107,9 +107,17 @@ NEXT_PUBLIC_BASE_SEPOLIA_RPC=https://base-sepolia.g.alchemy.com/v2/YOUR_KEY
 # Paymaster (ERC-20 / Base) — added 2026-05-23
 # 仕様原文では Paymaster は将来扱いだったが、Q3 reframe で MVP 格上げ
 # 実値は別管理 (1Password / Secrets Manager)
+#
+# 候補プロバイダ (EntryPoint v0.7 対応):
+#   - Pimlico   : https://api.pimlico.io/v2/base-sepolia/rpc?apikey=...
+#   - Stackup   : https://api.stackup.sh/v1/paymaster/<key>
+#   - Alchemy   : https://base-sepolia.g.alchemy.com/v2/<key> (Account Kit)
+#   - Base公式  : https://paymaster.base.org/v1
 # =============================================================================
-NEXT_PUBLIC_PAYMASTER_URL=https://api.paymaster.example.com/v1
-NEXT_PUBLIC_PAYMASTER_API_KEY=DUMMY_REPLACE_ME
+NEXT_PUBLIC_PAYMASTER_URL=https://paymaster.base.org/v1
+NEXT_PUBLIC_PAYMASTER_API_KEY=REPLACE_WITH_REAL_KEY
+# ETH→USDC fallback 換算用 (Paymaster API 不通時のみ使用)
+NEXT_PUBLIC_ETH_USD_PRICE=3000
 
 # =============================================================================
 # Cloudflare

--- a/frontend/components/onboarding/GasFeeApprovalDialog.tsx
+++ b/frontend/components/onboarding/GasFeeApprovalDialog.tsx
@@ -12,16 +12,25 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Label } from "@/components/ui/label"
 
 export interface GasFeeApprovalDialogProps {
   /** ダイアログを開くかどうか */
   open: boolean
   /** USDC 建てのガス額 (例: 0.12 → "$0.12 USDC") */
   gasEstimateUsdc: number
-  /** ユーザが「承認」を押したときに呼ばれる */
-  onApprove: () => void
+  /**
+   * USD 換算額。省略時は USDC 額と同値表示 (USDC ≈ $1 前提)。
+   * 実値は呼出側でオラクル経由で渡す想定。
+   */
+  gasEstimateUsd?: number
+  /** ユーザが「承認」を押したときに呼ばれる。auto = 次回以降自動承認チェックの状態 */
+  onApprove: (opts: { rememberApproval: boolean }) => void
   /** ユーザが「キャンセル」を押したとき・閉じたときに呼ばれる */
   onCancel: () => void
+  /** approve 押下後の処理中フラグ。true の間ボタンを無効化しスピナ表示 */
+  loading?: boolean
 }
 
 /**
@@ -29,38 +38,71 @@ export interface GasFeeApprovalDialogProps {
  *
  * 仕様原文では Paymaster は将来扱いだったが、Q3 reframe で MVP 格上げ。
  * 初回 tx 前にこのダイアログでユーザに承認を取り、以降は自動送信させる前提。
+ *
+ * - USD 換算を併記 (オラクル経由の値を呼出側で渡す)
+ * - 「次回以降は自動で承認します」チェックボックス (localStorage は呼出側の hook で保存)
+ * - キャンセル時は tx を発火しない
+ * - a11y: aria-label / keyboard escape (Radix Dialog 経由)
+ * - loading 状態
  */
 export function GasFeeApprovalDialog({
   open,
   gasEstimateUsdc,
+  gasEstimateUsd,
   onApprove,
   onCancel,
+  loading = false,
 }: GasFeeApprovalDialogProps): React.ReactElement {
-  const formatted = gasEstimateUsdc.toLocaleString("en-US", {
+  const [rememberApproval, setRememberApproval] = React.useState<boolean>(true)
+
+  const formattedUsdc = gasEstimateUsdc.toLocaleString("en-US", {
     minimumFractionDigits: 2,
     maximumFractionDigits: 4,
   })
+  const usdValue = gasEstimateUsd ?? gasEstimateUsdc
+  const formattedUsd = usdValue.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+
+  const handleApprove = React.useCallback(() => {
+    if (loading) return
+    onApprove({ rememberApproval })
+  }, [loading, onApprove, rememberApproval])
 
   return (
     <Dialog
       open={open}
       onOpenChange={(next) => {
+        if (loading) return // 処理中の close は無視
         if (!next) onCancel()
       }}
     >
-      <DialogContent className="sm:max-w-md">
+      <DialogContent
+        className="sm:max-w-md"
+        aria-label="初回ガス代の承認ダイアログ"
+      >
         <DialogHeader>
           <DialogTitle>初回ガス代の承認</DialogTitle>
           <DialogDescription>
-            初回のガス代として ~${formatted} USDC を消費します。
-            次回以降は自動です。
+            初回のガス代として ~${formattedUsdc} USDC (約 ${formattedUsd}) を消費します。
+            次回以降は自動で承認することもできます。
           </DialogDescription>
         </DialogHeader>
 
-        <div className="rounded-md border p-3 text-sm">
+        <div
+          className="rounded-md border p-3 text-sm"
+          role="group"
+          aria-label="ガス代見積もり"
+        >
           <div className="flex items-center justify-between">
             <span className="text-muted-foreground">推定ガス代</span>
-            <span className="font-medium">~${formatted} USDC</span>
+            <span className="font-medium">
+              ~${formattedUsdc} USDC
+              <span className="ml-2 text-xs text-muted-foreground">
+                (≈ ${formattedUsd})
+              </span>
+            </span>
           </div>
           <p className="mt-2 text-xs text-muted-foreground">
             Base 上の ERC-20 Paymaster を使い、ETH を持っていなくても
@@ -68,11 +110,49 @@ export function GasFeeApprovalDialog({
           </p>
         </div>
 
+        <div className="flex items-center gap-2 pt-1">
+          <Checkbox
+            id="remember-approval"
+            checked={rememberApproval}
+            onCheckedChange={(v) => setRememberApproval(v === true)}
+            disabled={loading}
+            aria-label="次回以降は自動で承認します"
+          />
+          <Label
+            htmlFor="remember-approval"
+            className="cursor-pointer text-sm font-normal"
+          >
+            次回以降は自動で承認します
+          </Label>
+        </div>
+
         <DialogFooter className="gap-2 sm:gap-2">
-          <Button variant="outline" onClick={onCancel}>
+          <Button
+            variant="outline"
+            onClick={onCancel}
+            disabled={loading}
+            aria-label="キャンセル"
+          >
             キャンセル
           </Button>
-          <Button onClick={onApprove}>承認</Button>
+          <Button
+            onClick={handleApprove}
+            disabled={loading}
+            aria-label="承認"
+            aria-busy={loading}
+          >
+            {loading ? (
+              <span className="inline-flex items-center gap-2">
+                <span
+                  className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent"
+                  aria-hidden="true"
+                />
+                送信中...
+              </span>
+            ) : (
+              "承認"
+            )}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/components/onboarding/GasFeeApprovalDialog.tsx
+++ b/frontend/components/onboarding/GasFeeApprovalDialog.tsx
@@ -1,0 +1,82 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+"use client"
+
+import * as React from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+
+export interface GasFeeApprovalDialogProps {
+  /** ダイアログを開くかどうか */
+  open: boolean
+  /** USDC 建てのガス額 (例: 0.12 → "$0.12 USDC") */
+  gasEstimateUsdc: number
+  /** ユーザが「承認」を押したときに呼ばれる */
+  onApprove: () => void
+  /** ユーザが「キャンセル」を押したとき・閉じたときに呼ばれる */
+  onCancel: () => void
+}
+
+/**
+ * 初回 tx の前に、ガス代として消費する USDC 額を提示し、承認を取る Dialog。
+ *
+ * 仕様原文では Paymaster は将来扱いだったが、Q3 reframe で MVP 格上げ。
+ * 初回 tx 前にこのダイアログでユーザに承認を取り、以降は自動送信させる前提。
+ */
+export function GasFeeApprovalDialog({
+  open,
+  gasEstimateUsdc,
+  onApprove,
+  onCancel,
+}: GasFeeApprovalDialogProps): React.ReactElement {
+  const formatted = gasEstimateUsdc.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  })
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onCancel()
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>初回ガス代の承認</DialogTitle>
+          <DialogDescription>
+            初回のガス代として ~${formatted} USDC を消費します。
+            次回以降は自動です。
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="rounded-md border p-3 text-sm">
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground">推定ガス代</span>
+            <span className="font-medium">~${formatted} USDC</span>
+          </div>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Base 上の ERC-20 Paymaster を使い、ETH を持っていなくても
+            USDC でガス代を支払える仕組みです。
+          </p>
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button variant="outline" onClick={onCancel}>
+            キャンセル
+          </Button>
+          <Button onClick={onApprove}>承認</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default GasFeeApprovalDialog

--- a/frontend/hooks/useGasFeeApproval.ts
+++ b/frontend/hooks/useGasFeeApproval.ts
@@ -1,0 +1,86 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+"use client"
+
+import * as React from "react"
+
+/**
+ * localStorage key for "user has approved gas fee deduction in USDC at least once"
+ *
+ * 仕様原文では Paymaster は将来扱いだったが、Q3 reframe で MVP 格上げ。
+ * 初回 tx 前に GasFeeApprovalDialog で承認を取り、ユーザが「次回以降自動」を
+ * チェックしていればこのフラグを localStorage に保存する。
+ */
+export const PAYMASTER_APPROVED_KEY = "uata.paymaster.approved"
+
+export interface UseGasFeeApprovalResult {
+  /** true なら GasFeeApprovalDialog を表示する必要がある */
+  needsApproval: boolean
+  /** 「承認 + 次回以降も自動」を選んだときに呼ぶ */
+  markApproved: () => void
+  /** 設定を消し、次回 tx で再度ダイアログを出す */
+  reset: () => void
+}
+
+function readApproved(): boolean {
+  if (typeof window === "undefined") return false
+  try {
+    return window.localStorage.getItem(PAYMASTER_APPROVED_KEY) === "1"
+  } catch {
+    // localStorage アクセス不可 (Private mode / SSR 等) は未承認扱い
+    return false
+  }
+}
+
+/**
+ * 「初回承認済みフラグ」を localStorage で管理する hook。
+ *
+ * - SSR/CSR の hydration 差分を避けるため、初期値は false で mount 後に同期する。
+ * - storage event を購読し、別タブでの変更にも追従する。
+ */
+export function useGasFeeApproval(): UseGasFeeApprovalResult {
+  const [approved, setApproved] = React.useState<boolean>(false)
+
+  React.useEffect(() => {
+    setApproved(readApproved())
+
+    const handler = (e: StorageEvent) => {
+      if (e.key === PAYMASTER_APPROVED_KEY) {
+        setApproved(readApproved())
+      }
+    }
+    if (typeof window !== "undefined") {
+      window.addEventListener("storage", handler)
+      return () => window.removeEventListener("storage", handler)
+    }
+    return undefined
+  }, [])
+
+  const markApproved = React.useCallback(() => {
+    if (typeof window === "undefined") return
+    try {
+      window.localStorage.setItem(PAYMASTER_APPROVED_KEY, "1")
+    } catch {
+      // 無視 (Private mode 等)
+    }
+    setApproved(true)
+  }, [])
+
+  const reset = React.useCallback(() => {
+    if (typeof window === "undefined") return
+    try {
+      window.localStorage.removeItem(PAYMASTER_APPROVED_KEY)
+    } catch {
+      // 無視
+    }
+    setApproved(false)
+  }, [])
+
+  return {
+    needsApproval: !approved,
+    markApproved,
+    reset,
+  }
+}
+
+export default useGasFeeApproval

--- a/frontend/lib/wallet/paymaster.ts
+++ b/frontend/lib/wallet/paymaster.ts
@@ -1,15 +1,16 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
 //
-// ERC-20 Paymaster client helper (Base).
+// ERC-20 Paymaster client helper (Base, EntryPoint v0.7).
 //
 // 仕様原文では Paymaster は将来扱いだったが、Q3 reframe で MVP 格上げ。
 // ユーザの初回 tx 前にガス額(USDC)を見積もり、承認 UI を経由して
 // Paymaster API へ UserOperation を投げる導線をここに集約する。
 //
-// TODO(privy): Privy の useSendTransaction() / EIP-4337 bundler 接続を結合する。
-// TODO(viem):  viem の TransactionRequest -> UserOperation 変換を実装する。
-// TODO(estim): 実 Paymaster (e.g. Pimlico / Alchemy Account Kit) の見積 RPC を結ぶ。
+// 想定 Paymaster: Pimlico / Stackup / Alchemy Account Kit (いずれも EntryPoint v0.7 互換)
+
+import { createPublicClient, http } from 'viem'
+import { base, baseSepolia } from 'viem/chains'
 
 export type TxHash = `0x${string}`
 
@@ -22,20 +23,84 @@ export interface TransactionRequest {
   to: `0x${string}`
   data?: `0x${string}`
   value?: bigint
+  from?: `0x${string}`
 }
 
+/**
+ * EIP-4337 v0.7 UserOperation。Paymaster 経由送信時に bundler に渡す形。
+ */
 export interface UserOperation {
   sender: `0x${string}`
   nonce: bigint
   callData: `0x${string}`
-  // 実装時に EIP-4337 の他フィールド (callGasLimit, verificationGasLimit, ...) を追加
+  callGasLimit?: bigint
+  verificationGasLimit?: bigint
+  preVerificationGas?: bigint
+  maxFeePerGas?: bigint
+  maxPriorityFeePerGas?: bigint
+  /** EntryPoint v0.7: paymaster は paymasterAndData ではなく分割フィールド */
+  paymaster?: `0x${string}`
+  paymasterVerificationGasLimit?: bigint
+  paymasterPostOpGasLimit?: bigint
+  paymasterData?: `0x${string}`
+  signature?: `0x${string}`
+  factory?: `0x${string}`
+  factoryData?: `0x${string}`
 }
 
 // 最小の WalletClient interface (Privy / wagmi / viem いずれにも適応できるよう緩く)
 export interface PaymasterWalletClient {
   account?: { address: `0x${string}` }
   sendTransaction?: (tx: TransactionRequest) => Promise<TxHash>
+  /** EIP-4337 v0.7: 署名済み UserOperation を bundler へ送る関数 (Privy / viem AA) */
+  sendUserOperation?: (userOp: UserOperation) => Promise<TxHash>
+  /** UserOperation の署名 (Privy embedded wallet に存在) */
+  signUserOperation?: (userOp: UserOperation) => Promise<`0x${string}`>
 }
+
+/** EntryPoint v0.7 公式アドレス (Base mainnet / Base Sepolia 共通) */
+export const ENTRY_POINT_V07_ADDRESS =
+  '0x0000000071727De22E5E9d8BAf0edAc6f37da032' as const
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+/** Paymaster 由来エラーの基底クラス */
+export class PaymasterError extends Error {
+  public readonly cause?: unknown
+  constructor(message: string, cause?: unknown) {
+    super(message)
+    this.name = 'PaymasterError'
+    this.cause = cause
+  }
+}
+
+/** Paymaster URL/API key 未設定 or 到達不可 */
+export class PaymasterUnavailableError extends PaymasterError {
+  constructor(message: string, cause?: unknown) {
+    super(message, cause)
+    this.name = 'PaymasterUnavailableError'
+  }
+}
+
+/** ユーザ残高が見積もった USDC ガス代に満たない */
+export class InsufficientUsdcError extends PaymasterError {
+  public readonly requiredUsdc6dp: bigint
+  public readonly currentUsdc6dp: bigint
+  constructor(requiredUsdc6dp: bigint, currentUsdc6dp: bigint) {
+    super(
+      `[paymaster] insufficient USDC: required=${requiredUsdc6dp.toString()} have=${currentUsdc6dp.toString()}`
+    )
+    this.name = 'InsufficientUsdcError'
+    this.requiredUsdc6dp = requiredUsdc6dp
+    this.currentUsdc6dp = currentUsdc6dp
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Config helpers
+// ---------------------------------------------------------------------------
 
 /**
  * 環境変数から Paymaster の URL / API Key を返す。
@@ -56,21 +121,6 @@ export function isPaymasterEnabled(): boolean {
 }
 
 /**
- * tx のガス代を USDC 建てで見積もる雛形。
- * 実装時は Paymaster の `pm_estimateUserOperationGas` 相当を叩き、
- * 返ってきた gasLimit * gasPrice を USDC レートで換算する。
- *
- * 現状は安全側 (UI に表示するためのプレースホルダ値) を返す。
- */
-export async function estimateGasInUsdc(
-  _tx: TransactionRequest
-): Promise<bigint> {
-  // TODO(estim): 実 RPC 呼び出し。現状は 0.10 USDC (6 decimals) を仮置き。
-  const PLACEHOLDER_USDC_6DP = 100_000n // = 0.10 USDC
-  return PLACEHOLDER_USDC_6DP
-}
-
-/**
  * USDC (6 decimals, bigint) を画面表示用の数値に変換するヘルパ。
  */
 export function formatUsdc6dp(amount: bigint): number {
@@ -78,24 +128,273 @@ export function formatUsdc6dp(amount: bigint): number {
   return Number(amount) / 1_000_000
 }
 
+// ---------------------------------------------------------------------------
+// Public chain client (viem)
+// ---------------------------------------------------------------------------
+
+function getDefaultChain() {
+  const id = parseInt(process.env.NEXT_PUBLIC_DEFAULT_CHAIN_ID || '8453', 10)
+  return id === 84532 ? baseSepolia : base
+}
+
+/** モジュール内部で使う viem PublicClient (gas / gasPrice 取得用) */
+function getPublicClient() {
+  const chain = getDefaultChain()
+  const rpc =
+    chain.id === 84532
+      ? process.env.NEXT_PUBLIC_BASE_SEPOLIA_RPC
+      : process.env.NEXT_PUBLIC_BASE_MAINNET_RPC
+  return createPublicClient({
+    chain,
+    transport: http(rpc || undefined),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// ETH -> USDC fallback rate
+// ---------------------------------------------------------------------------
+
 /**
- * UserOperation を Paymaster 経由で送信する雛形。
- * 実装は Privy embedded wallet の signUserOperation() + Bundler RPC への
- * eth_sendUserOperation を組み合わせる予定。
+ * Paymaster API 不通時に使う ETH→USD 換算レート。
+ * `NEXT_PUBLIC_ETH_USD_PRICE` で上書き可、未設定なら 3000 USD/ETH。
+ */
+function getEthUsdPrice(): number {
+  const raw = process.env.NEXT_PUBLIC_ETH_USD_PRICE
+  const parsed = raw ? Number(raw) : NaN
+  if (!Number.isFinite(parsed) || parsed <= 0) return 3000
+  return parsed
+}
+
+/**
+ * gas units × gas price (wei) → USDC(6dp, bigint) のローカル換算。
+ * Paymaster API 不通時の fallback。
+ */
+function ethGasToUsdc6dp(gasUnits: bigint, gasPriceWei: bigint): bigint {
+  const ethUsd = getEthUsdPrice()
+  // 整数演算で 6dp を維持: (gas * price * usd * 1e6) / 1e18
+  // ethUsd は浮動小数の可能性があるので 1e6 倍してから整数化。
+  const usdScaled = BigInt(Math.round(ethUsd * 1_000_000)) // USD * 1e6 / ETH
+  const numerator = gasUnits * gasPriceWei * usdScaled
+  const denominator = 10n ** 18n * 1_000_000n // wei -> ETH (1e18) と USD*1e6 を相殺
+  // 結果は USDC * 1e6 (= 6dp)
+  return numerator / denominator
+}
+
+// ---------------------------------------------------------------------------
+// estimateGasInUsdc
+// ---------------------------------------------------------------------------
+
+/**
+ * tx のガス代を USDC 建てで見積もる。
  *
- * TODO(privy): Privy の useSendTransaction との接続点をここに追加。
+ * 1) viem `estimateGas` で gas units を出す
+ * 2) viem `getGasPrice` で現在のガス価格を取る
+ * 3) Paymaster API `/quote` に POST して USDC 単価を取得
+ * 4) 失敗時は ETH→USDC 換算で fallback
+ *
+ * @returns bigint (USDC 6 decimals)
+ */
+export async function estimateGasInUsdc(
+  tx: TransactionRequest
+): Promise<bigint> {
+  const client = getPublicClient()
+
+  let gasUnits: bigint
+  let gasPrice: bigint
+  try {
+    // viem 2.x の estimateGas は account を要求するが、ここでは tx.from を渡す。
+    // from 未指定なら 0 アドレスで概算 (UI 表示用なので許容)。
+    const account =
+      tx.from ??
+      ('0x0000000000000000000000000000000000000000' as `0x${string}`)
+    ;[gasUnits, gasPrice] = await Promise.all([
+      client.estimateGas({
+        account,
+        to: tx.to,
+        data: tx.data,
+        value: tx.value,
+      }),
+      client.getGasPrice(),
+    ])
+  } catch (err) {
+    // RPC 自体が落ちている場合は安全側 (典型値 200k gas × 0.1 gwei) で概算
+    gasUnits = 200_000n
+    gasPrice = 100_000_000n // 0.1 gwei (Base は安い)
+    // eslint-disable-next-line no-console
+    console.warn('[paymaster] estimateGas failed, using fallback gas units:', err)
+  }
+
+  const { url, apiKey } = getPaymasterConfig()
+  if (url && apiKey) {
+    try {
+      const res = await fetch(`${url}/quote`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': apiKey,
+        },
+        body: JSON.stringify({
+          userOp: {
+            sender: tx.from ?? null,
+            callData: tx.data ?? '0x',
+          },
+          gasUnits: gasUnits.toString(),
+          gasPrice: gasPrice.toString(),
+          chainId: getDefaultChain().id,
+          token: 'USDC',
+        }),
+      })
+      if (res.ok) {
+        const body = (await res.json()) as { usdcAmount?: string | number }
+        if (body.usdcAmount !== undefined && body.usdcAmount !== null) {
+          // API は 6dp の整数文字列を返す想定 (Pimlico/Stackup 仕様に合わせる)
+          return BigInt(body.usdcAmount)
+        }
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[paymaster] /quote returned ${res.status}, falling back to ETH→USDC`
+        )
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn('[paymaster] /quote unreachable, falling back to ETH→USDC:', err)
+    }
+  }
+
+  // Fallback: gasUnits × gasPrice × ETH_USD_PRICE / 10^18 で USDC 換算
+  return ethGasToUsdc6dp(gasUnits, gasPrice)
+}
+
+// ---------------------------------------------------------------------------
+// sendUserOpWithPaymaster
+// ---------------------------------------------------------------------------
+
+interface SponsorResponse {
+  // EntryPoint v0.7 分割フィールド
+  paymaster?: `0x${string}`
+  paymasterData?: `0x${string}`
+  paymasterVerificationGasLimit?: string
+  paymasterPostOpGasLimit?: string
+  // 互換: v0.6 形式を返す Paymaster もあるので受けておく
+  paymasterAndData?: `0x${string}`
+  // bundler が再見積もりした gas
+  callGasLimit?: string
+  verificationGasLimit?: string
+  preVerificationGas?: string
+  maxFeePerGas?: string
+  maxPriorityFeePerGas?: string
+}
+
+function toBigIntOrUndef(s?: string): bigint | undefined {
+  if (s === undefined || s === null || s === '') return undefined
+  try {
+    return BigInt(s)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * UserOperation を Paymaster 経由で送信する。
+ *
+ * 1) Paymaster API `/sponsor` に POST → paymaster/paymasterData (v0.7) を取得
+ * 2) walletClient.sendUserOperation で bundler に投げる
+ * 3) tx hash を返す
+ *
+ * EntryPoint v0.7 想定。エラー時は PaymasterError 系でラップ。
  */
 export async function sendUserOpWithPaymaster(
-  _walletClient: PaymasterWalletClient,
-  _userOp: UserOperation
+  walletClient: PaymasterWalletClient,
+  userOp: UserOperation
 ): Promise<TxHash> {
   const { url, apiKey } = getPaymasterConfig()
   if (!url || !apiKey) {
-    throw new Error(
+    throw new PaymasterUnavailableError(
       '[paymaster] NEXT_PUBLIC_PAYMASTER_URL / NEXT_PUBLIC_PAYMASTER_API_KEY が未設定です'
     )
   }
-  // TODO(impl): fetch(url, { headers: { 'x-api-key': apiKey }, ... }) で
-  //             eth_sendUserOperation を投げ、txHash を返す。
-  throw new Error('[paymaster] sendUserOpWithPaymaster: not implemented yet')
+
+  // 1) /sponsor: Paymaster に署名 (paymasterData) を要求
+  let sponsor: SponsorResponse
+  try {
+    const res = await fetch(`${url}/sponsor`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+      },
+      body: JSON.stringify({
+        userOp: {
+          sender: userOp.sender,
+          nonce: userOp.nonce.toString(),
+          callData: userOp.callData,
+          callGasLimit: userOp.callGasLimit?.toString(),
+          verificationGasLimit: userOp.verificationGasLimit?.toString(),
+          preVerificationGas: userOp.preVerificationGas?.toString(),
+          maxFeePerGas: userOp.maxFeePerGas?.toString(),
+          maxPriorityFeePerGas: userOp.maxPriorityFeePerGas?.toString(),
+          factory: userOp.factory,
+          factoryData: userOp.factoryData,
+        },
+        entryPoint: ENTRY_POINT_V07_ADDRESS,
+        chainId: getDefaultChain().id,
+        token: 'USDC',
+      }),
+    })
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      throw new PaymasterUnavailableError(
+        `[paymaster] /sponsor returned ${res.status}: ${text}`
+      )
+    }
+    sponsor = (await res.json()) as SponsorResponse
+  } catch (err) {
+    if (err instanceof PaymasterError) throw err
+    throw new PaymasterUnavailableError(
+      '[paymaster] /sponsor request failed',
+      err
+    )
+  }
+
+  // 2) sponsored fields を userOp にマージ (v0.7 形式優先)
+  const sponsored: UserOperation = {
+    ...userOp,
+    paymaster: sponsor.paymaster ?? userOp.paymaster,
+    paymasterData: sponsor.paymasterData ?? userOp.paymasterData,
+    paymasterVerificationGasLimit:
+      toBigIntOrUndef(sponsor.paymasterVerificationGasLimit) ??
+      userOp.paymasterVerificationGasLimit,
+    paymasterPostOpGasLimit:
+      toBigIntOrUndef(sponsor.paymasterPostOpGasLimit) ??
+      userOp.paymasterPostOpGasLimit,
+    callGasLimit:
+      toBigIntOrUndef(sponsor.callGasLimit) ?? userOp.callGasLimit,
+    verificationGasLimit:
+      toBigIntOrUndef(sponsor.verificationGasLimit) ??
+      userOp.verificationGasLimit,
+    preVerificationGas:
+      toBigIntOrUndef(sponsor.preVerificationGas) ?? userOp.preVerificationGas,
+    maxFeePerGas:
+      toBigIntOrUndef(sponsor.maxFeePerGas) ?? userOp.maxFeePerGas,
+    maxPriorityFeePerGas:
+      toBigIntOrUndef(sponsor.maxPriorityFeePerGas) ??
+      userOp.maxPriorityFeePerGas,
+  }
+
+  // 3) bundler / wallet 経由で送信
+  if (!walletClient.sendUserOperation) {
+    throw new PaymasterError(
+      '[paymaster] walletClient.sendUserOperation is not available — Privy AA / viem account-abstraction を初期化してください'
+    )
+  }
+
+  try {
+    return await walletClient.sendUserOperation(sponsored)
+  } catch (err) {
+    throw new PaymasterError(
+      '[paymaster] sendUserOperation failed at bundler',
+      err
+    )
+  }
 }

--- a/frontend/lib/wallet/paymaster.ts
+++ b/frontend/lib/wallet/paymaster.ts
@@ -1,0 +1,101 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+//
+// ERC-20 Paymaster client helper (Base).
+//
+// 仕様原文では Paymaster は将来扱いだったが、Q3 reframe で MVP 格上げ。
+// ユーザの初回 tx 前にガス額(USDC)を見積もり、承認 UI を経由して
+// Paymaster API へ UserOperation を投げる導線をここに集約する。
+//
+// TODO(privy): Privy の useSendTransaction() / EIP-4337 bundler 接続を結合する。
+// TODO(viem):  viem の TransactionRequest -> UserOperation 変換を実装する。
+// TODO(estim): 実 Paymaster (e.g. Pimlico / Alchemy Account Kit) の見積 RPC を結ぶ。
+
+export type TxHash = `0x${string}`
+
+export interface PaymasterConfig {
+  url: string
+  apiKey: string
+}
+
+export interface TransactionRequest {
+  to: `0x${string}`
+  data?: `0x${string}`
+  value?: bigint
+}
+
+export interface UserOperation {
+  sender: `0x${string}`
+  nonce: bigint
+  callData: `0x${string}`
+  // 実装時に EIP-4337 の他フィールド (callGasLimit, verificationGasLimit, ...) を追加
+}
+
+// 最小の WalletClient interface (Privy / wagmi / viem いずれにも適応できるよう緩く)
+export interface PaymasterWalletClient {
+  account?: { address: `0x${string}` }
+  sendTransaction?: (tx: TransactionRequest) => Promise<TxHash>
+}
+
+/**
+ * 環境変数から Paymaster の URL / API Key を返す。
+ * 値が未設定の場合は空文字を返し、呼び出し側で fallback (Paymaster 無し送信) させる。
+ */
+export function getPaymasterConfig(): PaymasterConfig {
+  const url = process.env.NEXT_PUBLIC_PAYMASTER_URL || ''
+  const apiKey = process.env.NEXT_PUBLIC_PAYMASTER_API_KEY || ''
+  return { url, apiKey }
+}
+
+/**
+ * Paymaster が利用可能か (URL/API Key の両方が設定されているか) を返す。
+ */
+export function isPaymasterEnabled(): boolean {
+  const { url, apiKey } = getPaymasterConfig()
+  return url.length > 0 && apiKey.length > 0
+}
+
+/**
+ * tx のガス代を USDC 建てで見積もる雛形。
+ * 実装時は Paymaster の `pm_estimateUserOperationGas` 相当を叩き、
+ * 返ってきた gasLimit * gasPrice を USDC レートで換算する。
+ *
+ * 現状は安全側 (UI に表示するためのプレースホルダ値) を返す。
+ */
+export async function estimateGasInUsdc(
+  _tx: TransactionRequest
+): Promise<bigint> {
+  // TODO(estim): 実 RPC 呼び出し。現状は 0.10 USDC (6 decimals) を仮置き。
+  const PLACEHOLDER_USDC_6DP = 100_000n // = 0.10 USDC
+  return PLACEHOLDER_USDC_6DP
+}
+
+/**
+ * USDC (6 decimals, bigint) を画面表示用の数値に変換するヘルパ。
+ */
+export function formatUsdc6dp(amount: bigint): number {
+  // bigint -> number で精度は落ちるが UI 表示用なので許容。
+  return Number(amount) / 1_000_000
+}
+
+/**
+ * UserOperation を Paymaster 経由で送信する雛形。
+ * 実装は Privy embedded wallet の signUserOperation() + Bundler RPC への
+ * eth_sendUserOperation を組み合わせる予定。
+ *
+ * TODO(privy): Privy の useSendTransaction との接続点をここに追加。
+ */
+export async function sendUserOpWithPaymaster(
+  _walletClient: PaymasterWalletClient,
+  _userOp: UserOperation
+): Promise<TxHash> {
+  const { url, apiKey } = getPaymasterConfig()
+  if (!url || !apiKey) {
+    throw new Error(
+      '[paymaster] NEXT_PUBLIC_PAYMASTER_URL / NEXT_PUBLIC_PAYMASTER_API_KEY が未設定です'
+    )
+  }
+  // TODO(impl): fetch(url, { headers: { 'x-api-key': apiKey }, ... }) で
+  //             eth_sendUserOperation を投げ、txHash を返す。
+  throw new Error('[paymaster] sendUserOpWithPaymaster: not implemented yet')
+}


### PR DESCRIPTION
## 概要
Asana タスク: P2-paymaster (ERC-20 Paymaster + 初回ガス承認 UI)

仕様原文では Paymaster は将来扱いだったが、**Q3 reframe で MVP 格上げ**。
初回 tx 前にガス額を提示 → 承認 → Paymaster 経由で送信。

## 変更ファイル
```
 .env.production.example                            |   8 ++
 .env.staging.example                               |   8 ++
 .../components/onboarding/GasFeeApprovalDialog.tsx |  82 +++++++++++++++++
 frontend/lib/wallet/paymaster.ts                   | 101 +++++++++++++++++++++
 4 files changed, 199 insertions(+)
```

## 検証 (verbatim)

### `head -50 frontend/lib/wallet/paymaster.ts`
```
// Copyright (c) Ultra AutoTrade. All rights reserved.
// Unauthorized copying or distribution is strictly prohibited.
//
// ERC-20 Paymaster client helper (Base).
//
// 仕様原文では Paymaster は将来扱いだったが、Q3 reframe で MVP 格上げ。
// ユーザの初回 tx 前にガス額(USDC)を見積もり、承認 UI を経由して
// Paymaster API へ UserOperation を投げる導線をここに集約する。
//
// TODO(privy): Privy の useSendTransaction() / EIP-4337 bundler 接続を結合する。
// TODO(viem):  viem の TransactionRequest -> UserOperation 変換を実装する。
// TODO(estim): 実 Paymaster (e.g. Pimlico / Alchemy Account Kit) の見積 RPC を結ぶ。

export type TxHash = `0x${string}`

export interface PaymasterConfig {
  url: string
  apiKey: string
}

export interface TransactionRequest {
  to: `0x${string}`
  data?: `0x${string}`
  value?: bigint
}

export interface UserOperation {
  sender: `0x${string}`
  nonce: bigint
  callData: `0x${string}`
  // 実装時に EIP-4337 の他フィールド (callGasLimit, verificationGasLimit, ...) を追加
}

// 最小の WalletClient interface (Privy / wagmi / viem いずれにも適応できるよう緩く)
export interface PaymasterWalletClient {
  account?: { address: `0x${string}` }
  sendTransaction?: (tx: TransactionRequest) => Promise<TxHash>
}

/**
 * 環境変数から Paymaster の URL / API Key を返す。
 * 値が未設定の場合は空文字を返し、呼び出し側で fallback (Paymaster 無し送信) させる。
 */
export function getPaymasterConfig(): PaymasterConfig {
  const url = process.env.NEXT_PUBLIC_PAYMASTER_URL || ''
  const apiKey = process.env.NEXT_PUBLIC_PAYMASTER_API_KEY || ''
  return { url, apiKey }
}

/**
```

### `grep -c "Paymaster" frontend/lib/wallet/paymaster.ts`
```
18
```

### `head -50 frontend/components/onboarding/GasFeeApprovalDialog.tsx`
```
// Copyright (c) Ultra AutoTrade. All rights reserved.
// Unauthorized copying or distribution is strictly prohibited.
"use client"

import * as React from "react"
import {
  Dialog,
  DialogContent,
  DialogDescription,
  DialogFooter,
  DialogHeader,
  DialogTitle,
} from "@/components/ui/dialog"
import { Button } from "@/components/ui/button"

export interface GasFeeApprovalDialogProps {
  /** ダイアログを開くかどうか */
  open: boolean
  /** USDC 建てのガス額 (例: 0.12 → "$0.12 USDC") */
  gasEstimateUsdc: number
  /** ユーザが「承認」を押したときに呼ばれる */
  onApprove: () => void
  /** ユーザが「キャンセル」を押したとき・閉じたときに呼ばれる */
  onCancel: () => void
}

/**
 * 初回 tx の前に、ガス代として消費する USDC 額を提示し、承認を取る Dialog。
 *
 * 仕様原文では Paymaster は将来扱いだったが、Q3 reframe で MVP 格上げ。
 * 初回 tx 前にこのダイアログでユーザに承認を取り、以降は自動送信させる前提。
 */
export function GasFeeApprovalDialog({
  open,
  gasEstimateUsdc,
  onApprove,
  onCancel,
}: GasFeeApprovalDialogProps): React.ReactElement {
  const formatted = gasEstimateUsdc.toLocaleString("en-US", {
    minimumFractionDigits: 2,
    maximumFractionDigits: 4,
  })

  return (
    <Dialog
      open={open}
      onOpenChange={(next) => {
        if (!next) onCancel()
      }}
    >
```

### `.env.*.example` 行追加確認 (`grep PAYMASTER`)
```
.env.staging.example:NEXT_PUBLIC_PAYMASTER_URL=https://api.paymaster.example.com/v1
.env.staging.example:NEXT_PUBLIC_PAYMASTER_API_KEY=DUMMY_REPLACE_ME
.env.production.example:NEXT_PUBLIC_PAYMASTER_URL=https://api.paymaster.example.com/v1
.env.production.example:NEXT_PUBLIC_PAYMASTER_API_KEY=DUMMY_REPLACE_ME
```

`.env.staging-new.example` は存在しなかったため、既存の `.env.staging.example` および `.env.production.example` に追記。

### `.env.staging.example` 末尾 KEY=VALUE 構文確認 (`python3` で読み込み)
```
NEXT_PUBLIC_BASE_SEPOLIA_RPC=https://base-sepolia.g.alchemy.com/v2/YOUR_KEY

# =============================================================================
# Paymaster (ERC-20 / Base) — added 2026-05-23
# 仕様原文では Paymaster は将来扱いだったが、Q3 reframe で MVP 格上げ
# 実値は別管理 (1Password / Secrets Manager)
# =============================================================================
NEXT_PUBLIC_PAYMASTER_URL=https://api.paymaster.example.com/v1
NEXT_PUBLIC_PAYMASTER_API_KEY=DUMMY_REPLACE_ME
```

## ⚠️ 依存・注意
- 依存: P1 (Privy MVP)
- Tier-S 不触 (main.py / ai_judgment_scheduler.py / aave/client.py / 過去 alembic いずれも変更なし)
- merge 禁止
- 実値の Paymaster URL/API KEY は別管理(本 PR はダミー `DUMMY_REPLACE_ME`)
- tsc skip (`head -50` 目視 + `grep -c Paymaster` で内容存在確認)
- `estimateGasInUsdc` / `sendUserOpWithPaymaster` は雛形 (TODO 含む)
- shadcn `Dialog` (`@radix-ui/react-dialog` ベース) を流用

🤖 Generated with [Claude Code](https://claude.com/claude-code)