### PR TITLE
fix(aave): Web3AaveClient.__init__ で wallet_private_key を任意化 (staging soak 100% HOLD 真因対応)

### DIFF
--- a/backend/app/aave/client.py
+++ b/backend/app/aave/client.py
@@ -387,11 +387,11 @@ class Web3AaveClient(AaveClientBase):
             raise AaveClientError("web3 package is required. Install with: pip install web3")
 
         # 後方互換: settings から rpc_url/pool_address を取得することもできる
+        # wallet_private_key は read-only ユースケース (Indicator Agent / shadow mode) のため任意化。
+        # 署名 tx (supply/withdraw) は呼出時に fail-fast する。v4 §14「backend wallet 持たない」設計と整合。
         if settings is not None:
             if not settings.rpc_url:
                 raise AaveClientError("AAVE_RPC_URL is required for Web3AaveClient")
-            if not settings.wallet_private_key:
-                raise AaveClientError("AAVE_WALLET_PRIVATE_KEY is required for Web3AaveClient")
             if not settings.pool_address:
                 raise AaveClientError("AAVE_POOL_ADDRESS is required for Web3AaveClient")
             if not settings.usdc_address:
@@ -446,23 +446,31 @@ class Web3AaveClient(AaveClientBase):
             self._w3_tx = self._w3
 
         # 後方互換: settings が渡された場合はウォレット情報を保持
+        # wallet_private_key が未設定なら self.account は設定せず、read-only クライアントとして動作。
+        # supply/withdraw は呼出時に getattr(self, "account", None) 経由で fail-fast する。
         if settings is not None:
-            try:
-                from eth_account import Account
+            self.w3 = self._w3
+            self.pool = self._pool
+            self.settings = settings
+            # トークンアドレスマップ（後方互換）
+            if settings.usdc_address:
+                self.token_addresses = {
+                    "USDC": Web3.to_checksum_address(settings.usdc_address),
+                }
+            if settings.wallet_private_key:
+                try:
+                    from eth_account import Account
 
-                self.account = Account.from_key(settings.wallet_private_key)
-                self.w3 = self._w3
-                self.pool = self._pool
-                self.settings = settings
-                # トークンアドレスマップ（後方互換）
-                if settings.usdc_address:
-                    self.token_addresses = {
-                        "USDC": Web3.to_checksum_address(settings.usdc_address),
-                    }
-            except ImportError as exc:
-                raise AaveClientError(
-                    "eth-account package is required. Install with: pip install eth-account"
-                ) from exc
+                    self.account = Account.from_key(settings.wallet_private_key)
+                except ImportError as exc:
+                    raise AaveClientError(
+                        "eth-account package is required. Install with: pip install eth-account"
+                    ) from exc
+            else:
+                logger.info(
+                    "Web3AaveClient: wallet_private_key 未設定 → read-only モードで起動 "
+                    "(supply/withdraw は呼出時に fail-fast)"
+                )
 
         logger.info(
             "Web3AaveClient 初期化完了 (pool=%s...%s)",
@@ -635,6 +643,13 @@ class Web3AaveClient(AaveClientBase):
                 "amount": str(amount),
                 "dry_run": True,
             }
+
+        # 署名 tx (非 dry_run) 経路では signer 必須。
+        # __init__ 時の wallet_private_key を任意化したため、ここで明示 fail-fast。
+        if not getattr(self, "account", None) and not private_key:
+            raise AaveClientError(
+                "AAVE_WALLET_PRIVATE_KEY (or private_key arg) is required for signed supply tx"
+            )
 
         try:
             # ERC-20 コントラクト取得
@@ -858,6 +873,13 @@ class Web3AaveClient(AaveClientBase):
                 "amount": str(amount),
                 "dry_run": True,
             }
+
+        # 署名 tx (非 dry_run) 経路では signer 必須。
+        # __init__ 時の wallet_private_key を任意化したため、ここで明示 fail-fast。
+        if not getattr(self, "account", None) and not private_key:
+            raise AaveClientError(
+                "AAVE_WALLET_PRIVATE_KEY (or private_key arg) is required for signed withdraw tx"
+            )
 
         try:
             # CRITICAL: HF check before withdrawal (docs/13_security_design.md rule 2)

--- a/backend/tests/test_aave_web3_client.py
+++ b/backend/tests/test_aave_web3_client.py
@@ -131,12 +131,67 @@ def test_missing_rpc_url_raises_error(mock_settings):
         Web3AaveClient(settings=mock_settings)
 
 
-def test_missing_wallet_private_key_raises_error(mock_settings):
-    """ウォレット秘密鍵が未設定の場合にエラーが発生すること。"""
-    mock_settings.wallet_private_key = None
+@patch("eth_account.Account")
+@patch("app.aave.client.Web3")
+def test_missing_wallet_private_key_allows_read_only_init(mock_web3, mock_account, mock_settings):
+    """wallet_private_key 未設定でも read-only モードで初期化できること (v4 §14 設計)。
 
-    with pytest.raises(AaveClientError, match="AAVE_WALLET_PRIVATE_KEY is required"):
-        Web3AaveClient(settings=mock_settings)
+    Indicator Agent / shadow mode 等の eth_call のみ経路では signer 不要。
+    署名 tx (supply/withdraw) 呼出時に fail-fast する。
+    """
+    mock_settings.wallet_private_key = None
+    mock_web3_instance = MagicMock()
+    mock_web3_instance.is_connected.return_value = True
+    mock_web3.return_value = mock_web3_instance
+    mock_web3.HTTPProvider = MagicMock()
+    mock_web3.to_checksum_address = lambda addr: addr
+
+    client = Web3AaveClient(settings=mock_settings)
+    assert not hasattr(client, "account") or client.account is None
+
+
+@patch("eth_account.Account")
+@patch("app.aave.client.Web3")
+def test_supply_without_wallet_fails_fast(mock_web3, mock_account, mock_settings):
+    """wallet 未設定の read-only クライアントで supply を呼ぶと fail-fast すること。"""
+    mock_settings.wallet_private_key = None
+    mock_web3_instance = MagicMock()
+    mock_web3_instance.is_connected.return_value = True
+    mock_web3.return_value = mock_web3_instance
+    mock_web3.HTTPProvider = MagicMock()
+    mock_web3.to_checksum_address = lambda addr: addr
+
+    client = Web3AaveClient(settings=mock_settings)
+    with pytest.raises(
+        AaveClientError, match="AAVE_WALLET_PRIVATE_KEY.*required for signed supply"
+    ):
+        client.deposit(
+            asset_address="0xba50Cd2A20f6DA35D788639E581bca8d0B5d4D5f",
+            amount=Decimal("1.0"),
+            wallet_address="0x" + "a" * 40,
+        )
+
+
+@patch("eth_account.Account")
+@patch("app.aave.client.Web3")
+def test_withdraw_without_wallet_fails_fast(mock_web3, mock_account, mock_settings):
+    """wallet 未設定の read-only クライアントで withdraw を呼ぶと fail-fast すること。"""
+    mock_settings.wallet_private_key = None
+    mock_web3_instance = MagicMock()
+    mock_web3_instance.is_connected.return_value = True
+    mock_web3.return_value = mock_web3_instance
+    mock_web3.HTTPProvider = MagicMock()
+    mock_web3.to_checksum_address = lambda addr: addr
+
+    client = Web3AaveClient(settings=mock_settings)
+    with pytest.raises(
+        AaveClientError, match="AAVE_WALLET_PRIVATE_KEY.*required for signed withdraw"
+    ):
+        client.withdraw(
+            asset_address="0xba50Cd2A20f6DA35D788639E581bca8d0B5d4D5f",
+            amount=Decimal("1.0"),
+            wallet_address="0x" + "a" * 40,
+        )
 
 
 def test_missing_pool_address_raises_error(mock_settings):


### PR DESCRIPTION
## Summary

staging soak で AI 判定が 48h 連続 100% HOLD だった真因の修正。`Web3AaveClient.__init__` で `AAVE_WALLET_PRIVATE_KEY` を必須化していたが、Indicator Agent / shadow mode 経路は eth_call (read-only) しか使わないため矛盾していた。v4 §14「backend wallet を持たない」設計とも一致しない。

## 真因チェーン (前セッション調査結果)

`Web3AaveClient.__init__` が `wallet_private_key` 未設定で `AaveClientError`
→ `get_default_aave_client()` 失敗
→ `fetch_aave_market_data_safe` が fail-open で全 None 返却 (`aave_data_fetcher.py:272-293`)
→ `MarketContext.health_factor / aave_*` が全 None
→ `indicator_agent` (`agents.py:237`) が `confidence=30` 固定
→ AND-condition 不成立 (Indicator AND Macro >= 70% で BUY/SELL)
→ 全 HOLD

## 修正

- `backend/app/aave/client.py`:
  - `__init__`: `wallet_private_key` 必須チェック削除。未設定なら `self.account` は生成せず read-only モードで起動。`rpc_url` / `pool_address` / `usdc_address` は引き続き必須
  - `deposit` / `withdraw`: 非 dry_run の署名 tx 経路で `getattr(self, "account", None)` + `private_key` 引数の有無を明示 fail-fast
- `backend/tests/test_aave_web3_client.py`:
  - `test_missing_wallet_private_key_raises_error` → `test_missing_wallet_private_key_allows_read_only_init`
  - 新規: `test_supply_without_wallet_fails_fast` / `test_withdraw_without_wallet_fails_fast`

## 関連 PR / Issue

- **本 PR は staging 復旧の片側のみ**。もう片側として `.env.staging-new` に以下キー追記が必要 (別作業):
  - `AAVE_POOL_ADDRESS=0x8bAB6d1b75f19e9eD9fCe8b9BD338844fF79aE27`
  - `AAVE_USDC_ADDRESS=0xba50Cd2A20f6DA35D788639E581bca8d0B5d4D5f`
  - (任意) `AAVE_WALLET_PRIVATE_KEY=` (testnet 専用 wallet)
- **根本対策 (Tier A, launch 後)**: `ReadOnlyAaveClient` / `SignerAaveClient` の 2 クラス分割 — 別 Asana タスクで起票予定

## Test plan

- [x] pytest tests/test_aave_web3_client.py: 23 passed (4 E2E skipped)
- [x] pytest tests/test_aave_{client,service,integration,data_fetcher}.py: 83 passed
- [x] ruff check / format: 全 pass
- [x] mypy app/aave/client.py: 全 pass
- [ ] staging soak 再開後、ai_decisions テーブルで BUY/SELL が出ること (.env 修正と併せて検証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)