### PR TITLE
fix(logging): app.* logger に handler 配線 (basicConfig force=True)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -88,6 +88,9 @@ from app.webhook.router import router as webhook_router
 logger = logging.getLogger(__name__)
 # Ensure app.* loggers output at INFO level regardless of root logger config
 logging.getLogger("app").setLevel(logging.INFO)
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s", force=True
+)
 
 
 def _is_inactive_color_skip() -> bool:


### PR DESCRIPTION
## Summary

`backend/app/main.py:90` 直下に `logging.basicConfig(level=INFO, format=..., force=True)` を追加し、`app.*` logger の INFO ログが docker logs に出るよう handler を確立する。

## 背景

2026-05-26 staging soak 調査で確定:

```python
# backend/app/main.py:88-90 (修正前)
logger = logging.getLogger(__name__)
logging.getLogger("app").setLevel(logging.INFO)
```

`setLevel(INFO)` のみで **handler を attach していない**。uvicorn `--log-level info` は uvicorn 自身のロガーのみ設定し root logger には触らない。結果、`app.*` logger の INFO は handler 不在で **Python lastResort (stderr, threshold=WARNING)** に落ち、INFO は全 drop、WARNING+ のみ通過。

影響:
- `startup_data_feeds()` の「GeoRisk/News/Finance background task started」INFO が docker logs に一切出ない
- feed loop は実際には正常起動しているのに「未起動」と誤断する盲点が発生
- WARNING (GDELT 429, oracle stale) と ERROR (DB error) のみ可視なので正常系の動作確認ができない

## 修正

```python
logger = logging.getLogger(__name__)
logging.getLogger("app").setLevel(logging.INFO)
logging.basicConfig(
    level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s", force=True
)
```

`force=True` で既存 handler を上書きして root logger に StreamHandler を明示配線。

## Scope

- main.py 1ファイル / 3行追加のみ (最小 PR を維持)
- 本 PR は **診断盲点の解消のみ**。25% AI HOLD 固着の解消ではない (Asana タスク注意書通り)

## DoD

- [x] main.py に basicConfig(force=True) を追加
- [x] verify.sh Gate 0-7 通過 (ruff / format / mypy / pytest coverage 85.61% / security / tsc / build)
- [ ] staging で recreate 後、startup の app.* INFO が docker logs に出ることを確認 (本 PR merge 後 staging deploy 時に検証)

## Test plan

- [x] `./scripts/verify.sh` → All checks passed (722s)
- [ ] staging deploy 後に `docker logs backend-blue 2>&1 | grep -i "background task started"` で INFO 可視性を実機確認

## 関連

- Asana: https://app.asana.com/1/817733952351708/project/1213916581114014/task/1215114989698959
- 2026-05-26 staging soak 三重故障調査 (CLAUDE.lessons.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)