### PR TITLE
docs: AAVE_NETWORK 期待値を base_mainnet → base に訂正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -896,7 +896,7 @@ claude.ai が Step 0 をスキップして §9 を実行した場合、それは
 - [ ] staging-production クロスコンタミがないか(PR #154 / #155)
 - [ ] DATABASE_URL / AAVE_NETWORK / *_API_KEY / container_name / volume が分離されているか
 - [ ] APP_ENV が正しい値か(staging で APP_ENV=staging, prod で APP_ENV=production)
-- [ ] AAVE_NETWORK が staging=base_sepolia / production=base_mainnet か
+- [ ] AAVE_NETWORK が staging=base_sepolia / production=base か
 
 ### Migration / Schema
 - [ ] models 変更で alembic migration が生成されているか(PR #155 privy_did)

--- a/docs/ops/03_deploy_procedures.md
+++ b/docs/ops/03_deploy_procedures.md
@@ -130,7 +130,7 @@ grep '^BYBIT_SANDBOX=' .env.production
 
 # AAVE_NETWORK が mainnet か（sepolia が含まれないか）
 grep '^AAVE_NETWORK=' .env.production
-# → AAVE_NETWORK=base_mainnet
+# → AAVE_NETWORK=base
 
 # INTERNAL_API_TOKEN が設定されているか
 grep '^INTERNAL_API_TOKEN=' .env.production


### PR DESCRIPTION
## Summary

PR #441 で `scripts/launch_gate/L1_env.sh` の期待値が `base_mainnet → base` に修正されたが、同じ誤表記が docs 2 ケ所に残っていた。実値 (本番 `.env.production` の `AAVE_NETWORK=base`) に合わせる訂正のみ。

- `CLAUDE.md` §Codex Review セルフチェック §環境分離 (L899): `production=base_mainnet` → `production=base`
- `docs/ops/03_deploy_procedures.md` §デプロイ後検証 (L133): 期待出力 `# → AAVE_NETWORK=base_mainnet` → `# → AAVE_NETWORK=base`

## Scope 外 (意図的に未修正)

| ファイル | 理由 |
|---|---|
| `.env.production.example:67` | タスク指示「`.env.*` は触らない」(Asana 1215185650318084 §一切しないこと) |
| `scripts/launch_gate/L1_env.sh` (7 件) | PR #441 (`fix/launch-gate-l1-aave-network-20260528`) で別途修正済 — merge 待ち |

## 背景

ドリフト再発防止。.env.production の実値は `base` だが、docs が `base_mainnet` 表記だと今後他スクリプトや手手順で同じドリフトを起こす。CLAUDE.md §ドリフト再発カタログ §環境/Infra にも該当する典型パターン。

## Test plan

- [x] `grep -rn 'base_mainnet'` で残存箇所が scope 外 2 種類のみであることを確認
- [x] `git diff --stat` = 2 ファイル / 2 行変更のみ
- [ ] Codex Review 通過

## Asana

Closes [Asana 1215185650318084](https://app.asana.com/1/817733952351708/project/1213916581114014/task/1215185650318084)

🤖 Generated with [Claude Code](https://claude.com/claude-code)