### PR TITLE
fix(infra): /var/run/ultra Permission denied 解消 (Asana 1215189630575554)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,12 @@ RUN if [ "$BUILD_MODE" = "production" ]; then \
     fi
 
 # 非 root ユーザーで実行（docs/13_security_design.md）
-RUN useradd --no-create-home --shell /bin/false appuser
-RUN mkdir -p /var/log/ultra-autotrade && chown appuser:appuser /var/log/ultra-autotrade
+# UID/GID は 10001 で固定。docker-compose の ultra-state-init が同じ UID で
+# named volume (/var/run/ultra) を chown するためここと値が一致している必要がある。
+RUN groupadd --gid 10001 appuser \
+    && useradd --no-create-home --shell /bin/false --uid 10001 --gid 10001 appuser
+RUN mkdir -p /var/log/ultra-autotrade /var/run/ultra \
+    && chown appuser:appuser /var/log/ultra-autotrade /var/run/ultra
 USER appuser
 
 EXPOSE 8000

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -122,6 +122,34 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  # ===== Init: backend volume permissions =====
+  # 主目的: state.json (Asana 1215189630575554, 2026-05-28 soak 調査)。
+  # 名前付き volume `ultra-state` は作成時に root:root で初期化されるため
+  # Dockerfile の `USER appuser` (UID=10001) では state.json を書けず、
+  # `Failed to write state file /var/run/ultra/state.json: [Errno 13] Permission denied`
+  # を毎分発生させていた。root で chown 10001:10001 する。
+  #
+  # 副次対応: `ultra-log-staging` (production の log volume) も chown する。
+  # Dockerfile で appuser を UID 固定 (10001) に変更したため、旧 dynamic UID で
+  # chown 済みの既存 log volume 内ファイル所有者を新 UID に揃える必要がある。
+  #
+  # 毎回の `docker compose up` で実行されるが、idempotent で数百 ms で完了する。
+  backend-volume-init:
+    image: alpine:3.19
+    container_name: ultra-autotrade-backend-volume-init-production
+    command: ["chown", "-R", "10001:10001", "/var/run/ultra", "/var/log/ultra-autotrade"]
+    volumes:
+      - ultra-state:/var/run/ultra
+      - ultra-log-staging:/var/log/ultra-autotrade
+    restart: "no"
+    networks:
+      - production-net
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1m"
+        max-file: "1"
+
   # ===== Blue/Green Backend =====
   # 両者は build / env / volume が同一。container_name と公開ポートのみ異なる。
   # active 側のみ nginx の upstream.conf に登録される。
@@ -168,6 +196,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      backend-volume-init:
+        condition: service_completed_successfully
     restart: always
     networks:
       - production-net
@@ -208,6 +238,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      backend-volume-init:
+        condition: service_completed_successfully
     restart: always
     networks:
       - production-net

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -132,6 +132,34 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  # ===== Init: backend volume permissions =====
+  # 主目的: state.json (Asana 1215189630575554, 2026-05-28 soak 調査)。
+  # 名前付き volume `ultra-state-staging-new` は作成時に root:root で初期化されるため
+  # Dockerfile の `USER appuser` (UID=10001) では state.json を書けず、
+  # `Failed to write state file /var/run/ultra/state.json: [Errno 13] Permission denied`
+  # を毎分発生させていた。root で chown 10001:10001 する。
+  #
+  # 副次対応: `ultra-log-staging-new` も chown する。Dockerfile で appuser を
+  # UID 固定 (10001) に変更したため、旧 dynamic UID で chown 済みの既存 log volume
+  # 内ファイル所有者を新 UID に揃える必要がある。
+  #
+  # 毎回の `docker compose up` で実行されるが、idempotent で数百 ms で完了する。
+  backend-volume-init:
+    image: alpine:3.19
+    container_name: ultra-autotrade-backend-volume-init-staging-new
+    command: ["chown", "-R", "10001:10001", "/var/run/ultra", "/var/log/ultra-autotrade"]
+    volumes:
+      - ultra-state-staging-new:/var/run/ultra
+      - ultra-log-staging-new:/var/log/ultra-autotrade
+    restart: "no"
+    networks:
+      - staging-net
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1m"
+        max-file: "1"
+
   # ===== Blue/Green Backend =====
   # active 側のみ nginx の upstream.conf に登録される。
   # host側 port は production (8010/8011) と衝突回避のため 8020/8021。
@@ -170,6 +198,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      backend-volume-init:
+        condition: service_completed_successfully
     restart: always
     networks:
       - staging-net
@@ -212,6 +242,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      backend-volume-init:
+        condition: service_completed_successfully
     restart: always
     networks:
       - staging-net


### PR DESCRIPTION
## Summary
- `aave.state_manager` が `/var/run/ultra/state.json` を書けず `[Errno 13] Permission denied: /var/run/ultra/state_*.tmp` を毎分発生させ、state 永続化が完全停止していた問題を修正 (2026-05-28 staging soak で発覚)
- Dockerfile で `/var/run/ultra` を mkdir+chown、`appuser` の UID/GID を 10001 に固定
- staging/production の docker-compose に `backend-volume-init` (alpine root) を追加し、既存 root 所有 volume を `chown 10001:10001 /var/run/ultra /var/log/ultra-autotrade` してから backend-blue/green を起動

## 根本原因
- 旧 Dockerfile は `/var/run/ultra` を作成・chown していなかった
- 結果 Docker は named volume 初回マウント時に root:root の空ディレクトリを作成
- `USER appuser` ではそこに `tempfile.mkstemp` できず atomic write が失敗

## 修正内容
### Dockerfile
- `appuser` の UID/GID を 10001 で明示固定 (init container の chown 対象 UID と一致させるため)
- `/var/run/ultra` を `mkdir -p && chown appuser:appuser` (新規 named volume の初回 mount で正しい所有者が伝播)

### docker-compose.staging.yml / docker-compose.production.yml
- `backend-volume-init` service (alpine:3.19, root, restart: "no") を追加
- `chown -R 10001:10001 /var/run/ultra /var/log/ultra-autotrade` をべき等に実行
- `backend-blue` / `backend-green` の `depends_on` に `condition: service_completed_successfully` で接続

### 副次対応: log volume
- UID を 10001 に固定した結果、旧 dynamic UID で chown 済みの既存 `ultra-log-*` volume が新 UID から書けなくなる懸念があるため、同 init service で同時 chown

## ローカル検証
- `docker compose -f docker-compose.staging.yml config` exit=0
- `docker compose -f docker-compose.production.yml config` exit=0
- Probe image build + `id`: `uid=10001(appuser) gid=10001(appuser)`
- root 所有 named volume → alpine `chown -R 10001:10001` → appuser から `touch /var/run/ultra/probe` 成功を simulate で確認

## Test plan (staging 実機, deploy 後に貼付け予定)
- [ ] `scripts/deploy_staging.sh` 経由で deploy 完了
- [ ] `docker exec ultra-autotrade-backend-blue-staging-new ls -la /var/run/ultra/` → appuser 所有 / state.json 存在
- [ ] `docker logs ultra-autotrade-backend-blue-staging-new --since 5m 2>&1 | grep -E 'state\\.json|Permission denied'` → "Permission denied" 0 件、"Successfully wrote state file" あり
- [ ] `docker exec ultra-autotrade-backend-blue-staging-new cat /var/run/ultra/state.json` → 有効な JSON
- [ ] backend-green も同様

## 関連
- Asana: https://app.asana.com/1/817733952351708/project/1213916581114014/task/1215189630575554
- §22 (入力データ欠落の三重故障の一つ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)