### PR TITLE
feat(invitations): open registration mode (type=open|invite)

### DIFF
--- a/backend/alembic/versions/j0k1l2m3n4o5_add_invitation_type.py
+++ b/backend/alembic/versions/j0k1l2m3n4o5_add_invitation_type.py
@@ -1,0 +1,52 @@
+"""add_invitation_type
+
+invitations テーブルへの変更（open registration mode 対応）:
+  - type 列追加: VARCHAR(10) DEFAULT 'invite' (open | invite)
+  - partner_id を nullable 変更: open 登録時は partner 不要
+
+Revision ID: j0k1l2m3n4o5
+Revises: i9j0k1l2m3n4
+Create Date: 2026-06-01 00:00:00.000000
+
+既存 invitations レコードは type='invite' (server_default) で自動補完されるため後方互換。
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "j0k1l2m3n4o5"
+down_revision = "i9j0k1l2m3n4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # invitations.type 列追加 (open | invite)
+    op.add_column(
+        "invitations",
+        sa.Column(
+            "type",
+            sa.String(10),
+            nullable=False,
+            server_default="invite",
+        ),
+    )
+    # partner_id を nullable に変更 (open 招待は partner 不要)
+    op.alter_column(
+        "invitations",
+        "partner_id",
+        existing_type=sa.Integer(),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    # partner_id を NOT NULL に戻す (open レコードは NULL なので手動対処が必要)
+    op.alter_column(
+        "invitations",
+        "partner_id",
+        existing_type=sa.Integer(),
+        nullable=False,
+    )
+    op.drop_column("invitations", "type")

--- a/backend/alembic/versions/j0k1l2m3n4o5_add_invitation_type.py
+++ b/backend/alembic/versions/j0k1l2m3n4o5_add_invitation_type.py
@@ -12,6 +12,7 @@ Create Date: 2026-06-01 00:00:00.000000
 """
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -38,6 +38,7 @@ from .models import (
 from .privy_verifier import get_privy_verifier
 from .schemas import (
     LoginRequest,
+    OpenRegisterRequest,
     PasswordChangeRequest,
     RegisterRequest,
     RegisterResponse,
@@ -212,6 +213,75 @@ def register_with_referral(
     )
 
     # Step 7: JWT
+    token, expires_in = AuthService.create_access_token(user.id, user.email, user.role)
+    return RegisterResponse(
+        **UserResponse.model_validate(user).model_dump(),
+        access_token=token,
+        expires_in=expires_in,
+    )
+
+
+@router.post(
+    "/register-open",
+    response_model=RegisterResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="一般登録（partner 招待不要）",
+)
+def register_open(
+    request: OpenRegisterRequest,
+    db: Session = Depends(get_db),
+) -> RegisterResponse:
+    """
+    一般登録（open registration mode）。
+
+    フロー:
+    1. 利用規約同意確認 (terms_consent == True)
+    2. [KYC ゲート接続点] — TODO: KYC 実装は別 Lane で追加予定
+       # kyc_service.check(request.email) → KYC 未通過なら 403 で弾く予定
+    3. Email/username 重複チェック
+    4. ユーザー作成 (role=viewer)
+    5. open 招待レコード作成（監査用・即使用済みマーク）
+    6. JWT 発行 → 201
+
+    利用規約はログイン後に GET /auth/terms/status で確認し、
+    POST /auth/terms/accept で正式同意する（バージョン管理済み）。
+    """
+    # terms_consent フィールドバリデーターで False は既に 422 にしているが
+    # 防御的に router 側でも確認する
+    if not request.terms_consent:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="利用規約への同意が必要です",
+        )
+
+    # [KYC ゲート接続点] ─────────────────────────────────────────────
+    # 実装予定: kyc_service.verify(request.email)
+    #   - PENDING  → 202 (KYC審査中) または 403 (要KYC完了)
+    #   - REJECTED → 403
+    #   - APPROVED → 通過
+    # ────────────────────────────────────────────────────────────────
+
+    from datetime import timedelta  # noqa: PLC0415
+
+    from app.invitations import service as invitation_service  # noqa: PLC0415
+
+    try:
+        user = AuthService.create_user(db, request, role=UserRole.VIEWER.value)
+    except ValueError as e:
+        detail = str(e)
+        if "already registered" in detail or "already taken" in detail:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+
+    # open 招待レコードを監査用に作成（登録完了時点で即使用済み）
+    open_inv = invitation_service.create_open_invitation(
+        db,
+        expires_at=datetime.now(timezone.utc) + timedelta(seconds=1),
+        max_uses=1,
+    )
+    invitation_service.increment_usage(db, open_inv, user_id=user.id)
+
+    logger.info("User registered via open registration: %s", user.email)
     token, expires_in = AuthService.create_access_token(user.id, user.email, user.role)
     return RegisterResponse(
         **UserResponse.model_validate(user).model_dump(),

--- a/backend/app/auth/schemas.py
+++ b/backend/app/auth/schemas.py
@@ -222,6 +222,45 @@ class UserUpdateRequest(BaseModel):
         return v.lower()
 
 
+class OpenRegisterRequest(BaseModel):
+    """一般登録（open）リクエスト。partner 招待不要で自己申請。
+
+    terms_consent == True が必須。KYC ゲートは別 Lane で実装予定。
+    """
+
+    email: EmailStr
+    username: str = Field(min_length=3, max_length=50)
+    password: str = Field(min_length=8, max_length=100)
+    terms_consent: bool = Field(..., description="利用規約への同意（必須）")
+
+    @field_validator("username")
+    @classmethod
+    def validate_username(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("ユーザー名は空白のみにできません")
+        if not (v[0].isalpha() or v[0].isdigit()):
+            raise ValueError(
+                "ユーザー名は文字か数字で始まる必要があります (must start with a letter or number)"
+            )
+        if not re.match(r"^[\w\s\-]+$", v):
+            raise ValueError("ユーザー名には文字・数字・スペース・_・- のみ使用できます")
+        return v.lower()
+
+    @field_validator("password")
+    @classmethod
+    def validate_password(cls, v: str) -> str:
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters")
+        return v
+
+    @field_validator("terms_consent")
+    @classmethod
+    def consent_must_be_true(cls, v: bool) -> bool:
+        if not v:
+            raise ValueError("利用規約への同意が必要です (terms_consent must be True)")
+        return v
+
+
 class PasswordChangeRequest(BaseModel):
     """パスワード変更リクエスト。"""
 

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -26,7 +26,12 @@ from web3 import Web3
 
 from .constants import ExecutionPolicy
 from .models import User, UserRole
-from .schemas import RegisterRequest, RegisterWithReferralRequest, UserCreateRequest
+from .schemas import (
+    OpenRegisterRequest,
+    RegisterRequest,
+    RegisterWithReferralRequest,
+    UserCreateRequest,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -239,7 +244,7 @@ class AuthService:
     def create_user(
         cls,
         db: Session,
-        request: RegisterRequest | RegisterWithReferralRequest | UserCreateRequest,
+        request: RegisterRequest | RegisterWithReferralRequest | UserCreateRequest | OpenRegisterRequest,
         role: str = UserRole.VIEWER.value,
     ) -> User:
         """

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -244,7 +244,10 @@ class AuthService:
     def create_user(
         cls,
         db: Session,
-        request: RegisterRequest | RegisterWithReferralRequest | UserCreateRequest | OpenRegisterRequest,
+        request: RegisterRequest
+        | RegisterWithReferralRequest
+        | UserCreateRequest
+        | OpenRegisterRequest,
         role: str = UserRole.VIEWER.value,
     ) -> User:
         """

--- a/backend/app/invitations/models.py
+++ b/backend/app/invitations/models.py
@@ -3,6 +3,11 @@
 # backend/app/invitations/models.py
 """
 招待コードモデル定義。
+
+Migration (ALTER TABLE):
+  -- j0k1l2m3n4o5: open registration mode 対応
+  ALTER TABLE invitations ADD COLUMN type VARCHAR(10) NOT NULL DEFAULT 'invite';
+  ALTER TABLE invitations ALTER COLUMN partner_id DROP NOT NULL;
 """
 
 from datetime import datetime, timezone
@@ -13,6 +18,9 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
 
+INVITATION_TYPE_OPEN = "open"
+INVITATION_TYPE_INVITE = "invite"
+
 
 class Invitation(Base):
     """
@@ -21,7 +29,8 @@ class Invitation(Base):
     Attributes:
         id:              プライマリキー
         code:            招待コード（16文字ランダム、ユニーク）
-        partner_id:      発行者ユーザーID（FK: users.id）
+        type:            招待種別 (open | invite)。open は partner 認証不要。
+        partner_id:      発行者ユーザーID（FK: users.id）。open 登録時は NULL。
         expires_at:      有効期限
         max_uses:        最大使用回数（デフォルト1）
         used_count:      使用済み回数
@@ -33,8 +42,11 @@ class Invitation(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     code: Mapped[str] = mapped_column(String(16), unique=True, nullable=False, index=True)
-    partner_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    type: Mapped[str] = mapped_column(
+        String(10), nullable=False, default=INVITATION_TYPE_INVITE, server_default=INVITATION_TYPE_INVITE
+    )
+    partner_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=True, index=True
     )
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     max_uses: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
@@ -48,4 +60,4 @@ class Invitation(Base):
     )
 
     def __repr__(self) -> str:
-        return f"<Invitation(id={self.id}, code={self.code}, partner_id={self.partner_id})>"
+        return f"<Invitation(id={self.id}, code={self.code}, type={self.type}, partner_id={self.partner_id})>"

--- a/backend/app/invitations/models.py
+++ b/backend/app/invitations/models.py
@@ -43,7 +43,10 @@ class Invitation(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     code: Mapped[str] = mapped_column(String(16), unique=True, nullable=False, index=True)
     type: Mapped[str] = mapped_column(
-        String(10), nullable=False, default=INVITATION_TYPE_INVITE, server_default=INVITATION_TYPE_INVITE
+        String(10),
+        nullable=False,
+        default=INVITATION_TYPE_INVITE,
+        server_default=INVITATION_TYPE_INVITE,
     )
     partner_id: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=True, index=True

--- a/backend/app/invitations/schemas.py
+++ b/backend/app/invitations/schemas.py
@@ -23,7 +23,8 @@ class InvitationResponse(BaseModel):
 
     id: int
     code: str
-    partner_id: int
+    type: str = "invite"
+    partner_id: Optional[int] = None
     expires_at: datetime
     max_uses: int
     used_count: int
@@ -37,6 +38,7 @@ class InvitationValidateResponse(BaseModel):
     """招待コード検証レスポンス。"""
 
     valid: bool
+    type: Optional[str] = None
     partner_id: Optional[int] = None
     expires_at: Optional[datetime] = None
     uses_remaining: Optional[int] = None

--- a/backend/app/invitations/service.py
+++ b/backend/app/invitations/service.py
@@ -15,7 +15,7 @@ from typing import Optional
 
 from sqlalchemy.orm import Session
 
-from .models import Invitation
+from .models import INVITATION_TYPE_INVITE, INVITATION_TYPE_OPEN, Invitation
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +53,7 @@ def create_invitation(
     code = _generate_unique_code(db)
     invitation = Invitation(
         code=code,
+        type=INVITATION_TYPE_INVITE,
         partner_id=partner_id,
         expires_at=expires_at,
         max_uses=max_uses,
@@ -61,6 +62,37 @@ def create_invitation(
     db.commit()
     db.refresh(invitation)
     logger.info("Created invitation: code=%s partner_id=%d", code, partner_id)
+    return invitation
+
+
+def create_open_invitation(
+    db: Session,
+    expires_at: datetime,
+    max_uses: int = 1,
+) -> Invitation:
+    """
+    open 登録用招待コードを作成する（partner 不要）。
+
+    Args:
+        db:         データベースセッション
+        expires_at: 有効期限
+        max_uses:   最大使用回数
+
+    Returns:
+        作成された Invitation (type='open', partner_id=None)
+    """
+    code = _generate_unique_code(db)
+    invitation = Invitation(
+        code=code,
+        type=INVITATION_TYPE_OPEN,
+        partner_id=None,
+        expires_at=expires_at,
+        max_uses=max_uses,
+    )
+    db.add(invitation)
+    db.commit()
+    db.refresh(invitation)
+    logger.info("Created open invitation: code=%s", code)
     return invitation
 
 

--- a/backend/tests/test_open_registration.py
+++ b/backend/tests/test_open_registration.py
@@ -1,0 +1,248 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/test_open_registration.py
+"""
+Open Registration (一般登録) API のテスト。
+
+POST /auth/register-open:
+- 利用規約同意あり → 201 (viewer ロール)
+- 利用規約同意なし → 422
+- Email 重複 → 409
+- open 招待レコード (type='open', partner_id=None) が監査用に生成される
+- KYC ゲート接続点の存在確認（コメント）
+- 既存 invite フロー (POST /auth/register + invitation_code) は無変更
+
+InvitationService:
+- create_open_invitation で type='open', partner_id=None のレコードが作成される
+"""
+
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ["JWT_SECRET_KEY"] = "test-secret-key-open-registration"
+os.environ["JWT_ALGORITHM"] = "HS256"
+os.environ["JWT_ACCESS_TOKEN_EXPIRE_MINUTES"] = "30"
+os.environ["INITIAL_ADMIN_EMAIL"] = "admin@example.com"
+os.environ["DISABLE_AI_JUDGMENT_SCHEDULER"] = "1"
+os.environ["DISABLE_BACKGROUND_MONITORING"] = "1"
+
+from app.auth.models import User
+from app.auth.service import AuthService
+from app.database import Base, get_db
+from app.invitations import service as invitation_service
+from app.invitations.models import INVITATION_TYPE_INVITE, INVITATION_TYPE_OPEN, Invitation
+from app.main import create_app
+
+
+@pytest.fixture()
+def test_db() -> Generator:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db() -> Generator:
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    yield override_get_db, engine
+
+    Base.metadata.drop_all(bind=engine)
+    os.unlink(path)
+
+
+@pytest.fixture()
+def client(test_db) -> TestClient:
+    override_get_db, _ = test_db
+    app = create_app()
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app)
+
+
+def _future(hours: int = 24) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(hours=hours)
+
+
+# ────────────────────────────────────────────────────────────────
+# InvitationService: create_open_invitation のユニットテスト
+# ────────────────────────────────────────────────────────────────
+
+
+class TestOpenInvitationService:
+    def test_create_open_invitation_type_and_no_partner(self, test_db) -> None:
+        """create_open_invitation は type='open', partner_id=None を生成する。"""
+        override_get_db, _ = test_db
+        db: Session = next(override_get_db())
+        try:
+            inv = invitation_service.create_open_invitation(db, expires_at=_future())
+            assert inv.type == INVITATION_TYPE_OPEN
+            assert inv.partner_id is None
+            assert len(inv.code) == 16
+        finally:
+            db.close()
+
+    def test_create_invitation_keeps_invite_type(self, test_db) -> None:
+        """既存 create_invitation は type='invite' のまま（後方互換）。"""
+        override_get_db, _ = test_db
+        db: Session = next(override_get_db())
+        try:
+            inv = invitation_service.create_invitation(db, partner_id=1, expires_at=_future())
+            assert inv.type == INVITATION_TYPE_INVITE
+            assert inv.partner_id == 1
+        finally:
+            db.close()
+
+    def test_open_invitation_validates_normally(self, test_db) -> None:
+        """open 招待コードも validate_code で有効判定される。"""
+        override_get_db, _ = test_db
+        db: Session = next(override_get_db())
+        try:
+            inv = invitation_service.create_open_invitation(db, expires_at=_future())
+            result = invitation_service.validate_code(db, inv.code)
+            assert result is not None
+            assert result.type == INVITATION_TYPE_OPEN
+        finally:
+            db.close()
+
+
+# ────────────────────────────────────────────────────────────────
+# POST /auth/register-open API テスト
+# ────────────────────────────────────────────────────────────────
+
+
+class TestOpenRegistrationAPI:
+    def test_register_open_success(self, client: TestClient, test_db) -> None:
+        """利用規約同意ありで 201 / role=viewer が返る。"""
+        resp = client.post(
+            "/auth/register-open",
+            json={
+                "email": "openuser@example.com",
+                "username": "openuser",
+                "password": "Password123",
+                "terms_consent": True,
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["email"] == "openuser@example.com"
+        assert data["role"] == "viewer"
+        assert "access_token" in data
+
+    def test_register_open_creates_audit_invitation(self, client: TestClient, test_db) -> None:
+        """open 登録後に type='open' の監査レコードが invitations テーブルに作られる。"""
+        _, engine = test_db
+        resp = client.post(
+            "/auth/register-open",
+            json={
+                "email": "audit@example.com",
+                "username": "audituser",
+                "password": "Password123",
+                "terms_consent": True,
+            },
+        )
+        assert resp.status_code == 201
+
+        SessionLocal = sessionmaker(bind=engine)
+        db = SessionLocal()
+        try:
+            inv = (
+                db.query(Invitation)
+                .filter(Invitation.type == INVITATION_TYPE_OPEN)
+                .order_by(Invitation.id.desc())
+                .first()
+            )
+            assert inv is not None
+            assert inv.partner_id is None
+            assert inv.used_count == 1
+        finally:
+            db.close()
+
+    def test_register_open_terms_consent_false_returns_422(self, client: TestClient) -> None:
+        """terms_consent=False は 422 を返す。"""
+        resp = client.post(
+            "/auth/register-open",
+            json={
+                "email": "noconsent@example.com",
+                "username": "noconsent",
+                "password": "Password123",
+                "terms_consent": False,
+            },
+        )
+        assert resp.status_code == 422
+
+    def test_register_open_duplicate_email_returns_409(self, client: TestClient) -> None:
+        """同一 email で 2 回登録すると 409。"""
+        payload = {
+            "email": "dup@example.com",
+            "username": "dupuser",
+            "password": "Password123",
+            "terms_consent": True,
+        }
+        resp1 = client.post("/auth/register-open", json=payload)
+        assert resp1.status_code == 201
+
+        payload2 = dict(payload)
+        payload2["username"] = "dupuser2"
+        resp2 = client.post("/auth/register-open", json=payload2)
+        assert resp2.status_code == 409
+
+    def test_register_open_does_not_affect_invite_flow(self, client: TestClient, test_db) -> None:
+        """open 登録後も既存 invite フロー (POST /auth/register + invitation_code) が動作する。"""
+        override_get_db, _ = test_db
+        db: Session = next(override_get_db())
+        try:
+            # partner ユーザーを直接作成
+            partner = User(
+                email="partner@example.com",
+                username="partner",
+                hashed_password=AuthService.hash_password("Password123"),
+                role="partner",
+            )
+            db.add(partner)
+            db.commit()
+            db.refresh(partner)
+            partner_id = partner.id
+
+            # partner が invite 招待を発行
+            inv = invitation_service.create_invitation(
+                db, partner_id=partner_id, expires_at=_future()
+            )
+            code = inv.code
+        finally:
+            db.close()
+
+        # open 登録（別ユーザー）
+        client.post(
+            "/auth/register-open",
+            json={
+                "email": "openonly@example.com",
+                "username": "openonly",
+                "password": "Password123",
+                "terms_consent": True,
+            },
+        )
+
+        # invite フローで別ユーザー登録 → 動作確認
+        resp = client.post(
+            "/auth/register",
+            json={
+                "email": "invited@example.com",
+                "username": "inviteduser",
+                "password": "Password123",
+                "invitation_code": code,
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["role"] == "viewer"


### PR DESCRIPTION
## Summary

- **invitations.type 列追加**（`open` | `invite`、DEFAULT `'invite'`）+ `partner_id` を nullable に変更（Alembic migration `j0k1l2m3n4o5`、Lane 1 fee migration とは別ファイル）
- **`create_open_invitation()`** 追加：`type='open'`, `partner_id=None` で監査レコード生成
- **`POST /auth/register-open`** 新エンドポイント：`terms_consent` 必須、KYC ゲート接続点コメント明示（KYC 実装は別 Lane）
- **`OpenRegisterRequest`** スキーマ追加（`terms_consent` バリデーター付き）
- 既存 invite フロー（`POST /auth/register` + `invitation_code`）は**無変更・後方互換**

## 変更ファイル一覧

| ファイル | 種別 |
|---|---|
| `backend/alembic/versions/j0k1l2m3n4o5_add_invitation_type.py` | 新規 migration |
| `backend/app/invitations/models.py` | `type` 列追加、`partner_id` nullable |
| `backend/app/invitations/schemas.py` | `type` フィールド追加 |
| `backend/app/invitations/service.py` | `create_open_invitation()` 追加 |
| `backend/app/auth/schemas.py` | `OpenRegisterRequest` 追加 |
| `backend/app/auth/service.py` | `create_user()` 型ヒント拡張 |
| `backend/app/auth/router.py` | `POST /auth/register-open` 追加 |
| `backend/tests/test_open_registration.py` | 新規テスト 8 件 |

## Gate 結果

- **Gate 1 (ruff lint)**: ✅ pass (auto-fix 2 件、0 remaining)
- **Gate 2 (ruff format)**: ✅ pass
- **Gate 3 (mypy)**: ✅ no issues found in 7 source files
- **pytest**: ✅ 14 passed, 12 skipped（skip は PR #201 以前の旧 API テスト）

## Asana

Closes GID: 1215272519696785

## KYC ゲート接続点

`POST /auth/register-open` の router に以下のコメントを明示済み：

```python
# [KYC ゲート接続点] ─────────────────────────────────────────────
# 実装予定: kyc_service.verify(request.email)
#   - PENDING  → 202 (KYC審査中) または 403 (要KYC完了)
#   - REJECTED → 403
#   - APPROVED → 通過
# ────────────────────────────────────────────────────────────────
```

## 利用規約フロー

1. `POST /auth/register-open` → `terms_consent: true` 必須（false は 422）
2. 登録完了後、`GET /auth/terms/status` でバージョン確認
3. `POST /auth/terms/accept` で正式同意（バージョン管理済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)