### PR TITLE
fix(docker): backend/frontend image への .env 焼き込み撤去 (3ヶ月 env drift 真因)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,18 @@
 # 環境ファイル — Docker build context に secrets を含めない
 # .env.staging は 2026-04-17 以降 .env.staging-new が正式
+#
+# 2026-05-27 追記 (Asana [chore] backend image env 焼き込み調査):
+#   旧パターン `.env.*` はルート直下しかマッチせず、`backend/.env.production`
+#   や `backend/.env.staging-new` が image に焼き込まれていた。
+#   `**/` プレフィックスで全階層を対象にする。
 .env
 .env.*
+**/.env
+**/.env.*
 !.env.example
 !.env.*.example
+!**/.env.example
+!**/.env.*.example
 
 # Git / CI — build context 削減
 .git/

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,44 @@
+# frontend/.dockerignore
+# 2026-05-27 作成 (Asana [chore] backend image env 焼き込み調査):
+#   frontend Dockerfile は `COPY . .` (build context: ./frontend) を実施。
+#   ルートの .dockerignore は適用されないため、frontend 単独で env file を
+#   除外する。NEXT_PUBLIC_* は docker-compose の build.args 経由で注入される
+#   ので、.env.* を image に含める必要はない。
+
+# 環境ファイル — secrets / 環境別設定を image に焼き込まない
+.env
+.env.*
+**/.env
+**/.env.*
+!.env.example
+!.env.*.example
+!**/.env.example
+!**/.env.*.example
+
+# Node ビルド成果物 / 依存
+node_modules/
+.next/
+out/
+build/
+.turbo/
+
+# Git / CI
+.git/
+.gitignore
+
+# Test artifacts
+playwright-report/
+test-results/
+coverage/
+
+# IDE / OS
+.vscode/
+.idea/
+*.swp
+.DS_Store
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
## Summary
backend image / frontend image に `.env*` が焼き込まれていた構造的真因を修正。3ヶ月再発している env drift の真因の一つ ([[project-recurring-drift-patterns]])。

## 検証で確認できた問題
- 旧 `.dockerignore` パターン `.env.*` は **ルート直下しかマッチしない仕様**
- `COPY backend/ backend/` 経由で `backend/.env*` が image に流入
- frontend は `.dockerignore` 自体が存在せず、`frontend/.env.local` 等が無条件焼き込み
- 実検証: `touch backend/.env.production.testfile` → build → image 内に存在 (再現)

## 修正
- `.dockerignore`: `**/.env`, `**/.env.*` 追加 + `!**/.env.*.example` で example のみ再 include
- `frontend/.dockerignore` 新規作成 (frontend build context にはルート .dockerignore 不適用のため必須)
- Dockerfile / docker-compose は変更不要 (env_file: 指定済み)

## 検証結果
- `docker compose -f docker-compose.production.yml config`: exit 0
- `docker compose -f docker-compose.staging.yml config`: exit 0
- 修正後 build → `.testfile` が image に入らないことを確認

Asana 関連: 本番運用「chore: backend image に .env.staging / .env.production が焼き込まれている件の調査」

## ⚠️ 重要 — merge 後の追加作業 (人間担当)
**既存の production / staging image には焼き込まれたままなので、merge 後に rebuild + deploy が必須**。
- staging: `bash scripts/deploy_staging_backend.sh` (rebuild)
- production: `bash scripts/deploy_production.sh --backend-only` (Blue/Green rebuild)

## Test plan
- [x] .dockerignore パターン検証 (testfile で再現 → 修正後で除外確認)
- [x] docker compose config 両 env で OK
- [ ] staging で rebuild + deploy 後、image 内に env が無いことを確認(人間)
- [ ] production 同上(人間)