### PR TITLE
docs(frontend): copy-trading/trade に PrivyProvider 二重ラップ禁止コメント (Asana #1215000484642381)

### DIFF
--- a/frontend/app/(user)/copy-trading/page.tsx
+++ b/frontend/app/(user)/copy-trading/page.tsx
@@ -2,6 +2,8 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
 
+// PrivyProvider は (user)/layout.tsx の UserProviders 経由で供給される。
+// このページで <UserProviders> / <PrivyProvider> を再ラップすると prerender が失敗する (Asana #1215000484642381, 修正: a86a714)。
 export const dynamic = 'force-dynamic'
 
 import { useState, useEffect, useCallback } from 'react'

--- a/frontend/app/(user)/trade/page.tsx
+++ b/frontend/app/(user)/trade/page.tsx
@@ -2,6 +2,8 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
 
+// PrivyProvider は (user)/layout.tsx の UserProviders 経由で供給される。
+// このページで <UserProviders> / <PrivyProvider> を再ラップすると prerender が失敗する (Asana #1215000484642381, 修正: a86a714)。
 export const dynamic = 'force-dynamic'
 
 import { useState, useEffect, useCallback } from 'react'


### PR DESCRIPTION
## Summary

- Asana #1215000484642381 (Tier S, 2026-05-21 起票) で報告された staging frontend build 失敗
  (`/copy-trading` `/trade` の static export error) は、5/22 に以下 3 commit で **既に解決済み** ことを確認:
  - `a86a714` — copy-trading/trade の PrivyProvider 二重ネスト除去 (prerender 失敗の真因)
  - `e8611b0` — `frontend/next.config.js` を `output:'standalone'` に revert
  - `40f6175` — PR #335 で誤混入した demo static-export config の revert
- 本 PR は **再発防止のためのコメント追加のみ**。`(user)/copy-trading/page.tsx` と `(user)/trade/page.tsx`
  の冒頭に「PrivyProvider は `(user)/layout.tsx` の `UserProviders` 経由で供給される。ページで再ラップ禁止」
  と明記。

## 経緯

- ローカル (dev VPS worktree) で `npm run build` 通過済み (`/copy-trading` `/trade` ともに `ƒ Dynamic` で出力)
- Asana タスク notes の最有力仮説 (「staging が demo 用 static-export config を誤用」) は `40f6175` で既に対処済み
- Asana タスク notes の真因 (PrivyProvider 二重ネスト) は `a86a714` で除去済み

## Test plan

- [x] `npm run build` (worktree 内) — 全 route 通過、`/copy-trading` `/trade` `/user/copy-trading` `/user/trade` 全て `ƒ Dynamic` 出力
- [x] `npx tsc --noEmit` — エラー 0
- [ ] Asana #1215000484642381 を本 PR merge 後に close
- [ ] staging redeploy で Docker build が通ることを次回 deploy 時に確認

## Scope

- frontend のみ (page.tsx 2 ファイルにコメント計 4 行追加)
- backend / infra / Dockerfile 変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)