### PR TITLE
fix(alembic): g7 down_revision を a7 に張り替え、多頭分岐解消 [Tier S]

### DIFF
--- a/backend/alembic/versions/g7h8i9j0k1l2_execution_policy_safe_default.py
+++ b/backend/alembic/versions/g7h8i9j0k1l2_execution_policy_safe_default.py
@@ -42,7 +42,13 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "g7h8i9j0k1l2"
-down_revision: Union[str, Sequence[str], None] = "f6a7b8c9d0e1"
+# 2026-05-25: down_revision を f6a7b8c9d0e1 → a7b8c9d0e1f2 に張り替え。
+# 旧設定では a7b8c9d0e1f2(execution_policy CHECK 制約)と本 migration が
+# 同一の f6a7b8c9d0e1(privy_did)を down_revision にしており、alembic heads が
+# 2 head に分岐 → `alembic upgrade head` が "Multiple head revisions" で停止していた。
+# 論理的にも CHECK 制約(a7)→ default 変更+backfill(g7)の順が自然なため、
+# g7 を a7 の後ろに付け替えて単線化する。
+down_revision: Union[str, Sequence[str], None] = "a7b8c9d0e1f2"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary

[Tier S — execution_policy 系 migration] dev VPS の `backend/alembic/versions/` で **多頭分岐**を検出、`g7h8i9j0k1l2` の `down_revision` を `f6a7b8c9d0e1` → `a7b8c9d0e1f2` に張り替えて単線化する。**本 PR は merge せず HUMAN-REVIEW で止める** ことを前提に作成。

## 真因

`a7b8c9d0e1f2`(execution_policy CHECK 制約)と `g7h8i9j0k1l2`(execution_policy default + backfill)の両方が同一の `f6a7b8c9d0e1`(privy_did)を `down_revision` にしており、双方が leaf head。

```
$ alembic heads
a7b8c9d0e1f2 (head)
g7h8i9j0k1l2 (head)
```

→ `alembic upgrade head` が `Multiple head revisions are present for given argument 'head'` で停止。CUSTOM_LIMITER 期限切れ(2026-05-15 で既に過ぎている、`backend/app/aave/risk_limiter.py:43`)後の `require_approval` 安全 default 適用が永久ブロックされる状態。

## 修正

```diff
-down_revision: Union[str, Sequence[str], None] = "f6a7b8c9d0e1"
+down_revision: Union[str, Sequence[str], None] = "a7b8c9d0e1f2"
```

論理的にも `CHECK 制約(a7)で値ドメイン固定 → default+backfill(g7)を流す` 順が自然(backfill 結果も CHECK で検証される)。

## 検証 (dev VPS の `backend/.venv` 内のみ、本番 DB 不接触)

### Before
```
$ alembic heads
a7b8c9d0e1f2 (head)
g7h8i9j0k1l2 (head)
```

### After
```
$ alembic heads
g7h8i9j0k1l2 (head)

$ alembic history | tail -3
a7b8c9d0e1f2 -> g7h8i9j0k1l2 (head), execution_policy_safe_default
f6a7b8c9d0e1 -> a7b8c9d0e1f2, add_execution_policy_check_constraint_and_default
e5f6a7b8c9d0 -> f6a7b8c9d0e1, add_privy_did_to_users

$ DATABASE_URL=postgresql://dummy:dummy@localhost/dummy \
  alembic upgrade base:head --sql
exit=0, 389 行の SQL 生成成功
```

生成 SQL の末尾 2 段(順序確認):

```sql
-- Running upgrade f6a7b8c9d0e1 -> a7b8c9d0e1f2
ALTER TABLE users DROP CONSTRAINT IF EXISTS users_execution_policy_check;
ALTER TABLE users ADD CONSTRAINT users_execution_policy_check
  CHECK (execution_policy IN ('auto_execute', 'require_approval', 'proposal_only'));

-- Running upgrade a7b8c9d0e1f2 -> g7h8i9j0k1l2
ALTER TABLE users ALTER COLUMN execution_policy SET DEFAULT 'require_approval';
UPDATE users SET execution_policy='require_approval' WHERE execution_policy='auto_execute';
```

`g7h8i9j0k1l2` の HUMAN-REVIEW ゲート (deploy 前 SELECT で `role != 'viewer'` の auto_execute 行を監査)は migration 本文側で生きている。

## Scope

- dev VPS worktree (`/opt/ultra-autotrade/main`) のソースのみ変更
- 本番 DB への適用は本 PR 範囲外 (Tier S なので HUMAN-REVIEW 経由のデプロイで別途)
- staging 反映も merge 後の通常デプロイ経路で

## Test plan

- [ ] HUMAN-REVIEW (Tier S):
  - g7 の前提 (a7 が先に流れている = users_execution_policy_check 制約が存在する) を staging で確認後、本 PR を merge
  - staging で `alembic current` が `a7b8c9d0e1f2` (または `f6a7b8c9d0e1` 以前) のとき、本 PR merge 後の `alembic upgrade head` が g7 まで一気通貫で流れることを staging で確認
  - production への適用前に `SELECT role, count(*) FROM users WHERE execution_policy='auto_execute' GROUP BY role;` を実行し、`role != 'viewer'` が出ないことを deploy ログに残す ([g7 migration の DEPLOY 必須前手順](../blob/fix/migration-g7-down-revision-a7-20260525/backend/alembic/versions/g7h8i9j0k1l2_execution_policy_safe_default.py) に準拠)

## Notes

- alembic は `backend/requirements*.txt` に未登録 (本番 Docker image 側でのインストール想定)。dev 検証のため backend/.venv に `alembic==1.18.4` を追加導入。requirements への追加は本 PR スコープ外
- g7 の backfill SQL に末尾セミコロン重複 (`;;`) が dry-run で観測 — PG は空文として無視するため動作影響なし。別 PR 候補
- 同じく open の PR #394 (chore: backtest mock 撤去) とは独立、conflict なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)