### PR TITLE
feat(notification): LINE_MIN_SEVERITY env で AI proposal を LINE 配信可能化 (Tier A)

### DIFF
--- a/backend/app/notifications/config.py
+++ b/backend/app/notifications/config.py
@@ -166,9 +166,7 @@ def load_notification_settings() -> NotificationSettings:
     channel_str = os.getenv("NOTIFICATION_CHANNEL")
     line_channel_access_token = os.getenv("LINE_CHANNEL_ACCESS_TOKEN") or ""
     line_user_id = os.getenv("LINE_USER_ID") or ""
-    line_min_severity = _parse_severity(
-        os.getenv("LINE_MIN_SEVERITY"), NotificationSeverity.ALERT
-    )
+    line_min_severity = _parse_severity(os.getenv("LINE_MIN_SEVERITY"), NotificationSeverity.ALERT)
     # Twilio
     twilio_account_sid = os.getenv("TWILIO_ACCOUNT_SID") or None
     twilio_auth_token = os.getenv("TWILIO_AUTH_TOKEN") or None

--- a/backend/app/notifications/config.py
+++ b/backend/app/notifications/config.py
@@ -15,6 +15,10 @@
         - LINE: LINE Notify
         - SLACK: Slack Webhook
         - ALL: 全チャンネル
+    LINE_MIN_SEVERITY: LINENotificationSender の送信下限 severity
+        (info / warning / alert / emergency, デフォルト: alert)
+        UAT で AI proposal (severity=warning) を LINE 配信したい場合は
+        本番 .env に LINE_MIN_SEVERITY=warning を設定する。
     TWILIO_ACCOUNT_SID: Twilio Account SID (AC...)
     TWILIO_AUTH_TOKEN: Twilio Auth Token（ログ出力厳禁）
     TWILIO_FROM_NUMBER: Twilio 発信元電話番号 (+1...)
@@ -29,11 +33,14 @@ Phase 6 で導入。Twilio / エスカレーション設定は本 PR で追加�
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass
 from typing import Optional
 
-from .schemas import NotificationChannel
+from .schemas import NotificationChannel, NotificationSeverity
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -49,6 +56,8 @@ class NotificationSettings:
     default_channel: NotificationChannel = NotificationChannel.INTERNAL_LOG
     line_channel_access_token: str = ""
     line_user_id: str = ""
+    # LINE Messaging API 送信下限 severity (デフォルト ALERT で従来挙動を維持)
+    line_min_severity: NotificationSeverity = NotificationSeverity.ALERT
     # Twilio オンコール設定
     twilio_account_sid: Optional[str] = None
     twilio_auth_token: Optional[str] = None
@@ -116,6 +125,30 @@ def _parse_notification_channel(value: Optional[str]) -> NotificationChannel:
         return NotificationChannel.INTERNAL_LOG
 
 
+def _parse_severity(value: Optional[str], default: NotificationSeverity) -> NotificationSeverity:
+    """
+    文字列から NotificationSeverity を解析する。
+
+    Args:
+        value: severity 名（大文字小文字不問）
+        default: 不正値・未指定時のフォールバック
+
+    Returns:
+        NotificationSeverity: 解析結果（不正な場合は default）
+    """
+    if not value:
+        return default
+    try:
+        return NotificationSeverity(value.lower())
+    except ValueError:
+        logger.warning(
+            "LINE_MIN_SEVERITY: 不正な値 %r。default=%s を使用します。",
+            value,
+            default.value,
+        )
+        return default
+
+
 def load_notification_settings() -> NotificationSettings:
     """
     環境変数から通知設定を読み込む。
@@ -126,12 +159,16 @@ def load_notification_settings() -> NotificationSettings:
     Note:
         - トークン/URL が空文字の場合は None として扱う
         - 無効なチャンネル名の場合は INTERNAL_LOG がデフォルト
+        - LINE_MIN_SEVERITY が未設定・不正値の場合は ALERT がデフォルト
     """
     line_token = os.getenv("LINE_NOTIFY_TOKEN") or None
     slack_url = os.getenv("SLACK_WEBHOOK_URL") or None
     channel_str = os.getenv("NOTIFICATION_CHANNEL")
     line_channel_access_token = os.getenv("LINE_CHANNEL_ACCESS_TOKEN") or ""
     line_user_id = os.getenv("LINE_USER_ID") or ""
+    line_min_severity = _parse_severity(
+        os.getenv("LINE_MIN_SEVERITY"), NotificationSeverity.ALERT
+    )
     # Twilio
     twilio_account_sid = os.getenv("TWILIO_ACCOUNT_SID") or None
     twilio_auth_token = os.getenv("TWILIO_AUTH_TOKEN") or None
@@ -148,6 +185,7 @@ def load_notification_settings() -> NotificationSettings:
         default_channel=_parse_notification_channel(channel_str),
         line_channel_access_token=line_channel_access_token,
         line_user_id=line_user_id,
+        line_min_severity=line_min_severity,
         twilio_account_sid=twilio_account_sid,
         twilio_auth_token=twilio_auth_token,
         twilio_from_number=twilio_from_number,

--- a/backend/app/notifications/factory.py
+++ b/backend/app/notifications/factory.py
@@ -90,6 +90,11 @@ def get_notification_service() -> CompositeNotificationService:
             line_sender = LINENotificationSender(
                 channel_access_token=settings.line_channel_access_token,
                 user_id=settings.line_user_id,
+                min_severity=settings.line_min_severity,
+            )
+            logger.info(
+                "LINENotificationSender: 設定済み (min_severity=%s)。",
+                settings.line_min_severity.value,
             )
             senders.append(line_sender)
 

--- a/backend/tests/test_notification_config.py
+++ b/backend/tests/test_notification_config.py
@@ -171,9 +171,7 @@ class TestLoadNotificationSettingsLineMinSeverity:
 
     def test_load_line_min_severity_default_alert(self):
         """LINE_MIN_SEVERITY 未設定 → ALERT (既定挙動を維持)。"""
-        env = {
-            k: v for k, v in os.environ.items() if k != "LINE_MIN_SEVERITY"
-        }
+        env = {k: v for k, v in os.environ.items() if k != "LINE_MIN_SEVERITY"}
         with patch.dict(os.environ, env, clear=True):
             settings = load_notification_settings()
             assert settings.line_min_severity == NotificationSeverity.ALERT

--- a/backend/tests/test_notification_config.py
+++ b/backend/tests/test_notification_config.py
@@ -12,11 +12,12 @@ from unittest.mock import patch
 from app.notifications.config import (
     NotificationSettings,
     _parse_notification_channel,
+    _parse_severity,
     get_notification_settings,
     load_notification_settings,
     reset_notification_settings,
 )
-from app.notifications.schemas import NotificationChannel
+from app.notifications.schemas import NotificationChannel, NotificationSeverity
 
 
 class TestParseNotificationChannel:
@@ -142,6 +143,52 @@ class TestLoadNotificationSettings:
             assert settings.line_notify_token is None
             assert settings.slack_webhook_url is None
             assert settings.default_channel == NotificationChannel.INTERNAL_LOG
+
+
+class TestParseSeverity:
+    """_parse_severity 関数のテスト (LINE_MIN_SEVERITY 用)"""
+
+    def test_parse_warning(self):
+        assert (
+            _parse_severity("warning", NotificationSeverity.ALERT) == NotificationSeverity.WARNING
+        )
+
+    def test_parse_alert_uppercase(self):
+        assert _parse_severity("ALERT", NotificationSeverity.ALERT) == NotificationSeverity.ALERT
+
+    def test_parse_none_returns_default(self):
+        assert _parse_severity(None, NotificationSeverity.ALERT) == NotificationSeverity.ALERT
+
+    def test_parse_empty_returns_default(self):
+        assert _parse_severity("", NotificationSeverity.ALERT) == NotificationSeverity.ALERT
+
+    def test_parse_invalid_returns_default(self):
+        assert _parse_severity("bogus", NotificationSeverity.ALERT) == NotificationSeverity.ALERT
+
+
+class TestLoadNotificationSettingsLineMinSeverity:
+    """LINE_MIN_SEVERITY env var の解釈テスト"""
+
+    def test_load_line_min_severity_default_alert(self):
+        """LINE_MIN_SEVERITY 未設定 → ALERT (既定挙動を維持)。"""
+        env = {
+            k: v for k, v in os.environ.items() if k != "LINE_MIN_SEVERITY"
+        }
+        with patch.dict(os.environ, env, clear=True):
+            settings = load_notification_settings()
+            assert settings.line_min_severity == NotificationSeverity.ALERT
+
+    def test_load_line_min_severity_warning_opt_in(self):
+        """LINE_MIN_SEVERITY=warning → WARNING (AI proposal opt-in)。"""
+        with patch.dict(os.environ, {"LINE_MIN_SEVERITY": "warning"}):
+            settings = load_notification_settings()
+            assert settings.line_min_severity == NotificationSeverity.WARNING
+
+    def test_load_line_min_severity_invalid_falls_back(self):
+        """不正な LINE_MIN_SEVERITY → ALERT にフォールバック。"""
+        with patch.dict(os.environ, {"LINE_MIN_SEVERITY": "loud"}):
+            settings = load_notification_settings()
+            assert settings.line_min_severity == NotificationSeverity.ALERT
 
 
 class TestGetNotificationSettings:

--- a/backend/tests/test_notifications_factory.py
+++ b/backend/tests/test_notifications_factory.py
@@ -1,0 +1,163 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/test_notifications_factory.py
+"""
+get_notification_service() ファクトリの構成テスト。
+
+LINE_MIN_SEVERITY env を LINENotificationSender に伝播することを担保し、
+AI proposal (severity=warning) を本番で LINE 配信するための opt-in
+パスがコード側で完成していることを検証する。
+
+実通知送信はしない (httpx も触らない)。
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from app.notifications import config as notif_config
+from app.notifications.factory import (
+    get_notification_service,
+    reset_notification_service,
+)
+from app.notifications.line_sender import LINENotificationSender
+from app.notifications.schemas import NotificationSeverity
+
+
+def _clean_env_patch() -> dict[str, str]:
+    """テストで触る通知系 env 以外はそのまま継承する辞書を返す。"""
+    return {
+        k: v
+        for k, v in os.environ.items()
+        if k
+        not in {
+            "LINE_NOTIFY_TOKEN",
+            "SLACK_WEBHOOK_URL",
+            "NOTIFICATION_CHANNEL",
+            "LINE_CHANNEL_ACCESS_TOKEN",
+            "LINE_USER_ID",
+            "LINE_MIN_SEVERITY",
+        }
+    }
+
+
+def _reset() -> None:
+    """サービスと設定のシングルトンキャッシュをリセット。"""
+    reset_notification_service()
+    notif_config.reset_notification_settings()
+
+
+class TestFactoryLineMinSeverityPropagation:
+    """LINE Messaging API 設定済みのとき、LINE_MIN_SEVERITY が伝播するか。"""
+
+    def _line_sender_from_service(self) -> LINENotificationSender | None:
+        svc = get_notification_service()
+        for sender in svc._senders:  # noqa: SLF001 - test inspection
+            if isinstance(sender, LINENotificationSender):
+                return sender
+        return None
+
+    def test_default_min_severity_is_alert(self) -> None:
+        """LINE_MIN_SEVERITY 未指定なら既定 ALERT を維持。"""
+        env = _clean_env_patch()
+        env["LINE_CHANNEL_ACCESS_TOKEN"] = "dummy_channel_token"
+        env["LINE_USER_ID"] = "U_dummy"
+        with patch.dict(os.environ, env, clear=True):
+            _reset()
+            try:
+                ls = self._line_sender_from_service()
+                assert ls is not None, "LINE sender should be configured"
+                assert ls._min_severity == NotificationSeverity.ALERT  # noqa: SLF001
+            finally:
+                _reset()
+
+    def test_warning_opt_in_propagates(self) -> None:
+        """LINE_MIN_SEVERITY=warning なら LINE sender も WARNING になる。"""
+        env = _clean_env_patch()
+        env["LINE_CHANNEL_ACCESS_TOKEN"] = "dummy_channel_token"
+        env["LINE_USER_ID"] = "U_dummy"
+        env["LINE_MIN_SEVERITY"] = "warning"
+        with patch.dict(os.environ, env, clear=True):
+            _reset()
+            try:
+                ls = self._line_sender_from_service()
+                assert ls is not None
+                assert ls._min_severity == NotificationSeverity.WARNING  # noqa: SLF001
+            finally:
+                _reset()
+
+    def test_no_line_sender_when_not_configured(self) -> None:
+        """LINE Messaging 未設定 (token / user_id なし) なら LINE sender は構成されない。"""
+        env = _clean_env_patch()
+        with patch.dict(os.environ, env, clear=True):
+            _reset()
+            try:
+                ls = self._line_sender_from_service()
+                assert ls is None
+            finally:
+                _reset()
+
+
+class TestFactoryNoSlackWhenWebhookUnset:
+    """SLACK_WEBHOOK_URL 未設定環境では Slack sender が組み込まれない。"""
+
+    def test_no_slack_sender_means_no_implicit_send(self) -> None:
+        from app.notifications.escalation import SlackEscalationSender
+        from app.notifications.slack_sender import SlackNotificationSender
+
+        env = _clean_env_patch()
+        with patch.dict(os.environ, env, clear=True):
+            _reset()
+            try:
+                svc = get_notification_service()
+                assert not any(
+                    isinstance(s, (SlackEscalationSender, SlackNotificationSender))
+                    for s in svc._senders  # noqa: SLF001
+                )
+            finally:
+                _reset()
+
+
+class TestLineSenderSeverityGatingForProposalLevel:
+    """ai_proposal_notification (severity=warning) と LINE sender の gating。"""
+
+    def test_proposal_warning_dropped_when_min_alert(self) -> None:
+        from app.notifications.templates import ai_proposal_notification
+
+        sender = LINENotificationSender(
+            channel_access_token="dummy_token",
+            user_id="U_dummy",
+            min_severity=NotificationSeverity.ALERT,
+        )
+        payload = ai_proposal_notification(
+            operation="BUY",
+            asset="USDC",
+            amount=100,  # type: ignore[arg-type]
+            confidence=70,
+        )
+        with patch("httpx.post") as mock_post:
+            sender.send(payload.notification_message)
+            mock_post.assert_not_called()
+
+    def test_proposal_warning_delivered_when_min_warning(self) -> None:
+        from unittest.mock import MagicMock
+
+        from app.notifications.templates import ai_proposal_notification
+
+        sender = LINENotificationSender(
+            channel_access_token="dummy_token",
+            user_id="U_dummy",
+            min_severity=NotificationSeverity.WARNING,
+        )
+        payload = ai_proposal_notification(
+            operation="BUY",
+            asset="USDC",
+            amount=100,  # type: ignore[arg-type]
+            confidence=70,
+        )
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        with patch("httpx.post", return_value=mock_response) as mock_post:
+            sender.send(payload.notification_message)
+            mock_post.assert_called_once()


### PR DESCRIPTION
## 経緯

PR #225 (2026-05-13) で proposal 作成 2 経路への通知配線は完了済み:
- `backend/app/automation/workflow.py::_create_proposal_from_judgment`
- `backend/app/automation/ai_judgment_scheduler.py::_create_proposals_for_users`

両方とも `get_notification_service().send(ai_proposal_notification(...).notification_message)` を呼んでいる。

ところが `LINENotificationSender` の `min_severity` がコンストラクタ既定値 `ALERT` でハードコードされており、`ai_proposal_notification` テンプレートの severity が `"warning"` のため **LINE 側で silent drop** される。Slack 側は SlackEscalationSender 経由で severity に関係なく送信されるので機能している。

結果: UAT 中ユーザー (山本さん) は Slack では AI 提案を受け取れるが、**LINE では受け取れない**。山本さんが LINE 主体で動いている場合、承認動線が形骸化する。

## 修正前後の挙動

### 修正前
- proposal 作成 → notification fanout
  - LoggingSender: ログ出力 (OK)
  - Slack: 送信成功 (OK)
  - LINE: severity=warning < min=ALERT で silent skip
  - DB: notification_logs に記録 (OK)

### 修正後 (default 値 / `LINE_MIN_SEVERITY` 未設定)
- 挙動完全に同じ。`min_severity` 既定値 `ALERT` を維持。

### 修正後 (本番 `.env` に `LINE_MIN_SEVERITY=warning` を設定した場合)
- proposal 作成 → notification fanout
  - LINE: severity=warning ≥ min=WARNING で **送信される**
- 他 sender 影響なし

## 変更内容

| ファイル | 変更 |
|---|---|
| `backend/app/notifications/config.py` | `NotificationSettings.line_min_severity` 追加 / `_parse_severity()` ヘルパー / `LINE_MIN_SEVERITY` env 解釈 |
| `backend/app/notifications/factory.py` | `LINENotificationSender` 構築時に `min_severity=settings.line_min_severity` を渡す |
| `backend/tests/test_notification_config.py` | `TestParseSeverity` / `TestLoadNotificationSettingsLineMinSeverity` 追加 |
| `backend/tests/test_notifications_factory.py` | **新規** factory 構成 + LINE severity gating + `ai_proposal_notification` への適用テスト |

## DoD

- [x] proposal 作成 → 通知発火 (既存配線; Slack で動作中)
- [x] 通知失敗で proposal 作成は落ちない (best-effort 既存; PR #225 でカバー済)
- [x] `LINE_MIN_SEVERITY=warning` 設定時、AI proposal warning が LINE Push に届く (新規 test で担保)
- [x] default 動作は変更なし (ALERT 維持)
- [x] dev では実通知送信しない (httpx mock のみ)

## 一切しないこと

- 本番 deploy
- merge (HUMAN-REVIEW)
- W1 schema migration (別タスクで本番確認後)
- 本番 `.env` への `LINE_MIN_SEVERITY=warning` 設定 (運用判断)
- 本番 VPS への SSH / psql / docker / curl (no-prod-vps-commands-from-dev 厳守)

## HUMAN-REVIEW

- 本番 deploy 前に小林さんが merge 判断
- 本番 `.env` に `LINE_MIN_SEVERITY=warning` を入れるかは UAT 運用方針として別途判断 (LINE 通知頻度が増えるトレードオフあり)

## 既知の懸念

- `LINE_MIN_SEVERITY=warning` を本番に入れない限り LINE には届かない (本 PR のみでは UAT 通知到達は変わらない)
- 本 PR の DoD は「opt-in 経路をコード側で完成させる」までで、本番設定変更は別タスク

## test plan

- [x] `pytest tests/test_notification_config.py tests/test_notifications_factory.py tests/automation/test_proposals_notification.py` (48 passed)
- [x] `ruff check` 該当 4 ファイル (All checks passed)
- [x] `mypy app/notifications/config.py app/notifications/factory.py` (Success: no issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)