### PR TITLE
fix(ai/agents): Indicator Agent neutral 固着の暫定修正 (soak HOLD 100% 真因)

### DIFF
--- a/backend/app/ai/agents.py
+++ b/backend/app/ai/agents.py
@@ -202,11 +202,25 @@ class MultiAgentContext(BaseModel):
 def indicator_agent(ctx: MarketContext) -> AgentSignal:
     """Analyze Aave on-chain indicators (utilization, APY, HF).
 
-    Rules:
-    - HF < 1.6 → bearish (liquidation risk)
-    - HF 1.6-2.0 → neutral (safe but watch)
-    - HF > 2.0 → bullish (plenty of room)
-    - High utilization (>80%) → bearish (less liquidity, higher rates)
+    Scoring (2026-05-27 — neutral-stuck mitigation):
+      The original three-tier HF curve produced a -25 step-function at HF=2.0
+      (1.99 → -10, 2.00 → +15) and left the dominant "moderately healthy" case
+      (HF 1.7-1.99 / util 50-80% / APY 2-4%) at score=40 → NEUTRAL, blocking the
+      v4/v5 AND-condition (Indicator+Macro both ≥70% conf) and pinning soak HOLD
+      at ~100%.
+
+      Mitigation: replace the three-tier HF with a smoother five-band curve,
+      reward moderate utilization (ample liquidity) instead of only <50%, and
+      add a mild bearish nudge when supply APY collapses (yield compression).
+      This lets realistic-but-favourable data clear score≥65 and confidence≥70.
+
+    Rules (post-fix):
+    - HF < 1.6 → strongly bearish; HF 1.6-1.75 → bearish; 1.75-1.9 → mild cau-
+      tion; 1.9-2.1 → mild comfort; 2.1-2.5 → bullish; ≥2.5 → strongly bullish.
+    - Util >85% → bearish; 70-85% → mild caution; 30-70% → mild comfort;
+      <30% → bullish (ample liquidity).
+    - Supply APY >5% → bullish (attractive yield); <1% → mild bearish (yield
+      compression suggests over-supply / weak demand).
     """
     hf = ctx.health_factor
     util = ctx.aave_utilization_rate
@@ -222,27 +236,47 @@ def indicator_agent(ctx: MarketContext) -> AgentSignal:
         if hf_float < 1.6:
             score -= 40
             reasons.append(f"HF={hf} is critically low")
-        elif hf_float < 2.0:
-            score -= 10
+        elif hf_float < 1.75:
+            score -= 18
+            reasons.append(f"HF={hf} is thin — liquidation risk if price moves")
+        elif hf_float < 1.9:
+            score -= 6
             reasons.append(f"HF={hf} is acceptable but watch closely")
-        else:
-            score += 15
+        elif hf_float < 2.1:
+            score += 8
+            reasons.append(f"HF={hf} provides reasonable buffer")
+        elif hf_float < 2.5:
+            score += 16
             reasons.append(f"HF={hf} provides comfortable buffer")
+        else:
+            score += 22
+            reasons.append(f"HF={hf} provides ample buffer")
 
     if util is not None:
+        util_float = float(util)
         key_data["utilization_rate"] = str(util)
-        if float(util) > 80:
-            score -= 15
-            reasons.append(f"Utilization at {util}% — liquidity pressure")
-        elif float(util) < 50:
-            score += 10
+        if util_float > 85:
+            score -= 18
+            reasons.append(f"Utilization at {util}% — heavy liquidity pressure")
+        elif util_float > 70:
+            score -= 4
+            reasons.append(f"Utilization at {util}% — elevated, monitor")
+        elif util_float >= 30:
+            score += 6
             reasons.append(f"Utilization at {util}% — healthy liquidity")
+        else:
+            score += 12
+            reasons.append(f"Utilization at {util}% — ample liquidity")
 
     if supply_apy is not None:
+        apy_float = float(supply_apy)
         key_data["supply_apy"] = str(supply_apy)
-        if float(supply_apy) > 5:
+        if apy_float > 5:
             score += 10
             reasons.append(f"Supply APY at {supply_apy}% — attractive yield")
+        elif apy_float < 1:
+            score -= 6
+            reasons.append(f"Supply APY at {supply_apy}% — yield compressed, weak demand")
 
     if score >= 65:
         bias = Bias.BULLISH

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -55,6 +55,67 @@ class TestIndicatorAgent:
         signal = indicator_agent(ctx)
         assert "attractive yield" in signal.reasoning.lower()
 
+    # ------------------------------------------------------------------
+    # Neutral-stuck mitigation tests (2026-05-27)
+    # The v4/v5 AND-condition requires Indicator confidence ≥ 70 with a
+    # directional bias. Pre-fix, the dominant "moderately good / moderately
+    # tight" Aave market band produced NEUTRAL conf=50, which silently
+    # blocked every SELL/BUY at the rule engine and pinned soak HOLD ~100%.
+    # These tests pin the post-fix behaviour for that band.
+    # ------------------------------------------------------------------
+
+    def test_moderately_tight_market_yields_directional_signal(self) -> None:
+        """Typical staging-soak shape: HF 1.7 / util 72 / APY 4 → was NEUTRAL/50.
+
+        Must now produce a BEARISH bias with confidence high enough to clear
+        the v4/v5 AND-condition (≥70). This is the headline regression guard.
+        """
+        ctx = build_market_context(
+            health_factor=Decimal("1.7"),
+            aave_utilization_rate=Decimal("72"),
+            aave_supply_apy=Decimal("4.0"),
+        )
+        signal = indicator_agent(ctx)
+        assert signal.bias == Bias.BEARISH
+        assert signal.confidence >= 70
+
+    def test_moderately_comfortable_market_yields_directional_signal(self) -> None:
+        """Mirror case: HF 2.15 / util 40 / APY 4 → should clear BULLISH ≥70."""
+        ctx = build_market_context(
+            health_factor=Decimal("2.15"),
+            aave_utilization_rate=Decimal("40"),
+            aave_supply_apy=Decimal("4.0"),
+        )
+        signal = indicator_agent(ctx)
+        assert signal.bias == Bias.BULLISH
+        assert signal.confidence >= 70
+
+    def test_hf_2_0_boundary_is_smooth(self) -> None:
+        """HF 1.99 vs 2.00 must not produce a -25 step-function in score.
+
+        Pre-fix: HF=1.99 → -10, HF=2.00 → +15 (Δ=25 on 0.01 input change),
+        causing flapping between NEUTRAL and BULLISH at the boundary.
+        Post-fix: both fall in the 1.9-2.1 band → identical contribution.
+        """
+        same_other = {
+            "aave_utilization_rate": Decimal("65"),
+            "aave_supply_apy": Decimal("3.0"),
+        }
+        sig_lo = indicator_agent(build_market_context(health_factor=Decimal("1.99"), **same_other))
+        sig_hi = indicator_agent(build_market_context(health_factor=Decimal("2.00"), **same_other))
+        assert sig_lo.bias == sig_hi.bias
+        assert abs(sig_lo.confidence - sig_hi.confidence) <= 5
+
+    def test_yield_compression_is_mildly_bearish(self) -> None:
+        """Supply APY < 1% (yield compressed) contributes a mild bearish nudge."""
+        ctx = build_market_context(
+            health_factor=Decimal("2.05"),
+            aave_supply_apy=Decimal("0.5"),
+        )
+        signal = indicator_agent(ctx)
+        assert signal.key_data.get("supply_apy") == "0.5"
+        assert "compressed" in signal.reasoning.lower() or "weak demand" in signal.reasoning.lower()
+
 
 class TestPatternAgent:
     def test_no_history_is_neutral(self) -> None:


### PR DESCRIPTION
## Summary
staging shadow soak が HOLD 100% に張り付き UAT データが集まらない問題の真因を修正。

## 真因 (実コード検証で確認)
- `indicator_agent` の HF スコアリングが 3 段階のみ (`<1.6` / `1.6-2.0` / `>2.0`)
- HF=1.99→2.00 で Δ=25 の **step-function**
- 典型 soak 帯 (HF 1.7-1.99 / util 50-80% / APY 2-4%) では HF 中段 -10 のみが効き → score=40 → **NEUTRAL conf=50 に張り付き**
- AND-condition は Indicator+Macro いずれも `conf>=70` を要求 → 典型データで rule engine が必ず HOLD クランプ → soak HOLD 100% が成立

シミュレーション(10 シナリオ)で再現確認済み。

## 修正
- HF: 3 帯 → 6 帯に細分化 (`<1.6 / 1.6-1.75 / 1.75-1.9 / 1.9-2.1 / 2.1-2.5 / >=2.5`)、step-function 解消
- util: 70-85% に -4, 30-70% に +6 (弱い signal)
- APY: <1% に -6 (yield compression signal)

## 変更
- `backend/app/ai/agents.py` (+49 / -15)
- `backend/tests/test_agents.py` (+61, 新規ケース 4)

## Test
- `pytest test_agents.py`: 35 passed (元 31 + 新規 4)
- `pytest test_ai_sell_and_condition.py`: 40 passed (regression 0)
- ruff check / format --check: pass

## ⚠️ 完全解決ではない
Macro Agent 側が常に neutral だと AND-condition は依然満たされない可能性あり。staging shadow soak で 1-2 日観察必要。memory `disable-scheduler-flag-inverted` の罠 (DISABLE_SCHEDULER 値の取り違え) も先に裏取り。

## soak で確認すべき指標
1. `ai_decisions` の `action='BUY'|'SELL'` 件数 (pre ≒ 0 → 改善目安 1-2%+)
2. `reason LIKE '%AND-condition not met%'` 比率の低下
3. `indicator_signal.bias` の neutral 比率: pre ~95% → 70-80%
4. 誤検知ガード: compound risk 件数 / win_rate 悪化していないか

Asana 関連: 本番運用「investigate: Indicator Agent neutral 固着 soak HOLD 残因」

## Test plan
- [x] pytest 75 passed / 0 failed
- [x] ruff pass
- [ ] staging shadow soak 24-48h で指標観察(人間)