### PR TITLE
fix(launch-gate): L1_env.sh AAVE_NETWORK 期待値を base に修正 (Asana 1215155583389760)

### DIFF
--- a/scripts/launch_gate/L1_env.sh
+++ b/scripts/launch_gate/L1_env.sh
@@ -10,7 +10,7 @@
 #
 # 実装:
 #   1. 既存 scripts/check_env_separation.sh を呼ぶ (exit 0 必須)
-#   2. .env.production の重要キー (APP_ENV=production, AAVE_NETWORK=base_mainnet 等)
+#   2. .env.production の重要キー (APP_ENV=production, AAVE_NETWORK=base 等)
 #      を手元 grep でも検証する (二重チェック)
 #
 # Usage:
@@ -51,7 +51,7 @@ if [[ "${#missing[@]}" -gt 0 ]]; then
          grep -E '^(APP_ENV|AAVE_NETWORK|BYBIT_SANDBOX)=' ${STAGING_ENV}
 
        期待値:
-         .env.production: APP_ENV=production / AAVE_NETWORK=base_mainnet / BYBIT_SANDBOX=false
+         .env.production: APP_ENV=production / AAVE_NETWORK=base         / BYBIT_SANDBOX=false
          .env.staging:    APP_ENV=staging    / AAVE_NETWORK=base_sepolia / BYBIT_SANDBOX=true
 EOF
   gate_record SKIP "${LABEL}" "${missing[*]} がこの host に無し (prod VPS で要手動確認)"
@@ -82,13 +82,15 @@ else
   echo "  [ok] APP_ENV=production"
 fi
 
-# AAVE_NETWORK=base_mainnet 必須
+# AAVE_NETWORK=base 必須 (Base Mainnet chain 8453 / v4 指示文 §21)
+# 注: backend は env 値 "base" を Base Mainnet として解釈する。
+#     "base_mainnet" は launch_gate 旧設計の誤った期待値で、実 env には存在しない。
 aave_net=$(grep -E '^AAVE_NETWORK=' "${PROD_ENV}" | head -n 1 | cut -d= -f2- | tr -d '[:space:]')
-if [[ "${aave_net}" != "base_mainnet" ]]; then
-  violations+=("AAVE_NETWORK expected=base_mainnet got='${aave_net}'")
-  echo "  [ng] AAVE_NETWORK='${aave_net}' (期待: base_mainnet)"
+if [[ "${aave_net}" != "base" ]]; then
+  violations+=("AAVE_NETWORK expected=base got='${aave_net}'")
+  echo "  [ng] AAVE_NETWORK='${aave_net}' (期待: base)"
 else
-  echo "  [ok] AAVE_NETWORK=base_mainnet"
+  echo "  [ok] AAVE_NETWORK=base"
 fi
 
 # DATABASE_URL は存在のみ (値はマスク)


### PR DESCRIPTION
## 📝 このPRの目的
`scripts/launch_gate/L1_env.sh` がハードコードしていた `.env.production` の `AAVE_NETWORK` 期待値 `base_mainnet` を、実 env 値である `base` (Base Mainnet chain 8453 / v4 指示文 §21) に揃える。

2026-05-27 staging 検証で launch_gate L1 が「期待値ハードコード誤り」により誤 FAIL していた問題の修正。**`.env.production` 側は触らない** (本番 Aave 接続は `base` で正常稼働中)。

Refs: Asana 1215155583389760

## 🔧 変更内容（概要）
- `L1_env.sh` の `AAVE_NETWORK` 期待値: `base_mainnet` → `base`
- 同ファイルの冒頭コメント・SKIP 時の案内メッセージ表記も `base` に統一
- 期待値を `base` とした根拠 (v4 指示文 §21, backend は `base` を Base Mainnet として解釈) をコードコメントに残し、`base_mainnet` を期待する旧誤設計が再混入しないようにした

## 🤔 「他のハードコード期待値も env 読み取りに変えるか」検討結果
L1_env.sh 内の他の固定値はそのまま据え置きが妥当と判断:
| キー | 期待値 | 判断 |
| --- | --- | --- |
| `APP_ENV` | `production` | 検査対象ファイル自体が `.env.production` なので必然的に固定値で正しい |
| `BYBIT_SANDBOX` | `false` | 本番要件として固定値が正解。env 読み取り化は循環参照 |
| `AAVE_NETWORK` | **`base`** | 本 PR で誤値修正 |
| `DATABASE_URL` | 存在のみ | 値は secret マスク方針で OK |

env 読み取りに置き換えると「期待値が env 自身」となり検査が無意味化するため、今回は AAVE_NETWORK の値修正のみ。

## 📁 変更したファイル
- `scripts/launch_gate/L1_env.sh`

## 🧪 動作確認
ローカルで `.env.production` / `.env.staging` の fixture を用意し L1_env.sh を 3 ケースで実行:

### 1. POST-FIX × 正 env (`.env.production: AAVE_NETWORK=base`) → PASS ✅
```
--- L1 env: .env.production critical keys ---
  [ok] APP_ENV=production
  [ok] AAVE_NETWORK=base
  [ok] DATABASE_URL is set
  [ok] BYBIT_SANDBOX=false
[PASS] L1 env: env 分離 OK & .env.production の critical key 期待値一致
=== exit code: 0 ===
```

### 2. PRE-FIX (origin/staging) × 正 env (`AAVE_NETWORK=base`) → FAIL (= 報告された不具合の再現) ✅
```
  [ng] AAVE_NETWORK='base' (期待: base_mainnet)
[FAIL] L1 env: check_env_separation rc=0; critical-key NG: AAVE_NETWORK expected=base_mainnet got='base'
=== exit code: 1 ===
```

### 3. POST-FIX × 誤 env (`AAVE_NETWORK=base_mainnet`) → FAIL (= ドリフト検出が今も機能する確認) ✅
```
  [ng] AAVE_NETWORK='base_mainnet' (期待: base)
[FAIL] L1 env: check_env_separation rc=0; critical-key NG: AAVE_NETWORK expected=base got='base_mainnet'
=== exit code: 1 ===
```

実機 (prod VPS 77.42.46.155 上の本番/staging) での確認は同 VPS 上で `bash scripts/launch_gate/L1_env.sh` を実行し PASS 出力を貼り付けて完了とする。

- [x] ローカル fixture テスト済み (上記 3 ケース)
- [x] フェーズ要件に沿っている (launch_gate 整備 / Tier B)
- [x] .md とコードの整合性チェック済み (本 PR スコープは L1_env.sh のみ、後述スコープ外 doc は別タスク)
- [x] 破壊的変更なし (env ファイル/本番設定は無変更)

## 📘 関連Issue
- Asana 1215155583389760 (本タスク)
- PR #431 (launch_gate 本体)
- PR #432 (P5 検証中に本バグ発見)
- memory: `project-recurring-drift-patterns`

## 📚 ドキュメント更新
本 PR スコープ外の doc に同じ `base_mainnet` 誤表記が残存している:
- `CLAUDE.md` L899: `AAVE_NETWORK が staging=base_sepolia / production=base_mainnet か`
- `docs/ops/03_deploy_procedures.md` L133: `# → AAVE_NETWORK=base_mainnet`

これらは「L1_env.sh の期待値修正」というタスクスコープ外のため別タスクで対応推奨 (フォロー Asana 起票候補)。

- [ ] docs/*.md 更新済み (本 PR スコープ外につき未着手)
- [x] 変更内容が仕様書 (v4 指示文 §21) と一致している

## ⚠ 注意事項
- **`.env.production` は一切書き換えていない** (本番 Aave 接続を壊さない最優先要件)
- launch_gate L1 のロジック変更は無し (比較対象の文字列リテラルのみ変更)
- backward compat: 既存の staging/production .env 両方ともそのままで PASS する

## チェーン設定関連 (チェーン関連の PR のみ)
- [x] **いいえ** (チェーン設定そのものの変更ではなく、launch_gate スクリプトの期待値ラベルのみ修正。実チェーン (Base Mainnet 8453) や `.env.production` 値は無変更)

---

## ✅ Codex セルフチェック
- 1. `.env.production` 書き換えなし → PASS (該当: コード変更のみ)
- 2. 非 2xx は failure 扱いか → 該当なし (HTTP なし)
- 3. try/except 握りつぶし → 該当なし
- 4. 後方互換 → PASS (正しい env では PASS、誤 env では FAIL が正しく出る)
- 5. migration → 該当なし
- 6. 配線 → 該当なし (既存スクリプト内文字列のみ)
- 7. env 分離 → PASS (production 期待値の整合性を取った)

🤖 Generated with [Claude Code](https://claude.com/claude-code)