### PR TITLE
feat(hermes): Phase 0 capture — ai_decision_features + outcomes (Asana 1215219987634293)

### DIFF
--- a/backend/alembic/versions/i9j0k1l2m3n4_add_learning_data_tables.py
+++ b/backend/alembic/versions/i9j0k1l2m3n4_add_learning_data_tables.py
@@ -1,0 +1,181 @@
+"""add_learning_data_tables
+
+Hermes 学習 Phase 0 capture (Asana 1215219987634293):
+  3 テーブルを追加する。h8i9j0k1l2m3 (add_proposals_execution_attempts) の次を取る
+  ことで main の二重採番コンフリクトを解消する。
+
+  - user_actions:
+      manual UI / onboarding 経由でのユーザ click を supervised signal として蓄積。
+      後段の学習データ抽出で ai_decisions と結合し判定→行動系列を学習データ化する。
+
+  - ai_decision_features:
+      ai_decisions と 1:1 で判定時点の特徴量を保存する。
+      特徴量棚卸し: utilization_rate/supply_apy/borrow_apy/health_factor は
+      fetch_aave_market_data_safe() で取得可能。RSI/MACD/volatility/gas は現コードに
+      存在しないため本テーブルに列を持たない (NULL確定列は追加しない)。
+      agent_signals jsonb: 4エージェント (indicator/pattern/risk/macro) の
+      bias+confidence+key_data を保存 (service.py の run_all_agents() 結果)。
+      raw_features jsonb: Aave raw 数値 + geo_risk/fed_stance/stablecoin_risk。
+      embedding: text-embedding-3-small 1536次元 (pgvector)。NULL許容 (fail-open)。
+
+  - ai_decision_outcomes:
+      列定義のみ。Phase 1 バッチで後付け入力する realized_yield_delta 等。
+      partner_approved は承認/却下時に proposals/router.py から即時 capture。
+
+  既存テーブルは変更しない。
+
+Revision ID: i9j0k1l2m3n4
+Revises: h8i9j0k1l2m3
+Create Date: 2026-05-29 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+try:
+    import pgvector.sqlalchemy  # noqa: F401  # available on PostgreSQL envs
+except ImportError:
+    pgvector = None  # type: ignore[assignment]
+
+revision: str = "i9j0k1l2m3n4"
+down_revision: Union[str, Sequence[str], None] = "h8i9j0k1l2m3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # user_actions: manual UI / onboarding click ログ (supervised signal)
+    # ------------------------------------------------------------------
+    op.create_table(
+        "user_actions",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "action_type",
+            sa.String(length=64),
+            nullable=False,
+            comment="e.g. manual_buy_click, manual_sell_click, onramp_completed",
+        ),
+        sa.Column(
+            "target_type",
+            sa.String(length=32),
+            nullable=True,
+            comment="e.g. proposal, asset",
+        ),
+        sa.Column("target_id", sa.String(length=128), nullable=True),
+        sa.Column(
+            "clicked_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("session_id", sa.String(length=128), nullable=True),
+        sa.Column("context_json", postgresql.JSONB(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_user_actions_user_clicked",
+        "user_actions",
+        ["user_id", "clicked_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_user_actions_action_type",
+        "user_actions",
+        ["action_type"],
+        unique=False,
+    )
+
+    # ------------------------------------------------------------------
+    # ai_decision_features: ai_decisions と 1:1 の特徴量保存
+    #
+    # 列選定方針: 判定時に実際に取得できる値のみ。NULL確定の RSI/MACD/gas 等は含めない。
+    # ------------------------------------------------------------------
+    op.create_table(
+        "ai_decision_features",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("ai_decision_id", sa.Integer(), nullable=False),
+        # 4エージェント (indicator/pattern/risk/macro) の bias+confidence+key_data
+        sa.Column("agent_signals", postgresql.JSONB(), nullable=True),
+        # Aave raw + geo_risk/fed_stance/stablecoin_risk の実測値
+        sa.Column("raw_features", postgresql.JSONB(), nullable=True),
+        # 最終判定アクション (BUY/SELL/HOLD)
+        sa.Column("judge_action", sa.String(length=10), nullable=False),
+        # 最終信頼度スコア (0-100)
+        sa.Column("confidence", sa.Integer(), nullable=False),
+        # primary と secondary が一致したか
+        sa.Column("cross_verify", sa.Boolean(), nullable=False),
+        # text-embedding-3-small 1536次元。pgvector が利用可能な場合のみ有効。NULL許容。
+        sa.Column(
+            "embedding",
+            pgvector.sqlalchemy.vector.VECTOR(dim=1536) if pgvector else sa.Text(),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["ai_decision_id"], ["ai_decisions.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_ai_decision_features_decision",
+        "ai_decision_features",
+        ["ai_decision_id"],
+        unique=True,
+    )
+
+    # ------------------------------------------------------------------
+    # ai_decision_outcomes: Phase 1 バッチが書き込む実績データ
+    # partner_approved は承認/却下エンドポイントから即時 INSERT する。
+    # 他列は Phase 1 まで NULL のまま（列定義のみ）。
+    # ------------------------------------------------------------------
+    op.create_table(
+        "ai_decision_outcomes",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("decision_id", sa.Integer(), nullable=False),
+        sa.Column("horizon_hours", sa.Integer(), nullable=True),
+        sa.Column(
+            "realized_yield_delta",
+            sa.Numeric(precision=20, scale=8),
+            nullable=True,
+        ),
+        sa.Column("gas_cost_usd", sa.Numeric(precision=20, scale=8), nullable=True),
+        sa.Column("hf_min_after", sa.Numeric(precision=10, scale=4), nullable=True),
+        sa.Column("partner_approved", sa.Boolean(), nullable=True),
+        sa.Column("regret_score", sa.Numeric(precision=10, scale=4), nullable=True),
+        sa.Column("is_positive_example", sa.Boolean(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["decision_id"], ["ai_decisions.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_ai_decision_outcomes_decision",
+        "ai_decision_outcomes",
+        ["decision_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ai_decision_outcomes_decision", table_name="ai_decision_outcomes")
+    op.drop_table("ai_decision_outcomes")
+    op.drop_index("uq_ai_decision_features_decision", table_name="ai_decision_features")
+    op.drop_table("ai_decision_features")
+    op.drop_index("ix_user_actions_action_type", table_name="user_actions")
+    op.drop_index("ix_user_actions_user_clicked", table_name="user_actions")
+    op.drop_table("user_actions")

--- a/backend/app/ai/models.py
+++ b/backend/app/ai/models.py
@@ -3,12 +3,22 @@
 """AI判定結果の永続化モデル。"""
 
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any, List, Optional
 
-from sqlalchemy import JSON, Boolean, DateTime, Integer, String, Text
+from sqlalchemy import JSON, Boolean, DateTime, Integer, Numeric, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
+
+
+def _embedding_column_type() -> Any:
+    """pgvector が利用可能な場合は Vector(1536)、否の場合は Text を返す。"""
+    try:
+        from pgvector.sqlalchemy import Vector  # noqa: PLC0415
+
+        return Vector(1536)
+    except ImportError:
+        return Text()
 
 
 class AIDecision(Base):
@@ -37,3 +47,86 @@ class AIDecision(Base):
         default=lambda: datetime.now(timezone.utc),
         index=True,
     )
+
+
+class AiDecisionFeature(Base):
+    """AI判定時の特徴量テーブル (Hermes Phase 0 capture)。
+
+    ai_decisions と 1:1。判定ループから INSERT される。
+    列選定: fetch_aave_market_data_safe() + run_all_agents() で取得できる値のみ。
+    RSI/MACD/volatility/gas 等、現コードに存在しない値は含めない (NULL確定列禁止)。
+    """
+
+    __tablename__ = "ai_decision_features"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    ai_decision_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True, unique=True)
+    # 4エージェント (indicator/pattern/risk/macro) の bias+confidence+key_data
+    agent_signals: Mapped[Optional[Any]] = mapped_column(JSON, nullable=True)
+    # Aave raw (utilization/supply_apy/borrow_apy/health_factor) + geo/macro コンテキスト
+    raw_features: Mapped[Optional[Any]] = mapped_column(JSON, nullable=True)
+    judge_action: Mapped[str] = mapped_column(String(10), nullable=False)
+    confidence: Mapped[int] = mapped_column(Integer, nullable=False)
+    cross_verify: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    # text-embedding-3-small 1536次元。pgvector 利用可能時のみ実値が入る。NULL許容 (fail-open)。
+    embedding: Mapped[Optional[List[float]]] = mapped_column(
+        _embedding_column_type(), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+
+class AiDecisionOutcome(Base):
+    """AI判定の実績アウトカムテーブル (Phase 1 バッチで後付け入力)。
+
+    partner_approved のみ承認/却下エンドポイントから即時 INSERT される。
+    他列は Phase 1 まで NULL のまま (列定義のみ)。
+    """
+
+    __tablename__ = "ai_decision_outcomes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    decision_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    horizon_hours: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    realized_yield_delta: Mapped[Optional[Any]] = mapped_column(
+        Numeric(precision=20, scale=8), nullable=True
+    )
+    gas_cost_usd: Mapped[Optional[Any]] = mapped_column(
+        Numeric(precision=20, scale=8), nullable=True
+    )
+    hf_min_after: Mapped[Optional[Any]] = mapped_column(
+        Numeric(precision=10, scale=4), nullable=True
+    )
+    partner_approved: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True)
+    regret_score: Mapped[Optional[Any]] = mapped_column(
+        Numeric(precision=10, scale=4), nullable=True
+    )
+    is_positive_example: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+
+class UserAction(Base):
+    """ユーザ行動ログ (supervised signal)。
+
+    manual UI / onboarding 経由でのクリックを蓄積し、後段の学習データ抽出で
+    ai_decisions と結合して判定→行動の系列を学習データ化する。
+    """
+
+    __tablename__ = "user_actions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    action_type: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    target_type: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    target_id: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    clicked_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+    session_id: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    context_json: Mapped[Optional[Any]] = mapped_column(JSON, nullable=True)

--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -21,13 +21,13 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.ai.judgment_log import get_judgment_logger
-from app.ai.models import AIDecision
+from app.ai.models import AIDecision, AiDecisionFeature
 from app.ai.schemas import CrossValidationResult, RAGContext, TradeAction
 from app.ai.service import AIService
 from app.auth.constants import ExecutionPolicy
 from app.auth.models import InvestmentTier, User, normalize_tier
-from app.automation.aave_data_fetcher import fetch_aave_market_data_safe
-from app.data_feeds.context import build_market_context
+from app.automation.aave_data_fetcher import AaveMarketData, fetch_aave_market_data_safe
+from app.data_feeds.context import MarketContext, build_market_context
 from app.database import SessionLocal
 from app.knowledge.schemas import KnowledgeSearchRequest
 from app.knowledge.service import KnowledgeService
@@ -171,6 +171,141 @@ def save_ai_decision(
     db.add(decision)
     db.flush()  # id を確定させる
     return decision
+
+
+def _build_agent_signals_json(market_ctx: Any) -> Optional[dict[str, Any]]:
+    """MarketContext から run_all_agents() を呼び、jsonb 用 dict を返す。
+
+    market_ctx が MarketContext でない場合 (degraded dict) は None を返す。
+    """
+    from app.ai.agents import run_all_agents  # noqa: PLC0415
+
+    if not isinstance(market_ctx, MarketContext):
+        return None
+    try:
+        agent_ctx = run_all_agents(market_ctx)
+        signals: dict[str, Any] = {}
+        for key, sig in (
+            ("indicator", agent_ctx.indicator_signal),
+            ("pattern", agent_ctx.pattern_signal),
+            ("risk", agent_ctx.risk_signal),
+            ("macro", agent_ctx.macro_signal),
+        ):
+            if sig is not None:
+                signals[key] = {
+                    "bias": sig.bias.value,
+                    "confidence": sig.confidence,
+                    "key_data": {k: str(v) for k, v in sig.key_data.items()},
+                }
+        return signals or None
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("_build_agent_signals_json failed: %s", exc)
+        return None
+
+
+def _build_raw_features_json(
+    aave_data: "AaveMarketData",
+    market_ctx: Any,
+) -> dict[str, Any]:
+    """fetch_aave_market_data_safe() の結果 + MarketContext から raw_features dict を返す。
+
+    RSI/MACD/volatility/gas は現コードに存在しないため含めない。
+    """
+    raw: dict[str, Any] = {
+        "utilization_rate": str(aave_data["utilization_rate"])
+        if aave_data["utilization_rate"] is not None
+        else None,
+        "supply_apy": str(aave_data["supply_apy"])
+        if aave_data["supply_apy"] is not None
+        else None,
+        "borrow_apy": str(aave_data["borrow_apy"])
+        if aave_data["borrow_apy"] is not None
+        else None,
+        "health_factor": str(aave_data["health_factor"])
+        if aave_data["health_factor"] is not None
+        else None,
+    }
+    if isinstance(market_ctx, MarketContext):
+        raw["geo_risk_score"] = market_ctx.geo_risk.geo_risk_score
+        raw["news_sentiment"] = market_ctx.news.sentiment
+        raw["fed_stance"] = market_ctx.finance.fed_stance
+        raw["stablecoin_risk"] = market_ctx.finance.stablecoin_risk
+    return raw
+
+
+def _generate_embedding(text: str) -> Optional[list[float]]:
+    """text-embedding-3-small で 1536 次元ベクトルを生成する (fail-open)。
+
+    OpenAI キーが未設定または API 呼び出し失敗時は None を返す。
+    """
+    try:
+        from openai import OpenAI  # noqa: PLC0415
+
+        from app.ai.config import get_ai_settings  # noqa: PLC0415
+
+        api_key = get_ai_settings().openai_api_key
+        if not api_key:
+            return None
+        client = OpenAI(api_key=api_key)
+        resp = client.embeddings.create(
+            model="text-embedding-3-small",
+            input=text,
+            dimensions=1536,
+        )
+        return resp.data[0].embedding
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("embedding generation failed (fail-open): %s", exc)
+        return None
+
+
+def save_ai_decision_features(
+    db: Session,
+    decision: AIDecision,
+    result: CrossValidationResult,
+    aave_data: "AaveMarketData",
+    market_ctx: Any,
+) -> None:
+    """ai_decision_features に判定時の特徴量を INSERT する (fail-open)。
+
+    呼び出し元の db.commit() 前に呼ぶこと。INSERT 失敗は WARNING ログに留め、
+    判定結果の保存 (save_ai_decision) には影響させない。
+
+    Args:
+        db: SQLAlchemy セッション (flush 済み decision を持つ)。
+        decision: flush 済みの AIDecision (id が確定している)。
+        result: AI クロスバリデーション結果。
+        aave_data: fetch_aave_market_data_safe() の返り値。
+        market_ctx: build_market_context() の返り値、または degraded dict。
+    """
+    try:
+        agent_signals = _build_agent_signals_json(market_ctx)
+        raw_features = _build_raw_features_json(aave_data, market_ctx)
+        embed_text = result.final_reason or _DEFAULT_QUERY
+        embedding = _generate_embedding(embed_text)
+
+        feature = AiDecisionFeature(
+            ai_decision_id=decision.id,
+            agent_signals=agent_signals,
+            raw_features=raw_features,
+            judge_action=result.final_action.value,
+            confidence=result.final_confidence,
+            cross_verify=result.agreed,
+            embedding=embedding,
+        )
+        db.add(feature)
+        db.flush()
+        logger.info(
+            "ai_decision_features inserted: decision_id=%d action=%s confidence=%d",
+            decision.id,
+            result.final_action.value,
+            result.final_confidence,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "save_ai_decision_features failed (fail-open, decision_id=%d): %s",
+            decision.id,
+            exc,
+        )
 
 
 def _get_tier_interval_hours(tier: str) -> int:
@@ -403,6 +538,13 @@ def run_ai_judgment_job(db: Optional[Session] = None) -> dict[str, Any]:
         # cognitive_state は HOLD 連続抑制のため LLM プロンプトに渡す。
         context_degraded = False
         market_ctx: Any
+        # aave_data は ai_decision_features INSERT にも使うため None-safe に初期化しておく。
+        aave_data: AaveMarketData = {
+            "utilization_rate": None,
+            "supply_apy": None,
+            "borrow_apy": None,
+            "health_factor": None,
+        }
         try:
             aave_data = fetch_aave_market_data_safe()
             cognitive_state = get_judgment_logger().get_cognitive_state()
@@ -435,6 +577,9 @@ def run_ai_judgment_job(db: Optional[Session] = None) -> dict[str, Any]:
 
         # DB 保存
         decision = save_ai_decision(db, result, _DEFAULT_QUERY, rag_context=rag_ctx)
+
+        # Hermes Phase 0: 判定時の特徴量を ai_decision_features に INSERT (fail-open)
+        save_ai_decision_features(db, decision, result, aave_data, market_ctx)
 
         # BUY / SELL 時は Proposal 作成
         proposals_created = 0

--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -49,6 +49,44 @@ def _is_permanent_error(exc: Exception) -> bool:
     return isinstance(exc, _PERMANENT_EXCEPTION_TYPES)
 
 
+def _capture_partner_decision(
+    db: Session,
+    ai_decision_id: Optional[int],
+    partner_approved: bool,
+) -> None:
+    """Hermes Phase 0: partner 承認/却下を ai_decision_outcomes に INSERT (fail-open)。
+
+    ai_decision_id が NULL の提案 (手動作成等) は no-op。
+    INSERT 失敗は WARNING に留め、呼び出し元の処理には影響させない。
+    """
+    if ai_decision_id is None:
+        return
+    try:
+        from app.ai.models import AiDecisionOutcome  # noqa: PLC0415
+
+        outcome = AiDecisionOutcome(
+            decision_id=ai_decision_id,
+            partner_approved=partner_approved,
+        )
+        db.add(outcome)
+        db.commit()
+        logger.info(
+            "ai_decision_outcomes captured: decision_id=%d partner_approved=%s",
+            ai_decision_id,
+            partner_approved,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "_capture_partner_decision failed (fail-open, decision_id=%d): %s",
+            ai_decision_id,
+            exc,
+        )
+        try:
+            db.rollback()
+        except Exception:  # noqa: BLE001
+            pass
+
+
 def _expire_old_proposals(db: Session, user_id: int) -> None:
     """期限切れのpending提案をexpiredに更新する。"""
     now = datetime.now(timezone.utc)
@@ -465,6 +503,9 @@ def approve_proposal(
     db.commit()
     db.refresh(proposal)
 
+    # Hermes Phase 0: partner 承認を ai_decision_outcomes に capture (fail-open)
+    _capture_partner_decision(db, proposal.ai_decision_id, partner_approved=True)
+
     # Step 2: Aave 操作を実行（失敗時は 'failed' に遷移）
     _execute_aave_for_proposal(proposal, db)
     db.commit()
@@ -494,6 +535,10 @@ def reject_proposal(
     proposal.rejected_at = datetime.now(timezone.utc)
     db.commit()
     db.refresh(proposal)
+
+    # Hermes Phase 0: partner 却下を ai_decision_outcomes に capture (fail-open)
+    _capture_partner_decision(db, proposal.ai_decision_id, partner_approved=False)
+
     return ProposalResponse.model_validate(proposal)
 
 

--- a/backend/tests/test_ai_judgment_scheduler.py
+++ b/backend/tests/test_ai_judgment_scheduler.py
@@ -1160,3 +1160,132 @@ def test_create_proposals_db_error_one_user_does_not_stop_others(db_session):
     assert count == 1, f"Expected 1 proposal (user_ok only) but got {count}"
     # _resolve_proposal_amount は両ユーザー分呼ばれていること
     assert call_count == 2, f"Expected resolve called twice but got {call_count}"
+
+
+# ---------------------------------------------------------------------------
+# Hermes Phase 0 capture: save_ai_decision_features + save_ai_decision_outcomes
+# ---------------------------------------------------------------------------
+
+
+def test_save_ai_decision_features_inserts_row(db_session):
+    """save_ai_decision_features が ai_decision_features テーブルに1行 INSERT すること。"""
+    from unittest.mock import patch  # noqa: PLC0415
+
+    from app.ai.models import AiDecisionFeature  # noqa: PLC0415
+    from app.automation.ai_judgment_scheduler import save_ai_decision_features  # noqa: PLC0415
+
+    decision = AIDecision(
+        query="test",
+        action="HOLD",
+        confidence=60,
+        primary_provider="claude",
+        primary_action="HOLD",
+        primary_confidence=60,
+        agreed=True,
+    )
+    db_session.add(decision)
+    db_session.flush()
+
+    result = _make_cross_validation_result(TradeAction.HOLD)
+    aave_data = {
+        "utilization_rate": None,
+        "supply_apy": None,
+        "borrow_apy": None,
+        "health_factor": None,
+    }
+    market_ctx = {"degraded": True, "reason": "test"}
+
+    with patch(
+        "app.automation.ai_judgment_scheduler._generate_embedding", return_value=None
+    ):
+        save_ai_decision_features(db_session, decision, result, aave_data, market_ctx)
+
+    db_session.flush()
+    row = db_session.query(AiDecisionFeature).filter_by(ai_decision_id=decision.id).one()
+    assert row.judge_action == "HOLD"
+    assert row.confidence == 80
+    assert row.cross_verify is True
+
+
+def test_save_ai_decision_features_fail_open(db_session):
+    """save_ai_decision_features が失敗しても例外を伝播しないこと (fail-open)。"""
+    from unittest.mock import patch  # noqa: PLC0415
+
+    from app.automation.ai_judgment_scheduler import save_ai_decision_features  # noqa: PLC0415
+
+    decision = AIDecision(
+        query="test",
+        action="HOLD",
+        confidence=60,
+        primary_provider="claude",
+        primary_action="HOLD",
+        primary_confidence=60,
+        agreed=True,
+    )
+    db_session.add(decision)
+    db_session.flush()
+
+    result = _make_cross_validation_result(TradeAction.HOLD)
+    aave_data = {
+        "utilization_rate": None,
+        "supply_apy": None,
+        "borrow_apy": None,
+        "health_factor": None,
+    }
+
+    # db.add が例外を投げてもエラー伝播しないことを確認
+    with patch.object(db_session, "add", side_effect=RuntimeError("db add error")):
+        save_ai_decision_features(db_session, decision, result, aave_data, {})
+    # ここに到達すれば fail-open 動作が確認できている
+
+
+def test_run_ai_judgment_job_inserts_features(test_db):
+    """run_ai_judgment_job 実行後に ai_decision_features が INSERT されること。"""
+    from unittest.mock import patch  # noqa: PLC0415
+
+    from app.ai.models import AiDecisionFeature  # noqa: PLC0415
+    from app.automation.ai_judgment_scheduler import run_ai_judgment_job  # noqa: PLC0415
+
+    session = test_db()
+    try:
+        result = _make_cross_validation_result(TradeAction.HOLD)
+        with (
+            patch(
+                "app.automation.ai_judgment_scheduler.AIService.judge_with_rag",
+                return_value=result,
+            ),
+            patch(
+                "app.automation.ai_judgment_scheduler.KnowledgeService.search",
+                return_value=[],
+            ),
+            patch(
+                "app.automation.ai_judgment_scheduler.fetch_aave_market_data_safe",
+                return_value={
+                    "utilization_rate": None,
+                    "supply_apy": None,
+                    "borrow_apy": None,
+                    "health_factor": None,
+                },
+            ),
+            patch(
+                "app.automation.ai_judgment_scheduler.get_judgment_logger"
+            ) as mock_logger,
+            patch(
+                "app.automation.ai_judgment_scheduler.build_market_context",
+                side_effect=RuntimeError("degraded"),
+            ),
+            patch(
+                "app.automation.ai_judgment_scheduler._generate_embedding",
+                return_value=None,
+            ),
+        ):
+            from app.ai.judgment_log import CognitiveState  # noqa: PLC0415
+
+            mock_logger.return_value.get_cognitive_state.return_value = CognitiveState()
+            run_ai_judgment_job(db=session)
+
+        rows = session.query(AiDecisionFeature).all()
+        assert len(rows) == 1
+        assert rows[0].judge_action == "HOLD"
+    finally:
+        session.close()

--- a/backend/tests/test_hermes_phase0_capture.py
+++ b/backend/tests/test_hermes_phase0_capture.py
@@ -1,0 +1,117 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_hermes_phase0_capture.py
+"""Hermes Phase 0 capture — ai_decision_outcomes.partner_approved 配線テスト。"""
+
+import os
+import tempfile
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-hermes-capture")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "admin@example.com")
+
+from app.ai.models import AIDecision, AiDecisionFeature, AiDecisionOutcome  # noqa: E402
+from app.database import Base  # noqa: E402
+from app.proposals.router import _capture_partner_decision  # noqa: E402
+
+
+@pytest.fixture()
+def db_session():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    Session = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    session = Session()
+    try:
+        yield session
+    finally:
+        session.close()
+    Base.metadata.drop_all(bind=engine)
+    os.unlink(path)
+
+
+def _make_decision(session) -> AIDecision:
+    d = AIDecision(
+        query="test",
+        action="HOLD",
+        confidence=60,
+        primary_provider="claude",
+        primary_action="HOLD",
+        primary_confidence=60,
+        agreed=True,
+    )
+    session.add(d)
+    session.flush()
+    return d
+
+
+class TestCapturePartnerDecision:
+    def test_approve_inserts_outcome_row(self, db_session):
+        decision = _make_decision(db_session)
+        db_session.commit()
+
+        _capture_partner_decision(db_session, decision.id, partner_approved=True)
+
+        row = db_session.query(AiDecisionOutcome).filter_by(decision_id=decision.id).one()
+        assert row.partner_approved is True
+
+    def test_reject_inserts_outcome_row(self, db_session):
+        decision = _make_decision(db_session)
+        db_session.commit()
+
+        _capture_partner_decision(db_session, decision.id, partner_approved=False)
+
+        row = db_session.query(AiDecisionOutcome).filter_by(decision_id=decision.id).one()
+        assert row.partner_approved is False
+
+    def test_no_ai_decision_id_is_noop(self, db_session):
+        """ai_decision_id が NULL の提案は no-op で例外しないこと。"""
+        _capture_partner_decision(db_session, None, partner_approved=True)
+        count = db_session.query(AiDecisionOutcome).count()
+        assert count == 0
+
+    def test_outcome_other_fields_are_null(self, db_session):
+        """Phase 1 までは partner_approved 以外の列は NULL であること。"""
+        decision = _make_decision(db_session)
+        db_session.commit()
+
+        _capture_partner_decision(db_session, decision.id, partner_approved=True)
+
+        row = db_session.query(AiDecisionOutcome).filter_by(decision_id=decision.id).one()
+        assert row.horizon_hours is None
+        assert row.realized_yield_delta is None
+        assert row.gas_cost_usd is None
+        assert row.hf_min_after is None
+        assert row.regret_score is None
+        assert row.is_positive_example is None
+
+
+class TestAiDecisionFeatureModel:
+    def test_model_creates_and_reads_back(self, db_session):
+        """AiDecisionFeature テーブルへの INSERT/SELECT が動作すること。"""
+        decision = _make_decision(db_session)
+
+        feature = AiDecisionFeature(
+            ai_decision_id=decision.id,
+            agent_signals={"indicator": {"bias": "bullish", "confidence": 72}},
+            raw_features={"utilization_rate": "45.5", "health_factor": "2.1"},
+            judge_action="HOLD",
+            confidence=60,
+            cross_verify=True,
+            embedding=None,
+        )
+        db_session.add(feature)
+        db_session.flush()
+
+        row = (
+            db_session.query(AiDecisionFeature)
+            .filter_by(ai_decision_id=decision.id)
+            .one()
+        )
+        assert row.judge_action == "HOLD"
+        assert row.cross_verify is True
+        assert row.agent_signals["indicator"]["bias"] == "bullish"
+        assert row.raw_features["health_factor"] == "2.1"


### PR DESCRIPTION
## Summary

- **revision コンフリクト解消**: `h8i9j0k1l2m3` が main (add_proposals_execution_attempts) と旧 PR #385 で二重採番されていた問題を解消。新 revision `i9j0k1l2m3n4` を `h8i9j0k1l2m3` の後続として作成し、正しいチェーンを構成。
- **ai_decision_features capture 配線**: `ai_judgment_scheduler.py` の判定ループ1箇所に `save_ai_decision_features()` を挿入。`agent_signals` (4エージェント bias+conf) / `raw_features` (Aave raw + geo/fed/stablecoin) / `judge_action` / `confidence` / `cross_verify` / `embedding` (1536次元, fail-open) を INSERT。NULL確定列 (RSI/MACD/gas 等) は含めない。
- **ai_decision_outcomes 追加**: 列定義のみ。`partner_approved` は承認/却下エンドポイントから即時 INSERT。他列は Phase 1 バッチが入力。
- **user_actions 追加**: supervised signal として手動 UI クリックを蓄積 (Phase 1 以降に結合)。
- **partner capture 配線**: `approve_proposal` / `reject_proposal` に `_capture_partner_decision()` を追加。`ai_decision_id` が設定された提案の partner 判断を `ai_decision_outcomes.partner_approved` に記録 (fail-open)。

## Files Changed

| File | Change |
|------|--------|
| `alembic/versions/i9j0k1l2m3n4_add_learning_data_tables.py` | 新規 migration |
| `app/ai/models.py` | AiDecisionFeature / AiDecisionOutcome / UserAction 追加 |
| `app/automation/ai_judgment_scheduler.py` | INSERT 配線 + ヘルパー関数群 |
| `app/proposals/router.py` | `_capture_partner_decision` 追加・配線 |
| `tests/test_hermes_phase0_capture.py` | 新規 (5 tests) |
| `tests/test_ai_judgment_scheduler.py` | 3 tests 追加 |

## Test plan

- [x] `pytest tests/test_hermes_phase0_capture.py` — 5 passed
- [x] `pytest tests/test_ai_judgment_scheduler.py -k "features"` — 3 passed
- [x] Full suite: 3010 passed, coverage 85.85% (≥80%)
- [x] `ruff check .` — All checks passed
- [x] `mypy app/` — 自分コード 0 errors (既存 finance_feed 1 件は pre-existing)
- [ ] 実機確認: migration `alembic upgrade head` → `SELECT * FROM ai_decision_features` で INSERT 確認 (staging で人間実施)

## DoD チェックリスト (MVP-P0-6 反省)

- [x] NULL確定列なし: RSI/MACD/gas/volatility は現コードに存在しないため未追加
- [x] revision 二重採番解消: i9j0k1l2m3n4 → down_revision=h8i9j0k1l2m3 (main の add_proposals_execution_attempts)
- [x] 判定ループ配線1箇所: `save_ai_decision_features` は `save_ai_decision` 直後の1行
- [x] fail-open: features INSERT 失敗は WARNING ログ止まり、判定結果 commit に影響しない
- [x] partner capture fail-open: outcomes INSERT 失敗は WARNING + rollback、propose 処理は継続

🤖 Generated with [Claude Code](https://claude.com/claude-code)