### PR TITLE
fix(aave): oracle staleness threshold を env 化 (AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS)

### DIFF
--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -134,6 +134,12 @@ AAVE_OPERATION_MODE=NORMAL
 AAVE_STATE_FILE_PATH=/var/run/ultra/state.json
 AAVE_STATE_STALE_THRESHOLD_SECONDS=300
 
+# Chainlink price feed staleness threshold (seconds).
+# Base mainnet USDC/USD heartbeat ≈ 24h → 90000s (25h) with safety buffer.
+# Override per chain/feed in production; default fallback (3600s) is unsafe
+# for long-heartbeat stable-coin feeds and will spuriously HOLD trades.
+AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS=90000
+
 # Rebalance Shadow Mode（production は false）
 REBALANCE_SHADOW_MODE=false
 

--- a/backend/.env.staging.example
+++ b/backend/.env.staging.example
@@ -68,6 +68,10 @@ AAVE_MAX_SINGLE_TRADE_USD=10.0
 AAVE_MIN_HEALTH_FACTOR=1.6
 AAVE_TRADE_COOLDOWN_SECONDS=600
 AAVE_STATE_FILE_PATH=/var/run/ultra/state.json
+# Chainlink feed staleness threshold (seconds). Base Sepolia USDC/USD (0xd30e2101)
+# heartbeat ≈ 24h; 90000s = 25h includes a safety buffer. Default 3600s would
+# spuriously HOLD on long-heartbeat feeds.
+AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS=90000
 REBALANCE_SHADOW_MODE=false
 
 # ============================================================

--- a/backend/app/aave/oracle_checker.py
+++ b/backend/app/aave/oracle_checker.py
@@ -10,12 +10,60 @@ Aave V3 Oracle (Chainlink) 鮮度チェック・Circuit Breaker。
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+# Default fallback for staleness threshold when env var is unset.
+# Conservative 1h default suits fast-heartbeat feeds; long-heartbeat feeds
+# (Base Sepolia USDC/USD ≈ 24h, Base mainnet USDC/USD ≈ 24h) must override
+# via AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS to avoid spurious HOLD.
+_DEFAULT_STALENESS_THRESHOLD_SECONDS = 3600
+
+# Bounds for env-based override. Reject 0 / negatives and absurdly large values
+# (over 7 days) at startup to surface misconfiguration early.
+_MIN_STALENESS_THRESHOLD_SECONDS = 60
+_MAX_STALENESS_THRESHOLD_SECONDS = 7 * 24 * 3600  # 604800
+
+_ENV_STALENESS_THRESHOLD = "AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS"
+
+
+def get_staleness_threshold_from_env(default: int = _DEFAULT_STALENESS_THRESHOLD_SECONDS) -> int:
+    """
+    Read AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS from env, validating bounds.
+
+    Raises RuntimeError on invalid values so misconfiguration is loud.
+    """
+    raw = os.getenv(_ENV_STALENESS_THRESHOLD)
+    if raw is None or raw == "":
+        return default
+
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise RuntimeError(f"Invalid integer for {_ENV_STALENESS_THRESHOLD}: {raw!r}") from exc
+
+    if value < _MIN_STALENESS_THRESHOLD_SECONDS or value > _MAX_STALENESS_THRESHOLD_SECONDS:
+        raise RuntimeError(
+            f"{_ENV_STALENESS_THRESHOLD}={value} out of bounds "
+            f"[{_MIN_STALENESS_THRESHOLD_SECONDS}, {_MAX_STALENESS_THRESHOLD_SECONDS}]"
+        )
+    return value
+
+
+def validate_staleness_threshold_env() -> int:
+    """
+    Startup validation entry point.
+
+    Returns the resolved threshold (env or default) so it can be logged.
+    Raises RuntimeError on invalid env, blocking startup.
+    """
+    return get_staleness_threshold_from_env()
+
 
 _AGGREGATOR_ABI = [
     {
@@ -66,15 +114,21 @@ class OracleCheckResult:
 def check_oracle_staleness(
     feed_address: str,
     rpc_url: str,
-    staleness_threshold_seconds: int = 3600,
+    staleness_threshold_seconds: Optional[int] = None,
     deviation_threshold_pct: Decimal = Decimal("10"),
     previous_price: Optional[Decimal] = None,
 ) -> Optional[OracleCheckResult]:
     """
     Chainlink price feed の鮮度と価格乖離を検証する。
 
+    staleness_threshold_seconds=None の場合は AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS を読む
+    (default _DEFAULT_STALENESS_THRESHOLD_SECONDS)。明示指定があれば env より優先する。
+
     Returns None if web3 is unavailable or RPC call fails.
     """
+    if staleness_threshold_seconds is None:
+        staleness_threshold_seconds = get_staleness_threshold_from_env()
+
     try:
         from web3 import Web3  # noqa: PLC0415
     except ImportError:
@@ -198,12 +252,11 @@ def is_oracle_fresh(
     """Zero-arg convenience wrapper for use in rule engine.
 
     Reads AAVE_ORACLE_FEED_ADDRESS and WEB3_RPC_URL from environment if not provided.
+    Threshold is read from AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS (default 3600s).
     Returns True if oracle data is fresh (safe to trade).
     Returns False (fail-closed) if RPC fails or oracle is stale.
     If env vars are not configured, oracle check is skipped (returns True).
     """
-    import os  # noqa: PLC0415
-
     _feed = feed_address or os.getenv("AAVE_ORACLE_FEED_ADDRESS")
     _rpc = rpc_url or os.getenv("WEB3_RPC_URL") or os.getenv("POLYGON_RPC_URL")
 
@@ -215,7 +268,13 @@ def is_oracle_fresh(
         return True  # env not configured → skip check
 
     try:
-        result = check_oracle_staleness(_feed, _rpc)
+        threshold = get_staleness_threshold_from_env()
+    except RuntimeError as exc:
+        logger.error("[oracle_checker] invalid staleness threshold env - fail-closed: %s", exc)
+        return False
+
+    try:
+        result = check_oracle_staleness(_feed, _rpc, staleness_threshold_seconds=threshold)
     except Exception as exc:
         logger.error("[oracle_checker] is_oracle_fresh call failed - fail-closed: %s", exc)
         return False

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -313,6 +313,23 @@ def create_app() -> FastAPI:
         _validate_model_config()
         logger.info("AI model config validation passed")
 
+    # --- Aave Oracle staleness threshold env validation (fail-fast) ---
+    @app.on_event("startup")
+    async def startup_validate_oracle_staleness_env() -> None:
+        """Fail-fast: reject invalid AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS at boot.
+
+        Long-heartbeat feeds (Base Sepolia / Base mainnet USDC/USD ≈ 24h) must
+        configure this env to avoid spurious HOLD; default 3600s is unsafe there.
+        """
+        from app.aave.oracle_checker import validate_staleness_threshold_env  # noqa: PLC0415
+
+        threshold = validate_staleness_threshold_env()
+        logger.info(
+            "Aave oracle staleness threshold validated: %ds "
+            "(env=AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS)",
+            threshold,
+        )
+
     # --- Database initialization (Phase12) ---
     @app.on_event("startup")
     async def startup_database() -> None:

--- a/backend/tests/test_aave_oracle_checker.py
+++ b/backend/tests/test_aave_oracle_checker.py
@@ -5,10 +5,13 @@ Tests for Aave V3 oracle staleness and circuit breaker checks.
 
 from __future__ import annotations
 
+import os
 import sys
 from datetime import datetime, timezone
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 def _make_round_data(updated_at_ts: int, answer: int = 200000000000) -> tuple:  # type: ignore[type-arg]
@@ -263,3 +266,119 @@ class TestCheckSequencerUptime:
             )
         # fail-closed: RPC failure → block trades
         assert result is False
+
+
+class TestStalenessThresholdEnv:
+    """Tests for env-based AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS."""
+
+    def test_unset_env_returns_default(self) -> None:
+        from app.aave.oracle_checker import (
+            _DEFAULT_STALENESS_THRESHOLD_SECONDS,
+            get_staleness_threshold_from_env,
+        )
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS", None)
+            assert get_staleness_threshold_from_env() == _DEFAULT_STALENESS_THRESHOLD_SECONDS
+
+    def test_empty_env_returns_default(self) -> None:
+        from app.aave.oracle_checker import (
+            _DEFAULT_STALENESS_THRESHOLD_SECONDS,
+            get_staleness_threshold_from_env,
+        )
+
+        with patch.dict(os.environ, {"AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS": ""}):
+            assert get_staleness_threshold_from_env() == _DEFAULT_STALENESS_THRESHOLD_SECONDS
+
+    def test_valid_env_overrides_default(self) -> None:
+        from app.aave.oracle_checker import get_staleness_threshold_from_env
+
+        with patch.dict(os.environ, {"AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS": "90000"}):
+            assert get_staleness_threshold_from_env() == 90000
+
+    def test_non_integer_env_raises(self) -> None:
+        from app.aave.oracle_checker import get_staleness_threshold_from_env
+
+        with patch.dict(os.environ, {"AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS": "abc"}):
+            with pytest.raises(RuntimeError, match="Invalid integer"):
+                get_staleness_threshold_from_env()
+
+    def test_below_min_raises(self) -> None:
+        from app.aave.oracle_checker import get_staleness_threshold_from_env
+
+        with patch.dict(os.environ, {"AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS": "30"}):
+            with pytest.raises(RuntimeError, match="out of bounds"):
+                get_staleness_threshold_from_env()
+
+    def test_zero_raises(self) -> None:
+        from app.aave.oracle_checker import get_staleness_threshold_from_env
+
+        with patch.dict(os.environ, {"AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS": "0"}):
+            with pytest.raises(RuntimeError, match="out of bounds"):
+                get_staleness_threshold_from_env()
+
+    def test_negative_raises(self) -> None:
+        from app.aave.oracle_checker import get_staleness_threshold_from_env
+
+        with patch.dict(os.environ, {"AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS": "-1"}):
+            with pytest.raises(RuntimeError, match="out of bounds"):
+                get_staleness_threshold_from_env()
+
+    def test_above_max_raises(self) -> None:
+        from app.aave.oracle_checker import get_staleness_threshold_from_env
+
+        # 7 days + 1 second → exceeds upper bound
+        with patch.dict(os.environ, {"AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS": "604801"}):
+            with pytest.raises(RuntimeError, match="out of bounds"):
+                get_staleness_threshold_from_env()
+
+    def test_validate_returns_threshold(self) -> None:
+        from app.aave.oracle_checker import validate_staleness_threshold_env
+
+        with patch.dict(os.environ, {"AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS": "90000"}):
+            assert validate_staleness_threshold_env() == 90000
+
+    def test_check_oracle_staleness_uses_env_when_arg_omitted(self) -> None:
+        """When staleness_threshold_seconds is None, env value applies."""
+        from app.aave.oracle_checker import check_oracle_staleness
+
+        # Updated 80,000s ago: fresh under 90000s env, stale under default 3600
+        now_ts = int(datetime.now(timezone.utc).timestamp())
+        updated_ts = now_ts - 80000
+        mock_mod = _make_web3_mock(_make_round_data(updated_ts))
+
+        with (
+            patch.dict(os.environ, {"AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS": "90000"}),
+            patch.dict(sys.modules, {"web3": mock_mod}),
+        ):
+            result = check_oracle_staleness(
+                feed_address="0xFEED",
+                rpc_url="http://localhost:8545",
+                # staleness_threshold_seconds omitted → env applies
+            )
+
+        assert result is not None
+        assert result.is_stale is False
+        assert result.should_hold is False
+
+    def test_explicit_arg_overrides_env(self) -> None:
+        """Caller-provided staleness_threshold_seconds beats env."""
+        from app.aave.oracle_checker import check_oracle_staleness
+
+        # 80,000s ago: stale under explicit 3600, fresh under env 90000
+        now_ts = int(datetime.now(timezone.utc).timestamp())
+        updated_ts = now_ts - 80000
+        mock_mod = _make_web3_mock(_make_round_data(updated_ts))
+
+        with (
+            patch.dict(os.environ, {"AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS": "90000"}),
+            patch.dict(sys.modules, {"web3": mock_mod}),
+        ):
+            result = check_oracle_staleness(
+                feed_address="0xFEED",
+                rpc_url="http://localhost:8545",
+                staleness_threshold_seconds=3600,  # explicit < env → explicit wins
+            )
+
+        assert result is not None
+        assert result.is_stale is True


### PR DESCRIPTION
## 目的

Chainlink price feed の staleness 判定が hardcode 3600s で行われており、Base Sepolia
USDC/USD feed (`0xd30e2101`, heartbeat ≈24h) で常に stale → HOLD となり trade gate を
塞ぐ問題 (Asana [1215114691610454](https://app.asana.com/0/1213916581114014/1215114691610454))
の恒久修正。

## 変更内容

- `backend/app/aave/oracle_checker.py`
  - `AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS` を env から読む `get_staleness_threshold_from_env()` 追加 (範囲 `[60, 604800]`)
  - `check_oracle_staleness()` の `staleness_threshold_seconds` を `Optional[int]` 化。`None` なら env を読む。明示指定は env より優先
  - `is_oracle_fresh()` が env 経由で閾値を取得し `check_oracle_staleness()` に渡す
  - `validate_staleness_threshold_env()` を startup hook 用に公開
- `backend/app/main.py`
  - 起動時 hook `startup_validate_oracle_staleness_env` を追加。invalid env (非整数 / 範囲外) は fail-fast
- `backend/.env.staging.example` / `backend/.env.production.example`
  - `AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS=90000` (25h = Base Sepolia / mainnet USDC/USD heartbeat 24h + 安全マージン) を追記。コメントで「default 3600s は long-heartbeat feed で spurious HOLD する」旨明記
- `backend/tests/test_aave_oracle_checker.py`
  - env / default / explicit-overrides-env / 範囲外 / 非整数 / startup validation の 11 テスト追加

## 一切しないこと (タスク制約)

- feed アドレスの差し替え (本 PR ではしない、別タスク)

## DoD 確認

| Gate | 状態 |
|---|---|
| 0. Chain Config | ⚠ skipped (.env.production CI 外) |
| 1. ruff check | ✅ |
| 2. ruff format | ✅ |
| 3. mypy | ✅ |
| 4. pytest (cov 80%+) | ✅ 2966 passed, coverage 85.60% |
| 5. ruff security | ✅ |
| 6. tsc | ⚠ 本 PR は backend のみ変更で frontend スコープ外 (worktree に node_modules 未配置のため未実行、CI で確認) |
| 7. build | ⚠ 同上 |

新規 oracle 関連テスト: 41 passed (test_aave_oracle_checker.py + test_codex_p0_fail_closed.py)

## 関連

- Asana: [1215116522376075](https://app.asana.com/0/1213916581114014/1215116522376075) (本タスク)
- Asana: [1215114691610454](https://app.asana.com/0/1213916581114014/1215114691610454) (調査元)
- AI HOLD bias 残因対策の一環 (Phase A staging soak 連動)