### PR TITLE
fix(migration): fee_transactions risk_mode CHECK を conservative/balanced/aggressive に修正

### DIFF
--- a/backend/alembic/sql/045_fee_v10_tables.sql
+++ b/backend/alembic/sql/045_fee_v10_tables.sql
@@ -87,7 +87,7 @@ CREATE TABLE fee_transactions (
   finalized_at TIMESTAMP WITH TIME ZONE NULL,
 
   CONSTRAINT chk_fee_tx_tier CHECK (tier IN ('LOWER', 'MIDDLE', 'UPPER')),
-  CONSTRAINT chk_fee_tx_risk_mode CHECK (risk_mode IN ('LOW', 'MIDDLE', 'HIGH')),
+  CONSTRAINT chk_fee_tx_risk_mode CHECK (risk_mode IN ('conservative', 'balanced', 'aggressive')),
   CONSTRAINT uq_fee_tx_user_month UNIQUE (user_id, calculation_month)
 );
 
@@ -105,7 +105,7 @@ COMMENT ON TABLE fee_transactions IS
 COMMENT ON COLUMN fee_transactions.tier IS
   'v10 投資ティア (LOWER / MIDDLE / UPPER)';
 COMMENT ON COLUMN fee_transactions.risk_mode IS
-  'v10 リスクモード (LOW / MIDDLE / HIGH)';
+  'v10 リスクモード (conservative / balanced / aggressive) — F-3 RiskMode enum 内部値';
 COMMENT ON COLUMN fee_transactions.subscription_protected IS
   'サブスク控除によりユーザー手取りが負にならないよう保護されたか';
 

--- a/backend/alembic/versions/d4e5f6a7b8c9_fee_v10_tables.py
+++ b/backend/alembic/versions/d4e5f6a7b8c9_fee_v10_tables.py
@@ -153,7 +153,10 @@ def upgrade() -> None:
         ),
         sa.Column("finalized_at", sa.DateTime(timezone=True), nullable=True),
         sa.CheckConstraint("tier IN ('LOWER', 'MIDDLE', 'UPPER')", name="chk_fee_tx_tier"),
-        sa.CheckConstraint("risk_mode IN ('LOW', 'MIDDLE', 'HIGH')", name="chk_fee_tx_risk_mode"),
+        sa.CheckConstraint(
+            "risk_mode IN ('conservative', 'balanced', 'aggressive')",
+            name="chk_fee_tx_risk_mode",
+        ),
         sa.UniqueConstraint("user_id", "calculation_month", name="uq_fee_tx_user_month"),
     )
     op.create_index(

--- a/docs/ops/02_db_tables.md
+++ b/docs/ops/02_db_tables.md
@@ -1,6 +1,6 @@
 # Ultra AutoTrade — DB テーブル一覧
 
-> 生成: 2026-04-24 / ソース: `backend/app/*/models.py`
+> 生成: 2026-04-24 / 更新: 2026-06-01 (fee_configs v10 + fee_transactions 全カラム反映) / ソース: `backend/app/*/models.py`
 > DB: PostgreSQL 16 + pgvector (pg16)
 > 接続: `postgresql://ultra:<PW>@postgres:5432/ultra_autotrade`
 
@@ -273,46 +273,29 @@ docker exec ultra-autotrade-postgres-production \
 
 ---
 
-### `fee_configs` (billing/models.py)
+### `fee_configs` (fees/models.py — v10)
+
+> Fee Model v10 設定スナップショット。`is_active=True` かつ最新 `effective_from` のレコードが現行設定。
+> F-16 本番適用前は旧 v9 スキーマ (management_fee_rate 等) が存在する。適用手順: `alembic/sql/045_fee_v10_tables.sql`。
 
 | カラム | 型 | NULL | 説明 |
 |--------|-----|------|------|
-| id | Integer PK | NO | 自動採番 |
-| management_fee_rate | Numeric | NO | 管理手数料率 |
-| performance_fee_rate | Numeric | NO | 成功報酬率 |
-| high_water_mark_enabled | Boolean | NO | HWM有効 |
-| minimum_aum | Numeric | NO | 最低運用額 |
+| id | BigInteger PK | NO | 自動採番 |
+| config_name | String(64) UNIQUE | NO | 設定名 (例: `v10_default`) |
+| tier_thresholds_jpy | JSONB | NO | tier 境界 JPY 配列 (例: `[1000000, 10000000]`) |
+| tier_fee_rates | JSONB | NO | tier 別手数料率配列 (例: `[0.30, 0.25, 0.20]`) |
+| tier_monthly_yield_caps | JSONB | NO | tier 別月次利回り上限 (例: `[0.018, 0.023, 0.030]`) |
+| subscription_rates | JSONB | NO | リスクモード別月額サブスク率 (例: `{"conservative":0,"balanced":0.003,"aggressive":0.010}`) |
+| expense_markup_enabled | Boolean | NO | 経費マークアップ有効 (default: FALSE) |
+| expense_markup_rate | Numeric(6,4) | NO | 経費マークアップ率 (default: 0) |
+| affiliate_rate | Numeric(6,4) | NO | アフィリエイト率 (default: 0.30) |
+| is_active | Boolean | NO | 現行設定フラグ (default: FALSE) |
+| effective_from | DateTime(tz) | NO | 適用開始日時 |
 | created_at | DateTime(tz) | NO | 作成日時 |
 | updated_at | DateTime(tz) | NO | 更新日時 |
 
----
-
-### `fee_calculations` (billing/models.py)
-
-| カラム | 型 | NULL | 説明 |
-|--------|-----|------|------|
-| id | Integer PK | NO | 自動採番 |
-| user_id | Integer FK(users.id) | NO | ユーザーID |
-| calculation_date | Date | NO | 計算日 |
-| period_type | String(10) | NO | `daily` / `monthly` |
-| aum_snapshot | Numeric | NO | AUMスナップショット |
-| management_fee | Numeric | NO | 管理手数料 |
-| performance_fee | Numeric | NO | 成功報酬 |
-| total_fee | Numeric | NO | 合計手数料 |
-| profit_since_hwm | Numeric | NO | HWM以降の利益 |
-| high_water_mark | Numeric | NO | ハイウォーターマーク |
-| created_at | DateTime(tz) | NO | 作成日時 |
-
----
-
-### `high_water_marks` (billing/models.py)
-
-| カラム | 型 | NULL | 説明 |
-|--------|-----|------|------|
-| id | Integer PK | NO | 自動採番 |
-| user_id | Integer FK(users.id) UNIQUE | NO | ユーザーID |
-| hwm_value | Numeric | NO | HWM値 |
-| updated_at | DateTime(tz) | NO | 更新日時 |
+> **v9 旧テーブル** (`fee_calculations`, `high_water_marks`) は F-16 の 045 SQL 適用時に DROP される。
+> v9 fee_configs は 0 行確認済み (2026-04-25) のため安全に置換可能。
 
 ### `ai_feedbacks` (ai/feedback_models.py)
 
@@ -349,29 +332,37 @@ docker exec ultra-autotrade-postgres-production \
 
 > ⚠️ `fund_allocations` は本番DBクリーンアップインシデント (2026-04-28) の対象テーブル。テストデータ投入禁止。
 
-### `fee_transactions` (billing/v10_models.py)
+### `fee_transactions` (fees/models.py — v10)
 
 > Fee Model v10 (F-1〜F-16) の月次手数料計算結果。1ユーザー×1ヶ月で1レコード。
+> F-16 本番適用前はテーブル未作成。適用手順: `alembic/sql/045_fee_v10_tables.sql`。
+>
+> CHECK 制約: `tier IN ('LOWER','MIDDLE','UPPER')` / `risk_mode IN ('conservative','balanced','aggressive')`
+> UNIQUE: `(user_id, calculation_month)`
 
 | カラム | 型 | NULL | 説明 |
 |--------|-----|------|------|
 | id | BigInteger PK | NO | 自動採番 |
 | user_id | Integer FK(users.id) | NO | ユーザーID |
 | calculation_month | Date | NO | 計算月 (月初日) |
-| tier | VARCHAR(16) | NO | `LOWER` / `MIDDLE` / `UPPER` |
-| risk_mode | VARCHAR(16) | NO | `conservative` / `balanced` / `aggressive` |
+| tier | VARCHAR(16) | NO | `LOWER` / `MIDDLE` / `UPPER` (CHECK 制約あり) |
+| risk_mode | VARCHAR(16) | NO | `conservative` / `balanced` / `aggressive` (CHECK 制約あり) |
 | deposit_amount_jpy | Numeric(18,2) | NO | 運用元本 (JPY) |
-| gross_profit_jpy | Numeric(18,2) | NO | 総利益 (JPY) |
-| expense_jpy | Numeric(18,2) | NO | 費用 (JPY) |
-| net_profit_jpy | Numeric(18,2) | NO | 純利益 (JPY) |
-| fee_rate_applied | Numeric(6,4) | NO | 適用手数料率 |
-| fee_amount_jpy | Numeric(18,2) | NO | 手数料金額 (JPY) |
-| subscription_rate_applied | Numeric(6,4) | NO | 月額サブスク率 |
-| subscription_amount_jpy | Numeric(18,2) | NO | 月額サブスク金額 (JPY) |
-| user_takehome_jpy | Numeric(18,2) | NO | ユーザー手取り (JPY) |
-| finalized_at | DateTime(tz) | YES | 確定日時 (NULL=再計算可能) |
-| created_at | DateTime(tz) | NO | 作成日時 |
-| updated_at | DateTime(tz) | NO | 更新日時 |
+| gross_profit_jpy | Numeric(18,2) | NO | 総利益 (JPY, default 0) |
+| expense_jpy | Numeric(18,2) | NO | 費用 (JPY, default 0) |
+| net_profit_jpy | Numeric(18,2) | NO | 純利益 (JPY, default 0) |
+| fee_rate_applied | Numeric(6,4) | NO | 適用手数料率 (default 0) |
+| fee_amount_jpy | Numeric(18,2) | NO | 手数料金額 (JPY, default 0) |
+| subscription_rate_applied | Numeric(6,4) | NO | 月額サブスク率 (default 0) |
+| subscription_amount_jpy | Numeric(18,2) | NO | 月額サブスク金額 (JPY, default 0) |
+| subscription_protected | Boolean | NO | サブスク控除で手取り負防止フラグ (default FALSE) |
+| monthly_yield_cap_applied | Numeric(6,4) | NO | 適用月次利回り上限 (default 0) |
+| yield_excess_to_uata_jpy | Numeric(18,2) | NO | 上限超過分UATA取得額 (JPY, default 0) |
+| user_takehome_jpy | Numeric(18,2) | NO | ユーザー手取り (JPY, default 0) |
+| affiliate_id | Integer FK(users.id) | YES | アフィリエイターID (ON DELETE SET NULL) |
+| affiliate_amount_jpy | Numeric(18,2) | NO | アフィリエイト金額 (JPY, default 0) |
+| calculated_at | DateTime(tz) | NO | 計算実行日時 (default NOW()) |
+| finalized_at | DateTime(tz) | YES | 確定日時 (NULL=再計算可能)
 
 ---
 


### PR DESCRIPTION
## Summary

- `fee_transactions.risk_mode` の CHECK 制約が `('LOW','MIDDLE','HIGH')` と定義されており、F-3 RiskMode enum の内部値 `('conservative','balanced','aggressive')` と不一致だった
- 関連: Asana 1215153474347063, 1215272519685583

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `backend/alembic/sql/045_fee_v10_tables.sql` | CHECK 制約を `('conservative','balanced','aggressive')` に修正 |
| `backend/alembic/versions/d4e5f6a7b8c9_fee_v10_tables.py` | 同様に修正 (production 向け Alembic migration) |
| `docs/ops/02_db_tables.md` | fee_configs を v9→v10 スキーマに更新、fee_transactions の全カラム記載 |

## CHECK 制約の正解判定根拠

全コードベースを grep で確認した結果、`conservative/balanced/aggressive` が正解:

```
app/auth/models.py: RiskMode.CONSERVATIVE='conservative', BALANCED='balanced', AGGRESSIVE='aggressive'
  → RISK_MODE_JP_LABELS = {ローリスク/ミドルリスク/ハイリスク}
  → CLAUDE.md §18 (ローリスク/ミドル/ハイ) と一致

app/aave/mdd_tracker.py: MDD_THRESHOLDS キー = 'conservative'/'balanced'/'aggressive'
app/aave/rebalance_service.py: _VALID_RISK_MODES = frozenset({'conservative','balanced','aggressive'})
docs/ops/fee_model_v10.md: "内部値: conservative/balanced/aggressive (リネーム禁止)"
```

`LOW/MIDDLE/HIGH` は F-1 設計当初の暫定値で、F-3 で正式に小文字値に統一されている。
models.py の定義 (`'conservative','balanced','aggressive'`) は正しかった。

## 注意事項

- **production**: F-16 で 045 を初回適用 → この修正で最初から正しい CHECK が入る
- **staging-new**: 045 (旧 CHECK) 適用済み → 引き続き 046 (`e5f6a7b8c9d0`) を適用すること
- 046 (`alembic/versions/e5f6a7b8c9d0_check_constraint_alignment.py`) は staging-new 向けに残置

## Test plan

- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — 494 files already formatted
- [x] `mypy app/ --config-file ../pyproject.toml` — Success: no issues found in 243 source files
- [x] `pytest tests/test_seed_fee_config_v10.py tests/test_api_v1_fees.py -v` — 52 passed
- [x] `pytest tests/ -q` — 3069 passed, 21 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)