### PR TITLE
fix(launch-gate): L2_smoke.sh 認証必須 EP の 401 扱い + SMOKE_AUTH_TOKEN 対応 (Asana 1215155399947078)

### DIFF
--- a/scripts/launch_gate/L2_smoke.sh
+++ b/scripts/launch_gate/L2_smoke.sh
@@ -5,14 +5,29 @@
 # Launch Gate L2: 主要 endpoint smoke test。
 #
 # 目的:
-#   /health と主要 5 endpoint が 2xx で応答することを確認する。
+#   /health と主要 5 API endpoint がアプリ層まで届いていることを確認する。
+#   認証必須 EP は SMOKE_AUTH_TOKEN が設定されていれば Bearer 付きで 2xx を、
+#   未設定なら 401/403 を「到達 OK」(reachable) として PASS 扱いする。
 #
-# 主要 5 endpoint:
-#   /api/portfolio
-#   /api/transparency/safety-score
-#   /api/automation/status
-#   /api/ai/decisions/latest
-#   /api/proposals/pending
+# 主要 endpoint:
+#   /health                              (public)
+#   /api/portfolio                       (auth required)
+#   /api/transparency/safety-score       (auth required)
+#   /api/automation/status               (auth required)
+#   /api/ai/decisions/latest             (auth required)
+#   /api/proposals/pending               (auth required)
+#
+# 判定ロジック (Asana 1215155399947078 / 修正方針 B + A フォールバック):
+#   /health:
+#     2xx                                    -> PASS
+#     その他                                 -> FAIL
+#   /api/* (auth required):
+#     2xx                                    -> PASS
+#     401 / 403                              -> PASS (reachable: app 層まで届いている)
+#                                              ※SMOKE_AUTH_TOKEN 設定済の場合は
+#                                                token 切れ等の可能性があるため WARN を併記
+#     5xx / 接続拒否 / timeout (000)         -> FAIL (app down 疑い)
+#     その他 4xx (404 / 400 / 503 等以外)    -> FAIL (endpoint 消失 / 経路破損)
 #
 # 注意:
 #   staging は本番 Hetzner VPS (77.42.46.155) に同居しており dev VPS から
@@ -23,6 +38,7 @@
 #   ENV_TARGET=staging    bash scripts/launch_gate/L2_smoke.sh
 #   ENV_TARGET=production bash scripts/launch_gate/L2_smoke.sh
 #   LAUNCH_GATE_BASE_URL=http://localhost:8000 bash scripts/launch_gate/L2_smoke.sh
+#   SMOKE_AUTH_TOKEN=eyJ... bash scripts/launch_gate/L2_smoke.sh   # 2xx まで検証
 # ---------------------------------------------------------------------------
 set -uo pipefail
 
@@ -32,15 +48,16 @@ source "${SCRIPT_DIR}/lib.sh"
 
 LABEL="L2 smoke"
 ENV_TARGET="${ENV_TARGET:-staging}"
+SMOKE_AUTH_TOKEN="${SMOKE_AUTH_TOKEN:-}"
 
-# 主要 endpoint
+# 主要 endpoint と auth-required フラグ ("path|auth" 形式)
 ENDPOINTS=(
-  "/health"
-  "/api/portfolio"
-  "/api/transparency/safety-score"
-  "/api/automation/status"
-  "/api/ai/decisions/latest"
-  "/api/proposals/pending"
+  "/health|public"
+  "/api/portfolio|auth"
+  "/api/transparency/safety-score|auth"
+  "/api/automation/status|auth"
+  "/api/ai/decisions/latest|auth"
+  "/api/proposals/pending|auth"
 )
 
 # Base URL (env で override 可能)
@@ -60,11 +77,22 @@ if is_dev_vps; then
        prod VPS (77.42.46.155) で以下のコマンドを実行し、結果を貼り付けてください:
 
          BASE=${BASE_URL}
-$(for ep in "${ENDPOINTS[@]}"; do
-    printf '         curl -fsS -o /dev/null -w "%%{http_code} %s\\n" "\$BASE%s"\n' "${ep}" "${ep}"
+         # /health は 2xx 必須
+         curl -sS -o /dev/null -w "%{http_code} /health\\n" "\$BASE/health"
+         # /api/* は SMOKE_AUTH_TOKEN 設定済なら 2xx、未設定なら 401/403 でも到達 OK
+$(for entry in "${ENDPOINTS[@]}"; do
+    ep="${entry%%|*}"
+    [[ "${ep}" == "/health" ]] && continue
+    printf '         curl -sS -o /dev/null -w "%%{http_code} %s\\n" "$BASE%s"\n' "${ep}" "${ep}"
+    printf '         # token 付きで 2xx を確認したい場合:\n'
+    printf '         # curl -sS -o /dev/null -w "%%{http_code} %s\\n" -H "Authorization: Bearer $SMOKE_AUTH_TOKEN" "$BASE%s"\n' "${ep}" "${ep}"
   done)
 
-       全て 200 番台であること。
+       判定:
+         /health        : 2xx 必須
+         /api/*         : 2xx / 401 / 403 のいずれかなら到達 OK
+                          5xx / connection refused / timeout は FAIL
+
        env=${ENV_TARGET} の場合の想定 port:
          staging:    nginx 経由で host:8000 もしくは container 直 (要確認)
          production: nginx 経由で host:8001 もしくは container 直 (要確認)
@@ -81,23 +109,67 @@ if ! command -v curl >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "--- L2 smoke: env=${ENV_TARGET} base=${BASE_URL} ---"
+if [[ -n "${SMOKE_AUTH_TOKEN}" ]]; then
+  echo "--- L2 smoke: env=${ENV_TARGET} base=${BASE_URL} (auth: Bearer token, 2xx 検証) ---"
+else
+  echo "--- L2 smoke: env=${ENV_TARGET} base=${BASE_URL} (auth: none, 401/403 を到達 OK 扱い) ---"
+fi
+
 fails=()
-for ep in "${ENDPOINTS[@]}"; do
+warns=()
+for entry in "${ENDPOINTS[@]}"; do
+  ep="${entry%%|*}"
+  kind="${entry##*|}"
   url="${BASE_URL}${ep}"
-  code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "${url}" 2>/dev/null || echo "000")
-  if [[ "${code}" =~ ^2[0-9][0-9]$ ]]; then
-    echo "  [ok] ${code} ${ep}"
-  else
-    echo "  [ng] ${code} ${ep}"
-    fails+=("${ep}=${code}")
+
+  # auth-required EP かつ token あり → Bearer 付与
+  curl_auth_args=()
+  if [[ "${kind}" == "auth" ]] && [[ -n "${SMOKE_AUTH_TOKEN}" ]]; then
+    curl_auth_args=(-H "Authorization: Bearer ${SMOKE_AUTH_TOKEN}")
   fi
+
+  # curl は -w '%{http_code}' で connection refused / timeout 時も "000" を出す。
+  # 旧コードは `|| echo "000"` で重複出力していたため除去。
+  code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "${curl_auth_args[@]}" "${url}" 2>/dev/null)
+  code="${code:-000}"
+
+  if [[ "${code}" =~ ^2[0-9][0-9]$ ]]; then
+    echo "  [ok]        ${code} ${ep}"
+    continue
+  fi
+
+  # /health は 2xx 必須 (public なので 401/403 は異常)
+  if [[ "${kind}" == "public" ]]; then
+    echo "  [ng]        ${code} ${ep} (public EP は 2xx 必須)"
+    fails+=("${ep}=${code}")
+    continue
+  fi
+
+  # auth EP: 401/403 は到達 OK (アプリ層まで届いた証拠)
+  if [[ "${code}" == "401" ]] || [[ "${code}" == "403" ]]; then
+    if [[ -n "${SMOKE_AUTH_TOKEN}" ]]; then
+      # token 付きで 401/403 が返ったら token 切れ等の可能性 — PASS だが WARN
+      echo "  [reachable] ${code} ${ep} (auth token 設定済だが ${code}: token 切れ / scope 不足の可能性)"
+      warns+=("${ep}=${code}")
+    else
+      echo "  [reachable] ${code} ${ep} (auth-required, token 未設定 → 到達 OK 扱い)"
+    fi
+    continue
+  fi
+
+  # それ以外 (5xx / 000 / 404 / 400 等) は FAIL
+  echo "  [ng]        ${code} ${ep}"
+  fails+=("${ep}=${code}")
 done
 
 if [[ "${#fails[@]}" -eq 0 ]]; then
-  gate_record PASS "${LABEL}" "全 ${#ENDPOINTS[@]} endpoint 2xx (env=${ENV_TARGET})"
+  summary="全 ${#ENDPOINTS[@]} endpoint 到達 OK (env=${ENV_TARGET})"
+  if [[ "${#warns[@]}" -gt 0 ]]; then
+    summary="${summary}; warn: ${warns[*]}"
+  fi
+  gate_record PASS "${LABEL}" "${summary}"
   exit 0
 fi
 
-gate_record FAIL "${LABEL}" "non-2xx: ${fails[*]}"
+gate_record FAIL "${LABEL}" "到達不可: ${fails[*]}"
 exit 1


### PR DESCRIPTION
## Summary

`scripts/launch_gate/L2_smoke.sh` が全 endpoint で **2xx のみ PASS** としていたため、
認証必須 EP (`/api/*`) が **401 を返した時点で FAIL** になっていた。これは
「API ダウン (500/接続拒否) と認証エラー (401) を区別できない」設計不足。

Asana タスク [`1215155399947078`](https://app.asana.com/1/817733952351708/project/1213916581114014/task/1215155399947078) の DoD を満たす修正。

### 採用方針: **B** (SMOKE_AUTH_TOKEN 環境変数 + A フォールバック)

| 方針 | 内容 | 採用 |
|---|---|---|
| A | 401/403 を「到達 OK」として PASS、5xx/timeout/接続拒否は FAIL | (B のフォールバックとして包含) |
| **B** | `SMOKE_AUTH_TOKEN` env で Bearer 付与、未設定時は A フォールバック | **✅ 採用** |

**B を採用した理由**: A は包含関係で B のサブセット。token 設定済 (Phase A 以降の CI 整備時) なら **2xx まで実検証**できる将来の expansion 余地を残しつつ、現状の手動 smoke でも token 不要で動く。Asana 起票時の推奨パターン通り。

## 判定ロジック

| EP 種別 | 状況 | 判定 |
|---|---|---|
| `/health` (public) | 2xx | PASS |
| `/health` (public) | 401/403 など 2xx 以外 | **FAIL** (public EP で auth エラーは異常) |
| `/api/*` (auth) | 2xx | PASS |
| `/api/*` (auth), token 未設定 | 401 / 403 | **PASS** (reachable, A フォールバック) |
| `/api/*` (auth), token 設定済 | 401 / 403 | PASS + **WARN** (token 切れ疑い) |
| `/api/*` (auth) | 5xx / 404 / 接続拒否 / timeout (000) | **FAIL** |

## Changes (1 file / +97 / -25)

`scripts/launch_gate/L2_smoke.sh` のみ。
- ENDPOINTS を `\"path|kind\"` 形式に拡張 (public / auth 分類)
- `SMOKE_AUTH_TOKEN` 未設定/設定済の両分岐
- 5xx / 接続拒否 / 404 / その他 4xx を FAIL に
- token 設定済 + 401/403 で WARN 表示
- dev-VPS skip-with-instructions の貼付けコマンドも token 例 + 判定基準入りに更新
- 副次修正: `|| echo \"000\"` 重複出力 (000000) を除去 (旧コードのバグ。curl -w は失敗時も \"000\" を出す)

## 触らない (確認済)
- `scripts/launch_gate/{L0,L1,L3,L4,L5}_*.sh` 変更なし
- `scripts/launch_gate/lib.sh` 変更なし
- backend / frontend / CLAUDE.md 変更なし
- 山本さん user_id=11 関連の SQL / コード 変更なし
- production DB / .env 触らず

## 検証 (ローカル mock server 11 シナリオ)

`LAUNCH_GATE_FORCE_PROD=1 LAUNCH_GATE_BASE_URL=http://127.0.0.1:18000` で Python HTTP mock を立て、status code を制御:

| # | シナリオ | 期待 | 実測 |
|---|---|---|---|
| 1 | all-200, token なし | PASS rc=0 | ✅ PASS rc=0 |
| 2 | all-401, token なし (**本件主シナリオ**) | PASS reachable rc=0 | ✅ PASS rc=0 |
| 3 | all-403, token なし | PASS reachable rc=0 | ✅ PASS rc=0 |
| 4 | /health 500 | FAIL rc=1 | ✅ FAIL rc=1 |
| 5 | /api/portfolio 503 | FAIL rc=1 | ✅ FAIL rc=1 |
| 6 | /api/portfolio 404 | FAIL rc=1 | ✅ FAIL rc=1 |
| 7 | /health 401 (public 異常) | FAIL rc=1 | ✅ FAIL rc=1 |
| 8 | all-200, token 設定 | PASS rc=0 | ✅ PASS rc=0 |
| 9 | token 設定 + 401 | PASS + WARN rc=0 | ✅ PASS rc=0 (warn 表示) |
| 10 | port 12345 接続拒否 | FAIL rc=1 (code=000) | ✅ FAIL rc=1 (code=000) |
| 11 | `LAUNCH_GATE_FORCE_DEV=1` | SKIP rc=0 + 貼付けコマンド出力 | ✅ SKIP rc=0 |

`bash -n` / `shellcheck -S warning` クリーン。

### シナリオ 2 (主シナリオ) の実測出力
\`\`\`
--- L2 smoke: env=staging base=http://127.0.0.1:18000 (auth: none, 401/403 を到達 OK 扱い) ---
  [ok]        200 /health
  [reachable] 401 /api/portfolio (auth-required, token 未設定 → 到達 OK 扱い)
  [reachable] 401 /api/transparency/safety-score (auth-required, token 未設定 → 到達 OK 扱い)
  [reachable] 401 /api/automation/status (auth-required, token 未設定 → 到達 OK 扱い)
  [reachable] 401 /api/ai/decisions/latest (auth-required, token 未設定 → 到達 OK 扱い)
  [reachable] 401 /api/proposals/pending (auth-required, token 未設定 → 到達 OK 扱い)
[PASS] L2 smoke: 全 6 endpoint 到達 OK (env=staging)
>>> rc=0
\`\`\`

### シナリオ 9 (token 設定済で 401) の実測出力
\`\`\`
--- L2 smoke: env=staging base=http://127.0.0.1:18000 (auth: Bearer token, 2xx 検証) ---
  [ok]        200 /health
  [reachable] 401 /api/portfolio (auth token 設定済だが 401: token 切れ / scope 不足の可能性)
  [ok]        200 /api/transparency/safety-score
  [ok]        200 /api/automation/status
  [ok]        200 /api/ai/decisions/latest
  [ok]        200 /api/proposals/pending
[PASS] L2 smoke: 全 6 endpoint 到達 OK (env=staging); warn: /api/portfolio=401
\`\`\`

## DoD チェック

| 項目 | 状態 |
|---|---|
| A or B どちらを採用したか明示 | ✅ **B (Bearer token + A フォールバック)** |
| L2 が staging で PASS になる | ⏸ staging 実機実行は人間担当 ([[no-prod-vps-commands-from-dev]] / [[staging-lives-on-prod-vps]]) |
| PR を staging 経由で main 反映 | ⏸ merge 経路は staging 経由推奨 (本 PR 後、人間が staging branch へ先行 merge) |

## Merge 経路

memory [[staging-lives-on-prod-vps]] に従い、staging 経由を推奨:
1. 本 PR を `staging` branch へ先行 merge
2. prod VPS (77.42.46.155) staging container 上で実行:
   \`\`\`
   cd /opt/ultra-autotrade
   bash scripts/launch_gate/L2_smoke.sh   # ENV_TARGET=staging
   \`\`\`
3. 全 endpoint が 200 番台 / 401 / 403 で PASS になることを確認
4. (option) SMOKE_AUTH_TOKEN を env に追加して 2xx 検証
5. `main` に fast-forward

## Test plan
- [x] `bash -n` クリーン
- [x] `shellcheck -S warning` exit 0
- [x] ローカル mock 11 シナリオ全 PASS (上表)
- [x] dev-VPS `LAUNCH_GATE_FORCE_DEV=1` で skip-with-instructions モード動作
- [x] dev-VPS 貼付け curl コマンドの `\$BASE` / `\$SMOKE_AUTH_TOKEN` がリテラルで出力される (heredoc escape 検証済)
- [ ] **staging 実機で `bash scripts/launch_gate/L2_smoke.sh` 実行 → PASS 確認** (人間)
- [ ] (option) `SMOKE_AUTH_TOKEN` 設定して 2xx まで検証 (人間 / 後続タスク)

memory: [[no-prod-vps-commands-from-dev]] [[staging-lives-on-prod-vps]] [[feedback-no-done-without-e2e-output]] [[prod-steps-not-done-until-verified]]

関連: PR #431 (launch_gate 本体) / PR #432 (CI 配線、本件発覚) / Asana 1215155583389760 (L1 sibling fix)