### PR TITLE
feat(portfolio): snapshot_service per-partner Aave fetch (wallet_address 伝播 / Lane 14)

### DIFF
--- a/backend/app/portfolio/snapshot_service.py
+++ b/backend/app/portfolio/snapshot_service.py
@@ -12,13 +12,11 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any, Optional
 
-from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.aave.client import get_default_aave_client
 from app.auth.models import User
 from app.database import SessionLocal
-from app.partner.allocation_models import FundAllocation
 from app.portfolio.models import PortfolioHistory, PortfolioSnapshot
 
 logger = logging.getLogger(__name__)
@@ -32,6 +30,19 @@ def _normalize_hf(hf: Decimal) -> Optional[Decimal]:
     except Exception:
         return None
     return hf
+
+
+def _get_wallet_address(user: User) -> str:
+    """ユーザー（partner / admin）の Aave ウォレットアドレスを取得する。
+
+    users.wallet_address が設定されていれば優先、なければ
+    AAVE_WALLET_ADDRESS 環境変数にフォールバックする。
+
+    app.partner.allocation_service._get_wallet_address と同一セマンティクス。
+    """
+    if user.wallet_address:
+        return user.wallet_address
+    return os.getenv("AAVE_WALLET_ADDRESS", "")
 
 
 def _save_snapshot(
@@ -116,17 +127,20 @@ def _upsert_daily_history(
 def record_portfolio_snapshot(db: Optional[Session] = None) -> dict[str, Any]:
     """Aaveポートフォリオスナップショットを記録する（スケジュールタスク用）。
 
-    処理フロー:
-    1. Aave get_account_data() でポートフォリオ取得
-    2. FundAllocation 比率に基づき、パートナーが招待したテスターに按分して
-       PortfolioSnapshot を保存
-    3. テスターが存在しない場合は管理者ユーザーに全体スナップショットを保存
-    4. 日次 PortfolioHistory を作成または更新
+    処理フロー（wallet_address 伝播版 / Lane 14）:
+    1. パートナーごとに `_get_wallet_address(partner)` で対象ウォレットを決定
+       (users.wallet_address 優先 / 未設定なら AAVE_WALLET_ADDRESS env)
+    2. パートナー単位で Aave get_account_data() を取得
+    3. パートナーが招待したテスターに均等按分して PortfolioSnapshot を保存
+    4. テスターが存在しないパートナーはスキップ
+    5. 招待関係のテスターが 1 件も無い場合は管理者ユーザーに
+       admin.wallet_address ベースのスナップショットを保存（fallback）
+    6. 日次 PortfolioHistory を作成または更新
 
-    Aave 接続エラー時はログのみで早期リターン（fail-open）。
+    各パートナーの Aave 接続エラーはログのみで当該パートナーをスキップ（fail-open）。
 
     Returns:
-        dict: {"snapshots_created": int, "total_supply_usd": str, ...}
+        dict: {"snapshots_created": int, "partners_processed": int, ...}
     """
     _own_session = db is None
     if _own_session:
@@ -136,40 +150,32 @@ def record_portfolio_snapshot(db: Optional[Session] = None) -> dict[str, Any]:
 
     now = datetime.now(timezone.utc)
     snapshots_created = 0
+    partners_processed = 0
+    partners_skipped = 0
+    last_total_supply: Optional[Decimal] = None
+    last_total_debt: Optional[Decimal] = None
+    last_hf: Optional[Decimal] = None
 
     try:
-        # --- Aaveデータ取得（失敗時はスキップ） ---
-        wallet_address = os.getenv("AAVE_WALLET_ADDRESS", "")
         try:
             client = get_default_aave_client()
-            account_data = client.get_account_data(wallet_address)
         except Exception as exc:
-            logger.warning("portfolio_snapshot: Aave get_account_data failed, skipping: %s", exc)
+            logger.warning("portfolio_snapshot: Aave client init failed, skipping: %s", exc)
             return {"snapshots_created": 0, "skipped": True, "reason": str(exc)}
 
-        total_supply = Decimal(str(account_data.total_collateral_usd))
-        total_debt = Decimal(str(account_data.total_debt_usd))
-        net_worth = total_supply - total_debt
-        hf = _normalize_hf(Decimal(str(account_data.health_factor)))
-
-        # --- グローバルFundAllocation合計（比率計算用） ---
-        global_allocated_raw = (
-            db.query(func.sum(FundAllocation.allocated_amount_usd))
-            .filter(FundAllocation.status == "active")
-            .scalar()
-        )
-        global_total = Decimal(str(global_allocated_raw)) if global_allocated_raw else Decimal("0")
-
-        # --- パートナーごとにテスターへ按分して保存 ---
+        # --- パートナーごとに対象テスターを持つ partner_id を列挙 ---
         partner_rows = (
             db.query(User.invited_by)
             .filter(User.invited_by.isnot(None), User.is_active == True)  # noqa: E712
             .distinct()
             .all()
         )
-        n_partners = len(partner_rows) or 1
 
         for (partner_id,) in partner_rows:
+            partner = db.query(User).filter(User.id == partner_id).first()
+            if partner is None:
+                continue
+
             testers = (
                 db.query(User)
                 .filter(User.invited_by == partner_id, User.is_active == True)  # noqa: E712
@@ -178,63 +184,108 @@ def record_portfolio_snapshot(db: Optional[Session] = None) -> dict[str, Any]:
             if not testers:
                 continue
 
-            # このパートナーのアクティブFundAllocation合計
-            partner_allocated_raw = (
-                db.query(func.sum(FundAllocation.allocated_amount_usd))
-                .filter(
-                    FundAllocation.partner_id == partner_id,
-                    FundAllocation.status == "active",
+            wallet_addr = _get_wallet_address(partner)
+            if not wallet_addr:
+                logger.warning(
+                    "portfolio_snapshot: partner_id=%d has no wallet_address and"
+                    " AAVE_WALLET_ADDRESS is unset; skipping",
+                    partner_id,
                 )
-                .scalar()
-            )
-            partner_allocated = (
-                Decimal(str(partner_allocated_raw)) if partner_allocated_raw else Decimal("0")
-            )
+                partners_skipped += 1
+                continue
 
-            # パートナーの全体比率（FundAllocationがない場合はパートナー数で均等割り）
-            if global_total > Decimal("0") and partner_allocated > Decimal("0"):
-                partner_ratio = partner_allocated / global_total
-            else:
-                partner_ratio = Decimal("1") / Decimal(str(n_partners))
+            try:
+                account_data = client.get_account_data(wallet_addr)
+            except Exception as exc:
+                logger.warning(
+                    "portfolio_snapshot: Aave get_account_data failed for"
+                    " partner_id=%d (wallet=%s...): %s",
+                    partner_id,
+                    wallet_addr[:10] if wallet_addr else "<empty>",
+                    exc,
+                )
+                partners_skipped += 1
+                continue
 
-            partner_supply = (total_supply * partner_ratio).quantize(Decimal("0.000001"))
-            partner_debt = (total_debt * partner_ratio).quantize(Decimal("0.000001"))
+            partner_supply = Decimal(str(account_data.total_collateral_usd))
+            partner_debt = Decimal(str(account_data.total_debt_usd))
+            partner_hf = _normalize_hf(Decimal(str(account_data.health_factor)))
 
-            # テスターに均等按分
             n_testers = Decimal(str(len(testers)))
             tester_supply = (partner_supply / n_testers).quantize(Decimal("0.000001"))
             tester_debt = (partner_debt / n_testers).quantize(Decimal("0.000001"))
             tester_net = tester_supply - tester_debt
 
             for tester in testers:
-                _save_snapshot(db, tester.id, tester_supply, tester_debt, tester_net, hf, now)
-                _upsert_daily_history(db, tester.id, tester_net, hf, now)
+                _save_snapshot(
+                    db, tester.id, tester_supply, tester_debt, tester_net, partner_hf, now
+                )
+                _upsert_daily_history(db, tester.id, tester_net, partner_hf, now)
                 snapshots_created += 1
 
-        # --- テスターが誰もいない場合は管理者ユーザーに全体スナップショットを保存 ---
-        if snapshots_created == 0:
+            partners_processed += 1
+            last_total_supply = partner_supply
+            last_total_debt = partner_debt
+            last_hf = partner_hf
+            logger.info(
+                "portfolio_snapshot: partner_id=%d processed, testers=%d,"
+                " supply=%s, debt=%s, hf=%s",
+                partner_id,
+                len(testers),
+                partner_supply,
+                partner_debt,
+                partner_hf,
+            )
+
+        # --- 招待関係下のテスターが居ない場合: 管理者ユーザーに admin.wallet_address ベースで保存 ---
+        if snapshots_created == 0 and partners_skipped == 0:
             admin = (
                 db.query(User)
                 .filter(User.role == "admin", User.is_active == True)  # noqa: E712
                 .first()
             )
             if admin is not None:
-                _save_snapshot(db, admin.id, total_supply, total_debt, net_worth, hf, now)
-                _upsert_daily_history(db, admin.id, net_worth, hf, now)
-                snapshots_created += 1
+                admin_wallet = _get_wallet_address(admin)
+                if not admin_wallet:
+                    logger.warning(
+                        "portfolio_snapshot: admin has no wallet_address and"
+                        " AAVE_WALLET_ADDRESS is unset; skipping"
+                    )
+                else:
+                    try:
+                        account_data = client.get_account_data(admin_wallet)
+                    except Exception as exc:
+                        logger.warning(
+                            "portfolio_snapshot: Aave get_account_data failed for admin: %s",
+                            exc,
+                        )
+                        return {"snapshots_created": 0, "skipped": True, "reason": str(exc)}
+                    admin_supply = Decimal(str(account_data.total_collateral_usd))
+                    admin_debt = Decimal(str(account_data.total_debt_usd))
+                    admin_net = admin_supply - admin_debt
+                    admin_hf = _normalize_hf(Decimal(str(account_data.health_factor)))
+                    _save_snapshot(db, admin.id, admin_supply, admin_debt, admin_net, admin_hf, now)
+                    _upsert_daily_history(db, admin.id, admin_net, admin_hf, now)
+                    snapshots_created += 1
+                    last_total_supply = admin_supply
+                    last_total_debt = admin_debt
+                    last_hf = admin_hf
 
         db.commit()
         logger.info(
-            "portfolio_snapshot completed: snapshots_created=%d, total_supply=%s, health_factor=%s",
+            "portfolio_snapshot completed: snapshots_created=%d,"
+            " partners_processed=%d, partners_skipped=%d",
             snapshots_created,
-            total_supply,
-            hf,
+            partners_processed,
+            partners_skipped,
         )
         return {
             "snapshots_created": snapshots_created,
-            "total_supply_usd": str(total_supply),
-            "total_debt_usd": str(total_debt),
-            "health_factor": str(hf) if hf is not None else None,
+            "partners_processed": partners_processed,
+            "partners_skipped": partners_skipped,
+            "total_supply_usd": str(last_total_supply) if last_total_supply is not None else None,
+            "total_debt_usd": str(last_total_debt) if last_total_debt is not None else None,
+            "health_factor": str(last_hf) if last_hf is not None else None,
         }
 
     except Exception as exc:

--- a/backend/tests/test_portfolio_snapshot_service.py
+++ b/backend/tests/test_portfolio_snapshot_service.py
@@ -1,6 +1,11 @@
 # Copyright (c) Ultra AutoTrade. All rights reserved.
 # backend/tests/test_portfolio_snapshot_service.py
-"""ポートフォリオスナップショットサービスのテスト。"""
+"""ポートフォリオスナップショットサービスのテスト。
+
+wallet_address 伝播版 (Lane 14): パートナーごとに wallet_address を解決して
+Aave get_account_data() を個別に呼ぶ。テスター 1 件以上を抱える各パートナーが
+独立した Aave データを記録する。
+"""
 
 import os
 import tempfile
@@ -18,9 +23,10 @@ os.environ.setdefault("INITIAL_ADMIN_EMAIL", "admin@snapshot-test.com")
 from app.aave.client import AccountData  # noqa: E402
 from app.auth.models import User  # noqa: E402
 from app.database import Base  # noqa: E402
-from app.partner.allocation_models import FundAllocation  # noqa: E402
+from app.partner.allocation_models import FundAllocation  # noqa: E402,F401
 from app.portfolio.models import PortfolioHistory, PortfolioSnapshot  # noqa: E402
 from app.portfolio.snapshot_service import (  # noqa: E402
+    _get_wallet_address,
     _normalize_hf,
     _upsert_daily_history,
     record_portfolio_snapshot,
@@ -47,7 +53,7 @@ def db_session() -> Generator[Session, None, None]:
         os.unlink(path)
 
 
-def _make_admin(db: Session, uid: int = 1) -> User:
+def _make_admin(db: Session, uid: int = 1, wallet: str | None = None) -> User:
     user = User(
         id=uid,
         email=f"admin{uid}@test.com",
@@ -55,6 +61,7 @@ def _make_admin(db: Session, uid: int = 1) -> User:
         hashed_password="x",
         role="admin",
         is_active=True,
+        wallet_address=wallet,
     )
     db.add(user)
     db.flush()
@@ -66,6 +73,7 @@ def _make_user(
     uid: int,
     invited_by: int | None = None,
     role: str = "viewer",
+    wallet: str | None = None,
 ) -> User:
     user = User(
         id=uid,
@@ -75,6 +83,7 @@ def _make_user(
         role=role,
         is_active=True,
         invited_by=invited_by,
+        wallet_address=wallet,
     )
     db.add(user)
     db.flush()
@@ -114,6 +123,35 @@ class TestNormalizeHf:
 
 
 # ---------------------------------------------------------------------------
+# _get_wallet_address
+# ---------------------------------------------------------------------------
+
+
+class TestGetWalletAddress:
+    def test_user_wallet_preferred(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """users.wallet_address が設定されていれば env より優先される。"""
+        monkeypatch.setenv("AAVE_WALLET_ADDRESS", "0xENV_FALLBACK")
+        u = _make_user(db_session, uid=100, wallet="0xUSER_WALLET")
+        assert _get_wallet_address(u) == "0xUSER_WALLET"
+
+    def test_env_fallback(self, db_session: Session, monkeypatch: pytest.MonkeyPatch) -> None:
+        """users.wallet_address が None なら env にフォールバックする。"""
+        monkeypatch.setenv("AAVE_WALLET_ADDRESS", "0xENV_FALLBACK")
+        u = _make_user(db_session, uid=100, wallet=None)
+        assert _get_wallet_address(u) == "0xENV_FALLBACK"
+
+    def test_both_unset_returns_empty(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """users.wallet_address も env も未設定なら空文字を返す。"""
+        monkeypatch.delenv("AAVE_WALLET_ADDRESS", raising=False)
+        u = _make_user(db_session, uid=100, wallet=None)
+        assert _get_wallet_address(u) == ""
+
+
+# ---------------------------------------------------------------------------
 # _upsert_daily_history
 # ---------------------------------------------------------------------------
 
@@ -140,10 +178,8 @@ class TestUpsertDailyHistory:
 
         _make_admin(db_session)
         now = datetime.now(timezone.utc)
-        # 1回目 (open = 7000)
         _upsert_daily_history(db_session, 1, Decimal("7000"), Decimal("2.5"), now)
         db_session.flush()
-        # 2回目 (close = 7500)
         _upsert_daily_history(db_session, 1, Decimal("7500"), Decimal("2.6"), now)
         db_session.flush()
 
@@ -181,19 +217,26 @@ class TestRecordPortfolioSnapshot:
         mock_client.get_account_data.return_value = account_data
         return mock_client
 
-    def test_no_testers_saves_admin_snapshot(self, db_session: Session) -> None:
-        """テスターがいない場合、管理者ユーザーのスナップショットを保存する。"""
-        _make_admin(db_session, uid=1)
+    def test_no_testers_saves_admin_snapshot(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """テスターがいない場合、管理者ユーザーの wallet_address でスナップショットを保存する。"""
+        _make_admin(db_session, uid=1, wallet="0xADMIN")
+        monkeypatch.delenv("AAVE_WALLET_ADDRESS", raising=False)
         db_session.commit()
 
         account_data = _make_account_data("10000", "3000", "2.5")
+        mock_client = self._mock_aave_client(account_data)
         with patch(
             "app.portfolio.snapshot_service.get_default_aave_client",
-            return_value=self._mock_aave_client(account_data),
+            return_value=mock_client,
         ):
             result = record_portfolio_snapshot(db_session)
 
         assert result["snapshots_created"] == 1
+        # admin の wallet で Aave が呼ばれたことを確認
+        mock_client.get_account_data.assert_called_once_with("0xADMIN")
+
         snap = db_session.query(PortfolioSnapshot).first()
         assert snap is not None
         assert snap.user_id == 1
@@ -201,36 +244,80 @@ class TestRecordPortfolioSnapshot:
         assert Decimal(str(snap.total_borrow_usd)) == Decimal("3000")
         assert Decimal(str(snap.total_value_usd)) == Decimal("7000")  # net_worth
 
-    def test_with_testers_saves_per_tester(self, db_session: Session) -> None:
-        """テスターが2人いる場合、それぞれにスナップショットを保存する。"""
-        partner = _make_user(db_session, uid=10, role="partner")
+    def test_no_testers_admin_uses_env_fallback(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """admin.wallet_address が None でも AAVE_WALLET_ADDRESS env で fallback して保存される。"""
+        _make_admin(db_session, uid=1, wallet=None)
+        monkeypatch.setenv("AAVE_WALLET_ADDRESS", "0xENV_ADMIN")
+        db_session.commit()
+
+        account_data = _make_account_data("5000", "1000", "3.0")
+        mock_client = self._mock_aave_client(account_data)
+        with patch(
+            "app.portfolio.snapshot_service.get_default_aave_client",
+            return_value=mock_client,
+        ):
+            result = record_portfolio_snapshot(db_session)
+
+        assert result["snapshots_created"] == 1
+        mock_client.get_account_data.assert_called_once_with("0xENV_ADMIN")
+
+    def test_with_testers_saves_per_tester(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """テスター 2 人が同じパートナー配下のとき、partner.wallet_address で 1 回 Aave を呼んで均等按分する。"""
+        monkeypatch.delenv("AAVE_WALLET_ADDRESS", raising=False)
+        partner = _make_user(db_session, uid=10, role="partner", wallet="0xPARTNER_10")
         _make_user(db_session, uid=11, invited_by=partner.id)
         _make_user(db_session, uid=12, invited_by=partner.id)
         db_session.commit()
 
         account_data = _make_account_data("10000", "2000", "3.0")
+        mock_client = self._mock_aave_client(account_data)
         with patch(
             "app.portfolio.snapshot_service.get_default_aave_client",
-            return_value=self._mock_aave_client(account_data),
+            return_value=mock_client,
         ):
             result = record_portfolio_snapshot(db_session)
 
         assert result["snapshots_created"] == 2
+        assert result["partners_processed"] == 1
+        # partner の wallet で 1 回だけ呼ばれている
+        mock_client.get_account_data.assert_called_once_with("0xPARTNER_10")
+
         snaps = db_session.query(PortfolioSnapshot).all()
         user_ids = {s.user_id for s in snaps}
         assert user_ids == {11, 12}
-        # テスター2人で均等按分: supply = 5000, debt = 1000 each
+        # テスター 2 人で均等按分: supply = 5000, debt = 1000 each
         for snap in snaps:
             assert Decimal(str(snap.total_supply_usd)) == Decimal("5000.000000")
             assert Decimal(str(snap.total_borrow_usd)) == Decimal("1000.000000")
 
-    def test_aave_error_returns_skipped(self, db_session: Session) -> None:
-        """Aave接続エラー時はスキップして snapshots_created=0 を返す。"""
-        _make_admin(db_session, uid=1)
+    def test_partner_wallet_propagation_each_partner_isolated(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Lane 14 主旨: 各 partner.wallet_address で別個に Aave を fetch する。"""
+        monkeypatch.delenv("AAVE_WALLET_ADDRESS", raising=False)
+        partner1 = _make_user(db_session, uid=10, role="partner", wallet="0xWALLET_P1")
+        partner2 = _make_user(db_session, uid=20, role="partner", wallet="0xWALLET_P2")
+        tester1 = _make_user(db_session, uid=11, invited_by=partner1.id)
+        tester2 = _make_user(db_session, uid=21, invited_by=partner2.id)
         db_session.commit()
 
         mock_client = MagicMock()
-        mock_client.get_account_data.side_effect = Exception("RPC connection failed")
+        # partner1 は 8000/1000、partner2 は 4000/500 の独立した Aave データを持つ
+        partner1_data = _make_account_data("8000", "1000", "2.5")
+        partner2_data = _make_account_data("4000", "500", "3.0")
+
+        def get_data(wallet: str) -> AccountData:
+            if wallet == "0xWALLET_P1":
+                return partner1_data
+            if wallet == "0xWALLET_P2":
+                return partner2_data
+            raise AssertionError(f"unexpected wallet: {wallet!r}")
+
+        mock_client.get_account_data.side_effect = get_data
 
         with patch(
             "app.portfolio.snapshot_service.get_default_aave_client",
@@ -238,13 +325,131 @@ class TestRecordPortfolioSnapshot:
         ):
             result = record_portfolio_snapshot(db_session)
 
+        assert result["snapshots_created"] == 2
+        assert result["partners_processed"] == 2
+
+        # 各 partner の wallet で 1 回ずつ呼ばれている
+        called_wallets = {c.args[0] for c in mock_client.get_account_data.call_args_list}
+        assert called_wallets == {"0xWALLET_P1", "0xWALLET_P2"}
+
+        snap1 = db_session.query(PortfolioSnapshot).filter_by(user_id=tester1.id).first()
+        snap2 = db_session.query(PortfolioSnapshot).filter_by(user_id=tester2.id).first()
+        assert snap1 is not None
+        assert snap2 is not None
+        # tester1 は partner1 の全データ (testers=1)
+        assert Decimal(str(snap1.total_supply_usd)) == Decimal("8000.000000")
+        assert Decimal(str(snap1.total_borrow_usd)) == Decimal("1000.000000")
+        # tester2 は partner2 の全データ (testers=1)
+        assert Decimal(str(snap2.total_supply_usd)) == Decimal("4000.000000")
+        assert Decimal(str(snap2.total_borrow_usd)) == Decimal("500.000000")
+
+    def test_partner_env_fallback_when_no_wallet(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """partner.wallet_address が None のとき AAVE_WALLET_ADDRESS env でフォールバックする。"""
+        monkeypatch.setenv("AAVE_WALLET_ADDRESS", "0xENV_FALLBACK")
+        partner = _make_user(db_session, uid=10, role="partner", wallet=None)
+        _make_user(db_session, uid=11, invited_by=partner.id)
+        db_session.commit()
+
+        account_data = _make_account_data("6000", "0", "999")
+        mock_client = self._mock_aave_client(account_data)
+        with patch(
+            "app.portfolio.snapshot_service.get_default_aave_client",
+            return_value=mock_client,
+        ):
+            result = record_portfolio_snapshot(db_session)
+
+        assert result["snapshots_created"] == 1
+        mock_client.get_account_data.assert_called_once_with("0xENV_FALLBACK")
+
+    def test_partner_skipped_when_no_wallet_and_no_env(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """partner.wallet_address も env も未設定なら当該 partner はスキップ（fail-open）。"""
+        monkeypatch.delenv("AAVE_WALLET_ADDRESS", raising=False)
+        partner_ok = _make_user(db_session, uid=10, role="partner", wallet="0xPARTNER_10")
+        partner_no_wallet = _make_user(db_session, uid=20, role="partner", wallet=None)
+        _make_user(db_session, uid=11, invited_by=partner_ok.id)
+        _make_user(db_session, uid=21, invited_by=partner_no_wallet.id)
+        db_session.commit()
+
+        account_data = _make_account_data("8000", "0", "999")
+        mock_client = self._mock_aave_client(account_data)
+        with patch(
+            "app.portfolio.snapshot_service.get_default_aave_client",
+            return_value=mock_client,
+        ):
+            result = record_portfolio_snapshot(db_session)
+
+        # partner_ok のみ処理されて partner_no_wallet はスキップ
+        assert result["snapshots_created"] == 1
+        assert result["partners_processed"] == 1
+        assert result["partners_skipped"] == 1
+        mock_client.get_account_data.assert_called_once_with("0xPARTNER_10")
+
+        # tester2 (partner_no_wallet の招待) には snapshot が無い
+        assert db_session.query(PortfolioSnapshot).filter_by(user_id=21).count() == 0
+        # tester1 (partner_ok の招待) には snapshot がある
+        assert db_session.query(PortfolioSnapshot).filter_by(user_id=11).count() == 1
+
+    def test_partner_aave_error_skips_only_that_partner(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """1 partner の Aave fetch 失敗時、他 partner は継続して snapshot を作る（fail-open per partner）。"""
+        monkeypatch.delenv("AAVE_WALLET_ADDRESS", raising=False)
+        partner1 = _make_user(db_session, uid=10, role="partner", wallet="0xOK")
+        partner2 = _make_user(db_session, uid=20, role="partner", wallet="0xFAIL")
+        _make_user(db_session, uid=11, invited_by=partner1.id)
+        _make_user(db_session, uid=21, invited_by=partner2.id)
+        db_session.commit()
+
+        def side_effect(wallet: str) -> AccountData:
+            if wallet == "0xOK":
+                return _make_account_data("7000", "0", "999")
+            raise Exception("RPC connection failed")
+
+        mock_client = MagicMock()
+        mock_client.get_account_data.side_effect = side_effect
+        with patch(
+            "app.portfolio.snapshot_service.get_default_aave_client",
+            return_value=mock_client,
+        ):
+            result = record_portfolio_snapshot(db_session)
+
+        assert result["snapshots_created"] == 1
+        assert result["partners_processed"] == 1
+        assert result["partners_skipped"] == 1
+        # tester2 には snapshot 無し
+        assert db_session.query(PortfolioSnapshot).filter_by(user_id=21).count() == 0
+
+    def test_aave_client_init_error_returns_skipped(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Aave クライアント初期化失敗時はスキップして snapshots_created=0 を返す。"""
+        _make_admin(db_session, uid=1, wallet="0xADMIN")
+        monkeypatch.delenv("AAVE_WALLET_ADDRESS", raising=False)
+        db_session.commit()
+
+        def raise_init() -> None:
+            raise Exception("RPC connection failed")
+
+        with patch(
+            "app.portfolio.snapshot_service.get_default_aave_client",
+            side_effect=raise_init,
+        ):
+            result = record_portfolio_snapshot(db_session)
+
         assert result["snapshots_created"] == 0
         assert result.get("skipped") is True
         assert db_session.query(PortfolioSnapshot).count() == 0
 
-    def test_creates_daily_history(self, db_session: Session) -> None:
+    def test_creates_daily_history(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """スナップショット保存時に日次PortfolioHistoryも作成される。"""
-        _make_admin(db_session, uid=1)
+        _make_admin(db_session, uid=1, wallet="0xADMIN")
+        monkeypatch.delenv("AAVE_WALLET_ADDRESS", raising=False)
         db_session.commit()
 
         account_data = _make_account_data("8000", "0", "999")
@@ -261,14 +466,22 @@ class TestRecordPortfolioSnapshot:
         assert Decimal(str(history.open_value_usd)) == Decimal("8000")
         assert history.snapshot_count == 1
 
-    def test_fund_allocation_ratio(self, db_session: Session) -> None:
-        """FundAllocation の比率に基づいて按分される。"""
-        partner1 = _make_user(db_session, uid=10, role="partner")
-        partner2 = _make_user(db_session, uid=20, role="partner")
+    def test_fund_allocation_amount_does_not_affect_snapshot(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """新ロジック: FundAllocation の金額に関係なく、各 partner は自分の Aave 全額を記録する。
+
+        旧ロジック (グローバル fetch + ratio 按分) では FundAllocation の比率で
+        partner1=60%, partner2=40% に分割されていたが、wallet_address 伝播版では
+        各 partner が独立した Aave データを取得するため ratio は適用されない。
+        """
+        monkeypatch.delenv("AAVE_WALLET_ADDRESS", raising=False)
+        partner1 = _make_user(db_session, uid=10, role="partner", wallet="0xP1")
+        partner2 = _make_user(db_session, uid=20, role="partner", wallet="0xP2")
         tester1 = _make_user(db_session, uid=11, invited_by=partner1.id)
         tester2 = _make_user(db_session, uid=21, invited_by=partner2.id)
 
-        # partner1: 6000, partner2: 4000 → 合計10000
+        # 旧テストと同じ allocations: partner1=6000, partner2=4000
         db_session.add(
             FundAllocation(
                 partner_id=partner1.id,
@@ -287,10 +500,19 @@ class TestRecordPortfolioSnapshot:
         )
         db_session.commit()
 
-        account_data = _make_account_data("10000", "0", "999")
+        # 両 partner で異なる Aave データを返す
+        def get_data(wallet: str) -> AccountData:
+            if wallet == "0xP1":
+                return _make_account_data("10000", "0", "999")
+            if wallet == "0xP2":
+                return _make_account_data("3000", "0", "999")
+            raise AssertionError(f"unexpected wallet: {wallet!r}")
+
+        mock_client = MagicMock()
+        mock_client.get_account_data.side_effect = get_data
         with patch(
             "app.portfolio.snapshot_service.get_default_aave_client",
-            return_value=self._mock_aave_client(account_data),
+            return_value=mock_client,
         ):
             result = record_portfolio_snapshot(db_session)
 
@@ -299,13 +521,16 @@ class TestRecordPortfolioSnapshot:
         snap2 = db_session.query(PortfolioSnapshot).filter_by(user_id=tester2.id).first()
         assert snap1 is not None
         assert snap2 is not None
-        # partner1(60%): supply=6000, partner2(40%): supply=4000
-        assert Decimal(str(snap1.total_supply_usd)) == Decimal("6000.000000")
-        assert Decimal(str(snap2.total_supply_usd)) == Decimal("4000.000000")
+        # FundAllocation の比率は無視: 各 partner の wallet が返した実値を使う
+        assert Decimal(str(snap1.total_supply_usd)) == Decimal("10000.000000")
+        assert Decimal(str(snap2.total_supply_usd)) == Decimal("3000.000000")
 
-    def test_inactive_tester_excluded(self, db_session: Session) -> None:
+    def test_inactive_tester_excluded(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """is_active=False のテスターはスナップショット対象外。"""
-        partner = _make_user(db_session, uid=10, role="partner")
+        monkeypatch.delenv("AAVE_WALLET_ADDRESS", raising=False)
+        partner = _make_user(db_session, uid=10, role="partner", wallet="0xP10")
         _make_user(db_session, uid=11, invited_by=partner.id)
         inactive = _make_user(db_session, uid=12, invited_by=partner.id)
         inactive.is_active = False
@@ -321,10 +546,15 @@ class TestRecordPortfolioSnapshot:
         assert result["snapshots_created"] == 1
         snap = db_session.query(PortfolioSnapshot).first()
         assert snap.user_id == 11
+        # アクティブテスター 1 人なので全額が tester11 へ
+        assert Decimal(str(snap.total_supply_usd)) == Decimal("10000.000000")
 
-    def test_infinity_hf_stored_as_none(self, db_session: Session) -> None:
+    def test_infinity_hf_stored_as_none(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """HF が Infinity のとき health_factor=None で保存される。"""
-        _make_admin(db_session, uid=1)
+        _make_admin(db_session, uid=1, wallet="0xADMIN")
+        monkeypatch.delenv("AAVE_WALLET_ADDRESS", raising=False)
         db_session.commit()
 
         account_data = AccountData(


### PR DESCRIPTION
## Summary

`backend/app/portfolio/snapshot_service.py` の `record_portfolio_snapshot()` を **per-partner Aave fetch** に書き換える。各 `partner.wallet_address` (env fallback) で独立に `client.get_account_data()` を呼び、そのパートナーが招待したテスターに均等按分する。

旧ロジック (グローバル fetch 1 回 + `FundAllocation` ratio 按分) を撤去し、`app.partner.allocation_service._get_wallet_address` と同一セマンティクスに揃える。

**Asana**: 1215185706436406 (Lane 14)  
**並走**: Lane 13 (`backend/app/proposals/router.py`, wallet_address 伝播) — 触るファイル別なので conflict なし

## Changes

### `backend/app/portfolio/snapshot_service.py`

- `_get_wallet_address(user)` ヘルパ追加 (`users.wallet_address` 優先 / `AAVE_WALLET_ADDRESS` env fallback / 同一セマンティクスは `app.partner.allocation_service._get_wallet_address` 既存)
- `record_portfolio_snapshot()` を per-partner Aave fetch に書き換え:
  1. partner ごとに `_get_wallet_address(partner)` で対象ウォレット決定
  2. `client.get_account_data(wallet)` をパートナー単位で呼出
  3. パートナーが招待した active テスターに均等按分
  4. partner ごとに fail-open: Aave fetch 失敗 / wallet 未設定 → 当該 partner のみ skip (他 partner は継続)
- 招待関係下の active テスター 0 件のときのみ `admin.wallet_address` で fallback (env 経由 OK)
- 戻り値に `partners_processed` / `partners_skipped` 追加 (既存キー `snapshots_created` / `total_supply_usd` / `total_debt_usd` / `health_factor` / `skipped` / `reason` は温存。最後に処理した partner の数値が入る)
- 未使用 import (`sqlalchemy.func` / `FundAllocation`) を削除

### `backend/tests/test_portfolio_snapshot_service.py`

- 既存テストを per-partner セマンティクスに更新 (`monkeypatch` で env / wallet_address を明示的に制御)
- 旧 `test_fund_allocation_ratio` を `test_fund_allocation_amount_does_not_affect_snapshot` に置換 (FundAllocation 金額が snapshot 額に影響しないことを assert)
- 新規テスト 5 件追加:
  - `TestGetWalletAddress` 3 件 (user wallet 優先 / env fallback / 両方未設定で空文字)
  - `test_partner_wallet_propagation_each_partner_isolated` — 2 partner が別 wallet で独立 fetch されること
  - `test_partner_env_fallback_when_no_wallet` — partner.wallet_address None で env fallback
  - `test_partner_skipped_when_no_wallet_and_no_env` — wallet も env も無いと skip
  - `test_partner_aave_error_skips_only_that_partner` — partner 単位 fail-open
  - `test_aave_client_init_error_returns_skipped` — クライアント初期化失敗時の早期 skip

## DoD ゲート結果

| Gate | Result |
|---|---|
| 1. `ruff check`  | ✅ All checks passed |
| 2. `ruff format --check` | ✅ already formatted |
| 3. `mypy app/portfolio/snapshot_service.py` | ✅ Success: no issues found |
| 4. `pytest tests/test_portfolio_snapshot_service.py` | ✅ 22 passed |
| 4b. 周辺テスト (portfolio_api / portfolio_live / ai_judgment_scheduler) | ✅ 計 77 passed |
| 5. `ruff check . --select S` (security) | ✅ All checks passed |

## 互換性 / 配線確認

- 呼出元: `backend/app/automation/ai_judgment_scheduler.py:513` (`record_portfolio_snapshot` の戻り値を logger に流すだけ、シグネチャ変更なし)
- DB スキーマ変更なし
- `User.wallet_address` カラムは既に存在 (`backend/app/auth/models.py:246`)
- `FundAllocation` import を削除したが、本番では `allocation_service.py` 等で引き続き使用されているため影響なし

## 本番反映時の挙動変化 (重要)

旧:
- ENV の `AAVE_WALLET_ADDRESS` 1 ウォレットの Aave データを `FundAllocation` 比率で全 partner に按分 → tester に均等割

新:
- 各 partner が `partner.wallet_address` を持っていれば実 wallet のデータを記録 (より正確)
- `partner.wallet_address` 未設定 → `AAVE_WALLET_ADDRESS` env で fallback (旧 ENV 単独運用と同等の data だが、複数 partner が同じ ENV を共有する場合は **double-counting される** ことに注意)
- 本番で複数 partner を運用する場合は各 partner の wallet_address を DB に設定すること推奨

## DoD 本文未取得の旨

本作業に着手した background session から Asana MCP が利用できず、Asana タスク 1215185706436406 の DoD 本文を取得できなかった。実装方針は:

1. ユーザー hint「wallet_address 伝播」+ 「Lane 13 と同じ趣旨で別ファイル」
2. 既存 `app/partner/allocation_service.py` の `_get_wallet_address(partner)` パターン (allocation_service ではこの形が確立済み)

に基づき、`AskUserQuestion` で方針確認の上「per-partner Aave fetch に全面切替 (Recommended)」を採用した。Asana DoD 本文の精細な記述に応じた再調整が必要であれば追加コミットで対応する。

## Test plan

- [x] `python -m pytest backend/tests/test_portfolio_snapshot_service.py -q` (22 passed)
- [x] `python -m pytest backend/tests/test_portfolio_api.py backend/tests/test_portfolio_live.py -q` (regression なし)
- [x] `python -m pytest backend/tests/test_ai_judgment_scheduler.py -q` (caller 配線確認)
- [x] `ruff check / format / S` clean
- [x] `mypy` Success
- [ ] staging 反映時に複数 partner で `partners_processed` ログを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)