### PR TITLE
test(p0-1): DummyClient staging guard 回帰テスト (HTTP レベル)

### DIFF
--- a/backend/tests/protocols/test_risk/test_risk_router.py
+++ b/backend/tests/protocols/test_risk/test_risk_router.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -204,3 +205,46 @@ class TestGetPendleHealth:
             response = _client.get("/api/protocols/health/pendle")
 
         assert response.status_code == 503
+
+
+class TestStagingGuardRegression:
+    """P0-1 DummyClient staging guard 回帰テスト。
+
+    staging 環境で LIDO_SANDBOX=true / PENDLE_SANDBOX=true を設定しても
+    /api/protocols/health/* が 200 を返すことを HTTP レベルで検証する。
+    (旧 guard: 'staging' in ('staging', 'production') → RuntimeError → 500
+     新 guard: 'staging' == 'production' → False → DummyClient 利用可能 → 200)
+    """
+
+    def test_lido_health_staging_with_sandbox_returns_200(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """APP_ENV=staging + LIDO_SANDBOX=true で /health/lido が 200 を返すこと。"""
+        monkeypatch.setenv("APP_ENV", "staging")
+        monkeypatch.setenv("LIDO_SANDBOX", "true")
+        monkeypatch.setenv("PENDLE_SANDBOX", "true")
+        staging_client = TestClient(_app, raise_server_exceptions=False)
+        resp = staging_client.get("/api/protocols/health/lido")
+        assert resp.status_code == 200
+
+    def test_pendle_health_staging_with_sandbox_returns_200(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """APP_ENV=staging + PENDLE_SANDBOX=true で /health/pendle が 200 を返すこと。"""
+        monkeypatch.setenv("APP_ENV", "staging")
+        monkeypatch.setenv("LIDO_SANDBOX", "true")
+        monkeypatch.setenv("PENDLE_SANDBOX", "true")
+        staging_client = TestClient(_app, raise_server_exceptions=False)
+        resp = staging_client.get("/api/protocols/health/pendle")
+        assert resp.status_code == 200
+
+    def test_lido_health_production_with_sandbox_returns_5xx(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """APP_ENV=production + LIDO_SANDBOX=true で /health/lido が 5xx を返すこと。"""
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("LIDO_SANDBOX", "true")
+        monkeypatch.setenv("PENDLE_SANDBOX", "true")
+        prod_client = TestClient(_app, raise_server_exceptions=False)
+        resp = prod_client.get("/api/protocols/health/lido")
+        assert resp.status_code in (500, 503)


### PR DESCRIPTION
## 概要

P0-1 DummyClient staging guard バグ（lido/client.py:435 / pendle/client.py:386）の回帰テストを追加。

コード修正（`if app_env in ('staging', 'production')` → `if app_env == 'production'`）は PR #294 で main に マージ済み。本 PR は HTTP レベルの回帰テストを追加し、再発防止する。

## 変更内容

`backend/tests/protocols/test_risk/test_risk_router.py` に `TestStagingGuardRegression` クラスを追加:

| テスト | 検証内容 |
|---|---|
| `test_lido_health_staging_with_sandbox_returns_200` | APP_ENV=staging + LIDO_SANDBOX=true → `/health/lido` 200 |
| `test_pendle_health_staging_with_sandbox_returns_200` | APP_ENV=staging + PENDLE_SANDBOX=true → `/health/pendle` 200 |
| `test_lido_health_production_with_sandbox_returns_5xx` | APP_ENV=production + LIDO_SANDBOX=true → 5xx（guard 有効） |

## Gate 結果

- Gate 1: `ruff check` ✅ PASS
- Gate 2: `ruff format --check` ✅ PASS
- Gate 3a: `mypy` ✅ PASS (no issues in 243 files)
- Gate 3b: `pytest` ✅ 3091 passed, coverage 85.67%
- 新規テスト 3/3 PASS

## 関連

- Asana P0-1: GID 1214821930631284
- Asana Phase A-1: GID 1214820920029683
- 修正コミット: 8c451d7 (PR #294)

🤖 Generated with [Claude Code](https://claude.com/claude-code)