### PR TITLE
chore(backend): alembic を requirements に追加 + g7 backfill SQL ;; 修正 [Tier B]

### DIFF
--- a/backend/alembic/versions/g7h8i9j0k1l2_execution_policy_safe_default.py
+++ b/backend/alembic/versions/g7h8i9j0k1l2_execution_policy_safe_default.py
@@ -67,9 +67,12 @@ def upgrade() -> None:
         existing_nullable=False,
     )
     # Backfill: 全 auto_execute 行を安全側 (require_approval) に倒す (role 限定なし)
+    # NOTE: ステートメント末尾の `;` は文字列内に書かない (alembic が `--sql` 出力で
+    # 自動的に `;` を付けるため、文字列に含めると `;;` の重複が出る — 動作影響なしだが
+    # 見栄え悪)。
     op.execute(
         "UPDATE users SET execution_policy='require_approval' "
-        "WHERE execution_policy='auto_execute';"
+        "WHERE execution_policy='auto_execute'"
     )
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,6 +15,7 @@ python-dotenv>=1.0.0
 
 # Authentication & Database (Phase 12)
 sqlalchemy>=2.0.0
+alembic>=1.13.0    # SQLAlchemy 2.0 互換。本番 deploy 時の `alembic upgrade head` および dev での migration 操作に必要
 bcrypt>=4.1.0
 PyJWT[crypto]>=2.9.0    # [crypto] extra で cryptography (RS256/ES256 等) を有効化 — Privy ID Token 検証に必要
 pydantic[email]>=2.0.0


### PR DESCRIPTION
## Summary

[Tier B cleanup — PR #398 検証時に判明した副次発見 1+2 の bundle]

1. `alembic>=1.13.0` を `backend/requirements.txt` に追加(本番では Docker image 焼き込みで動いていたが dev には宣言が無く、毎回個別 install 必要だった)
2. `g7h8i9j0k1l2` の backfill SQL 末尾 `;;` を `;` に修正(`op.execute()` の文字列内末尾 `;` が alembic 自動付与の `;` と重複)

副次発見 3(`CUSTOM_LIMITER_EXPIRES_ON=2026-05-15` 期限切れ)は env 編集が Tier S のため本 PR スコープ外。人間が本番 env から別途削除する想定。`backend/app/aave/risk_limiter.py:118-131` の自動 strict revert が機能しているため未削除でも動作影響なし。

## 検証 (dev VPS の `backend/.venv` 内のみ、本番 DB 不接触)

multi-head のまま(本 PR は #398 とは独立、merge 順不問)なので `--sql` は明示 revision 範囲指定で g7 単独を dry-run:

```
$ DATABASE_URL=postgresql://dummy:dummy@localhost/dummy \
  alembic upgrade f6a7b8c9d0e1:g7h8i9j0k1l2 --sql
ALTER TABLE users ALTER COLUMN execution_policy SET DEFAULT 'require_approval';

UPDATE users SET execution_policy='require_approval' WHERE execution_policy='auto_execute';
```

`;;` → `;` に正常化を確認。

## Diff (該当行のみ)

### `backend/requirements.txt`
```diff
 # Authentication & Database (Phase 12)
 sqlalchemy>=2.0.0
+alembic>=1.13.0    # SQLAlchemy 2.0 互換。本番 deploy 時の `alembic upgrade head` および dev での migration 操作に必要
 bcrypt>=4.1.0
```

### `backend/alembic/versions/g7h8i9j0k1l2_execution_policy_safe_default.py`
```diff
     # Backfill: 全 auto_execute 行を安全側 (require_approval) に倒す (role 限定なし)
+    # NOTE: ステートメント末尾の `;` は文字列内に書かない (alembic が `--sql` 出力で
+    # 自動的に `;` を付けるため、文字列に含めると `;;` の重複が出る — 動作影響なしだが
+    # 見栄え悪)。
     op.execute(
         "UPDATE users SET execution_policy='require_approval' "
-        "WHERE execution_policy='auto_execute';"
+        "WHERE execution_policy='auto_execute'"
     )
```

## 関連 PR

- PR #398 (`fix(alembic): g7 down_revision を a7 に張り替え、多頭分岐解消 [Tier S]`)
  - 本 PR と independent、textual conflict なし(触る行が違う)
  - merge 順は不問

## Test plan

- [ ] CI green(alembic 追加で wheel build 等が壊れないこと)
- [ ] merge 後の本番 deploy で `alembic upgrade head` の dry-run/実走時の出力に `;;` が消えていること
- [ ] requirements 追加で venv 再構築コストが許容範囲内であること(`alembic` は軽量、Mako + MarkupSafe を引き連れるが計 100KB 程度)

🤖 Generated with [Claude Code](https://claude.com/claude-code)