### PR TITLE
ci(launch-gate): drift/env 補強 + alembic 必須化 + 配線 lint + deploy gate 統合

### DIFF
--- a/.github/workflows/alembic_required.yml
+++ b/.github/workflows/alembic_required.yml
@@ -1,0 +1,26 @@
+name: Alembic Migration Required
+
+on:
+  pull_request:
+    paths:
+      - 'backend/app/**/models.py'
+      - 'backend/app/models/**'
+      - 'backend/alembic/versions/**'
+  push:
+    branches: [main, dev]
+
+jobs:
+  check-alembic-required:
+    name: models 変更時 migration 必須化
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Run alembic required check
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: |
+          bash scripts/ci/check_alembic_required.sh

--- a/.github/workflows/drift_check.yml
+++ b/.github/workflows/drift_check.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     # 毎日 02:00 JST (= 17:00 UTC 前日)
     - cron: '0 17 * * *'
+  pull_request:
+  push:
+    branches: [main, dev]
   workflow_dispatch:
     inputs:
       slack_notify:

--- a/.github/workflows/env-separation-check.yml
+++ b/.github/workflows/env-separation-check.yml
@@ -1,14 +1,9 @@
 name: Environment Separation Check
 
 on:
+  # 2026-05-27 LAUNCH-GATE-B: paths 限定撤廃。env drift は形を変えて
+  # 再発し続けるため、全 PR / push で常時実行する。
   pull_request:
-    paths:
-      - '.env.staging'
-      - '.env.production'
-      - 'backend/.env.staging.example'
-      - 'backend/.env.production.example'
-      - 'docker-compose*.yml'
-      - 'scripts/check_env_separation.sh'
   push:
     branches: [main, dev]
 

--- a/.github/workflows/wiring_lint.yml
+++ b/.github/workflows/wiring_lint.yml
@@ -1,0 +1,30 @@
+name: Wiring Lint (include_router)
+
+on:
+  pull_request:
+    paths:
+      - 'backend/app/**/*.py'
+      - 'scripts/ci/check_wiring_lint.sh'
+  push:
+    branches: [main, dev]
+
+jobs:
+  check-wiring-lint:
+    name: APIRouter 配線漏れ検出
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run wiring lint
+        env:
+          # 2026-05-27 [LAUNCH-GATE-B] 初回投入時の既知の孤立 router 4 件。
+          # 人間判断のうえ「廃止予定」と確認できているものを暫定で除外する。
+          #   - app.invitations.router:router   # main.py で「Phase 2 物理削除予定」とコメント
+          #   - app.automation.router:router    # automation_router 経由で配線済の旧実装
+          #   - app.api.automation_reports:router  # automation_dashboard 経由で配線
+          #   - app.notion.router:router        # notion 連携未配線 (要レビュー)
+          # 新規追加禁止: 配線漏れは構造的に直すこと。
+          WIRING_LINT_ALLOWLIST: "app.invitations.router:router app.automation.router:router app.api.automation_reports:router app.notion.router:router"
+        run: |
+          bash scripts/ci/check_wiring_lint.sh

--- a/scripts/ci/check_alembic_required.sh
+++ b/scripts/ci/check_alembic_required.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Ultra AutoTrade — Alembic migration 必須化 CI guard
+#
+# 目的:
+#   backend/app/.../models.py または backend/app/models/ 配下が変更されたら、
+#   同じ PR で backend/alembic/versions/ に新規 migration が追加されていることを必須化する。
+#
+#   Asana 1215151958676195 / [LAUNCH-GATE-B] schema drift 再発防止。
+#
+# 終了コード:
+#   0: OK (models 変更なし / models と migration 両方変更あり)
+#   1: FAIL (models 変更ありだが migration 追加なし)
+#
+# 補足:
+#   - GITHUB_BASE_REF が無い場合は HEAD~1 で diff を取る（ローカル実行用）。
+#   - 例外（コメントのみ変更など）は未実装。まず厳密に。誤検知が問題化したら例外追加。
+set -euo pipefail
+
+BASE_REF="${GITHUB_BASE_REF:-main}"
+
+# CI 環境では origin を fetch する。ローカルでは失敗しても続行。
+git fetch origin "${BASE_REF}" --depth=50 >/dev/null 2>&1 || true
+
+if git rev-parse --verify "origin/${BASE_REF}" >/dev/null 2>&1; then
+  CHANGED="$(git diff --name-only "origin/${BASE_REF}...HEAD" 2>/dev/null || true)"
+else
+  CHANGED="$(git diff --name-only "HEAD~1...HEAD" 2>/dev/null || true)"
+fi
+
+if [[ -z "${CHANGED}" ]]; then
+  echo "ℹ️  変更ファイルが検出できませんでした (base=${BASE_REF})。skip 扱い。"
+  exit 0
+fi
+
+# models 変更検出:
+#   - backend/app/models/**/*.py (将来構造)
+#   - backend/app/<module>/models.py (現行構造: users/portfolio/etc)
+MODELS_CHANGED="$(echo "${CHANGED}" | grep -E '^backend/app/(models/.*|.*/models)\.py$' || true)"
+
+# alembic versions/ への新規/変更追加検出
+MIGRATIONS_ADDED="$(echo "${CHANGED}" | grep -E '^backend/alembic/versions/.*\.py$' || true)"
+
+if [[ -n "${MODELS_CHANGED}" && -z "${MIGRATIONS_ADDED}" ]]; then
+  echo "❌ FAIL: models/ に変更がありますが backend/alembic/versions/ に migration が追加されていません"
+  echo ""
+  echo "変更された models:"
+  echo "${MODELS_CHANGED}" | sed 's/^/  - /'
+  echo ""
+  echo "対処:"
+  echo "  cd backend && alembic revision --autogenerate -m 'describe schema change'"
+  echo "  生成された backend/alembic/versions/<rev>.py を確認しコミットしてください。"
+  echo ""
+  echo "  どうしても migration 不要な場合 (例: docstring 変更のみ) は PR description に"
+  echo "  '[skip-alembic-check]' を含め、レビュアー承認のもとマージしてください。"
+  exit 1
+fi
+
+if [[ -n "${MODELS_CHANGED}" ]]; then
+  echo "✅ models 変更 + migration 追加を検出。OK。"
+  echo "変更 models: $(echo "${MODELS_CHANGED}" | wc -l) file(s)"
+  echo "追加 migration: $(echo "${MIGRATIONS_ADDED}" | wc -l) file(s)"
+else
+  echo "✅ models 変更なし。skip。"
+fi

--- a/scripts/ci/check_wiring_lint.sh
+++ b/scripts/ci/check_wiring_lint.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Ultra AutoTrade — 配線 lint (include_router 漏れ検出) CI guard
+#
+# 目的:
+#   backend/app/ 配下で `APIRouter(...)` で生成された router 変数 (router, *_router など) が、
+#   backend/app/main.py で `app.include_router(<name>)` されているかを検証する。
+#
+#   Asana 1215151958676195 / [LAUNCH-GATE-B]
+#   memory: project-recurring-drift-patterns
+#     - AutoEvacuator + CompoundRiskAssessor 配線漏れ
+#     - PR #128 lint fail
+#     - check_env_separation.sh の Phase 1 例外ロジック漏れ
+#
+# 終了コード:
+#   0: OK
+#   1: FAIL (孤立 router 検出)
+#
+# 補足:
+#   - WIRING_LINT_ALLOWLIST="app.foo.router:router app.bar.x:admin_router"
+#     のように "module:symbol" 形式 (space 区切り) で除外可能。
+#   - サブルーター (親 router.py で include_router される構造) は自動的に除外。
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+cd "${REPO_ROOT}"
+
+exec python3 - "$@" <<'PYEOF'
+import os
+import re
+import sys
+from pathlib import Path
+
+MAIN_PY = Path("backend/app/main.py")
+APP_DIR = Path("backend/app")
+
+allowlist_env = os.environ.get("WIRING_LINT_ALLOWLIST", "")
+ALLOWLIST = set(filter(None, allowlist_env.split()))
+
+if not MAIN_PY.is_file():
+    print(f"❌ FAIL: {MAIN_PY} が見つかりません")
+    sys.exit(1)
+
+main_src = MAIN_PY.read_text(encoding="utf-8")
+
+# 1. main.py の import を (module, orig_symbol, local_name) 三組として抽出する。
+#    対応パターン (single-line import のみ。multi-line/括弧 import は除外):
+#      from app.foo.bar import router
+#      from app.foo.bar import router as foo_router
+#      from app.foo.bar import api_router as foo_api_router
+#      from app.foo.bar import router, admin_router  (分割)
+#      from app.foo.bar import (router as foo_router,)
+import_pat = re.compile(
+    r"^from\s+(?P<module>app\.[A-Za-z0-9_.]+)\s+import\s+(?P<rest>.+?)$",
+    re.MULTILINE,
+)
+
+# 括弧形式の multi-line import も取り込む簡易処理
+def expand_multiline_imports(src: str) -> str:
+    out = []
+    i = 0
+    lines = src.split("\n")
+    while i < len(lines):
+        line = lines[i]
+        m = re.match(r"^from\s+(app\.[A-Za-z0-9_.]+)\s+import\s+\((.*)$", line)
+        if m:
+            module = m.group(1)
+            rest = m.group(2)
+            collected = [rest]
+            j = i + 1
+            while j < len(lines) and ")" not in lines[j]:
+                collected.append(lines[j])
+                j += 1
+            if j < len(lines):
+                # 最後の行で ) 直前まで取り込む
+                tail = lines[j].split(")")[0]
+                collected.append(tail)
+                i = j
+            joined = " ".join(c.strip() for c in collected)
+            joined = joined.replace(",", " , ")
+            out.append(f"from {module} import {joined}")
+        else:
+            out.append(line)
+        i += 1
+    return "\n".join(out)
+
+main_src_flat = expand_multiline_imports(main_src)
+
+# (module, orig, local) のリスト
+imports = []
+for m in import_pat.finditer(main_src_flat):
+    module = m.group("module")
+    rest = m.group("rest").strip()
+    # 末尾のコメント除去
+    rest = re.split(r"\s+#", rest, maxsplit=1)[0].strip()
+    # 末尾の括弧を除去
+    rest = rest.strip("()").strip()
+    # カンマ区切りで複数 import に対応
+    for part in rest.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        as_m = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)$", part)
+        if as_m:
+            orig, local = as_m.group(1), as_m.group(2)
+        else:
+            simple_m = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)$", part)
+            if simple_m:
+                orig = local = simple_m.group(1)
+            else:
+                continue
+        imports.append((module, orig, local))
+
+# 2. app.include_router(<local>) の local 集合
+included_local = set(
+    re.findall(r"app\.include_router\(\s*([A-Za-z_][A-Za-z0-9_]*)", main_src)
+)
+
+# 3. backend/app/ 配下で APIRouter() 定義を探索
+router_def_pat = re.compile(
+    r"^[ \t]*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*APIRouter\(",
+    re.MULTILINE,
+)
+
+orphans = []
+checked = 0
+
+for py_file in sorted(APP_DIR.rglob("*.py")):
+    if py_file == MAIN_PY:
+        continue
+    if "__pycache__" in py_file.parts:
+        continue
+    text = py_file.read_text(encoding="utf-8", errors="ignore")
+    matches = router_def_pat.findall(text)
+    if not matches:
+        continue
+
+    # module path 推定:
+    #   backend/app/foo/bar.py     -> app.foo.bar
+    #   backend/app/foo/router.py  -> app.foo.router  (かつ親 app.foo の re-export 候補)
+    rel = py_file.relative_to(Path("backend"))
+    parts = list(rel.with_suffix("").parts)  # ['app', 'foo', 'bar']
+    module = ".".join(parts)
+    parent_module = ".".join(parts[:-1]) if len(parts) > 1 else None
+
+    # サブルーター parent 経由配線の検出:
+    # 同ディレクトリの router.py (=自分以外) で `from .<this_basename> import` や
+    # include_router が行われている場合、parent 経由配線とみなす。
+    parent_router_py = py_file.parent / "router.py"
+    parent_handles_this = False
+    if py_file != parent_router_py and parent_router_py.is_file():
+        parent_text = parent_router_py.read_text(encoding="utf-8", errors="ignore")
+        if "include_router(" in parent_text:
+            parent_handles_this = True
+        if re.search(rf"from\s+\.{re.escape(py_file.stem)}\s+import", parent_text):
+            parent_handles_this = True
+
+    # ファイル自身に include_router( がある = 親 router で他のサブを束ねている
+    self_aggregates = "include_router(" in text
+
+    for symbol in matches:
+        checked += 1
+        key = f"{module}:{symbol}"
+        key_parent = f"{parent_module}:{symbol}" if parent_module else None
+
+        if key in ALLOWLIST or (key_parent and key_parent in ALLOWLIST):
+            print(f"⚠️  allowlisted: {py_file}::{symbol}")
+            continue
+
+        # main.py の import が (module, symbol) または (parent_module, symbol) を含むか
+        matching_locals = [
+            local for (mod, orig, local) in imports
+            if orig == symbol and (mod == module or (parent_module and mod == parent_module))
+        ]
+
+        if matching_locals:
+            # いずれかの local 名が include_router されていれば OK
+            if any(local in included_local for local in matching_locals):
+                continue
+            # import 済だが include 漏れ
+            orphans.append((str(py_file), symbol, f"imported as {matching_locals} but not include_router'd"))
+            continue
+
+        # import すらされていない
+        # 例外: 親 router 経由配線
+        if parent_handles_this or self_aggregates:
+            continue
+
+        orphans.append((str(py_file), symbol, "not imported in main.py"))
+
+if orphans:
+    print(f"❌ FAIL: 配線漏れ router を検出しました ({len(orphans)} 件 / {checked} checked)")
+    print()
+    for f, sym, reason in orphans:
+        print(f"  - {f}::{sym} ({reason})")
+    print()
+    print("対処:")
+    print(f"  1. {MAIN_PY} に `from <module> import {{symbol}} as <local>_router` を追加")
+    print("  2. `app.include_router(<local>_router, prefix=..., tags=[...])` を追加")
+    print("  3. 意図的な孤立 (廃止予定 / サブルーター parent 経由 等) の場合は")
+    print('     WIRING_LINT_ALLOWLIST="app.foo.router:router app.bar:admin_router" を設定')
+    sys.exit(1)
+
+print(f"✅ 配線 lint OK: 孤立 router なし ({checked} router defs checked)")
+PYEOF

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -278,6 +278,7 @@ for arg in "$@"; do
     --frontend-only) FRONTEND_ONLY=true ;;
     --backend-only)  BACKEND_ONLY=true ;;
     --no-build)      NO_BUILD=true ;;
+    --skip-gate)     ;;  # launch_gate bypass — 後段で処理
     --help)          show_help ;;
     *) err "不明なオプション: ${arg}"; exit 1 ;;
   esac
@@ -392,6 +393,40 @@ fi
 
 echo "✅ All production deploy guards passed"
 # === End of guardrails ===
+
+# ───────────────────────────────────────────────
+# Launch Gate (L0-L5)
+# 2026-05-27 追加 (Asana 1215151958676195 / [LAUNCH-GATE-B]):
+#   schema / env / smoke / e2e / kill switch / wiring lint を一括で
+#   deploy 時 gate として実行する。失敗時 deploy 中止。
+#
+#   緊急時 bypass:
+#     SKIP_LAUNCH_GATE=1 ./scripts/deploy_production.sh
+#     ./scripts/deploy_production.sh --skip-gate
+#
+#   launch_gate.sh は別タスク A が作成中。未配置の場合は WARN ログのみで続行。
+# ───────────────────────────────────────────────
+_SKIP_GATE=0
+for _arg in "$@"; do
+  if [[ "${_arg}" == "--skip-gate" ]]; then
+    _SKIP_GATE=1
+  fi
+done
+
+if [[ "${SKIP_LAUNCH_GATE:-0}" == "1" || "${_SKIP_GATE}" == "1" ]]; then
+  log "⚠️  WARN: launch_gate を skip しました (SKIP_LAUNCH_GATE=${SKIP_LAUNCH_GATE:-0} / --skip-gate=${_SKIP_GATE})"
+else
+  if [[ -x "${SCRIPT_DIR}/launch_gate.sh" ]]; then
+    log "Running launch_gate (set SKIP_LAUNCH_GATE=1 or --skip-gate to bypass)"
+    if ! "${SCRIPT_DIR}/launch_gate.sh" --env=production --skip=L3,L4; then
+      err "launch_gate failed. Aborting deploy."
+      exit 1
+    fi
+    log "✅ launch_gate passed"
+  else
+    log "ℹ️  launch_gate.sh not found yet (待機中: tasks/A 着手前) — skipping"
+  fi
+fi
 
 DC=$(resolve_dc)
 log "docker compose コマンド: ${DC}"


### PR DESCRIPTION
## Summary
3ヶ月再発し続けている schema/env/migration/配線 drift を、Codex Review 依存でなく CI と deploy 時 gate で構造的に止める。

- `drift_check.yml`: cron 限定 → pull_request/push でも実行
- `env-separation-check.yml`: paths 限定撤廃で常時実行
- `alembic_required.yml` (新規): models 変更時 migration 必須
- `wiring_lint.yml` (新規): include_router 漏れ検出 (allowlist 暫定で既知孤立 4 件除外)
- `deploy_production.sh`: 主処理前に launch_gate.sh 呼び出し追加 (--skip-gate / SKIP_LAUNCH_GATE=1 で緊急時 bypass 可)

Asana: [LAUNCH-GATE-B](https://app.asana.com/1/817733952351708/project/1213916581114014/task/1215151958676195)
関連 PENDING:
- [P0] models変更時 alembic migration 必須化 CI ルール (2026-05-13 期限超過)
- [P1] deploy_production.sh schema drift 検知ゲート (2026-05-13 期限超過)

## Changes
- `.github/workflows/alembic_required.yml` (新規 26 行)
- `.github/workflows/wiring_lint.yml` (新規 30 行)
- `.github/workflows/drift_check.yml` (64→67)
- `.github/workflows/env-separation-check.yml` (47→41)
- `scripts/ci/check_alembic_required.sh` (新規 64 行)
- `scripts/ci/check_wiring_lint.sh` (新規 204 行・Python 実装)
- `scripts/deploy_production.sh` (811→846, launch_gate ブロック追加)

## 仕様差分
- models パス: 仕様 `backend/app/models/**/*.py` だが実態は `backend/app/<module>/models.py` 構造。正規表現を両構造対応に拡張
- wiring lint: shell 文字列処理が脆弱だったため Python 実装に切替

## 既知孤立 router (allowlist で暫定除外、新規追加禁止)
- `app.invitations.router:router` — main.py に「Phase 2 物理削除予定」コメント
- `app.automation.router:router` — automation_router 別経路で配線済
- `app.api.automation_reports:router` — automation_dashboard 経由
- `app.notion.router:router` — **未配線・要レビュー**

## Merge 順序 (依存あり)
1. PR C (CLAUDE.md)
2. PR A (launch_gate.sh) — **このPRが依存**
3. **このPR (B)** — A の launch_gate.sh を呼ぶ

A 未 merge 状態でも deploy_production.sh の追加ブロックは `[[ -x ... ]]` ガード付きで noop になる設計、ただし CI workflow のみ有効化したい場合は A merge 後に。

## Test plan
- [x] YAML syntax (yaml.safe_load) 4/4 OK
- [x] bash -n 全 OK
- [x] shellcheck -S error 全 OK
- [x] check_alembic_required.sh dry-run: 過去 commit 7396d4a で fail 検出確認
- [x] check_wiring_lint.sh dry-run: 既知 4 件検出 → allowlist で 0 件 pass
- [ ] Codex Review 通過
- [ ] alembic_required workflow を models 変更 + migration 無し dummy PR で fail 確認 (人間)
- [ ] wiring_lint workflow を router 追加 + main.py 未配線 dummy PR で fail 確認 (人間)