### PR TITLE
fix(finance-feed): log Perplexity 400 body + retry on 5xx/429

### DIFF
--- a/backend/app/data_feeds/finance_feed.py
+++ b/backend/app/data_feeds/finance_feed.py
@@ -184,8 +184,9 @@ async def fetch_finance_data(client: httpx.AsyncClient) -> FinanceFeedResult:
         except Exception:  # noqa: BLE001 — body may be unreadable
             body_preview = "<body unavailable>"
         logger.error(
-            "Perplexity Finance API error %s — body: %s",
+            "Perplexity Finance API error %s (model: %s) — body: %s",
             exc.response.status_code,
+            payload.get("model", "unknown"),
             body_preview,
         )
         return FinanceFeedResult(macro_summary="API error: %d" % exc.response.status_code)
@@ -253,8 +254,9 @@ async def _post_with_retry(
         )
         await asyncio.sleep(_PERPLEXITY_RETRY_BACKOFF_SECONDS)
 
-    # Unreachable: loop always returns or raises, but mypy/pyright wants this.
-    assert last_resp is not None
+    # Unreachable: loop always returns or raises, but mypy needs a non-None guard.
+    if last_resp is None:  # pragma: no cover
+        raise RuntimeError("_post_with_retry: exhausted retries without response")
     return last_resp
 
 

--- a/backend/app/data_feeds/finance_feed.py
+++ b/backend/app/data_feeds/finance_feed.py
@@ -20,7 +20,7 @@ import json
 import logging
 import os
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Any, Optional
 
 import httpx
 from pydantic import BaseModel, Field
@@ -196,7 +196,7 @@ async def fetch_finance_data(client: httpx.AsyncClient) -> FinanceFeedResult:
 
 async def _post_with_retry(
     client: httpx.AsyncClient,
-    payload: dict,
+    payload: dict[str, Any],
     api_key: str,
 ) -> httpx.Response:
     """POST to Perplexity with bounded retry on transient errors.

--- a/backend/tests/data_feeds/test_finance_feed.py
+++ b/backend/tests/data_feeds/test_finance_feed.py
@@ -133,6 +133,78 @@ async def test_fetch_finance_data_list_of_dicts() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fetch_finance_data_400_logs_response_body(caplog: pytest.LogCaptureFixture) -> None:
+    """400 error: response body must be logged to diagnose root cause."""
+    import httpx
+
+    mock_resp = MagicMock(spec=httpx.Response)
+    mock_resp.status_code = 400
+    mock_resp.text = '{"error":{"message":"model not found","type":"invalid_request_error"}}'
+    mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        message="400",
+        request=MagicMock(),
+        response=mock_resp,
+    )
+
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = mock_resp
+        async with httpx.AsyncClient() as client:
+            with patch.dict(os.environ, {"PERPLEXITY_API_KEY": "test-key"}):
+                with caplog.at_level(logging.ERROR, logger="app.data_feeds.finance_feed"):
+                    result = await fetch_finance_data(client)
+
+    assert result.updated_at is None
+    assert "400" in result.macro_summary
+    assert any("model not found" in r.message for r in caplog.records), (
+        "400 response body must appear in error log"
+    )
+    assert any("sonar-pro" in r.message for r in caplog.records), (
+        "model name must appear in error log"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_finance_data_429_retries(caplog: pytest.LogCaptureFixture) -> None:
+    """429 rate-limit: retries once with delay, succeeds on second attempt."""
+    import httpx
+
+    payload_success = {
+        "macro_summary": "Retry succeeded.",
+        "fed_stance": "neutral",
+        "stablecoin_risk": "low",
+        "key_indicators": [],
+    }
+    success_resp = _make_mock_response(json.dumps(payload_success))
+
+    mock_resp_429 = MagicMock(spec=httpx.Response)
+    mock_resp_429.status_code = 429
+    mock_resp_429.text = '{"error":"rate_limit_exceeded"}'
+    mock_resp_429.raise_for_status.side_effect = httpx.HTTPStatusError(
+        message="429",
+        request=MagicMock(),
+        response=mock_resp_429,
+    )
+
+    call_count = 0
+
+    async def _side_effect(*_args: object, **_kwargs: object) -> MagicMock:
+        nonlocal call_count
+        call_count += 1
+        return mock_resp_429 if call_count == 1 else success_resp
+
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock, side_effect=_side_effect):
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            async with httpx.AsyncClient() as client:
+                with patch.dict(os.environ, {"PERPLEXITY_API_KEY": "test-key"}):
+                    result = await fetch_finance_data(client)
+
+    assert result.fed_stance == "neutral"
+    assert result.updated_at is not None
+    assert call_count == 2, "should have retried exactly once"
+    mock_sleep.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_fetch_finance_data_no_api_key() -> None:
     """Missing PERPLEXITY_API_KEY returns default result without error."""
     import httpx


### PR DESCRIPTION
## Summary

- **現象**: `finance_feed.py` が Perplexity API で 200/400 を交互に返し、`fed_stance` が取得できない周期が発生
- **旧実装の問題**: `HTTPStatusError` 時に status code しかログ出力せず、400 の根本原因 (model名/schema/rate limit/token) が不明

## 変更内容

### `backend/app/data_feeds/finance_feed.py`
- `_RETRY_ON_STATUS = {429, 500, 502, 503, 504}` を定義 (400 は含まない)
- `fetch_finance_data` を `for attempt in range(2)` ループに変更
- `HTTPStatusError` 時に `attempt/model/status/body[:500]` をすべてログ出力
  → 次回 400 発生時に `model not found` / `rate_limit_exceeded` 等の真因が即判明
- 429/5xx の場合は 5s 待機後に 1 回リトライ (400 は即時失敗でログ観察に集中)

### `backend/tests/data_feeds/test_finance_feed.py`
- `test_fetch_finance_data_400_logs_response_body`: 400 時に body + model 名がログに出ることを検証
- `test_fetch_finance_data_429_retries`: 429 で 1 回リトライし 2 回目に成功することを検証

## 真因の扱い

400 response body が実機ログに出たら、内容に応じて次の対応を検討:
- `"model not found"` → model 名を `sonar` 等に変更
- `"rate_limit_exceeded"` (400で返す場合) → `_RETRY_ON_STATUS` に 400 追加
- `"invalid_request_error"` → payload 構造の修正

## Test plan

- [x] `pytest tests/data_feeds/test_finance_feed.py` — 9/9 PASS
- [x] `ruff check` / `ruff format --check` — all OK
- [ ] staging deploy 後、次回 60min バックグラウンドタスク実行時のログで 400 body 確認

Closes Asana 1215189378837169

🤖 Generated with [Claude Code](https://claude.com/claude-code)