### PR TITLE
feat(skill): defi-security-audit §14a non-custodial 検証を追加

### DIFF
--- a/.claude/skills/defi-security-audit/SKILL.md
+++ b/.claude/skills/defi-security-audit/SKILL.md
@@ -51,6 +51,121 @@ description: Run security audit checklist for Ultra AutoTrade. Use when reviewin
 - [ ] #9: main ブランチへの直接push禁止
 - [ ] #10: LLM出力 — JSON Schema バリデーション必須
 
+## §14a Non-Custodial 検証（誰の資産が動くか）— custodial 見落とし再発防止
+
+> **背景 (2026-05-31 RCA)**: Aave `supply()` の `onBehalfOf` にパートナーの `wallet_address` が
+> 渡らず、サーバー共通鍵アドレスが使われる custodial 実装が 5 ゲートを全スルーしてローンチ直前まで
+> 検出されなかった。本セクションはその再発防止のための必須監査項目。
+
+### 対象操作
+
+money が動くすべての操作で本セクションのチェックを実施する:
+- Aave: `supply()` / `withdraw()` / `repay()` / `borrow()`
+- ERC-20: `transfer()` / `transferFrom()` / `approve()`
+- その他 DeFi: LP deposit/withdraw、staking、vault deposit/withdraw
+
+---
+
+### チェックリスト（コードレビュー）
+
+#### 呼び出し経路の `wallet_address` 伝播確認
+- [ ] `service.py` → `client.deposit/withdraw` の呼び出しで `wallet_address` 引数を渡しているか
+  ```bash
+  grep -n "self\._client\.\(deposit\|withdraw\|supply\|repay\|borrow\)" backend/app/aave/service.py
+  # NG 例: self._client.deposit(token, amount)  ← wallet_address 未渡し
+  # OK 例: self._client.deposit(token, amount, wallet_address, private_key)
+  ```
+- [ ] `wallet_address` が `None` / デフォルト値で `self.account.address`（サーバー鍵）に fall-back しないか
+  ```bash
+  grep -n "self\.account\.address\|AAVE_WALLET_ADDRESS" backend/app/aave/client.py
+  # fall-back パスが存在する場合: 必ず呼び出し側で wallet_address を渡しているか確認
+  ```
+- [ ] Protocol / ABC インターフェースのシグネチャ差異を確認
+  ```bash
+  grep -nE "def (deposit|withdraw|supply)\(" backend/app/aave/client.py
+  # 2 引数 Protocol と 5 引数 Base が混在 → どちらが実際に使われているか追跡
+  ```
+
+#### `onBehalfOf` の値確認
+- [ ] `Web3AaveClient.deposit()` が Aave pool の `supply(asset, amount, onBehalfOf, referralCode)` を呼ぶ際に `onBehalfOf = wallet_address` か
+  ```bash
+  grep -n "onBehalfOf\|supply(" backend/app/aave/client.py | head -20
+  ```
+- [ ] `onBehalfOf` に `self.account.address`（サーバー共通鍵）が直接ハードコードされていないか
+
+#### テストの wallet_address 検証
+- [ ] `FakeAaveClient.deposit()` が `wallet_address` を `deposit_calls` に記録しているか
+  ```bash
+  grep -n "deposit_calls\|wallet_address" backend/tests/test_aave_service.py
+  ```
+- [ ] `test_aave_client.py` に `pool_mock.functions.supply.assert_called_once_with(...)` の `onBehalfOf` 引数 assert があるか
+  ```bash
+  grep -n "assert_called\|onBehalfOf\|supply" backend/tests/test_aave_client.py
+  ```
+- [ ] E2E スクリプトが `Web3AaveClient` を直接呼ばず `AaveService` 経由か（AaveService bypass は custodial バグを隠蔽する）
+  ```bash
+  grep -n "Web3AaveClient\|AaveService" scripts/e2e_aave_sepolia.py scripts/aave_e2e_base.py 2>/dev/null
+  ```
+
+---
+
+### チェックリスト（basescan 実 tx 確認）
+
+**実行タイミング**: dry run、UAT、本番 launch 前に必ず実施。
+
+#### Step 1: 対象 tx_hash を取得
+```sql
+-- staging / production: 実行済み提案を取得
+SELECT p.id, p.user_id, u.wallet_address AS partner_wallet, p.tx_hash, p.executed_at
+FROM proposals p
+JOIN users u ON u.id = p.user_id
+WHERE p.status = 'executed' AND p.tx_hash IS NOT NULL
+ORDER BY p.executed_at DESC
+LIMIT 5;
+```
+
+#### Step 2: basescan.org で tx を開く
+`https://basescan.org/tx/<tx_hash>` を開き、以下を **目視確認**:
+
+| 確認項目 | 期待値 | 実際の値（記録） |
+|---------|--------|-----------------|
+| `From` アドレス | サーバー共通鍵 (`AAVE_WALLET_ADDRESS`) | — |
+| Aave supply イベントの `onBehalfOf` | **パートナーの `wallet_address`** | — |
+| トークン転送の `from` | パートナーの `wallet_address` OR サーバー鍵 (approve 済みなら可) | — |
+| `status` | Success | — |
+
+> **判定基準**:
+> - `onBehalfOf` = パートナー wallet → **non-custodial 正常**
+> - `onBehalfOf` = サーバー共通鍵アドレス → **custodial バグ、ローンチブロッカー**
+
+#### basescan で onBehalfOf を探す方法
+1. tx ページの "Input Data" タブを開く
+2. `Decode Input Data` をクリック → `onBehalfOf` 引数の値を確認
+3. または "Logs" タブで `Supply` イベント → `onBehalfOf` トピックを確認
+
+---
+
+### 5 ゲートで見落とす構造的リスク（参考: 2026-05-31 RCA）
+
+| ゲート | 見落とし理由 | 対策 |
+|--------|-------------|------|
+| pytest unit | FakeAaveClient が 2 引数で wallet 未記録 | FakeAaveClient に `wallet_address` を記録・assert 必須化 |
+| pytest Web3 | `supply()` の `call_args` を assert しない | `pool_mock.functions.supply.assert_called_once_with(...)` で `onBehalfOf` 検証 |
+| E2E スクリプト | AaveService を bypass して Web3AaveClient 直呼び | E2E は必ず AaveService 経由 |
+| Production dry run | Aave SUPPLY 確認が「任意」かつ basescan 確認項目なし | 本セクションの Step 2 を dry run DoD に追加 |
+| UAT DoD | `status=Success` のみ確認、`onBehalfOf` 確認なし | 上記 basescan チェック表を UAT DoD 条件4 に追記 |
+
+---
+
+### サーバー共通鍵不在チェック（コード全体）
+
+```bash
+# サーバー共通鍵アドレスが onBehalfOf / recipient に直接使われていないか
+grep -rn "AAVE_WALLET_ADDRESS\|self\.account\.address" backend/app/ \
+  | grep -v "# server-key-ok\|# from-address"
+# ヒットした行を精査: 資産帰属の文脈で使われていれば要修正
+```
+
 ## ASH (Automated Security Helper) Integration
 
 ### Running ASH Locally


### PR DESCRIPTION
## Summary

- `defi-security-audit` skill に §14a「Non-Custodial 検証（誰の資産が動くか）」セクションを追加
- supply/withdraw 等 money 操作で `from` / `onBehalfOf` / トークン帰属 / サーバー共通鍵不在を basescan 実 tx で確認する監査項目を明記
- 2026-05-31 RCA（5 ゲートで custodial バグが検出されなかった）の再発防止

## 変更内容

追加したチェック項目:
1. **コードレビューチェックリスト**
   - `service.py` → `client.deposit/withdraw` の `wallet_address` 伝播確認（grep コマンド付き）
   - `onBehalfOf` の値確認（サーバー鍵にハードコードされていないか）
   - `FakeAaveClient` / `test_aave_client.py` の `wallet_address` 検証確認
   - E2E スクリプトが `AaveService` 経由か（bypass は custodial バグを隠蔽する）

2. **basescan 実 tx 確認チェックリスト**
   - tx_hash 取得 SQL（proposals JOIN users）
   - basescan.org での目視確認表（From / onBehalfOf / status）
   - 判定基準: onBehalfOf = パートナー wallet → non-custodial 正常、= サーバー鍵 → ローンチブロッカー
   - Input Data タブで onBehalfOf を探す手順

3. **5 ゲート見落としリスク表**（FakeAaveClient 2 引数 / AaveService bypass / dry run 任意 / UAT DoD 不備）

4. **サーバー共通鍵不在 grep コマンド**

## 背景（RCA）

2026-05-31 RCA にて確定:
- service.py:357 が self._client.deposit(token, amount) と wallet_address 未伝播で呼び出し
- client.py 内の後方互換パスで onBehalfOf = self.account.address（サーバー共通鍵）が確定
- pytest unit / Web3 test / E2E スクリプト / dry run / UAT DoD の 5 ゲートが全スルー

## Test plan

- [ ] SKILL.md の文法確認（Markdown lint）
- [ ] grep コマンドが実際のリポジトリ構造で動作するか確認
- [ ] defi-security-audit スキル発火時に §14a が参照されることをセッション手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)