### PR TITLE
docs(§17): ローンチ条件 14日連続緑 → 両 partner 本運用 14日 (Closes Asana 1215186751757662)

### DIFF
--- a/docs/launch/roadmap_to_launch.md
+++ b/docs/launch/roadmap_to_launch.md
@@ -11,12 +11,14 @@
 
 | 項目 | 値 |
 |---|---|
-| ローンチ目標日 (claude.ai 提案 v1) | **2026-06-03** (最早シナリオ) |
+| **ローンチ目標日 (2026-05-28 改訂版)** | **2026-06-01 (Day 1) 両 partner 本運用 launch → 2026-06-14 (Day 14) 達成 → 2026-06-15 full launch** (Asana 1215186751757662 / Lane H 案採用 / userMemories #8 訂正済) |
+| 旧ローンチ目標日 | ~~2026-06-03 (claude.ai 提案 v1、最早シナリオ)~~ — 数学的不達確定で 6/1 両 partner 本運用案に置換 |
 | 並列構成 | Tier B 4本並列 |
 | handoff thread | https://mooores.slack.com/archives/C0ACS09FMGC/p1779245661503999 |
-| **§17 原文格納先** | **`docs/launch_decision_criteria_v2.md` L11-18 (PR #254 merge 済、2026-05-18)** |
-| **§17「14日連続緑」定義** | **`docs/l1_l6_evaluation_v1.md` §2-§3 (PR #252 merge 済、2026-05-18)** |
-| **§17 原文の判断方針** | **「5/31 強行はしない。客観条件で判断」(`docs/launch_decision_criteria_v2.md` §17 原文より)** |
+| **§17 原文格納先** | **`docs/launch_decision_criteria_v2.md` §17 (2026-05-28 改訂版、本 PR で更新)** |
+| **§17 ローンチ判定軸の定義 (2026-05-28 改訂)** | **`docs/launch_decision_criteria_v2.md` §1「両 partner 本運用 14日」(本 PR で新設)** |
+| **L1-L6 監視 (判定軸外、参考指標)** | **`docs/launch_decision_criteria_v2.md` §1.5 (2026-05-28 改訂で参考指標化) / `docs/l1_l6_evaluation_v1.md` §2-§3 (PR #252 merge 済、2026-05-18)** |
+| **§17 原文の判断方針** | **「5/31 強行はしない。客観条件で判断」(`docs/launch_decision_criteria_v2.md` §17 原文より、2026-05-28 改訂版)** |
 | Asana ハブ GID | [TBD: 小林さんが起票後追記] |
 | 関連 Asana プロジェクト | 1213741124336104 (Phase 1-2 機能タスク), 1213916581114014 (本番運用・パートナー実運用) |
 | 起票セッション | dev VPS `/opt/ultra-autotrade/main` (Claude Code CLI / Opus 4.7) |
@@ -32,21 +34,25 @@
 
 ```
 5/31 強行はしない。客観条件で判断:
-- L1-L6 14日連続緑
+- 両 partner (山本 user_id=11 + 橋口 user_id=18) 本運用 14日 (L1-L6 は監視継続だがローンチ判定軸として使わない)
 - staging で chaos test 3日連続失敗ゼロ
 - 本番 Tier S 操作の人間承認率 100% (auto-bypass ゼロ)
 - 山本さん UAT 完走 (proposals 全件 EXECUTED 判定基準満たす)
 - 森先生 法務確認 (BVI / non-custodial)
 ```
 
+> **2026-05-28 改訂**: 条件 1 を「L1-L6 14日連続緑」から「両 partner 本運用 14日」に置換 (Asana 1215186751757662)。旧原文は `docs/launch_decision_criteria_v2.md` §9.1 アーカイブ。
+
 ---
 
-### 条件 1: L1-L6 14日連続緑
-- **詳細仕様**: `docs/launch_decision_criteria_v2.md` §1 (PASS/FAIL 判定式 + healthcheck_l1_l6.sh 整合版)
-- **14日連続緑の定義**: `docs/l1_l6_evaluation_v1.md` §2-§3 (日次緑 = `pass_rate ≥ 0.95` かつ `daily_total ≥ 240`、14日連続 = streak == 14)
-- **現状値 (2026-05-18 時点、`launch_decision_criteria_v2.md` §1.4 より)**: 0/14 日 (L2 閾値 bug、id=29 修正後カウント開始予定)
-- **6/3 達成見込み**: L2 修正翌日 0:00 JST から 14日積み上げ。L2 修正日次第 (本ロードマップでは TBD、Lane 2 で実機集計)
-- **依存タスク**: id=29 L2 閾値 270min 修正 (Tier B)
+### 条件 1: 両 partner (山本+橋口) 本運用 14日 (2026-05-28 改訂)
+- **詳細仕様**: `docs/launch_decision_criteria_v2.md` §1.1-§1.4 (両 partner 本運用 1日達成 SQL + streak カウント方法 + 起算条件)
+- **本運用 14日の定義**: 両 partner それぞれが当該 JST 暦日内に ① `ai_decisions` 生成 ② `stale_proposals_count = 0` の両条件を満たす日が連続 14 日。詳細 SQL は `docs/launch_decision_criteria_v2.md` §1.2
+- **6/1 (Day 1) 起算条件**: ① 山本さん wallet 登録 (`0x2064...cc66` 済) + ② 橋口さん wallet 登録 (2026-06-01 まで) + ③ scheduler flag conflict (Asana 1215153474346999) 解消 + ④ §17 改訂 PR (本 PR) merge
+- **現状値 (2026-05-28 改訂時点)**: 0/14 日 (起算前)
+- **6/15 full launch 達成見込み**: 6/1 (Day 1) 起算 → 6/14 (Day 14) 達成 → 6/15 full launch
+- **依存タスク**: 橋口さん wallet 登録 / scheduler flag conflict 解消 / 本 PR merge
+- **L1-L6 は判定軸外** (`docs/launch_decision_criteria_v2.md` §1.5 で参考指標として監視継続)
 
 ### 条件 2: staging で chaos test 3日連続失敗ゼロ
 - **詳細仕様**: `docs/launch_decision_criteria_v2.md` §2 (postgres / backend / nginx / Loki kill シナリオ、5分以内自動再起動 + `/health` 200 復帰)
@@ -102,7 +108,8 @@
 | chaos test 3日連続 | TBD (Lane 1 起動次第) | 3日 + 観測 1日 | TBD |
 | HUMAN-REVIEW 14本処理完了 | TBD | TBD | TBD |
 | v4 反映後の観察期間 | 2026-05-19 (PR #302 merge済) | TBD | TBD |
-| L1-L6 14日 PASS 率 100% | L2 閾値 270min 修正 (id=29) 翌日 0:00 JST | 14日 | TBD |
+| **両 partner 本運用 14日 (2026-05-28 改訂)** | **2026-06-01 (Day 1)** (起算条件: §1 参照) | 14日 | **2026-06-14 (Day 14) → 6/15 full launch** |
+| ~~旧 L1-L6 14日 PASS 率 100%~~ (判定軸から外し、§1.5 参考指標化) | L2 閾値 270min 修正 (id=29) 翌日 0:00 JST | 14日 | n/a (判定軸外) |
 
 ### 2.2 critical path
 
@@ -116,7 +123,7 @@
 
 | 条件 | 現在値 | 判定 | ブロッカー / 次アクション (同 docs §7 より) |
 |---|---|---|---|
-| L1-L6 14日連続緑 | 0/14 日 | ❌ 未達 | L2 閾値 270min 修正 (id=29) → 修正後から連続緑カウント開始 |
+| **両 partner 本運用 14日 (2026-05-28 改訂)** | 0/14 日 (起算前) | ❌ 未達 | 6/1 起算 → 6/14 達成 → 6/15 full launch (詳細は §1 条件 1) |
 | chaos test 3日連続 | 未実施 | ❌ 未計測 | id=10 タスク起動 |
 | Tier S 承認率 100% | 未計測 | ❌ 未計測 | gh CLI 計測 + Step 0 記録機能実装 |
 | Partner UAT 完走 (山本+橋口) | 進行中 | ❌ 未完走 | proposals 生成フロー到達待ち (5/20 INSERT 完了で起点進行 / 5/28 から 2 partner 体制) |
@@ -170,7 +177,9 @@ CLAUDE.md §「Claude Code Agent View 運用」に従い、Agent View (`claude a
 - GID 1214890565948368: **completed (2026-05-19, PR #302 merge済)**
 - memory `phase1-progress-20260519` の「Pushover 通知済み → staging 反映待ち」記述は **陳腐化**
 
-### 4.3 L1-L6 14日 PASS 率
+### 4.3 L1-L6 14日 PASS 率 (2026-05-28 改訂で判定軸外、参考指標)
+
+> **2026-05-28 改訂**: L1-L6 はローンチ判定軸ではなく **監視・参考指標** として継続。Day 1 起算後の障害早期検出に使う。判定軸は §1「両 partner 本運用 14日」(`docs/launch_decision_criteria_v2.md` §1)。
 
 - **評価方法は `docs/l1_l6_evaluation_v1.md` で定義済** (PR #252 merge 済 2026-05-18)
   - §1 項目定義 + 重み (L1/L2/L5=critical / L3/L4=normal / L6=warning-only)
@@ -266,5 +275,6 @@ docker exec ultra-autotrade-postgres-production \
 |---|---|---|---|
 | 2026-05-20 | v1.0-skeleton | 初版 (placeholder)。Tier B 4本並列構成のみ確定、本文 5条件・6/3 計算は TBD | Claude Code (dev VPS) |
 | 2026-05-20 | v1.0-skeleton+criteria_link | §17 原文転記 (実コピー、`docs/launch_decision_criteria_v2.md` L11-18) + §References path 訂正 (`docs/launch/` 配下誤判定 → `docs/` 直下に修正) + §4.3 L1-L6 評価方法 link + §0 メタに criteria_v2 / l1_l6_v1 明記 + §2.1 起算点更新 (P0-X2 close) + §5 ブロッカー P0-X2 を closed 化 + §2.4 / §4.5 追加 (launch_decision_criteria_v2.md §7 / §6 への link) | Claude Code (dev VPS) |
-| TBD | v1.0 | §2 / §4 / §6 の TBD 本文埋め (claude.ai 案の 6/3 計算原文反映) | 小林さん |
-| TBD | v1.1 | 実機データ再計算結果反映 (Lane 2 完了後) | TBD |
+| 2026-05-28 | v1.1-section17-revise | **§17 条件 1 改訂**: 旧「L1-L6 14日連続緑」→ 新「両 partner (山本+橋口) 本運用 14日」(Asana 1215186751757662 / Lane H 案採用 / userMemories #8 訂正済)。§0 メタ情報のローンチ目標日 6/3 → 6/1 起算 + 6/14 達成 + 6/15 full launch。§1 §17 原文 + 条件 1 全面改訂。§2.1 起算点 / §2.4 サマリー table / §4.3 注記 (判定軸外) を更新。`docs/launch_decision_criteria_v2.md` PR と並走 | Claude Code (Lane) |
+| TBD | v1.2 | §2 / §4 / §6 の TBD 本文埋め (claude.ai 案の 6/1 計算原文反映) | 小林さん |
+| TBD | v1.3 | 実機データ再計算結果反映 (Lane 2 完了後) | TBD |

--- a/docs/launch_decision_criteria_v2.md
+++ b/docs/launch_decision_criteria_v2.md
@@ -6,22 +6,107 @@
 
 ---
 
-## §17 原文 (変更不可)
+## §17 原文 (2026-05-28 改訂版)
 
 ```
 5/31 強行はしない。客観条件で判断:
-- L1-L6 14日連続緑
+- 両 partner (山本 user_id=11 + 橋口 user_id=18) 本運用 14日 (L1-L6 は監視継続だがローンチ判定軸として使わない)
 - staging で chaos test 3日連続失敗ゼロ
 - 本番 Tier S 操作の人間承認率 100% (auto-bypass ゼロ)
 - 山本さん UAT 完走 (proposals 全件 EXECUTED 判定基準満たす)
 - 森先生 法務確認 (BVI / non-custodial)
 ```
 
+> **改訂経緯 (2026-05-28)**: 旧原文の条件 1「L1-L6 14日連続緑」は数学的に 6/1 不達確定だったため、両 partner 本運用 14日に置換。**6/1 (Day 1) 両 partner 本運用起算 → 6/14 達成 → 6/15 full launch**。L1-L6 評価は継続するが、ローンチ判定軸ではない(§1.5 で監視枠として保持)。条件 2-5 は変更なし。Asana 1215186751757662。旧原文は §9 変更履歴に保存。
+
 ---
 
-## 1. L1-L6 14日連続緑
+## 1. ローンチ判定軸 — 両 partner (山本+橋口) 本運用 14日
 
-### 1.1「緑」の定義
+> **2026-05-28 改訂**: 旧「L1-L6 14日連続緑」をローンチ判定軸から外し、両 partner (山本 user_id=11 + 橋口 user_id=18) **本運用 14日観測** を新判定軸とする。L1-L6 詳細評価は §1.5「L1-L6 監視 (判定軸外、参考指標)」に移植して継続。
+
+### 1.1「両 partner 本運用 14日」の定義
+
+| 用語 | 定義 |
+|---|---|
+| 本運用 (Day 1 起算) | 両 partner (山本 user_id=11, 橋口 user_id=18) が production 環境で実 launch (Shadow Mode 並走でなく実 launch)。6/1 (Day 1) 起算予定 |
+| 「本運用 1日達成」 | その暦日 (JST 00:00-23:59) 内に両 partner それぞれ:<br/>① `ai_decisions` が生成されている (production AI 判定が稼働している)<br/>② proposals が active (ステータス変更フローを経て final 状態に到達 or 期限内継続) で「stale ≥ 24h」がゼロ<br/>③ `non_executed_active = 0` 又は当該 partner の `proposals.expires_at > NOW()` で進行中 |
+| 「14日達成」 | 上記「本運用 1日達成」が両 partner で連続 14 日継続 (= 6/1 起算で 6/14 達成) |
+| 既存 UAT 5条件 (条件 4) との関係 | 条件 4 は UAT 完走判定 (proposals 全件 EXECUTED)、本条件 1 は 14日継続観測。両者は別軸。条件 4 完走後に本条件 1 が起算可能になる構造ではなく、両者は並行観測 |
+
+### 1.2 判定 SQL (両 partner 本運用 1日達成チェック)
+
+```sql
+-- 両 partner それぞれが当該 JST 暦日内に ai_decisions を生成し、stale proposals がゼロかを確認
+WITH partners AS (
+  SELECT id, name FROM users WHERE id IN (11, 18) AND role = 'partner' AND is_active = TRUE
+),
+target_day AS (
+  -- ${TARGET_DATE} を引数で渡す。デフォルトは「昨日 JST」
+  SELECT (CURRENT_DATE - INTERVAL '1 day' AT TIME ZONE 'Asia/Tokyo')::date AS d
+),
+daily_ai_decisions AS (
+  SELECT p.id AS partner_id, COUNT(ad.id) AS ai_decision_count
+  FROM partners p
+  LEFT JOIN ai_decisions ad
+    ON ad.user_id = p.id
+   AND ad.created_at >= (SELECT d FROM target_day) AT TIME ZONE 'Asia/Tokyo'
+   AND ad.created_at <  (SELECT d FROM target_day) AT TIME ZONE 'Asia/Tokyo' + INTERVAL '1 day'
+  GROUP BY p.id
+),
+stale_proposals AS (
+  SELECT p.id AS partner_id, COUNT(pr.id) AS stale_count
+  FROM partners p
+  LEFT JOIN proposals pr
+    ON pr.user_id = p.id
+   AND pr.status NOT IN ('executed','expired','rejected')
+   AND pr.expires_at < NOW()
+  GROUP BY p.id
+)
+SELECT
+  p.name,
+  COALESCE(d.ai_decision_count, 0) AS ai_decision_count,
+  COALESCE(s.stale_count, 0) AS stale_proposals_count,
+  CASE
+    WHEN COALESCE(d.ai_decision_count, 0) >= 1
+     AND COALESCE(s.stale_count, 0) = 0
+    THEN '✅ 1日達成'
+    ELSE '❌ 未達 (ai_decisions=' || COALESCE(d.ai_decision_count, 0)::text
+         || ', stale=' || COALESCE(s.stale_count, 0)::text || ')'
+  END AS daily_status
+FROM partners p
+LEFT JOIN daily_ai_decisions d ON d.partner_id = p.id
+LEFT JOIN stale_proposals s ON s.partner_id = p.id
+ORDER BY p.id;
+```
+
+両 partner で「✅ 1日達成」が出た日のみ「本運用 1日達成」をカウント。連続 14 日で 14 日達成。
+
+### 1.3「両 partner 本運用 14日」カウント方法
+
+- **起算条件**: 両 partner の wallet 登録完了 + production 反映 + 本 PR (§17 改訂) merge + scheduler flag conflict 解消 (Asana 1215153474346999) が全て満たされた翌 JST 暦日 0:00 から起算
+- **streak リセット条件**:
+  - いずれかの partner で当該日 `ai_decision_count = 0` (production AI 判定が走っていない)
+  - いずれかの partner で当該日 `stale_proposals_count > 0` (stale ≥ 24h の proposals がある = 障害)
+  - production 障害発生 (`docs/postmortems/*.md` 該当日付に追加されたら streak リセット候補)
+- **集計タイミング**: 翌日 JST 00:30 (24 時間集計余裕後) に上記 SQL を batch 実行、結果を `launch_partner_uat_streak.log` (or 同等の summary) に追記
+
+### 1.4 現在値 (2026-05-28 時点)
+
+| 項目 | 現在値 | 判定 |
+|---|---|---|
+| 山本さん (id=11) wallet 登録 | `0x2064...cc66` 登録済 | ✅ |
+| 橋口さん (id=18) wallet 登録 | 2026-06-01 までに登録予定 | ⏳ |
+| scheduler flag conflict (Asana 1215153474346999) | production .env で ENABLE/DISABLE 両 set 競合中 | ❌ |
+| 両 partner 本運用 14日 streak | 0/14 日 (起算前、6/1 予定) | ❌ |
+
+> **6/1 launch 起算条件**: 上記 4 項目を全て解消 + 本 PR merge で 6/1 (Day 1) から streak カウント開始。
+
+### 1.5 L1-L6 監視 (判定軸外、参考指標)
+
+> **2026-05-28 改訂注記**: L1-L6 評価は **継続して監視**するが、ローンチ判定軸ではない(参考指標扱い)。Day 1 起算後の障害早期検出に使う。詳細仕様 (PASS/FAIL 判定式 / 14日連続緑カウント方法 / healthcheck_l1_l6.sh 整合版) は以下に保持。
+
+#### 1.5.1「緑」の定義 (旧 §1.1)
 
 | 用語 | 定義 |
 |---|---|
@@ -30,7 +115,7 @@
 | L6 WARN の扱い | L6 WARN は UAT 期間中「緑」判定に影響しない (FAIL でない限り許容) |
 | 5% 失敗許容の根拠 | nginx restart 等の一時 502 を吸収する設計余裕。連続 15 回以上の FAIL は即 Slack 通知 |
 
-### 1.2 L1-L6 PASS/FAIL 判定式 (healthcheck_l1_l6.sh 整合版)
+#### 1.5.2 L1-L6 PASS/FAIL 判定式 (旧 §1.2、healthcheck_l1_l6.sh 整合版)
 
 | チェック | PASS 条件 | FAIL 条件 | 備考 |
 |---|---|---|---|
@@ -47,7 +132,7 @@ overall = PASS  ← L1 PASS AND L2 PASS AND L3 PASS AND L4 PASS AND L5 PASS
 L6 WARN は overall=PASS に影響しない
 ```
 
-### 1.3「14日連続緑」カウント方法
+#### 1.5.3「14日連続緑」(参考、旧 §1.3) カウント方法
 
 **DB 側 (L3-L5)**: 下記 §5 のダッシュボード SQL で集計
 
@@ -88,7 +173,7 @@ for day_str in sorted(day_total.keys()):
 "
 ```
 
-### 1.4 現在値 (2026-05-18 時点)
+#### 1.5.4 L1-L6 現在値 (旧 §1.4、2026-05-18 時点、参考)
 
 | 項目 | 現在値 | 判定 |
 |---|---|---|
@@ -468,7 +553,7 @@ UNION ALL SELECT '============================================', ''
 
 | 条件 | 現在値 | 判定 | ブロッカー / 次アクション |
 |---|---|---|---|
-| L1-L6 14日連続緑 | 0/14 日 | ❌ 未達 | L2 閾値 270min 修正 (id=29) → 修正後から連続緑カウント開始 |
+| 両 partner 本運用 14日 (2026-05-28 改訂 / 旧「L1-L6 14日連続緑」) | 0/14 日 (起算前) | ❌ 未達 | 6/1 (Day 1) 起算 → 6/14 達成 → 6/15 full launch。起算条件: 山本さん wallet 登録済、橋口さん wallet 6/1 までに登録 + scheduler flag conflict (Asana 1215153474346999) 解消 + 本 PR merge |
 | chaos test 3日連続 | 未実施 | ❌ 未計測 | id=10 タスク起動 |
 | Tier S 承認率 100% | 未計測 | ❌ 未計測 | gh CLI 計測 + Step 0 記録機能実装 |
 | 山本さん UAT 完走 | 進行中 | ❌ 未完走 | proposals 生成フロー到達待ち |
@@ -478,6 +563,8 @@ UNION ALL SELECT '============================================', ''
 ---
 
 ## 8. ローンチ判断フロー
+
+> **2026-05-28 改訂注記**: 旧フロー (L2 閾値 270min 修正 → L1-L6 14日連続緑) は条件 1 改訂で **判定軸ではなく参考指標** に移行 (§1.5)。新フローでは「両 partner wallet 登録 + scheduler flag conflict 解消 + 本 PR merge → 6/1 (Day 1) 起算 → 6/14 達成」が条件 1 の流れ。下記フロー図は旧版のままだが、6/1 launch を狙う実機は §1.3 を正本とする(本フロー図は次版 v2.2 で書き換え予定)。
 
 ```
 [現在 2026-05-18]
@@ -508,3 +595,15 @@ L1-L6 14日連続緑 積み上げ開始 (5/18 L2 修正後から)    chaos test 
 | 日付 | バージョン | 変更内容 |
 |---|---|---|
 | 2026-05-18 | v2.0 | 新規作成。§17 v5 原文を客観指標に落とし込み。healthcheck_l1_l6.sh (PR #247) と整合 |
+| 2026-05-28 | v2.1 | **§17 条件 1 改訂**: 旧「L1-L6 14日連続緑」→ 新「両 partner (山本+橋口) 本運用 14日」(Asana 1215186751757662 / Lane H 案採用 / userMemories #8 訂正済)。L1-L6 評価詳細は §1.5 に移植し参考指標として保持。§7 サマリー / §8 フロー注記更新。**6/1 (Day 1) 両 partner 本運用 launch → 6/14 達成 → 6/15 full launch**。旧 §17 原文は下記アーカイブに保存。 |
+
+### 9.1 旧 §17 原文アーカイブ (2026-05-18 〜 2026-05-28)
+
+```
+5/31 強行はしない。客観条件で判断:
+- L1-L6 14日連続緑                                                ← 2026-05-28 改訂で削除、新条件 1 に置換
+- staging で chaos test 3日連続失敗ゼロ
+- 本番 Tier S 操作の人間承認率 100% (auto-bypass ゼロ)
+- 山本さん UAT 完走 (proposals 全件 EXECUTED 判定基準満たす)
+- 森先生 法務確認 (BVI / non-custodial)
+```


### PR DESCRIPTION
## Summary

2026-05-28 hkobayashi 判断 (Lane H 案採用 / userMemories #8 訂正済) で §17 ローンチ判断 5条件のうち **条件 1 を「L1-L6 14日連続緑」から「両 partner (山本 user_id=11 + 橋口 user_id=18) 本運用 14日」に置換**。6/1 launch 数学的不達を解消し、**6/1 (Day 1) 両 partner 本運用 launch → 6/14 達成 → 6/15 full launch** シナリオを成立させる。

## 改訂方針 (最小 invasive)

- 旧 §1 (L1-L6 14日連続緑) の **詳細内容は §1.5「L1-L6 監視 (判定軸外、参考指標)」として継続保持** (情報損失なし)
- 新規 §1.1-§1.4 で「両 partner 本運用 14日」のローンチ判定軸を定義
- 旧 §17 原文は `docs/launch_decision_criteria_v2.md` §9.1 アーカイブに保存
- 条件 2-5 (chaos / Tier S 承認率 / UAT 完走 / 森先生法務) は **変更なし**

## 変更ファイル

| File | 変更内容 |
|---|---|
| `docs/launch_decision_criteria_v2.md` | §17 原文 / §1 全面改訂 + §1.5 (旧 §1 内容を移植) / §7 サマリー / §8 注記 / §9 履歴 + アーカイブ |
| `docs/launch/roadmap_to_launch.md` | §0 ローンチ目標日 6/1 / §1 §17 原文 + 条件 1 全面改訂 / §2.1 起算点 / §2.4 サマリー / §4.3 注記 / §改訂履歴 |

## DoD (Asana 1215186751757662)

- [x] §17 原文 改訂
- [x] `docs/launch_decision_criteria_v2.md` 改訂
- [x] `docs/launch/roadmap_to_launch.md` 改訂 (6/1 / 6/14 / 6/15)
- [ ] v4 指示文 §17 (claude.ai 側) は hkobayashi 直接修正 (Lane scope 外)
- [x] PR #444 (UAT 5条件 SQL 2 partner 拡張) と整合 (条件 4 は変更なし)
- [ ] Codex Review + main 反映

## 依存 (整合確認済)

- [x] PR #446 (snapshot_service per-partner Aave fetch) **merged**
- [x] PR #447 (proposals.wallet_address 伝播) **merged**

両 PR が main に反映済のため、両 partner 並走の **構造的前提は既に満たされている**。

## L1-L6 評価の扱い

- `docs/l1_l6_evaluation_v1.md` (PR #252) は **削除しない**、参考指標として継続
- `docs/launch_decision_criteria_v2.md` §1.5 で監視枠として詳細仕様を保持
- `scripts/healthcheck_l1_l6.sh` / `scripts/l1_l6_daily_summary.sh` は変更なし

## 関連 PR (並走)

- PR #448 (G scope: launch_gate skip-only FAIL 構造的判定 helper) — launch_gate 側の構造改修と並走。本 PR は §17 改訂、PR #448 は launch_gate 側の skip-only 検出強化、独立スコープ

## Tier

S — docs としては「ローンチ判断条件」の最上位 docs なので影響範囲大。Tier S ファイル (CLAUDE.md / migrations / docker-compose 等) は触らない。

## Review point (重点)

1. **§17 原文の差し替え可否** — 旧「変更不可」原文を新原文に差し替えた判断
2. **§1 構造の変更** — 旧 §1.1-§1.4 を §1.5 sub-section として保持した判断
3. **6/1 起算条件 4 項目** — wallet 2 件 / scheduler flag conflict / 本 PR merge で過不足ないか
4. **判定 SQL (§1.2)** — `ai_decisions` + `stale_proposals_count = 0` の組合せで「1日達成」を判定する設計が妥当か

🤖 Generated with [Claude Code](https://claude.com/claude-code)