### PR TITLE
feat(fees): SSOT constants for v10 tier values (P0-18)

### DIFF
--- a/backend/app/fees/constants.py
+++ b/backend/app/fees/constants.py
@@ -1,0 +1,52 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/fees/constants.py
+"""Fee Model v10 launch 値の Single Source Of Truth (P0-18)。
+
+`scripts/seed_fee_config_v10.py` と `docs/ops/fee_model_v10.md` の数値が
+過去ドリフトしていたため、本 module に集約する。値変更時の更新先:
+1. 本ファイル
+2. `docs/ops/fee_model_v10.md` (人間向け解説 + 数値表)
+3. `scripts/seed_fee_config_v10.py` (本 module を import すれば自動同期)
+
+設計:
+- 値は plain Python 型 (list[int], list[float], Decimal)。
+- ``Decimal`` は固定小数の比率にのみ使う (gas/expense)。
+- list は **MIDDLE / UPPER の monotonicity (tier_thresholds, yield_caps)** を満たす。
+  - tier_fee_rates は monotonic DECREASING (上位ティアほど低料率)。
+- 整合性 invariant は ``tests/fees/test_constants.py`` で機械検査。
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+#: tier 境界 (JPY)。len == 2、LOWER と MIDDLE / MIDDLE と UPPER の境界。
+#: LOWER: ~1,000,000 円、MIDDLE: 1,000,001 ~ 10,000,000 円、UPPER: 10,000,001 円~。
+TIER_THRESHOLDS_JPY: list[int] = [1_000_000, 10_000_000]
+
+#: tier ごとの月次手数料率。LOWER / MIDDLE / UPPER の順 (3 要素)。
+#: 上位ティアほど低率。Decimal ではなく float で保持しているのは fee_configs の
+#: JSONB カラムが list[float] 型のため。Decimal 化は将来検討。
+TIER_FEE_RATES: list[float] = [0.30, 0.25, 0.20]
+
+#: tier ごとの月次最大利回り cap。LOWER / MIDDLE / UPPER の順 (3 要素)。
+#: 1.8% / 2.3% / 3.0%。上位ほど高 cap (リスク許容拡大)。
+TIER_MONTHLY_YIELD_CAPS: list[float] = [0.018, 0.023, 0.030]
+
+#: アフィリエイト還元率 (固定 30%)。
+AFFILIATE_RATE: Decimal = Decimal("0.30")
+
+#: 旧 v9 経費マークアップ率 (v10 では既定 OFF)。
+EXPENSE_MARKUP_ENABLED_DEFAULT: bool = False
+EXPENSE_MARKUP_RATE_DEFAULT: Decimal = Decimal("0")
+
+
+__all__ = [
+    "TIER_THRESHOLDS_JPY",
+    "TIER_FEE_RATES",
+    "TIER_MONTHLY_YIELD_CAPS",
+    "AFFILIATE_RATE",
+    "EXPENSE_MARKUP_ENABLED_DEFAULT",
+    "EXPENSE_MARKUP_RATE_DEFAULT",
+]

--- a/backend/scripts/seed_fee_config_v10.py
+++ b/backend/scripts/seed_fee_config_v10.py
@@ -34,7 +34,6 @@ import logging
 import os
 import sys
 from datetime import datetime, timedelta, timezone
-from decimal import Decimal
 
 # backend/ をパスに追加 (seed_test_data.py と同じパターン)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -44,6 +43,14 @@ from sqlalchemy.orm import Session  # noqa: E402
 
 from app.auth.models import RISK_MODE_SUBSCRIPTION_RATES, RiskMode  # noqa: E402
 from app.database import SessionLocal  # noqa: E402
+from app.fees.constants import (  # noqa: E402
+    AFFILIATE_RATE,
+    EXPENSE_MARKUP_ENABLED_DEFAULT,
+    EXPENSE_MARKUP_RATE_DEFAULT,
+    TIER_FEE_RATES,
+    TIER_MONTHLY_YIELD_CAPS,
+    TIER_THRESHOLDS_JPY,
+)
 from app.fees.models import FeeConfigV10  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -70,16 +77,17 @@ def build_v10_default_config() -> dict[str, object]:
     """
     return {
         "config_name": V10_DEFAULT_CONFIG_NAME,
-        "tier_thresholds_jpy": [1_000_000, 10_000_000],
-        "tier_fee_rates": [0.30, 0.25, 0.20],
-        "tier_monthly_yield_caps": [0.018, 0.023, 0.030],
+        # SSOT: app.fees.constants — 値変更時は constants と docs を同期更新する
+        "tier_thresholds_jpy": list(TIER_THRESHOLDS_JPY),
+        "tier_fee_rates": list(TIER_FEE_RATES),
+        "tier_monthly_yield_caps": list(TIER_MONTHLY_YIELD_CAPS),
         "subscription_rates": {
             mode.value: float(RISK_MODE_SUBSCRIPTION_RATES[mode]) for mode in RiskMode
         },
         # → {"conservative": 0.0, "balanced": 0.003, "aggressive": 0.01}
-        "expense_markup_enabled": False,
-        "expense_markup_rate": Decimal("0"),
-        "affiliate_rate": Decimal("0.30"),
+        "expense_markup_enabled": EXPENSE_MARKUP_ENABLED_DEFAULT,
+        "expense_markup_rate": EXPENSE_MARKUP_RATE_DEFAULT,
+        "affiliate_rate": AFFILIATE_RATE,
         "is_active": True,
         "effective_from": V10_DEFAULT_EFFECTIVE_FROM,
     }

--- a/backend/tests/fees/test_constants.py
+++ b/backend/tests/fees/test_constants.py
@@ -1,0 +1,67 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/fees/test_constants.py
+"""Tests for app.fees.constants invariants and seed-script alignment (P0-18)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.fees import constants as C
+
+
+def test_three_tiers() -> None:
+    """各 list は LOWER / MIDDLE / UPPER の 3 要素を持つ。"""
+    assert len(C.TIER_THRESHOLDS_JPY) == 2, "thresholds は 3 tier の境界 2 個"
+    assert len(C.TIER_FEE_RATES) == 3, "tier_fee_rates は 3 要素"
+    assert len(C.TIER_MONTHLY_YIELD_CAPS) == 3, "tier_monthly_yield_caps は 3 要素"
+
+
+def test_thresholds_monotonic_increasing() -> None:
+    assert C.TIER_THRESHOLDS_JPY[0] < C.TIER_THRESHOLDS_JPY[1]
+
+
+def test_fee_rates_monotonic_decreasing() -> None:
+    """上位ティアほど低料率 (invariant)。"""
+    a, b, c = C.TIER_FEE_RATES
+    assert a > b > c, f"tier_fee_rates must be strictly decreasing, got [{a}, {b}, {c}]"
+
+
+def test_yield_caps_monotonic_increasing() -> None:
+    """上位ティアほど高 cap (invariant)。"""
+    a, b, c = C.TIER_MONTHLY_YIELD_CAPS
+    assert a < b < c, f"tier_monthly_yield_caps must be strictly increasing, got [{a}, {b}, {c}]"
+
+
+def test_fee_rates_in_reasonable_range() -> None:
+    for r in C.TIER_FEE_RATES:
+        assert 0.0 < r < 1.0, f"fee rate out of range: {r}"
+
+
+def test_yield_caps_in_reasonable_range() -> None:
+    for r in C.TIER_MONTHLY_YIELD_CAPS:
+        assert 0.0 < r < 0.10, f"monthly yield cap out of range (>10%): {r}"
+
+
+def test_affiliate_rate_is_decimal_and_thirty_percent() -> None:
+    assert isinstance(C.AFFILIATE_RATE, Decimal)
+    assert C.AFFILIATE_RATE == Decimal("0.30")
+
+
+def test_expense_markup_default_off() -> None:
+    assert C.EXPENSE_MARKUP_ENABLED_DEFAULT is False
+    assert C.EXPENSE_MARKUP_RATE_DEFAULT == Decimal("0")
+
+
+def test_seed_script_uses_constants() -> None:
+    """seed_fee_config_v10.py が build した dict と constants が一致する。"""
+    from scripts.seed_fee_config_v10 import build_v10_default_config
+
+    cfg = build_v10_default_config()
+
+    assert cfg["tier_thresholds_jpy"] == C.TIER_THRESHOLDS_JPY
+    assert cfg["tier_fee_rates"] == C.TIER_FEE_RATES
+    assert cfg["tier_monthly_yield_caps"] == C.TIER_MONTHLY_YIELD_CAPS
+    assert cfg["affiliate_rate"] == C.AFFILIATE_RATE
+    assert cfg["expense_markup_enabled"] == C.EXPENSE_MARKUP_ENABLED_DEFAULT
+    assert cfg["expense_markup_rate"] == C.EXPENSE_MARKUP_RATE_DEFAULT

--- a/docs/ops/fee_model_v10.md
+++ b/docs/ops/fee_model_v10.md
@@ -18,3 +18,21 @@
 - API レスポンス: UserResponse に `risk_mode_label` (computed_field) 追加、フロントは英語値→日本語化辞書を持たない
 - 関連 endpoint: `GET /auth/risk-modes` (新規、全モード一覧 + Phase + 許可状態)
 - NULL 4 ユーザーの 'conservative' 物理 UPDATE: `docs/47_users_risk_mode_migration_plan.md` (F-16 で実行)
+
+## Tier × 料率 / Yield Cap マトリクス (P0-18、launch 値)
+
+> **SSOT: `backend/app/fees/constants.py`**。値変更時は本ドキュメントと
+> `scripts/seed_fee_config_v10.py` の 3 箇所を同時更新する (前者を import するだけ
+> で後者は自動同期、本ドキュメントは手動)。整合性は `tests/fees/test_constants.py` が機械検査。
+
+| Tier | JPY 境界 | 月次料率 | 月次 yield cap |
+|---|---|---|---|
+| **LOWER** | 〜 1,000,000 | 30% | 1.8% |
+| **MIDDLE** | 1,000,001 〜 10,000,000 | 25% | 2.3% |
+| **UPPER** | 10,000,001 〜 | 20% | 3.0% |
+
+- アフィリエイト還元率: **30%** (`AFFILIATE_RATE`)
+- 経費マークアップ: 既定 **OFF** (`EXPENSE_MARKUP_ENABLED_DEFAULT=False`)
+- Invariant: `tier_fee_rates` は単調 **減少** (上位ほど低料率)、`tier_monthly_yield_caps` は単調 **増加** (上位ほど高 cap)
+
+Launch 反映手順: `docs/48_fee_config_seed_runbook.md` の 3 段プロンプトに従い `seed_fee_config_v10.py` を実行 (F-16)。


### PR DESCRIPTION
## Summary
- Asana **P0-18** (tier_monthly_yield_caps データ設定 / FeeConfigV10) の claude.ai 担当
- 既存 `scripts/seed_fee_config_v10.py` の hardcoded 値を **SSOT module に集約**
- docs/code/test の 3 経路で同じ値を参照する形にし、drift を防ぐ

## Values (launch 用、変更不要)
| Tier | JPY 境界 | 月次料率 | 月次 yield cap |
|---|---|---|---|
| LOWER | 〜 1,000,000 | 30% | 1.8% |
| MIDDLE | 1,000,001 〜 10,000,000 | 25% | 2.3% |
| UPPER | 10,000,001 〜 | 20% | 3.0% |

- アフィリエイト還元率: 30%
- 経費マークアップ: OFF

## Files
- `backend/app/fees/constants.py` — SSOT (NEW)
- `backend/scripts/seed_fee_config_v10.py` — inline 値 → constants 参照
- `docs/ops/fee_model_v10.md` — 値マトリクスを表で追記
- `backend/tests/fees/test_constants.py` — 9 invariants tests (NEW)

## Invariants (テストで機械検査)
- `tier_fee_rates` strictly **decreasing** (上位ほど低料率)
- `tier_monthly_yield_caps` strictly **increasing** (上位ほど高 cap)
- レンジ: 0 < fee rate < 1 / 0 < yield cap < 10%
- seed 出力 dict と constants が一致 (drift 検知)

## Verified locally
- ruff check / format / mypy: pass
- pytest (constants 9 + 既存 seed 18) = 27 passed

## Test plan
- [ ] Reviewer: 値の launch 妥当性確認 (P0-18 owner)
- [ ] (本番 launch 時) `docs/48_fee_config_seed_runbook.md` の 3 段プロンプトに従い F-16 で seed 実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)