### PR TITLE
feat(launch-gate): skip-only FAIL 構造的判定 helper (G-1/G-2/G-3)

### DIFF
--- a/scripts/launch_gate/L3_e2e.sh
+++ b/scripts/launch_gate/L3_e2e.sh
@@ -144,23 +144,15 @@ if [[ ! -f "${RESULTS_JSON}" ]]; then
   exit 1
 fi
 
-if ! command -v jq >/dev/null 2>&1; then
-  # jq が無い環境 → 後方互換で rc のみ見る (skip-only 判定はできないので警告)
-  echo "[WARN] jq が見つからないため json 解析できません。rc のみで判定します。"
-  if [[ "${playwright_rc}" -eq 0 ]]; then
-    gate_record PASS "${LABEL}" "playwright rc=0 (jq 不在で skip-only 判定 skip)"
-    exit 0
-  fi
-  gate_record FAIL "${LABEL}" "playwright rc=${playwright_rc}"
-  exit 1
-fi
+# lib.sh 提供 _parse_playwright_stat による 3 段フォールバック (jq → python3 → grep)。
+# jq 不在環境でも skip-only 判定が機能するよう helper 経由化 (G scope, Asana 1215186819755146)。
+# memory [[feedback-skip-only-fail-at-gate-not-spec]]: gate 側で構造的に skip-only を FAIL に。
+PASSED=$(_parse_playwright_stat "${RESULTS_JSON}" "expected")
+FAILED=$(_parse_playwright_stat "${RESULTS_JSON}" "unexpected")
+SKIPPED=$(_parse_playwright_stat "${RESULTS_JSON}" "skipped")
+FLAKY=$(_parse_playwright_stat "${RESULTS_JSON}" "flaky")
 
-PASSED=$(jq -r '.stats.expected // 0' "${RESULTS_JSON}" 2>/dev/null || echo 0)
-FAILED=$(jq -r '.stats.unexpected // 0' "${RESULTS_JSON}" 2>/dev/null || echo 0)
-SKIPPED=$(jq -r '.stats.skipped // 0' "${RESULTS_JSON}" 2>/dev/null || echo 0)
-FLAKY=$(jq -r '.stats.flaky // 0' "${RESULTS_JSON}" 2>/dev/null || echo 0)
-
-# 数値防御 (jq が null 返した場合の保険)
+# 数値防御 (helper が空文字を返した場合の保険)
 PASSED=${PASSED:-0}
 FAILED=${FAILED:-0}
 SKIPPED=${SKIPPED:-0}

--- a/scripts/launch_gate/lib.sh
+++ b/scripts/launch_gate/lib.sh
@@ -8,6 +8,8 @@
 #   - log_pass / log_fail / log_skip   (統一フォーマット出力)
 #   - is_dev_vps                       (dev VPS 判定 — prod に SSH 不可な環境かどうか)
 #   - gate_record / gate_summary       (結果集約用)
+#   - assert_not_skip_only_playwright  (Playwright JSON で skip-only を構造的 FAIL に)
+#   - assert_not_skip_only_pytest      (pytest summary 行で skip-only を構造的 FAIL に)
 #
 # 出力フォーマット (色・CR は使わない):
 #   [PASS] L0 schema: <要約>
@@ -134,4 +136,103 @@ gate_project_root() {
   lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   # scripts/launch_gate/ から 2 つ上が PROJECT_ROOT
   (cd "${lib_dir}/../.." && pwd)
+}
+
+# ---------------------------------------------------------------------------
+# skip-only 構造的判定 helper (G scope, 2026-05-28 追加)
+#
+# memory [[feedback-skip-only-fail-at-gate-not-spec]] の意図:
+#   spec 内に skip-on-skip 多段配線するのではなく、gate script 側で
+#   「PASS=0 / FAIL=0 / SKIP>0」を機械的に検出して FAIL に倒す。
+#
+# 使い方:
+#   # Playwright JSON 結果
+#   if ! assert_not_skip_only_playwright "${RESULTS_JSON}"; then
+#     gate_record FAIL "${LABEL}" "skip-only run (gate 側構造的 FAIL)"
+#     exit 1
+#   fi
+#
+#   # pytest log (将来 L6/L7 で pytest 系を追加した場合)
+#   pytest ... 2>&1 | tee /tmp/Lx_pytest.log
+#   if ! assert_not_skip_only_pytest /tmp/Lx_pytest.log; then
+#     gate_record FAIL "${LABEL}" "pytest skip-only (gate 側構造的 FAIL)"
+#     exit 1
+#   fi
+#
+# 戻り値:
+#   0 — skip-only でない (passed>0 or failed>0)、または判定不能 (ファイル無し)
+#   1 — skip-only (passed=0 && failed=0 && skipped>0)
+# ---------------------------------------------------------------------------
+
+# Playwright JSON stats フィールド取得 (jq → python3 → grep の 3 段フォールバック)
+_parse_playwright_stat() {
+  local json="$1" field="$2"
+  if [[ ! -f "${json}" ]]; then
+    echo 0
+    return 0
+  fi
+  if command -v jq >/dev/null 2>&1; then
+    jq -r ".stats.${field} // 0" "${json}" 2>/dev/null || echo 0
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c "import json,sys
+try:
+  d=json.load(open('${json}'))
+  print(d.get('stats',{}).get('${field}',0))
+except Exception:
+  print(0)" 2>/dev/null || echo 0
+  else
+    # 最終フォールバック: grep ベース (脆弱だが skip 判定よりは強い)
+    grep -oE "\"${field}\"[[:space:]]*:[[:space:]]*[0-9]+" "${json}" 2>/dev/null \
+      | head -1 \
+      | grep -oE '[0-9]+$' \
+      || echo 0
+  fi
+}
+
+assert_not_skip_only_playwright() {
+  local json="${1:-}"
+  if [[ -z "${json}" || ! -f "${json}" ]]; then
+    # JSON 無し → 判定不能、別の check で扱う
+    return 0
+  fi
+  local passed failed skipped flaky passed_total
+  passed=$(_parse_playwright_stat "${json}" "expected")
+  failed=$(_parse_playwright_stat "${json}" "unexpected")
+  skipped=$(_parse_playwright_stat "${json}" "skipped")
+  flaky=$(_parse_playwright_stat "${json}" "flaky")
+  # 数値防御
+  passed=${passed:-0}; failed=${failed:-0}; skipped=${skipped:-0}; flaky=${flaky:-0}
+  passed_total=$(( passed + flaky ))
+  if [[ "${passed_total}" -eq 0 && "${failed}" -eq 0 && "${skipped}" -gt 0 ]]; then
+    log_info "assert_not_skip_only_playwright: skip-only detected (passed=0 failed=0 skipped=${skipped})"
+    return 1
+  fi
+  return 0
+}
+
+assert_not_skip_only_pytest() {
+  local logfile="${1:-}"
+  if [[ -z "${logfile}" || ! -f "${logfile}" ]]; then
+    return 0
+  fi
+  # pytest 最終 summary 行を抽出
+  # 例: "===== 5 passed, 1 skipped in 1.23s ====="
+  #     "===== 3 skipped in 0.5s ====="
+  #     "===== 3 failed, 2 passed in 0.5s ====="
+  local summary
+  summary=$(grep -E '^=+ .*=+$' "${logfile}" 2>/dev/null | grep -E ' in [0-9.]+s ?' | tail -1)
+  if [[ -z "${summary}" ]]; then
+    # summary 行なし → 判定不能
+    return 0
+  fi
+  local has_pass has_fail has_skip
+  has_pass=$(echo "${summary}" | grep -cE '[0-9]+ passed' || true)
+  has_fail=$(echo "${summary}" | grep -cE '[0-9]+ (failed|error)' || true)
+  has_skip=$(echo "${summary}" | grep -cE '[0-9]+ skipped' || true)
+  has_pass=${has_pass:-0}; has_fail=${has_fail:-0}; has_skip=${has_skip:-0}
+  if [[ "${has_pass}" -eq 0 && "${has_fail}" -eq 0 && "${has_skip}" -gt 0 ]]; then
+    log_info "assert_not_skip_only_pytest: skip-only summary detected ('${summary}')"
+    return 1
+  fi
+  return 0
 }

--- a/tests/launch_gate/fixtures/playwright_all_passed.json
+++ b/tests/launch_gate/fixtures/playwright_all_passed.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "rootDir": "/tmp/fixture",
+    "version": "1.40.0"
+  },
+  "stats": {
+    "startTime": "2026-05-28T00:00:00.000Z",
+    "duration": 5678,
+    "expected": 5,
+    "skipped": 0,
+    "unexpected": 0,
+    "flaky": 0
+  },
+  "suites": []
+}

--- a/tests/launch_gate/fixtures/playwright_mixed.json
+++ b/tests/launch_gate/fixtures/playwright_mixed.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "rootDir": "/tmp/fixture",
+    "version": "1.40.0"
+  },
+  "stats": {
+    "startTime": "2026-05-28T00:00:00.000Z",
+    "duration": 3456,
+    "expected": 2,
+    "skipped": 1,
+    "unexpected": 1,
+    "flaky": 0
+  },
+  "suites": []
+}

--- a/tests/launch_gate/fixtures/playwright_skip_only.json
+++ b/tests/launch_gate/fixtures/playwright_skip_only.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "rootDir": "/tmp/fixture",
+    "version": "1.40.0"
+  },
+  "stats": {
+    "startTime": "2026-05-28T00:00:00.000Z",
+    "duration": 1234,
+    "expected": 0,
+    "skipped": 3,
+    "unexpected": 0,
+    "flaky": 0
+  },
+  "suites": []
+}

--- a/tests/launch_gate/fixtures/pytest_all_passed.log
+++ b/tests/launch_gate/fixtures/pytest_all_passed.log
@@ -1,0 +1,12 @@
+============================= test session starts =============================
+platform linux -- Python 3.11.4, pytest-7.4.0, pluggy-1.3.0
+rootdir: /tmp/fixture
+collected 6 items
+
+tests/foo.py .....                                                        [ 83%]
+tests/bar.py s                                                            [100%]
+
+=========================== short test summary info ============================
+SKIPPED [1] tests/bar.py:20: optional
+
+======================= 5 passed, 1 skipped in 1.23s ===========================

--- a/tests/launch_gate/fixtures/pytest_mixed.log
+++ b/tests/launch_gate/fixtures/pytest_mixed.log
@@ -1,0 +1,13 @@
+============================= test session starts =============================
+platform linux -- Python 3.11.4, pytest-7.4.0, pluggy-1.3.0
+rootdir: /tmp/fixture
+collected 5 items
+
+tests/foo.py ...                                                          [ 60%]
+tests/bar.py FF                                                           [100%]
+
+=========================== short test summary info ============================
+FAILED tests/bar.py::test_one - AssertionError
+FAILED tests/bar.py::test_two - RuntimeError
+
+========================= 2 failed, 3 passed in 0.50s ==========================

--- a/tests/launch_gate/fixtures/pytest_skip_only.log
+++ b/tests/launch_gate/fixtures/pytest_skip_only.log
@@ -1,0 +1,15 @@
+============================= test session starts =============================
+platform linux -- Python 3.11.4, pytest-7.4.0, pluggy-1.3.0
+rootdir: /tmp/fixture
+collected 3 items
+
+tests/foo.py s                                                            [ 33%]
+tests/bar.py s                                                            [ 66%]
+tests/baz.py s                                                            [100%]
+
+=========================== short test summary info ============================
+SKIPPED [1] tests/foo.py:10: env not set
+SKIPPED [1] tests/bar.py:20: feature flag off
+SKIPPED [1] tests/baz.py:30: needs prod credentials
+
+============================== 3 skipped in 0.50s ==============================

--- a/tests/launch_gate/test_assert_not_skip_only.sh
+++ b/tests/launch_gate/test_assert_not_skip_only.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# tests/launch_gate/test_assert_not_skip_only.sh
+#
+# scripts/launch_gate/lib.sh の skip-only 構造的判定 helper を smoke test。
+#
+# 対象 helper:
+#   - assert_not_skip_only_playwright (Playwright JSON 入力)
+#   - assert_not_skip_only_pytest     (pytest log 入力)
+#
+# Fixture: tests/launch_gate/fixtures/
+#   - playwright_skip_only.json   → exit 1 (skip-only)
+#   - playwright_all_passed.json  → exit 0
+#   - playwright_mixed.json       → exit 0 (failed > 0 は別 check に委ねる)
+#   - pytest_skip_only.log        → exit 1
+#   - pytest_all_passed.log       → exit 0
+#   - pytest_mixed.log            → exit 0
+#
+# Usage:
+#   bash tests/launch_gate/test_assert_not_skip_only.sh
+#   echo $?   # 0 = 全 case 期待通り, 1 以上 = 失敗件数
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+FIXTURES="${SCRIPT_DIR}/fixtures"
+
+# shellcheck disable=SC1091
+source "${ROOT}/scripts/launch_gate/lib.sh"
+
+pass=0
+fail=0
+total=0
+
+run_case() {
+  local name="$1" expected_rc="$2"
+  shift 2
+  total=$((total + 1))
+  local actual_rc
+  if "$@" >/dev/null 2>&1; then
+    actual_rc=0
+  else
+    actual_rc=$?
+  fi
+  if [[ "${actual_rc}" -eq "${expected_rc}" ]]; then
+    echo "  [PASS] ${name}  (rc=${actual_rc})"
+    pass=$((pass + 1))
+  else
+    echo "  [FAIL] ${name}  (expected rc=${expected_rc}, actual rc=${actual_rc})"
+    fail=$((fail + 1))
+  fi
+}
+
+echo "=== smoke: assert_not_skip_only_playwright ==="
+run_case "skip_only.json   → FAIL (rc=1)" 1 \
+  assert_not_skip_only_playwright "${FIXTURES}/playwright_skip_only.json"
+run_case "all_passed.json  → PASS (rc=0)" 0 \
+  assert_not_skip_only_playwright "${FIXTURES}/playwright_all_passed.json"
+run_case "mixed.json       → PASS (rc=0)" 0 \
+  assert_not_skip_only_playwright "${FIXTURES}/playwright_mixed.json"
+
+echo ""
+echo "=== smoke: assert_not_skip_only_pytest ==="
+run_case "skip_only.log    → FAIL (rc=1)" 1 \
+  assert_not_skip_only_pytest "${FIXTURES}/pytest_skip_only.log"
+run_case "all_passed.log   → PASS (rc=0)" 0 \
+  assert_not_skip_only_pytest "${FIXTURES}/pytest_all_passed.log"
+run_case "mixed.log        → PASS (rc=0)" 0 \
+  assert_not_skip_only_pytest "${FIXTURES}/pytest_mixed.log"
+
+echo ""
+echo "--- Result: ${pass}/${total} passed, ${fail} failed ---"
+exit "${fail}"


### PR DESCRIPTION
## Summary

memory [[feedback-skip-only-fail-at-gate-not-spec]] の方針に従い、spec 内多段 skip 配線ではなく **gate script 側で `PASS=0 / FAIL=0 / SKIP>0` を機械的に検出して FAIL に倒す** helper を `lib.sh` に追加し、`L3_e2e.sh` の jq 必須分岐(skip-only 判定を skip して PASS を返す構造的穴)を helper 経由化。

## 背景

`scripts/launch_gate/L3_e2e.sh` line 147-156 に以下の穴があった:

```bash
if ! command -v jq >/dev/null 2>&1; then
  if [[ "${playwright_rc}" -eq 0 ]]; then
    gate_record PASS "${LABEL}" "playwright rc=0 (jq 不在で skip-only 判定 skip)"
    exit 0
  fi
fi
```

jq 不在環境では playwright が全 spec を skip しても rc=0 なら PASS を返してしまう。これは「skip-only が PASS と誤判定される」典型的な §7 罠。

調査の結果、L0-L5 のうち pytest/playwright を実行するのは L3_e2e.sh のみ(他は alembic / curl / docker / shell)。よって本 PR は L3 中心 + 将来 pytest 系 L 追加用の helper を `lib.sh` に汎用化。

## 変更内容

| File | 変更 |
|---|---|
| `scripts/launch_gate/lib.sh` | `_parse_playwright_stat` (jq → python3 → grep の 3 段フォールバック) + `assert_not_skip_only_playwright` + `assert_not_skip_only_pytest` を追加 |
| `scripts/launch_gate/L3_e2e.sh` | jq 必須分岐(line 147-156)を削除、`_parse_playwright_stat` 経由化。jq 不在環境でも構造的 skip-only FAIL が機能 |
| `tests/launch_gate/fixtures/playwright_*.json` (3 種) | skip_only / all_passed / mixed の Playwright JSON サンプル |
| `tests/launch_gate/fixtures/pytest_*.log` (3 種) | skip_only / all_passed / mixed の pytest log サンプル |
| `tests/launch_gate/test_assert_not_skip_only.sh` | 6 case smoke (ローカルで 6/6 緑確認済) |

## DoD (Asana G parent)

- [x] L3_e2e.sh: jq 不在環境で skip-only run が FAIL を返す
- [x] pytest 正常 pass / FAIL の挙動は変えない(既存 line 183-194 判定維持)
- [x] lib.sh helper を pytest 系にも汎用化(将来 L6/L7 追加時用)
- [x] 6 fixture + 6 smoke case 全部期待通り
- [x] §17 改訂 (両 partner 14日本運用) との整合 確認(G-4 で docs 反映予定)

## Test plan

- [x] ローカル: `bash tests/launch_gate/test_assert_not_skip_only.sh` → 6/6 passed
- [ ] CI: pytest / lint / shellcheck 緑
- [ ] CI: smoke test を CI workflow に組み込みは G-4 で別 PR(本 PR は実装のみ)

## Asana

Closes 1215186819887474 (G-1: lib.sh helper)
Closes 1215186764693750 (G-2: L3_e2e.sh helper 経由化)
Closes 1215186929140320 (G-3: fixture + smoke)
親: 1215186819755146 (G parent)
祖父: 1215186751757662 (§17 改訂)

## Tier

B (実装) — Tier S ファイル(main.py / migrations / docker-compose 等)未触

## 6/1 launch クリティカルパス

[[project-launch-target-shifted-to-jun3]] に従い、両 partner (山本+橋口) 本運用 14 日観測の前提として launch_gate が skip-only を構造的に FAIL に倒せることが必須。

🤖 Generated with [Claude Code](https://claude.com/claude-code)