### PR TITLE
fix(frontend): hoist tslib v2 via dep + override (Tier-A, unblocks W3)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,6 +39,7 @@
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^3.4.19",
         "tailwindcss-animate": "^1.0.7",
+        "tslib": "^2.6.0",
         "viem": "^2.47.1",
         "wagmi": "^3.5.0"
       },
@@ -1788,14 +1789,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@emnapi/core/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/@emnapi/runtime": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
@@ -1807,14 +1800,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@emnapi/runtime/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -1825,14 +1810,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@emnapi/wasi-threads/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.4.0",
@@ -2507,12 +2484,6 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/@formatjs/ecma402-abstract/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/@formatjs/fast-memoize": {
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
@@ -2521,12 +2492,6 @@
       "dependencies": {
         "tslib": "^2.8.0"
       }
-    },
-    "node_modules/@formatjs/fast-memoize/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
       "version": "2.11.4",
@@ -2539,12 +2504,6 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/@formatjs/icu-messageformat-parser/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/@formatjs/icu-skeleton-parser": {
       "version": "1.8.16",
       "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
@@ -2555,12 +2514,6 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/@formatjs/icu-skeleton-parser/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/@formatjs/intl-localematcher": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.10.tgz",
@@ -2569,12 +2522,6 @@
       "dependencies": {
         "tslib": "2"
       }
-    },
-    "node_modules/@formatjs/intl-localematcher/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/@gemini-wallet/core": {
       "version": "0.3.2",
@@ -3738,12 +3685,6 @@
         "whatwg-fetch": "^3.0.0"
       }
     },
-    "node_modules/@line/liff/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
@@ -4333,12 +4274,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@metamask/sdk/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/@metamask/sdk/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -4403,12 +4338,6 @@
         "tslib": "^2.3.1"
       }
     },
-    "node_modules/@motionone/animation/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/@motionone/dom": {
       "version": "10.18.0",
       "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.18.0.tgz",
@@ -4423,12 +4352,6 @@
         "tslib": "^2.3.1"
       }
     },
-    "node_modules/@motionone/dom/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/@motionone/easing": {
       "version": "10.18.0",
       "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.18.0.tgz",
@@ -4438,12 +4361,6 @@
         "@motionone/utils": "^10.18.0",
         "tslib": "^2.3.1"
       }
-    },
-    "node_modules/@motionone/easing/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/@motionone/generators": {
       "version": "10.18.0",
@@ -4456,12 +4373,6 @@
         "tslib": "^2.3.1"
       }
     },
-    "node_modules/@motionone/generators/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/@motionone/svelte": {
       "version": "10.16.4",
       "resolved": "https://registry.npmjs.org/@motionone/svelte/-/svelte-10.16.4.tgz",
@@ -4471,12 +4382,6 @@
         "@motionone/dom": "^10.16.4",
         "tslib": "^2.3.1"
       }
-    },
-    "node_modules/@motionone/svelte/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/@motionone/types": {
       "version": "10.17.1",
@@ -4495,12 +4400,6 @@
         "tslib": "^2.3.1"
       }
     },
-    "node_modules/@motionone/utils/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/@motionone/vue": {
       "version": "10.16.4",
       "resolved": "https://registry.npmjs.org/@motionone/vue/-/vue-10.16.4.tgz",
@@ -4511,12 +4410,6 @@
         "@motionone/dom": "^10.16.4",
         "tslib": "^2.3.1"
       }
-    },
-    "node_modules/@motionone/vue/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/@msgpack/msgpack": {
       "version": "3.1.2",
@@ -9770,12 +9663,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@swc/helpers/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/@tanstack/query-core": {
       "version": "5.94.5",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.94.5.tgz",
@@ -9839,14 +9726,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@tybys/wasm-util/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
@@ -11926,12 +11805,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/aria-hidden/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -12148,12 +12021,6 @@
       "dependencies": {
         "tslib": "^2.0.0"
       }
-    },
-    "node_modules/async-mutex/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -14687,12 +14554,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "node_modules/ethers/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD"
-    },
     "node_modules/ethers/node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
@@ -15675,12 +15536,6 @@
         "@formatjs/icu-messageformat-parser": "2.11.4",
         "tslib": "^2.8.0"
       }
-    },
-    "node_modules/intl-messageformat/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
@@ -18330,18 +18185,6 @@
         }
       }
     },
-    "node_modules/react-remove-scroll-bar/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
-    "node_modules/react-remove-scroll/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/react-smooth": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
@@ -18378,12 +18221,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/react-style-singleton/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
@@ -18765,12 +18602,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/rpc-websockets/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/rpc-websockets/node_modules/utf-8-validate": {
       "version": "6.0.6",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
@@ -18851,13 +18682,6 @@
       "dependencies": {
         "tslib": "^2.1.0"
       }
-    },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -20062,9 +19886,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -20547,12 +20371,6 @@
         }
       }
     },
-    "node_modules/use-callback-ref/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/use-intl": {
       "version": "3.26.5",
       "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-3.26.5.tgz",
@@ -20587,12 +20405,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/use-sidecar/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/use-sync-external-store": {
       "version": "1.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^3.4.19",
     "tailwindcss-animate": "^1.0.7",
+    "tslib": "^2.6.0",
     "viem": "^2.47.1",
     "wagmi": "^3.5.0"
   },
@@ -67,6 +68,7 @@
     "picomatch": "^4.0.4",
     "lodash": "^4.18.0",
     "serialize-javascript": "^7.0.3",
-    "axios": "^1.15.0"
+    "axios": "^1.15.0",
+    "tslib": "^2.6.0"
   }
 }


### PR DESCRIPTION
## Summary
- Tier-A Asana ブロッカー: E2E Smoke 全件 fail の真因 = `tslib@1.14.1` hoist 問題
- `package.json` の `dependencies` と `overrides` 両方に `tslib: ^2.6.0` を追加し、top-level に **v2 を強制 hoist**

## Root cause
- 旧 `@line/liff` の pin で legacy v1.14.1 が node_modules root に居座っていた
- だが `@line/liff@2.28.0` 自身も 40+ の `@liff/*` sub-deps も全て `tslib ^2.3.0` を要求
- v1 hoist → TypeScript helper resolve 不整合 → E2E Smoke が落ちる連鎖

## Fix
```diff
   "dependencies": {
+    "tslib": "^2.6.0",
     ...
   },
   "overrides": {
+    "tslib": "^2.6.0",
     ...
   }
```

`overrides` は npm 8.3+ の機能で **全 sub-tree を強制的に置換**。dependencies の追加で top-level hoist が確実。

## Verified locally
- `npm install --legacy-peer-deps` → exit 0
- `node_modules/tslib/package.json` → `"version": "2.8.1"` (1.14.1 から更新)
- `npm ls tslib` invalid 件数: **84 → 1** (残り 1 は `@walletconnect/ethereum-provider` 自体のバージョン警告、tslib 無関係)
- `npx tsc --noEmit` → exit 0、エラー 0 件

## Why this unblocks W3
W3 frontend 機能 PR (W3-22 / W3-23 / W3-24 等) は TypeScript build がパスすることを前提とする。本 PR の merge 後、それらの PR の検証が成立する。

## Test plan
- [ ] Reviewer: `npm ci` または `npm install --legacy-peer-deps` 後、`cat frontend/node_modules/tslib/package.json | grep version` で 2.x を確認
- [ ] Reviewer: `cd frontend && npx tsc --noEmit` がパス
- [ ] (任意) E2E Smoke 走らせて落ち着いたか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)