### PR TITLE
fix(aave): Web3.is_connected() の二重 health check を削除 (staging soak 復旧 blocker)

### DIFF
--- a/backend/app/aave/client.py
+++ b/backend/app/aave/client.py
@@ -424,10 +424,12 @@ class Web3AaveClient(AaveClientBase):
             raise AaveClientError(
                 f"RPC に接続できません: {effective_rpc_url[:20]}..."
             ) from exc  # URLを切り詰めてログ
-        if not self._w3.is_connected():
-            raise AaveClientError(
-                f"RPC に接続できません: {effective_rpc_url[:20]}..."
-            )  # URLを切り詰めてログ
+        # NOTE: 旧コードは self._w3.is_connected() を二重 health check していたが、
+        # web3.py 7.x の Web3.is_connected() は内部で `web3_clientVersion` RPC を呼ぶ。
+        # Base Sepolia 公式 public RPC (https://sepolia.base.org) 等の一部 RPC は
+        # この method を未サポート → False 返却 → false positive で AaveClientError。
+        # RPCProvider.get_web3() 内で既に `eth.block_number` で疎通確認済みなので、
+        # 二重チェックは削除して RPCProvider を単一責任の疎通判定窓口とする。
         self._pool = self._w3.eth.contract(
             address=Web3.to_checksum_address(effective_pool_address),
             abi=_POOL_ABI_MINIMAL,

--- a/backend/tests/test_aave_client.py
+++ b/backend/tests/test_aave_client.py
@@ -10,7 +10,7 @@ docs/14_test_strategy.md §3.4:
 """
 
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -156,9 +156,17 @@ class TestWeb3AaveClient:
 
     @patch("app.aave.client.Web3")
     def test_rpc_connection_failure(self, mock_web3_cls: MagicMock) -> None:
-        """初期化時に RPC 未接続 → AaveClientError"""
+        """初期化時に RPC 未接続 → AaveClientError
+
+        接続判定は RPCProvider.get_web3() に一本化されており、内部の `_is_connected`
+        が `eth.block_number` で疎通確認する。block_number の取得が例外を投げる
+        ケースを模擬すれば primary/secondary ともに失敗扱いとなり ConnectionError
+        が伝播し、Web3AaveClient.__init__ で AaveClientError に変換される。
+        """
         mock_w3 = MagicMock()
-        mock_w3.is_connected.return_value = False
+        # RPCProvider._is_connected は eth.block_number で疎通確認するので
+        # ここを例外にすれば接続失敗扱いになる
+        type(mock_w3.eth).block_number = PropertyMock(side_effect=Exception("rpc down"))
         mock_web3_cls.return_value = mock_w3
         mock_web3_cls.HTTPProvider = MagicMock()
 

--- a/backend/tests/test_aave_web3_client.py
+++ b/backend/tests/test_aave_web3_client.py
@@ -160,15 +160,22 @@ def test_missing_usdc_address_raises_error(mock_settings):
 # ==============================================================================
 
 
+@patch("app.aave.rpc_provider.RPCProvider")
 @patch("eth_account.Account")
 @patch("app.aave.client.Web3")
-def test_web3_connection_error(mock_web3, mock_account, mock_settings):
-    """RPC 接続失敗時のエラーハンドリング。"""
-    # Web3 接続失敗をシミュレート
-    mock_web3_instance = MagicMock()
-    mock_web3_instance.is_connected.return_value = False
-    mock_web3.return_value = mock_web3_instance
+def test_web3_connection_error(mock_web3, mock_account, mock_rpc_provider_cls, mock_settings):
+    """RPC 接続失敗時のエラーハンドリング。
+
+    接続判定は RPCProvider.get_web3() に一本化されており、ConnectionError を投げる
+    ケースのみが「RPC に接続できません」エラーに繋がる。`Web3.is_connected()` は
+    web3.py 7.x で `web3_clientVersion` RPC を呼ぶ仕様となり、Base Sepolia 等の一部
+    public RPC で false positive を返すため、二段目のチェックは削除済み。
+    """
     mock_web3.HTTPProvider = MagicMock()
+
+    mock_provider_instance = MagicMock()
+    mock_provider_instance.get_web3.side_effect = ConnectionError("All RPC endpoints unavailable")
+    mock_rpc_provider_cls.return_value = mock_provider_instance
 
     with pytest.raises(AaveClientError, match="RPC に接続できません"):
         Web3AaveClient(settings=mock_settings)


### PR DESCRIPTION
## TL;DR

staging soak 復旧の **最後の blocker**。env / 公式アドレス / RPC 疎通すべて正常にもかかわらず Indicator Agent が confidence 30% 固定 → 全 HOLD だった真因。**fast-track merge 推奨**。

## 真因 (dev VPS 実機再現済み)

```
$ python3 -c \"from web3 import Web3; w3=Web3(Web3.HTTPProvider('https://sepolia.base.org')); ...\"
is_connected: False     ← 二重 health check の二段目で False 返却
block_number: 41995148  ← 正常取得
chain_id: 84532         ← 正常取得
```

`Web3.is_connected()` は web3.py 7.x で内部 `web3_clientVersion` RPC を呼ぶが、Base 公式 public RPC (https://sepolia.base.org) を含む一部 public RPC は当該 method を未サポート → False 返却 → false positive で `AaveClientError`。

## 修正

`backend/app/aave/client.py:427-430` の `is_connected()` 二重 health check 4 行を削除。

接続判定は `RPCProvider.get_web3()` (`rpc_provider.py:41-70`) に一本化:
- `_is_connected` は `eth.block_number` で疎通確認 (web3_clientVersion 非依存)
- primary/secondary 両方失敗時のみ `ConnectionError` を投げる
- client 側はこの `ConnectionError` を catch → `AaveClientError` に変換

二重チェックは設計上もアンチパターン (単一責任原則違反)。削除で RPCProvider を疎通判定の窓口に統一する。

## テスト修正

is_connected mock 前提だった既存 2 テストを RPCProvider 経路の検証に書き換え:

- `tests/test_aave_web3_client.py::test_web3_connection_error`
  - `RPCProvider.get_web3` を `ConnectionError(\"All RPC endpoints unavailable\")` で `side_effect` mock
- `tests/test_aave_client.py::test_rpc_connection_failure`
  - `mock_w3.eth.block_number` を `PropertyMock(side_effect=Exception)` で例外化 (RPCProvider 内部の `_is_connected` を間接的に False 化)

## 検証

| Gate | 結果 |
|---|---|
| pytest tests/test_aave_* (7 ファイル) | 143 passed, 4 skipped |
| pytest backend 全体 (E2E 除く) | 2955 passed, 21 skipped |
| ruff check . / ruff format --check . | 全 pass |
| mypy app/ | Success (241 files) |

## 関連

- staging soak 復旧の **最終 blocker** — fast-track merge 推奨
- PR #412 (Web3AaveClient wallet 任意化) とは独立、別ブランチで提出 (粒度が異なる + soak 復旧緊急度の違い)
- backend 全体に POA middleware (`ExtraDataToPOAMiddleware`) 未挿入の件は別件で要対応 (今回の症状とは無関係だが Base/OP Stack L2 で `extraData > 32 bytes` を返すブロックを `get_block` する経路で `ExtraDataLengthError` リスク)

## Tier 判定

**Tier B** — `backend/app/aave/client.py` は CLAUDE.md §Tier 分類の Tier S リストに無く、本変更は単一ファイル・単一 method (`__init__`) 内の局所的削除。並列レーン非対象。

ただし PR #412 (`fix/aave-client-wallet-optional-20260526`) も同じ `__init__` を編集しているため、PR #412 が後追いで merge される場合に line 番号衝突が発生する可能性あり (実体は別 section の編集なので merge tool で解決可能、ただし手動 review 推奨)。

## Test plan

- [x] dev VPS 上 unit test 全 pass
- [ ] staging deploy 後、`docker logs <staging backend-blue> 2>&1 | grep -E \"AaveClientError|Web3AaveClient 初期化\"` で AaveClientError 消滅 + 初期化完了ログ確認
- [ ] staging ai_decisions で BUY/SELL が出始めるか観測 (24-48h)

🤖 Generated with [Claude Code](https://claude.com/claude-code)