### PR TITLE
feat(ops): auto-recovery scope expansion + systemd timer (B-4)

### DIFF
--- a/docs/auto_recovery_scope.md
+++ b/docs/auto_recovery_scope.md
@@ -71,6 +71,59 @@ backend 自体が死んでいる場合はこのパターンに合致しないた
 
 ---
 
+## Phase 2 拡張提案 (P0-B-4 / 2026-05-25 追記)
+
+> 「1 人プロジェクト前提の自動復旧範囲最大化」(Asana B-4) を満たすための追加スコープ案。
+> 各 AR-N は **別 PR で個別に実装**する想定 (auto_recovery.sh は本番稼働中のため小さく追加)。
+
+### AR-5 (proposed): frontend コンテナ hang → `docker restart frontend`
+
+| 項目 | 内容 |
+|------|------|
+| **検知** | frontend `/api/health` (静的) または `/` GET が 60 秒以内に応答しない、かつ container は Up |
+| **原因** | Node.js GC スパイク / hot-reload 残骸 / ファイル descriptor 枯渇 |
+| **自動アクション** | `docker restart ultra-autotrade-frontend-production` |
+| **検証** | restart 後 90 秒以内に `/` 200 |
+| **クールダウン** | 1時間に3回まで |
+| **理由** | `restart: always` は **クラッシュ**は救うが **hang** は救わない |
+
+### AR-6 (proposed): promtail / loki スタックの自動復旧
+
+| 項目 | 内容 |
+|------|------|
+| **検知** | promtail が Loki に push 失敗を 10 分連続 (Loki down) |
+| **原因** | Loki OOM、disk 枯渇、index 破損 |
+| **自動アクション** | `docker restart ultra-autotrade-loki-production` (1 回のみ) → 失敗時 HR エスカレ |
+| **検証** | promtail metrics で push 成功 |
+| **クールダウン** | 1時間に1回 (慎重) |
+
+### AR-7 (proposed): postgres replication lag (将来)
+
+| 項目 | 内容 |
+|------|------|
+| **検知** | replica lag > 60s (SCALE-B3 PostgreSQL replica 導入後) |
+| **自動アクション** | replica restart は **しない** (HR エスカレ) — data 整合性優先 |
+| **理由** | プロトタイプ段階。実装は SCALE-B3 完了後 |
+
+### Runtime 配信 (本 PR で systemd template 追加)
+
+外部 cron / systemd timer から 5 分間隔で `auto_recovery.sh --check-all` を起動する。
+
+| ファイル | 役割 |
+|---|---|
+| `infra/systemd/ultra-autotrade-auto-recovery.timer` | 5 分間隔 trigger |
+| `infra/systemd/ultra-autotrade-auto-recovery.service` | one-shot 実行 unit。default `DRY_RUN=true` (観察期間用) |
+
+**本番反映 (人間タスク)**:
+```bash
+sudo cp infra/systemd/ultra-autotrade-auto-recovery.{timer,service} /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now ultra-autotrade-auto-recovery.timer
+# 観察 1 週間後、DRY_RUN=false にする (/etc/default/ultra-autotrade-auto-recovery を作成)
+```
+
+---
+
 ## 自動復旧しない範囲 (HUMAN-REQUIRED)
 
 以下はいずれも「人間の判断が必要」または「自動アクションが状況を悪化させるリスクが高い」。

--- a/infra/systemd/ultra-autotrade-auto-recovery.service
+++ b/infra/systemd/ultra-autotrade-auto-recovery.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=Ultra AutoTrade Auto-Recovery Check (one-shot per timer firing)
+Documentation=https://github.com/milechy/ultra-autotrade-project/blob/main/docs/auto_recovery_scope.md
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+# Run as ultra user (same as docker compose). adjust if production differs.
+User=ultra
+Group=ultra
+WorkingDirectory=/opt/ultra-autotrade
+# DRY_RUN=false の本番反映は人間が後から ON-Calendar 起動を確認した後で
+# /etc/default/ultra-autotrade-auto-recovery で上書きすること。本 unit
+# テンプレ自体は DRY_RUN=true を default に保ち、観察期間を取れる設計。
+Environment=DRY_RUN=true
+EnvironmentFile=-/etc/default/ultra-autotrade-auto-recovery
+ExecStart=/usr/bin/env bash /opt/ultra-autotrade/scripts/auto_recovery.sh --check-all
+StandardOutput=append:/var/log/ultra/auto_recovery.log
+StandardError=append:/var/log/ultra/auto_recovery.log
+# auto_recovery.sh 自体が cool-down を実装しているため systemd 側 retry は最小に
+Restart=no
+TimeoutStartSec=120
+# nginx/backend/cloudflared restart 用に docker socket への書き込み権限が必要。
+# ultra ユーザを docker group に所属させること (本番反映時に systemctl で有効化前)。
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/systemd/ultra-autotrade-auto-recovery.timer
+++ b/infra/systemd/ultra-autotrade-auto-recovery.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Ultra AutoTrade Auto-Recovery Check Timer
+Documentation=https://github.com/milechy/ultra-autotrade-project/blob/main/docs/auto_recovery_scope.md
+After=docker.service
+
+[Timer]
+# Check every 5 minutes — matches existing staging-watchdog cadence
+OnBootSec=2min
+OnUnitActiveSec=5min
+AccuracySec=30s
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- Asana **B-4** (1人プロジェクト前提の自動復旧範囲最大化)
- 既存 `scripts/auto_recovery.sh` (AR-1〜AR-4 実装済) を破壊せず、scope と起動 unit のみ追加

## Changes
1. `docs/auto_recovery_scope.md` に **Phase 2 拡張提案** 節追加
   - **AR-5** (proposed): frontend hang → restart (`restart: always` では救えない hang を補完)
   - **AR-6** (proposed): promtail / loki 復旧 (logging stack)
   - **AR-7** (future): postgres replication lag (SCALE-B3 後)
2. `infra/systemd/ultra-autotrade-auto-recovery.timer` 新規 (5 分間隔)
3. `infra/systemd/ultra-autotrade-auto-recovery.service` 新規 (oneshot、`DRY_RUN=true` default)

## Why split: docs + timer in this PR, AR-5/6/7 impl 後
本番稼働中の `auto_recovery.sh` への新ロジック追加はリスク。本 PR は
**scope の合意 + 配信機構**にとどめ、各 AR 実装は別 PR で個別レビューする。

## DRY_RUN=true デフォルトの理由
配信開始直後は誤検知が出やすい。1 週間ログ観察してから `/etc/default/ultra-autotrade-auto-recovery` で `DRY_RUN=false` に切替える運用 (本 PR description に手順明記)。

## Verified
- `bash -n scripts/auto_recovery.sh`: OK (本 PR は script 自体を編集しない)
- systemd unit 構文: 人間が `systemd-analyze verify` で確認推奨

## Test plan
- [ ] Reviewer: AR-5/6/7 の scope 妥当性 (特に AR-6 Loki restart 1 回制限)
- [ ] Reviewer: systemd unit User=ultra と docker group メンバーシップ確認
- [ ] (本番反映時) `systemctl enable --now`、1 週間 DRY_RUN ログ観察 → 切替

🤖 Generated with [Claude Code](https://claude.com/claude-code)