### PR TITLE
feat(legal): TosConsent model + migration (P0-14 schema)

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -23,6 +23,7 @@ from app.knowledge.models import (  # noqa: F401, E402
     KnowledgeDocument,
     KnowledgeSource,
 )
+from app.legal.models import TosConsent  # noqa: F401, E402
 from app.portfolio.models import PortfolioHistory, PortfolioSnapshot  # noqa: F401, E402
 from app.proposals.models import Proposal  # noqa: F401, E402
 from app.transactions.models import Transaction  # noqa: F401, E402

--- a/backend/alembic/versions/e1f2a3b4c5d6_add_tos_consents.py
+++ b/backend/alembic/versions/e1f2a3b4c5d6_add_tos_consents.py
@@ -1,0 +1,71 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""add_tos_consents
+
+P0-14 (ToS active consent UI + 同意ログ永続化) の DB schema。
+
+Revision ID: e1f2a3b4c5d6
+Revises: a7b8c9d0e1f2
+Create Date: 2026-05-25 00:00:00.000000
+
+注: alembic heads が a7b8c9d0e1f2 と g7h8i9j0k1l2 の 2 つに分岐している。
+本 migration は a7b8c9d0e1f2 のみを親とする。g7 との合流は別 PR で
+merge migration を作成する想定 (本 PR の責務外)。
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e1f2a3b4c5d6"
+down_revision: Union[str, Sequence[str], None] = "a7b8c9d0e1f2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create tos_consents table."""
+    op.create_table(
+        "tos_consents",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("tos_version", sa.String(length=32), nullable=False),
+        sa.Column("consent_hash", sa.String(length=64), nullable=False),
+        sa.Column(
+            "consented_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("ip", sa.String(length=45), nullable=True),
+        sa.Column("ua", sa.Text(), nullable=True),
+        sa.Column("withdrawn_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("user_id", "tos_version", name="uq_tos_consents_user_version"),
+    )
+    op.create_index(
+        "ix_tos_consents_user_id",
+        "tos_consents",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_tos_consents_user_version",
+        "tos_consents",
+        ["user_id", "tos_version"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop tos_consents table."""
+    op.drop_index("ix_tos_consents_user_version", table_name="tos_consents")
+    op.drop_index("ix_tos_consents_user_id", table_name="tos_consents")
+    op.drop_table("tos_consents")

--- a/backend/app/legal/__init__.py
+++ b/backend/app/legal/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/legal/__init__.py
+"""Legal / ToS / consent log データモデル。
+
+P0-14 (ToS active consent UI + 同意ログ永続化) の backend 永続化層。
+UI は W3-23 の別 PR、本 module は schema と pure dataclass のみ。
+"""
+
+from app.legal.models import TosConsent
+
+__all__ = ["TosConsent"]

--- a/backend/app/legal/models.py
+++ b/backend/app/legal/models.py
@@ -1,0 +1,83 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/legal/models.py
+"""ToS consent log の SQLAlchemy model (P0-14)。
+
+設計:
+- 1 ユーザ × 1 ToS version で 1 行 (unique constraint)。
+- ``consent_hash`` は同意時の ToS 全文の SHA-256 (改ざん検知 + 完全一致確認)。
+- ``ip`` / ``ua`` は legal audit 時に有用。null 可 (IP マスキング等の運用裁量)。
+- ``withdrawn_at`` が non-null なら同意撤回。撤回後は新規取引を停止する想定 (UI/policy 別レイヤ)。
+
+依存:
+- ``app.database.Base``
+- 既存 ``users`` テーブル (FK)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class TosConsent(Base):
+    """ToS 同意ログ。
+
+    Attributes:
+        id: 主キー (auto increment)。
+        user_id: ``users.id`` への FK。
+        tos_version: 同意時の ToS バージョン文字列 (例 ``"2026-05-25"``)。
+        consent_hash: ToS 全文の SHA-256 hex (64 文字)。
+        consented_at: 同意時刻 (timezone aware)。
+        ip: クライアント IP (最大 45 文字、IPv6 対応)。
+        ua: User-Agent 文字列 (Text、長くなり得るため)。
+        withdrawn_at: 撤回時刻 (null = 撤回されていない)。
+    """
+
+    __tablename__ = "tos_consents"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    tos_version: Mapped[str] = mapped_column(String(32), nullable=False)
+    consent_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    consented_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("CURRENT_TIMESTAMP"),
+    )
+    ip: Mapped[Optional[str]] = mapped_column(String(45), nullable=True)
+    ua: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    withdrawn_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "tos_version", name="uq_tos_consents_user_version"),
+        Index("ix_tos_consents_user_version", "user_id", "tos_version"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<TosConsent id={self.id} user_id={self.user_id} "
+            f"tos_version={self.tos_version!r} withdrawn={self.withdrawn_at is not None}>"
+        )

--- a/backend/tests/legal/test_models.py
+++ b/backend/tests/legal/test_models.py
@@ -1,0 +1,100 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/legal/test_models.py
+"""Tests for app.legal.models.TosConsent (P0-14 schema)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+
+from app.auth.models import User  # noqa: F401  (must be imported so users table exists)
+from app.database import Base
+from app.legal.models import TosConsent
+
+
+def _make_engine_with_minimal_users() -> tuple[Engine, int]:
+    """In-memory SQLite engine with only the columns this test needs.
+
+    The real ``users`` table has many domain-specific NOT NULL columns whose
+    requirements drift over time. To keep this schema test resilient, we use a
+    minimal mock ``users`` table (id only) and rely on the FK shape of
+    ``tos_consents`` rather than on the full User model.
+    """
+    engine = create_engine("sqlite:///:memory:", future=True)
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT)"))
+    # Create only tos_consents from the metadata (skip the full ``users`` table).
+    Base.metadata.tables["tos_consents"].create(engine)
+    # Insert a stub user row to satisfy the FK in the assertions below.
+    with engine.begin() as conn:
+        result = conn.execute(text("INSERT INTO users DEFAULT VALUES"))
+        user_id = int(result.lastrowid or 0)
+    return engine, user_id
+
+
+def test_table_metadata_present() -> None:
+    """tos_consents table is registered on the shared metadata."""
+    assert "tos_consents" in Base.metadata.tables
+    table = Base.metadata.tables["tos_consents"]
+    cols = {c.name for c in table.columns}
+    assert {
+        "id",
+        "user_id",
+        "tos_version",
+        "consent_hash",
+        "consented_at",
+        "ip",
+        "ua",
+        "withdrawn_at",
+    } <= cols
+
+
+def test_unique_constraint_user_version_present() -> None:
+    table = Base.metadata.tables["tos_consents"]
+    uc_names = {c.name for c in table.constraints if c.name}
+    assert "uq_tos_consents_user_version" in uc_names
+
+
+def test_insert_and_query_in_sqlite() -> None:
+    """Round-trip insert/query against an in-memory SQLite (no Postgres required)."""
+    engine, user_id = _make_engine_with_minimal_users()
+
+    with Session(engine) as session:
+        consent = TosConsent(
+            user_id=user_id,
+            tos_version="2026-05-25",
+            consent_hash="a" * 64,
+            consented_at=datetime(2026, 5, 25, 9, 0, tzinfo=timezone.utc),
+            ip="203.0.113.1",
+            ua="Mozilla/5.0",
+        )
+        session.add(consent)
+        session.commit()
+        session.refresh(consent)
+
+        assert consent.id is not None
+        assert consent.user_id == user_id
+        assert consent.withdrawn_at is None
+        assert "TosConsent" in repr(consent)
+
+
+def test_withdraw_flag_set_when_non_null() -> None:
+    engine, user_id = _make_engine_with_minimal_users()
+
+    with Session(engine) as session:
+        consent = TosConsent(
+            user_id=user_id,
+            tos_version="2026-05-25",
+            consent_hash="b" * 64,
+            withdrawn_at=datetime(2026, 5, 26, 9, 0, tzinfo=timezone.utc),
+        )
+        session.add(consent)
+        session.commit()
+        session.refresh(consent)
+        assert consent.withdrawn_at is not None
+        # repr exposes the withdrawn=True flag
+        assert "withdrawn=True" in repr(consent)


### PR DESCRIPTION
## Summary
- Asana **P0-14** (ToS active consent UI + 同意ログ永続化) の backend schema
- UI は W3-23 別 PR で実装。本 PR は SQLAlchemy model + alembic migration + tests のみ

## Schema
```
tos_consents (
  id            PRIMARY KEY,
  user_id       FK users.id ON DELETE CASCADE,
  tos_version   VARCHAR(32) NOT NULL,
  consent_hash  CHAR(64)   NOT NULL,    -- SHA-256 hex
  consented_at  TIMESTAMPTZ DEFAULT NOW(),
  ip            VARCHAR(45) NULL,        -- IPv6 max
  ua            TEXT NULL,
  withdrawn_at  TIMESTAMPTZ NULL,
  UNIQUE (user_id, tos_version)
)
INDEX ix_tos_consents_user_id
INDEX ix_tos_consents_user_version (user_id, tos_version)
```

## Files
- `backend/app/legal/__init__.py` + `models.py` — model
- `backend/alembic/versions/d4e5f6a7b8c9_add_tos_consents.py` — migration
- `backend/alembic/env.py` — register for autogenerate
- `backend/tests/legal/test_models.py` — 4 tests

## ⚠️ Alembic head 分岐 注意
現在 main に alembic head が 2 つ (`a7b8c9d0e1f2` と `g7h8i9j0k1l2`)。本 migration は `a7b8c9d0e1f2` を親に取る (3 head 状態になる)。merge migration の作成は **本 PR の責務外** で、g7 を所有する別 PR で対応する想定。

## Verified locally
- `ruff check / format --check`: pass
- `mypy --config-file pyproject.toml`: Success
- `pytest tests/legal/`: 4 passed (metadata 確認 + sqlite roundtrip)
- `alembic upgrade head && downgrade -1 && upgrade head` against Postgres: **deferred to reviewer DB** (sqlite では server_default `CURRENT_TIMESTAMP` の TIMESTAMPTZ が再現できないため)

## Why SHA-256 hash of ToS body?
- ToS 改訂時 (version up) と「同意した時点の本文」の **同一性検証**を可能にする
- Audit 時に「user は version X に同意した。X の本文は Y で hash は Z」が立証可能
- 文字コードや末尾 LF の違いで誤判定を防ぐため、ToS 本文の正規化手順は W3-23 (UI) と揃える

## Test plan
- [ ] Reviewer (DB): staging で `alembic upgrade head && downgrade -1 && upgrade head` round-trip 確認
- [ ] Reviewer: merge migration を別 PR で起票 (g7 head との合流)
- [ ] W3-23 (UI 側) で `consent_hash` 計算ロジックを共通化

🤖 Generated with [Claude Code](https://claude.com/claude-code)