### PR TITLE
fix(env): AAVE_NETWORK 期待値を base_mainnet → base に統一

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -67,7 +67,7 @@ EXCHANGE_SANDBOX=false
 # =============================================================================
 # Aave V3（Base Mainnet — sepolia は絶対に指定しない）
 # =============================================================================
-AAVE_NETWORK=base_mainnet
+AAVE_NETWORK=base
 AAVE_RPC_URL=https://base-mainnet.g.alchemy.com/v2/YOUR_KEY
 CHAIN_ID=8453
 AAVE_POOL_ADDRESS=0x...  # Base Mainnet Aave V3 Pool


### PR DESCRIPTION
## Summary

- `.env.production.example` L67: `AAVE_NETWORK=base_mainnet` → `base`
- `scripts/launch_gate/L1_env.sh`: 期待値・コメント・違反メッセージ全 4 箇所を `base_mainnet` → `base`

## Why

`backend/app/aave/client.py` L998 のネットワークキーマップ:
```python
"base": _POOL_ADDRESS_BASE_MAINNET,
"base_sepolia": _POOL_ADDRESS_BASE_SEPOLIA,
```
`base_mainnet` というキーは存在しないため、L1_env.sh gate が常に NG になり、production deploy が通らない。

## Test plan

- [ ] `grep -rn base_mainnet` で残存ゼロを確認（このPRでクリア）
- [ ] L1_env.sh の期待値が `base` になったことをコードレビューで確認
- [ ] staging/prod .env.production に `AAVE_NETWORK=base` が設定済みであることを人間が確認（実 .env は触らない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)