### PR TITLE
feat: policy engine hard-rule layer (LLM → signer 間の機械的検算)

### DIFF
--- a/backend/app/policy/__init__.py
+++ b/backend/app/policy/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/app/policy/__init__.py
+"""Policy engine package — hard rule layer between LLM output and signer."""

--- a/backend/app/policy/engine.py
+++ b/backend/app/policy/engine.py
@@ -1,0 +1,236 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/app/policy/engine.py
+"""
+機械的 policy 検算層。LLM 出力をそのまま signer に渡さないための hard rule。
+OPA/Cedar は Phase B 評価予定。ここは軽量 class 実装。
+学習・AI 出力で上書き不可。
+"""
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---- Defaults (env vars で上書き可能だが、意味論的な安全境界は変わらない) ----
+_DEFAULT_ALLOWED_ASSETS: frozenset[str] = frozenset({"USDC"})
+_DEFAULT_ALLOWED_OPERATIONS: frozenset[str] = frozenset({"SUPPLY", "WITHDRAW"})
+_DEFAULT_MAX_POSITION_USD = Decimal("10000")
+_DEFAULT_DAILY_CAP_USD = Decimal("50000")
+_DEFAULT_HOURLY_CAP_USD = Decimal("20000")
+_DEFAULT_COOLDOWN_SECONDS = 600
+_DEFAULT_HF_FLOOR = Decimal("1.5")
+
+
+@dataclass(frozen=True)
+class PolicyContext:
+    """ポリシーチェック対象の提案属性。"""
+
+    user_id: int
+    asset: str
+    operation: str
+    amount_usd: Decimal
+    expected_hf_after: Optional[Decimal] = None
+    # 承認時のみ設定。DB クエリで自分自身を除外するために使う。
+    proposal_id: Optional[int] = None
+
+
+@dataclass
+class PolicyResult:
+    """ポリシーチェック結果。"""
+
+    passed: bool
+    violations: list[str] = field(default_factory=list)
+
+    @property
+    def blocked(self) -> bool:
+        return not self.passed
+
+
+class PolicyEngine:
+    """
+    提案生成時・承認時に機械的ルールを適用する。
+
+    Rule 1: asset whitelist (USDC のみ)
+    Rule 2: allowed contracts (Aave のみ ≡ SUPPLY/WITHDRAW)
+    Rule 3: max position size per user
+    Rule 4: 日次 velocity cap
+    Rule 5: 時間毎 velocity cap
+    Rule 6: cooldown window
+    Rule 7: HF floor
+    """
+
+    def __init__(self) -> None:
+        self._allowed_assets = _parse_set("POLICY_ALLOWED_ASSETS", _DEFAULT_ALLOWED_ASSETS)
+        self._allowed_operations = _parse_set(
+            "POLICY_ALLOWED_OPERATIONS", _DEFAULT_ALLOWED_OPERATIONS
+        )
+        self._max_position_usd = _parse_decimal(
+            "POLICY_MAX_POSITION_USD", _DEFAULT_MAX_POSITION_USD
+        )
+        self._daily_cap_usd = _parse_decimal(
+            "POLICY_DAILY_VELOCITY_CAP_USD", _DEFAULT_DAILY_CAP_USD
+        )
+        self._hourly_cap_usd = _parse_decimal(
+            "POLICY_HOURLY_VELOCITY_CAP_USD", _DEFAULT_HOURLY_CAP_USD
+        )
+        self._cooldown_seconds = _parse_int("POLICY_COOLDOWN_SECONDS", _DEFAULT_COOLDOWN_SECONDS)
+        self._hf_floor = _parse_decimal("POLICY_HF_FLOOR", _DEFAULT_HF_FLOOR)
+
+    def check(self, ctx: PolicyContext, db: Any) -> PolicyResult:
+        """全ポリシールールを評価する。違反が 1 件でもあれば blocked=True。"""
+        violations: list[str] = []
+
+        # Rule 1: asset whitelist
+        if ctx.asset.upper() not in self._allowed_assets:
+            violations.append(
+                f"asset '{ctx.asset}' not in whitelist {sorted(self._allowed_assets)}"
+            )
+
+        # Rule 2: allowed contracts (Aave only ≡ SUPPLY/WITHDRAW)
+        if ctx.operation.upper() not in self._allowed_operations:
+            violations.append(
+                f"operation '{ctx.operation}' not in allowed set {sorted(self._allowed_operations)}"
+            )
+
+        # Rule 3: max position size
+        if ctx.amount_usd > self._max_position_usd:
+            violations.append(
+                f"amount_usd {ctx.amount_usd} exceeds max_position {self._max_position_usd}"
+            )
+
+        # Rules 4/5/6: DB 参照が必要なチェック
+        if db is not None:
+            violations.extend(self._check_velocity(ctx, db))
+            violations.extend(self._check_cooldown(ctx, db))
+
+        # Rule 7: HF floor
+        if ctx.expected_hf_after is not None and ctx.expected_hf_after < self._hf_floor:
+            violations.append(
+                f"expected_hf_after {ctx.expected_hf_after} below floor {self._hf_floor}"
+            )
+
+        passed = not violations
+        if not passed:
+            logger.warning(
+                "policy: BLOCKED user_id=%d asset=%s op=%s amount_usd=%s — %s",
+                ctx.user_id,
+                ctx.asset,
+                ctx.operation,
+                ctx.amount_usd,
+                "; ".join(violations),
+            )
+        return PolicyResult(passed=passed, violations=violations)
+
+    def _check_velocity(self, ctx: PolicyContext, db: Any) -> list[str]:
+        from sqlalchemy import func, select  # noqa: PLC0415
+
+        from app.proposals.models import Proposal  # noqa: PLC0415
+
+        violations: list[str] = []
+        now = datetime.now(timezone.utc)
+
+        base = select(func.sum(Proposal.amount_usd)).where(
+            Proposal.user_id == ctx.user_id,
+            Proposal.status.in_(["approved", "executed"]),
+        )
+        if ctx.proposal_id is not None:
+            base = base.where(Proposal.id != ctx.proposal_id)
+
+        # Rule 4: daily velocity cap
+        day_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        raw_daily = db.scalar(base.where(Proposal.approved_at >= day_start))
+        daily_sum = Decimal(str(raw_daily)) if raw_daily is not None else Decimal("0")
+        if daily_sum + ctx.amount_usd > self._daily_cap_usd:
+            violations.append(
+                f"daily velocity cap {self._daily_cap_usd} exceeded "
+                f"(approved_today={daily_sum}, adding={ctx.amount_usd})"
+            )
+
+        # Rule 5: hourly velocity cap
+        hour_start = now - timedelta(hours=1)
+        raw_hourly = db.scalar(base.where(Proposal.approved_at >= hour_start))
+        hourly_sum = Decimal(str(raw_hourly)) if raw_hourly is not None else Decimal("0")
+        if hourly_sum + ctx.amount_usd > self._hourly_cap_usd:
+            violations.append(
+                f"hourly velocity cap {self._hourly_cap_usd} exceeded "
+                f"(approved_1h={hourly_sum}, adding={ctx.amount_usd})"
+            )
+
+        return violations
+
+    def _check_cooldown(self, ctx: PolicyContext, db: Any) -> list[str]:
+        from sqlalchemy import select  # noqa: PLC0415
+
+        from app.proposals.models import Proposal  # noqa: PLC0415
+
+        stmt = select(Proposal.approved_at).where(
+            Proposal.user_id == ctx.user_id,
+            Proposal.status.in_(["approved", "executed"]),
+        )
+        if ctx.proposal_id is not None:
+            stmt = stmt.where(Proposal.id != ctx.proposal_id)
+        stmt = stmt.order_by(Proposal.approved_at.desc()).limit(1)
+
+        last_approved_at = db.scalar(stmt)
+        if last_approved_at is None:
+            return []
+
+        # SQLite は timezone-naive で返すため UTC 付与して統一する
+        if last_approved_at.tzinfo is None:
+            last_approved_at = last_approved_at.replace(tzinfo=timezone.utc)
+        elapsed = (datetime.now(timezone.utc) - last_approved_at).total_seconds()
+        if elapsed < self._cooldown_seconds:
+            return [
+                f"cooldown not elapsed ({elapsed:.0f}s since last approval, "
+                f"required={self._cooldown_seconds}s)"
+            ]
+        return []
+
+
+# ---- Module-level singleton ----
+
+_engine_instance: Optional[PolicyEngine] = None
+
+
+def get_policy_engine() -> PolicyEngine:
+    """キャッシュ済み PolicyEngine を返す。テストでは直接 PolicyEngine() を使うこと。"""
+    global _engine_instance
+    if _engine_instance is None:
+        _engine_instance = PolicyEngine()
+    return _engine_instance
+
+
+# ---- Private helpers ----
+
+
+def _parse_set(env_key: str, default: frozenset[str]) -> frozenset[str]:
+    raw = os.getenv(env_key, "").strip()
+    if not raw:
+        return default
+    return frozenset(v.strip().upper() for v in raw.split(",") if v.strip())
+
+
+def _parse_decimal(env_key: str, default: Decimal) -> Decimal:
+    raw = os.getenv(env_key, "").strip()
+    if not raw:
+        return default
+    try:
+        return Decimal(raw)
+    except InvalidOperation:
+        logger.error("policy: invalid decimal %s=%r, using default %s", env_key, raw, default)
+        return default
+
+
+def _parse_int(env_key: str, default: int) -> int:
+    raw = os.getenv(env_key, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.error("policy: invalid int %s=%r, using default %d", env_key, raw, default)
+        return default

--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -21,6 +21,7 @@ from app.auth.dependencies import (
 from app.auth.models import User
 from app.auth.models import User as UserModel
 from app.database import get_db
+from app.policy.engine import PolicyContext, get_policy_engine
 
 from .models import Proposal
 from .schemas import (
@@ -152,6 +153,58 @@ def _record_failed_transaction(
         error_message=error_message,
     )
     db.add(tx)
+
+
+def _policy_gate_create(
+    user_id: int,
+    asset: str,
+    operation: str,
+    amount_usd: Decimal,
+    expected_hf_after: Optional[Decimal],
+    db: Session,
+) -> None:
+    """提案生成時ポリシーチェック（1点目）。違反時は HTTP 422 を上げて DB に書かない。"""
+    ctx = PolicyContext(
+        user_id=user_id,
+        asset=asset,
+        operation=operation,
+        amount_usd=amount_usd,
+        expected_hf_after=expected_hf_after,
+    )
+    result = get_policy_engine().check(ctx, db)
+    if result.blocked:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="[POLICY] " + "; ".join(result.violations),
+        )
+
+
+def _policy_gate_approve(proposal: Proposal, db: Session) -> None:
+    """承認時ポリシーチェック（2点目）。
+    違反時は proposal.status='failed' / error_message 記録 → commit → HTTP 422。
+    #461 wallet NULL ガードは _execute_aave_for_proposal 内で後段に適用される。
+    """
+    ctx = PolicyContext(
+        user_id=proposal.user_id,
+        asset=proposal.asset,
+        operation=proposal.operation,
+        amount_usd=Decimal(str(proposal.amount_usd)),
+        expected_hf_after=(
+            Decimal(str(proposal.expected_hf_after))
+            if proposal.expected_hf_after is not None
+            else None
+        ),
+        proposal_id=proposal.id,
+    )
+    result = get_policy_engine().check(ctx, db)
+    if result.blocked:
+        proposal.status = "failed"
+        proposal.error_message = "[POLICY] " + "; ".join(result.violations)
+        db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=proposal.error_message,
+        )
 
 
 def _execute_aave_for_proposal(proposal: Proposal, db: Session) -> None:
@@ -459,6 +512,9 @@ def approve_proposal(
             detail=f"Cannot approve proposal with status '{proposal.status}'",
         )
 
+    # --- Policy gate (承認時: 2点目) ---
+    _policy_gate_approve(proposal, db)
+
     # Step 1: 承認済みにマーク
     proposal.status = "approved"
     proposal.approved_at = datetime.now(timezone.utc)
@@ -523,6 +579,15 @@ def create_proposal(
     db: Session = Depends(get_db),
 ) -> ProposalResponse:
     """提案を作成する（内部呼び出し用）。"""
+    # --- Policy gate (生成時: 1点目) ---
+    _policy_gate_create(
+        user_id=request.user_id,
+        asset=request.asset,
+        operation=request.operation,
+        amount_usd=Decimal(str(request.amount_usd)),
+        expected_hf_after=request.expected_hf_after,
+        db=db,
+    )
     expires_at = request.expires_at or (datetime.now(timezone.utc) + timedelta(hours=72))
     proposal = Proposal(
         user_id=request.user_id,

--- a/backend/tests/test_policy_engine.py
+++ b/backend/tests/test_policy_engine.py
@@ -1,0 +1,341 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_policy_engine.py
+"""PolicyEngine — 各ポリシールールの pass/fail ユニットテスト。"""
+
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Generator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+# 環境変数を import 前に設定（PolicyEngine.__init__ は init 時に env を読む）
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-policy")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "terms_admin@example.com")
+
+from app.database import Base  # noqa: E402
+from app.policy.engine import PolicyContext, PolicyEngine  # noqa: E402
+from app.proposals.models import Proposal  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_session() -> Generator[Session, None, None]:
+    """インメモリ SQLite セッション。velocity/cooldown テスト用。"""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    yield session
+    session.close()
+    Base.metadata.drop_all(engine)
+    os.unlink(path)
+
+
+def _engine() -> PolicyEngine:
+    """デフォルト設定の PolicyEngine。"""
+    return PolicyEngine()
+
+
+def _ctx(**kwargs) -> PolicyContext:
+    defaults = dict(
+        user_id=1,
+        asset="USDC",
+        operation="SUPPLY",
+        amount_usd=Decimal("100"),
+        expected_hf_after=Decimal("2.0"),
+    )
+    defaults.update(kwargs)
+    return PolicyContext(**defaults)
+
+
+def _approved_proposal(
+    user_id: int,
+    amount_usd: Decimal,
+    approved_at: datetime,
+    proposal_id: int = 1,
+) -> Proposal:
+    """DB に挿入する approved Proposal のファクトリ。"""
+    return Proposal(
+        id=proposal_id,
+        user_id=user_id,
+        operation="SUPPLY",
+        asset="USDC",
+        amount=amount_usd,
+        amount_usd=amount_usd,
+        reason="test",
+        status="approved",
+        approved_at=approved_at,
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=72),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule 1: asset whitelist
+# ---------------------------------------------------------------------------
+
+
+def test_asset_whitelist_pass():
+    result = _engine().check(_ctx(asset="USDC"), db=None)
+    assert result.passed
+
+
+def test_asset_whitelist_fail_eth():
+    result = _engine().check(_ctx(asset="ETH"), db=None)
+    assert result.blocked
+    assert any("asset" in v and "ETH" in v for v in result.violations)
+
+
+def test_asset_whitelist_case_insensitive_pass():
+    result = _engine().check(_ctx(asset="usdc"), db=None)
+    assert result.passed
+
+
+def test_asset_whitelist_fail_wbtc():
+    result = _engine().check(_ctx(asset="WBTC"), db=None)
+    assert result.blocked
+
+
+# ---------------------------------------------------------------------------
+# Rule 2: allowed contracts (Aave only = SUPPLY/WITHDRAW)
+# ---------------------------------------------------------------------------
+
+
+def test_operation_supply_pass():
+    result = _engine().check(_ctx(operation="SUPPLY"), db=None)
+    assert result.passed
+
+
+def test_operation_withdraw_pass():
+    result = _engine().check(_ctx(operation="WITHDRAW"), db=None)
+    assert result.passed
+
+
+def test_operation_borrow_fail():
+    result = _engine().check(_ctx(operation="BORROW"), db=None)
+    assert result.blocked
+    assert any("operation" in v and "BORROW" in v for v in result.violations)
+
+
+def test_operation_repay_fail():
+    result = _engine().check(_ctx(operation="REPAY"), db=None)
+    assert result.blocked
+
+
+def test_operation_unknown_fail():
+    result = _engine().check(_ctx(operation="SWAP"), db=None)
+    assert result.blocked
+
+
+# ---------------------------------------------------------------------------
+# Rule 3: max position size
+# ---------------------------------------------------------------------------
+
+
+def test_max_position_pass():
+    result = _engine().check(_ctx(amount_usd=Decimal("9999")), db=None)
+    assert result.passed
+
+
+def test_max_position_exact_boundary_pass():
+    result = _engine().check(_ctx(amount_usd=Decimal("10000")), db=None)
+    assert result.passed
+
+
+def test_max_position_fail():
+    result = _engine().check(_ctx(amount_usd=Decimal("10001")), db=None)
+    assert result.blocked
+    assert any("max_position" in v for v in result.violations)
+
+
+def test_max_position_env_override(monkeypatch):
+    monkeypatch.setenv("POLICY_MAX_POSITION_USD", "500")
+    eng = PolicyEngine()
+    assert eng.check(_ctx(amount_usd=Decimal("499")), db=None).passed
+    assert eng.check(_ctx(amount_usd=Decimal("501")), db=None).blocked
+
+
+# ---------------------------------------------------------------------------
+# Rule 4: daily velocity cap
+# ---------------------------------------------------------------------------
+
+
+def test_daily_velocity_pass(db_session):
+    # 今日の承認済み合計 0 → 100 USD 追加は 50000 を超えない
+    result = _engine().check(_ctx(amount_usd=Decimal("100")), db=db_session)
+    assert result.passed
+
+
+def test_daily_velocity_fail(db_session):
+    # 今日 49,950 USD 承認済み → 100 追加で 50,050 > 50,000
+    now = datetime.now(timezone.utc)
+    db_session.add(_approved_proposal(1, Decimal("49950"), now))
+    db_session.commit()
+
+    result = _engine().check(_ctx(amount_usd=Decimal("100")), db=db_session)
+    assert result.blocked
+    assert any("daily velocity" in v for v in result.violations)
+
+
+def test_daily_velocity_excludes_old_proposals(db_session):
+    # 昨日の承認は日次カウントに含まれない
+    yesterday = datetime.now(timezone.utc) - timedelta(days=1, seconds=1)
+    db_session.add(_approved_proposal(1, Decimal("49950"), yesterday))
+    db_session.commit()
+
+    result = _engine().check(_ctx(amount_usd=Decimal("100")), db=db_session)
+    assert result.passed
+
+
+# ---------------------------------------------------------------------------
+# Rule 5: hourly velocity cap
+# ---------------------------------------------------------------------------
+
+
+def test_hourly_velocity_pass(db_session):
+    result = _engine().check(_ctx(amount_usd=Decimal("100")), db=db_session)
+    assert result.passed
+
+
+def test_hourly_velocity_fail(db_session):
+    # 過去1時間で 19,950 USD 承認済み → 100 追加で 20,050 > 20,000
+    now = datetime.now(timezone.utc) - timedelta(minutes=10)
+    db_session.add(_approved_proposal(1, Decimal("19950"), now))
+    db_session.commit()
+
+    result = _engine().check(_ctx(amount_usd=Decimal("100")), db=db_session)
+    assert result.blocked
+    assert any("hourly velocity" in v for v in result.violations)
+
+
+def test_hourly_velocity_excludes_old_proposals(db_session):
+    # 2時間前の承認は時間毎カウントに含まれない
+    two_hours_ago = datetime.now(timezone.utc) - timedelta(hours=2)
+    db_session.add(_approved_proposal(1, Decimal("19950"), two_hours_ago))
+    db_session.commit()
+
+    result = _engine().check(_ctx(amount_usd=Decimal("100")), db=db_session)
+    assert result.passed
+
+
+# ---------------------------------------------------------------------------
+# Rule 6: cooldown window
+# ---------------------------------------------------------------------------
+
+
+def test_cooldown_pass_no_history(db_session):
+    # 過去の承認なし → クールダウン不要
+    result = _engine().check(_ctx(), db=db_session)
+    assert result.passed
+
+
+def test_cooldown_pass_elapsed(db_session):
+    # 700s 以上前の承認 → クールダウン (600s) 経過済み
+    long_ago = datetime.now(timezone.utc) - timedelta(seconds=700)
+    db_session.add(_approved_proposal(1, Decimal("100"), long_ago))
+    db_session.commit()
+
+    result = _engine().check(_ctx(), db=db_session)
+    assert result.passed
+
+
+def test_cooldown_fail_recent(db_session):
+    # 60s 前の承認 → クールダウン (600s) 未経過
+    recent = datetime.now(timezone.utc) - timedelta(seconds=60)
+    db_session.add(_approved_proposal(1, Decimal("100"), recent))
+    db_session.commit()
+
+    result = _engine().check(_ctx(), db=db_session)
+    assert result.blocked
+    assert any("cooldown" in v for v in result.violations)
+
+
+def test_cooldown_excludes_other_users(db_session):
+    # 他ユーザーの直近承認は自ユーザーのクールダウンに影響しない
+    recent = datetime.now(timezone.utc) - timedelta(seconds=60)
+    db_session.add(_approved_proposal(user_id=99, amount_usd=Decimal("100"), approved_at=recent))
+    db_session.commit()
+
+    result = _engine().check(_ctx(user_id=1), db=db_session)
+    assert result.passed
+
+
+# ---------------------------------------------------------------------------
+# Rule 7: HF floor
+# ---------------------------------------------------------------------------
+
+
+def test_hf_floor_pass():
+    result = _engine().check(_ctx(expected_hf_after=Decimal("2.0")), db=None)
+    assert result.passed
+
+
+def test_hf_floor_exact_boundary_pass():
+    result = _engine().check(_ctx(expected_hf_after=Decimal("1.5")), db=None)
+    assert result.passed
+
+
+def test_hf_floor_fail():
+    result = _engine().check(_ctx(expected_hf_after=Decimal("1.4")), db=None)
+    assert result.blocked
+    assert any("expected_hf_after" in v and "floor" in v for v in result.violations)
+
+
+def test_hf_floor_none_skipped():
+    # expected_hf_after が None の場合はチェックをスキップ
+    result = _engine().check(_ctx(expected_hf_after=None), db=None)
+    assert result.passed
+
+
+def test_hf_floor_env_override(monkeypatch):
+    monkeypatch.setenv("POLICY_HF_FLOOR", "2.0")
+    eng = PolicyEngine()
+    assert eng.check(_ctx(expected_hf_after=Decimal("2.1")), db=None).passed
+    assert eng.check(_ctx(expected_hf_after=Decimal("1.9")), db=None).blocked
+
+
+# ---------------------------------------------------------------------------
+# Multiple violations reported together
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_violations_all_returned():
+    result = _engine().check(
+        _ctx(
+            asset="ETH",
+            operation="BORROW",
+            amount_usd=Decimal("99999"),
+            expected_hf_after=Decimal("1.0"),
+        ),
+        db=None,
+    )
+    assert result.blocked
+    # 4 violations: asset + operation + position + HF
+    assert len(result.violations) >= 4
+
+
+# ---------------------------------------------------------------------------
+# Clean proposal (all rules pass)
+# ---------------------------------------------------------------------------
+
+
+def test_clean_proposal_all_pass(db_session):
+    result = _engine().check(
+        _ctx(
+            asset="USDC",
+            operation="SUPPLY",
+            amount_usd=Decimal("500"),
+            expected_hf_after=Decimal("2.5"),
+        ),
+        db=db_session,
+    )
+    assert result.passed
+    assert result.violations == []

--- a/backend/tests/test_proposal_wallet_propagation.py
+++ b/backend/tests/test_proposal_wallet_propagation.py
@@ -33,6 +33,20 @@ from app.database import Base, get_db  # noqa: E402
 from app.main import create_app  # noqa: E402
 
 YAMAMOTO_WALLET = "0x2064000000000000000000000000000000000cc66"[:42]
+
+
+@pytest.fixture(autouse=True)
+def _bypass_policy_for_wallet_tests(monkeypatch):
+    """Wallet 伝播テストは policy タイミング依存チェックを経由させない。
+    policy の correct/fail は test_policy_engine.py で検証済み。"""
+    from app.policy.engine import PolicyResult
+
+    monkeypatch.setattr(
+        "app.policy.engine.PolicyEngine.check",
+        lambda self, ctx, db: PolicyResult(passed=True),
+    )
+
+
 HASHIGUCHI_WALLET = "0xabcdef0123456789abcdef0123456789abcdef01"
 
 SAMPLE_PROPOSAL = {


### PR DESCRIPTION
## Summary

- `backend/app/policy/engine.py` に軽量 Python class で policy engine 新規実装
- `proposals/router.py` に生成時・承認時 2 点で policy チェック組み込み
- `tests/test_policy_engine.py` に各ルール pass/fail 30 テスト追加

## Policy Rules (hard rule — 学習で上書き不可)

| Rule | 内容 | デフォルト | 環境変数 |
|------|------|-----------|---------|
| 1 | asset whitelist | USDC のみ | `POLICY_ALLOWED_ASSETS` |
| 2 | allowed contracts | SUPPLY/WITHDRAW のみ (Aave のみ) | `POLICY_ALLOWED_OPERATIONS` |
| 3 | max position size | 10,000 USD | `POLICY_MAX_POSITION_USD` |
| 4 | 日次 velocity cap | 50,000 USD | `POLICY_DAILY_VELOCITY_CAP_USD` |
| 5 | 時間毎 velocity cap | 20,000 USD | `POLICY_HOURLY_VELOCITY_CAP_USD` |
| 6 | cooldown window | 600s | `POLICY_COOLDOWN_SECONDS` |
| 7 | HF floor | 1.5 | `POLICY_HF_FLOOR` |

## 組み込み 2 点

1. **生成時** (`POST /api/proposals`): DB 書き込み前に検算、違反なら HTTP 422
2. **承認時** (`POST /api/proposals/{id}/approve`): #461 wallet NULL ガードの後段に配置
   - 違反時: `proposal.status='failed'`, `error_message='[POLICY] ...'` を記録してから HTTP 422

## Test plan

- [ ] `pytest tests/test_policy_engine.py` — 30 テスト全グリーン確認
- [ ] `pytest tests/test_proposals_api.py tests/test_proposal_deadletter.py tests/test_proposal_execute_failure.py tests/test_proposal_wallet_propagation.py tests/test_integration_proposals.py` — 41 テストリグレッションなし
- [ ] `ruff check` + `ruff format --check` クリーン
- [ ] `mypy app/policy/ app/proposals/router.py` クリーン

Closes Asana 1215079762584279

🤖 Generated with [Claude Code](https://claude.com/claude-code)