### PR TITLE
fix(nginx): upstream.staging.conf を backend-green に修正

### DIFF
--- a/docker/nginx/upstream.staging.conf
+++ b/docker/nginx/upstream.staging.conf
@@ -1,1 +1,1 @@
-set $backend backend-blue:8000;
+set $backend backend-green:8000;


### PR DESCRIPTION
## Summary

- `docker/nginx/upstream.staging.conf` の `backend-blue:8000` を `backend-green:8000` に修正
- Blue/Green 切替時に本番 VPS ローカル手編集のみで main 未反映 → `git pull` が pull blocker になっていた根本解決
- `upstream.production.conf` は変更なし
- staging 系ファイルの `backend-blue` ハードコード grep 確認済み（docker-compose / deploy_staging.sh 内はサービス定義・スイッチングロジックのため対象外）

## Test plan

- [x] `verify.sh` 全チェック pass（ruff / mypy / pytest 80%+ / tsc / npm build）
- [x] diff: `upstream.staging.conf` 1行のみ変更、`upstream.production.conf` 未変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)