### PR TITLE
feat(ops): scripts/restore_test.sh + docs/ops/restore_runbook.md (MVP-P0-1)

### DIFF
--- a/docs/ops/restore_runbook.md
+++ b/docs/ops/restore_runbook.md
@@ -1,0 +1,417 @@
+# Restore Runbook (本番 / staging DB 災害復旧手順)
+
+**作成日**: 2026-05-27
+**対象**: Asana 本番運用「MVP-P0-1 Backup 復元検証 (prod DB / .env / wallet 鍵)」
+**前提**: launch gate L0 / L1 / L2 が PASS する状態の復元
+**実行責任**: 人間 (この runbook は読みながら手で実行する想定)
+**Lane / Claude の責任範囲**: scripts/restore_test.sh (dry-run) と本 runbook の整備まで。
+  実機の本番 backup を使った復元実行は **Lane / Claude は実施しない**
+  (memory: `no-prod-vps-commands-from-dev`)
+
+---
+
+## 0. 前提
+
+本 runbook は以下の状況を想定する:
+
+- 本番 / staging の DB データが破損した (例: 誤 DELETE、storage 障害、disk corruption、
+  誤 ALTER TABLE による不可逆な変更、誤 DROP TABLE 等)
+- 復元元: `scripts/backup_db.sh` で生成された `.sql.gz` (gzip-compressed pg_dump plain SQL)
+- 復元先: 既存 DB を上書きするのではなく、**まず一時 DB に復元 → 検証 → 既存と差し替え** の手順を取る
+
+### backup file 形式 (前提知識)
+
+| 項目 | 値 |
+|------|-----|
+| 生成元 | `scripts/backup_db.sh` (production / staging-new 両対応) |
+| ファイル名 | `${ENVIRONMENT}_ultra_autotrade_${TIMESTAMP}.sql.gz` |
+| 形式 | `pg_dump -U ultra <db>` の標準出力を gzip 圧縮 (plain SQL 形式) |
+| 保管場所 | `/opt/ultra-autotrade/db_backups/` (本番 VPS) |
+| 月次アーカイブ | `/opt/ultra-autotrade/db_backups/monthly/${ENV}_monthly_${YYYYMM}.sql.gz` |
+| 保持期間 | 直近 28 日 + 月次 6 ヶ月 |
+| 自己検証 | backup 時点で gzip integrity + 最低サイズ (10 KB) を確認済み |
+
+### 関連 doc
+
+- `scripts/backup_db.sh` — 日次 backup スクリプト (cron 03:00 JST)
+- `scripts/restore_test.sh` — 本 runbook の §2 で使う dry-run 検証スクリプト
+- `docs/internal/2026-05-26_alembic_stamp_production_sync_runbook.md` — alembic head が
+  本番と乖離した場合の stamp 手順 (本 runbook §3.4 から参照)
+- `docs/ops/disable_release_runbook.md` — `DISABLE_AI_JUDGMENT_SCHEDULER` 周りの kill switch 操作
+- `docs/ops/02_db_tables.md` — 復元後に存在することを確認すべきテーブル一覧
+- `scripts/launch_gate/L0_schema.sh` / `L1_env.sh` / `L2_smoke.sh` — 復元後 PASS させる gate
+
+---
+
+## 1. Backup file の準備
+
+### 1.1 担当者
+
+- **本番 VPS への SSH 担当**: 小林さん (Lane / Claude は SSH しない)
+- 復元の意思決定: 小林さん + claude.ai 朝プロトコル
+
+### 1.2 backup 取得元
+
+```bash
+# 本番 VPS 上で実行 (人間担当)
+ssh prod-vps
+ls -lh /opt/ultra-autotrade/db_backups/ | tail -10
+ls -lh /opt/ultra-autotrade/db_backups/monthly/ | tail -10
+```
+
+### 1.3 取得する世代の判断基準
+
+| 状況 | 取得する世代 |
+|------|--------------|
+| 直前 24h 以内のデータ破損 | 前日 03:00 JST の日次 backup |
+| 数日前からの破損 | 破損より前の最新日次 backup |
+| 月単位の破損 | 月次アーカイブ `monthly/` から該当月のもの |
+
+### 1.4 gzip integrity 再確認
+
+復元前に必ず実行 (backup_db.sh の self-check と二重で):
+
+```bash
+gzip -t /opt/ultra-autotrade/db_backups/production_ultra_autotrade_YYYYMMDD_HHMMSS.sql.gz
+echo "gzip exit=$?"   # 0 が期待値
+```
+
+---
+
+## 2. Pre-flight: restore 動作確認 (`scripts/restore_test.sh`)
+
+**本番に流す前に必ず一時 DB で動作確認する。** これが MVP-P0-1 の本質。
+
+### 2.1 dev VPS / 検証用 VPS 上で実行する場合
+
+dev VPS には本番 backup ファイルは存在しないので、復元検証は **本番 VPS 上の隔離した postgres
+インスタンス**、または **小林さんがローカル/別 VPS にコピーした backup** で行う。
+
+```bash
+# host モード (postgres が localhost で listen している場合)
+RESTORE_TEST_PG_HOST=localhost \
+RESTORE_TEST_PG_PORT=5432 \
+RESTORE_TEST_PG_USER=postgres \
+  ./scripts/restore_test.sh \
+    --backup-file=/path/to/production_ultra_autotrade_YYYYMMDD_HHMMSS.sql.gz \
+    --env=production
+```
+
+### 2.2 本番 VPS 上の docker postgres を借りる場合
+
+**注意**: ここで使う postgres コンテナは「**本番 DB と同じインスタンス**」になる。
+スクリプト側の安全装置 (`restore_test_` プレフィックス強制) により本番 DB (`ultra_autotrade` /
+`ultra_autotrade_staging`) を上書きすることはないが、念のため staging-new コンテナを使うのが推奨。
+
+```bash
+# 推奨: staging-new コンテナを使う (本番コンテナと隔離)
+RESTORE_TEST_PG_CONTAINER=ultra-autotrade-postgres-staging-new \
+RESTORE_TEST_PG_USER=ultra \
+  ./scripts/restore_test.sh \
+    --backup-file=/opt/ultra-autotrade/db_backups/production_ultra_autotrade_YYYYMMDD_HHMMSS.sql.gz \
+    --env=production
+```
+
+### 2.3 期待出力
+
+```
+[restore-test] Restore: OK
+[restore-test] ...
+[restore-test]   restore         : OK
+[restore-test]   tables          : <N>           # 02_db_tables.md と概ね一致
+[restore-test]   expected tables : 8 / 8
+[restore-test]   alembic head    : <head id>     # 本番 alembic head と一致するか確認
+[restore-test]   total rows      : <M>           # > 0
+[restore-test]   FK count        : <K>           # > 0、invalid: 0
+[restore-test]   integrity       : OK
+[restore-test] Final: OK
+```
+
+終了コード:
+- `0`: OK → §3 に進んでよい
+- `1`: restore 失敗 or 整合性 NG → **§3 に進まない**。別世代の backup を試す or 小林さんに報告
+- `2`: 設定エラー (引数不正 / backup file 不存在 / 一時 DB 作成失敗) → 引数や接続情報を見直す
+
+### 2.4 NG 時の判定
+
+| 症状 | 対処 |
+|------|------|
+| `gzip integrity check failed` | backup file が破損。別世代を使う |
+| `Restore FAILED` (psql エラー) | tail されたエラーを読む。pg version 不整合の場合は同じ pg major version の postgres で再試行 |
+| `alembic_version head not found` | backup が alembic 管理外の古い世代。stamp 手順 (§3.4) と併用が必要 |
+| `Missing expected tables` (users, alembic_version 以外) | backup の取得タイミングによっては新規追加テーブルが無い場合あり。02_db_tables.md と照合し、テーブルが「無くて当然」なら継続可 |
+| `Unvalidated FK constraints exist` | restore は通ったが FK が壊れている。**§3 に進まない**。別世代を使う |
+
+### 2.5 詳細調査が必要な場合
+
+`--keep-temp-db` を付けると検証用 DB が残るので、手動で `psql` 接続して調査できる:
+
+```bash
+./scripts/restore_test.sh \
+  --backup-file=... --env=production --keep-temp-db
+
+# 残った DB を見る
+psql -U postgres -d restore_test_YYYYMMDD_HHMMSS_<pid>
+\dt
+SELECT * FROM alembic_version;
+SELECT count(*) FROM proposals;
+...
+
+# 終わったら DROP
+psql -U postgres -d postgres -c 'DROP DATABASE "restore_test_...";'
+```
+
+---
+
+## 3. 本番 DB 復元手順 (人間担当)
+
+> **Lane / Claude はここを実行しない。** 小林さんが本 runbook を読みながら手で実行する。
+
+### 3.1 影響範囲告知 + 緊急停止
+
+```bash
+# 1. Slack #ultra-auto-project に告知
+#    "本番 DB 復元のため X 分間サービスを停止します"
+
+# 2. AI scheduler を停止 (kill switch)
+#    詳細: docs/ops/disable_release_runbook.md
+ssh prod-vps
+docker exec ultra-autotrade-backend-blue-production \
+  /bin/sh -c 'kill -SIGTERM $(pgrep -f "python -m app")' \
+  || true
+# または .env.production の DISABLE_AI_JUDGMENT_SCHEDULER=1 で再起動
+```
+
+> memory `disable-scheduler-flag-inverted`: production では DISABLE_SCHEDULER=ON で停止。
+> staging とフラグの意味が逆なので取り違えないこと。
+
+### 3.2 既存 DB のスナップショット (念のため)
+
+復元前に必ず取得 (復元に失敗したときに戻すため):
+
+```bash
+# 本番 VPS 上 (小林さん担当)
+docker exec ultra-autotrade-postgres-production \
+  pg_dump -U ultra ultra_autotrade \
+  | gzip > /opt/ultra-autotrade/db_backups/pre_restore_$(date +%Y%m%d_%H%M%S).sql.gz
+
+# gzip 検証
+gzip -t /opt/ultra-autotrade/db_backups/pre_restore_*.sql.gz
+```
+
+### 3.3 復元
+
+#### 方針 A: 既存 DB を rename + 復元 DB を本番名に rename (推奨、ダウンタイム最小)
+
+```bash
+# 1. backend を停止 (postgres は残す)
+docker compose -f docker-compose.production.yml stop backend-blue backend-green
+
+# 2. 復元用 DB を作成
+docker exec ultra-autotrade-postgres-production \
+  psql -U ultra -d postgres -c 'CREATE DATABASE ultra_autotrade_restored;'
+
+# 3. backup を流し込む
+gunzip -c /opt/ultra-autotrade/db_backups/production_ultra_autotrade_YYYYMMDD_HHMMSS.sql.gz \
+  | docker exec -i ultra-autotrade-postgres-production \
+      psql -U ultra -d ultra_autotrade_restored -v ON_ERROR_STOP=1
+
+# 4. 既存 DB を退避名にリネーム
+docker exec ultra-autotrade-postgres-production \
+  psql -U ultra -d postgres -c \
+  'ALTER DATABASE ultra_autotrade RENAME TO ultra_autotrade_broken_YYYYMMDD;'
+
+# 5. 復元 DB を本番名にリネーム
+docker exec ultra-autotrade-postgres-production \
+  psql -U ultra -d postgres -c \
+  'ALTER DATABASE ultra_autotrade_restored RENAME TO ultra_autotrade;'
+
+# 6. backend を再開
+docker compose -f docker-compose.production.yml start backend-blue backend-green
+```
+
+#### 方針 B: 既存 DB を DROP + CREATE で復元 (ダウンタイム長め、シンプル)
+
+> 既存 DB が完全に破損していて rename しても価値が無い場合のみ採用。
+
+```bash
+docker compose -f docker-compose.production.yml stop backend-blue backend-green
+
+docker exec ultra-autotrade-postgres-production \
+  psql -U ultra -d postgres -c \
+  'DROP DATABASE ultra_autotrade; CREATE DATABASE ultra_autotrade;'
+
+gunzip -c /opt/ultra-autotrade/db_backups/production_ultra_autotrade_YYYYMMDD_HHMMSS.sql.gz \
+  | docker exec -i ultra-autotrade-postgres-production \
+      psql -U ultra -d ultra_autotrade -v ON_ERROR_STOP=1
+
+docker compose -f docker-compose.production.yml start backend-blue backend-green
+```
+
+### 3.4 alembic upgrade head
+
+復元した backup の alembic head が、現在の repo の `alembic heads` と一致しない場合は
+stamp / upgrade を行う:
+
+```bash
+# 復元 DB の現在 head 確認
+docker exec ultra-autotrade-postgres-production \
+  psql -U ultra -d ultra_autotrade -c "SELECT version_num FROM alembic_version;"
+
+# repo 側の head 確認
+docker exec ultra-autotrade-backend-blue-production \
+  alembic heads
+
+# 差分がある場合の対処:
+# - backup が古く、repo が進んでいる → alembic upgrade head
+# - backup と repo の head が乖離している → stamp が必要
+#   → 詳細手順: docs/internal/2026-05-26_alembic_stamp_production_sync_runbook.md
+```
+
+> ※ memory `custom-limiter-expired-env-cleanup-pending`:
+> `CUSTOM_LIMITER_EXPIRES_ON=2026-05-15` 期限切れにより、コード側は自動 strict revert 動作中。
+> 復元後の .env 削除は人間担当 (dev からは env 触らない)。
+
+### 3.5 動作確認 (launch_gate L0 / L1 / L2)
+
+```bash
+# L0: schema sync (model vs DB schema gap)
+./scripts/launch_gate/L0_schema.sh
+
+# L1: env (本番 env が想定通り)
+./scripts/launch_gate/L1_env.sh
+
+# L2: smoke (基本的な read API が応答する)
+./scripts/launch_gate/L2_smoke.sh
+```
+
+3 つすべて PASS で復元完了。
+
+### 3.6 解放 (緊急停止解除)
+
+```bash
+# AI scheduler 復帰
+# .env.production: DISABLE_AI_JUDGMENT_SCHEDULER を 0 or unset に
+# (production では DISABLE=OFF が稼働状態。memory: disable-scheduler-flag-inverted)
+
+docker compose -f docker-compose.production.yml restart backend-blue backend-green
+
+# Slack #ultra-auto-project に復旧告知
+```
+
+---
+
+## 4. .env / wallet 鍵の復元 (該当する場合)
+
+DB だけでなく .env / wallet 鍵も損失した場合の手順 (Lane / Claude は触らない領域)。
+
+### 4.1 .env の復元
+
+- `.env.production` / `.env.staging-new` は **secrets manager / 別保管** からのみ復元する。
+  Lane / Claude は本番 env に触らない (memory: `no-prod-vps-commands-from-dev`)。
+- secrets の保管場所 + decryption key の所在は別途 1Password / Vault / 紙保管を参照。
+- 復元後は `./scripts/launch_gate/L1_env.sh` で必須 env が揃っていることを確認。
+
+### 4.2 wallet 鍵の復元
+
+- ホットウォレット private key は **DB / repo 内に保存しない** ことが原則。
+- 復元元: cold backup (paper / HSM / encrypted USB) のみ。
+- 復元後は少額 send をテストしてから本番取引に使うこと。
+
+---
+
+## 5. 復元 OK の判定基準 (チェックリスト)
+
+すべてチェックが入って初めて「復元完了」と宣言できる。
+
+- [ ] `scripts/restore_test.sh` が exit 0 (Pre-flight 検証 PASS)
+- [ ] `pre_restore_*.sql.gz` (退避 backup) が取得済み
+- [ ] `alembic_version` の head id が repo の `alembic heads` と一致
+- [ ] `02_db_tables.md` で list されているテーブルがすべて存在
+- [ ] 主要テーブル (users / proposals / ai_decisions / transactions /
+      fund_allocations / fee_transactions / portfolio_snapshots) の row count が 0 以上、
+      かつ復元前と概ね一致 (大幅減なら別世代を疑う)
+- [ ] `launch_gate/L0_schema.sh` PASS
+- [ ] `launch_gate/L1_env.sh` PASS
+- [ ] `launch_gate/L2_smoke.sh` PASS
+- [ ] Slack #ultra-auto-project に復旧告知済み
+- [ ] `DISABLE_AI_JUDGMENT_SCHEDULER` を稼働モード (production=OFF) に戻し、AI judgment が
+      流れている (ai_decisions テーブルに新規 row が積まれる) のを 5 分以内に確認
+
+---
+
+## 6. NG 時の rollback
+
+復元後に launch_gate L0-L2 のいずれかが NG だった、もしくは AI judgment が回らない
+等の不具合が発生したら即時 rollback:
+
+### 方針 A (rename 方式) からの rollback
+
+```bash
+docker compose -f docker-compose.production.yml stop backend-blue backend-green
+
+docker exec ultra-autotrade-postgres-production \
+  psql -U ultra -d postgres -c \
+  'ALTER DATABASE ultra_autotrade RENAME TO ultra_autotrade_restored_failed;'
+
+docker exec ultra-autotrade-postgres-production \
+  psql -U ultra -d postgres -c \
+  'ALTER DATABASE ultra_autotrade_broken_YYYYMMDD RENAME TO ultra_autotrade;'
+
+docker compose -f docker-compose.production.yml start backend-blue backend-green
+```
+
+### 方針 B (DROP/CREATE 方式) からの rollback
+
+```bash
+docker compose -f docker-compose.production.yml stop backend-blue backend-green
+
+docker exec ultra-autotrade-postgres-production \
+  psql -U ultra -d postgres -c 'DROP DATABASE ultra_autotrade; CREATE DATABASE ultra_autotrade;'
+
+gunzip -c /opt/ultra-autotrade/db_backups/pre_restore_YYYYMMDD_HHMMSS.sql.gz \
+  | docker exec -i ultra-autotrade-postgres-production \
+      psql -U ultra -d ultra_autotrade -v ON_ERROR_STOP=1
+
+docker compose -f docker-compose.production.yml start backend-blue backend-green
+```
+
+### 後始末
+
+- 復元失敗した DB (`ultra_autotrade_restored_failed` 等) は **1 週間は残す** (調査用)
+- Slack #ultra-auto-project に rollback 結果を告知
+- 失敗原因を `docs/internal/` に YYYY-MM-DD_restore_failure_postmortem.md として記録
+
+---
+
+## 付録 A. dev VPS / Lane / Claude の制約
+
+本 runbook の実行範囲のうち、Lane / Claude (dev VPS) は以下のみ実施できる:
+
+| 項目 | Lane / Claude | 人間 (小林さん) |
+|------|---------------|----------------|
+| `scripts/restore_test.sh` の dry-run (一時 DB) | ○ (dev local postgres があれば) | ○ |
+| 本番 VPS への SSH | × | ○ |
+| 本番 backup ファイルの取得 / 閲覧 | × | ○ |
+| 本番 DB への接続 (read-only でも) | × | ○ |
+| `.env.production` の read / write | × | ○ |
+| wallet 鍵への access | × | ○ |
+| 本 runbook §3 / §6 の実行 | × | ○ |
+
+memory 参照:
+- `no-prod-vps-commands-from-dev` — dev からは本番 VPS 向けコマンドを提案しない
+- `staging-lives-on-prod-vps` — staging も本番 Hetzner VPS (77.42.46.155) 上に同居
+- `prod-steps-not-done-until-verified` — 実機出力で裏取りするまで「完了」と書かない
+
+---
+
+## 付録 B. 定期訓練 (推奨)
+
+MVP-P0-1 完了後、四半期ごとに以下を実施する:
+
+1. 本番 backup の最新世代を取得
+2. `scripts/restore_test.sh` を **本番に触らない隔離環境** (dev 専用 postgres)
+   で実行し、exit 0 を確認
+3. 結果を Asana タスク「Backup 復元検証 (Q<N>)」に記録
+
+これにより、実際の災害発生前に backup が復元可能であることを継続的に保証する。

--- a/scripts/restore_test.sh
+++ b/scripts/restore_test.sh
@@ -1,0 +1,467 @@
+#!/usr/bin/env bash
+# restore_test.sh — backup ファイルを一時 DB に restore して整合性確認する dry-run スクリプト
+#
+# 目的:
+#   災害復旧 (本番 DB / staging DB 復元) に先立ち、backup ファイルが
+#   正常に restore できることを「本番に触らずに」検証する。
+#
+# 関連:
+#   - 生成元 backup: scripts/backup_db.sh (pg_dump | gzip → .sql.gz)
+#   - 災害復旧手順: docs/ops/restore_runbook.md
+#   - Asana 本番運用: MVP-P0-1 Backup 復元検証 (prod DB / .env / wallet 鍵)
+#
+# Usage:
+#   ./scripts/restore_test.sh --backup-file=/path/to/backup.sql.gz
+#   ./scripts/restore_test.sh --backup-file=... --env=staging
+#   ./scripts/restore_test.sh --backup-file=... --temp-db-name=restore_test_custom
+#   ./scripts/restore_test.sh --backup-file=... --keep-temp-db
+#   ./scripts/restore_test.sh --help
+#
+# 安全装置:
+#   - 本番 DB / staging DB に絶対に書き込まない。CREATE/DROP は一時 DB 名のみ。
+#   - 一時 DB 名は restore_test_ プレフィックス必須 (他名は拒否)。
+#   - DATABASE_URL は読まない。一時 DB 専用接続情報を組み立てる。
+#   - --env は形だけの目印 (表示用) で、実 DB には接続しない。
+#
+# Exit codes:
+#   0 -- restore OK + 整合性 OK
+#   1 -- restore 失敗 or 整合性 NG
+#   2 -- 設定エラー (引数不正 / backup file 不存在 / 一時 DB 作成失敗)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC2034  # reserved for future use (relative path resolution)
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# ── デフォルト値 ────────────────────────────────────────────────
+BACKUP_FILE=""
+ENV_TARGET="staging"
+TEMP_DB_NAME=""
+KEEP_TEMP_DB=0
+
+# 一時 DB 名のプレフィックス (安全装置: 他プレフィックスの DB に対する DROP/CREATE を拒否)
+TEMP_DB_PREFIX="restore_test_"
+
+# 検証時に「最低 1 件以上 row が期待される」テーブル群
+# (空 DB を誤って backup した場合に検出するため。
+#  ただし新規 staging 等 row が無い場合もあるので、警告扱いに留める)
+EXPECTED_TABLES=(
+  "users"
+  "ai_decisions"
+  "proposals"
+  "transactions"
+  "portfolio_snapshots"
+  "fund_allocations"
+  "fee_transactions"
+  "alembic_version"
+)
+
+# ── ログ ────────────────────────────────────────────────────────
+log()  { echo "[restore-test] $*"; }
+warn() { echo "[restore-test][WARN] $*" >&2; }
+err()  { echo "[restore-test][ERROR] $*" >&2; }
+
+# ── help ────────────────────────────────────────────────────────
+print_help() {
+  # 先頭の連続するコメント行 (shebang を除く) だけを抽出して表示する
+  awk '
+    NR==1 && /^#!/ { next }
+    /^#/           { sub(/^# ?/,""); print; next }
+    { exit }
+  ' "$0"
+  cat <<'EOF'
+
+Arguments:
+  --backup-file=<path>    (required) restore する backup ファイル (.sql.gz / .sql / pg_dump custom format)
+  --env=<staging|production>
+                          (default: staging) backup 元環境ラベル (表示用のみ。実 DB には接続しない)
+  --temp-db-name=<name>   (default: restore_test_<timestamp>) 検証用一時 DB 名
+                          ※ "restore_test_" プレフィックス必須
+  --keep-temp-db          (default: false) 検証後に一時 DB を残す (調査用)
+  --help                  このヘルプを表示
+
+Environment variables:
+  RESTORE_TEST_PG_HOST    PostgreSQL ホスト (default: localhost)
+  RESTORE_TEST_PG_PORT    PostgreSQL ポート (default: 5432)
+  RESTORE_TEST_PG_USER    PostgreSQL ユーザ (default: postgres)
+  RESTORE_TEST_PG_CONTAINER
+                          docker exec 経由で実行する場合のコンテナ名
+                          (未設定なら host の psql/pg_restore を使用)
+
+Examples:
+  # 最小実行
+  ./scripts/restore_test.sh --backup-file=/tmp/staging_backup.sql.gz
+
+  # 本番 backup の検証 (env ラベルのみ。実 DB には接続しない)
+  ./scripts/restore_test.sh \
+    --backup-file=/opt/ultra-autotrade/db_backups/production_ultra_autotrade_20260527_030000.sql.gz \
+    --env=production
+
+  # docker postgres コンテナを使う
+  RESTORE_TEST_PG_CONTAINER=ultra-autotrade-postgres-staging-new \
+    ./scripts/restore_test.sh --backup-file=/tmp/backup.sql.gz
+EOF
+}
+
+# ── 引数パース ──────────────────────────────────────────────────
+for arg in "$@"; do
+  case "${arg}" in
+    --backup-file=*)  BACKUP_FILE="${arg#--backup-file=}" ;;
+    --env=*)          ENV_TARGET="${arg#--env=}" ;;
+    --temp-db-name=*) TEMP_DB_NAME="${arg#--temp-db-name=}" ;;
+    --keep-temp-db)   KEEP_TEMP_DB=1 ;;
+    --help|-h)        print_help; exit 0 ;;
+    *)
+      err "Unknown argument: ${arg}"
+      err "Run with --help for usage."
+      exit 2
+      ;;
+  esac
+done
+
+# ── バリデーション ──────────────────────────────────────────────
+if [[ -z "${BACKUP_FILE}" ]]; then
+  err "--backup-file=<path> is required."
+  err "Run with --help for usage."
+  exit 2
+fi
+
+if [[ ! -f "${BACKUP_FILE}" ]]; then
+  err "backup file not found: ${BACKUP_FILE}"
+  exit 2
+fi
+
+case "${ENV_TARGET}" in
+  staging|production) ;;
+  *)
+    err "--env must be 'staging' or 'production' (got: '${ENV_TARGET}')"
+    exit 2
+    ;;
+esac
+
+# 一時 DB 名のデフォルト + プレフィックス強制
+if [[ -z "${TEMP_DB_NAME}" ]]; then
+  TEMP_DB_NAME="${TEMP_DB_PREFIX}$(date +%Y%m%d_%H%M%S)_$$"
+fi
+
+if [[ "${TEMP_DB_NAME}" != ${TEMP_DB_PREFIX}* ]]; then
+  err "--temp-db-name must start with '${TEMP_DB_PREFIX}' (got: '${TEMP_DB_NAME}')"
+  err "This is a safety guard to prevent accidental CREATE/DROP on production DBs."
+  exit 2
+fi
+
+# 一時 DB 名は本番 / staging の既知 DB 名と被ってはならない (二重ガード)
+case "${TEMP_DB_NAME}" in
+  ultra_autotrade|ultra_autotrade_staging|postgres|template0|template1)
+    err "--temp-db-name collides with a reserved/known DB name: ${TEMP_DB_NAME}"
+    exit 2
+    ;;
+esac
+
+# ── backup file sanity check ────────────────────────────────────
+BACKUP_SIZE="$(stat -c%s "${BACKUP_FILE}" 2>/dev/null || stat -f%z "${BACKUP_FILE}" 2>/dev/null || echo 0)"
+if [[ "${BACKUP_SIZE}" -le 0 ]]; then
+  err "backup file is empty (0 bytes): ${BACKUP_FILE}"
+  exit 2
+fi
+
+BACKUP_FILE_BASENAME="$(basename "${BACKUP_FILE}")"
+BACKUP_FORMAT=""
+case "${BACKUP_FILE_BASENAME}" in
+  *.sql.gz)
+    BACKUP_FORMAT="sql.gz"
+    # gzip integrity 確認
+    if ! gzip -t "${BACKUP_FILE}" 2>/dev/null; then
+      err "gzip integrity check failed: ${BACKUP_FILE}"
+      exit 2
+    fi
+    ;;
+  *.sql)
+    BACKUP_FORMAT="sql"
+    ;;
+  *.dump|*.pgdump|*.custom)
+    BACKUP_FORMAT="custom"
+    ;;
+  *)
+    warn "Unknown backup file extension: ${BACKUP_FILE_BASENAME}"
+    warn "Assuming plain SQL format. Use --help for supported formats."
+    BACKUP_FORMAT="sql"
+    ;;
+esac
+
+# ── PostgreSQL 接続情報 (一時 DB 用、本番 DB には触らない) ──────
+PG_HOST="${RESTORE_TEST_PG_HOST:-localhost}"
+PG_PORT="${RESTORE_TEST_PG_PORT:-5432}"
+PG_USER="${RESTORE_TEST_PG_USER:-postgres}"
+PG_CONTAINER="${RESTORE_TEST_PG_CONTAINER:-}"
+
+# psql / pg_restore のラッパー (docker exec or host)
+_psql() {
+  if [[ -n "${PG_CONTAINER}" ]]; then
+    docker exec -i "${PG_CONTAINER}" psql -U "${PG_USER}" "$@"
+  else
+    PGHOST="${PG_HOST}" PGPORT="${PG_PORT}" psql -U "${PG_USER}" "$@"
+  fi
+}
+
+_pg_isready() {
+  if [[ -n "${PG_CONTAINER}" ]]; then
+    docker exec "${PG_CONTAINER}" pg_isready -U "${PG_USER}" >/dev/null 2>&1
+  else
+    PGHOST="${PG_HOST}" PGPORT="${PG_PORT}" pg_isready -U "${PG_USER}" >/dev/null 2>&1
+  fi
+}
+
+# ── サマリ ──────────────────────────────────────────────────────
+log "=============================================="
+log "Restore test (dry-run / temporary DB)"
+log "=============================================="
+log "backup file       : ${BACKUP_FILE}"
+log "backup size       : $(( BACKUP_SIZE / 1024 )) KB"
+log "backup format     : ${BACKUP_FORMAT}"
+log "env label         : ${ENV_TARGET}  (display only; no connection to real DB)"
+log "temp DB name      : ${TEMP_DB_NAME}"
+log "keep temp DB      : $([[ ${KEEP_TEMP_DB} -eq 1 ]] && echo yes || echo no)"
+log "pg target         : $([[ -n "${PG_CONTAINER}" ]] && echo "container=${PG_CONTAINER}" || echo "host=${PG_HOST}:${PG_PORT}")"
+log "pg user           : ${PG_USER}"
+log "=============================================="
+
+# ── pg_isready 接続確認 ─────────────────────────────────────────
+if ! _pg_isready; then
+  err "PostgreSQL is not reachable."
+  err "  - host mode:   ensure PostgreSQL is running on ${PG_HOST}:${PG_PORT}"
+  err "  - docker mode: ensure RESTORE_TEST_PG_CONTAINER is running"
+  exit 2
+fi
+log "pg_isready: OK"
+
+# ── 一時 DB 作成 ────────────────────────────────────────────────
+log "Creating temporary DB: ${TEMP_DB_NAME}"
+if ! _psql -d postgres -c "CREATE DATABASE \"${TEMP_DB_NAME}\";" >/dev/null 2>&1; then
+  err "Failed to create temporary DB: ${TEMP_DB_NAME}"
+  err "(database may already exist, or user '${PG_USER}' lacks CREATEDB privilege)"
+  exit 2
+fi
+log "Temporary DB created."
+
+# ── クリーンアップトラップ ─────────────────────────────────────
+RESTORE_RC=1
+INTEGRITY_RC=1
+# shellcheck disable=SC2317  # invoked via `trap cleanup EXIT`
+cleanup() {
+  local exit_code=$?
+  if [[ "${KEEP_TEMP_DB}" -eq 1 ]]; then
+    log "--keep-temp-db: leaving ${TEMP_DB_NAME} for inspection."
+    log "Drop manually: psql -U ${PG_USER} -d postgres -c 'DROP DATABASE \"${TEMP_DB_NAME}\";'"
+  else
+    # 安全装置: TEMP_DB_NAME が restore_test_ プレフィックスでない場合は DROP しない (paranoid)
+    if [[ "${TEMP_DB_NAME}" == ${TEMP_DB_PREFIX}* ]]; then
+      log "Dropping temporary DB: ${TEMP_DB_NAME}"
+      _psql -d postgres -c "DROP DATABASE IF EXISTS \"${TEMP_DB_NAME}\";" >/dev/null 2>&1 || \
+        warn "Failed to drop ${TEMP_DB_NAME}. Manual cleanup may be needed."
+    else
+      warn "Refusing to drop DB without '${TEMP_DB_PREFIX}' prefix: ${TEMP_DB_NAME}"
+    fi
+  fi
+  exit "${exit_code}"
+}
+trap cleanup EXIT
+
+# ── restore 実行 ────────────────────────────────────────────────
+log "Restoring backup into ${TEMP_DB_NAME}..."
+RESTORE_LOG="$(mktemp -t restore_test.XXXXXX.log)"
+
+case "${BACKUP_FORMAT}" in
+  sql.gz)
+    if [[ -n "${PG_CONTAINER}" ]]; then
+      if gunzip -c "${BACKUP_FILE}" \
+          | docker exec -i "${PG_CONTAINER}" psql -U "${PG_USER}" -d "${TEMP_DB_NAME}" \
+              -v ON_ERROR_STOP=1 \
+          > "${RESTORE_LOG}" 2>&1; then
+        RESTORE_RC=0
+      fi
+    else
+      if PGHOST="${PG_HOST}" PGPORT="${PG_PORT}" \
+          gunzip -c "${BACKUP_FILE}" \
+          | psql -U "${PG_USER}" -d "${TEMP_DB_NAME}" -v ON_ERROR_STOP=1 \
+          > "${RESTORE_LOG}" 2>&1; then
+        RESTORE_RC=0
+      fi
+    fi
+    ;;
+  sql)
+    if [[ -n "${PG_CONTAINER}" ]]; then
+      if docker exec -i "${PG_CONTAINER}" psql -U "${PG_USER}" -d "${TEMP_DB_NAME}" \
+            -v ON_ERROR_STOP=1 < "${BACKUP_FILE}" \
+          > "${RESTORE_LOG}" 2>&1; then
+        RESTORE_RC=0
+      fi
+    else
+      if PGHOST="${PG_HOST}" PGPORT="${PG_PORT}" \
+          psql -U "${PG_USER}" -d "${TEMP_DB_NAME}" -v ON_ERROR_STOP=1 < "${BACKUP_FILE}" \
+          > "${RESTORE_LOG}" 2>&1; then
+        RESTORE_RC=0
+      fi
+    fi
+    ;;
+  custom)
+    # pg_restore は対象 DB を引数で指定する
+    if [[ -n "${PG_CONTAINER}" ]]; then
+      # コンテナ内に backup file を一旦コピーして使う
+      TMP_IN_CONTAINER="/tmp/restore_test_$$.dump"
+      if docker cp "${BACKUP_FILE}" "${PG_CONTAINER}:${TMP_IN_CONTAINER}" >/dev/null 2>&1 \
+         && docker exec "${PG_CONTAINER}" \
+              pg_restore -U "${PG_USER}" -d "${TEMP_DB_NAME}" --no-owner --no-acl \
+                "${TMP_IN_CONTAINER}" \
+              > "${RESTORE_LOG}" 2>&1; then
+        RESTORE_RC=0
+      fi
+      docker exec "${PG_CONTAINER}" rm -f "${TMP_IN_CONTAINER}" 2>/dev/null || true
+    else
+      if PGHOST="${PG_HOST}" PGPORT="${PG_PORT}" \
+          pg_restore -U "${PG_USER}" -d "${TEMP_DB_NAME}" --no-owner --no-acl \
+            "${BACKUP_FILE}" \
+          > "${RESTORE_LOG}" 2>&1; then
+        RESTORE_RC=0
+      fi
+    fi
+    ;;
+esac
+
+if [[ "${RESTORE_RC}" -ne 0 ]]; then
+  err "Restore FAILED. Log tail:"
+  tail -n 30 "${RESTORE_LOG}" >&2 || true
+  log "Result: restore=NG"
+  exit 1
+fi
+log "Restore: OK"
+
+# ── 整合性確認 ──────────────────────────────────────────────────
+log "Running integrity checks..."
+
+# (a) テーブル数
+TABLE_COUNT="$(_psql -d "${TEMP_DB_NAME}" -tAc \
+  "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';" \
+  2>/dev/null | tr -d '[:space:]' || echo 0)"
+log "  tables (public)      : ${TABLE_COUNT}"
+
+# (b) 期待テーブルの存在確認
+MISSING_TABLES=()
+_missing_contains() {
+  # POSIX-like helper to check whether a value is in MISSING_TABLES.
+  local needle="$1"
+  local item
+  for item in "${MISSING_TABLES[@]}"; do
+    [[ "${item}" == "${needle}" ]] && return 0
+  done
+  return 1
+}
+for t in "${EXPECTED_TABLES[@]}"; do
+  exists="$(_psql -d "${TEMP_DB_NAME}" -tAc \
+    "SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='${t}';" \
+    2>/dev/null | tr -d '[:space:]' || echo "")"
+  if [[ "${exists}" != "1" ]]; then
+    MISSING_TABLES+=("${t}")
+  fi
+done
+
+if [[ ${#MISSING_TABLES[@]} -gt 0 ]]; then
+  warn "Missing expected tables: ${MISSING_TABLES[*]}"
+else
+  log "  expected tables      : all present (${#EXPECTED_TABLES[@]})"
+fi
+
+# (c) alembic_version head id
+ALEMBIC_HEAD=""
+if ! _missing_contains "alembic_version"; then
+  ALEMBIC_HEAD="$(_psql -d "${TEMP_DB_NAME}" -tAc \
+    "SELECT version_num FROM alembic_version LIMIT 1;" 2>/dev/null \
+    | tr -d '[:space:]' || echo "")"
+  if [[ -n "${ALEMBIC_HEAD}" ]]; then
+    log "  alembic head         : ${ALEMBIC_HEAD}"
+  else
+    warn "alembic_version table exists but has no row."
+  fi
+else
+  warn "alembic_version table not found in backup."
+fi
+
+# (d) 主要テーブル row count
+log "  row counts:"
+TOTAL_ROWS=0
+for t in users ai_decisions proposals transactions portfolio_snapshots fund_allocations fee_transactions; do
+  if _missing_contains "${t}"; then
+    log "    ${t}: (missing)"
+    continue
+  fi
+  cnt="$(_psql -d "${TEMP_DB_NAME}" -tAc "SELECT count(*) FROM \"${t}\";" 2>/dev/null \
+    | tr -d '[:space:]' || echo 0)"
+  log "    ${t}: ${cnt}"
+  TOTAL_ROWS=$(( TOTAL_ROWS + ${cnt:-0} ))
+done
+
+# (e) FK 制約数
+FK_COUNT="$(_psql -d "${TEMP_DB_NAME}" -tAc \
+  "SELECT count(*) FROM information_schema.table_constraints
+   WHERE constraint_schema='public' AND constraint_type='FOREIGN KEY';" \
+  2>/dev/null | tr -d '[:space:]' || echo 0)"
+log "  foreign key count    : ${FK_COUNT}"
+
+# (f) FK 制約の妥当性チェック (referencing column が存在しているか)
+INVALID_FK="$(_psql -d "${TEMP_DB_NAME}" -tAc \
+  "SELECT count(*) FROM pg_constraint c
+     JOIN pg_namespace n ON c.connamespace = n.oid
+   WHERE n.nspname='public' AND c.contype='f' AND NOT c.convalidated;" \
+  2>/dev/null | tr -d '[:space:]' || echo 0)"
+log "  unvalidated FK count : ${INVALID_FK}"
+
+# ── 判定 ────────────────────────────────────────────────────────
+INTEGRITY_RC=0
+
+# critical: tables が 0 件 → 復元失敗扱い
+if [[ "${TABLE_COUNT}" -le 0 ]]; then
+  err "No public tables found after restore."
+  INTEGRITY_RC=1
+fi
+
+# critical: alembic_version が無い → 復元 NG (本プロジェクトは alembic 管理)
+if [[ -z "${ALEMBIC_HEAD}" ]]; then
+  err "alembic_version head not found. Restore is incomplete or backup is invalid."
+  INTEGRITY_RC=1
+fi
+
+# critical: 期待テーブルのうち alembic_version, users が無い → NG
+for t in users alembic_version; do
+  if _missing_contains "${t}"; then
+    err "Critical table missing: ${t}"
+    INTEGRITY_RC=1
+  fi
+done
+
+# critical: unvalidated FK が存在 → NG
+if [[ "${INVALID_FK}" -gt 0 ]]; then
+  err "Unvalidated FK constraints exist: ${INVALID_FK}"
+  INTEGRITY_RC=1
+fi
+
+# ── 結果 ────────────────────────────────────────────────────────
+log "=============================================="
+log "Result summary"
+log "=============================================="
+log "  restore         : OK"
+log "  tables          : ${TABLE_COUNT}"
+log "  expected tables : $(( ${#EXPECTED_TABLES[@]} - ${#MISSING_TABLES[@]} )) / ${#EXPECTED_TABLES[@]}"
+log "  alembic head    : ${ALEMBIC_HEAD:-<none>}"
+log "  total rows      : ${TOTAL_ROWS}  (primary tables only)"
+log "  FK count        : ${FK_COUNT}  (invalid: ${INVALID_FK})"
+log "  integrity       : $([[ ${INTEGRITY_RC} -eq 0 ]] && echo OK || echo NG)"
+log "=============================================="
+
+if [[ "${INTEGRITY_RC}" -ne 0 ]]; then
+  log "Final: NG"
+  exit 1
+fi
+
+log "Final: OK"
+exit 0


### PR DESCRIPTION
## Summary
MVP-P0-1 Backup 復元検証 (5/24 期限超過) の基盤整備。復元側の test スクリプト + 災害復旧 runbook を整備。**実機の本番 backup を使った復元実行は人間担当**で、Lane はやらない (memory `no-prod-vps-commands-from-dev`)。

Asana: 本番運用プロジェクト MVP-P0-1

## Changes
- 新規 `scripts/restore_test.sh` (467 行 / executable) — 一時 DB に backup を restore + 整合性確認する dry-run
- 新規 `docs/ops/restore_runbook.md` (417 行) — 災害復旧時の人間が読んで実行する手順書

## 安全装置 (本番 DB に触らない設計)
- 一時 DB 名は `restore_test_` プレフィックス強制 (二重ガード)
- reserved DB (`ultra_autotrade` / `ultra_autotrade_staging` / `postgres` / `template*`) は名前指定でも拒否
- `DATABASE_URL` を読まない (一時 DB 専用接続情報のみ使用: `RESTORE_TEST_PG_HOST/PORT/USER/CONTAINER`)
- `--env=staging|production` は表示ラベルのみで実 DB には接続しない
- `EXIT` trap で必ず DROP DATABASE (`--keep-temp-db` で skip 可) + trap 内でも prefix チェック再確認

## 整合性チェック (restore 後)
- テーブル数
- 期待 8 テーブル存在 (proposals / users / ai_decisions / transactions 等)
- `alembic_version` head id 取得
- 主要 7 テーブル row count
- FK 数 / unvalidated FK 数

## backup 形式の一致確認 (済)
`scripts/backup_db.sh` は `pg_dump | gzip > *.sql.gz` 出力 → `restore_test.sh` は拡張子で自動判定 (`.sql.gz` を gunzip 経由 psql、`.sql` / `.dump` も対応)。

## 検証結果
- `bash -n scripts/restore_test.sh`: OK
- `shellcheck` (v0.9.0): warnings ゼロ
- `--help`: 動作 OK
- 引数バリデーション全件 OK (必須欠落 / 不存在ファイル / invalid env / reserved DB 名 / 未知引数 → 全て exit 2)
- runbook の参照リンク先 7 件すべて repo 内存在確認済 (#426 alembic stamp / disable_release / 02_db_tables / launch_gate L0-L2 / backup_db.sh)
- 実機 restore は実行せず (本番 backup なし)

## スコープ外 (明示)
- 実機の本番 backup を使った restore 実行 → 人間担当
- 本番 / staging VPS への SSH や DB 接続 → 人間担当
- env / wallet 鍵への access → 別タスク

## Merge 経路
Path Access Control 警告 (main 直接 merge 推奨せず) を踏まえ、**staging 経由推奨**:
1. staging branch に merge
2. staging で `bash scripts/restore_test.sh --help` 動作確認 (deploy 不要、script 単体)
3. main に fast-forward

ただしこの PR は新規ファイル 2 件のみで稼働中サービスへの影響ゼロ → main 直接 merge も実害なし。判断は人間。

## Test plan
- [x] bash -n / shellcheck OK
- [x] 引数バリデーション 全件動作確認
- [x] backup 形式の一致確認
- [x] runbook 参照リンク存在確認
- [ ] 本番 backup を使った実機 restore 検証 (merge 後・人間担当)
- [ ] 次回 launch_gate L0 で alembic head id を `restore_test.sh` 経由でも確認できるか統合検討

memory: `prod-steps-not-done-until-verified`, `no-prod-vps-commands-from-dev`, `project-launch-target-shifted-to-jun3`