### PR TITLE
fix(aave): HF=inf を None に潰さず伝播させ借入なし状態を正確に判定する

### DIFF
--- a/backend/app/automation/aave_data_fetcher.py
+++ b/backend/app/automation/aave_data_fetcher.py
@@ -128,12 +128,15 @@ def _fetch_health_factor() -> Optional[Decimal]:
     から導出した self.account.address をデフォルトで読む。production は単一ウォレット
     運用なので追加の wallet 引数は不要。
 
-    取得失敗 / Decimal("inf") (借入なし) の場合は None を返す。
+    返り値:
+    - Decimal("inf"): 借入なし（清算リスクゼロ）— indicator_agent が score+22 を付与
+    - None: 取得失敗（不明）
+    これら 2 状態を同じ None に潰さないことで判定精度を維持する。
     """
     try:
         client = get_default_aave_client()
         hf = client.get_health_factor()
-        if hf is None or hf == Decimal("inf"):
+        if hf is None:
             return None
         return hf
     except AaveClientError as exc:

--- a/backend/app/data_feeds/context.py
+++ b/backend/app/data_feeds/context.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from app.ai.judgment_log import CognitiveState
 from app.data_feeds.finance_feed import FinanceFeedResult, get_cached_finance
@@ -32,6 +32,14 @@ class MarketContext(BaseModel):
     aave_supply_apy: Optional[Decimal] = None
     aave_borrow_apy: Optional[Decimal] = None
     health_factor: Optional[Decimal] = None
+
+    @field_validator("health_factor", mode="before")
+    @classmethod
+    def cap_infinity_hf(cls, v: Optional[Decimal]) -> Optional[Decimal]:
+        """借入なし (HF=∞) を 999.0 に変換して pydantic finite_number 制約を回避する。"""
+        if v is not None and isinstance(v, Decimal) and not v.is_finite():
+            return Decimal("999.0")
+        return v
 
     # News context (Perplexity Sonar — 15min cache)
     news: NewsFeedResult = Field(default_factory=get_cached_news)

--- a/backend/tests/test_aave_data_fetcher.py
+++ b/backend/tests/test_aave_data_fetcher.py
@@ -95,8 +95,11 @@ def test_aave_data_safe_partial_success_health_factor_only():
     assert result["borrow_apy"] is None
 
 
-def test_aave_data_safe_inf_health_factor_returns_none():
-    """HF=inf (借入なし) の場合、health_factor は None になり Pool データは正常取得されること。
+def test_aave_data_safe_inf_health_factor_propagates():
+    """HF=inf (借入なし) の場合、health_factor は Decimal("inf") のまま伝播し Pool データも正常取得されること。
+
+    修正前は inf を None に潰していたが、「借入なし（清算リスクゼロ）」と
+    「取得失敗（不明）」を区別するため inf をそのまま返す。
 
     Pool: currentLiquidityRate=5% APR ray, currentVariableBorrowRate=8% APR ray
     aToken.totalSupply = 1,000,000 USDC (1e12 at 6 decimals)
@@ -122,7 +125,9 @@ def test_aave_data_safe_inf_health_factor_returns_none():
     ):
         result = fetch_aave_market_data_safe()
 
-    assert result["health_factor"] is None
+    assert result["health_factor"] == Decimal("inf"), (
+        "HF=inf (借入なし) は None ではなく Decimal('inf') を返すべき"
+    )
     assert result["utilization_rate"] is not None
     assert abs(result["utilization_rate"] - Decimal("85")) < Decimal("0.01")
     # 5% APR ray → 約 5.127% APY (連続複利近似)
@@ -131,6 +136,26 @@ def test_aave_data_safe_inf_health_factor_returns_none():
     # 8% APR ray → 約 8.328% APY
     assert result["borrow_apy"] is not None
     assert abs(result["borrow_apy"] - Decimal("8.328")) < Decimal("0.01")
+
+
+def test_aave_data_safe_none_health_factor_returns_none():
+    """get_health_factor() が None を返した場合 (取得失敗)、health_factor は None になること。
+
+    HF=inf (借入なし) と HF=None (取得失敗) を同じ None に潰さないことを確認する。
+    """
+    mock_client = MagicMock()
+    mock_client.get_health_factor.return_value = None
+    mock_client.w3.eth.contract.side_effect = Exception("skip")
+
+    with patch(
+        "app.automation.aave_data_fetcher.get_default_aave_client",
+        return_value=mock_client,
+    ):
+        result = fetch_aave_market_data_safe()
+
+    assert result["health_factor"] is None, (
+        "get_health_factor() が None を返した場合は None のまま返すべき"
+    )
 
 
 def test_aave_data_safe_calls_get_health_factor_no_args():

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -116,6 +116,62 @@ class TestIndicatorAgent:
         assert signal.key_data.get("supply_apy") == "0.5"
         assert "compressed" in signal.reasoning.lower() or "weak demand" in signal.reasoning.lower()
 
+    # ------------------------------------------------------------------
+    # HF=inf (借入なし) の伝播テスト (2026-05-29)
+    # _fetch_health_factor が inf を None に潰していたバグ修正に対応。
+    # inf → score+22 → BULLISH が通ることを確認する。
+    # ------------------------------------------------------------------
+
+    def test_inf_hf_no_borrowing_scores_ample_buffer(self) -> None:
+        """HF=inf (借入なし=清算リスクゼロ) は score+22 で BULLISH を生成すること。
+
+        修正前: _fetch_health_factor が Decimal("inf") を None に潰す
+          → indicator_agent は hf=None として処理 → score に HF 寄与なし
+          → util=50%/APY=3% の典型入力で NEUTRAL になり BUY ゲートを通過できない。
+        修正後: inf がそのまま伝播 → MarketContext で 999.0 に変換
+          → hf_float=999.0 >= 2.5 → else 分岐で score+22
+          → 同入力で BULLISH → BUY 通過可。
+        MarketContext.cap_infinity_hf が inf → 999.0 に変換するため、
+        build_market_context(health_factor=Decimal("inf")) は ctx.health_factor=999.0 になる。
+        """
+        ctx = build_market_context(
+            health_factor=Decimal("inf"),
+            aave_utilization_rate=Decimal("50"),
+            aave_supply_apy=Decimal("3.0"),
+        )
+        assert ctx.health_factor == Decimal("999.0"), (
+            f"MarketContext は inf を 999.0 に変換するべき (got {ctx.health_factor})"
+        )
+        signal = indicator_agent(ctx)
+        assert signal.bias == Bias.BULLISH, (
+            f"HF=inf (借入なし) は BULLISH になるべき (got {signal.bias})"
+        )
+        assert signal.confidence >= 70, (
+            f"HF=inf シナリオは confidence >= 70 が必要 (got {signal.confidence})"
+        )
+        assert "buffer" in signal.reasoning.lower(), (
+            f"HF=999 の reasoning に 'buffer' が含まれるべき: {signal.reasoning}"
+        )
+
+    def test_inf_hf_is_distinct_from_none_hf(self) -> None:
+        """HF=inf (借入なし) と HF=None (取得失敗) は異なる score を生成すること。
+
+        None: score に HF 寄与なし → util/APY のみで判定
+        inf (→999.0): score+22 → 同 util/APY でも BULLISH に傾く
+        """
+        same_other = {
+            "aave_utilization_rate": Decimal("50"),
+            "aave_supply_apy": Decimal("3.0"),
+        }
+        sig_inf = indicator_agent(build_market_context(health_factor=Decimal("inf"), **same_other))
+        sig_none = indicator_agent(build_market_context(health_factor=None, **same_other))
+        assert sig_inf.bias != sig_none.bias or sig_inf.confidence > sig_none.confidence, (
+            "inf と None は異なるスコア/バイアスになるべき"
+        )
+        assert sig_inf.bias == Bias.BULLISH, (
+            f"inf シナリオは BULLISH になるべき (got {sig_inf.bias})"
+        )
+
 
 class TestPatternAgent:
     def test_no_history_is_neutral(self) -> None:


### PR DESCRIPTION
## 問題

`_fetch_health_factor()` が `Decimal("inf")`（Aave V3 での「借入なし」を表す値）を `None` に変換していた。その結果：

- 「借入なし（清算リスクゼロ）」と「取得失敗（不明）」が同じ `None` に潰されていた
- `indicator_agent` の HF スコアリングが機能せず、util=50%/APY=3% の典型シナリオで NEUTRAL → BUY ゲートを通過できなかった

## 真因

`aave_data_fetcher.py:136`
```python
# 変更前（バグあり）
if hf is None or hf == Decimal("inf"):
    return None

# 変更後（修正）
if hf is None:
    return None
# inf はそのまま return → 「借入なし」として伝播
```

## 修正内容

### 1行修正 (aave_data_fetcher.py)
- `hf == Decimal("inf")` を None に潰す条件を削除

### 副作用対応 (context.py)
- `MarketContext.health_factor` に `cap_infinity_hf` バリデータを追加
- pydantic v2 は `Decimal("inf")` を `finite_number` エラーで拒否するため、既存他スキーマ（`AaveSystemState`等）と同一パターン（inf → `Decimal("999.0")`）で変換

### フロー
```
_fetch_health_factor() → Decimal("inf")
↓
MarketContext.cap_infinity_hf → Decimal("999.0")
↓
indicator_agent: hf_float=999 >= 2.5 → else → score+22
↓
util=50%/APY=3% で BULLISH 86% → BUY 通過可
```

## 副作用 grep 確認

| 箇所 | inf での動作 | 判定 |
|------|------------|------|
| `monitoring_service.record_health_factor` | `Decimal("inf") < 1.6` = False → NORMAL | ✅ |
| `AaveSystemState` pydantic | `cap_infinity_hf` で 999.0 に変換 | ✅ |
| `oracle_monitor`: `hf < threshold` | False → 緊急停止なし | ✅ |
| `agents.py` geo risk: `float(hf) < 1.8` | `inf < 1.8` = False → COMPOUND RISK なし | ✅ |
| `snapshot_service._normalize_hf` | inf → None (DB格納用) — 独立パス | ✅ |

**agents.py は無変更。**

## テスト追加

- `test_aave_data_safe_inf_health_factor_propagates`: inf が伝播すること（`is None` → `== Decimal("inf")`）
- `test_aave_data_safe_none_health_factor_returns_none`: None(取得失敗) は None のまま
- `test_inf_hf_no_borrowing_scores_ample_buffer`: inf → BULLISH (score+22)
- `test_inf_hf_is_distinct_from_none_hf`: inf と None で異なる判定

## Verify

- ruff check: ✅
- ruff format: ✅
- mypy (変更ファイル): ✅
- pytest 3005 passed, coverage 85.85% (≥80%): ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)