### PR TITLE
fix(partner-dashboard): 誤解を生むラベル「運用総額」を「運用残高」に変更

### DIFF
--- a/frontend/app/(partner)/partner/dashboard/_components/PerformanceSummaryKPI.tsx
+++ b/frontend/app/(partner)/partner/dashboard/_components/PerformanceSummaryKPI.tsx
@@ -79,10 +79,10 @@ export default function PerformanceSummaryKPI() {
 
   return (
     <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-      {/* 運用総額 */}
+      {/* 現在の運用残高 */}
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium text-muted-foreground">運用総額</CardTitle>
+          <CardTitle className="text-sm font-medium text-muted-foreground">現在の運用残高</CardTitle>
           <DollarSign className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>

--- a/frontend/app/(partner)/partner/referral/[id]/page.tsx
+++ b/frontend/app/(partner)/partner/referral/[id]/page.tsx
@@ -112,7 +112,7 @@ export default function ReferralUserDetailPage() {
         ) : (
           <>
             <KPICard
-              label="今日の運用総額"
+              label="今日の運用残高"
               value={fmtUsd(stats?.today_amount)}
               prefix="$"
               icon={DollarSign}

--- a/frontend/app/(partner)/partner/users/[id]/page.tsx
+++ b/frontend/app/(partner)/partner/users/[id]/page.tsx
@@ -85,7 +85,7 @@ export default function PartnerUserDetailPage() {
         ) : (
           <>
             <KPICard
-              label="今日の運用総額"
+              label="今日の運用残高"
               value={fmtUsd(stats?.today_amount)}
               prefix="$"
               icon={DollarSign}

--- a/frontend/e2e/partner-users-detail.spec.ts
+++ b/frontend/e2e/partner-users-detail.spec.ts
@@ -176,7 +176,7 @@ test.describe('TC-F2-1: /partner/users/[id] 詳細ページ', () => {
     await expect(page.getByRole('heading', { name: 'テスター詳細' })).toBeVisible({ timeout: 10_000 })
 
     // KPI ラベルが 3 枚分表示される
-    const kpiLabels = ['今日の運用総額', '今月の利回り', '昨日の利回り']
+    const kpiLabels = ['今日の運用残高', '今月の利回り', '昨日の利回り']
     for (const label of kpiLabels) {
       await expect(page.getByText(label).first()).toBeVisible({ timeout: 10_000 })
     }
@@ -231,7 +231,7 @@ test.describe('TC-F2-2: DOM 制約 — wallet_address / tx_hash 非表示', () =
 // ── TC-F2-3: /partner/referral/[id] KPI セクション ────────────────────────────
 
 test.describe('TC-F2-3: /partner/referral/[id] 運用状況 KPI', () => {
-  test('KPI セクション（今日の運用総額 / 今月の利回り）が表示される', async ({ page }) => {
+  test('KPI セクション（今日の運用残高 / 今月の利回り）が表示される', async ({ page }) => {
     await setupPartnerMocks(page)
     await page.goto('/partner/referral/1')
     await page.waitForLoadState('domcontentloaded')
@@ -240,7 +240,7 @@ test.describe('TC-F2-3: /partner/referral/[id] 運用状況 KPI', () => {
     expect(page.url()).toContain('/partner/referral/1')
 
     // KPI ラベル
-    await expect(page.getByText('今日の運用総額').first()).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('今日の運用残高').first()).toBeVisible({ timeout: 10_000 })
     await expect(page.getByText('今月の利回り').first()).toBeVisible({ timeout: 10_000 })
 
     // 「紹介一覧に戻る」リンク


### PR DESCRIPTION
## Summary
partner dashboard の KPI ラベル「運用総額」が、ユーザーから「partner 自身の運用総額」「累計運用金額」と誤読されると指摘された。実装は **`total_supply_usd` = 配下 testers が現時点で Aave に supply している担保 USD 価値の合計 (stock 値、AUM 相当)** で、累計ではない。誤解を生まないラベルに変更。

## 確認した実装の事実

`frontend/app/(partner)/partner/dashboard/_components/PerformanceSummaryKPI.tsx:70`
```typescript
const supplyUsd = Number(data?.total_supply_usd ?? 0)
```

`backend/app/portfolio/router.py:68`:
```python
total_supply_usd = account_data.total_collateral_usd  # Aave の今 supply 合計
```

→ 「今 Aave に預けてる合計」(stock)。**過去から今までの累計預入額 (flow) ではない**。

例: A さん 4月に \$1,000 預入 → 5月に \$500 withdraw → 今 supply \$500。「運用総額」表示は \$500 (現状) で、累計 \$1,000 ではない。「運用総額」だと累計 \$1,000 と誤読される。

## Changes (4 files / +7 / -7)

| ファイル | 変更 |
|---|---|
| `PerformanceSummaryKPI.tsx` | 「運用総額」(コメント + CardTitle) → 「現在の運用残高」 |
| `partner/users/[id]/page.tsx` | 「今日の運用総額」→「今日の運用残高」 |
| `partner/referral/[id]/page.tsx` | 「今日の運用総額」→「今日の運用残高」 |
| `e2e/partner-users-detail.spec.ts` | 期待値 3 箇所を「今日の運用残高」に更新 |

検証: 編集後 \`grep "運用総額" frontend/\` count = 0、`grep "運用残高"` = 7 箇所(意図通り)。

## 衝突確認 (済)
- OPEN PR #437 (restore_test) / #438 (e2e credentials) はどちらも本 4 ファイルに触らない
- active worktree (w1-viewer-approve / lane-h/i/j/k/q/r / fee-finalize / proposal-notify / 30plan-backend) も本 4 ファイル無触
- ファイル単位コンフリクトゼロ

## i18n 化はスコープ外
- `frontend/messages/ja.json` には既に `aum: "運用資産額"` 等の用語規範あり
- 現コードはハードコードラベルだが、本 PR では key 切り出しまで踏み込まない
- i18n 化 + 用語規範統一は別タスクで対応

## Merge 経路
Path Access Control 警告 (main 直接 merge 推奨せず) を踏まえ **staging 経由推奨**:
1. staging branch に merge
2. staging frontend deploy 後、partner dashboard で表示確認 (\"現在の運用残高\" / \"今日の運用残高\" のテキスト表示)
3. main に fast-forward

ただし label 変更のみで稼働中サービス破壊リスクほぼゼロ → main 直接 merge も実害なし。判断は人間。

## Test plan
- [x] grep 「運用総額」 = 0 確認
- [x] git diff +7/-7 (label 文言のみ変更、ロジック変更なし)
- [ ] staging frontend deploy 後、partner dashboard / tester 詳細 / referral 詳細で表示確認 (人間)
- [ ] e2e partner-users-detail.spec.ts が staging で PASS (人間、credentials 設定済 staging で)

memory: [[feedback-no-done-without-e2e-output]]