### PR TITLE
ci(deploy-staging): push→main 自動トリガーを撤去し opt-in 化 + command_timeout 20m

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,9 +1,16 @@
 name: Deploy to Staging
 
+# 2026-05-26: push→main 自動トリガーを撤去し opt-in 化。
+# 背景: soak 観測中の PR merge が毎回 staging を recreate し、観測データが分断される。
+# 詳細: Asana 1215116762898441 / CLAUDE.lessons.md 2026-05-26「自動 deploy と手動操作の衝突」
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Deploy reason (e.g., manual rollout, soak test, post-merge sync)'
+        required: false
+        type: string
+        default: 'manual deploy'
 
 concurrency:
   group: staging-deployment
@@ -21,9 +28,14 @@ jobs:
           host: ${{ secrets.HETZNER_HOST }}
           username: ${{ secrets.HETZNER_USER }}
           key: ${{ secrets.HETZNER_SSH_KEY }}
+          # 2026-05-26: command_timeout を 10m(default) → 20m に延長。
+          # 背景: frontend npm build (~9min) + backend blue/green parallel build (~1min)
+          # + up -d + healthcheck で 10m を超え、SSH session timeout で workflow が
+          # failure 扱いになる (例: run 26427578136、10:55:38 Run Command Timeout)。
+          command_timeout: 20m
           script: |
             set -euo pipefail
-            echo "🚀 Starting staging deployment..."
+            echo "🚀 Starting staging deployment (reason: ${{ github.event.inputs.reason }})..."
             cd /opt/ultra-autotrade
             git fetch origin
             git reset --hard origin/main


### PR DESCRIPTION
## Summary

`.github/workflows/deploy-staging.yml` の自動トリガー (`on: push: branches: [main]`) を撤去し、`workflow_dispatch` (手動実行) に変更。あわせて appleboy/ssh-action の `command_timeout` を default 10m → 20m に延長。

## 背景 (2026-05-26 staging soak 三重故障調査より)

soak 観測中の PR #413 merge (10:45:28 JST) 直後、本 workflow が自動発火 (10:45:31 JST) して staging stack を recreate。下記の二次被害が発生:

| 時刻 (JST) | イベント |
|---|---|
| 10:45:31 | workflow 自動起動 (run 26427578136) |
| 10:45:52 | 旧 backend-blue / backend-green 削除 |
| 10:55:32.83 | backend-green Started |
| 10:55:32.99 | `deploy_staging.sh:470` の `stop backend-green` で SIGTERM |
| 10:55:38 | SSH `Run Command Timeout` (10m 経過) → workflow failure |
| ~10:55:42 | green SIGKILL (10s grace 超過) → **exit 137** |

soak 観測中の PR merge ごとに staging が勝手に recreate されると、観測データが分断される。
auto-trigger を撤去することで観測 / UAT 中の意図しない deploy を防ぐ。

## 変更内容

```diff
- on:
-   push:
-     branches:
-       - main
+ on:
+   workflow_dispatch:
+     inputs:
+       reason:
+         description: 'Deploy reason (e.g., manual rollout, soak test, post-merge sync)'
+         required: false
+         type: string
+         default: 'manual deploy'
```

```diff
        uses: appleboy/ssh-action@v1
        with:
          host: ${{ secrets.HETZNER_HOST }}
          username: ${{ secrets.HETZNER_USER }}
          key: ${{ secrets.HETZNER_SSH_KEY }}
+         command_timeout: 20m
```

## 影響

- main への push では staging deploy が走らなくなる (**意図的な動作変更**)
- staging deploy 手順: GitHub UI の **Actions → Deploy to Staging → Run workflow** ボタンから手動実行
- `deploy_staging.sh` 本体は変更なし
- production deploy 経路 (別 workflow) には触れていない

## 補完予定 (本 PR 外)

Asana 1215116762898441 に記載の対策 2-4 は別 PR で扱う:
- 標準: `deploy_staging.sh:470` の `stop backend-green` に `--timeout 30` 付与 (green exit 137 の根治)
- 根本: build を CI に移し staging は pull + up -d のみ (Hetzner build 負荷排除)

## DoD

- [x] `on: push` を撤去し `workflow_dispatch` 化
- [x] `command_timeout: 20m` を追加
- [x] verify.sh 全 gate 通過 (ruff / format / mypy / pytest coverage 85.61% / security / tsc / build, 937s)
- [x] YAML 構文検証 (PyYAML safe_load OK、`workflow_dispatch` trigger 認識確認)

## Test plan

- [ ] PR merge 後、main への次回 push で **workflow が起動しないこと**を gh run list で確認
- [ ] GitHub UI から手動 `Run workflow` で deploy が実行できることを確認
- [ ] command_timeout 20m が反映されていることを次回手動 deploy の run log で確認

## 関連

- Asana: https://app.asana.com/1/817733952351708/project/1213916581114014/task/1215116762898441
- 失敗 run 実機データ: https://github.com/milechy/ultra-autotrade-project/actions/runs/26427578136
- CLAUDE.lessons.md 2026-05-26 「自動 deploy と手動操作の衝突に注意」

🤖 Generated with [Claude Code](https://claude.com/claude-code)