### PR TITLE
feat(launch-gate): scripts/launch_gate.sh L0-L5 集約スクリプト

### DIFF
--- a/scripts/launch_gate.sh
+++ b/scripts/launch_gate.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# scripts/launch_gate.sh
+#
+# Ultra AutoTrade — Launch Gate (L0-L5 集約スクリプト)
+#
+# 「実装完了→ローンチ不能」が 3 ヶ月再発し続けているため、launch 直前に
+# L0-L5 全 green を機械的に強制する gate を 1 ファイルから実行可能にする。
+#
+# Usage:
+#   bash scripts/launch_gate.sh --env=staging
+#   bash scripts/launch_gate.sh --env=production
+#   bash scripts/launch_gate.sh --env=staging --only=L2
+#   bash scripts/launch_gate.sh --env=staging --skip=L3,L4
+#   bash scripts/launch_gate.sh --help
+#
+# Lanes:
+#   L0 schema    -- alembic / SQLAlchemy gap (staging == production)
+#   L1 env       -- .env.staging / .env.production の意味的分離
+#   L2 smoke     -- /health + 主要 5 endpoint が 2xx
+#   L3 e2e       -- yamamoto-partner-flow.spec.ts 完走
+#   L4 kill      -- POST /api/automation/emergency-stop が動く
+#   L5 wiring    -- 孤立 router (main.py 未 register) 検出
+#
+# Exit codes:
+#   0 -- FAIL ゼロ (SKIP は許容、人間貼付け確認が必要)
+#   1 -- 1 件以上 FAIL もしくは不正引数
+#
+# 出力フォーマット:
+#   [PASS] L0 schema: <summary>
+#   [FAIL] L1 env:    <summary>
+#   [SKIP] L2 smoke:  <reason>
+#   ...
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE_DIR="${SCRIPT_DIR}/launch_gate"
+
+# shellcheck disable=SC1091
+source "${GATE_DIR}/lib.sh"
+
+# ---------------------------------------------------------------------------
+# 引数 parse
+# ---------------------------------------------------------------------------
+ENV_TARGET="staging"
+ONLY=""
+SKIP=""
+
+show_help() {
+  # ファイル先頭のヘッダコメント (2行目から最初の非コメント行直前まで) を抽出
+  awk 'NR>1 && /^#/ {sub(/^# ?/, ""); print; next} NR>1 {exit}' "$0"
+}
+
+for arg in "$@"; do
+  case "${arg}" in
+    --env=*)   ENV_TARGET="${arg#--env=}" ;;
+    --only=*)  ONLY="${arg#--only=}" ;;
+    --skip=*)  SKIP="${arg#--skip=}" ;;
+    --help|-h) show_help; exit 0 ;;
+    *)
+      echo "[launch_gate] unknown arg: ${arg}" >&2
+      show_help
+      exit 1
+      ;;
+  esac
+done
+
+case "${ENV_TARGET}" in
+  staging|production) ;;
+  *)
+    echo "[launch_gate] --env must be 'staging' or 'production' (got: ${ENV_TARGET})" >&2
+    exit 1
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 実行する Lane の決定
+# ---------------------------------------------------------------------------
+ALL_LANES=(L0 L1 L2 L3 L4 L5)
+declare -A LANE_SCRIPT=(
+  [L0]="${GATE_DIR}/L0_schema.sh"
+  [L1]="${GATE_DIR}/L1_env.sh"
+  [L2]="${GATE_DIR}/L2_smoke.sh"
+  [L3]="${GATE_DIR}/L3_e2e.sh"
+  [L4]="${GATE_DIR}/L4_killswitch.sh"
+  [L5]="${GATE_DIR}/L5_wiring_lint.sh"
+)
+
+# --only / --skip を CSV split
+_csv_to_set() {
+  local csv="$1"
+  echo "${csv}" | tr ',' '\n' | sed '/^$/d'
+}
+
+selected=()
+if [[ -n "${ONLY}" ]]; then
+  while IFS= read -r ln; do
+    if [[ -n "${LANE_SCRIPT[${ln}]:-}" ]]; then
+      selected+=("${ln}")
+    else
+      echo "[launch_gate] --only に未知の lane: ${ln}" >&2
+      exit 1
+    fi
+  done < <(_csv_to_set "${ONLY}")
+else
+  selected=("${ALL_LANES[@]}")
+fi
+
+if [[ -n "${SKIP}" ]]; then
+  skipset="$(_csv_to_set "${SKIP}")"
+  remaining=()
+  for ln in "${selected[@]}"; do
+    if echo "${skipset}" | grep -qE "^${ln}$"; then
+      log_info "skipping ${ln} (per --skip)"
+    else
+      remaining+=("${ln}")
+    fi
+  done
+  selected=("${remaining[@]}")
+fi
+
+# ---------------------------------------------------------------------------
+# 実行ヘッダ
+# ---------------------------------------------------------------------------
+echo "=========================================="
+echo " Ultra AutoTrade Launch Gate"
+echo "   env:    ${ENV_TARGET}"
+echo "   lanes:  ${selected[*]:-(none)}"
+echo "   host:   $(hostname 2>/dev/null || uname -n)"
+echo "   time:   $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "=========================================="
+
+if [[ "${#selected[@]}" -eq 0 ]]; then
+  echo "[launch_gate] no lanes selected after --only/--skip; nothing to do."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Lane を順次実行。
+# 各 L*.sh は独立 bash subshell で起動する (内部の set -e / exit が
+# 親プロセスを終了させないようにするため)。
+# 親 (このスクリプト) は L*.sh が出力する [PASS]/[FAIL]/[SKIP] 行を
+# 標準出力に流すだけで、最終集約は最後にこちら側でもう一度計算する。
+# ---------------------------------------------------------------------------
+fail_lanes=()
+pass_lanes=()
+skip_lanes=()
+
+for ln in "${selected[@]}"; do
+  script="${LANE_SCRIPT[${ln}]}"
+  echo ""
+  echo "==> ${ln} (${script})"
+  if [[ ! -f "${script}" ]]; then
+    echo "[FAIL] ${ln}: lane script 不在: ${script}"
+    fail_lanes+=("${ln}")
+    continue
+  fi
+
+  # 各 lane を独立した bash で実行。終了コード:
+  #   0  -> PASS or SKIP (lane 側で gate_record SKIP の場合 exit 0)
+  #   1  -> FAIL
+  # PASS と SKIP の区別は標準出力の [PASS]/[SKIP] 行で行う。
+  output_file="$(mktemp -t "launch_gate_${ln}_XXXXXX")"
+  ENV_TARGET="${ENV_TARGET}" bash "${script}" 2>&1 | tee "${output_file}"
+  rc=${PIPESTATUS[0]}
+
+  if [[ "${rc}" -ne 0 ]]; then
+    fail_lanes+=("${ln}")
+  elif grep -q "^\[SKIP\] ${ln} " "${output_file}"; then
+    skip_lanes+=("${ln}")
+  else
+    pass_lanes+=("${ln}")
+  fi
+  rm -f "${output_file}"
+done
+
+# ---------------------------------------------------------------------------
+# 最終サマリ
+# ---------------------------------------------------------------------------
+echo ""
+echo "=========================================="
+echo " Launch Gate Summary (env=${ENV_TARGET})"
+echo "=========================================="
+echo "  PASS (${#pass_lanes[@]}): ${pass_lanes[*]:-}"
+echo "  SKIP (${#skip_lanes[@]}): ${skip_lanes[*]:-}"
+echo "  FAIL (${#fail_lanes[@]}): ${fail_lanes[*]:-}"
+echo "------------------------------------------"
+
+if [[ "${#fail_lanes[@]}" -gt 0 ]]; then
+  echo "Launch Gate: BLOCKED — launch 不可。上記 FAIL lane を修正してください。"
+  exit 1
+fi
+
+if [[ "${#skip_lanes[@]}" -gt 0 ]]; then
+  echo "Launch Gate: CONDITIONAL PASS — SKIP lane は人間が prod VPS で実行し"
+  echo "             結果を貼り付けて確認するまで実質完了ではありません。"
+else
+  echo "Launch Gate: PASSED — launch 可。"
+fi
+exit 0

--- a/scripts/launch_gate/L0_schema.sh
+++ b/scripts/launch_gate/L0_schema.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# scripts/launch_gate/L0_schema.sh
+#
+# Launch Gate L0: schema / migration ギャップ検査。
+#
+# 目的:
+#   staging と production の DB schema (= alembic head / model 定義) が
+#   一致しているかを確認する。launch 直前に不足 migration があると
+#   "実装完了→ローンチ不能" の典型パターンになる。
+#
+# 実装:
+#   既存 scripts/check_db_migration_gap.sh を staging / production それぞれで呼ぶ。
+#   両方 exit 0 (= ギャップ無し) なら PASS。
+#
+# Usage (launch_gate.sh から source して呼ばれる):
+#   ENV_TARGET=staging  bash scripts/launch_gate/L0_schema.sh
+#   ENV_TARGET=production bash scripts/launch_gate/L0_schema.sh
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib.sh"
+
+PROJECT_ROOT="$(gate_project_root)"
+GAP_SCRIPT="${PROJECT_ROOT}/scripts/check_db_migration_gap.sh"
+LABEL="L0 schema"
+
+ENV_TARGET="${ENV_TARGET:-staging}"
+
+if [[ ! -x "${GAP_SCRIPT}" && ! -f "${GAP_SCRIPT}" ]]; then
+  gate_record FAIL "${LABEL}" "check_db_migration_gap.sh が見つかりません: ${GAP_SCRIPT}"
+  exit 1
+fi
+
+# dev VPS からは prod DB に届かないので skip-with-instructions
+if is_dev_vps; then
+  cat <<EOF
+[INFO] L0 schema: dev VPS のため prod / staging DB に直接アクセスできません。
+       prod VPS (77.42.46.155) で以下を順に実行し、両方 exit 0 を確認してください:
+
+         bash ${GAP_SCRIPT} --env=staging
+         bash ${GAP_SCRIPT} --env=production
+
+       両方 0 でない場合は alembic head に gap あり → launch 不可。
+EOF
+  gate_record SKIP "${LABEL}" "dev VPS のため手動実行 (prod VPS で check_db_migration_gap.sh --env={staging,production})"
+  exit 0
+fi
+
+# prod / staging 側 (本物の VPS) で実行された場合
+fail_envs=()
+for env in staging production; do
+  echo "--- L0 schema: ${env} ---"
+  if bash "${GAP_SCRIPT}" --env="${env}"; then
+    echo "  [ok] ${env}"
+  else
+    rc=$?
+    fail_envs+=("${env}(rc=${rc})")
+  fi
+done
+
+if [[ "${#fail_envs[@]}" -eq 0 ]]; then
+  gate_record PASS "${LABEL}" "staging / production alembic gap なし"
+  exit 0
+fi
+
+gate_record FAIL "${LABEL}" "schema gap あり: ${fail_envs[*]}"
+exit 1

--- a/scripts/launch_gate/L1_env.sh
+++ b/scripts/launch_gate/L1_env.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# scripts/launch_gate/L1_env.sh
+#
+# Launch Gate L1: env 分離検査。
+#
+# 目的:
+#   .env.staging と .env.production が意味のある差分を持つこと、
+#   .env.production の重要キーが本番値であることを確認する。
+#
+# 実装:
+#   1. 既存 scripts/check_env_separation.sh を呼ぶ (exit 0 必須)
+#   2. .env.production の重要キー (APP_ENV=production, AAVE_NETWORK=base_mainnet 等)
+#      を手元 grep でも検証する (二重チェック)
+#
+# Usage:
+#   bash scripts/launch_gate/L1_env.sh
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib.sh"
+
+PROJECT_ROOT="$(gate_project_root)"
+SEP_SCRIPT="${PROJECT_ROOT}/scripts/check_env_separation.sh"
+LABEL="L1 env"
+
+PROD_ENV="${PROJECT_ROOT}/.env.production"
+STAGING_ENV="${PROJECT_ROOT}/.env.staging"
+
+if [[ ! -f "${SEP_SCRIPT}" ]]; then
+  gate_record FAIL "${LABEL}" "check_env_separation.sh が見つかりません: ${SEP_SCRIPT}"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Step 1: env ファイルが手元にあるか
+# ---------------------------------------------------------------------------
+missing=()
+[[ ! -f "${PROD_ENV}" ]]    && missing+=(".env.production")
+[[ ! -f "${STAGING_ENV}" ]] && missing+=(".env.staging")
+
+if [[ "${#missing[@]}" -gt 0 ]]; then
+  cat <<EOF
+[INFO] L1 env: ${missing[*]} がこの worktree に存在しません。
+       prod VPS (77.42.46.155) 上で以下を実行し、結果を貼り付けてください:
+
+         bash ${SEP_SCRIPT}
+         grep -E '^(APP_ENV|AAVE_NETWORK|BYBIT_SANDBOX)=' ${PROD_ENV}
+         grep -E '^(APP_ENV|AAVE_NETWORK|BYBIT_SANDBOX)=' ${STAGING_ENV}
+
+       期待値:
+         .env.production: APP_ENV=production / AAVE_NETWORK=base_mainnet / BYBIT_SANDBOX=false
+         .env.staging:    APP_ENV=staging    / AAVE_NETWORK=base_sepolia / BYBIT_SANDBOX=true
+EOF
+  gate_record SKIP "${LABEL}" "${missing[*]} がこの host に無し (prod VPS で要手動確認)"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: check_env_separation.sh
+# ---------------------------------------------------------------------------
+echo "--- L1 env: check_env_separation.sh ---"
+sep_rc=0
+bash "${SEP_SCRIPT}" || sep_rc=$?
+
+# ---------------------------------------------------------------------------
+# Step 3: 重要キー手元検査 (.env.production の固定値要求)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- L1 env: .env.production critical keys ---"
+
+violations=()
+
+# APP_ENV=production 必須
+app_env=$(grep -E '^APP_ENV=' "${PROD_ENV}" | head -n 1 | cut -d= -f2- | tr -d '[:space:]')
+if [[ "${app_env}" != "production" ]]; then
+  violations+=("APP_ENV expected=production got='${app_env}'")
+  echo "  [ng] APP_ENV='${app_env}' (期待: production)"
+else
+  echo "  [ok] APP_ENV=production"
+fi
+
+# AAVE_NETWORK=base_mainnet 必須
+aave_net=$(grep -E '^AAVE_NETWORK=' "${PROD_ENV}" | head -n 1 | cut -d= -f2- | tr -d '[:space:]')
+if [[ "${aave_net}" != "base_mainnet" ]]; then
+  violations+=("AAVE_NETWORK expected=base_mainnet got='${aave_net}'")
+  echo "  [ng] AAVE_NETWORK='${aave_net}' (期待: base_mainnet)"
+else
+  echo "  [ok] AAVE_NETWORK=base_mainnet"
+fi
+
+# DATABASE_URL は存在のみ (値はマスク)
+if grep -qE '^DATABASE_URL=' "${PROD_ENV}"; then
+  echo "  [ok] DATABASE_URL is set"
+else
+  violations+=("DATABASE_URL not set in .env.production")
+  echo "  [ng] DATABASE_URL 未設定"
+fi
+
+# BYBIT_SANDBOX=false 必須 (Phase1 例外期間中は WARN だが、launch gate は厳格)
+bybit=$(grep -E '^BYBIT_SANDBOX=' "${PROD_ENV}" | head -n 1 | cut -d= -f2- | tr -d '[:space:]')
+if [[ -n "${bybit}" && "${bybit}" != "false" ]]; then
+  violations+=("BYBIT_SANDBOX expected=false got='${bybit}'")
+  echo "  [ng] BYBIT_SANDBOX='${bybit}' (期待: false)"
+else
+  echo "  [ok] BYBIT_SANDBOX=${bybit:-(unset)}"
+fi
+
+# ---------------------------------------------------------------------------
+# 結果集約
+# ---------------------------------------------------------------------------
+if [[ "${sep_rc}" -ne 0 || "${#violations[@]}" -gt 0 ]]; then
+  msg="check_env_separation rc=${sep_rc}"
+  if [[ "${#violations[@]}" -gt 0 ]]; then
+    msg="${msg}; critical-key NG: ${violations[*]}"
+  fi
+  gate_record FAIL "${LABEL}" "${msg}"
+  exit 1
+fi
+
+gate_record PASS "${LABEL}" "env 分離 OK & .env.production の critical key 期待値一致"
+exit 0

--- a/scripts/launch_gate/L2_smoke.sh
+++ b/scripts/launch_gate/L2_smoke.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# scripts/launch_gate/L2_smoke.sh
+#
+# Launch Gate L2: 主要 endpoint smoke test。
+#
+# 目的:
+#   /health と主要 5 endpoint が 2xx で応答することを確認する。
+#
+# 主要 5 endpoint:
+#   /api/portfolio
+#   /api/transparency/safety-score
+#   /api/automation/status
+#   /api/ai/decisions/latest
+#   /api/proposals/pending
+#
+# 注意:
+#   staging は本番 Hetzner VPS (77.42.46.155) に同居しており dev VPS から
+#   到達不可。memory [[staging-lives-on-prod-vps]] / [[no-prod-vps-commands-from-dev]]
+#   に従い、dev VPS では skip-with-instructions モードに倒す。
+#
+# Usage:
+#   ENV_TARGET=staging    bash scripts/launch_gate/L2_smoke.sh
+#   ENV_TARGET=production bash scripts/launch_gate/L2_smoke.sh
+#   LAUNCH_GATE_BASE_URL=http://localhost:8000 bash scripts/launch_gate/L2_smoke.sh
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib.sh"
+
+LABEL="L2 smoke"
+ENV_TARGET="${ENV_TARGET:-staging}"
+
+# 主要 endpoint
+ENDPOINTS=(
+  "/health"
+  "/api/portfolio"
+  "/api/transparency/safety-score"
+  "/api/automation/status"
+  "/api/ai/decisions/latest"
+  "/api/proposals/pending"
+)
+
+# Base URL (env で override 可能)
+case "${ENV_TARGET}" in
+  staging)    DEFAULT_BASE="http://localhost:8000" ;;
+  production) DEFAULT_BASE="http://localhost:8001" ;;
+  *)          DEFAULT_BASE="http://localhost:8000" ;;
+esac
+BASE_URL="${LAUNCH_GATE_BASE_URL:-${DEFAULT_BASE}}"
+
+# ---------------------------------------------------------------------------
+# dev VPS では prod / staging に届かないため skip-with-instructions
+# ---------------------------------------------------------------------------
+if is_dev_vps; then
+  cat <<EOF
+[INFO] L2 smoke: dev VPS のため prod VPS 同居の ${ENV_TARGET} に直接到達できません。
+       prod VPS (77.42.46.155) で以下のコマンドを実行し、結果を貼り付けてください:
+
+         BASE=${BASE_URL}
+$(for ep in "${ENDPOINTS[@]}"; do
+    printf '         curl -fsS -o /dev/null -w "%%{http_code} %s\\n" "\$BASE%s"\n' "${ep}" "${ep}"
+  done)
+
+       全て 200 番台であること。
+       env=${ENV_TARGET} の場合の想定 port:
+         staging:    nginx 経由で host:8000 もしくは container 直 (要確認)
+         production: nginx 経由で host:8001 もしくは container 直 (要確認)
+EOF
+  gate_record SKIP "${LABEL}" "dev VPS のため prod VPS で手動 curl 確認 (env=${ENV_TARGET})"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 実機 (prod VPS) 実行
+# ---------------------------------------------------------------------------
+if ! command -v curl >/dev/null 2>&1; then
+  gate_record FAIL "${LABEL}" "curl コマンドが無い"
+  exit 1
+fi
+
+echo "--- L2 smoke: env=${ENV_TARGET} base=${BASE_URL} ---"
+fails=()
+for ep in "${ENDPOINTS[@]}"; do
+  url="${BASE_URL}${ep}"
+  code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "${url}" 2>/dev/null || echo "000")
+  if [[ "${code}" =~ ^2[0-9][0-9]$ ]]; then
+    echo "  [ok] ${code} ${ep}"
+  else
+    echo "  [ng] ${code} ${ep}"
+    fails+=("${ep}=${code}")
+  fi
+done
+
+if [[ "${#fails[@]}" -eq 0 ]]; then
+  gate_record PASS "${LABEL}" "全 ${#ENDPOINTS[@]} endpoint 2xx (env=${ENV_TARGET})"
+  exit 0
+fi
+
+gate_record FAIL "${LABEL}" "non-2xx: ${fails[*]}"
+exit 1

--- a/scripts/launch_gate/L3_e2e.sh
+++ b/scripts/launch_gate/L3_e2e.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# scripts/launch_gate/L3_e2e.sh
+#
+# Launch Gate L3: Playwright e2e (yamamoto-partner-flow.spec.ts) 完走。
+#
+# 目的:
+#   山本さんパートナーフローの e2e がフロント上で完走することを確認する。
+#   UI 側の結合崩れ (router 未登録 / 404 / 接続切れ) の最終検出網。
+#
+# 実装:
+#   frontend/e2e/yamamoto-partner-flow.spec.ts を対象に
+#   `npx playwright test e2e/yamamoto-partner-flow.spec.ts` を実行する。
+#   実機 staging URL に対する e2e は人間担当 (BASE_URL 切替が必要なため)、
+#   dev VPS 上で実行可能 (= 依存揃っている) ならローカル実行を試みる。
+#
+# Usage:
+#   ENV_TARGET=staging bash scripts/launch_gate/L3_e2e.sh
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib.sh"
+
+PROJECT_ROOT="$(gate_project_root)"
+LABEL="L3 e2e"
+ENV_TARGET="${ENV_TARGET:-staging}"
+
+FRONTEND_DIR="${PROJECT_ROOT}/frontend"
+SPEC_REL="e2e/yamamoto-partner-flow.spec.ts"
+SPEC_ABS="${FRONTEND_DIR}/${SPEC_REL}"
+PW_CONFIG="${FRONTEND_DIR}/playwright.config.ts"
+
+# ---------------------------------------------------------------------------
+# 前提物存在チェック
+# ---------------------------------------------------------------------------
+if [[ ! -f "${SPEC_ABS}" ]]; then
+  gate_record FAIL "${LABEL}" "spec が見つかりません: ${SPEC_ABS}"
+  exit 1
+fi
+if [[ ! -f "${PW_CONFIG}" ]]; then
+  gate_record FAIL "${LABEL}" "playwright.config.ts が見つかりません: ${PW_CONFIG}"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# staging 実機を対象にする場合は人間担当 (BASE_URL 切替・認証 token 注入が必要)
+# dev VPS で実行する場合も、staging URL に dev から到達できないので skip。
+# 実機実行は prod VPS or 開発者ローカルで実施し結果を貼り付けてもらう。
+# ---------------------------------------------------------------------------
+if is_dev_vps; then
+  cat <<EOF
+[INFO] L3 e2e: dev VPS のため staging URL ベースの Playwright を直接実行しません。
+       下記いずれかの方法で実行し、PASS 出力を貼り付けてください:
+
+         (A) 開発者ローカル (frontend dev サーバを起動した状態):
+             cd ${FRONTEND_DIR}
+             npx playwright test ${SPEC_REL}
+
+         (B) prod VPS (staging 同居) で実行する場合:
+             cd /opt/ultra-autotrade/frontend  # prod VPS 側 path
+             PLAYWRIGHT_BASE_URL=https://staging.<...> npx playwright test ${SPEC_REL}
+
+       期待: 1 passed (X.XXs) で exit 0 であること。
+EOF
+  gate_record SKIP "${LABEL}" "dev VPS のため Playwright 実機は手動実行 (yamamoto-partner-flow.spec.ts)"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 実機 (prod / 開発者ローカル) で実行可能なら実行
+# ---------------------------------------------------------------------------
+if ! command -v npx >/dev/null 2>&1; then
+  gate_record FAIL "${LABEL}" "npx コマンドが見つからない (Node.js / npm 要インストール)"
+  exit 1
+fi
+
+echo "--- L3 e2e: npx playwright test ${SPEC_REL} ---"
+(
+  cd "${FRONTEND_DIR}" || exit 1
+  npx playwright test "${SPEC_REL}"
+)
+rc=$?
+
+if [[ "${rc}" -eq 0 ]]; then
+  gate_record PASS "${LABEL}" "yamamoto-partner-flow.spec.ts 完走"
+  exit 0
+fi
+
+gate_record FAIL "${LABEL}" "playwright test rc=${rc}"
+exit 1

--- a/scripts/launch_gate/L4_killswitch.sh
+++ b/scripts/launch_gate/L4_killswitch.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# scripts/launch_gate/L4_killswitch.sh
+#
+# Launch Gate L4: 緊急停止 (kill switch) 動作確認。
+#
+# 目的:
+#   POST /api/automation/emergency-stop が staging で動作し、
+#   その後 /api/automation/status が is_trading_paused=true を返すことを確認する。
+#
+# 注意:
+#   staging に dev VPS からは到達不可。skip-with-instructions を出して
+#   人間に手元で実行してもらう (memory [[no-prod-vps-commands-from-dev]])。
+#
+# Usage:
+#   ENV_TARGET=staging bash scripts/launch_gate/L4_killswitch.sh
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib.sh"
+
+LABEL="L4 kill switch"
+ENV_TARGET="${ENV_TARGET:-staging}"
+
+case "${ENV_TARGET}" in
+  staging)    DEFAULT_BASE="http://localhost:8000" ;;
+  production) DEFAULT_BASE="http://localhost:8001" ;;
+  *)          DEFAULT_BASE="http://localhost:8000" ;;
+esac
+BASE_URL="${LAUNCH_GATE_BASE_URL:-${DEFAULT_BASE}}"
+
+# ---------------------------------------------------------------------------
+# dev VPS では prod / staging に届かないため skip-with-instructions
+# ---------------------------------------------------------------------------
+if is_dev_vps; then
+  cat <<EOF
+[INFO] L4 kill switch: dev VPS のため prod VPS 同居の ${ENV_TARGET} に到達できません。
+       prod VPS (77.42.46.155) で以下を実行し、結果を貼り付けてください:
+
+         BASE=${BASE_URL}
+         # 1) 緊急停止
+         curl -fsS -X POST "\$BASE/api/automation/emergency-stop" \\
+           -H 'Content-Type: application/json' \\
+           -d '{"reason":"launch-gate L4 verification"}'
+
+         # 2) 直後の status で is_trading_paused=true を確認
+         curl -fsS "\$BASE/api/automation/status" | jq '.is_trading_paused'
+
+       期待: 1) 2xx 応答, 2) "true" が返る。
+       検証後は自動取引を意図的に再開する必要がある場合のみ resume API を叩く。
+EOF
+  gate_record SKIP "${LABEL}" "dev VPS のため手動 curl 確認 (POST /api/automation/emergency-stop → status.is_trading_paused=true)"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 実機 (prod VPS) 実行
+# ---------------------------------------------------------------------------
+if ! command -v curl >/dev/null 2>&1; then
+  gate_record FAIL "${LABEL}" "curl コマンドが無い"
+  exit 1
+fi
+
+echo "--- L4 kill switch: env=${ENV_TARGET} base=${BASE_URL} ---"
+
+# 1) emergency-stop
+stop_code=$(curl -sS -o /tmp/launch_gate_l4_stop.json -w '%{http_code}' \
+  --max-time 10 \
+  -X POST "${BASE_URL}/api/automation/emergency-stop" \
+  -H 'Content-Type: application/json' \
+  -d '{"reason":"launch-gate L4 verification"}' 2>/dev/null || echo "000")
+echo "  emergency-stop: ${stop_code}"
+
+if [[ ! "${stop_code}" =~ ^2[0-9][0-9]$ ]]; then
+  gate_record FAIL "${LABEL}" "emergency-stop response=${stop_code}"
+  exit 1
+fi
+
+# 2) status 確認
+status_body=$(curl -sS --max-time 10 "${BASE_URL}/api/automation/status" 2>/dev/null || echo "")
+echo "  status body: ${status_body}"
+
+paused=""
+if command -v jq >/dev/null 2>&1; then
+  paused=$(echo "${status_body}" | jq -r '.is_trading_paused // empty' 2>/dev/null || echo "")
+else
+  # jq 無くても可: 雑 grep フォールバック
+  if echo "${status_body}" | grep -qE '"is_trading_paused"[[:space:]]*:[[:space:]]*true'; then
+    paused="true"
+  elif echo "${status_body}" | grep -qE '"is_trading_paused"[[:space:]]*:[[:space:]]*false'; then
+    paused="false"
+  fi
+fi
+
+if [[ "${paused}" == "true" ]]; then
+  gate_record PASS "${LABEL}" "emergency-stop → is_trading_paused=true"
+  exit 0
+fi
+
+gate_record FAIL "${LABEL}" "emergency-stop 後 is_trading_paused='${paused}' (期待: true)"
+exit 1

--- a/scripts/launch_gate/L5_wiring_lint.sh
+++ b/scripts/launch_gate/L5_wiring_lint.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# scripts/launch_gate/L5_wiring_lint.sh
+#
+# Launch Gate L5: 孤立コード (= 定義したが main.py から register されていない
+# router / startup hook) の検出。
+#
+# 目的:
+#   AutoEvacuator / CompoundRiskAssessor 等、過去に「実装したが
+#   main.py / startup から register されておらず本番では動かない」事例が
+#   繰り返し発生。launch 前に grep ベースで検出する。
+#
+# 完璧でなくてよい (過検出 OK)。launch 前に人間がレビューする前提。
+#
+# 検出ロジック:
+#   1. backend/app/ 配下から `APIRouter(` 定義のある .py を抽出
+#   2. 各ファイルで `router = APIRouter(` 等の symbol 名 (右辺の代入先) を抜く
+#   3. その module path + symbol が backend/app/main.py 内で
+#      include_router(<symbol_alias>) されているかを grep
+#   4. されていない symbol を fail として列挙
+#
+# Usage:
+#   bash scripts/launch_gate/L5_wiring_lint.sh
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib.sh"
+
+PROJECT_ROOT="$(gate_project_root)"
+LABEL="L5 wiring"
+APP_DIR="${PROJECT_ROOT}/backend/app"
+MAIN_PY="${APP_DIR}/main.py"
+
+if [[ ! -d "${APP_DIR}" ]]; then
+  gate_record FAIL "${LABEL}" "backend/app/ が見つかりません: ${APP_DIR}"
+  exit 1
+fi
+if [[ ! -f "${MAIN_PY}" ]]; then
+  gate_record FAIL "${LABEL}" "backend/app/main.py が見つかりません"
+  exit 1
+fi
+
+echo "--- L5 wiring lint: scan ${APP_DIR} ---"
+
+# main.py で import alias → 元 symbol を引くマップを作る。
+# パターン例:
+#   from app.aave.router import router as aave_router
+#   from app.aave.router import router
+#
+# main.py で include_router(X) されている alias の集合
+# 第1引数が同一行にあるパターンと、改行して次行にあるパターンの両方を拾う。
+# 例:
+#   app.include_router(auth_router)
+#   app.include_router(
+#       allocation_router, prefix="/api/partner",
+#   )
+INCLUDED_ALIASES="$(
+  python3 - <<'PYEOF' "${MAIN_PY}"
+import re, sys
+src = open(sys.argv[1], 'r', encoding='utf-8').read()
+# include_router( ... ) の中身の先頭 identifier を取る
+pattern = re.compile(r'include_router\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)')
+seen = set()
+for m in pattern.finditer(src):
+    seen.add(m.group(1))
+for s in sorted(seen):
+    print(s)
+PYEOF
+)"
+
+# main.py で import されている "module path -> alias" の対応を抽出。
+# 形式: <module> <orig_symbol> <alias>
+# 例:   app.aave.router router aave_router
+#       app.aave.router router router   (alias なしのケース)
+IMPORTS_RAW="$(grep -nE '^[[:space:]]*from[[:space:]]+app\.[A-Za-z0-9_.]+[[:space:]]+import[[:space:]]+' "${MAIN_PY}" || true)"
+
+# router 定義のあるファイルを列挙
+ROUTER_FILES="$(grep -rlE 'APIRouter\(' "${APP_DIR}" 2>/dev/null | sort -u || true)"
+
+if [[ -z "${ROUTER_FILES}" ]]; then
+  gate_record PASS "${LABEL}" "APIRouter 定義が backend/app/ 配下に無し (検出対象なし)"
+  exit 0
+fi
+
+orphans=()
+checked=0
+
+while IFS= read -r f; do
+  [[ -z "${f}" ]] && continue
+  checked=$(( checked + 1 ))
+
+  # symbol 名抽出: "router = APIRouter(" や "api_router = APIRouter(" 等
+  symbols="$(grep -nE '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=[[:space:]]*APIRouter\(' "${f}" \
+    | sed -E 's/^[0-9]+:[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=.*/\1/' \
+    | sort -u)"
+  [[ -z "${symbols}" ]] && continue
+
+  # module path 推定: backend/app/foo/bar.py -> app.foo.bar
+  rel="${f#"${APP_DIR}"/}"
+  rel="${rel%.py}"
+  module="app.${rel//\//.}"
+
+  for sym in ${symbols}; do
+    # main.py の import 行から、この module+symbol が import されているか / alias は何か
+    # 例: "from app.aave.router import router as aave_router"
+    #     "from app.aave.router import router"
+    alias_line="$(echo "${IMPORTS_RAW}" | grep -E "from[[:space:]]+${module}[[:space:]]+import[[:space:]]" || true)"
+
+    if [[ -z "${alias_line}" ]]; then
+      # main.py から一切 import されていない → 孤立疑い
+      orphans+=("${module}:${sym}  (main.py から未 import)")
+      continue
+    fi
+
+    # alias 解決: "import <sym> as <alias>" / "import <sym>" / "import (<sym>, ...)"
+    alias_name=""
+    if echo "${alias_line}" | grep -qE "import[[:space:]]+${sym}[[:space:]]+as[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)"; then
+      alias_name="$(echo "${alias_line}" | sed -nE "s/.*import[[:space:]]+${sym}[[:space:]]+as[[:space:]]+([A-Za-z_][A-Za-z0-9_]*).*/\1/p" | head -n 1)"
+    elif echo "${alias_line}" | grep -qE "import[[:space:]]+(\(|[^,]*\b)${sym}\b"; then
+      # alias 無し import → そのまま symbol 名で使われる
+      alias_name="${sym}"
+    fi
+
+    if [[ -z "${alias_name}" ]]; then
+      # import 行に sym 自体が含まれていない (他 symbol のみ import) → 孤立疑い
+      orphans+=("${module}:${sym}  (main.py の import に該当 symbol 不在)")
+      continue
+    fi
+
+    # main.py の include_router(<alias_name>) に含まれているか
+    if echo "${INCLUDED_ALIASES}" | grep -qE "^${alias_name}$"; then
+      : # OK
+    else
+      orphans+=("${module}:${sym}  (include_router(${alias_name}) されていない)")
+    fi
+  done
+done <<< "${ROUTER_FILES}"
+
+echo "  scanned router files: ${checked}"
+echo "  include_router 済 alias: $(echo "${INCLUDED_ALIASES}" | wc -l | tr -d ' ')"
+
+if [[ "${#orphans[@]}" -eq 0 ]]; then
+  gate_record PASS "${LABEL}" "孤立 router 検出なし (scanned=${checked})"
+  exit 0
+fi
+
+echo ""
+echo "  孤立疑い (over-detection 含む — 人間レビュー前提):"
+for o in "${orphans[@]}"; do
+  echo "    - ${o}"
+done
+
+gate_record FAIL "${LABEL}" "孤立 router 疑い ${#orphans[@]} 件 (scanned=${checked})"
+exit 1

--- a/scripts/launch_gate/lib.sh
+++ b/scripts/launch_gate/lib.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# scripts/launch_gate/lib.sh
+#
+# Launch Gate L0-L5 共通ヘルパー。
+#
+# 提供:
+#   - log_pass / log_fail / log_skip   (統一フォーマット出力)
+#   - is_dev_vps                       (dev VPS 判定 — prod に SSH 不可な環境かどうか)
+#   - gate_record / gate_summary       (結果集約用)
+#
+# 出力フォーマット (色・CR は使わない):
+#   [PASS] L0 schema: <要約>
+#   [FAIL] L1 env:    <要約>
+#   [SKIP] L2 smoke:  <理由>
+# ---------------------------------------------------------------------------
+
+# shellcheck shell=bash
+
+# 二重 source 防止
+if [[ "${_LAUNCH_GATE_LIB_SOURCED:-0}" == "1" ]]; then
+  return 0 2>/dev/null || true
+fi
+_LAUNCH_GATE_LIB_SOURCED=1
+
+# ---------------------------------------------------------------------------
+# 結果集約用 (parent shell からも見えるように export しない — 同一 shell 前提)
+# ---------------------------------------------------------------------------
+GATE_RESULTS=()       # 例: "PASS|L0|alembic head 一致"
+GATE_FAIL_COUNT=0
+GATE_SKIP_COUNT=0
+GATE_PASS_COUNT=0
+
+# ---------------------------------------------------------------------------
+# 出力ヘルパー (color / CR は使わない、CI で再利用可能なプレーンテキスト)
+# ---------------------------------------------------------------------------
+log_pass() {
+  # $1: ラベル (例 "L0 schema"), $2: 要約
+  local label="$1" summary="$2"
+  echo "[PASS] ${label}: ${summary}"
+}
+
+log_fail() {
+  local label="$1" summary="$2"
+  echo "[FAIL] ${label}: ${summary}"
+}
+
+log_skip() {
+  local label="$1" summary="$2"
+  echo "[SKIP] ${label}: ${summary}"
+}
+
+log_info() {
+  local msg="$1"
+  echo "[INFO] ${msg}"
+}
+
+# ---------------------------------------------------------------------------
+# 結果集約
+#   gate_record PASS|FAIL|SKIP <label> <summary>
+# ---------------------------------------------------------------------------
+gate_record() {
+  local status="$1" label="$2" summary="$3"
+  GATE_RESULTS+=("${status}|${label}|${summary}")
+  case "${status}" in
+    PASS) GATE_PASS_COUNT=$(( GATE_PASS_COUNT + 1 )); log_pass "${label}" "${summary}" ;;
+    FAIL) GATE_FAIL_COUNT=$(( GATE_FAIL_COUNT + 1 )); log_fail "${label}" "${summary}" ;;
+    SKIP) GATE_SKIP_COUNT=$(( GATE_SKIP_COUNT + 1 )); log_skip "${label}" "${summary}" ;;
+    *)    log_info "unknown status: ${status} ${label} ${summary}" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# 結果サマリ表示 (最後に呼ぶ)
+#   exit code:
+#     0 -- FAIL ゼロ
+#     1 -- FAIL 1件以上
+# ---------------------------------------------------------------------------
+gate_summary() {
+  echo ""
+  echo "=== Launch Gate Summary ==="
+  local r status label summary
+  for r in "${GATE_RESULTS[@]}"; do
+    status="${r%%|*}"
+    rest="${r#*|}"
+    label="${rest%%|*}"
+    summary="${rest#*|}"
+    printf "  [%s] %-20s %s\n" "${status}" "${label}" "${summary}"
+  done
+  echo "---------------------------"
+  echo "PASS=${GATE_PASS_COUNT}  FAIL=${GATE_FAIL_COUNT}  SKIP=${GATE_SKIP_COUNT}"
+
+  if [[ "${GATE_FAIL_COUNT}" -gt 0 ]]; then
+    echo "Launch Gate: BLOCKED (FAIL=${GATE_FAIL_COUNT})"
+    return 1
+  fi
+  echo "Launch Gate: PASSED (SKIP=${GATE_SKIP_COUNT} は人間貼付け確認が必要)"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# dev VPS 判定
+#
+# memory [[no-prod-vps-commands-from-dev]] に従い、dev VPS から prod に届く
+# コマンド (curl http://prod-host, ssh prod, docker exec prod-container 等) を
+# 実行しない。dev VPS であれば skip-with-instructions モードに倒す。
+#
+# 判定:
+#   - hostname が "uata-dev*" / "*-dev-*" / "dev-*" を含む
+#   - 環境変数 LAUNCH_GATE_FORCE_DEV=1 で強制 dev 扱い
+#   - 環境変数 LAUNCH_GATE_FORCE_PROD=1 で強制 prod 扱い (CI / prod VPS から)
+# ---------------------------------------------------------------------------
+is_dev_vps() {
+  if [[ "${LAUNCH_GATE_FORCE_PROD:-0}" == "1" ]]; then
+    return 1
+  fi
+  if [[ "${LAUNCH_GATE_FORCE_DEV:-0}" == "1" ]]; then
+    return 0
+  fi
+  local h
+  h="$(hostname 2>/dev/null || uname -n 2>/dev/null || echo "")"
+  case "${h}" in
+    *uata-dev*|*-dev-*|dev-*|*devbox*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# PROJECT_ROOT 解決
+#   各 L*.sh から source される前提。lib.sh は scripts/launch_gate/lib.sh にある。
+# ---------------------------------------------------------------------------
+gate_project_root() {
+  local lib_dir
+  lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/launch_gate/ から 2 つ上が PROJECT_ROOT
+  (cd "${lib_dir}/../.." && pwd)
+}


### PR DESCRIPTION
## Summary
3ヶ月続いている「実装完了→ローンチ不能」連鎖を構造的に止める Launch Gate。
launch 前に L0-L5 全 green でないと完了不可、を 1 ファイル `scripts/launch_gate.sh` から実行可能に。

- L0 schema: alembic current が staging == production
- L1 env: staging↔prod 分離 (DATABASE_URL/AAVE_NETWORK/container_name/volume)
- L2 smoke: /health + 主要 5 endpoint 200
- L3 e2e: yamamoto-partner-flow 完走
- L4 kill switch: 緊急停止動作確認
- L5 wiring lint: include_router 漏れ検出 (孤立コード再発防止)

既存 `scripts/check_db_migration_gap.sh` / `scripts/check_env_separation.sh` を呼び出して構成、重複実装はしない。dev VPS から prod 到達不可な L は skip-with-instructions モード (memory: `no-prod-vps-commands-from-dev`)。

Asana: [LAUNCH-GATE-A](https://app.asana.com/1/817733952351708/project/1213916581114014/task/1215151922018135)

## Changes
- `scripts/launch_gate.sh` (201) — entry
- `scripts/launch_gate/lib.sh` (137) — log/dispatch helpers
- `scripts/launch_gate/L{0..5}_*.sh` (合計 648) — 各 gate
- 合計 8 file / +986 行 / 既存ファイル変更 0

## Merge 順序
1. PR C (CLAUDE.md) — 運用ルール
2. **このPR (A)** — gate スクリプト本体
3. PR B (CI/deploy 統合) — このスクリプトを呼ぶ

## Test plan
- [x] bash -n: 8/8 OK
- [x] shellcheck -S warning: exit 0
- [x] --help, --only=Lx, --skip=Lx, --env=staging/production, invalid args 動作確認
- [x] L5 が既知の孤立 router を検出 (本来動作)
- [ ] Codex Review 通過
- [ ] staging 実機で --env=staging 完走 (人間検証)