### PR TITLE
feat(privy): Lane H — embedded wallet demo (frontend only)

### DIFF
--- a/frontend/app/user/wallet/page.tsx
+++ b/frontend/app/user/wallet/page.tsx
@@ -7,6 +7,16 @@ const WalletContent = dynamic(
   { ssr: false }
 )
 
+// 2026-05-26 Lane H: メール / SNS ログイン経由の Privy 埋込ウォレットを demo 表示。
+// 既存 WalletContent (外部 wallet 経路) はそのまま残し、上に並べる。
+const PrivyEmbeddedWalletInfo = dynamic(
+  () =>
+    import('@/components/wallet/PrivyEmbeddedWalletInfo').then((m) => ({
+      default: m.PrivyEmbeddedWalletInfo,
+    })),
+  { ssr: false }
+)
+
 export default function WalletPage() {
   return (
     <main className="px-4 py-6 max-w-md mx-auto space-y-6">
@@ -16,6 +26,7 @@ export default function WalletPage() {
           Base メインネットに接続してください
         </p>
       </div>
+      <PrivyEmbeddedWalletInfo />
       <WalletContent />
     </main>
   )

--- a/frontend/components/wallet/PrivyEmbeddedWalletInfo.tsx
+++ b/frontend/components/wallet/PrivyEmbeddedWalletInfo.tsx
@@ -1,0 +1,161 @@
+'use client'
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+
+// 2026-05-26 Lane H: Privy 埋込ウォレット情報表示コンポーネント (frontend-only / demo)。
+// メール / SNS ログイン → 自動生成された埋込ウォレットのアドレスとチェーンを表示。
+// 資金操作は含まない (Lane H demo 目的)。
+
+import { usePrivy } from '@privy-io/react-auth'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Mail, KeyRound, LogOut, Loader2 } from 'lucide-react'
+import { usePrivyEmbeddedWallet } from '@/hooks/usePrivyEmbeddedWallet'
+
+const CHAIN_NAMES: Record<number, string> = {
+  84532: 'Base Sepolia',
+  8453: 'Base メインネット',
+}
+
+export function PrivyEmbeddedWalletInfo() {
+  const { login, logout } = usePrivy()
+  const state = usePrivyEmbeddedWallet()
+
+  if (state.status === 'unconfigured') {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base flex items-center gap-2">
+            <KeyRound className="h-4 w-4" />
+            埋込ウォレット (Privy)
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            NEXT_PUBLIC_PRIVY_APP_ID が未設定のため利用できません。
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (state.status === 'initializing') {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base flex items-center gap-2">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            初期化中
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Privy SDK を読み込んでいます。
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (state.status === 'unauthenticated') {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base flex items-center gap-2">
+            <Mail className="h-4 w-4" />
+            メール / SNS でログイン
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            メールまたは SNS (Google / Apple) でログインすると、
+            外部 wallet 不要で自動的に埋込ウォレットが作成されます。
+          </p>
+          <Button onClick={login} className="w-full">
+            ログインして埋込ウォレットを作成
+          </Button>
+          <p className="text-[11px] text-muted-foreground">
+            ※ デモ環境です。実資金は入れないでください。
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (state.status === 'no-wallet') {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">埋込ウォレット未生成</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            ログイン済みですが埋込ウォレットが見つかりません。
+            一度ログアウトして再ログインしてください。
+          </p>
+          <Button variant="outline" onClick={logout} className="w-full">
+            <LogOut className="mr-2 h-4 w-4" />
+            ログアウト
+          </Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // state.status === 'ready'
+  const { address, chainId } = state
+  const chainName =
+    chainId != null && CHAIN_NAMES[chainId]
+      ? CHAIN_NAMES[chainId]
+      : chainId != null
+      ? `Chain ${chainId}`
+      : '不明'
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base flex items-center justify-between">
+          <span>埋込ウォレット</span>
+          <Badge variant="secondary">Privy</Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        <Row label="アドレス" value={address ?? '—'} mono />
+        <Row label="チェーン" value={chainName} />
+        <p className="text-[11px] text-muted-foreground pt-1">
+          ※ デモ環境です。実資金は入れないでください。
+        </p>
+        <Button variant="outline" size="sm" onClick={logout} className="w-full">
+          <LogOut className="mr-2 h-4 w-4" />
+          ログアウト
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}
+
+function Row({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string
+  value: string
+  mono?: boolean
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="text-muted-foreground shrink-0">{label}</span>
+      <span
+        className={
+          mono
+            ? 'font-mono text-xs break-all text-right'
+            : 'font-medium text-right'
+        }
+      >
+        {value}
+      </span>
+    </div>
+  )
+}

--- a/frontend/hooks/usePrivyEmbeddedWallet.ts
+++ b/frontend/hooks/usePrivyEmbeddedWallet.ts
@@ -1,0 +1,115 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+
+// 2026-05-26 Lane H: Privy 埋込ウォレット (email / SNS ログイン経由で生成) の
+// frontend-only ヘルパー。デモ参加者向けに address / chainId / 接続状態を返す。
+// 資金は入れない前提 (sign / send は将来 Lane で追加)。
+
+'use client'
+
+import { usePrivy, useWallets } from '@privy-io/react-auth'
+import { useMemo } from 'react'
+
+/**
+ * Privy が返す chainId は "eip155:84532" または "84532"。
+ * 数値に正規化して返す (parse 不能なら null)。
+ */
+function parsePrivyChainId(chainIdStr: string | undefined): number | null {
+  if (!chainIdStr) return null
+  const part = chainIdStr.includes(':') ? chainIdStr.split(':')[1] : chainIdStr
+  const num = Number.parseInt(part, 10)
+  return Number.isNaN(num) ? null : num
+}
+
+export type PrivyEmbeddedWalletStatus =
+  | 'unconfigured'   // NEXT_PUBLIC_PRIVY_APP_ID 未設定
+  | 'initializing'   // Privy SDK 初期化中
+  | 'unauthenticated'// 未ログイン
+  | 'no-wallet'      // ログイン済みだが embedded wallet 未生成 (createOnLogin 未動作)
+  | 'ready'          // 埋込ウォレット利用可能
+
+export interface PrivyEmbeddedWalletState {
+  status: PrivyEmbeddedWalletStatus
+  /** 0x... 形式の埋込ウォレットアドレス。status === 'ready' のときのみ非 null。 */
+  address: `0x${string}` | null
+  /** 現在接続中の chainId (数値)。未接続なら null。 */
+  chainId: number | null
+  /** Privy SDK が ready かつ embedded wallet が存在する。 */
+  isReady: boolean
+  /** authenticated かどうか (login 状態)。 */
+  isAuthenticated: boolean
+}
+
+/**
+ * usePrivyEmbeddedWallet
+ *
+ * デモ参加者の埋込ウォレット状態を一箇所で取得するための薄いラッパー。
+ * Privy SDK の usePrivy / useWallets の挙動を `status` enum に圧縮し、
+ * UI 側の条件分岐を見通し良くする。
+ *
+ * 既存 (user)/connect/page.tsx と (user)/wallet/* との重複を避けるため、
+ * 外部 wallet (MetaMask 等) と embedded wallet の判別は `walletClientType` で行う。
+ */
+export function usePrivyEmbeddedWallet(): PrivyEmbeddedWalletState {
+  const { ready, authenticated } = usePrivy()
+  const { wallets, ready: walletsReady } = useWallets()
+
+  return useMemo<PrivyEmbeddedWalletState>(() => {
+    const appId =
+      typeof process !== 'undefined' ? process.env.NEXT_PUBLIC_PRIVY_APP_ID : ''
+    const isConfigured =
+      Boolean(appId) && appId !== 'clplaceholder000000000000000000000'
+
+    if (!isConfigured) {
+      return {
+        status: 'unconfigured',
+        address: null,
+        chainId: null,
+        isReady: false,
+        isAuthenticated: false,
+      }
+    }
+
+    if (!ready || !walletsReady) {
+      return {
+        status: 'initializing',
+        address: null,
+        chainId: null,
+        isReady: false,
+        isAuthenticated: false,
+      }
+    }
+
+    if (!authenticated) {
+      return {
+        status: 'unauthenticated',
+        address: null,
+        chainId: null,
+        isReady: false,
+        isAuthenticated: false,
+      }
+    }
+
+    // Privy embedded wallet は walletClientType === 'privy'。
+    // 外部 wallet (metamask 等) は別 type なのでここでは除外する。
+    const embedded = wallets.find((w) => w.walletClientType === 'privy')
+    if (!embedded) {
+      return {
+        status: 'no-wallet',
+        address: null,
+        chainId: null,
+        isReady: false,
+        isAuthenticated: true,
+      }
+    }
+
+    const addr = embedded.address as `0x${string}`
+    return {
+      status: 'ready',
+      address: addr,
+      chainId: parsePrivyChainId(embedded.chainId),
+      isReady: true,
+      isAuthenticated: true,
+    }
+  }, [ready, walletsReady, authenticated, wallets])
+}

--- a/frontend/lib/wallet/PrivyRootClient.tsx
+++ b/frontend/lib/wallet/PrivyRootClient.tsx
@@ -34,7 +34,9 @@ export function PrivyRootClient({ children }: { children: ReactNode }) {
     <PrivyProvider
       appId={appId}
       config={{
-        loginMethods: ['email', 'wallet'],
+        // 2026-05-26 Lane H: SNS (google/apple) を loginMethods に追加し、デモ参加者が
+        // 外部 wallet 不要で onboarding できるようにする。LINE は OAuth 設定別途必要 (別 Lane)。
+        loginMethods: ['email', 'google', 'apple', 'wallet'],
         appearance: {
           theme: 'dark',
           accentColor: '#6366f1',
@@ -42,7 +44,9 @@ export function PrivyRootClient({ children }: { children: ReactNode }) {
         supportedChains: [base, baseSepolia],
         defaultChain,
         embeddedWallets: {
-          ethereum: { createOnLogin: 'users-without-wallets' },
+          // 'all-users' = 既存 wallet 有無に関わらず全ユーザーに埋込ウォレット作成。
+          // メール/SNS ログイン経路では必須 (資金は入れない demo 前提)。
+          ethereum: { createOnLogin: 'all-users' },
         },
       }}
     >


### PR DESCRIPTION
## Summary

Lane H — Privy 埋込ウォレット統合 (frontend のみ / demo / 資金は入れない)。
メール / SNS (google / apple) ログインで Privy 埋込ウォレットが自動生成され、
demo 参加者が外部 wallet 不要で onboarding できる状態を作る。

Asana: https://app.asana.com/1/817733952351708/project/1213916581114014/task/1215079707779125

## Changes

| File | Change |
|---|---|
| frontend/lib/wallet/PrivyRootClient.tsx | loginMethods に google/apple 追加、embeddedWallets.createOnLogin を 'all-users' に変更 |
| frontend/hooks/usePrivyEmbeddedWallet.ts (new) | Privy 埋込ウォレット状態を status enum で公開する薄いラッパー |
| frontend/components/wallet/PrivyEmbeddedWalletInfo.tsx (new) | メール/SNS ログイン → 埋込ウォレット表示 UI (demo / 資金操作なし) |
| frontend/app/user/wallet/page.tsx | PrivyEmbeddedWalletInfo を dynamic import で追加 (既存 WalletContent 維持) |

LINE OAuth は app 側 OAuth 設定が必要なため別 Lane に分離。

## Scope (frontend only)

- backend: 触らず (#387 と独立)
- DB migration: なし
- env 追加: なし (既存 NEXT_PUBLIC_PRIVY_APP_ID で動作)

## Verification

- frontend tsc --noEmit: pass
- frontend npm run build: pass
- backend ruff check: pass (unchanged)
- backend ruff format --check: pass (unchanged)
- backend mypy: pass (unchanged)
- backend pytest: 別途実行中 (本 PR は backend 不触のため緑見込み)

## Test plan

- [ ] /user/wallet 画面で未ログイン時にメール/SNS ログインカードが表示される
- [ ] ログイン後に埋込ウォレットアドレスと chain 名が表示される
- [ ] ログアウト動作

## Notes for reviewer

- 既存 (user)/connect/page.tsx の usePrivy/useWallets 経路はそのまま維持
- 既存 wallet ページ WalletContent (外部 wallet 経路) は維持
- HUMAN-REVIEW: 鍵リカバリ方針 docs は別 PR #387 で扱う (本 PR は frontend UI のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)