### PR TITLE
fix(compose): REBALANCE_SHADOW_MODE を compose environment: から完全削除 → .env 単一ソース化

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -20,6 +20,7 @@ COMPOSE_PROJECT_NAME=ultra-autotrade-project
 # Shadow Mode
 # AI_SHADOW_MODE=false  → 本番は実トレード (絶対に true にしない)
 # REBALANCE_SHADOW_MODE=true → リバランス判断をログのみ実行 (実注文なし)
+#   6/1 以降に false へ変更して実リバランス注文を解禁する
 # =============================================================================
 AI_SHADOW_MODE=false
 REBALANCE_SHADOW_MODE=true

--- a/.env.production.example
+++ b/.env.production.example
@@ -17,10 +17,12 @@ APP_ENV=production
 COMPOSE_PROJECT_NAME=ultra-autotrade-project
 
 # =============================================================================
-# Shadow Mode（本番は実トレード — 絶対に true にしない）
+# Shadow Mode
+# AI_SHADOW_MODE=false  → 本番は実トレード (絶対に true にしない)
+# REBALANCE_SHADOW_MODE=true → リバランス判断をログのみ実行 (実注文なし)
 # =============================================================================
 AI_SHADOW_MODE=false
-REBALANCE_SHADOW_MODE=false
+REBALANCE_SHADOW_MODE=true
 
 # =============================================================================
 # Database（stagingとは完全独立 — ultra_autotrade）

--- a/backend/.env.staging.example
+++ b/backend/.env.staging.example
@@ -72,7 +72,7 @@ AAVE_STATE_FILE_PATH=/var/run/ultra/state.json
 # heartbeat ≈ 24h; 90000s = 25h includes a safety buffer. Default 3600s would
 # spuriously HOLD on long-heartbeat feeds.
 AAVE_ORACLE_STALENESS_THRESHOLD_SECONDS=90000
-REBALANCE_SHADOW_MODE=false
+REBALANCE_SHADOW_MODE=true
 
 # ============================================================
 # Notifications（任意）

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -168,7 +168,7 @@ services:
     env_file:
       - .env.production
     environment:
-      REBALANCE_SHADOW_MODE: ${REBALANCE_SHADOW_MODE}
+      REBALANCE_SHADOW_MODE: ${REBALANCE_SHADOW_MODE:-false}
       DEPLOY_SLOT: "blue"
       # Stream 4 (2026-05-21): Blue/Green scheduler 二重起動防止。
       # BACKEND_COLOR はこのコンテナの固有色。ACTIVE_BACKEND_COLOR は .env.production から
@@ -222,7 +222,7 @@ services:
     env_file:
       - .env.production
     environment:
-      REBALANCE_SHADOW_MODE: ${REBALANCE_SHADOW_MODE}
+      REBALANCE_SHADOW_MODE: ${REBALANCE_SHADOW_MODE:-false}
       DEPLOY_SLOT: "green"
       # Stream 4 (2026-05-21): Blue/Green scheduler 二重起動防止。
       BACKEND_COLOR: "green"

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -168,7 +168,7 @@ services:
     env_file:
       - .env.production
     environment:
-      REBALANCE_SHADOW_MODE: "false"
+      REBALANCE_SHADOW_MODE: ${REBALANCE_SHADOW_MODE}
       DEPLOY_SLOT: "blue"
       # Stream 4 (2026-05-21): Blue/Green scheduler 二重起動防止。
       # BACKEND_COLOR はこのコンテナの固有色。ACTIVE_BACKEND_COLOR は .env.production から
@@ -222,7 +222,7 @@ services:
     env_file:
       - .env.production
     environment:
-      REBALANCE_SHADOW_MODE: "false"
+      REBALANCE_SHADOW_MODE: ${REBALANCE_SHADOW_MODE}
       DEPLOY_SLOT: "green"
       # Stream 4 (2026-05-21): Blue/Green scheduler 二重起動防止。
       BACKEND_COLOR: "green"

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -168,7 +168,6 @@ services:
     env_file:
       - .env.production
     environment:
-      REBALANCE_SHADOW_MODE: ${REBALANCE_SHADOW_MODE:-false}
       DEPLOY_SLOT: "blue"
       # Stream 4 (2026-05-21): Blue/Green scheduler 二重起動防止。
       # BACKEND_COLOR はこのコンテナの固有色。ACTIVE_BACKEND_COLOR は .env.production から
@@ -222,7 +221,6 @@ services:
     env_file:
       - .env.production
     environment:
-      REBALANCE_SHADOW_MODE: ${REBALANCE_SHADOW_MODE:-false}
       DEPLOY_SLOT: "green"
       # Stream 4 (2026-05-21): Blue/Green scheduler 二重起動防止。
       BACKEND_COLOR: "green"

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -179,7 +179,7 @@ services:
       - .env.staging-new
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-ultra}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ultra_autotrade_staging}
-      REBALANCE_SHADOW_MODE: ${REBALANCE_SHADOW_MODE}
+      REBALANCE_SHADOW_MODE: ${REBALANCE_SHADOW_MODE:-true}
       AI_SHADOW_MODE: "true"
       DEPLOY_SLOT: "blue"
       # Stream 4 (2026-05-21): Blue/Green scheduler 二重起動防止。
@@ -225,7 +225,7 @@ services:
       - .env.staging-new
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-ultra}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ultra_autotrade_staging}
-      REBALANCE_SHADOW_MODE: ${REBALANCE_SHADOW_MODE}
+      REBALANCE_SHADOW_MODE: ${REBALANCE_SHADOW_MODE:-true}
       AI_SHADOW_MODE: "true"
       DEPLOY_SLOT: "green"
       # Stream 4 (2026-05-21): Blue/Green scheduler 二重起動防止。

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -179,7 +179,7 @@ services:
       - .env.staging-new
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-ultra}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ultra_autotrade_staging}
-      REBALANCE_SHADOW_MODE: "true"
+      REBALANCE_SHADOW_MODE: ${REBALANCE_SHADOW_MODE}
       AI_SHADOW_MODE: "true"
       DEPLOY_SLOT: "blue"
       # Stream 4 (2026-05-21): Blue/Green scheduler 二重起動防止。
@@ -225,7 +225,7 @@ services:
       - .env.staging-new
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-ultra}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ultra_autotrade_staging}
-      REBALANCE_SHADOW_MODE: "true"
+      REBALANCE_SHADOW_MODE: ${REBALANCE_SHADOW_MODE}
       AI_SHADOW_MODE: "true"
       DEPLOY_SLOT: "green"
       # Stream 4 (2026-05-21): Blue/Green scheduler 二重起動防止。

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -179,7 +179,6 @@ services:
       - .env.staging-new
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-ultra}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ultra_autotrade_staging}
-      REBALANCE_SHADOW_MODE: ${REBALANCE_SHADOW_MODE:-true}
       AI_SHADOW_MODE: "true"
       DEPLOY_SLOT: "blue"
       # Stream 4 (2026-05-21): Blue/Green scheduler 二重起動防止。
@@ -225,7 +224,6 @@ services:
       - .env.staging-new
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-ultra}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ultra_autotrade_staging}
-      REBALANCE_SHADOW_MODE: ${REBALANCE_SHADOW_MODE:-true}
       AI_SHADOW_MODE: "true"
       DEPLOY_SLOT: "green"
       # Stream 4 (2026-05-21): Blue/Green scheduler 二重起動防止。

--- a/docs/43_mainnet_wallet_switch_guide.md
+++ b/docs/43_mainnet_wallet_switch_guide.md
@@ -53,7 +53,7 @@
 | `AAVE_WALLET_ADDRESS` | Sepolia アドレス | Mainnet アドレス (新規) | |
 | `BYBIT_SANDBOX` | `true` | `false` | 実資金取引に切替 |
 | `AI_SHADOW_MODE` | `false` | `false` | 変更なし |
-| `REBALANCE_SHADOW_MODE` | `true` | `true` | `.env.production` で管理 (compose は `${REBALANCE_SHADOW_MODE:-false}` 参照) |
+| `REBALANCE_SHADOW_MODE` | `true` | `true` | `.env.production` で管理 (compose は参照しない) |
 
 > **補足 — チェーンレジストリとの対応:**
 > `AAVE_ACTIVE_CHAINS=base` に設定すると、`chains.py` の `"base"` エントリを読み込む。

--- a/docs/43_mainnet_wallet_switch_guide.md
+++ b/docs/43_mainnet_wallet_switch_guide.md
@@ -53,7 +53,7 @@
 | `AAVE_WALLET_ADDRESS` | Sepolia アドレス | Mainnet アドレス (新規) | |
 | `BYBIT_SANDBOX` | `true` | `false` | 実資金取引に切替 |
 | `AI_SHADOW_MODE` | `false` | `false` | 変更なし |
-| `REBALANCE_SHADOW_MODE` | `false` | `false` | 変更なし |
+| `REBALANCE_SHADOW_MODE` | `true` | `true` | `.env.production` で管理 (compose は `${REBALANCE_SHADOW_MODE:-false}` 参照) |
 
 > **補足 — チェーンレジストリとの対応:**
 > `AAVE_ACTIVE_CHAINS=base` に設定すると、`chains.py` の `"base"` エントリを読み込む。

--- a/scripts/verify_rebalance_shadow_source.sh
+++ b/scripts/verify_rebalance_shadow_source.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# verify_rebalance_shadow_source.sh
+# REBALANCE_SHADOW_MODE が compose environment: ではなく .env 単一ソースで管理されているか検証する
+# DoD: PR #457 (chore/rebalance-shadow-mode-env-ref-20260529)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+ok()   { echo "✅ $1"; PASS=$((PASS+1)); }
+fail() { echo "❌ $1"; FAIL=$((FAIL+1)); }
+warn() { echo "⚠️  $1"; }
+
+echo "=== verify_rebalance_shadow_source ==="
+
+# ── [1] compose の environment: に REBALANCE_SHADOW_MODE が残っていないこと ──
+
+PROD_HIT=$(awk '
+  /^  [a-z]/ { in_env=0 }
+  /^    environment:/ { in_env=1 }
+  in_env && /REBALANCE_SHADOW_MODE/ && !/^[[:space:]]*#/ { print NR": "$0 }
+' "$PROJECT_ROOT/docker-compose.production.yml")
+
+if [ -z "$PROD_HIT" ]; then
+  ok "docker-compose.production.yml: REBALANCE_SHADOW_MODE は environment: に存在しない"
+else
+  fail "docker-compose.production.yml: REBALANCE_SHADOW_MODE が environment: に残存"
+  echo "  $PROD_HIT"
+fi
+
+STAGING_HIT=$(awk '
+  /^  [a-z]/ { in_env=0 }
+  /^    environment:/ { in_env=1 }
+  in_env && /REBALANCE_SHADOW_MODE/ && !/^[[:space:]]*#/ { print NR": "$0 }
+' "$PROJECT_ROOT/docker-compose.staging.yml")
+
+if [ -z "$STAGING_HIT" ]; then
+  ok "docker-compose.staging.yml: REBALANCE_SHADOW_MODE は environment: に存在しない"
+else
+  fail "docker-compose.staging.yml: REBALANCE_SHADOW_MODE が environment: に残存"
+  echo "  $STAGING_HIT"
+fi
+
+# ── [2] .env 側に REBALANCE_SHADOW_MODE が明示されているか ──
+
+if [ -f "$PROJECT_ROOT/.env.production" ]; then
+  if grep -q "^REBALANCE_SHADOW_MODE=" "$PROJECT_ROOT/.env.production"; then
+    VAL=$(grep "^REBALANCE_SHADOW_MODE=" "$PROJECT_ROOT/.env.production" | cut -d= -f2)
+    ok ".env.production: REBALANCE_SHADOW_MODE=$VAL"
+  else
+    fail ".env.production: REBALANCE_SHADOW_MODE が未設定"
+  fi
+else
+  warn ".env.production が存在しない (本番 VPS 上での確認が必要)"
+fi
+
+if [ -f "$PROJECT_ROOT/.env.staging-new" ]; then
+  if grep -q "^REBALANCE_SHADOW_MODE=" "$PROJECT_ROOT/.env.staging-new"; then
+    VAL=$(grep "^REBALANCE_SHADOW_MODE=" "$PROJECT_ROOT/.env.staging-new" | cut -d= -f2)
+    ok ".env.staging-new: REBALANCE_SHADOW_MODE=$VAL"
+  else
+    fail ".env.staging-new: REBALANCE_SHADOW_MODE が未設定"
+  fi
+else
+  warn ".env.staging-new が存在しない (本番 VPS 上での確認が必要)"
+fi
+
+# ── [3] .env.production.example に REBALANCE_SHADOW_MODE=true が記載されているか ──
+
+if grep -q "^REBALANCE_SHADOW_MODE=true" "$PROJECT_ROOT/.env.production.example"; then
+  ok ".env.production.example: REBALANCE_SHADOW_MODE=true"
+else
+  fail ".env.production.example: REBALANCE_SHADOW_MODE=true が未設定"
+fi
+
+# ── Summary ──
+
+echo ""
+echo "PASS=$PASS FAIL=$FAIL"
+if [ "$FAIL" -eq 0 ]; then
+  echo "✅ All checks passed"
+  exit 0
+else
+  echo "❌ $FAIL check(s) failed"
+  exit 1
+fi


### PR DESCRIPTION
## 概要

`REBALANCE_SHADOW_MODE` を compose ファイルの `environment:` セクションから**完全削除**し、`.env` ファイルの単一ソースで管理する。

**根拠**: Docker Compose の `environment:` は `env_file` を上書きするため、`.env.production` に `REBALANCE_SHADOW_MODE=true` を設定しても `environment: "false"` が優先されていた。  
行ごと削除で `.env` 単一ソース化 + backend の `_get_env_bool(default=True)` で fail-safe を確保。

Asana: https://app.asana.com/0/0/1215190770980388

## 変更内容

| ファイル | 変更 |
|---|---|
| `docker-compose.production.yml` (blue/green) | `REBALANCE_SHADOW_MODE:` 行を **完全削除** |
| `docker-compose.staging.yml` (blue/green) | `REBALANCE_SHADOW_MODE:` 行を **完全削除** |
| `.env.production.example` | `=false` → `=true` + 6/1 解禁コメント追記 |
| `backend/.env.staging.example` | `=false` → `=true` |
| `docs/43_mainnet_wallet_switch_guide.md` | テーブル説明を `.env` 管理に更新 |
| `scripts/verify_rebalance_shadow_source.sh` | DoD 検証スクリプト新規追加 |

## 本番 VPS での作業 (merge 後に人間が実施)

### 本番 VPS (77.42.46.155)
```bash
# .env.production に明示追加
grep "REBALANCE_SHADOW_MODE" /opt/ultra-autotrade/.env.production || \
  printf '\nREBALANCE_SHADOW_MODE=true\n' >> /opt/ultra-autotrade/.env.production

# .env.staging-new に明示追加
grep "REBALANCE_SHADOW_MODE" /opt/ultra-autotrade/.env.staging-new || \
  printf '\nREBALANCE_SHADOW_MODE=true\n' >> /opt/ultra-autotrade/.env.staging-new

# 検証
bash /opt/ultra-autotrade/scripts/verify_rebalance_shadow_source.sh
```

## DoD チェック

- [x] `docker-compose.production.yml` の environment: から REBALANCE_SHADOW_MODE 削除 (4箇所 → 0箇所)
- [x] `docker-compose.staging.yml` の environment: から REBALANCE_SHADOW_MODE 削除
- [x] `.env.production.example` に `REBALANCE_SHADOW_MODE=true` 明示
- [x] `backend/.env.staging.example` に `REBALANCE_SHADOW_MODE=true` 明示
- [x] `scripts/verify_rebalance_shadow_source.sh` で検証可能
- [ ] 本番 VPS の `.env.production` に `REBALANCE_SHADOW_MODE=true` 追記 (merge 後・人間)
- [ ] 本番 VPS の `.env.staging-new` に `REBALANCE_SHADOW_MODE=true` 追記 (merge 後・人間)

🤖 Generated with [Claude Code](https://claude.com/claude-code)