### PR TITLE
fix(ai/agents): AND-condition に fed_stance=unknown 分岐を追加 (staging soak 100% HOLD 真因対策)

### DIFF
--- a/backend/app/ai/agents.py
+++ b/backend/app/ai/agents.py
@@ -150,11 +150,22 @@ class MultiAgentContext(BaseModel):
 
         Evaluated by the Python rule engine BEFORE the LLM call so the guard is
         deterministic and cannot be overridden by the LLM's prompt interpretation.
+
+        fed_stance="unknown" branch (2026-05-26): when the FED signal is unavailable
+        (e.g. Perplexity Finance returned no usable data), the macro agent's
+        confidence floor of 25 would permanently block SELL. In that case drop the
+        macro axis from the AND requirement and qualify on Indicator alone. The
+        COMPOUND RISK guard (service.py Guard 1, evaluated before this method) is
+        the safety net that keeps SELL from running away in that mode. The
+        fed_stance="neutral" case is intentionally NOT relaxed — neutral means data
+        exists but the signal is non-directional, which is a meaningful HOLD vote.
         """
         ind = self.indicator_signal
         mac = self.macro_signal
         if ind is None or mac is None:
             return False
+        if mac.key_data.get("fed_stance") == "unknown":
+            return ind.bias == Bias.BEARISH and ind.confidence >= self._DIRECTIONAL_THRESHOLD
         return (
             ind.bias == Bias.BEARISH
             and ind.confidence >= self._DIRECTIONAL_THRESHOLD
@@ -166,11 +177,17 @@ class MultiAgentContext(BaseModel):
         """Return True only when BOTH Indicator AND Macro agents are BULLISH >= threshold.
 
         Symmetric guard to prevent single-agent BULLISH from triggering BUY.
+
+        See ``indicator_and_macro_agree_bearish`` for the fed_stance="unknown"
+        branch rationale; the same relaxation applies here so BUY is not
+        permanently blocked when FED data is unavailable.
         """
         ind = self.indicator_signal
         mac = self.macro_signal
         if ind is None or mac is None:
             return False
+        if mac.key_data.get("fed_stance") == "unknown":
+            return ind.bias == Bias.BULLISH and ind.confidence >= self._DIRECTIONAL_THRESHOLD
         return (
             ind.bias == Bias.BULLISH
             and ind.confidence >= self._DIRECTIONAL_THRESHOLD

--- a/backend/tests/test_ai_sell_and_condition.py
+++ b/backend/tests/test_ai_sell_and_condition.py
@@ -46,12 +46,14 @@ def _make_agent_signal(
     bias: Bias,
     confidence: int,
     reasoning: str = "",
+    key_data: dict[str, object] | None = None,
 ) -> AgentSignal:
     return AgentSignal(
         agent_name=name,
         bias=bias,
         confidence=confidence,
         reasoning=reasoning or f"{bias.value} signal",
+        key_data=key_data or {},
     )
 
 
@@ -190,6 +192,133 @@ class TestIndicatorAndMacroAgreeBullish:
             macro_signal=_make_agent_signal("Macro", Bias.BEARISH, 75),
         )
         assert mac.indicator_and_macro_agree_bullish() is False
+
+
+class TestFedStanceUnknownBranch:
+    """fed_stance="unknown" relaxes the AND-condition to Indicator-only (2026-05-26).
+
+    Rationale: when FED data is unavailable (Perplexity Finance returned no
+    parseable data → fed_stance="unknown"), the macro agent's confidence is
+    pinned at the floor of 25 and AND-condition is permanently false. That made
+    staging soak emit 100% HOLD for 48h+. The fix drops the macro axis from the
+    AND requirement specifically when fed_stance="unknown"; the COMPOUND RISK
+    guard (service.py Guard 1) remains the safety net upstream.
+
+    fed_stance="neutral" is NOT relaxed — neutral is a real, non-directional
+    macro vote.
+    """
+
+    def test_unknown_with_indicator_bearish_only_returns_true(self) -> None:
+        """fed_stance=unknown + Indicator BEARISH>=70 + Macro NEUTRAL → True."""
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.BEARISH, 75),
+            macro_signal=_make_agent_signal(
+                "Macro",
+                Bias.NEUTRAL,
+                25,
+                key_data={"fed_stance": "unknown"},
+            ),
+        )
+        assert mac.indicator_and_macro_agree_bearish() is True
+
+    def test_unknown_with_indicator_bullish_only_returns_true(self) -> None:
+        """fed_stance=unknown + Indicator BULLISH>=70 + Macro NEUTRAL → True."""
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.BULLISH, 75),
+            macro_signal=_make_agent_signal(
+                "Macro",
+                Bias.NEUTRAL,
+                25,
+                key_data={"fed_stance": "unknown"},
+            ),
+        )
+        assert mac.indicator_and_macro_agree_bullish() is True
+
+    def test_unknown_ignores_opposite_macro_bias(self) -> None:
+        """Under fed_stance=unknown, macro bias direction is disregarded entirely."""
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.BEARISH, 80),
+            macro_signal=_make_agent_signal(
+                "Macro",
+                Bias.BULLISH,
+                75,
+                key_data={"fed_stance": "unknown"},
+            ),
+        )
+        assert mac.indicator_and_macro_agree_bearish() is True
+
+    def test_unknown_still_requires_indicator_threshold(self) -> None:
+        """Even under fed_stance=unknown, Indicator confidence must be >=70."""
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.BEARISH, 65),
+            macro_signal=_make_agent_signal(
+                "Macro",
+                Bias.NEUTRAL,
+                25,
+                key_data={"fed_stance": "unknown"},
+            ),
+        )
+        assert mac.indicator_and_macro_agree_bearish() is False
+
+    def test_unknown_still_requires_indicator_directional(self) -> None:
+        """Under fed_stance=unknown, NEUTRAL indicator does not qualify."""
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.NEUTRAL, 80),
+            macro_signal=_make_agent_signal(
+                "Macro",
+                Bias.NEUTRAL,
+                25,
+                key_data={"fed_stance": "unknown"},
+            ),
+        )
+        assert mac.indicator_and_macro_agree_bearish() is False
+        assert mac.indicator_and_macro_agree_bullish() is False
+
+    def test_neutral_fed_stance_NOT_relaxed_bearish(self) -> None:
+        """fed_stance=neutral is intentionally NOT relaxed — macro must still co-sign."""
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.BEARISH, 80),
+            macro_signal=_make_agent_signal(
+                "Macro",
+                Bias.NEUTRAL,
+                25,
+                key_data={"fed_stance": "neutral"},
+            ),
+        )
+        assert mac.indicator_and_macro_agree_bearish() is False
+
+    def test_neutral_fed_stance_NOT_relaxed_bullish(self) -> None:
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.BULLISH, 80),
+            macro_signal=_make_agent_signal(
+                "Macro",
+                Bias.NEUTRAL,
+                25,
+                key_data={"fed_stance": "neutral"},
+            ),
+        )
+        assert mac.indicator_and_macro_agree_bullish() is False
+
+    def test_dovish_fed_stance_NOT_relaxed_when_indicator_disagrees(self) -> None:
+        """Sanity: with a real macro signal (dovish), the AND requirement still holds."""
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.BEARISH, 80),
+            macro_signal=_make_agent_signal(
+                "Macro",
+                Bias.BULLISH,
+                75,
+                key_data={"fed_stance": "dovish"},
+            ),
+        )
+        assert mac.indicator_and_macro_agree_bearish() is False
+
+    def test_missing_fed_stance_key_falls_through_to_AND(self) -> None:
+        """If key_data has no fed_stance entry at all, treat as the non-unknown path."""
+        mac = MultiAgentContext(
+            indicator_signal=_make_agent_signal("Indicator", Bias.BEARISH, 80),
+            macro_signal=_make_agent_signal("Macro", Bias.NEUTRAL, 25),
+        )
+        assert mac.indicator_and_macro_agree_bearish() is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- staging soak 48h+ 連続 100% HOLD の真因 (macro agent confidence が fed_stance=unknown 時 25 に固着 → AND-condition 構造的に永久 fail) を AND-condition 側の分岐で解消
- confidence 計算式 (`max(25, abs(score-50)*2+25)`) と AND 閾値 (70%) はいずれも変更しない (指示通り)

## Change
`backend/app/ai/agents.py` — `MultiAgentContext.indicator_and_macro_agree_bearish()` / `_bullish()` に fed_stance 分岐を追加:

| fed_stance | 挙動 |
|---|---|
| `"unknown"` | macro を AND 要件から外す。Indicator 単独 >=70% で qualify |
| `"neutral"` | **緩めない** (現状維持) — neutral は意味ある HOLD vote |
| `"dovish"` / `"hawkish"` | **緩めない** (現状維持) — 信号方向あり |

COMPOUND RISK guard (`service.py` Guard 1) は本メソッドより先に評価されるため、unknown 分岐でも暴走しない既存セーフティネットが残る。

## DoD
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — 485 files already formatted
- [x] `mypy app/` — Success, no issues found in 241 source files
- [x] `pytest tests/ --cov=app --cov-fail-under=80` — **2964 passed, 21 skipped, coverage 85.61%**
- [x] `ruff check . --select S` — All checks passed
- [ ] tsc / build — frontend 変更なしのため省略 (worktree に node_modules 未配置による environment skip)

## Test plan
- Unit tests 追加 (9 件、`tests/test_ai_sell_and_condition.py::TestFedStanceUnknownBranch`):
  - `test_unknown_with_indicator_bearish_only_returns_true`
  - `test_unknown_with_indicator_bullish_only_returns_true`
  - `test_unknown_ignores_opposite_macro_bias`
  - `test_unknown_still_requires_indicator_threshold` (Indicator <70% は依然 reject)
  - `test_unknown_still_requires_indicator_directional` (Indicator NEUTRAL は依然 reject)
  - `test_neutral_fed_stance_NOT_relaxed_bearish` (neutral は緩めない)
  - `test_neutral_fed_stance_NOT_relaxed_bullish`
  - `test_dovish_fed_stance_NOT_relaxed_when_indicator_disagrees`
  - `test_missing_fed_stance_key_falls_through_to_AND`
- 既存テスト (`TestIndicatorAndMacroAgreeBearish` / `_Bullish` 計 17 件) は変更なしで pass

## Refs
- Asana: https://app.asana.com/1/817733952351708/project/1213916581114014/task/1215114989650455
- 関連: 2026-05-26 staging soak 三重故障調査、queue id=32 の正しい後継

## 一切しないこと (タスク指示遵守)
- AND-condition 閾値の引き下げ → 70% のまま
- confidence 計算式 `abs(score-50)*2+25` の変更 → 触らない
- macro データソースの差し替え → 別タスク

🤖 Generated with [Claude Code](https://claude.com/claude-code)