### PR TITLE
feat(automation): Aave oracle monitor with auto emergency_stop (Asana 1215080599381152)

### DIFF
--- a/backend/app/automation/oracle_monitor.py
+++ b/backend/app/automation/oracle_monitor.py
@@ -1,0 +1,269 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/automation/oracle_monitor.py
+
+"""
+Aave 主要資産 (USDC / WETH 等) の Chainlink oracle 価格・staleness を監視し、
+異常検知時に MonitoringService.activate_emergency_stop を自動発火するモジュール。
+
+設計方針 (Asana 1215080599381152):
+- 既存 ``app.aave.oracle_checker.check_oracle_staleness`` を呼び出して staleness /
+  価格乖離を判定 (重複実装しない)
+- 既存 ``MonitoringService.activate_emergency_stop`` を経由して停止 + Slack 通知を
+  共通化 (本モジュールから直接通知しない)
+- 配線 (scheduler / router / agents.py) は本 PR では行わず、別 PR で提案する
+
+False positive 抑制:
+- 既定では oracle 異常 AND HF<warning 閾値の AND 条件でのみ emergency_stop 発火
+- ただし「極端な異常」(age > extreme_staleness_threshold_seconds または
+  deviation > extreme_deviation_pct) の場合は HF 状態に関わらず発火 (fail-safe)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Dict, List, Optional, Sequence
+
+from app.aave.oracle_checker import OracleCheckResult, check_oracle_staleness
+from app.automation.monitoring_service import MonitoringService
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_STALENESS_THRESHOLD_SECONDS = 3600
+DEFAULT_DEVIATION_THRESHOLD_PCT = Decimal("10")
+DEFAULT_EXTREME_STALENESS_THRESHOLD_SECONDS = 24 * 3600
+DEFAULT_EXTREME_DEVIATION_PCT = Decimal("30")
+DEFAULT_HF_GUARD_THRESHOLD = Decimal("1.8")
+
+
+@dataclass(frozen=True)
+class OracleFeedConfig:
+    """
+    監視対象の Chainlink price feed 設定。
+
+    name: USDC / WETH などのシンボル
+    feed_address: Chainlink AggregatorV3 のアドレス
+    rpc_url: 接続先 RPC エンドポイント (Polygon / Base / Arbitrum 等)
+    """
+
+    name: str
+    feed_address: str
+    rpc_url: str
+
+
+@dataclass
+class OracleMonitorReport:
+    """1 回分の oracle ポーリング結果。"""
+
+    feed_results: Dict[str, OracleCheckResult] = field(default_factory=dict)
+    fetch_failures: List[str] = field(default_factory=list)
+    anomaly_detected: bool = False
+    emergency_triggered: bool = False
+    reasons: List[str] = field(default_factory=list)
+
+
+class OracleMonitor:
+    """
+    Chainlink oracle の状態を定期取得し、異常時に emergency_stop を発火する。
+
+    Note:
+        - 価格乖離判定は前回ポーリング時の値を内部キャッシュして比較する
+          (oracle_checker.check_oracle_staleness の previous_price 引数に渡す)
+        - 通知は MonitoringService.activate_emergency_stop 内の既存実装に委譲する
+        - 配線 (scheduler) は本クラスを呼び出す側で行う (別 PR 想定)
+    """
+
+    def __init__(
+        self,
+        monitoring_service: MonitoringService,
+        feeds: Sequence[OracleFeedConfig],
+        *,
+        staleness_threshold_seconds: int = DEFAULT_STALENESS_THRESHOLD_SECONDS,
+        deviation_threshold_pct: Decimal = DEFAULT_DEVIATION_THRESHOLD_PCT,
+        extreme_staleness_threshold_seconds: int = (DEFAULT_EXTREME_STALENESS_THRESHOLD_SECONDS),
+        extreme_deviation_pct: Decimal = DEFAULT_EXTREME_DEVIATION_PCT,
+        hf_guard_threshold: Decimal = DEFAULT_HF_GUARD_THRESHOLD,
+        require_hf_confirmation: bool = True,
+    ) -> None:
+        if not feeds:
+            raise ValueError("OracleMonitor requires at least one feed")
+        if staleness_threshold_seconds <= 0:
+            raise ValueError("staleness_threshold_seconds must be positive")
+        if deviation_threshold_pct <= 0:
+            raise ValueError("deviation_threshold_pct must be positive")
+        if extreme_staleness_threshold_seconds < staleness_threshold_seconds:
+            raise ValueError(
+                "extreme_staleness_threshold_seconds must be >= staleness_threshold_seconds"
+            )
+        if extreme_deviation_pct < deviation_threshold_pct:
+            raise ValueError("extreme_deviation_pct must be >= deviation_threshold_pct")
+
+        self._monitoring = monitoring_service
+        self._feeds = list(feeds)
+        self._staleness_threshold_seconds = staleness_threshold_seconds
+        self._deviation_threshold_pct = Decimal(deviation_threshold_pct)
+        self._extreme_staleness_threshold_seconds = extreme_staleness_threshold_seconds
+        self._extreme_deviation_pct = Decimal(extreme_deviation_pct)
+        self._hf_guard_threshold = Decimal(hf_guard_threshold)
+        self._require_hf_confirmation = bool(require_hf_confirmation)
+
+        self._previous_prices: Dict[str, Decimal] = {}
+
+    @property
+    def feeds(self) -> List[OracleFeedConfig]:
+        return list(self._feeds)
+
+    def check_once(self) -> OracleMonitorReport:
+        """
+        全フィードを 1 回ポーリングし、判定結果と緊急停止発火状況を返す。
+
+        emergency_stop を発火する条件:
+          1. ``require_hf_confirmation=False`` で oracle 異常が 1 件以上
+          2. ``require_hf_confirmation=True`` のとき、oracle 異常 1 件以上 かつ
+             直近 HF が None でなく ``hf_guard_threshold`` 未満
+          3. 上記に関わらず、極端な異常 (age > extreme_staleness または
+             deviation > extreme_deviation_pct) が 1 件でもあれば発火 (fail-safe)
+        """
+        report = OracleMonitorReport()
+
+        for feed in self._feeds:
+            previous_price = self._previous_prices.get(feed.name)
+            try:
+                result = check_oracle_staleness(
+                    feed_address=feed.feed_address,
+                    rpc_url=feed.rpc_url,
+                    staleness_threshold_seconds=self._staleness_threshold_seconds,
+                    deviation_threshold_pct=self._deviation_threshold_pct,
+                    previous_price=previous_price,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "[oracle_monitor] check_oracle_staleness raised for feed=%s: %s",
+                    feed.name,
+                    exc,
+                )
+                report.fetch_failures.append(feed.name)
+                continue
+
+            if result is None:
+                report.fetch_failures.append(feed.name)
+                continue
+
+            report.feed_results[feed.name] = result
+
+            # 次回ポーリング時の deviation 比較に使う最新価格をキャッシュ
+            if result.price is not None:
+                self._previous_prices[feed.name] = result.price
+
+            if result.should_hold:
+                report.anomaly_detected = True
+                report.reasons.append(f"{feed.name}: " + "; ".join(result.reasons))
+
+        extreme_reasons = self._collect_extreme_reasons(report.feed_results)
+        if extreme_reasons:
+            report.anomaly_detected = True
+            report.reasons.extend(extreme_reasons)
+
+        if not report.anomaly_detected:
+            return report
+
+        if extreme_reasons:
+            self._trigger_emergency(report, mode="extreme")
+            return report
+
+        if not self._require_hf_confirmation:
+            self._trigger_emergency(report, mode="oracle_only")
+            return report
+
+        hf = self._get_last_health_factor()
+        if hf is not None and hf < self._hf_guard_threshold:
+            self._trigger_emergency(
+                report,
+                mode=f"oracle_and_hf(hf={hf})",
+            )
+        else:
+            logger.warning(
+                "[oracle_monitor] Oracle anomaly detected but HF=%s is healthy "
+                "(threshold=%s); emergency_stop suppressed by AND policy. reasons=%s",
+                hf,
+                self._hf_guard_threshold,
+                report.reasons,
+            )
+
+        return report
+
+    async def monitor_loop(self, interval_seconds: int = 60) -> None:
+        """
+        ``interval_seconds`` ごとに ``check_once`` を呼び出す常駐ループ。
+
+        個別の ``check_once`` 失敗は監視を停止させず、次回間隔まで待機する。
+        """
+        if interval_seconds <= 0:
+            raise ValueError("interval_seconds must be positive")
+        logger.info(
+            "[oracle_monitor] Starting monitor loop (feeds=%d, interval=%ds)",
+            len(self._feeds),
+            interval_seconds,
+        )
+        while True:
+            try:
+                self.check_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.exception(
+                    "[oracle_monitor] check_once raised unexpectedly: %s",
+                    exc,
+                )
+            await asyncio.sleep(interval_seconds)
+
+    def _collect_extreme_reasons(
+        self,
+        feed_results: Dict[str, OracleCheckResult],
+    ) -> List[str]:
+        reasons: List[str] = []
+        for name, result in feed_results.items():
+            if (
+                result.age_seconds is not None
+                and result.age_seconds > self._extreme_staleness_threshold_seconds
+            ):
+                reasons.append(
+                    f"{name}: extreme staleness age={result.age_seconds}s > "
+                    f"{self._extreme_staleness_threshold_seconds}s"
+                )
+            if (
+                result.deviation_pct is not None
+                and result.deviation_pct > self._extreme_deviation_pct
+            ):
+                reasons.append(
+                    f"{name}: extreme deviation {result.deviation_pct:.2f}% > "
+                    f"{self._extreme_deviation_pct}%"
+                )
+        return reasons
+
+    def _get_last_health_factor(self) -> Optional[Decimal]:
+        status = self._monitoring.get_status()
+        return status.last_health_factor
+
+    def _trigger_emergency(self, report: OracleMonitorReport, *, mode: str) -> None:
+        from app.automation.schemas import ComponentType  # noqa: PLC0415
+
+        reason = "Aave oracle anomaly [{}]: {}".format(
+            mode,
+            " | ".join(report.reasons) if report.reasons else "unspecified",
+        )
+        logger.error("[oracle_monitor] Activating emergency_stop: %s", reason)
+        try:
+            self._monitoring.activate_emergency_stop(
+                reason=reason,
+                component=ComponentType.AAVE,
+            )
+            report.emergency_triggered = True
+        except Exception as exc:
+            logger.exception(
+                "[oracle_monitor] activate_emergency_stop failed: %s",
+                exc,
+            )

--- a/backend/tests/automation/test_oracle_monitor.py
+++ b/backend/tests/automation/test_oracle_monitor.py
@@ -1,0 +1,451 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+"""
+Tests for app.automation.oracle_monitor.OracleMonitor.
+
+監視ロジック単体テスト:
+- check_once で feed_results が埋まる
+- staleness 検出 + HF 警告域で emergency_stop 自動発火 (AND モード)
+- HF 正常域では oracle 異常のみでは発火しない (false positive 抑制)
+- extreme staleness は HF に関わらず発火 (fail-safe)
+- require_hf_confirmation=False で oracle 異常のみで発火
+- RPC 失敗フィードは fetch_failures に積まれて他のフィードは継続処理
+- 不正なコンストラクタ引数で ValueError
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import List, Optional, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.aave.oracle_checker import OracleCheckResult
+from app.automation import oracle_monitor as om_mod
+from app.automation.monitoring_service import MonitoringService
+from app.automation.oracle_monitor import OracleFeedConfig, OracleMonitor
+
+
+def _new_monitoring_service() -> MonitoringService:
+    return MonitoringService(_internal=True, enable_state_sync=False)
+
+
+def _feed(name: str = "USDC") -> OracleFeedConfig:
+    return OracleFeedConfig(
+        name=name,
+        feed_address="0x" + name.encode("ascii").hex().ljust(40, "0")[:40],
+        rpc_url="http://localhost:8545",
+    )
+
+
+def _stub_result(
+    *,
+    is_stale: bool = False,
+    is_circuit_breaker: bool = False,
+    age_seconds: Optional[int] = 60,
+    price: Optional[Decimal] = Decimal("1.0"),
+    deviation_pct: Optional[Decimal] = None,
+    reasons: Optional[List[str]] = None,
+) -> OracleCheckResult:
+    return OracleCheckResult(
+        feed_address="0xFEED",
+        is_stale=is_stale,
+        is_circuit_breaker=is_circuit_breaker,
+        updated_at=datetime.now(timezone.utc),
+        price=price,
+        age_seconds=age_seconds,
+        deviation_pct=deviation_pct,
+        should_hold=is_stale or is_circuit_breaker,
+        reasons=reasons or [],
+    )
+
+
+class TestOracleMonitorConstruction:
+    def test_requires_at_least_one_feed(self) -> None:
+        with pytest.raises(ValueError, match="at least one feed"):
+            OracleMonitor(_new_monitoring_service(), feeds=[])
+
+    def test_rejects_non_positive_staleness(self) -> None:
+        with pytest.raises(ValueError, match="staleness_threshold_seconds"):
+            OracleMonitor(
+                _new_monitoring_service(),
+                feeds=[_feed()],
+                staleness_threshold_seconds=0,
+            )
+
+    def test_rejects_non_positive_deviation(self) -> None:
+        with pytest.raises(ValueError, match="deviation_threshold_pct"):
+            OracleMonitor(
+                _new_monitoring_service(),
+                feeds=[_feed()],
+                deviation_threshold_pct=Decimal("0"),
+            )
+
+    def test_rejects_extreme_below_normal_thresholds(self) -> None:
+        with pytest.raises(ValueError, match="extreme_staleness_threshold_seconds"):
+            OracleMonitor(
+                _new_monitoring_service(),
+                feeds=[_feed()],
+                staleness_threshold_seconds=3600,
+                extreme_staleness_threshold_seconds=1800,
+            )
+        with pytest.raises(ValueError, match="extreme_deviation_pct"):
+            OracleMonitor(
+                _new_monitoring_service(),
+                feeds=[_feed()],
+                deviation_threshold_pct=Decimal("10"),
+                extreme_deviation_pct=Decimal("5"),
+            )
+
+    def test_feeds_property_returns_copy(self) -> None:
+        feeds = [_feed("USDC"), _feed("WETH")]
+        monitor = OracleMonitor(_new_monitoring_service(), feeds=feeds)
+        snapshot = monitor.feeds
+        snapshot.clear()
+        assert len(monitor.feeds) == 2
+
+
+class TestCheckOnce:
+    def test_no_anomaly_does_not_trigger(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ms = _new_monitoring_service()
+        calls: list[str] = []
+
+        def fake_check(*, feed_address: str, **_kwargs: object) -> OracleCheckResult:
+            calls.append(feed_address)
+            return _stub_result(is_stale=False)
+
+        monkeypatch.setattr(om_mod, "check_oracle_staleness", fake_check)
+
+        monitor = OracleMonitor(ms, feeds=[_feed("USDC"), _feed("WETH")])
+        report = monitor.check_once()
+
+        assert report.anomaly_detected is False
+        assert report.emergency_triggered is False
+        assert report.reasons == []
+        assert set(report.feed_results.keys()) == {"USDC", "WETH"}
+        assert ms.is_trading_allowed() is True
+        assert len(calls) == 2
+
+    def test_stale_oracle_with_unhealthy_hf_triggers_emergency_stop(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ms = _new_monitoring_service()
+        ms.record_health_factor(Decimal("1.5"))
+
+        def fake_check(**_kwargs: object) -> OracleCheckResult:
+            return _stub_result(
+                is_stale=True,
+                age_seconds=7200,
+                reasons=["oracle price is stale"],
+            )
+
+        monkeypatch.setattr(om_mod, "check_oracle_staleness", fake_check)
+
+        monitor = OracleMonitor(
+            ms,
+            feeds=[_feed("USDC")],
+            hf_guard_threshold=Decimal("1.8"),
+        )
+        report = monitor.check_once()
+
+        assert report.anomaly_detected is True
+        assert report.emergency_triggered is True
+        assert ms.is_trading_allowed() is False
+        status = ms.get_status()
+        assert status.emergency_reason is not None
+        assert "Aave oracle anomaly" in status.emergency_reason
+        assert "oracle_and_hf" in status.emergency_reason
+
+    def test_stale_oracle_with_healthy_hf_does_not_trigger(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ms = _new_monitoring_service()
+        ms.record_health_factor(Decimal("2.5"))
+
+        def fake_check(**_kwargs: object) -> OracleCheckResult:
+            return _stub_result(
+                is_stale=True,
+                age_seconds=7200,
+                reasons=["oracle price is stale"],
+            )
+
+        monkeypatch.setattr(om_mod, "check_oracle_staleness", fake_check)
+
+        monitor = OracleMonitor(ms, feeds=[_feed("USDC")])
+        report = monitor.check_once()
+
+        assert report.anomaly_detected is True
+        assert report.emergency_triggered is False
+        assert ms.is_trading_allowed() is True
+
+    def test_stale_oracle_with_missing_hf_does_not_trigger(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ms = _new_monitoring_service()  # no HF recorded
+
+        def fake_check(**_kwargs: object) -> OracleCheckResult:
+            return _stub_result(
+                is_stale=True,
+                age_seconds=7200,
+                reasons=["oracle price is stale"],
+            )
+
+        monkeypatch.setattr(om_mod, "check_oracle_staleness", fake_check)
+
+        monitor = OracleMonitor(ms, feeds=[_feed("USDC")])
+        report = monitor.check_once()
+
+        assert report.anomaly_detected is True
+        assert report.emergency_triggered is False
+        assert ms.is_trading_allowed() is True
+
+    def test_extreme_staleness_triggers_regardless_of_hf(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ms = _new_monitoring_service()
+        ms.record_health_factor(Decimal("3.0"))  # healthy HF
+
+        def fake_check(**_kwargs: object) -> OracleCheckResult:
+            return _stub_result(
+                is_stale=True,
+                age_seconds=48 * 3600,  # 48h
+                reasons=["very old"],
+            )
+
+        monkeypatch.setattr(om_mod, "check_oracle_staleness", fake_check)
+
+        monitor = OracleMonitor(
+            ms,
+            feeds=[_feed("USDC")],
+            extreme_staleness_threshold_seconds=24 * 3600,
+        )
+        report = monitor.check_once()
+
+        assert report.anomaly_detected is True
+        assert report.emergency_triggered is True
+        status = ms.get_status()
+        assert status.emergency_reason is not None
+        assert "extreme" in status.emergency_reason
+
+    def test_extreme_deviation_triggers_regardless_of_hf(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ms = _new_monitoring_service()
+        ms.record_health_factor(Decimal("3.0"))  # healthy
+
+        def fake_check(**_kwargs: object) -> OracleCheckResult:
+            return _stub_result(
+                is_circuit_breaker=True,
+                deviation_pct=Decimal("45"),
+                reasons=["deviation 45%"],
+            )
+
+        monkeypatch.setattr(om_mod, "check_oracle_staleness", fake_check)
+
+        monitor = OracleMonitor(
+            ms,
+            feeds=[_feed("USDC")],
+            deviation_threshold_pct=Decimal("10"),
+            extreme_deviation_pct=Decimal("30"),
+        )
+        report = monitor.check_once()
+
+        assert report.emergency_triggered is True
+
+    def test_require_hf_false_triggers_on_any_anomaly(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ms = _new_monitoring_service()
+        ms.record_health_factor(Decimal("3.0"))  # healthy
+
+        def fake_check(**_kwargs: object) -> OracleCheckResult:
+            return _stub_result(is_stale=True, reasons=["stale"])
+
+        monkeypatch.setattr(om_mod, "check_oracle_staleness", fake_check)
+
+        monitor = OracleMonitor(
+            ms,
+            feeds=[_feed("USDC")],
+            require_hf_confirmation=False,
+        )
+        report = monitor.check_once()
+
+        assert report.emergency_triggered is True
+        status = ms.get_status()
+        assert status.emergency_reason is not None
+        assert "oracle_only" in status.emergency_reason
+
+    def test_rpc_failure_records_in_fetch_failures_and_continues(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ms = _new_monitoring_service()
+
+        def fake_check(*, feed_address: str, **_kwargs: object) -> Optional[OracleCheckResult]:
+            if "USDC" in feed_address.upper() or feed_address.lower().startswith(
+                "0x55534443"
+            ):  # "USDC" ascii hex
+                return None  # RPC failed
+            return _stub_result()
+
+        monkeypatch.setattr(om_mod, "check_oracle_staleness", fake_check)
+
+        monitor = OracleMonitor(ms, feeds=[_feed("USDC"), _feed("WETH")])
+        report = monitor.check_once()
+
+        assert "USDC" in report.fetch_failures
+        assert "WETH" in report.feed_results
+        assert report.emergency_triggered is False
+
+    def test_check_raises_is_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ms = _new_monitoring_service()
+
+        def fake_check(**_kwargs: object) -> OracleCheckResult:
+            raise RuntimeError("simulated RPC error")
+
+        monkeypatch.setattr(om_mod, "check_oracle_staleness", fake_check)
+
+        monitor = OracleMonitor(ms, feeds=[_feed("USDC")])
+        report = monitor.check_once()
+
+        assert report.fetch_failures == ["USDC"]
+        assert report.feed_results == {}
+        assert report.emergency_triggered is False
+
+    def test_previous_price_cached_for_next_check(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ms = _new_monitoring_service()
+        observed_previous: list[Optional[Decimal]] = []
+
+        def fake_check(
+            *,
+            previous_price: Optional[Decimal] = None,
+            **_kwargs: object,
+        ) -> OracleCheckResult:
+            observed_previous.append(previous_price)
+            return _stub_result(price=Decimal("2000"))
+
+        monkeypatch.setattr(om_mod, "check_oracle_staleness", fake_check)
+
+        monitor = OracleMonitor(ms, feeds=[_feed("WETH")])
+        monitor.check_once()
+        monitor.check_once()
+
+        assert observed_previous == [None, Decimal("2000")]
+
+    def test_activate_emergency_stop_failure_does_not_propagate(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ms = _new_monitoring_service()
+        ms.record_health_factor(Decimal("1.4"))
+
+        def fake_check(**_kwargs: object) -> OracleCheckResult:
+            return _stub_result(is_stale=True, reasons=["stale"])
+
+        monkeypatch.setattr(om_mod, "check_oracle_staleness", fake_check)
+
+        broken_ms = cast(MonitoringService, MagicMock(spec=MonitoringService))
+        broken_status = MagicMock()
+        broken_status.last_health_factor = Decimal("1.4")
+        cast(MagicMock, broken_ms.get_status).return_value = broken_status
+        cast(MagicMock, broken_ms.activate_emergency_stop).side_effect = RuntimeError(
+            "notify failed"
+        )
+
+        monitor = OracleMonitor(broken_ms, feeds=[_feed("USDC")])
+        report = monitor.check_once()
+
+        assert report.anomaly_detected is True
+        assert report.emergency_triggered is False  # set only on success
+
+
+class TestMonitorLoop:
+    @pytest.mark.asyncio
+    async def test_loop_calls_check_and_sleeps(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ms = _new_monitoring_service()
+
+        def fake_check(**_kwargs: object) -> OracleCheckResult:
+            return _stub_result()
+
+        monkeypatch.setattr(om_mod, "check_oracle_staleness", fake_check)
+
+        monitor = OracleMonitor(ms, feeds=[_feed("USDC")])
+        call_count = {"n": 0}
+        original_check_once = monitor.check_once
+
+        def counting_check() -> object:
+            call_count["n"] += 1
+            return original_check_once()
+
+        monkeypatch.setattr(monitor, "check_once", counting_check)
+
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+            if len(sleep_calls) >= 2:
+                raise asyncio.CancelledError()
+
+        import asyncio  # noqa: PLC0415
+
+        monkeypatch.setattr(om_mod.asyncio, "sleep", fake_sleep)
+
+        with pytest.raises(asyncio.CancelledError):
+            await monitor.monitor_loop(interval_seconds=5)
+
+        assert call_count["n"] >= 2
+        assert sleep_calls == [5, 5]
+
+    @pytest.mark.asyncio
+    async def test_loop_rejects_non_positive_interval(self) -> None:
+        ms = _new_monitoring_service()
+        monitor = OracleMonitor(ms, feeds=[_feed("USDC")])
+        with pytest.raises(ValueError, match="interval_seconds"):
+            await monitor.monitor_loop(interval_seconds=0)
+
+    @pytest.mark.asyncio
+    async def test_loop_recovers_from_check_exception(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ms = _new_monitoring_service()
+        monitor = OracleMonitor(ms, feeds=[_feed("USDC")])
+
+        call_count = {"n": 0}
+
+        def boom() -> object:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("simulated")
+            return None
+
+        monkeypatch.setattr(monitor, "check_once", boom)
+
+        import asyncio  # noqa: PLC0415
+
+        sleep_calls = {"n": 0}
+
+        async def fake_sleep(_seconds: float) -> None:
+            sleep_calls["n"] += 1
+            if sleep_calls["n"] >= 2:
+                raise asyncio.CancelledError()
+
+        monkeypatch.setattr(om_mod.asyncio, "sleep", fake_sleep)
+
+        with pytest.raises(asyncio.CancelledError):
+            await monitor.monitor_loop(interval_seconds=1)
+
+        assert call_count["n"] >= 2


### PR DESCRIPTION
## 概要

Asana [MVP-P0-11] Aave Oracle monitoring + 自動 emergency_stop (gid 1215080599381152) の実装。

2026 年 Aave $26-27M wstETH 清算で露呈した oracle malfunction リスクを、
Chainlink price feed の定期 polling + 異常時 emergency_stop 発火で防御する仕組みを追加。

## スコープ

`backend/app/automation/oracle_monitor.py` を新規追加。既存:
- `app.aave.oracle_checker.check_oracle_staleness` — staleness / 価格乖離判定
- `app.automation.monitoring_service.MonitoringService.activate_emergency_stop` — 停止 + state.json 永続化 + Slack 通知

を組み合わせるオーケストレータ。重複実装も新規通知経路も持たない。

## False positive 抑制 (AND ポリシー)

| 状態 | 動作 |
|---|---|
| oracle 正常 | 何もしない |
| oracle 異常 + HF healthy (≥ 1.8 or None) | log warning のみ |
| oracle 異常 + HF unhealthy (< 1.8) | `activate_emergency_stop(reason='[oracle_and_hf(...)]')` |
| 極端 staleness (age > 24h) または 極端 deviation (> 30%) | HF 状態に関わらず発火 (fail-safe) |
| `require_hf_confirmation=False` | oracle 異常のみで発火 (オペレータ判断用) |

## 触っていない範囲

タスク制約に従い、配線は本 PR では行わない:
- `backend/app/main.py` (router 登録なし)
- `backend/app/aave/service.py` / `app.aave/agents.py` (呼び出し追加なし)
- `backend/app/automation/scheduled_tasks.py` (monitor_loop 配線なし)

**配線提案 (別 PR 案)**: `scheduled_tasks.py` に `oracle_monitor_loop(interval_seconds=60)` を追加し、`background_tasks.start_background_tasks()` から起動。フィード設定 (`OracleFeedConfig`) は `.env.production` に `AAVE_ORACLE_FEEDS_JSON` 等で投入する案を後続 PR で提案。

## 実装

| 追加要素 | 概要 |
|---|---|
| `OracleFeedConfig` (frozen dataclass) | name / feed_address / rpc_url |
| `OracleMonitorReport` (dataclass) | feed_results / fetch_failures / anomaly_detected / emergency_triggered / reasons |
| `OracleMonitor.check_once()` | 全フィードを 1 回ポーリングし AND ポリシーに従い emergency_stop 判定 |
| `OracleMonitor.monitor_loop(interval_seconds)` | 常駐 async ループ。check_once 例外で停止しない |
| `_previous_prices` キャッシュ | 次回 deviation 比較用に最新価格をフィードごとに保持 |

## テスト

`backend/tests/automation/test_oracle_monitor.py` — 19 新規テスト:

- **construction (5)**: ValueError 系コンストラクタ検証 + feeds プロパティ防御コピー
- **check_once (10)**:
  - 異常なし → 発火しない
  - stale + HF unhealthy → emergency_triggered=True / `oracle_and_hf` reason
  - stale + HF healthy → 発火しない (AND policy)
  - stale + HF=None (未記録) → 発火しない (慎重側)
  - 極端 staleness (48h) → HF healthy でも発火 (`extreme` reason)
  - 極端 deviation (45%) → HF healthy でも発火
  - `require_hf_confirmation=False` → oracle のみで発火 (`oracle_only` reason)
  - RPC None (失敗) → `fetch_failures` に積み、他フィード継続
  - check_oracle_staleness 例外 → fetch_failures に積み swallow
  - previous_price 値が次回 polling に渡る
  - activate_emergency_stop 例外で `emergency_triggered=False` 維持
- **monitor_loop (3)**: check + sleep ループ動作 / 不正 interval / check 例外でループ継続

## DoD / Gate 結果

| Gate | 結果 |
|---|---|
| 1. ruff check | ✅ All checks passed |
| 2. ruff format --check | ✅ 487 files already formatted |
| 3. mypy (242 source files) | ✅ Success: no issues found |
| 4. pytest + coverage 80% | ✅ 2974 passed / 21 skipped (新規 19 含む) |
| 5. ruff S (security) | ✅ All checks passed |
| 6. tsc --noEmit | ⚠ worktree に frontend/node_modules 不在のため未実行 (本 PR は backend-only / CI でカバー) |
| 7. frontend build | 同上 |

## Asana

Closes Asana 1215080599381152

## 既存ロジックとの関係

- 既存 `MonitoringService.record_health_factor` は HF < 1.6 で自動的に emergency_stop を発火する (既実装)。本 PR は oracle 起因のシグナルを追加して **HF が劣化する前** に止めることを狙う層を一段足す。
- 既存 `oracle_checker.check_oracle_staleness` は単発呼び出し API。本 PR は複数フィードの定期 polling と発火判定のオーケストレータ層に責務分離。

## 教訓記録

特記なし (純粋な additive モジュール + テスト)。