### PR TITLE
docs(uat): §14 UAT 完走 5条件 SQL を 2 partner 体制に拡張 (山本+橋口) (Asana 1215185448109917)

### DIFF
--- a/docs/launch/roadmap_to_launch.md
+++ b/docs/launch/roadmap_to_launch.md
@@ -62,13 +62,15 @@
 - **6/3 達成見込み**: 計測機能実装 (別 Tier B タスク) + 直近 PR の Approve 状況確認後に評価
 - **依存タスク**: Step 0 記録機能実装 (要別タスク起票)
 
-### 条件 4: 山本さん UAT 完走 (proposals 全件 EXECUTED 判定基準満たす)
-- **詳細仕様**: `docs/launch_decision_criteria_v2.md` §4 (UAT 完走 SQL: `non_executed_active = 0` かつ `total_proposals ≥ 5` かつ `executed ≥ 1` + 山本さんから明示承認 DM)
-- **判定 SQL** (同 docs §4.2): `proposals` テーブル WHERE `user_id=11` の group by status + uat_state 判定 CASE 式
-- **現状値 (2026-05-18 時点、同 docs §4.3)**: ❌ 未完走 (total_proposals=0、ウォレット接続完了 / proposals 生成待ち)
+### 条件 4: Partner UAT 完走 (proposals 全件 EXECUTED 判定基準満たす)
+- **詳細仕様**: `docs/launch_decision_criteria_v2.md` §4 (UAT 完走 SQL: `non_executed_active = 0` かつ `total_proposals ≥ 5` かつ `executed ≥ 1` + 各 partner から明示承認 DM)
+- **判定 SQL** (同 docs §4.2): `proposals` JOIN `users` WHERE `role='partner' AND is_active=TRUE` の group by status + uat_state 判定 CASE 式（2026-05-28 改訂で 2 partner 化 / Asana 1215185448109917）
+- **partner 別内訳 SQL**: `docs/uat_completion_criteria.md` § partner 別内訳 SQL（合算で達成しても 1 partner に集中していないか確認）
+- **現状値 (2026-05-28 改訂時点)**: ❌ 未完走 (旧山本さん単独 total_proposals=2 expired のみ / 橋口さん proposals 未生成 / partner 合算 baseline は本改訂後再計測)
 - **5/20 進捗**: P0-X2 fund_allocations $4,600 INSERT 完了 (Asana 1214825504961756 / id=6 / 2026-05-20 04:49:51 UTC) — UAT proposals 生成フローの起算点が立った
-- **6/3 達成見込み**: proposals 5 件以上生成 + 全件 EXECUTED/EXPIRED/REJECTED + 山本さん承認 DM。proposals 生成速度に依存 (TBD)
-- **依存タスク**: id=16 (A-4) UAT 完走閾値詳細化 / 山本さん wallet 接続後の proposals 生成
+- **5/28 進捗**: 橋口さん (id=18, role=partner) を `users` テーブルに INSERT 済。山本さん wallet `0x2064...cc66` 登録済、橋口さん 2026-06-01 までに wallet 登録予定 — 2 partner 並走で UAT を回す体制が整った
+- **6/3 達成見込み**: proposals 5 件以上生成 + 全件 EXECUTED/EXPIRED/REJECTED + 各 partner 承認 DM。proposals 生成速度に依存 (TBD)
+- **依存タスク**: id=16 (A-4) UAT 完走閾値詳細化 / 橋口さん wallet 登録 (6/1 までに) → 2 partner 体制で proposals 生成
 
 ### 条件 5: 森先生 法務確認 (BVI / non-custodial)
 - **詳細仕様**: `docs/launch_decision_criteria_v2.md` §5 (BVI 設立 / non-custodial 構造 / 日本居住者向け配信)
@@ -86,17 +88,17 @@
 >
 > 1. 6/3-6/5 最早が本当に最早か実機ベースで再計算
 > 2. 各条件の進捗が引継ぎパッケージの数字を鵜呑みにしただけ
-> 3. 山本さん UAT 14日観察が 5/25 - 6/8 で完走できるか (現状 100% HOLD)
+> 3. Partner UAT 14日観察が 5/25 - 6/8 で完走できるか (現状 100% HOLD / 2026-05-28 から 2 partner 体制)
 > 4. chaos test 3日連続が staging で実施可能か (PR #253 実機状態未確認)
 > 5. 並列 4本構成の Tier S 禁止ファイル抵触リスク
-> 6. 抜けているリスク (HUMAN-REVIEW 14本処理 / v4 反映後の観察期間 / 山本さん wallet 接続 / 営業チーム運用 docs / Phase 2 機能の Phase 1 ローンチ前必要性)
+> 6. 抜けているリスク (HUMAN-REVIEW 14本処理 / v4 反映後の観察期間 / 橋口さん wallet 接続 (6/1 までに登録予定 / 山本さんは 0x2064...cc66 登録済) / 営業チーム運用 docs / Phase 2 機能の Phase 1 ローンチ前必要性)
 > 7. (handoff 内に明示なし)
 
 ### 2.1 起算点と着地点 (calendar 計算)
 
 | 起算イベント | 起算日 (実機) | 必要日数 | 着地日 |
 |---|---|---|---|
-| 山本さん UAT 開始 (P0-X2 INSERT) | 2026-05-20 04:49:51 UTC (Asana 1214825504961756 / id=6 完了) | proposals 生成速度依存 (TBD) | TBD |
+| Partner UAT 開始 (P0-X2 INSERT) | 2026-05-20 04:49:51 UTC (Asana 1214825504961756 / id=6 完了 / 2026-05-28 から 2 partner 体制: 山本=id 11 wallet 登録済、橋口=id 18 wallet 6/1 まで登録予定) | proposals 生成速度依存 (TBD) | TBD |
 | chaos test 3日連続 | TBD (Lane 1 起動次第) | 3日 + 観測 1日 | TBD |
 | HUMAN-REVIEW 14本処理完了 | TBD | TBD | TBD |
 | v4 反映後の観察期間 | 2026-05-19 (PR #302 merge済) | TBD | TBD |
@@ -117,7 +119,7 @@
 | L1-L6 14日連続緑 | 0/14 日 | ❌ 未達 | L2 閾値 270min 修正 (id=29) → 修正後から連続緑カウント開始 |
 | chaos test 3日連続 | 未実施 | ❌ 未計測 | id=10 タスク起動 |
 | Tier S 承認率 100% | 未計測 | ❌ 未計測 | gh CLI 計測 + Step 0 記録機能実装 |
-| 山本さん UAT 完走 | 進行中 | ❌ 未完走 | proposals 生成フロー到達待ち (5/20 INSERT 完了で起点進行) |
+| Partner UAT 完走 (山本+橋口) | 進行中 | ❌ 未完走 | proposals 生成フロー到達待ち (5/20 INSERT 完了で起点進行 / 5/28 から 2 partner 体制) |
 | 森先生 法務確認 | 未送信 | ❌ 未確認 | 5/22 DM 送信 (id=9 / Lane 4) |
 | **総合** | **0/5 green** | ❌ **ローンチ不可** (2026-05-18 評価) | L2 修正 → 14日緑積み上げ → 他項目並行 |
 
@@ -198,7 +200,7 @@ docker exec ultra-autotrade-postgres-production \
   -f /opt/ultra-autotrade/scripts/launch_dashboard.sql
 ```
 
-集計対象: L3 (ai_decisions 14日)、L4 (proposals expired_rate)、L5 (transactions fail_rate)、直近 24h スナップショット、山本さん UAT (user_id=11) 状態。
+集計対象: L3 (ai_decisions 14日)、L4 (proposals expired_rate)、L5 (transactions fail_rate)、直近 24h スナップショット、Partner UAT (`role='partner' AND is_active=TRUE` で合算: 山本 id=11 + 橋口 id=18) 状態。
 
 ---
 

--- a/docs/launch_decision_criteria_v2.md
+++ b/docs/launch_decision_criteria_v2.md
@@ -218,55 +218,63 @@ grep "Step 0 確認済" /opt/ultra-autotrade/logs/morning_protocol.log | wc -l
 
 ---
 
-## 4. 山本さん UAT 完走
+## 4. Partner UAT 完走
+
+> 2026-05-28 改訂: 2 partner 体制（山本+橋口）対応。SQL を `user_id=11` ハードコードから `role='partner' AND is_active=TRUE` 一般化（Asana 1215185448109917）。
+> 詳細閾値・partner 別内訳 SQL は `docs/uat_completion_criteria.md` 参照。
 
 ### 4.1 定義
 
-「山本さん UAT 完走」= 以下の**全条件**を満たす状態:
+「Partner UAT 完走」= 以下の**全条件**を満たす状態:
 
 | 条件 | 測定方法 |
 |---|---|
 | UAT シナリオ全ステップ実行完了 | Asana id=16 (A-4) タスクで閾値詳細化中 |
-| 山本さん (user_id=11) の全 proposals が `executed` or `expired` | `non_executed_active = 0` (下記 SQL) |
-| proposals が実際に生成・承認フローを経ている | `total_proposals ≥ 5` かつ `executed ≥ 1` |
-| 山本さんから小林さんへの明示的承認メッセージ受領 | DM 確認 (非自動化) |
+| 全 partner (`role='partner' AND is_active=TRUE`) の active な未完了 proposals が 0 | `non_executed_active = 0` (下記 SQL) |
+| partner 合算で proposals が実際に生成・承認フローを経ている | `total_proposals ≥ 5` かつ `executed ≥ 1` |
+| 各 partner から小林さんへの明示的承認メッセージ受領 | DM 確認 (非自動化) |
 
-> **注**: id=16 Lane で proposals 全件 EXECUTED の数値閾値を詳細化中。本ドキュメントでは枠組みのみ。
+> **注**: id=16 Lane で proposals 全件 EXECUTED の数値閾値を詳細化済 (`docs/uat_completion_criteria.md` PR #251 → Asana 1215185448109917 改訂)。本ドキュメントは枠組みのみ。
 
 ### 4.2 UAT 完走判定 SQL
 
 ```sql
--- 山本さん (user_id=11) UAT 状態確認
+-- Partner UAT 状態確認 (role='partner' AND is_active=TRUE で合算)
+WITH partners AS (
+  SELECT id FROM users WHERE role = 'partner' AND is_active = TRUE
+)
 SELECT
-  (SELECT COUNT(*) FROM proposals WHERE user_id = 11) AS total_proposals,
-  (SELECT COUNT(*) FROM proposals WHERE user_id = 11 AND status = 'executed') AS executed,
-  (SELECT COUNT(*) FROM proposals WHERE user_id = 11 AND status = 'expired') AS expired,
-  (SELECT COUNT(*) FROM proposals WHERE user_id = 11 AND status = 'rejected') AS rejected,
+  (SELECT COUNT(*) FROM proposals p JOIN partners ON partners.id = p.user_id) AS total_proposals,
+  (SELECT COUNT(*) FROM proposals p JOIN partners ON partners.id = p.user_id WHERE p.status = 'executed') AS executed,
+  (SELECT COUNT(*) FROM proposals p JOIN partners ON partners.id = p.user_id WHERE p.status = 'expired')  AS expired,
+  (SELECT COUNT(*) FROM proposals p JOIN partners ON partners.id = p.user_id WHERE p.status = 'rejected') AS rejected,
   (SELECT COUNT(*)
-   FROM proposals
-   WHERE user_id = 11
-     AND status NOT IN ('executed', 'expired', 'rejected')
-     AND expires_at > NOW()) AS non_executed_active,
-  -- UAT 完走候補判定: active な未完了 proposals が 0件かつ total >= 5
+     FROM proposals p
+     JOIN partners ON partners.id = p.user_id
+    WHERE p.status NOT IN ('executed', 'expired', 'rejected')
+      AND p.expires_at > NOW()) AS non_executed_active,
+  -- UAT 完走候補判定: active な未完了 proposals が 0件かつ partner 合算 total >= 5
   CASE
-    WHEN (SELECT COUNT(*) FROM proposals WHERE user_id = 11) < 5
+    WHEN (SELECT COUNT(*) FROM proposals p JOIN partners ON partners.id = p.user_id) < 5
       THEN 'WAITING (proposals 生成待ち)'
-    WHEN (SELECT COUNT(*) FROM proposals WHERE user_id = 11
-          AND status NOT IN ('executed','expired','rejected')
-          AND expires_at > NOW()) = 0
+    WHEN (SELECT COUNT(*) FROM proposals p JOIN partners ON partners.id = p.user_id
+          WHERE p.status NOT IN ('executed','expired','rejected')
+            AND p.expires_at > NOW()) = 0
       THEN 'CANDIDATE (最終承認 DM 待ち)'
     ELSE 'IN_PROGRESS'
   END AS uat_state;
 ```
 
-### 4.3 現在値 (2026-05-18 時点)
+partner 別内訳は `docs/uat_completion_criteria.md` § partner 別内訳 SQL を参照。
+
+### 4.3 現在値 (2026-05-28 改訂時点)
 
 | 項目 | 現在値 |
 |---|---|
-| UAT 進行段階 | ウォレット接続完了、proposals 生成待ち |
-| total_proposals (user_id=11) | 0件 (AI 判定 14件あるが proposals 生成に至っていない) |
+| UAT 進行段階 | 山本さん wallet `0x2064...cc66` 登録済、橋口さん 2026-06-01 までに wallet 登録予定。proposals 生成待ち |
+| total_proposals (partner 合算) | 旧値（2026-05-18, 山本さん単独）2件 expired のみ。本 PR マージ後に partner 合算で再計測 |
 | non_executed_active | 0件 (proposals 自体が未生成のため) |
-| 山本さん承認 DM | 未受領 |
+| partner 承認 DM | 未受領 |
 | 判定 | ❌ 未完走 (proposals 生成・承認フロー未到達) |
 
 ---
@@ -395,15 +403,16 @@ recent AS (
      WHERE recorded_at > NOW() - INTERVAL '24 hours')                        AS l6_zero_pct
 ),
 
--- 山本さん UAT 状態
+-- Partner UAT 状態 (2026-05-28: 2 partner 化 / role='partner' AND is_active=TRUE 一般化)
 uat AS (
   SELECT
     COUNT(*)                                                                   AS total,
-    COUNT(*) FILTER (WHERE status = 'executed')                               AS executed,
-    COUNT(*) FILTER (WHERE status NOT IN ('executed','expired','rejected')
-                     AND expires_at > NOW())                                   AS active_non_exec
-  FROM proposals
-  WHERE user_id = 11
+    COUNT(*) FILTER (WHERE p.status = 'executed')                              AS executed,
+    COUNT(*) FILTER (WHERE p.status NOT IN ('executed','expired','rejected')
+                     AND p.expires_at > NOW())                                 AS active_non_exec
+  FROM proposals p
+  JOIN users u ON u.id = p.user_id
+  WHERE u.role = 'partner' AND u.is_active = TRUE
 )
 
 SELECT '============================================' AS metric, '' AS value

--- a/docs/uat_completion_criteria.md
+++ b/docs/uat_completion_criteria.md
@@ -1,38 +1,55 @@
-# 山本さん UAT 完走判定基準
+# Partner UAT 完走判定基準
 
-> 作成: 2026-05-18 / Lane A-4
-> 対象ユーザー: 山本さん (user_id=11, m.yamamoto1017@gmail.com, role=partner, execution_policy=require_approval)
+> 作成: 2026-05-18 / Lane A-4 (PR #251)
+> 2026-05-28 改訂: 2 partner 体制（山本+橋口）対応 / Asana 1215185448109917
+>
+> **対象 partner (2026-05-28 時点)**:
+>
+> | id | email | role | wallet_address | execution_policy |
+> |---|---|---|---|---|
+> | 11 | m.yamamoto1017@gmail.com | partner | `0x2064...cc66` 登録済 | require_approval |
+> | 18 | (橋口さん) | partner | 2026-06-01 までに登録予定 | require_approval |
+>
+> 新規 partner が追加された場合も自動で対象に含めるため、SQL は **`WHERE role='partner' AND is_active = TRUE`** を採用する（id ハードコードしない）。
 
 ---
 
 ## 概要
 
-「UAT 完走」を客観的に判定するため、以下 5 条件をすべて満たした時点を完走とする。
+「Partner UAT 完走」を客観的に判定するため、以下 5 条件をすべて満たした時点を完走とする。
 条件は本番 PostgreSQL から 1 コマンドで検証できる SQL を提供する（§ SQL セクション参照）。
+
+**判定単位**:
+- **合算判定**: 全 partner (`role='partner' AND is_active = TRUE`) の executed 提案を合算して 5 条件を評価する（業務フロー安定の最終判定）。
+- **partner 別内訳**: 各 partner ごとの件数・金額・中央値も補助的に表示し、偏りがあれば気付けるようにする（合算で達成しても 1 partner に集中していたら追加観察する）。
 
 ---
 
-## 完走条件 5 件
+## 完走条件 5 件（閾値は PR #251 から変更なし）
 
 ### 条件 1: 実行済み提案 5 件以上
 
 ```
-proposals.user_id = 11
-AND proposals.status = 'executed'
+proposals.status = 'executed'
+JOIN users ON users.id = proposals.user_id
+WHERE users.role = 'partner' AND users.is_active = TRUE
 COUNT ≥ 5
 ```
 
 - **根拠**: 1 回の成功では一過性の可能性がある。5 件のフルサイクル（AI 判定 → 提案生成 → 承認 → Aave 実行）完走で業務フロー安定を確認。
 - **上限なし**: 5 件を超えた分はすべてカウント対象。
+- **対象拡張理由 (2026-05-28)**: 2 partner 体制になるため、partner を id ハードコードせず `role='partner' AND is_active=TRUE` で集計する。山本さん単独前提だと橋口さん側の executed 提案が漏れる。
 
 ### 条件 2: 実行済み提案の合計 amount_usd ≥ $500
 
 ```
-SUM(proposals.amount_usd) WHERE status='executed' AND user_id=11 ≥ 500
+SUM(proposals.amount_usd)
+  WHERE status='executed' AND user_id IN (partner ids)
+  ≥ 500
 ```
 
 - **根拠**: 合計 $500 は実運用の最小有意水準。テスト用少額（$1 等）が大量に通過するだけでは不十分。
-- **注意**: 1 件あたりの金額は問わない（合計値で判定）。
+- **注意**: 1 件あたりの金額は問わない（合計値で判定）。partner 横断合算。
 
 ### 条件 3: proposal → transaction 中央値 < 10 分
 
@@ -43,10 +60,11 @@ PERCENTILE_CONT(0.5) WITHIN GROUP (
 WHERE proposals.status='executed'
   AND proposals.approved_at IS NOT NULL
   AND proposals.executed_at IS NOT NULL
+  AND user_id IN (partner ids)
 ```
 
-- **根拠**: approved_at（山本さんが承認押下）から executed_at（Aave 実行完了）まで。10 分超は Aave 実行遅延・ガス詰まり等の異常シグナル。
-- **中央値**: 外れ値（ガス高騰時の 1 件）に引きずられないよう中央値を採用。
+- **根拠**: approved_at（partner が承認押下）から executed_at（Aave 実行完了）まで。10 分超は Aave 実行遅延・ガス詰まり等の異常シグナル。
+- **中央値**: 外れ値（ガス高騰時の 1 件）に引きずられないよう中央値を採用。partner 横断で集計。
 
 ### 条件 4: 実行済み提案に tx_hash あり（Base Mainnet 確認可能）
 
@@ -60,7 +78,7 @@ COUNT(tx_hash IS NOT NULL) WHERE status='executed' = 条件1のCOUNT
 
 ### 条件 5: Slack #ultra-auto-project 異常報告ゼロ（過去 14 日）
 
-- **判定方法**: Slack MCP または手動検索で `山本` / `エラー` / `動かない` / `壊れた` を検索。
+- **判定方法**: Slack MCP または手動検索で `山本` / `橋口` / `エラー` / `動かない` / `壊れた` を検索。
 - **期間**: 完走判定日の 14 日前まで。
 - **除外**: テスト用のエラーログ通知（`⚠️` プレフィックス）は正常動作の証左として除外。
 
@@ -75,17 +93,21 @@ ssh -i ~/.ssh/hetzner_direct ultra@77.42.46.155 <<'ENDSSH'
 docker exec ultra-autotrade-postgres-production \
   psql -U ultra -d ultra_autotrade -c "
 WITH
+partners AS (
+  SELECT id, email FROM users
+   WHERE role = 'partner' AND is_active = TRUE
+),
 executed AS (
   SELECT
     COUNT(*) AS cnt,
-    COALESCE(SUM(amount_usd), 0) AS total_usd,
-    COUNT(tx_hash) AS with_tx_hash,
+    COALESCE(SUM(p.amount_usd), 0) AS total_usd,
+    COUNT(p.tx_hash) AS with_tx_hash,
     PERCENTILE_CONT(0.5) WITHIN GROUP (
-      ORDER BY EXTRACT(EPOCH FROM (executed_at - approved_at)) / 60
+      ORDER BY EXTRACT(EPOCH FROM (p.executed_at - p.approved_at)) / 60
     ) AS median_minutes
-  FROM proposals
-  WHERE user_id = 11
-    AND status = 'executed'
+  FROM proposals p
+  JOIN partners ON partners.id = p.user_id
+  WHERE p.status = 'executed'
 ),
 checks AS (
   SELECT
@@ -108,56 +130,86 @@ checks AS (
   FROM executed
 )
 SELECT condition, result FROM (
-  SELECT 1 ord, '条件1: executed≥5件'    AS condition, c1 AS result FROM checks
+  SELECT 1 ord, '条件1: executed≥5件 (partner 合算)'    AS condition, c1 AS result FROM checks
   UNION ALL
-  SELECT 2,     '条件2: 合計≥\$500',                  c2         FROM checks
+  SELECT 2,     '条件2: 合計≥\$500 (partner 合算)',     c2         FROM checks
   UNION ALL
-  SELECT 3,     '条件3: 中央値<10分',                  c3         FROM checks
+  SELECT 3,     '条件3: 中央値<10分 (partner 合算)',    c3         FROM checks
   UNION ALL
-  SELECT 4,     '条件4: tx_hash全件あり',              c4         FROM checks
+  SELECT 4,     '条件4: tx_hash全件あり',               c4         FROM checks
   UNION ALL
-  SELECT 5,     '条件5: Slack異常報告',               '手動確認要'
+  SELECT 5,     '条件5: Slack異常報告',                 '手動確認要'
   UNION ALL
-  SELECT 6,     '--- 集計値 ---',                      '---'
+  SELECT 6,     '--- 合算 集計値 ---',                   '---'
   UNION ALL
-  SELECT 7,     'executed件数',          cnt::text              FROM checks
+  SELECT 7,     'executed件数 (全 partner 合算)',         cnt::text   FROM checks
   UNION ALL
-  SELECT 8,     '合計USD',              '\$' || total_usd       FROM checks
+  SELECT 8,     '合計USD (全 partner 合算)',             '\$' || total_usd                                            FROM checks
   UNION ALL
-  SELECT 9,     '中央値(分)',            COALESCE(ROUND(median_minutes::numeric,1)::text, 'N/A') FROM checks
+  SELECT 9,     '中央値(分)',                            COALESCE(ROUND(median_minutes::numeric,1)::text, 'N/A')      FROM checks
   UNION ALL
-  SELECT 10,    'tx_hash有件数',         with_tx_hash::text     FROM checks
+  SELECT 10,    'tx_hash有件数',                         with_tx_hash::text                                           FROM checks
 ) t ORDER BY ord;
 "
 ENDSSH
 ```
 
+### partner 別内訳 SQL（補助 / 偏り検知用）
+
+```bash
+ssh -i ~/.ssh/hetzner_direct ultra@77.42.46.155 <<'ENDSSH'
+docker exec ultra-autotrade-postgres-production \
+  psql -U ultra -d ultra_autotrade -c "
+SELECT
+  u.id,
+  u.email,
+  COUNT(p.id) FILTER (WHERE p.status = 'executed') AS executed_count,
+  COALESCE(SUM(p.amount_usd) FILTER (WHERE p.status = 'executed'), 0) AS executed_total_usd,
+  COUNT(p.tx_hash) FILTER (WHERE p.status = 'executed' AND p.tx_hash IS NOT NULL) AS with_tx_hash,
+  ROUND(
+    PERCENTILE_CONT(0.5) WITHIN GROUP (
+      ORDER BY EXTRACT(EPOCH FROM (p.executed_at - p.approved_at)) / 60
+    ) FILTER (WHERE p.status = 'executed')
+  ::numeric, 1) AS median_minutes
+FROM users u
+LEFT JOIN proposals p ON p.user_id = u.id
+WHERE u.role = 'partner' AND u.is_active = TRUE
+GROUP BY u.id, u.email
+ORDER BY u.id;
+"
+ENDSSH
+```
+
+partner 別の executed 件数・合計 USD・中央値を見て、どちらかの partner に極端に偏っていないか確認する（例: 山本さん 5 件 / 橋口さん 0 件 でも合算 5 件で条件1 PASS になるが、業務安定性としては不十分）。
+
 ---
 
-## 現在値（2026-05-18 時点）
+## 現在値（2026-05-28 改訂時点 / 2 partner 化後 初回 baseline）
 
-本番 DB クエリ実行結果:
+実機 baseline は本 PR マージ後に本番で SQL を再実行して取得する。
+2 partner 化以前 (2026-05-18 PR #251 時点) の値は以下:
 
-| 条件 | 設定値 | 現在値 | 判定 |
+| 条件 | 設定値 | 2026-05-18 値 (旧山本さん単独) | 判定 |
 |------|--------|--------|------|
-| 条件1: executed 件数 | ≥ 5件 | **0件** | **FAIL (未達)** |
-| 条件2: 合計 amount_usd | ≥ $500 | **$0** | **FAIL (未達)** |
-| 条件3: 承認→実行 中央値 | < 10分 | **N/A** (executed=0件) | **FAIL (未達)** |
-| 条件4: tx_hash 有件数 | 全 executed 件 | **0件** | **FAIL (未達)** |
-| 条件5: Slack 異常報告 | 0件/14日 | 手動確認要 | **未確認** |
+| 条件1: executed 件数 (合算) | ≥ 5件 | 0件 | FAIL (未達) |
+| 条件2: 合計 amount_usd (合算) | ≥ $500 | $0 | FAIL (未達) |
+| 条件3: 承認→実行 中央値 (合算) | < 10分 | N/A (executed=0件) | FAIL (未達) |
+| 条件4: tx_hash 有件数 | 全 executed 件 | 0件 | FAIL (未達) |
+| 条件5: Slack 異常報告 | 0件/14日 | 手動確認要 | 未確認 |
 
-### 現状サマリー
+### 現状サマリー (2026-05-28 改訂時点で既知の情報)
 
-- proposals テーブル: 2件 (`expired` のみ、2026-05-06 / 2026-05-07)
-- transactions テーブル: 0件
-- 実行済み提案: 0件（全件 expired で承認前に期限切れ）
-- ブロッカー: 山本さん (execution_policy=`require_approval`) が提案を承認しないまま期限切れになっている
+- 2026-05-28 朝、`users` テーブルに橋口さん (id=18, role=partner) を INSERT 済。
+- 山本さん (id=11) は wallet_address `0x2064...cc66` 登録済。
+- 橋口さん (id=18) は 2026-06-01 までに wallet_address 登録予定。
+- PR #251 (2026-05-18) 時点での山本さん単独 proposals: 2件 (`expired` のみ / 2026-05-06, 2026-05-07 作成)。橋口さん側 proposals: 未生成。
+- 本 PR マージ後、上記 SQL を本番で再実行して 2 partner 合算 baseline を取得し本セクションを更新する。
 
-### ブロッカー原因候補
+### ブロッカー原因候補 (2026-05-18 時点・以後の改善状況は別途追跡)
 
 1. proposals の `expires_at` が短すぎる（提案が承認前に期限切れ）
-2. 山本さんへの提案通知（Slack / LINE / Push）が届いていない
-3. 山本さんのフロントエンドで承認ボタンが機能していない（UI バグ）
+2. partner への提案通知（Slack / LINE / Push）が届いていない
+3. partner のフロントエンドで承認ボタンが機能していない（UI バグ）
 
 ---
 
@@ -169,10 +221,12 @@ ENDSSH
 ssh -i ~/.ssh/hetzner_direct ultra@77.42.46.155 <<'ENDSSH'
 docker exec ultra-autotrade-postgres-production \
   psql -U ultra -d ultra_autotrade -c "
-SELECT id, tx_hash, executed_at, amount_usd
-FROM proposals
-WHERE user_id=11 AND status='executed' AND tx_hash IS NOT NULL
-ORDER BY executed_at DESC LIMIT 5;
+SELECT p.id, p.user_id, u.email, p.tx_hash, p.executed_at, p.amount_usd
+FROM proposals p
+JOIN users u ON u.id = p.user_id
+WHERE u.role = 'partner' AND u.is_active = TRUE
+  AND p.status='executed' AND p.tx_hash IS NOT NULL
+ORDER BY p.executed_at DESC LIMIT 5;
 "
 ENDSSH
 ```
@@ -186,7 +240,16 @@ ENDSSH
 
 5 条件が全 PASS になったら:
 
-1. 本 SQL を実行してスクリーンショット取得
+1. 本 SQL（合算判定 + partner 別内訳の両方）を実行してスクリーンショット取得
 2. basescan.org で代表 1 件の tx_hash を確認してスクリーンショット取得
-3. Asana の「山本さん UAT 完走判定」タスクを close
-4. 小林さんが山本さんへ完走報告（CLAUDE.md §10 文面禁止・本人送信ルール遵守）
+3. Asana の「Partner UAT 完走判定」タスクを close
+4. 小林さんが各 partner（山本さん・橋口さん）へ完走報告（CLAUDE.md §10 文面禁止・本人送信ルール遵守）
+
+---
+
+## 変更履歴
+
+| 日付 | 変更 | PR / Asana |
+|------|------|------------|
+| 2026-05-18 | 初版（山本さん user_id=11 単独前提） | PR #251 |
+| 2026-05-28 | 2 partner 体制（山本+橋口）対応 / `role='partner' AND is_active=TRUE` 一般化 / wallet_address 状況更新。**5 条件の閾値（5件 / $500 / 10分 / tx_hash / 14日異常ゼロ）は変更なし**、対象 user_id のみ拡張。 | Asana 1215185448109917 |


### PR DESCRIPTION
## Summary

Asana 1215185448109917 / Tier B / docs only

PR #251 で確定した UAT 完走判定 5条件 SQL が `user_id=11` 単独ハードコード前提だった。
2026-05-28 朝に橋口さん (id=18, role=partner) を `users` テーブルへ INSERT 済で、山本さんと並走で
UAT を回す体制になったため、判定 SQL を 2 partner 体制 (将来の partner 追加にも自動対応) に拡張する。

**重要: PR #251 で確定した完走条件の閾値 (5件 / \$500 / 10分 / tx_hash / 14日異常ゼロ) は変更なし、
対象 user_id だけを `role='partner' AND is_active=TRUE` で一般化する。**

### 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `docs/uat_completion_criteria.md` | 「山本さん UAT」→「Partner UAT」リネーム / 5 条件 SQL を `WHERE role='partner' AND is_active=TRUE` に書換 / 合算判定 SQL + partner 別内訳 SQL の両方を提供 / 山本=`0x2064...cc66` 登録済 / 橋口=6/1 までに登録予定を明記 / 変更履歴セクション追加 |
| `docs/launch_decision_criteria_v2.md` | §4「山本さん UAT」→「Partner UAT」リネーム / 判定 SQL を partner JOIN 一般化 / §6 ダッシュボード SQL の uat CTE を partner 集計に変更 |
| `docs/launch/roadmap_to_launch.md` | 条件 4 ラベルを「Partner UAT 完走」に / wallet 古記述 (「山本さん wallet 接続」) を「山本さん 0x2064...cc66 登録済、橋口さん 6/1 までに登録予定」に更新 / 起算点テーブルに 2 partner 構成を反映 |

### 採用方針 (Asana DoD「IN (11, 18) か role='partner' か方針決定」への回答)

`WHERE role='partner' AND is_active=TRUE` の users JOIN 方式を採用。理由:

- **id ハードコード回避**: 将来 partner が追加された際にも自動で対象に含まれる。SQL を毎回 grep して書き換えるリスクを排除
- **失活した partner を自動除外**: `is_active=FALSE` の partner は集計から外れる
- **観察粒度の確保**: 合算判定だけでなく partner 別内訳 SQL も併記。「合算 5 件達成」でも「山本さん 5 件 / 橋口さん 0 件」なら偏りとして気付ける

### v4 docs の wallet_address 古記述更新

`docs/launch/roadmap_to_launch.md` の以下 3 箇所を更新:

1. 条件 4 詳細 (L65-71): 「ウォレット接続完了 / proposals 生成待ち」→「山本さん 0x2064...cc66 登録済、橋口さん 6/1 までに登録予定」+ 2 partner 体制への進捗追記
2. §2 抜けているリスク (L92): 「山本さん wallet 接続」→「橋口さん wallet 接続 (6/1 までに登録予定)」
3. §2.1 起算点 (L99): Partner UAT 起算点を 2 partner 体制で記載

なお `docs/uat_completion_criteria.md` 冒頭にも対象 partner 表として wallet_address 状態を明記。

## 判定 SQL (本 PR でリライト後)

合算判定 (本番 postgres で実行可能):

\`\`\`sql
WITH partners AS (SELECT id FROM users WHERE role = 'partner' AND is_active = TRUE),
executed AS (
  SELECT COUNT(*) AS cnt, COALESCE(SUM(p.amount_usd), 0) AS total_usd,
         COUNT(p.tx_hash) AS with_tx_hash,
         PERCENTILE_CONT(0.5) WITHIN GROUP (
           ORDER BY EXTRACT(EPOCH FROM (p.executed_at - p.approved_at)) / 60
         ) AS median_minutes
  FROM proposals p JOIN partners ON partners.id = p.user_id
  WHERE p.status = 'executed'
)
SELECT cnt, total_usd, with_tx_hash, median_minutes FROM executed;
\`\`\`

partner 別内訳 SQL は本文 `docs/uat_completion_criteria.md` § partner 別内訳 SQL を参照。

## Gate 結果

- Gate 1-3 (verify.sh): docs only → N/A
- Gate 4 (E2E): docs only → N/A
- Gate 5 (孤立コード): docs only → N/A
- Gate 6 (Codex Review): 本 PR 作成後に `/codex:review` 実行予定
- Gate 7 (Chrome): docs only → N/A

## SQL の実機検証

dev VPS に postgres コンテナはないため、SQL の実機 baseline は本 PR マージ後に本番 VPS で
以下を実行して取得する (docs/uat_completion_criteria.md に手順記載済み):

\`\`\`bash
ssh -i ~/.ssh/hetzner_direct ultra@77.42.46.155
docker exec ultra-autotrade-postgres-production psql -U ultra -d ultra_autotrade -c "<上記 SQL>"
\`\`\`

## 一切しないこと (Asana DoD より)

- ❌ PR #251 で確定した完走条件の閾値変更 (5件 / \$500 / 10分 / tx_hash / 14日異常ゼロ) — 変更していない
- ❌ docs 以外のコード変更 — していない (Tier B / docs only)

## Test plan

- [ ] Codex Review 通過
- [ ] 本番 VPS で改訂後 SQL を実行し partner 合算 baseline を取得
- [ ] partner 別内訳 SQL を実行し山本/橋口の現状件数確認
- [ ] 橋口さん wallet_address 登録 (6/1 までに) 完了後、改訂後 SQL を再実行して動作確認

Closes Asana 1215185448109917

🤖 Generated with [Claude Code](https://claude.com/claude-code)