### PR TITLE
feat(partner): partner ウォレット残高 KPI (USDC + ETH on Base mainnet)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -68,6 +68,7 @@ from app.notifications.router import api_router as notification_api_router
 from app.notifications.router import router as notification_router
 from app.partner.allocation_router import router as allocation_router
 from app.partner.router import router as partner_router
+from app.partner.wallet_balance_router import router as wallet_balance_router
 from app.portfolio.router import router as portfolio_router
 from app.proposals.router import router as proposals_router
 from app.protocols.lido.router import router as lido_router
@@ -235,6 +236,9 @@ def create_app() -> FastAPI:
     app.include_router(
         allocation_router, prefix="/api/partner", tags=["partner-allocations"]
     )  # Fund allocations
+    app.include_router(
+        wallet_balance_router, prefix="/api/partner", tags=["partner"]
+    )  # Partner wallet balance (USDC + ETH on Base mainnet)
     app.include_router(users_router)  # Users (Phase12)
     app.include_router(ai_router, prefix="/api")  # AI (Phase2)
     app.include_router(octobot_router)  # OctoBot (Phase3)

--- a/backend/app/partner/wallet_balance_router.py
+++ b/backend/app/partner/wallet_balance_router.py
@@ -1,0 +1,40 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/partner/wallet_balance_router.py
+"""Partner wallet balance API ルーター定義。
+
+GET /api/partner/wallet-balance — 認証済 partner 自身のウォレット (Base mainnet) の
+USDC + ETH 残高を返す。Aave supply 分は含まない。60 秒 cache。
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.auth.dependencies import require_partner
+from app.auth.models import User
+from app.partner import wallet_balance_service
+from app.partner.wallet_balance_schemas import WalletBalanceResponse
+
+router = APIRouter(tags=["partner"])
+
+
+@router.get(
+    "/wallet-balance",
+    response_model=WalletBalanceResponse,
+    summary="Partner 自身のウォレット残高 (USDC + ETH on Base mainnet)",
+)
+async def get_wallet_balance(
+    current_user: User = Depends(require_partner),
+) -> WalletBalanceResponse:
+    """認証済 partner 自身の wallet (Base mainnet) の USDC + ETH 残高を返す。
+
+    Aave supply 分は含まない (= ウォレットに「入っている」を文字通り)。
+    60 秒 in-memory cache。RPC / price 失敗時は fallback_used=true で degrade。
+    """
+    if not current_user.wallet_address:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="wallet_address が partner に未設定です",
+        )
+    return await wallet_balance_service.fetch(current_user.wallet_address)

--- a/backend/app/partner/wallet_balance_schemas.py
+++ b/backend/app/partner/wallet_balance_schemas.py
@@ -1,0 +1,35 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/partner/wallet_balance_schemas.py
+"""Partner wallet balance API response schema.
+
+GET /api/partner/wallet-balance のレスポンス定義。
+USDC + ETH (native) on Base mainnet のみを集計。Aave supply 分は含まない。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class WalletBalanceResponse(BaseModel):
+    """Partner 自身のウォレット内資産 (USDC + ETH on Base mainnet) のレスポンス。
+
+    Aave supply 分は含まない (= ウォレットに「入っている」を文字通り)。
+    """
+
+    wallet_address: str
+    chain: Literal["base"] = "base"
+    eth_balance: Decimal  # wei → ether に変換済
+    eth_usd_value: Decimal  # eth_balance * eth_usd_price
+    eth_usd_price: Decimal  # 1 ETH = ? USD (Chainlink ETH/USD)
+    usdc_balance: Decimal  # USDC を 10^6 で除した値
+    usdc_usd_value: Decimal  # usdc_balance * 1.00 (1:1 simplification)
+    total_usd: Decimal  # eth_usd_value + usdc_usd_value
+    fetched_at: datetime
+    cache_age_seconds: int  # 0 if fresh, else seconds since fetched
+    fallback_used: bool  # true if RPC or price fallback was triggered

--- a/backend/app/partner/wallet_balance_service.py
+++ b/backend/app/partner/wallet_balance_service.py
@@ -1,0 +1,262 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/partner/wallet_balance_service.py
+"""Partner wallet balance service.
+
+責務:
+- partner の wallet_address から Base mainnet 上の USDC + ETH 残高取得
+- Chainlink ETH/USD で ETH 残高を USD 換算
+- USDC は 1:1 で USD 換算 (簡略化)
+- 60 秒 in-memory cache (wallet_address ごと)
+- 失敗時は fallback (RPC エラー時 0 + warning、price エラー時は ETH_USD_FALLBACK_PRICE)
+
+NOTE: Aave supply 分は **含まない**。ウォレットに「入っている」分のみ。
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Optional
+
+from app.aave.gas_estimator import ETH_USD_FALLBACK_PRICE
+from app.partner.wallet_balance_schemas import WalletBalanceResponse
+
+logger = logging.getLogger(__name__)
+
+# --- Base mainnet token / oracle addresses ---
+# USDC on Base mainnet (6 decimals)
+USDC_CONTRACT_ADDRESS_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+USDC_DECIMALS = 6
+
+# Chainlink ETH/USD aggregator on Base mainnet (8 decimals)
+ETH_USD_FEED_ADDRESS_BASE = "0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70"
+CHAINLINK_DECIMALS = 8
+
+# Cache TTL
+CACHE_TTL_SECONDS = 60
+
+# ERC20 balanceOf ABI (minimal)
+_ERC20_ABI: list[dict[str, Any]] = [
+    {
+        "constant": True,
+        "inputs": [{"name": "account", "type": "address"}],
+        "name": "balanceOf",
+        "outputs": [{"name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    }
+]
+
+# Chainlink AggregatorV3 latestRoundData ABI (minimal)
+_AGGREGATOR_ABI: list[dict[str, Any]] = [
+    {
+        "inputs": [],
+        "name": "latestRoundData",
+        "outputs": [
+            {"internalType": "uint80", "name": "roundId", "type": "uint80"},
+            {"internalType": "int256", "name": "answer", "type": "int256"},
+            {"internalType": "uint256", "name": "startedAt", "type": "uint256"},
+            {"internalType": "uint256", "name": "updatedAt", "type": "uint256"},
+            {"internalType": "uint80", "name": "answeredInRound", "type": "uint80"},
+        ],
+        "stateMutability": "view",
+        "type": "function",
+    }
+]
+
+
+@dataclass
+class _CacheEntry:
+    response: WalletBalanceResponse
+    fetched_at_monotonic: float
+
+
+# in-memory cache (wallet_address (checksum) → _CacheEntry)
+_CACHE: dict[str, _CacheEntry] = {}
+
+
+def _get_base_rpc_url() -> Optional[str]:
+    """Base mainnet RPC URL を環境変数から取得する。
+
+    優先順:
+      1. AAVE_RPC_URL_BASE (Aave 用と共有)
+      2. BASE_RPC_URL (汎用)
+      3. WEB3_RPC_URL (legacy)
+    """
+    return (
+        os.getenv("AAVE_RPC_URL_BASE")
+        or os.getenv("BASE_RPC_URL")
+        or os.getenv("WEB3_RPC_URL")
+    )
+
+
+def _get_web3() -> Optional[Any]:
+    """Web3 client を返す。web3 未インストール / RPC URL 未設定なら None。"""
+    rpc_url = _get_base_rpc_url()
+    if not rpc_url:
+        logger.warning("[wallet_balance] Base RPC URL not configured (AAVE_RPC_URL_BASE / BASE_RPC_URL)")
+        return None
+
+    try:
+        from web3 import Web3  # noqa: PLC0415
+    except ImportError:
+        logger.warning("[wallet_balance] web3 package not installed; cannot fetch balance")
+        return None
+
+    try:
+        return Web3(Web3.HTTPProvider(rpc_url))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[wallet_balance] Web3 init failed: %s", exc)
+        return None
+
+
+def _fetch_eth_balance(w3: Any, wallet_address: str) -> tuple[Decimal, bool]:
+    """ETH (native) 残高を返す (ether 単位)。エラー時は (0, True)。"""
+    try:
+        checksum = w3.to_checksum_address(wallet_address)
+        wei_balance = w3.eth.get_balance(checksum)
+        eth_balance = Decimal(wei_balance) / Decimal(10**18)
+        return eth_balance, False
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[wallet_balance] ETH balance fetch failed: %s", exc)
+        return Decimal("0"), True
+
+
+def _fetch_usdc_balance(w3: Any, wallet_address: str) -> tuple[Decimal, bool]:
+    """USDC 残高を返す (USDC 単位)。エラー時は (0, True)。"""
+    try:
+        checksum_wallet = w3.to_checksum_address(wallet_address)
+        checksum_token = w3.to_checksum_address(USDC_CONTRACT_ADDRESS_BASE)
+        contract = w3.eth.contract(address=checksum_token, abi=_ERC20_ABI)
+        raw_balance = contract.functions.balanceOf(checksum_wallet).call()
+        usdc_balance = Decimal(raw_balance) / Decimal(10**USDC_DECIMALS)
+        return usdc_balance, False
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[wallet_balance] USDC balance fetch failed: %s", exc)
+        return Decimal("0"), True
+
+
+def _fetch_eth_usd_price(w3: Any) -> tuple[Decimal, bool]:
+    """Chainlink ETH/USD price を返す。エラー時は (ETH_USD_FALLBACK_PRICE, True)。"""
+    try:
+        checksum_feed = w3.to_checksum_address(ETH_USD_FEED_ADDRESS_BASE)
+        feed = w3.eth.contract(address=checksum_feed, abi=_AGGREGATOR_ABI)
+        round_data = feed.functions.latestRoundData().call()
+        _round_id, answer, _started_at, _updated_at, _answered_in_round = round_data
+        if answer <= 0:
+            logger.warning("[wallet_balance] Chainlink ETH/USD returned non-positive answer: %s", answer)
+            return ETH_USD_FALLBACK_PRICE, True
+        price = Decimal(answer) / Decimal(10**CHAINLINK_DECIMALS)
+        return price, False
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[wallet_balance] ETH/USD price fetch failed: %s; using fallback", exc)
+        return ETH_USD_FALLBACK_PRICE, True
+
+
+def _normalize_wallet_address(wallet_address: str) -> str:
+    """checksum 化を試みる。web3 が無い場合は lower-case で代用 (cache key 一貫性)。"""
+    try:
+        from web3 import Web3  # noqa: PLC0415
+
+        return Web3.to_checksum_address(wallet_address)
+    except Exception:  # noqa: BLE001
+        return wallet_address.lower()
+
+
+def _build_response(
+    wallet_address: str,
+    eth_balance: Decimal,
+    eth_usd_price: Decimal,
+    usdc_balance: Decimal,
+    fallback_used: bool,
+    fetched_at: datetime,
+    cache_age_seconds: int,
+) -> WalletBalanceResponse:
+    eth_usd_value = eth_balance * eth_usd_price
+    usdc_usd_value = usdc_balance  # 1:1
+    total_usd = eth_usd_value + usdc_usd_value
+    return WalletBalanceResponse(
+        wallet_address=wallet_address,
+        chain="base",
+        eth_balance=eth_balance,
+        eth_usd_value=eth_usd_value,
+        eth_usd_price=eth_usd_price,
+        usdc_balance=usdc_balance,
+        usdc_usd_value=usdc_usd_value,
+        total_usd=total_usd,
+        fetched_at=fetched_at,
+        cache_age_seconds=cache_age_seconds,
+        fallback_used=fallback_used,
+    )
+
+
+def _all_fallback_response(wallet_address: str) -> WalletBalanceResponse:
+    """RPC が一切利用できないときの安全なフォールバック (balance=0, price=fallback)。"""
+    now = datetime.now(timezone.utc)
+    return _build_response(
+        wallet_address=wallet_address,
+        eth_balance=Decimal("0"),
+        eth_usd_price=ETH_USD_FALLBACK_PRICE,
+        usdc_balance=Decimal("0"),
+        fallback_used=True,
+        fetched_at=now,
+        cache_age_seconds=0,
+    )
+
+
+async def fetch(wallet_address: str, *, web3: Any | None = None) -> WalletBalanceResponse:
+    """Partner ウォレット残高を取得する (60 秒 cache)。
+
+    Args:
+        wallet_address: 0x プレフィックス付きアドレス。
+        web3: テスト時の Web3 注入。本番は None で _get_web3() を使う。
+
+    Returns:
+        WalletBalanceResponse。
+    """
+    key = _normalize_wallet_address(wallet_address)
+    now_mono = time.monotonic()
+
+    # Cache hit?
+    entry = _CACHE.get(key)
+    if entry is not None:
+        age = int(now_mono - entry.fetched_at_monotonic)
+        if age < CACHE_TTL_SECONDS:
+            # 既存 response の cache_age_seconds だけ差し替えて返す
+            resp = entry.response
+            return resp.model_copy(update={"cache_age_seconds": age})
+
+    # Cache miss: fetch fresh
+    w3 = web3 if web3 is not None else _get_web3()
+    if w3 is None:
+        resp = _all_fallback_response(key)
+        _CACHE[key] = _CacheEntry(response=resp, fetched_at_monotonic=now_mono)
+        return resp
+
+    eth_balance, eth_err = _fetch_eth_balance(w3, wallet_address)
+    usdc_balance, usdc_err = _fetch_usdc_balance(w3, wallet_address)
+    eth_usd_price, price_err = _fetch_eth_usd_price(w3)
+    fallback_used = eth_err or usdc_err or price_err
+
+    fetched_at = datetime.now(timezone.utc)
+    resp = _build_response(
+        wallet_address=key,
+        eth_balance=eth_balance,
+        eth_usd_price=eth_usd_price,
+        usdc_balance=usdc_balance,
+        fallback_used=fallback_used,
+        fetched_at=fetched_at,
+        cache_age_seconds=0,
+    )
+    _CACHE[key] = _CacheEntry(response=resp, fetched_at_monotonic=now_mono)
+    return resp
+
+
+def clear_cache() -> None:
+    """Test 用 cache クリア。"""
+    _CACHE.clear()

--- a/backend/app/partner/wallet_balance_service.py
+++ b/backend/app/partner/wallet_balance_service.py
@@ -88,18 +88,16 @@ def _get_base_rpc_url() -> Optional[str]:
       2. BASE_RPC_URL (汎用)
       3. WEB3_RPC_URL (legacy)
     """
-    return (
-        os.getenv("AAVE_RPC_URL_BASE")
-        or os.getenv("BASE_RPC_URL")
-        or os.getenv("WEB3_RPC_URL")
-    )
+    return os.getenv("AAVE_RPC_URL_BASE") or os.getenv("BASE_RPC_URL") or os.getenv("WEB3_RPC_URL")
 
 
 def _get_web3() -> Optional[Any]:
     """Web3 client を返す。web3 未インストール / RPC URL 未設定なら None。"""
     rpc_url = _get_base_rpc_url()
     if not rpc_url:
-        logger.warning("[wallet_balance] Base RPC URL not configured (AAVE_RPC_URL_BASE / BASE_RPC_URL)")
+        logger.warning(
+            "[wallet_balance] Base RPC URL not configured (AAVE_RPC_URL_BASE / BASE_RPC_URL)"
+        )
         return None
 
     try:
@@ -149,7 +147,9 @@ def _fetch_eth_usd_price(w3: Any) -> tuple[Decimal, bool]:
         round_data = feed.functions.latestRoundData().call()
         _round_id, answer, _started_at, _updated_at, _answered_in_round = round_data
         if answer <= 0:
-            logger.warning("[wallet_balance] Chainlink ETH/USD returned non-positive answer: %s", answer)
+            logger.warning(
+                "[wallet_balance] Chainlink ETH/USD returned non-positive answer: %s", answer
+            )
             return ETH_USD_FALLBACK_PRICE, True
         price = Decimal(answer) / Decimal(10**CHAINLINK_DECIMALS)
         return price, False

--- a/backend/tests/partner/test_wallet_balance.py
+++ b/backend/tests/partner/test_wallet_balance.py
@@ -79,7 +79,7 @@ def _clear_cache() -> None:
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 class TestWalletBalanceServiceHappyPath:

--- a/backend/tests/partner/test_wallet_balance.py
+++ b/backend/tests/partner/test_wallet_balance.py
@@ -1,0 +1,180 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/partner/test_wallet_balance.py
+"""Partner wallet balance service / router の unit test。
+
+Web3 / Chainlink を mock し、cache hit / fallback / 404 を検証する。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-wallet-balance")
+
+from app.aave.gas_estimator import ETH_USD_FALLBACK_PRICE  # noqa: E402
+from app.partner import wallet_balance_service  # noqa: E402
+
+# --- Test constants ---
+_TEST_WALLET = "0x1234567890abcdef1234567890abcdef12345678"
+_TEST_WALLET_CHECKSUM = "0x1234567890AbcdEF1234567890aBcdef12345678"
+
+
+def _make_mock_w3(
+    *,
+    eth_wei: int = 2 * 10**18,
+    usdc_raw: int = 100 * 10**6,
+    eth_usd_answer: int = 3000 * 10**8,
+    eth_raises: bool = False,
+    usdc_raises: bool = False,
+    price_raises: bool = False,
+) -> MagicMock:
+    """Web3 mock を生成する。"""
+    w3 = MagicMock()
+
+    # to_checksum_address: 入力をそのまま返す (テストでは checksum 化不要)
+    w3.to_checksum_address = lambda addr: _TEST_WALLET_CHECKSUM
+
+    # eth.get_balance
+    if eth_raises:
+        w3.eth.get_balance.side_effect = Exception("RPC eth balance error")
+    else:
+        w3.eth.get_balance.return_value = eth_wei
+
+    # contract().functions.balanceOf().call() / latestRoundData().call()
+    def _contract_factory(address: str, abi: list) -> MagicMock:
+        contract = MagicMock()
+        # USDC balanceOf
+        balance_call = MagicMock()
+        if usdc_raises:
+            balance_call.call.side_effect = Exception("RPC usdc balance error")
+        else:
+            balance_call.call.return_value = usdc_raw
+        contract.functions.balanceOf = MagicMock(return_value=balance_call)
+
+        # Chainlink latestRoundData
+        round_call = MagicMock()
+        if price_raises:
+            round_call.call.side_effect = Exception("RPC price error")
+        else:
+            round_call.call.return_value = (0, eth_usd_answer, 0, 0, 0)
+        contract.functions.latestRoundData = MagicMock(return_value=round_call)
+
+        return contract
+
+    w3.eth.contract.side_effect = _contract_factory
+    return w3
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> None:
+    wallet_balance_service.clear_cache()
+    yield
+    wallet_balance_service.clear_cache()
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestWalletBalanceServiceHappyPath:
+    def test_returns_eth_and_usdc_values(self) -> None:
+        """ETH + USDC を Chainlink price で USD 換算して返す"""
+        w3 = _make_mock_w3(
+            eth_wei=2 * 10**18,
+            usdc_raw=100 * 10**6,
+            eth_usd_answer=3000 * 10**8,
+        )
+        resp = _run(wallet_balance_service.fetch(_TEST_WALLET, web3=w3))
+
+        assert resp.eth_balance == Decimal("2")
+        assert resp.eth_usd_price == Decimal("3000")
+        assert resp.eth_usd_value == Decimal("6000")
+        assert resp.usdc_balance == Decimal("100")
+        assert resp.usdc_usd_value == Decimal("100")
+        assert resp.total_usd == Decimal("6100")
+        assert resp.fallback_used is False
+        assert resp.chain == "base"
+        assert resp.cache_age_seconds == 0
+
+
+class TestWalletBalanceCache:
+    def test_cache_hit_returns_same_response(self) -> None:
+        """2 回目の fetch は cache hit して RPC を呼ばないこと"""
+        w3 = _make_mock_w3(eth_wei=1 * 10**18, usdc_raw=50 * 10**6)
+        first = _run(wallet_balance_service.fetch(_TEST_WALLET, web3=w3))
+        # 2 回目は別の web3 を渡しても cache が優先される
+        w3_other = _make_mock_w3(eth_wei=999 * 10**18, usdc_raw=999 * 10**6)
+        second = _run(wallet_balance_service.fetch(_TEST_WALLET, web3=w3_other))
+        # 値が初回と一致 (= cache から返った)
+        assert second.eth_balance == first.eth_balance
+        assert second.usdc_balance == first.usdc_balance
+        # cache_age_seconds は更新後の経過秒
+        assert second.cache_age_seconds >= 0
+
+
+class TestWalletBalanceFallback:
+    def test_eth_rpc_failure_returns_zero_with_fallback_flag(self) -> None:
+        """ETH RPC 失敗時は ETH 残高 0、fallback_used=true"""
+        w3 = _make_mock_w3(
+            eth_raises=True,
+            usdc_raw=50 * 10**6,
+            eth_usd_answer=2000 * 10**8,
+        )
+        resp = _run(wallet_balance_service.fetch(_TEST_WALLET, web3=w3))
+        assert resp.eth_balance == Decimal("0")
+        assert resp.usdc_balance == Decimal("50")
+        assert resp.fallback_used is True
+
+    def test_price_rpc_failure_uses_fallback_price(self) -> None:
+        """Chainlink 失敗時は ETH_USD_FALLBACK_PRICE を使い fallback_used=true"""
+        w3 = _make_mock_w3(
+            eth_wei=1 * 10**18,
+            usdc_raw=0,
+            price_raises=True,
+        )
+        resp = _run(wallet_balance_service.fetch(_TEST_WALLET, web3=w3))
+        assert resp.eth_usd_price == ETH_USD_FALLBACK_PRICE
+        assert resp.eth_usd_value == ETH_USD_FALLBACK_PRICE  # 1 ETH * fallback
+        assert resp.fallback_used is True
+
+    def test_no_web3_returns_full_fallback(self) -> None:
+        """Web3 取得不可なら全部 0 + fallback price"""
+        # web3=None で _get_web3() に進むが RPC URL も未設定なので None になる
+        # 直接 web3=None のままだと _get_web3() が呼ばれるので、env を未設定にして検証
+        old_envs = {
+            k: os.environ.pop(k, None)
+            for k in ("AAVE_RPC_URL_BASE", "BASE_RPC_URL", "WEB3_RPC_URL")
+        }
+        try:
+            resp = _run(wallet_balance_service.fetch(_TEST_WALLET))
+            assert resp.eth_balance == Decimal("0")
+            assert resp.usdc_balance == Decimal("0")
+            assert resp.eth_usd_price == ETH_USD_FALLBACK_PRICE
+            assert resp.fallback_used is True
+        finally:
+            for k, v in old_envs.items():
+                if v is not None:
+                    os.environ[k] = v
+
+
+class TestWalletBalanceRouter:
+    """Router レイヤの 404 (wallet_address 未設定) 動作。"""
+
+    def test_router_returns_404_when_wallet_address_missing(self) -> None:
+        from fastapi import HTTPException
+
+        from app.partner.wallet_balance_router import get_wallet_balance
+
+        # current_user.wallet_address = None
+        mock_user = MagicMock()
+        mock_user.wallet_address = None
+
+        with pytest.raises(HTTPException) as excinfo:
+            _run(get_wallet_balance(current_user=mock_user))
+        assert excinfo.value.status_code == 404

--- a/docs/integration/backend_deps.md
+++ b/docs/integration/backend_deps.md
@@ -89,6 +89,16 @@
 - **影響範囲**: 新規 router 追加のみ。既存 endpoint への影響なし。tests/test_referral_router.py で既存 endpoint の404でないことを保証。
 - **承認**: feature/ras-l2-backend-api → main の通常フロー経由（PR #194）
 
+### 変更 #9: Partner wallet balance KPI — wallet_balance_router 登録 (PR #440 / 2026-05-28)
+- **コミット範囲**: `6713794` (feat/partner-wallet-balance-20260527)
+- **変更内容**:
+  - `from app.partner.wallet_balance_router import router as wallet_balance_router` を追加
+  - `app.include_router(wallet_balance_router, prefix="/api/partner", tags=["partner"])` を `allocation_router` の直後に追加
+  - 計 4 行追加のみ。既存 router・エンドポイント・ロジックへの変更なし
+- **理由**: Asana 1215185901145482 / partner ダッシュボード — partner 自身のウォレット残高 (USDC + ETH on Base mainnet) を `/api/partner/wallet-balance` で取得し、`PerformanceSummaryKPI.tsx` に表示する。既存 `partner_router` / `allocation_router` と同パターンの新規 router 登録。
+- **影響範囲**: 新規 router 追加のみ。既存 endpoint への影響なし。`backend/tests/partner/test_wallet_balance.py` で endpoint の存在と response shape を保証。
+- **承認**: feat/partner-wallet-balance-20260527 → main の通常フロー経由（PR #440）
+
 ### 変更 #8: P0-2 Safety wiring — compound_risk_monitor startup 登録 (PR #240 / 2026-05-15)
 - **コミット範囲**: `d6a4ed3` (feat/safety-wiring)
 - **変更内容**:

--- a/frontend/app/(partner)/partner/dashboard/_components/PerformanceSummaryKPI.tsx
+++ b/frontend/app/(partner)/partner/dashboard/_components/PerformanceSummaryKPI.tsx
@@ -3,11 +3,12 @@
 // Unauthorized copying or distribution is strictly prohibited.
 
 import { useEffect, useState } from 'react'
-import { DollarSign, TrendingUp, Users, Shield } from 'lucide-react'
+import { DollarSign, TrendingUp, Users, Shield, Wallet, AlertTriangle } from 'lucide-react'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { fetchPerformance, type PerformanceResponse } from '@/lib/api/allocations'
 import { getStoredToken } from '@/lib/auth'
+import { useWalletBalance } from '@/hooks/useWalletBalance'
 
 function fmtUsd(v: number | undefined | null): string {
   const n = Number(v ?? 0)
@@ -35,9 +36,18 @@ function hfColor(hf: number | null): string {
   return 'text-red-600 dark:text-red-400'
 }
 
+function fmtTokenAmount(v: string | number | undefined | null, maxFractionDigits = 4): string {
+  const n = Number(v ?? 0)
+  if (!Number.isFinite(n)) return '0'
+  return new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: maxFractionDigits,
+  }).format(n)
+}
+
 export default function PerformanceSummaryKPI() {
   const [data, setData] = useState<PerformanceResponse | null>(null)
   const [loading, setLoading] = useState(true)
+  const { data: walletBalance, loading: walletLoading } = useWalletBalance()
 
   useEffect(() => {
     const load = () => {
@@ -57,8 +67,8 @@ export default function PerformanceSummaryKPI() {
 
   if (loading) {
     return (
-      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-        {Array.from({ length: 4 }).map((_, i) => (
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
+        {Array.from({ length: 5 }).map((_, i) => (
           <Skeleton key={i} className="h-28 rounded-xl" />
         ))}
       </div>
@@ -78,7 +88,7 @@ export default function PerformanceSummaryKPI() {
   const hf = data?.health_factor != null ? Number(data.health_factor) : null
 
   return (
-    <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+    <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
       {/* 運用総額 */}
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -141,6 +151,39 @@ export default function PerformanceSummaryKPI() {
           {hf != null && (
             <div className={`text-xs mt-1 ${hfColor(hf)}`}>
               {hf > 1.8 ? '安全' : hf >= 1.6 ? '注意' : '危険'}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ウォレット残高 (Base) — USDC + ETH on Base mainnet。Aave supply 分は含まない */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            ウォレット残高 (Base)
+          </CardTitle>
+          <div className="flex items-center gap-1">
+            {walletBalance?.fallback_used && (
+              <AlertTriangle
+                className="h-4 w-4 text-yellow-500"
+                aria-label="価格またはRPC取得失敗 (フォールバック使用中)"
+              />
+            )}
+            <Wallet className="h-4 w-4 text-muted-foreground" />
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">
+            {walletLoading
+              ? '—'
+              : walletBalance != null
+                ? `$${fmtUsd(Number(walletBalance.total_usd))}`
+                : '—'}
+          </div>
+          {walletBalance != null && (
+            <div className="text-xs text-muted-foreground mt-1">
+              ETH {fmtTokenAmount(walletBalance.eth_balance)} / USDC{' '}
+              {fmtTokenAmount(walletBalance.usdc_balance, 2)}
             </div>
           )}
         </CardContent>

--- a/frontend/hooks/useWalletBalance.ts
+++ b/frontend/hooks/useWalletBalance.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+// frontend/hooks/useWalletBalance.ts
+'use client'
+
+import { useEffect, useState } from 'react'
+import { fetchWalletBalance, type WalletBalance } from '@/lib/api/wallet_balance'
+import { getStoredToken } from '@/lib/auth'
+
+const POLL_INTERVAL_MS = 60_000
+
+/**
+ * Partner 自身のウォレット残高 (USDC + ETH on Base mainnet) を 60 秒間隔で取得する hook。
+ *
+ * - 認証 token が無ければ data=null のまま loading=false
+ * - 取得失敗時は data=null
+ * - backend 側にも 60 秒 cache があるので二重 cache だが、UI の即時応答性を優先する
+ */
+export function useWalletBalance(): { data: WalletBalance | null; loading: boolean } {
+  const [data, setData] = useState<WalletBalance | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const load = () => {
+      const token = getStoredToken()
+      if (!token) {
+        setLoading(false)
+        return
+      }
+      fetchWalletBalance(token)
+        .then(setData)
+        .catch(() => setData(null))
+        .finally(() => setLoading(false))
+    }
+
+    setLoading(true)
+    load()
+    const id = setInterval(load, POLL_INTERVAL_MS)
+    return () => clearInterval(id)
+  }, [])
+
+  return { data, loading }
+}

--- a/frontend/lib/api/wallet_balance.ts
+++ b/frontend/lib/api/wallet_balance.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+// frontend/lib/api/wallet_balance.ts
+
+import { getJson } from './http'
+
+// ---- Types ----
+
+export interface WalletBalance {
+  wallet_address: string
+  chain: 'base'
+  /** ETH 残高 (ether 単位)。Decimal を string で受ける。 */
+  eth_balance: string
+  /** ETH × ETH/USD price */
+  eth_usd_value: string
+  /** 1 ETH = ? USD */
+  eth_usd_price: string
+  /** USDC 残高 (USDC 単位) */
+  usdc_balance: string
+  /** USDC × 1.00 (1:1 simplification) */
+  usdc_usd_value: string
+  /** eth_usd_value + usdc_usd_value */
+  total_usd: string
+  /** ISO datetime */
+  fetched_at: string
+  /** 0 if fresh, else seconds since fetched */
+  cache_age_seconds: number
+  /** true if RPC or price fallback was triggered */
+  fallback_used: boolean
+}
+
+// ---- Helpers ----
+
+function authHeaders(token: string): HeadersInit {
+  return { Authorization: `Bearer ${token}` }
+}
+
+// ---- API Functions ----
+
+export async function fetchWalletBalance(token: string): Promise<WalletBalance> {
+  return getJson<WalletBalance>('/api/partner/wallet-balance', {
+    headers: authHeaders(token),
+  })
+}


### PR DESCRIPTION
## Summary
partner dashboard に partner 自身のウォレット内総資産 (USDC + ETH on Base mainnet) の KPI を新規追加。配下 tester の `total_supply_usd` 集計とは別概念で、partner 個人の wallet 残高を可視化 (運用代行報酬・fee 受取・自身運用資産の確認用)。

## 設計 (ユーザー承認: b/i/X/P/2)
| 項目 | 値 |
|---|---|
| token カバー | USDC + ETH (native) のみ |
| チェーン | Base mainnet のみ |
| Aave supply 分 | **含まない** (ウォレット内のみ) |
| 表示先 | PerformanceSummaryKPI に 5 枚目カード追加 (4→5) |
| 更新頻度 | 60 秒 cache (backend) |

## Changes (9 files / +621 / -4)

**新規 (7)**:
- `backend/app/partner/wallet_balance_router.py` (43) — `GET /api/partner/wallet-balance`, `require_partner` guard 再利用
- `backend/app/partner/wallet_balance_service.py` (235) — Web3 (Base) + ERC20.balanceOf + Chainlink ETH/USD + 60s cache + fallback
- `backend/app/partner/wallet_balance_schemas.py` (37) — `WalletBalanceResponse` Pydantic
- `backend/tests/partner/__init__.py` (0)
- `backend/tests/partner/test_wallet_balance.py` (167) — mocked unit test 6 件
- `frontend/lib/api/wallet_balance.ts` (45) — fetch client
- `frontend/hooks/useWalletBalance.ts` (43) — 60s polling hook

**編集 (2)**:
- `backend/app/main.py` (+4) — `wallet_balance_router` を `include_router(prefix=\"/api/partner\")` で配線
- `frontend/app/(partner)/partner/dashboard/_components/PerformanceSummaryKPI.tsx` (+47/-4) — 5 枚目「ウォレット残高 (Base)」カード追加、`lg:grid-cols-4` → `5`、Skeleton 4 → 5

## 検証結果 (実機出力)

- **py_compile**: PASS (4 files)
- **ruff check**: PASS (0 errors)
- **pytest** \`tests/partner/test_wallet_balance.py\`: **6 passed / 0 failed**
  - happy path (ETH+USDC USD 換算) / cache hit / ETH RPC fail fallback / price fail fallback / Web3 全体取得不可 / wallet_address 未設定 404
- **配線 lint** (\`bash scripts/ci/check_wiring_lint.sh\`): 新規 \`wallet_balance_router\` は **正しく include_router 済 (allowlist 不要)**
- **frontend tsc** (\`tsc --noEmit\`): exit 0

## 安全装置
- RPC エラー時: 該当 token balance=0 + warning log + \`fallback_used=true\`
- Chainlink price エラー時: \`ETH_USD_FALLBACK_PRICE\` (既存 const, Decimal('4000.00')) 再利用 + \`fallback_used=true\`
- Web3 全体取得不可: 全 balance 0 + fallback price + \`fallback_used=true\`
- \`partner.wallet_address\` 未設定: 404 \"wallet_address が partner に未設定です\"
- UI: \`fallback_used=true\` 時に \`AlertTriangle\` icon を CardHeader に表示、loading 中は \`—\`

## PR #439 (運用残高リネーム) との非衝突確認 (済)
- 既存 4 枚 CardTitle (\`運用総額\`/\`全体損益\`/\`テスター数\`/\`Health Factor\`) いずれも **無改変**
- \`lg:grid-cols-4\` → \`5\` 変更 + 5 枚目追加のみ
- supplyUsd / allocatedUsd / pnl / hf 計算ロジック完全無改変

merge 順序: #439 / X どちらが先でも git 行レベル衝突は起きない。

## 安全classifier note
Agent が \"safety classifier was unavailable\" と前置きしているため、merge 前に人間レビューを推奨 (特に Web3 RPC URL / Chainlink address のハードコード値、fallback ロジックの境界)。

## Merge 経路
**staging 経由推奨**:
1. staging に merge
2. staging で partner login (e2e user 等) → /api/partner/wallet-balance を curl で叩いて確認
3. staging frontend で partner dashboard の 5 枚目 KPI 表示確認
4. main に fast-forward

## Test plan
- [x] py_compile / ruff / pytest 6/6 / 配線 lint / tsc 全 PASS
- [x] PR #439 非衝突確認
- [ ] staging で \`/api/partner/wallet-balance\` 200 + 期待 schema 返却 (人間)
- [ ] staging frontend で 5 枚目カード表示確認 (人間)
- [ ] RPC fail を意図的に起こして fallback 動作確認 (人間 or 別 task)
- [ ] partner.wallet_address 未設定の partner で 404 確認 (人間)

memory: [[feedback-no-done-without-e2e-output]], [[project-recurring-drift-patterns]]