### PR TITLE
fix(frontend): viewer (tester) に操作 UI を非表示にする RBAC 穴 3 箇所を塞ぐ

### DIFF
--- a/frontend/app/(user)/settings/page.tsx
+++ b/frontend/app/(user)/settings/page.tsx
@@ -167,16 +167,18 @@ export default function SettingsPage() {
           />
         )}
 
-        {/* 2. リスク設定 — riskMode synced with PUT /auth/risk-mode */}
-        <RiskSettingsCard
-          riskMode={settings.riskMode}
-          onRiskModeChange={(mode) => set('riskMode', mode)}
-          maxSingleTradeUsd={settings.maxSingleTradeUsd}
-          onMaxSingleTradeUsdChange={(value) => set('maxSingleTradeUsd', value)}
-          maxDailyTradeUsd={settings.maxDailyTradeUsd}
-          onMaxDailyTradeUsdChange={(value) => set('maxDailyTradeUsd', value)}
-          allowedModes={allowedModes}
-        />
+        {/* 2. リスク設定 — admin/partner のみ表示（viewer/tester は非表示） */}
+        {isPartner && (
+          <RiskSettingsCard
+            riskMode={settings.riskMode}
+            onRiskModeChange={(mode) => set('riskMode', mode)}
+            maxSingleTradeUsd={settings.maxSingleTradeUsd}
+            onMaxSingleTradeUsdChange={(value) => set('maxSingleTradeUsd', value)}
+            maxDailyTradeUsd={settings.maxDailyTradeUsd}
+            onMaxDailyTradeUsdChange={(value) => set('maxDailyTradeUsd', value)}
+            allowedModes={allowedModes}
+          />
+        )}
 
         {/* 3. 通知設定 — synced with PUT /api/user/settings */}
         <NotificationCard
@@ -192,12 +194,14 @@ export default function SettingsPage() {
           onLanguageChange={(value) => set('language', value)}
         />
 
-        {/* 5. ウォレット情報 */}
-        <WalletInfoCard
-          address={address}
-          chainId={chainId}
-          onDisconnect={disconnect}
-        />
+        {/* 5. ウォレット情報 — admin/partner のみ表示（viewer/tester は非表示） */}
+        {isPartner && (
+          <WalletInfoCard
+            address={address}
+            chainId={chainId}
+            onDisconnect={disconnect}
+          />
+        )}
 
         {/* 6. パスワード変更 */}
         <PasswordChangeCard />

--- a/frontend/app/user/approve/page.tsx
+++ b/frontend/app/user/approve/page.tsx
@@ -95,7 +95,7 @@ type ProposalState = {
 }
 
 export default function ApprovePage() {
-  const { isAuthenticated, isLoading: authLoading } = useAuth()
+  const { isAuthenticated, isLoading: authLoading, isPartner } = useAuth()
   const router = useRouter()
   const { isConnected, chainId } = useWallet()
   const { isReady, approve: approveToken, supply, withdraw, borrow, repay } = useAaveV3()
@@ -130,12 +130,14 @@ export default function ApprovePage() {
   useEffect(() => {
     if (!authLoading && !isAuthenticated) {
       router.replace('/login?redirect=/user/approve')
+    } else if (!authLoading && isAuthenticated && !isPartner) {
+      router.replace('/user/dashboard')
     }
-  }, [authLoading, isAuthenticated, router])
+  }, [authLoading, isAuthenticated, isPartner, router])
 
   useEffect(() => {
-    if (isAuthenticated) { fetchData() }
-  }, [fetchData, isAuthenticated])
+    if (isAuthenticated && isPartner) { fetchData() }
+  }, [fetchData, isAuthenticated, isPartner])
 
   const handleApprove = useCallback(async (id: string) => {
     const proposal = proposals.find((p) => p.id === id)


### PR DESCRIPTION
## Summary

§14 ユーザーダッシュボード権限設計 (`docs/tester_onboarding_guide.md` §4-1) の
監査で発見した RBAC 抜け穴 3 件を修正。viewer/tester ロールに対し、運用に
影響する操作 UI を非表示にする。

- **穴1**: `frontend/app/user/approve/page.tsx` — role check 完全欠落。URL 直打ちで viewer が AI 提案承認/拒否ボタンに到達できた → `isPartner` で `/user/dashboard` に redirect
- **穴2**: `frontend/app/(user)/settings/page.tsx` の `RiskSettingsCard` — リスクモード/取引額が viewer にも書込可能に見えていた → `isPartner` で出し分け
- **穴3**: `frontend/app/(user)/settings/page.tsx` の `WalletInfoCard` — ウォレット切断ボタンが viewer に表示 → `isPartner` で出し分け

## §14 要件と実装の対応表 (修正後)

| 機能 | 要件 (admin/partner のみ操作可) | 実装箇所 | 状態 |
|---|---|---|---|
| AI 提案承認 | viewer 非表示 | `(user)/approve`: `isPartner` redirect / `user/approve`: **本PRで修正** | ✅ |
| 緊急停止 (FAB) | admin/partner 表示、停止解除は admin のみ | `EmergencyStopFloat` | ✅ 既存 |
| 緊急停止 (settings) | admin のみ | `(user)/settings` / `user/settings` | ✅ 既存 |
| 運用モード切替 | admin/partner のみ | `(user)/settings` `OperationModeCard` `isPartner` | ✅ 既存 |
| リスク設定書込 | admin/partner のみ | `(user)/settings` `RiskSettingsCard`: **本PRで修正** | ✅ |
| ウォレット切断 | admin/partner のみ | `(user)/settings` `WalletInfoCard`: **本PRで修正** | ✅ |
| BottomNav | viewer: ホーム/AI判定/ヘルプのみ | `BottomNav.viewerNavItems` | ✅ 既存 |

## Scope

`frontend/` のみ。`backend/agents.py` / `backend/service.py` / `backend/main.py` は無変更。

## Test plan

- [x] `tsc --noEmit` — 0 errors
- [ ] viewer ログインで `/user/approve` 直打 → `/user/dashboard` redirect 確認 (staging)
- [ ] viewer ログインで `/settings` → RiskSettingsCard・WalletInfoCard が非表示確認 (staging)
- [ ] admin/partner ログインで上記が引き続き表示・操作可能なこと確認 (staging)
- [ ] Playwright E2E `e2e/role-based-ui.spec.ts` 等の既存 spec が pass (CI)

## 関連

- 監査基準: `docs/tester_onboarding_guide.md` §4-1
- CLAUDE.md L804「admin / partner / viewer(tester) の権限分離（role === \"admin\" で操作系の表示/非表示）」

🤖 Generated with [Claude Code](https://claude.com/claude-code)