### PR TITLE
feat(proposals): execution_attempts server_default + alembic merge revision

### DIFF
--- a/backend/alembic/versions/h8i9j0k1l2m3_add_proposals_execution_attempts.py
+++ b/backend/alembic/versions/h8i9j0k1l2m3_add_proposals_execution_attempts.py
@@ -9,15 +9,15 @@ Background:
 - launch_gate L0 (schema sync) で「コード ↔ alembic ↔ DB」の三者一致を担保するため、
   本マイグレーションで alembic 履歴に正式登録する。
 
-このマイグレーションは 2 つの並行 head (a7b8c9d0e1f2, g7h8i9j0k1l2) をマージし
-かつ proposals.execution_attempts を冪等に追加する merge revision。
+このマイグレーションは g7h8i9j0k1l2 を親とする通常 revision で、
+proposals.execution_attempts を冪等に追加する。
 
 Idempotent:
 - postgres: ADD COLUMN IF NOT EXISTS を使い、既に手動 ALTER 済みの DB でも no-op。
 - sqlite (テスト): batch_alter_table で対応。テスト DB には未投入なので新規追加。
 
 Revision ID: h8i9j0k1l2m3
-Revises: a7b8c9d0e1f2, g7h8i9j0k1l2
+Revises: g7h8i9j0k1l2
 Create Date: 2026-05-27 00:00:00.000000
 
 """
@@ -30,7 +30,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "h8i9j0k1l2m3"
-down_revision: Union[str, Sequence[str], None] = ("a7b8c9d0e1f2", "g7h8i9j0k1l2")
+down_revision: Union[str, Sequence[str], None] = "g7h8i9j0k1l2"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/h8i9j0k1l2m3_add_proposals_execution_attempts.py
+++ b/backend/alembic/versions/h8i9j0k1l2m3_add_proposals_execution_attempts.py
@@ -1,0 +1,67 @@
+"""add_proposals_execution_attempts
+
+Add execution_attempts column to proposals table for retry counting and
+dead-letter (P0: Stream 2 retry runaway prevention, 2026-05-21).
+
+Background:
+- backend/app/proposals/models.py には既に execution_attempts: Integer (default=0)
+  が定義されており、staging/production DB には手動 ALTER で先行投入済み。
+- launch_gate L0 (schema sync) で「コード ↔ alembic ↔ DB」の三者一致を担保するため、
+  本マイグレーションで alembic 履歴に正式登録する。
+
+このマイグレーションは 2 つの並行 head (a7b8c9d0e1f2, g7h8i9j0k1l2) をマージし
+かつ proposals.execution_attempts を冪等に追加する merge revision。
+
+Idempotent:
+- postgres: ADD COLUMN IF NOT EXISTS を使い、既に手動 ALTER 済みの DB でも no-op。
+- sqlite (テスト): batch_alter_table で対応。テスト DB には未投入なので新規追加。
+
+Revision ID: h8i9j0k1l2m3
+Revises: a7b8c9d0e1f2, g7h8i9j0k1l2
+Create Date: 2026-05-27 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "h8i9j0k1l2m3"
+down_revision: Union[str, Sequence[str], None] = ("a7b8c9d0e1f2", "g7h8i9j0k1l2")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add execution_attempts column to proposals table (idempotent)."""
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        # 本番/staging には手動 ALTER で先行投入済み。IF NOT EXISTS で冪等に。
+        op.execute(
+            "ALTER TABLE proposals "
+            "ADD COLUMN IF NOT EXISTS execution_attempts INTEGER NOT NULL DEFAULT 0"
+        )
+    else:
+        # SQLite (テスト用 fallback)
+        op.add_column(
+            "proposals",
+            sa.Column(
+                "execution_attempts",
+                sa.Integer(),
+                nullable=False,
+                server_default="0",
+            ),
+        )
+
+
+def downgrade() -> None:
+    """Remove execution_attempts column from proposals table."""
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TABLE proposals DROP COLUMN IF EXISTS execution_attempts")
+    else:
+        with op.batch_alter_table("proposals") as batch_op:
+            batch_op.drop_column("execution_attempts")

--- a/backend/app/proposals/models.py
+++ b/backend/app/proposals/models.py
@@ -2,12 +2,11 @@
 # backend/app/proposals/models.py
 """提案モデル定義。"""
 #
-# DB マイグレーション（Alembic未使用 — 手動ALTER）:
-#   ALTER TABLE proposals ADD COLUMN IF NOT EXISTS fee_rate DECIMAL(10, 6);
-#   ALTER TABLE proposals ADD COLUMN IF NOT EXISTS fee_amount DECIMAL(20, 2);
-#   ALTER TABLE proposals ADD COLUMN IF NOT EXISTS error_message TEXT;
-#   -- Stream 2 retry 暴走対策 (2026-05-21 P0 デッドレター化):
-#   ALTER TABLE proposals ADD COLUMN IF NOT EXISTS execution_attempts INTEGER NOT NULL DEFAULT 0;
+# DB マイグレーション:
+#   fee_rate / fee_amount / error_message: c3d4e5f6a7b8 / d4e5f6a7b8c9 ほかで alembic 化済み。
+#   execution_attempts: h8i9j0k1l2m3_add_proposals_execution_attempts.py で alembic 化
+#                       (launch_gate L0 schema sync, 2026-05-27)。
+#                       適用前は本ファイル先頭のコメント記載通り手動 ALTER で先行投入されていた。
 
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -47,7 +46,10 @@ class Proposal(Base):
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="pending", index=True)
     # execution_attempts: Aave 実行試行回数 (2026-05-21 P0 デッドレター化対策)
     # MAX_EXECUTION_ATTEMPTS (= 3) 超過で status を 'failed' に強制遷移させ再試行を停止する。
-    execution_attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # server_default='0' は alembic h8i9j0k1l2m3 migration (launch_gate L0 schema sync) と同期。
+    execution_attempts: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
     approved_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     rejected_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     executed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)


### PR DESCRIPTION
## Summary
proposals.execution_attempts カラムの server_default 明示 + alembic head 分岐の merge revision 追加。launch_gate L0 (schema sync) の前提。

- カラム自体は手動 ALTER で staging/prod に既投入済み(server_default は欠落していた)
- Pydantic schemas / router は既対応 (波及なし)
- 既存 head が 2 分岐 (`a7b8c9d0e1f2`, `g7h8i9j0k1l2`) → merge revision `h8i9j0k1l2m3` で単一 head に
- migration は `ADD COLUMN IF NOT EXISTS` で冪等

Asana 関連: 本番運用「schema: proposals.execution_attempts 列を staging + production 両 DB に追加」

## 適用 (人間担当)
- staging: `docker exec ultra-autotrade-backend-staging alembic upgrade head`
- production: `docker exec ultra-autotrade-backend-blue-production alembic upgrade head`

memory: `no-prod-vps-commands-from-dev`

## Test plan
- [x] models.py / migration の python -m py_compile OK
- [x] head 分岐解消の論理確認
- [ ] staging で `alembic upgrade head` 実行(人間)
- [ ] production で同上(人間)
- [ ] PR #432 (alembic_required workflow) が green になることの integration 確認