### PR TITLE
feat(policy): Transaction Policy Engine MVP (P0-7)

### DIFF
--- a/backend/app/policy/__init__.py
+++ b/backend/app/policy/__init__.py
@@ -1,0 +1,24 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/policy/__init__.py
+"""Transaction Policy Engine (P0-7 MVP).
+
+Pre-sign rule evaluation. 純粋関数ベース、I/O なし。呼出し側が context を組み立てて
+``evaluate(...)`` に渡す。Verdict (allow / hold / deny) と理由文字列で返す。
+"""
+
+from app.policy.engine import (
+    DEFAULT_RULES,
+    PolicyDecision,
+    TransactionContext,
+    Verdict,
+    evaluate,
+)
+
+__all__ = [
+    "DEFAULT_RULES",
+    "PolicyDecision",
+    "TransactionContext",
+    "Verdict",
+    "evaluate",
+]

--- a/backend/app/policy/engine.py
+++ b/backend/app/policy/engine.py
@@ -1,0 +1,245 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/policy/engine.py
+"""Transaction Policy Engine (P0-7 MVP)。
+
+承認時 (proposal → approval) に署名前のルール検査を行う。
+Pure functions: I/O / DB アクセス / on-chain call なし。呼出し側が
+``TransactionContext`` を組み立てて ``evaluate`` に渡す。
+
+Verdict (allow / hold / deny) で返却。``hold`` は人手判断を促し
+proposal を pending のまま留め、``deny`` は明確に拒否する。
+
+設計原則 (CLAUDE.md security と整合):
+- 値は Decimal (float 禁止)
+- 危険な方向 (拒否) に倒れるべき; 不明値は hold
+- emergency_stop は OR 論理で必ず deny を返す
+
+呼出し方:
+    >>> from app.policy import TransactionContext, evaluate
+    >>> ctx = TransactionContext(...)
+    >>> decision = evaluate(ctx)
+    >>> if decision.verdict is Verdict.ALLOW: ...
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from decimal import Decimal
+from enum import Enum
+from typing import Callable, Optional
+
+
+class Verdict(str, Enum):
+    """ポリシー判定結果。"""
+
+    ALLOW = "allow"  # 全 rule pass → 署名へ進む
+    HOLD = "hold"  # 1 つ以上 rule で「人手判断が必要」 → proposal を pending に
+    DENY = "deny"  # 1 つ以上 rule で明確 violation → tx を破棄
+
+
+@dataclass(frozen=True)
+class TransactionContext:
+    """ポリシー評価対象の context。
+
+    呼出し側が DB / on-chain / env から組み立てる。Engine は dataclass の値しか見ない。
+
+    Attributes:
+        user_id: 対象 user id。
+        amount_usd: 今回の tx 金額 (USD)。
+        recipient_address: 送金先 EVM address (lowercase 0x... 想定)。
+        recipient_allowlist: 許可された recipient 集合 (lower-case)。
+        health_factor: Aave HF。HF<min_hf で hold/deny。
+        min_health_factor: HF の最小許容値 (default 1.6)。
+        daily_traded_usd: 当日累計 tx 額。
+        daily_cap_usd: 当日 cap (default 30% of total assets)。
+        single_trade_cap_usd: 単発 tx cap (default 10% of total assets)。
+        cooldown_until: 次回 tx 許可時刻 (None = cooldown 無し)。
+        now: 現在時刻 (tz aware、default: ``datetime.now(timezone.utc)``)。
+        oracle_updated_at: Aave Oracle 最新更新時刻 (tz aware)。
+        oracle_max_staleness_sec: Oracle 鮮度上限 (default 300s)。
+        emergency_stop: True なら全て deny (OR 論理)。
+    """
+
+    user_id: int
+    amount_usd: Decimal
+    recipient_address: str
+    recipient_allowlist: frozenset[str]
+    health_factor: Decimal
+    min_health_factor: Decimal = Decimal("1.6")
+    daily_traded_usd: Decimal = Decimal("0")
+    daily_cap_usd: Decimal = Decimal("0")
+    single_trade_cap_usd: Decimal = Decimal("0")
+    cooldown_until: Optional[datetime] = None
+    now: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    oracle_updated_at: Optional[datetime] = None
+    oracle_max_staleness_sec: int = 300
+    emergency_stop: bool = False
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    """Engine の評価結果。
+
+    Attributes:
+        verdict: ALLOW / HOLD / DENY。
+        reasons: 違反した rule 名と理由メッセージのリスト (allow なら空)。
+    """
+
+    verdict: Verdict
+    reasons: list[tuple[str, str]] = field(default_factory=list)
+
+    def is_allowed(self) -> bool:
+        return self.verdict is Verdict.ALLOW
+
+
+#: 1 rule = ``(ctx) -> Optional[tuple[Verdict, str]]`` の callable。
+#: None を返すと「pass」。
+Rule = Callable[[TransactionContext], Optional[tuple[Verdict, str]]]
+
+
+# ──────────────────────────────────────────────────────────────
+# 個別 rule (純粋関数)
+# ──────────────────────────────────────────────────────────────
+
+
+def rule_emergency_stop(ctx: TransactionContext) -> Optional[tuple[Verdict, str]]:
+    """emergency_stop が True なら DENY (OR 論理、最優先)。"""
+    if ctx.emergency_stop:
+        return Verdict.DENY, "emergency_stop is ON"
+    return None
+
+
+def rule_amount_positive(ctx: TransactionContext) -> Optional[tuple[Verdict, str]]:
+    """tx 金額が 0 以下なら DENY。"""
+    if ctx.amount_usd <= 0:
+        return Verdict.DENY, f"amount must be > 0 (got {ctx.amount_usd})"
+    return None
+
+
+def rule_health_factor(ctx: TransactionContext) -> Optional[tuple[Verdict, str]]:
+    """Aave HF が下限未満なら DENY (HARD_STOP 連動)。"""
+    if ctx.health_factor < ctx.min_health_factor:
+        return (
+            Verdict.DENY,
+            f"health_factor {ctx.health_factor} < min {ctx.min_health_factor}",
+        )
+    return None
+
+
+def rule_single_trade_cap(ctx: TransactionContext) -> Optional[tuple[Verdict, str]]:
+    """単発 tx が cap を超えるなら DENY。cap=0 はチェックスキップ。"""
+    if ctx.single_trade_cap_usd > 0 and ctx.amount_usd > ctx.single_trade_cap_usd:
+        return (
+            Verdict.DENY,
+            f"single_trade {ctx.amount_usd} > cap {ctx.single_trade_cap_usd}",
+        )
+    return None
+
+
+def rule_daily_cap(ctx: TransactionContext) -> Optional[tuple[Verdict, str]]:
+    """当日累計 + 今回額が cap を超えるなら DENY。cap=0 はスキップ。"""
+    if ctx.daily_cap_usd <= 0:
+        return None
+    projected = ctx.daily_traded_usd + ctx.amount_usd
+    if projected > ctx.daily_cap_usd:
+        return (
+            Verdict.DENY,
+            f"daily total {projected} > cap {ctx.daily_cap_usd}",
+        )
+    return None
+
+
+def rule_cooldown(ctx: TransactionContext) -> Optional[tuple[Verdict, str]]:
+    """cooldown_until を未過ぎていれば HOLD (DENY ではない、後続 retry 想定)。"""
+    if ctx.cooldown_until is None:
+        return None
+    if ctx.now < ctx.cooldown_until:
+        return (
+            Verdict.HOLD,
+            f"cooldown active until {ctx.cooldown_until.isoformat()}",
+        )
+    return None
+
+
+def rule_oracle_freshness(ctx: TransactionContext) -> Optional[tuple[Verdict, str]]:
+    """Oracle 最終更新が staleness を超えていれば HOLD。
+
+    未設定 (None) なら HOLD (不明=安全側)。
+    """
+    if ctx.oracle_updated_at is None:
+        return Verdict.HOLD, "oracle_updated_at is unknown"
+    age = (ctx.now - ctx.oracle_updated_at).total_seconds()
+    if age > ctx.oracle_max_staleness_sec:
+        return (
+            Verdict.HOLD,
+            f"oracle stale: {age:.0f}s > {ctx.oracle_max_staleness_sec}s",
+        )
+    return None
+
+
+def rule_recipient_allowlist(ctx: TransactionContext) -> Optional[tuple[Verdict, str]]:
+    """recipient が allowlist にあるか確認。空の allowlist はスキップ。"""
+    if not ctx.recipient_allowlist:
+        return None
+    if ctx.recipient_address.lower() not in ctx.recipient_allowlist:
+        return (
+            Verdict.DENY,
+            f"recipient {ctx.recipient_address} not in allowlist",
+        )
+    return None
+
+
+#: Default ルール順序。emergency_stop は必ず先頭。
+DEFAULT_RULES: list[Rule] = [
+    rule_emergency_stop,
+    rule_amount_positive,
+    rule_health_factor,
+    rule_single_trade_cap,
+    rule_daily_cap,
+    rule_cooldown,
+    rule_oracle_freshness,
+    rule_recipient_allowlist,
+]
+
+
+# ──────────────────────────────────────────────────────────────
+# Engine
+# ──────────────────────────────────────────────────────────────
+
+
+def evaluate(
+    ctx: TransactionContext,
+    rules: Optional[list[Rule]] = None,
+) -> PolicyDecision:
+    """全 rule を順に評価し、最終 Verdict を返す。
+
+    集約ロジック:
+    - DENY が 1 つでもあれば DENY (危険側優先、emergency_stop は最優先で短絡しない)
+    - HOLD が 1 つ以上 / DENY なし → HOLD
+    - 全て None → ALLOW
+
+    全 rule の結果を蓄積するため、複数違反を 1 度に返せる (運用ログで便利)。
+    """
+    rules = rules if rules is not None else DEFAULT_RULES
+    reasons: list[tuple[str, str]] = []
+    has_deny = False
+    has_hold = False
+
+    for rule in rules:
+        result = rule(ctx)
+        if result is None:
+            continue
+        verdict, msg = result
+        reasons.append((rule.__name__, msg))
+        if verdict is Verdict.DENY:
+            has_deny = True
+        elif verdict is Verdict.HOLD:
+            has_hold = True
+
+    if has_deny:
+        return PolicyDecision(verdict=Verdict.DENY, reasons=reasons)
+    if has_hold:
+        return PolicyDecision(verdict=Verdict.HOLD, reasons=reasons)
+    return PolicyDecision(verdict=Verdict.ALLOW, reasons=[])

--- a/backend/tests/policy/test_engine.py
+++ b/backend/tests/policy/test_engine.py
@@ -1,0 +1,401 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/policy/test_engine.py
+"""Tests for `app.policy.engine` (P0-7 MVP).
+
+純粋関数の Policy Engine の rule 単位 + evaluate 集約挙動を網羅。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from app.policy import (
+    DEFAULT_RULES,
+    PolicyDecision,
+    TransactionContext,
+    Verdict,
+    evaluate,
+)
+from app.policy.engine import (
+    rule_amount_positive,
+    rule_cooldown,
+    rule_daily_cap,
+    rule_emergency_stop,
+    rule_health_factor,
+    rule_oracle_freshness,
+    rule_recipient_allowlist,
+    rule_single_trade_cap,
+)
+
+_NOW = datetime(2026, 5, 25, 12, 0, 0, tzinfo=timezone.utc)
+_OK_RECIPIENT = "0xabc0000000000000000000000000000000000001"
+
+
+def _ctx(**overrides) -> TransactionContext:
+    """安全側 default を持つ context factory。
+
+    overrides を渡さなければ全 rule が pass する。
+    """
+    base = dict(
+        user_id=1,
+        amount_usd=Decimal("100"),
+        recipient_address=_OK_RECIPIENT,
+        recipient_allowlist=frozenset({_OK_RECIPIENT}),
+        health_factor=Decimal("2.0"),
+        min_health_factor=Decimal("1.6"),
+        daily_traded_usd=Decimal("0"),
+        daily_cap_usd=Decimal("1000"),
+        single_trade_cap_usd=Decimal("500"),
+        cooldown_until=None,
+        now=_NOW,
+        oracle_updated_at=_NOW - timedelta(seconds=60),
+        oracle_max_staleness_sec=300,
+        emergency_stop=False,
+    )
+    base.update(overrides)
+    return TransactionContext(**base)
+
+
+# ──────────────────────────────────────────────────────────────
+# rule 単体
+# ──────────────────────────────────────────────────────────────
+
+
+class TestRuleEmergencyStop:
+    def test_off_returns_none(self) -> None:
+        assert rule_emergency_stop(_ctx(emergency_stop=False)) is None
+
+    def test_on_returns_deny(self) -> None:
+        result = rule_emergency_stop(_ctx(emergency_stop=True))
+        assert result is not None
+        verdict, msg = result
+        assert verdict is Verdict.DENY
+        assert "emergency_stop" in msg
+
+
+class TestRuleAmountPositive:
+    def test_positive_pass(self) -> None:
+        assert rule_amount_positive(_ctx(amount_usd=Decimal("1"))) is None
+
+    def test_zero_denied(self) -> None:
+        result = rule_amount_positive(_ctx(amount_usd=Decimal("0")))
+        assert result is not None
+        assert result[0] is Verdict.DENY
+
+    def test_negative_denied(self) -> None:
+        result = rule_amount_positive(_ctx(amount_usd=Decimal("-1")))
+        assert result is not None
+        assert result[0] is Verdict.DENY
+
+
+class TestRuleHealthFactor:
+    def test_above_min_passes(self) -> None:
+        assert (
+            rule_health_factor(_ctx(health_factor=Decimal("2.0"), min_health_factor=Decimal("1.6")))
+            is None
+        )
+
+    def test_at_min_passes(self) -> None:
+        # 等値はギリギリ pass (< のみ NG)
+        assert (
+            rule_health_factor(_ctx(health_factor=Decimal("1.6"), min_health_factor=Decimal("1.6")))
+            is None
+        )
+
+    def test_below_min_denied(self) -> None:
+        result = rule_health_factor(
+            _ctx(health_factor=Decimal("1.5"), min_health_factor=Decimal("1.6"))
+        )
+        assert result is not None
+        verdict, msg = result
+        assert verdict is Verdict.DENY
+        assert "1.5" in msg and "1.6" in msg
+
+
+class TestRuleSingleTradeCap:
+    def test_zero_cap_skipped(self) -> None:
+        assert (
+            rule_single_trade_cap(
+                _ctx(amount_usd=Decimal("1000"), single_trade_cap_usd=Decimal("0"))
+            )
+            is None
+        )
+
+    def test_under_cap_passes(self) -> None:
+        assert (
+            rule_single_trade_cap(
+                _ctx(amount_usd=Decimal("499"), single_trade_cap_usd=Decimal("500"))
+            )
+            is None
+        )
+
+    def test_at_cap_passes(self) -> None:
+        assert (
+            rule_single_trade_cap(
+                _ctx(amount_usd=Decimal("500"), single_trade_cap_usd=Decimal("500"))
+            )
+            is None
+        )
+
+    def test_over_cap_denied(self) -> None:
+        result = rule_single_trade_cap(
+            _ctx(amount_usd=Decimal("501"), single_trade_cap_usd=Decimal("500"))
+        )
+        assert result is not None
+        assert result[0] is Verdict.DENY
+
+
+class TestRuleDailyCap:
+    def test_zero_cap_skipped(self) -> None:
+        assert (
+            rule_daily_cap(
+                _ctx(
+                    amount_usd=Decimal("100000"),
+                    daily_traded_usd=Decimal("100000"),
+                    daily_cap_usd=Decimal("0"),
+                )
+            )
+            is None
+        )
+
+    def test_projected_under_cap_passes(self) -> None:
+        assert (
+            rule_daily_cap(
+                _ctx(
+                    amount_usd=Decimal("100"),
+                    daily_traded_usd=Decimal("800"),
+                    daily_cap_usd=Decimal("1000"),
+                )
+            )
+            is None
+        )
+
+    def test_projected_at_cap_passes(self) -> None:
+        assert (
+            rule_daily_cap(
+                _ctx(
+                    amount_usd=Decimal("200"),
+                    daily_traded_usd=Decimal("800"),
+                    daily_cap_usd=Decimal("1000"),
+                )
+            )
+            is None
+        )
+
+    def test_projected_over_cap_denied(self) -> None:
+        result = rule_daily_cap(
+            _ctx(
+                amount_usd=Decimal("201"),
+                daily_traded_usd=Decimal("800"),
+                daily_cap_usd=Decimal("1000"),
+            )
+        )
+        assert result is not None
+        assert result[0] is Verdict.DENY
+
+
+class TestRuleCooldown:
+    def test_none_passes(self) -> None:
+        assert rule_cooldown(_ctx(cooldown_until=None)) is None
+
+    def test_past_cooldown_passes(self) -> None:
+        past = _NOW - timedelta(seconds=1)
+        assert rule_cooldown(_ctx(cooldown_until=past)) is None
+
+    def test_at_cooldown_passes(self) -> None:
+        # now == cooldown_until は OK (< のみ NG)
+        assert rule_cooldown(_ctx(cooldown_until=_NOW)) is None
+
+    def test_active_cooldown_held(self) -> None:
+        future = _NOW + timedelta(seconds=60)
+        result = rule_cooldown(_ctx(cooldown_until=future))
+        assert result is not None
+        assert result[0] is Verdict.HOLD
+
+
+class TestRuleOracleFreshness:
+    def test_unknown_held(self) -> None:
+        result = rule_oracle_freshness(_ctx(oracle_updated_at=None))
+        assert result is not None
+        assert result[0] is Verdict.HOLD
+
+    def test_fresh_passes(self) -> None:
+        fresh = _NOW - timedelta(seconds=100)
+        assert (
+            rule_oracle_freshness(_ctx(oracle_updated_at=fresh, oracle_max_staleness_sec=300))
+            is None
+        )
+
+    def test_at_threshold_passes(self) -> None:
+        at = _NOW - timedelta(seconds=300)
+        assert (
+            rule_oracle_freshness(_ctx(oracle_updated_at=at, oracle_max_staleness_sec=300)) is None
+        )
+
+    def test_stale_held(self) -> None:
+        stale = _NOW - timedelta(seconds=301)
+        result = rule_oracle_freshness(_ctx(oracle_updated_at=stale, oracle_max_staleness_sec=300))
+        assert result is not None
+        assert result[0] is Verdict.HOLD
+
+
+class TestRuleRecipientAllowlist:
+    def test_empty_allowlist_skipped(self) -> None:
+        assert (
+            rule_recipient_allowlist(
+                _ctx(
+                    recipient_address="0xdeadbeef",
+                    recipient_allowlist=frozenset(),
+                )
+            )
+            is None
+        )
+
+    def test_in_allowlist_passes(self) -> None:
+        assert (
+            rule_recipient_allowlist(
+                _ctx(
+                    recipient_address=_OK_RECIPIENT,
+                    recipient_allowlist=frozenset({_OK_RECIPIENT}),
+                )
+            )
+            is None
+        )
+
+    def test_case_insensitive_match(self) -> None:
+        # ctx 側に upper-case で来ても allowlist (lower) と一致する
+        assert (
+            rule_recipient_allowlist(
+                _ctx(
+                    recipient_address=_OK_RECIPIENT.upper(),
+                    recipient_allowlist=frozenset({_OK_RECIPIENT}),
+                )
+            )
+            is None
+        )
+
+    def test_not_in_allowlist_denied(self) -> None:
+        result = rule_recipient_allowlist(
+            _ctx(
+                recipient_address="0xbad0000000000000000000000000000000000002",
+                recipient_allowlist=frozenset({_OK_RECIPIENT}),
+            )
+        )
+        assert result is not None
+        assert result[0] is Verdict.DENY
+
+
+# ──────────────────────────────────────────────────────────────
+# evaluate 集約
+# ──────────────────────────────────────────────────────────────
+
+
+class TestEvaluate:
+    def test_all_pass_allows(self) -> None:
+        decision = evaluate(_ctx())
+        assert isinstance(decision, PolicyDecision)
+        assert decision.verdict is Verdict.ALLOW
+        assert decision.reasons == []
+        assert decision.is_allowed() is True
+
+    def test_single_deny_denies(self) -> None:
+        decision = evaluate(_ctx(amount_usd=Decimal("0")))
+        assert decision.verdict is Verdict.DENY
+        assert decision.is_allowed() is False
+        assert any(name == "rule_amount_positive" for name, _ in decision.reasons)
+
+    def test_single_hold_holds(self) -> None:
+        future = _NOW + timedelta(seconds=60)
+        decision = evaluate(_ctx(cooldown_until=future))
+        assert decision.verdict is Verdict.HOLD
+        assert any(name == "rule_cooldown" for name, _ in decision.reasons)
+
+    def test_deny_overrides_hold(self) -> None:
+        # HOLD (cooldown) と DENY (amount<=0) が同居 → DENY 採用
+        future = _NOW + timedelta(seconds=60)
+        decision = evaluate(_ctx(amount_usd=Decimal("0"), cooldown_until=future))
+        assert decision.verdict is Verdict.DENY
+        # reasons には両方蓄積される (運用ログ用)
+        rule_names = {name for name, _ in decision.reasons}
+        assert "rule_amount_positive" in rule_names
+        assert "rule_cooldown" in rule_names
+
+    def test_emergency_stop_denies(self) -> None:
+        # 他は全部 pass でも emergency_stop だけで DENY
+        decision = evaluate(_ctx(emergency_stop=True))
+        assert decision.verdict is Verdict.DENY
+        assert decision.reasons[0][0] == "rule_emergency_stop"
+
+    def test_multiple_denies_all_recorded(self) -> None:
+        decision = evaluate(
+            _ctx(
+                amount_usd=Decimal("0"),
+                health_factor=Decimal("1.0"),
+                emergency_stop=True,
+            )
+        )
+        assert decision.verdict is Verdict.DENY
+        names = {name for name, _ in decision.reasons}
+        # 全 3 rule が違反として記録されている
+        assert "rule_emergency_stop" in names
+        assert "rule_amount_positive" in names
+        assert "rule_health_factor" in names
+
+    def test_custom_rules_override_default(self) -> None:
+        def always_hold(_ctx):
+            return Verdict.HOLD, "manual hold"
+
+        decision = evaluate(_ctx(), rules=[always_hold])
+        assert decision.verdict is Verdict.HOLD
+        assert decision.reasons == [("always_hold", "manual hold")]
+
+    def test_empty_rules_allows(self) -> None:
+        # rule リストが空なら必ず ALLOW (engine の仕様)
+        decision = evaluate(_ctx(emergency_stop=True), rules=[])
+        assert decision.verdict is Verdict.ALLOW
+
+    def test_default_rules_includes_emergency_stop_first(self) -> None:
+        # rule の登録順保証 (運用上 emergency_stop は最優先記録)
+        assert DEFAULT_RULES[0] is rule_emergency_stop
+
+
+# ──────────────────────────────────────────────────────────────
+# 不正値 / 境界
+# ──────────────────────────────────────────────────────────────
+
+
+class TestEdgeCases:
+    def test_decimal_precision_preserved(self) -> None:
+        # float 混入バグ検出: 0.1+0.2 != 0.3 を Decimal で扱えるか
+        ctx = _ctx(
+            amount_usd=Decimal("0.1"),
+            daily_traded_usd=Decimal("0.2"),
+            daily_cap_usd=Decimal("0.3"),
+        )
+        decision = evaluate(ctx)
+        assert decision.verdict is Verdict.ALLOW
+
+    def test_decimal_precision_over_cap(self) -> None:
+        ctx = _ctx(
+            amount_usd=Decimal("0.10001"),
+            daily_traded_usd=Decimal("0.2"),
+            daily_cap_usd=Decimal("0.3"),
+        )
+        decision = evaluate(ctx)
+        assert decision.verdict is Verdict.DENY
+
+    @pytest.mark.parametrize(
+        "hf,minhf,expected",
+        [
+            (Decimal("1.60"), Decimal("1.6"), Verdict.ALLOW),
+            (Decimal("1.60001"), Decimal("1.6"), Verdict.ALLOW),
+            (Decimal("1.59999"), Decimal("1.6"), Verdict.DENY),
+        ],
+    )
+    def test_hf_boundary(self, hf: Decimal, minhf: Decimal, expected: Verdict) -> None:
+        decision = evaluate(_ctx(health_factor=hf, min_health_factor=minhf))
+        assert decision.verdict is expected


### PR DESCRIPTION
## Summary

Asana **P0-7** — 承認時 (proposal → approval) に署名前のルール検査を行う Transaction Policy Engine を追加。pure functions ベース、I/O / DB / on-chain call なし。

### Verdict
- `ALLOW` — 全 rule pass → 署名へ進む
- `HOLD` — 1 つ以上 rule で「人手判断が必要」 → proposal を pending に維持
- `DENY` — 1 つ以上 rule で明確 violation → tx 破棄

集約は「DENY 優先 → HOLD → ALLOW」。複数違反は `reasons` に全蓄積 (運用ログ用)。

### 実装 rule (8 本)

| Rule | Verdict | 備考 |
|---|---|---|
| `rule_emergency_stop` | DENY | OR 論理、最優先 (security rule #6) |
| `rule_amount_positive` | DENY | amount ≤ 0 |
| `rule_health_factor` | DENY | HF < min_hf (HARD_STOP 連動、rule #2) |
| `rule_single_trade_cap` | DENY | cap=0 はスキップ (rule #3) |
| `rule_daily_cap` | DENY | 累計+今回 > cap (rule #4) |
| `rule_cooldown` | HOLD | 期限未過ぎ、retry 想定 (rule #5) |
| `rule_oracle_freshness` | HOLD | unknown / stale → 安全側 |
| `rule_recipient_allowlist` | DENY | lower-case 比較、空 allowlist はスキップ |

### Security 整合 (CLAUDE.md ABSOLUTE)
- Decimal 統一 (float 禁止、rule #11) — `0.1+0.2 ≠ 0.3` 回避テスト含む
- 不明値は HOLD (危険側に倒れる)
- emergency_stop は短絡せず必ず reasons に記録

## Test plan

- [x] pytest tests/policy/test_engine.py → **42 passed**, 0.23s
- [x] ruff check app/policy tests/policy → All checks passed
- [x] ruff format --check → 4 files clean
- [x] mypy app/policy → no issues
- [x] rule 単体テスト (各 rule の境界 / 等値 / skip 条件)
- [x] evaluate 集約テスト (DENY > HOLD > ALLOW、複数違反、custom rules)
- [x] Decimal 境界テスト (HF パラメトリック、cap 0.1+0.2)
- [ ] 呼出し側 (proposal → approval 配線) は別 PR

## Files

- `backend/app/policy/__init__.py` — public API
- `backend/app/policy/engine.py` — Verdict / TransactionContext / PolicyDecision / 8 rules / evaluate
- `backend/tests/policy/__init__.py`
- `backend/tests/policy/test_engine.py` — 42 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)