### PR TITLE
feat(fees): F-S6 on-chain fee transfer — FEE_TRANSFER_ENABLED gate + non-custodial pull model

### DIFF
--- a/backend/alembic/versions/j0k1l2m3n4o5_fee_transfer_columns.py
+++ b/backend/alembic/versions/j0k1l2m3n4o5_fee_transfer_columns.py
@@ -15,6 +15,7 @@ Create Date: 2026-06-01 00:00:00.000000
 from typing import Sequence, Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 revision: str = "j0k1l2m3n4o5"

--- a/backend/alembic/versions/j0k1l2m3n4o5_fee_transfer_columns.py
+++ b/backend/alembic/versions/j0k1l2m3n4o5_fee_transfer_columns.py
@@ -1,0 +1,53 @@
+"""add_fee_transfer_columns
+
+fee_transactions テーブルに on-chain 送金追跡カラムを追加する (F-S6)。
+
+Columns added:
+  transfer_status   VARCHAR(16)  NULL: 'sent'|'failed'|'no_allowance'|'low_fee'|'skipped'
+  transfer_tx_hash  VARCHAR(66)  NULL: on-chain tx hash (0x... 64 hex)
+  usd_jpy_rate      NUMERIC(8,2) NULL: 計算時の USD/JPY レート (手数料 USD 換算に使用)
+
+Revision ID: j0k1l2m3n4o5
+Revises: i9j0k1l2m3n4
+Create Date: 2026-06-01 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "j0k1l2m3n4o5"
+down_revision: Union[str, Sequence[str], None] = "i9j0k1l2m3n4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """fee_transactions に on-chain 送金追跡カラムを追加。"""
+    op.add_column(
+        "fee_transactions",
+        sa.Column("transfer_status", sa.String(16), nullable=True),
+    )
+    op.add_column(
+        "fee_transactions",
+        sa.Column("transfer_tx_hash", sa.String(66), nullable=True),
+    )
+    op.add_column(
+        "fee_transactions",
+        sa.Column("usd_jpy_rate", sa.Numeric(8, 2), nullable=True),
+    )
+    op.create_index(
+        "idx_fee_tx_transfer_status",
+        "fee_transactions",
+        ["transfer_status"],
+        postgresql_where=sa.text("transfer_status IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    """追加したカラムとインデックスを削除。"""
+    op.drop_index("idx_fee_tx_transfer_status", table_name="fee_transactions")
+    op.drop_column("fee_transactions", "usd_jpy_rate")
+    op.drop_column("fee_transactions", "transfer_tx_hash")
+    op.drop_column("fee_transactions", "transfer_status")

--- a/backend/alembic/versions/k1l2m3n4o5p6_fee_transfer_columns.py
+++ b/backend/alembic/versions/k1l2m3n4o5p6_fee_transfer_columns.py
@@ -7,8 +7,8 @@ Columns added:
   transfer_tx_hash  VARCHAR(66)  NULL: on-chain tx hash (0x... 64 hex)
   usd_jpy_rate      NUMERIC(8,2) NULL: 計算時の USD/JPY レート (手数料 USD 換算に使用)
 
-Revision ID: j0k1l2m3n4o5
-Revises: i9j0k1l2m3n4
+Revision ID: k1l2m3n4o5p6
+Revises: j0k1l2m3n4o5
 Create Date: 2026-06-01 00:00:00.000000
 """
 
@@ -18,8 +18,8 @@ import sqlalchemy as sa
 
 from alembic import op
 
-revision: str = "j0k1l2m3n4o5"
-down_revision: Union[str, Sequence[str], None] = "i9j0k1l2m3n4"
+revision: str = "k1l2m3n4o5p6"
+down_revision: Union[str, Sequence[str], None] = "j0k1l2m3n4o5"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/app/api/v1/fees.py
+++ b/backend/app/api/v1/fees.py
@@ -45,6 +45,11 @@ from app.auth.dependencies import require_active_user, require_admin
 from app.auth.models import InvestmentTier, RiskMode, User
 from app.database import get_db
 from app.fees import FeeCalculationInput, FeeCalculator
+from app.fees.fee_transfer_service import (
+    FeeTransferConfig,
+    FeeTransferService,
+    is_fee_transfer_enabled,
+)
 from app.fees.models import FeeConfigV10, FeeTransaction
 from app.portfolio.models import PortfolioSnapshot
 from app.transactions.models import Transaction
@@ -179,7 +184,7 @@ class UataIncomeResponse(BaseModel):
 
 
 class FinalizeMonthResponse(BaseModel):
-    """月次 finalize バッチの実行結果サマリ (F-7)。"""
+    """月次 finalize バッチの実行結果サマリ (F-7 + F-S6)。"""
 
     calculation_month: date
     usd_jpy_rate: str
@@ -190,6 +195,11 @@ class FinalizeMonthResponse(BaseModel):
     total_fee_jpy: str
     total_subscription_jpy: str
     total_user_takehome_jpy: str
+    # F-S6: on-chain transfer 統計
+    fee_transfer_enabled: bool = False
+    transfer_sent: int = 0
+    transfer_skipped: int = 0
+    transfer_failed: int = 0
 
 
 # ===========================================================================
@@ -352,6 +362,7 @@ def finalize_month_core(
                         user_takehome_jpy=result.user_takehome_jpy,
                         affiliate_id=result.affiliate_id,
                         affiliate_amount_jpy=result.affiliate_amount_jpy,
+                        usd_jpy_rate=usd_jpy_rate,
                     )
                 )
             else:
@@ -371,6 +382,7 @@ def finalize_month_core(
                 existing.user_takehome_jpy = result.user_takehome_jpy
                 existing.affiliate_id = result.affiliate_id
                 existing.affiliate_amount_jpy = result.affiliate_amount_jpy
+                existing.usd_jpy_rate = usd_jpy_rate
 
         total_fee += result.fee_amount_jpy
         total_sub += result.subscription_amount_jpy
@@ -391,6 +403,73 @@ def finalize_month_core(
         dry_run,
     )
 
+    # --- F-S6: on-chain fee transfer (FEE_TRANSFER_ENABLED=true の場合のみ) ---
+    # FEE_TRANSFER_ENABLED=false (default) → DB 記録のみ、送金しない (現状維持)
+    # FEE_TRANSFER_ENABLED=true  → operator wallet が aToken.transferFrom を実行
+    # non-custodial §14a: operator wallet は自身の鍵 (OPERATOR_FEE_WALLET_KEY) を使用。
+    # ユーザーの秘密鍵は不要。ユーザーが事前に aToken の allowance を operator に付与。
+    transfer_sent = 0
+    transfer_skipped = 0
+    transfer_failed = 0
+    fee_transfer_enabled = is_fee_transfer_enabled()
+
+    if not dry_run and fee_transfer_enabled:
+        transfer_cfg = FeeTransferConfig.from_env()
+        transfer_svc = FeeTransferService(transfer_cfg)
+
+        fee_txs_to_transfer = (
+            db.execute(
+                select(FeeTransaction).where(
+                    FeeTransaction.calculation_month == month_start,
+                    FeeTransaction.finalized_at.is_(None),
+                    FeeTransaction.transfer_status.is_(None),
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        for fee_tx in fee_txs_to_transfer:
+            fee_user = db.get(User, fee_tx.user_id)
+            user_wallet = fee_user.wallet_address if fee_user else None
+            t_result = transfer_svc.transfer_fee(
+                user_id=fee_tx.user_id,
+                user_wallet=user_wallet or "",
+                fee_amount_jpy=fee_tx.fee_amount_jpy or Decimal("0"),
+                subscription_amount_jpy=fee_tx.subscription_amount_jpy or Decimal("0"),
+                yield_excess_jpy=fee_tx.yield_excess_to_uata_jpy or Decimal("0"),
+                usd_jpy_rate=usd_jpy_rate,
+            )
+            fee_tx.transfer_status = t_result.status
+            fee_tx.transfer_tx_hash = t_result.tx_hash
+            if t_result.status == "sent":
+                fee_tx.finalized_at = datetime.now(timezone.utc)
+                transfer_sent += 1
+                logger.info(
+                    "fee_transfer sent: user_id=%d tx=%s fee_usd=%s",
+                    fee_tx.user_id,
+                    t_result.tx_hash,
+                    t_result.fee_usd,
+                )
+            elif t_result.status in ("skipped", "low_fee"):
+                transfer_skipped += 1
+            else:
+                transfer_failed += 1
+                logger.warning(
+                    "fee_transfer %s: user_id=%d error=%s",
+                    t_result.status,
+                    fee_tx.user_id,
+                    t_result.error,
+                )
+
+        db.commit()
+        logger.info(
+            "fee_transfer phase done: sent=%d skipped=%d failed=%d",
+            transfer_sent,
+            transfer_skipped,
+            transfer_failed,
+        )
+
     return FinalizeMonthResponse(
         calculation_month=month_start,
         usd_jpy_rate=str(usd_jpy_rate),
@@ -401,6 +480,10 @@ def finalize_month_core(
         total_fee_jpy=str(total_fee),
         total_subscription_jpy=str(total_sub),
         total_user_takehome_jpy=str(total_takehome),
+        fee_transfer_enabled=fee_transfer_enabled,
+        transfer_sent=transfer_sent,
+        transfer_skipped=transfer_skipped,
+        transfer_failed=transfer_failed,
     )
 
 

--- a/backend/app/fees/fee_transfer_service.py
+++ b/backend/app/fees/fee_transfer_service.py
@@ -29,10 +29,7 @@ import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, Optional
-
-if TYPE_CHECKING:
-    from web3 import Web3 as Web3Type
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/fees/fee_transfer_service.py
+++ b/backend/app/fees/fee_transfer_service.py
@@ -1,0 +1,462 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/fees/fee_transfer_service.py
+"""F-S6: On-chain fee transfer service (月次手数料 on-chain 徴収).
+
+Non-custodial design (§14a):
+  FROM:  user.wallet_address — Aave aToken がユーザー自身の wallet に存在
+  TO:    OPERATOR_FEE_WALLET_ADDRESS env var — operator 自身の wallet
+  HOW:   operator wallet が aToken.transferFrom(user, operator, amount) を実行
+  KEY:   OPERATOR_FEE_WALLET_KEY = operator **自身の** 秘密鍵 (ユーザー鍵 ≠)
+  GATE:  FEE_TRANSFER_ENABLED=false → DB 記録のみ (デフォルト)、true → 実送金
+
+non-custodial 保護ロジック:
+  - サーバーはユーザーの秘密鍵を持たない (今日直した custodial 問題 §14a 再発防止)
+  - ユーザーは供給時に aToken の operator wallet への allowance を事前承認
+  - Operator は承認された分だけ引き出し可能。ユーザーはいつでも revoke 可能
+  - Operator wallet は自身の資金のみコントロール — ユーザー資産を代理管理しない
+
+参考:
+  - docs/45_fee_model_v10_migration_plan.md §4 F-S6
+  - /home/uata/handoffs/2026-06-01_fee_collection_method.md
+  - backend/app/proposals/router.py — AUTO_EXECUTION_ENABLED フラグと同型
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from web3 import Web3 as Web3Type
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# ABI (最小限)
+# ---------------------------------------------------------------------------
+
+#: ERC-20 最小 ABI: allowance, transferFrom
+_ERC20_ABI_MINIMAL: list[dict[str, object]] = [
+    {
+        "name": "allowance",
+        "type": "function",
+        "stateMutability": "view",
+        "inputs": [
+            {"name": "owner", "type": "address"},
+            {"name": "spender", "type": "address"},
+        ],
+        "outputs": [{"name": "", "type": "uint256"}],
+    },
+    {
+        "name": "transferFrom",
+        "type": "function",
+        "stateMutability": "nonpayable",
+        "inputs": [
+            {"name": "from", "type": "address"},
+            {"name": "to", "type": "address"},
+            {"name": "amount", "type": "uint256"},
+        ],
+        "outputs": [{"name": "", "type": "bool"}],
+    },
+    {
+        "name": "decimals",
+        "type": "function",
+        "stateMutability": "view",
+        "inputs": [],
+        "outputs": [{"name": "", "type": "uint8"}],
+    },
+]
+
+#: Aave Pool Data Provider ABI: getReserveTokensAddresses
+_DATA_PROVIDER_ABI_MINIMAL: list[dict[str, object]] = [
+    {
+        "name": "getReserveTokensAddresses",
+        "type": "function",
+        "stateMutability": "view",
+        "inputs": [{"name": "asset", "type": "address"}],
+        "outputs": [
+            {"name": "aTokenAddress", "type": "address"},
+            {"name": "stableDebtTokenAddress", "type": "address"},
+            {"name": "variableDebtTokenAddress", "type": "address"},
+        ],
+    },
+]
+
+# ---------------------------------------------------------------------------
+# データクラス
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FeeTransferConfig:
+    """on-chain fee transfer の設定。環境変数から組み立て。"""
+
+    enabled: bool
+    operator_wallet_address: str
+    operator_wallet_key: str
+    rpc_url: str
+    data_provider_address: str
+    usdc_address: str
+    chain_id: int
+
+    @classmethod
+    def from_env(cls, chain_name: str = "base_sepolia") -> "FeeTransferConfig":
+        """環境変数から設定を読み込む。
+
+        FEE_TRANSFER_ENABLED=false の場合、他の変数は空でも構わない。
+        """
+        from app.aave.chains import get_chain_config  # noqa: PLC0415
+
+        enabled = os.getenv("FEE_TRANSFER_ENABLED", "false").lower() == "true"
+        op_address = os.getenv("OPERATOR_FEE_WALLET_ADDRESS", "")
+        op_key = os.getenv("OPERATOR_FEE_WALLET_KEY", "")
+        active_chain = os.getenv("AAVE_ACTIVE_CHAINS", chain_name).split(",")[0].strip()
+        chain_cfg = get_chain_config(active_chain)
+        rpc_url = os.getenv(chain_cfg.rpc_url_env_var, "") if chain_cfg.rpc_url_env_var else ""
+        return cls(
+            enabled=enabled,
+            operator_wallet_address=op_address,
+            operator_wallet_key=op_key,
+            rpc_url=rpc_url,
+            data_provider_address=chain_cfg.data_provider_address or "",
+            usdc_address=chain_cfg.tokens.get("USDC", ""),
+            chain_id=chain_cfg.chain_id,
+        )
+
+
+@dataclass(frozen=True)
+class FeeTransferResult:
+    """1 ユーザー分の on-chain 手数料送金結果。"""
+
+    user_id: int
+    user_wallet: str
+    fee_usd: Decimal
+    atoken_units: int  # aUSDC raw units (6 decimals)
+    tx_hash: Optional[str] = None
+    status: str = "skipped"  # 'sent' | 'skipped' | 'failed' | 'low_fee' | 'no_allowance'
+    error: Optional[str] = None
+    debug_log: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# サービス
+# ---------------------------------------------------------------------------
+
+
+class FeeTransferService:
+    """月次手数料 on-chain 徴収サービス。
+
+    FEE_TRANSFER_ENABLED=false の間は何もしない (dry run と同等)。
+    true になった時点で operator wallet が aToken.transferFrom を実行する。
+    """
+
+    #: 1 件の fee_transfer が処理対象とみなす最低 USD 金額
+    MIN_FEE_USD: Decimal = Decimal("0.01")
+
+    def __init__(self, config: FeeTransferConfig) -> None:
+        self.config = config
+        self._w3: Optional[Any] = None  # lazy init
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def transfer_fee(
+        self,
+        user_id: int,
+        user_wallet: str,
+        fee_amount_jpy: Decimal,
+        subscription_amount_jpy: Decimal,
+        yield_excess_jpy: Decimal,
+        usd_jpy_rate: Decimal,
+    ) -> FeeTransferResult:
+        """1 ユーザー分の月次手数料を on-chain で送金する。
+
+        FEE_TRANSFER_ENABLED=false → status='skipped' を返す (送金しない)。
+
+        Args:
+            user_id: 手数料対象ユーザー ID (logging 用)
+            user_wallet: ユーザーの on-chain wallet address
+            fee_amount_jpy: 成功報酬 (JPY)
+            subscription_amount_jpy: サブスク手数料 (JPY)
+            yield_excess_jpy: yield cap 超過分 (JPY)
+            usd_jpy_rate: 計算時の USD/JPY レート
+        """
+        debug: list[str] = []
+
+        # Gate 1: flag
+        if not self.config.enabled:
+            debug.append("FEE_TRANSFER_ENABLED=false → skipped")
+            return FeeTransferResult(
+                user_id=user_id,
+                user_wallet=user_wallet,
+                fee_usd=Decimal("0"),
+                atoken_units=0,
+                status="skipped",
+                debug_log=debug,
+            )
+
+        # Gate 2: operator wallet 設定
+        if not self.config.operator_wallet_address or not self.config.operator_wallet_key:
+            msg = "OPERATOR_FEE_WALLET_ADDRESS or OPERATOR_FEE_WALLET_KEY not configured"
+            logger.error("fee_transfer user_id=%d: %s", user_id, msg)
+            return FeeTransferResult(
+                user_id=user_id,
+                user_wallet=user_wallet,
+                fee_usd=Decimal("0"),
+                atoken_units=0,
+                status="failed",
+                error=msg,
+                debug_log=debug,
+            )
+
+        # Gate 3: user wallet
+        if not user_wallet:
+            msg = f"user_id={user_id} has no wallet_address"
+            logger.warning("fee_transfer: %s", msg)
+            return FeeTransferResult(
+                user_id=user_id,
+                user_wallet="",
+                fee_usd=Decimal("0"),
+                atoken_units=0,
+                status="skipped",
+                error=msg,
+                debug_log=debug,
+            )
+
+        # 手数料 JPY → USD 変換
+        total_operator_jpy = fee_amount_jpy + subscription_amount_jpy + yield_excess_jpy
+        if usd_jpy_rate <= Decimal("0"):
+            return FeeTransferResult(
+                user_id=user_id,
+                user_wallet=user_wallet,
+                fee_usd=Decimal("0"),
+                atoken_units=0,
+                status="failed",
+                error=f"invalid usd_jpy_rate={usd_jpy_rate}",
+                debug_log=debug,
+            )
+        fee_usd = (total_operator_jpy / usd_jpy_rate).quantize(Decimal("0.000001"))
+        debug.append(
+            f"total_operator_jpy={total_operator_jpy} / rate={usd_jpy_rate} = fee_usd={fee_usd}"
+        )
+
+        # Gate 4: 最低金額チェック (dust 防止)
+        if fee_usd < self.MIN_FEE_USD:
+            debug.append(f"fee_usd={fee_usd} < MIN_FEE_USD={self.MIN_FEE_USD} → low_fee")
+            return FeeTransferResult(
+                user_id=user_id,
+                user_wallet=user_wallet,
+                fee_usd=fee_usd,
+                atoken_units=0,
+                status="low_fee",
+                debug_log=debug,
+            )
+
+        # on-chain 実行
+        return self._execute_transfer(user_id, user_wallet, fee_usd, debug)
+
+    def check_allowance(self, user_wallet: str) -> Decimal:
+        """ユーザーが operator wallet に付与した aToken allowance を USD 換算で返す。
+
+        FEE_TRANSFER_ENABLED=false の場合でも呼び出し可能 (diagnostic 用)。
+
+        Returns:
+            Decimal allowance in USD (0 if not configured or RPC error)
+        """
+        if not self.config.rpc_url or not self.config.operator_wallet_address:
+            return Decimal("0")
+        try:
+            w3 = self._get_w3()
+            atoken = self._get_atoken_address(w3)
+            if not atoken:
+                return Decimal("0")
+            atoken_contract = w3.eth.contract(
+                address=w3.to_checksum_address(atoken),
+                abi=_ERC20_ABI_MINIMAL,
+            )
+            raw_allowance = atoken_contract.functions.allowance(
+                w3.to_checksum_address(user_wallet),
+                w3.to_checksum_address(self.config.operator_wallet_address),
+            ).call()
+            decimals = atoken_contract.functions.decimals().call()
+            allowance_usd = Decimal(raw_allowance) / Decimal(10**decimals)
+            return allowance_usd
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("check_allowance error: %s", exc)
+            return Decimal("0")
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _get_w3(self) -> Any:
+        """Web3 インスタンスをlazy initで返す。"""
+        if self._w3 is None:
+            from web3 import Web3  # noqa: PLC0415
+
+            self._w3 = Web3(Web3.HTTPProvider(self.config.rpc_url))
+        return self._w3
+
+    def _get_atoken_address(self, w3: Any) -> Optional[str]:
+        """Pool Data Provider から aUSDC の address を取得する。"""
+        if not self.config.data_provider_address or not self.config.usdc_address:
+            return None
+        try:
+            dp = w3.eth.contract(
+                address=w3.to_checksum_address(self.config.data_provider_address),
+                abi=_DATA_PROVIDER_ABI_MINIMAL,
+            )
+            result = dp.functions.getReserveTokensAddresses(
+                w3.to_checksum_address(self.config.usdc_address)
+            ).call()
+            atoken_addr: str = result[0]
+            logger.debug("aUSDC address: %s", atoken_addr)
+            return atoken_addr
+        except Exception as exc:  # noqa: BLE001
+            logger.error("_get_atoken_address error: %s", exc)
+            return None
+
+    def _execute_transfer(
+        self,
+        user_id: int,
+        user_wallet: str,
+        fee_usd: Decimal,
+        debug: list[str],
+    ) -> FeeTransferResult:
+        """aToken.transferFrom を実行する。
+
+        operator wallet が user_wallet から operator_wallet_address へ fee を引き出す。
+        """
+        try:
+            w3 = self._get_w3()
+
+            # aToken アドレス取得
+            atoken_addr = self._get_atoken_address(w3)
+            if not atoken_addr:
+                return FeeTransferResult(
+                    user_id=user_id,
+                    user_wallet=user_wallet,
+                    fee_usd=fee_usd,
+                    atoken_units=0,
+                    status="failed",
+                    error="aToken address unavailable",
+                    debug_log=debug,
+                )
+
+            atoken_contract = w3.eth.contract(
+                address=w3.to_checksum_address(atoken_addr),
+                abi=_ERC20_ABI_MINIMAL,
+            )
+            decimals = atoken_contract.functions.decimals().call()
+            atoken_units = int(fee_usd * Decimal(10**decimals))
+            debug.append(f"atoken_addr={atoken_addr} decimals={decimals} units={atoken_units}")
+
+            # Allowance チェック
+            op_addr_cs = w3.to_checksum_address(self.config.operator_wallet_address)
+            user_addr_cs = w3.to_checksum_address(user_wallet)
+            raw_allowance = atoken_contract.functions.allowance(user_addr_cs, op_addr_cs).call()
+            if raw_allowance < atoken_units:
+                msg = f"insufficient allowance: allowed={raw_allowance} < required={atoken_units}"
+                logger.warning("fee_transfer user_id=%d: %s", user_id, msg)
+                debug.append(msg)
+                return FeeTransferResult(
+                    user_id=user_id,
+                    user_wallet=user_wallet,
+                    fee_usd=fee_usd,
+                    atoken_units=atoken_units,
+                    status="no_allowance",
+                    error=msg,
+                    debug_log=debug,
+                )
+
+            # Nonce 取得
+            account = w3.eth.account.from_key(self.config.operator_wallet_key)
+            nonce = w3.eth.get_transaction_count(account.address, "pending")
+
+            # transferFrom tx 構築
+            tx = atoken_contract.functions.transferFrom(
+                user_addr_cs,
+                op_addr_cs,
+                atoken_units,
+            ).build_transaction(
+                {
+                    "from": account.address,
+                    "nonce": nonce,
+                    "chainId": self.config.chain_id,
+                    "gas": 100000,
+                    "gasPrice": w3.eth.gas_price,
+                }
+            )
+            signed = w3.eth.account.sign_transaction(
+                tx, private_key=self.config.operator_wallet_key
+            )
+            tx_hash = w3.eth.send_raw_transaction(signed.raw_transaction)
+            receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=120)
+
+            tx_hash_hex = tx_hash.hex()
+            if receipt.status != 1:
+                msg = f"tx reverted: {tx_hash_hex}"
+                logger.error("fee_transfer user_id=%d: %s", user_id, msg)
+                return FeeTransferResult(
+                    user_id=user_id,
+                    user_wallet=user_wallet,
+                    fee_usd=fee_usd,
+                    atoken_units=atoken_units,
+                    tx_hash=tx_hash_hex,
+                    status="failed",
+                    error=msg,
+                    debug_log=debug,
+                )
+
+            logger.info(
+                "fee_transfer sent: user_id=%d wallet=%s...%s fee_usd=%s tx=%s",
+                user_id,
+                user_wallet[:6],
+                user_wallet[-4:],
+                fee_usd,
+                tx_hash_hex,
+            )
+            debug.append(f"tx_hash={tx_hash_hex} status=1")
+            return FeeTransferResult(
+                user_id=user_id,
+                user_wallet=user_wallet,
+                fee_usd=fee_usd,
+                atoken_units=atoken_units,
+                tx_hash=tx_hash_hex,
+                status="sent",
+                debug_log=debug,
+            )
+
+        except Exception as exc:  # noqa: BLE001
+            msg = f"transfer exception: {exc}"
+            logger.error("fee_transfer user_id=%d: %s", user_id, msg)
+            return FeeTransferResult(
+                user_id=user_id,
+                user_wallet=user_wallet,
+                fee_usd=fee_usd,
+                atoken_units=0,
+                status="failed",
+                error=msg,
+                debug_log=debug,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Helpers (module-level)
+# ---------------------------------------------------------------------------
+
+
+def is_fee_transfer_enabled() -> bool:
+    """FEE_TRANSFER_ENABLED=true かどうかを返す。"""
+    return os.getenv("FEE_TRANSFER_ENABLED", "false").lower() == "true"
+
+
+def get_fee_transfer_datetime() -> datetime:
+    """現在時刻 (UTC, timezone-aware)。テストでモック可能なように分離。"""
+    return datetime.now(timezone.utc)

--- a/backend/app/fees/models.py
+++ b/backend/app/fees/models.py
@@ -168,6 +168,14 @@ class FeeTransaction(Base):
     )
     finalized_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
 
+    # F-S6: on-chain fee transfer 追跡 (j0k1l2m3n4o5 migration)
+    # ALTER TABLE fee_transactions ADD COLUMN IF NOT EXISTS transfer_status VARCHAR(16);
+    # ALTER TABLE fee_transactions ADD COLUMN IF NOT EXISTS transfer_tx_hash VARCHAR(66);
+    # ALTER TABLE fee_transactions ADD COLUMN IF NOT EXISTS usd_jpy_rate NUMERIC(8,2);
+    transfer_status: Mapped[Optional[str]] = mapped_column(String(16), nullable=True)
+    transfer_tx_hash: Mapped[Optional[str]] = mapped_column(String(66), nullable=True)
+    usd_jpy_rate: Mapped[Optional[Decimal]] = mapped_column(Numeric(8, 2), nullable=True)
+
     __table_args__ = (
         CheckConstraint(
             "tier IN ('LOWER', 'MIDDLE', 'UPPER')",

--- a/backend/scripts/test_fee_transfer_staging.py
+++ b/backend/scripts/test_fee_transfer_staging.py
@@ -52,29 +52,59 @@ CHAIN_ID = 84532
 FEE_USD_TEST = Decimal("0.01")  # 0.01 USDC (最小テスト金額)
 
 ERC20_ABI = [
-    {"name": "approve", "type": "function", "stateMutability": "nonpayable",
-     "inputs": [{"name": "spender", "type": "address"}, {"name": "amount", "type": "uint256"}],
-     "outputs": [{"name": "", "type": "bool"}]},
-    {"name": "allowance", "type": "function", "stateMutability": "view",
-     "inputs": [{"name": "owner", "type": "address"}, {"name": "spender", "type": "address"}],
-     "outputs": [{"name": "", "type": "uint256"}]},
-    {"name": "balanceOf", "type": "function", "stateMutability": "view",
-     "inputs": [{"name": "account", "type": "address"}],
-     "outputs": [{"name": "", "type": "uint256"}]},
-    {"name": "decimals", "type": "function", "stateMutability": "view",
-     "inputs": [], "outputs": [{"name": "", "type": "uint8"}]},
-    {"name": "transferFrom", "type": "function", "stateMutability": "nonpayable",
-     "inputs": [{"name": "from", "type": "address"}, {"name": "to", "type": "address"},
-                {"name": "amount", "type": "uint256"}],
-     "outputs": [{"name": "", "type": "bool"}]},
+    {
+        "name": "approve",
+        "type": "function",
+        "stateMutability": "nonpayable",
+        "inputs": [{"name": "spender", "type": "address"}, {"name": "amount", "type": "uint256"}],
+        "outputs": [{"name": "", "type": "bool"}],
+    },
+    {
+        "name": "allowance",
+        "type": "function",
+        "stateMutability": "view",
+        "inputs": [{"name": "owner", "type": "address"}, {"name": "spender", "type": "address"}],
+        "outputs": [{"name": "", "type": "uint256"}],
+    },
+    {
+        "name": "balanceOf",
+        "type": "function",
+        "stateMutability": "view",
+        "inputs": [{"name": "account", "type": "address"}],
+        "outputs": [{"name": "", "type": "uint256"}],
+    },
+    {
+        "name": "decimals",
+        "type": "function",
+        "stateMutability": "view",
+        "inputs": [],
+        "outputs": [{"name": "", "type": "uint8"}],
+    },
+    {
+        "name": "transferFrom",
+        "type": "function",
+        "stateMutability": "nonpayable",
+        "inputs": [
+            {"name": "from", "type": "address"},
+            {"name": "to", "type": "address"},
+            {"name": "amount", "type": "uint256"},
+        ],
+        "outputs": [{"name": "", "type": "bool"}],
+    },
 ]
 
 DATA_PROVIDER_ABI = [
-    {"name": "getReserveTokensAddresses", "type": "function", "stateMutability": "view",
-     "inputs": [{"name": "asset", "type": "address"}],
-     "outputs": [{"name": "aTokenAddress", "type": "address"},
-                 {"name": "stableDebtTokenAddress", "type": "address"},
-                 {"name": "variableDebtTokenAddress", "type": "address"}]},
+    {
+        "name": "getReserveTokensAddresses",
+        "type": "function",
+        "stateMutability": "view",
+        "inputs": [{"name": "asset", "type": "address"}],
+        "outputs": [
+            {"name": "aTokenAddress", "type": "address"},
+            {"name": "stableDebtTokenAddress", "type": "address"},
+            {"name": "variableDebtTokenAddress", "type": "address"},
+        ],
+    },
 ]
 
 
@@ -85,12 +115,16 @@ def main() -> None:
     user_wallet = os.getenv("TEST_USER_WALLET", "")
     user_key = os.getenv("TEST_USER_PRIVATE_KEY", "")
 
-    missing = [k for k, v in [
-        ("ALCHEMY_RPC_URL_BASE_SEPOLIA", rpc_url),
-        ("OPERATOR_FEE_WALLET_ADDRESS", operator_addr),
-        ("OPERATOR_FEE_WALLET_KEY", operator_key),
-        ("TEST_USER_WALLET", user_wallet),
-    ] if not v]
+    missing = [
+        k
+        for k, v in [
+            ("ALCHEMY_RPC_URL_BASE_SEPOLIA", rpc_url),
+            ("OPERATOR_FEE_WALLET_ADDRESS", operator_addr),
+            ("OPERATOR_FEE_WALLET_KEY", operator_key),
+            ("TEST_USER_WALLET", user_wallet),
+        ]
+        if not v
+    ]
     if missing:
         print(f"[ERROR] 環境変数未設定: {missing}")
         print("  設定方法は本スクリプト冒頭のコメントを参照してください。")
@@ -122,7 +156,7 @@ def main() -> None:
     op_cs = w3.to_checksum_address(operator_addr)
 
     balance = atoken.functions.balanceOf(user_cs).call()
-    balance_usd = Decimal(balance) / Decimal(10 ** decimals)
+    balance_usd = Decimal(balance) / Decimal(10**decimals)
     print(f"[OK] ユーザー aUSDC 残高: {balance_usd:.6f} USDC (raw={balance})")
 
     if balance == 0:
@@ -133,7 +167,7 @@ def main() -> None:
 
     # Step 1: allowance 確認 / 付与
     current_allowance = atoken.functions.allowance(user_cs, op_cs).call()
-    test_units = int(FEE_USD_TEST * Decimal(10 ** decimals))
+    test_units = int(FEE_USD_TEST * Decimal(10**decimals))
     print(f"\n[INFO] current allowance: {current_allowance} raw (need {test_units})")
 
     if current_allowance < test_units:
@@ -145,13 +179,15 @@ def main() -> None:
         print(f"[INFO] allowance 付与中: {test_units} raw → operator {op_cs[:10]}...")
         user_account = w3.eth.account.from_key(user_key)
         nonce = w3.eth.get_transaction_count(user_account.address, "pending")
-        approve_tx = atoken.functions.approve(op_cs, test_units * 10).build_transaction({
-            "from": user_account.address,
-            "nonce": nonce,
-            "chainId": CHAIN_ID,
-            "gas": 80000,
-            "gasPrice": w3.eth.gas_price,
-        })
+        approve_tx = atoken.functions.approve(op_cs, test_units * 10).build_transaction(
+            {
+                "from": user_account.address,
+                "nonce": nonce,
+                "chainId": CHAIN_ID,
+                "gas": 80000,
+                "gasPrice": w3.eth.gas_price,
+            }
+        )
         signed_approve = w3.eth.account.sign_transaction(approve_tx, private_key=user_key)
         approve_hash = w3.eth.send_raw_transaction(signed_approve.raw_transaction)
         print(f"[INFO] approve tx 送信: {approve_hash.hex()}")
@@ -167,6 +203,7 @@ def main() -> None:
     print(f"  amount: {test_units} raw ({FEE_USD_TEST} USDC)")
 
     from app.fees.fee_transfer_service import FeeTransferConfig, FeeTransferService  # noqa: PLC0415
+
     cfg = FeeTransferConfig(
         enabled=True,
         operator_wallet_address=operator_addr,

--- a/backend/scripts/test_fee_transfer_staging.py
+++ b/backend/scripts/test_fee_transfer_staging.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/scripts/test_fee_transfer_staging.py
+"""F-S6: staging (Base Sepolia) on-chain fee transfer 実 tx 検証スクリプト。
+
+事前準備:
+  1. テスト用ウォレット (TEST_USER_WALLET / TEST_USER_PRIVATE_KEY) に Base Sepolia USDC を用意
+     - USDC faucet: https://faucet.circle.com/  (Base Sepolia を選択)
+  2. テスト用 operator wallet (OPERATOR_FEE_WALLET_ADDRESS / OPERATOR_FEE_WALLET_KEY) を作成
+     - Base Sepolia ETH (gas 用) が必要: https://www.alchemy.com/faucets/base-sepolia
+  3. ユーザーウォレットが Aave Base Sepolia に USDC を供給済み (aUSDC 所持)
+  4. ユーザーウォレットが operator wallet に aUSDC allowance を付与済み
+
+実行:
+  export ALCHEMY_RPC_URL_BASE_SEPOLIA="https://base-sepolia.g.alchemy.com/v2/<KEY>"
+  export OPERATOR_FEE_WALLET_ADDRESS="0x..."
+  export OPERATOR_FEE_WALLET_KEY="0x..."
+  export TEST_USER_WALLET="0x..."
+  export TEST_USER_PRIVATE_KEY="0x..."  # ユーザーウォレット秘密鍵 (grant allowance 用)
+  export FEE_TRANSFER_ENABLED="true"
+
+  cd backend
+  source .venv/bin/activate
+  python scripts/test_fee_transfer_staging.py
+
+  # basescan で確認:
+  # https://sepolia.basescan.org/tx/0x<tx_hash>
+
+Non-custodial 設計確認ポイント:
+  - from: TEST_USER_WALLET (ユーザーの aToken 保有者)
+  - to:   OPERATOR_FEE_WALLET_ADDRESS (operator 受け取り先)
+  - 署名: OPERATOR_FEE_WALLET_KEY (operator 自身の鍵) が transferFrom を call
+  - ユーザーの秘密鍵は allowance 付与にのみ使用 (本番では Privy 経由で browser 署名)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from decimal import Decimal
+
+from web3 import Web3
+
+# Base Sepolia 定数
+USDC_ADDRESS = "0xba50cd2a20f6da35d788639e581bca8d0b5d4d5f"
+POOL_ADDRESS = "0x8bAB6d1b75f19e9eD9fCe8b9BD338844fF79aE27"
+DATA_PROVIDER_ADDRESS = "0xBc9f5b7E248451CdD7cA54e717a2BFe1F32b566b"
+CHAIN_ID = 84532
+FEE_USD_TEST = Decimal("0.01")  # 0.01 USDC (最小テスト金額)
+
+ERC20_ABI = [
+    {"name": "approve", "type": "function", "stateMutability": "nonpayable",
+     "inputs": [{"name": "spender", "type": "address"}, {"name": "amount", "type": "uint256"}],
+     "outputs": [{"name": "", "type": "bool"}]},
+    {"name": "allowance", "type": "function", "stateMutability": "view",
+     "inputs": [{"name": "owner", "type": "address"}, {"name": "spender", "type": "address"}],
+     "outputs": [{"name": "", "type": "uint256"}]},
+    {"name": "balanceOf", "type": "function", "stateMutability": "view",
+     "inputs": [{"name": "account", "type": "address"}],
+     "outputs": [{"name": "", "type": "uint256"}]},
+    {"name": "decimals", "type": "function", "stateMutability": "view",
+     "inputs": [], "outputs": [{"name": "", "type": "uint8"}]},
+    {"name": "transferFrom", "type": "function", "stateMutability": "nonpayable",
+     "inputs": [{"name": "from", "type": "address"}, {"name": "to", "type": "address"},
+                {"name": "amount", "type": "uint256"}],
+     "outputs": [{"name": "", "type": "bool"}]},
+]
+
+DATA_PROVIDER_ABI = [
+    {"name": "getReserveTokensAddresses", "type": "function", "stateMutability": "view",
+     "inputs": [{"name": "asset", "type": "address"}],
+     "outputs": [{"name": "aTokenAddress", "type": "address"},
+                 {"name": "stableDebtTokenAddress", "type": "address"},
+                 {"name": "variableDebtTokenAddress", "type": "address"}]},
+]
+
+
+def main() -> None:
+    rpc_url = os.getenv("ALCHEMY_RPC_URL_BASE_SEPOLIA", "")
+    operator_addr = os.getenv("OPERATOR_FEE_WALLET_ADDRESS", "")
+    operator_key = os.getenv("OPERATOR_FEE_WALLET_KEY", "")
+    user_wallet = os.getenv("TEST_USER_WALLET", "")
+    user_key = os.getenv("TEST_USER_PRIVATE_KEY", "")
+
+    missing = [k for k, v in [
+        ("ALCHEMY_RPC_URL_BASE_SEPOLIA", rpc_url),
+        ("OPERATOR_FEE_WALLET_ADDRESS", operator_addr),
+        ("OPERATOR_FEE_WALLET_KEY", operator_key),
+        ("TEST_USER_WALLET", user_wallet),
+    ] if not v]
+    if missing:
+        print(f"[ERROR] 環境変数未設定: {missing}")
+        print("  設定方法は本スクリプト冒頭のコメントを参照してください。")
+        sys.exit(1)
+
+    w3 = Web3(Web3.HTTPProvider(rpc_url))
+    if not w3.is_connected():
+        print(f"[ERROR] RPC 接続失敗: {rpc_url[:60]}...")
+        sys.exit(1)
+
+    print(f"[OK] Base Sepolia RPC 接続成功 (chain_id={w3.eth.chain_id})")
+
+    # aUSDC アドレス取得
+    dp = w3.eth.contract(
+        address=w3.to_checksum_address(DATA_PROVIDER_ADDRESS),
+        abi=DATA_PROVIDER_ABI,
+    )
+    atoken_address = dp.functions.getReserveTokensAddresses(
+        w3.to_checksum_address(USDC_ADDRESS)
+    ).call()[0]
+    print(f"[OK] aUSDC address: {atoken_address}")
+
+    atoken = w3.eth.contract(
+        address=w3.to_checksum_address(atoken_address),
+        abi=ERC20_ABI,
+    )
+    decimals = atoken.functions.decimals().call()
+    user_cs = w3.to_checksum_address(user_wallet)
+    op_cs = w3.to_checksum_address(operator_addr)
+
+    balance = atoken.functions.balanceOf(user_cs).call()
+    balance_usd = Decimal(balance) / Decimal(10 ** decimals)
+    print(f"[OK] ユーザー aUSDC 残高: {balance_usd:.6f} USDC (raw={balance})")
+
+    if balance == 0:
+        print("[WARN] aUSDC 残高ゼロ。Aave への供給が必要です。")
+        print("  1. https://faucet.circle.com/ で Base Sepolia USDC を入手")
+        print("  2. https://app.aave.com/ で Base Sepolia に切り替えて USDC を供給")
+        sys.exit(1)
+
+    # Step 1: allowance 確認 / 付与
+    current_allowance = atoken.functions.allowance(user_cs, op_cs).call()
+    test_units = int(FEE_USD_TEST * Decimal(10 ** decimals))
+    print(f"\n[INFO] current allowance: {current_allowance} raw (need {test_units})")
+
+    if current_allowance < test_units:
+        if not user_key:
+            print("[ERROR] allowance 不足。TEST_USER_PRIVATE_KEY を設定してください。")
+            print("  本番では Privy browser 署名で付与。staging では直接鍵で付与。")
+            sys.exit(1)
+
+        print(f"[INFO] allowance 付与中: {test_units} raw → operator {op_cs[:10]}...")
+        user_account = w3.eth.account.from_key(user_key)
+        nonce = w3.eth.get_transaction_count(user_account.address, "pending")
+        approve_tx = atoken.functions.approve(op_cs, test_units * 10).build_transaction({
+            "from": user_account.address,
+            "nonce": nonce,
+            "chainId": CHAIN_ID,
+            "gas": 80000,
+            "gasPrice": w3.eth.gas_price,
+        })
+        signed_approve = w3.eth.account.sign_transaction(approve_tx, private_key=user_key)
+        approve_hash = w3.eth.send_raw_transaction(signed_approve.raw_transaction)
+        print(f"[INFO] approve tx 送信: {approve_hash.hex()}")
+        w3.eth.wait_for_transaction_receipt(approve_hash, timeout=60)
+        print(f"[OK] approve 確認: https://sepolia.basescan.org/tx/{approve_hash.hex()}")
+    else:
+        print(f"[OK] allowance 十分: {current_allowance} raw")
+
+    # Step 2: FeeTransferService で transferFrom 実行
+    print(f"\n[INFO] fee transfer 実行: {FEE_USD_TEST} USDC を operator に送付")
+    print(f"  from: {user_cs}")
+    print(f"  to:   {op_cs}")
+    print(f"  amount: {test_units} raw ({FEE_USD_TEST} USDC)")
+
+    from app.fees.fee_transfer_service import FeeTransferConfig, FeeTransferService  # noqa: PLC0415
+    cfg = FeeTransferConfig(
+        enabled=True,
+        operator_wallet_address=operator_addr,
+        operator_wallet_key=operator_key,
+        rpc_url=rpc_url,
+        data_provider_address=DATA_PROVIDER_ADDRESS,
+        usdc_address=USDC_ADDRESS,
+        chain_id=CHAIN_ID,
+    )
+    svc = FeeTransferService(cfg)
+    result = svc.transfer_fee(
+        user_id=999,  # staging test user
+        user_wallet=user_wallet,
+        fee_amount_jpy=FEE_USD_TEST * Decimal("150"),  # 1.5 JPY @ 150
+        subscription_amount_jpy=Decimal("0"),
+        yield_excess_jpy=Decimal("0"),
+        usd_jpy_rate=Decimal("150"),
+    )
+
+    print(f"\n[RESULT] status: {result.status}")
+    print(f"         tx_hash: {result.tx_hash}")
+    print(f"         fee_usd: {result.fee_usd}")
+    print(f"         atoken_units: {result.atoken_units}")
+    if result.error:
+        print(f"         error: {result.error}")
+    for line in result.debug_log:
+        print(f"         debug: {line}")
+
+    if result.status == "sent" and result.tx_hash:
+        print(f"\n[SUCCESS] basescan で確認:")
+        print(f"  https://sepolia.basescan.org/tx/{result.tx_hash}")
+        print("\n確認すべき項目:")
+        print(f"  1. from: {user_cs}")
+        print(f"  2. to:   {op_cs}")
+        print(f"  3. token: aUSDC ({atoken_address})")
+        print(f"  4. amount: {test_units} raw = {FEE_USD_TEST} USDC")
+        print("  5. tx status: Success (1)")
+    elif result.status == "no_allowance":
+        print("[FAIL] allowance 不足。前の approve ステップを確認してください。")
+        sys.exit(1)
+    else:
+        print(f"[FAIL] 送金失敗: {result.error}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/test_fee_transfer_staging.py
+++ b/backend/scripts/test_fee_transfer_staging.py
@@ -196,7 +196,7 @@ def main() -> None:
         print(f"         debug: {line}")
 
     if result.status == "sent" and result.tx_hash:
-        print(f"\n[SUCCESS] basescan で確認:")
+        print("\n[SUCCESS] basescan で確認:")
         print(f"  https://sepolia.basescan.org/tx/{result.tx_hash}")
         print("\n確認すべき項目:")
         print(f"  1. from: {user_cs}")

--- a/backend/tests/test_fee_transfer_service.py
+++ b/backend/tests/test_fee_transfer_service.py
@@ -1,0 +1,364 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""F-S6: FeeTransferService ユニットテスト。
+
+on-chain 呼び出しはすべて mock。実際の RPC は使わない。
+staging 実 tx は scripts/test_fee_transfer_staging.py で別途実施。
+"""
+
+from __future__ import annotations
+
+import os
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.fees.fee_transfer_service import (
+    FeeTransferConfig,
+    FeeTransferService,
+    is_fee_transfer_enabled,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+BASE_SEPOLIA_CFG = FeeTransferConfig(
+    enabled=True,
+    operator_wallet_address="0xOperator000000000000000000000000000000001",
+    operator_wallet_key="0xdeadbeef" + "00" * 28,
+    rpc_url="https://base-sepolia.example.com",
+    data_provider_address="0xBc9f5b7E248451CdD7cA54e717a2BFe1F32b566b",
+    usdc_address="0xba50cd2a20f6da35d788639e581bca8d0b5d4d5f",
+    chain_id=84532,
+)
+
+DISABLED_CFG = FeeTransferConfig(
+    enabled=False,
+    operator_wallet_address="",
+    operator_wallet_key="",
+    rpc_url="",
+    data_provider_address="",
+    usdc_address="",
+    chain_id=84532,
+)
+
+USER_WALLET = "0xUserWallet00000000000000000000000000000001"
+
+
+# ---------------------------------------------------------------------------
+# is_fee_transfer_enabled
+# ---------------------------------------------------------------------------
+
+
+def test_is_fee_transfer_enabled_default_false():
+    """デフォルト (未設定) では False。"""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("FEE_TRANSFER_ENABLED", None)
+        assert is_fee_transfer_enabled() is False
+
+
+def test_is_fee_transfer_enabled_true():
+    with patch.dict(os.environ, {"FEE_TRANSFER_ENABLED": "true"}):
+        assert is_fee_transfer_enabled() is True
+
+
+def test_is_fee_transfer_enabled_uppercase():
+    with patch.dict(os.environ, {"FEE_TRANSFER_ENABLED": "TRUE"}):
+        assert is_fee_transfer_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# transfer_fee: disabled / skipped ケース
+# ---------------------------------------------------------------------------
+
+
+def test_transfer_fee_disabled_returns_skipped():
+    """FEE_TRANSFER_ENABLED=false → status='skipped'、送金なし。"""
+    svc = FeeTransferService(DISABLED_CFG)
+    result = svc.transfer_fee(
+        user_id=1,
+        user_wallet=USER_WALLET,
+        fee_amount_jpy=Decimal("10000"),
+        subscription_amount_jpy=Decimal("5000"),
+        yield_excess_jpy=Decimal("0"),
+        usd_jpy_rate=Decimal("150"),
+    )
+    assert result.status == "skipped"
+    assert result.tx_hash is None
+    assert result.fee_usd == Decimal("0")
+
+
+def test_transfer_fee_no_wallet_returns_skipped():
+    """user_wallet が空の場合 → status='skipped'。"""
+    svc = FeeTransferService(BASE_SEPOLIA_CFG)
+    result = svc.transfer_fee(
+        user_id=2,
+        user_wallet="",
+        fee_amount_jpy=Decimal("10000"),
+        subscription_amount_jpy=Decimal("0"),
+        yield_excess_jpy=Decimal("0"),
+        usd_jpy_rate=Decimal("150"),
+    )
+    assert result.status == "skipped"
+
+
+def test_transfer_fee_low_fee_returns_low_fee():
+    """fee_usd < MIN_FEE_USD → status='low_fee'。"""
+    svc = FeeTransferService(BASE_SEPOLIA_CFG)
+    # 1円 / 150 = 0.0067 USD だが、0.001 USD になるよう rate を大きく
+    result = svc.transfer_fee(
+        user_id=3,
+        user_wallet=USER_WALLET,
+        fee_amount_jpy=Decimal("1"),  # 1 JPY
+        subscription_amount_jpy=Decimal("0"),
+        yield_excess_jpy=Decimal("0"),
+        usd_jpy_rate=Decimal("10000"),  # 1 JPY = 0.0001 USD → below MIN_FEE_USD
+    )
+    assert result.status == "low_fee"
+    assert result.tx_hash is None
+
+
+def test_transfer_fee_invalid_rate_returns_failed():
+    """usd_jpy_rate=0 → status='failed'。"""
+    svc = FeeTransferService(BASE_SEPOLIA_CFG)
+    result = svc.transfer_fee(
+        user_id=4,
+        user_wallet=USER_WALLET,
+        fee_amount_jpy=Decimal("10000"),
+        subscription_amount_jpy=Decimal("0"),
+        yield_excess_jpy=Decimal("0"),
+        usd_jpy_rate=Decimal("0"),
+    )
+    assert result.status == "failed"
+    assert "usd_jpy_rate" in (result.error or "")
+
+
+def test_transfer_fee_no_operator_key_returns_failed():
+    """OPERATOR_FEE_WALLET_KEY 未設定 → status='failed'。"""
+    cfg = FeeTransferConfig(
+        enabled=True,
+        operator_wallet_address="0xOperator",
+        operator_wallet_key="",  # 空
+        rpc_url="https://rpc",
+        data_provider_address="0xDP",
+        usdc_address="0xUSDC",
+        chain_id=84532,
+    )
+    svc = FeeTransferService(cfg)
+    result = svc.transfer_fee(
+        user_id=5,
+        user_wallet=USER_WALLET,
+        fee_amount_jpy=Decimal("10000"),
+        subscription_amount_jpy=Decimal("0"),
+        yield_excess_jpy=Decimal("0"),
+        usd_jpy_rate=Decimal("150"),
+    )
+    assert result.status == "failed"
+
+
+# ---------------------------------------------------------------------------
+# transfer_fee: mock Web3 — sent ケース
+# ---------------------------------------------------------------------------
+
+
+def _make_w3_mock(
+    decimals: int = 6,
+    allowance: int = 10_000_000,  # 10 USDC
+    tx_receipt_status: int = 1,
+    atoken_address: str = "0xAToken000000000000000000000000000000000001",
+) -> MagicMock:
+    """Web3 モックを返す。"""
+    w3 = MagicMock()
+    w3.to_checksum_address.side_effect = lambda x: x
+
+    # Pool Data Provider mock
+    dp_contract = MagicMock()
+    dp_contract.functions.getReserveTokensAddresses.return_value.call.return_value = (
+        atoken_address,
+        "0xSDebt",
+        "0xVDebt",
+    )
+
+    # aToken contract mock
+    atoken_contract = MagicMock()
+    atoken_contract.functions.decimals.return_value.call.return_value = decimals
+    atoken_contract.functions.allowance.return_value.call.return_value = allowance
+
+    def contract_factory(address, abi):
+        if "getReserveTokensAddresses" in str(abi):
+            return dp_contract
+        return atoken_contract
+
+    w3.eth.contract.side_effect = contract_factory
+
+    # tx signing / sending
+    account = MagicMock()
+    account.address = "0xOperator000000000000000000000000000000001"
+    w3.eth.account.from_key.return_value = account
+    w3.eth.get_transaction_count.return_value = 0
+    w3.eth.gas_price = 1000000000
+
+    signed_tx = MagicMock()
+    signed_tx.raw_transaction = b"\x00" * 100
+    w3.eth.account.sign_transaction.return_value = signed_tx
+
+    tx_hash = MagicMock()
+    tx_hash.hex.return_value = "0xdeadbeef" + "00" * 28
+    w3.eth.send_raw_transaction.return_value = tx_hash
+
+    receipt = MagicMock()
+    receipt.status = tx_receipt_status
+    w3.eth.wait_for_transaction_receipt.return_value = receipt
+
+    # build_transaction on function mock
+    atoken_contract.functions.transferFrom.return_value.build_transaction.return_value = {
+        "to": atoken_address,
+        "data": "0x",
+        "from": account.address,
+        "nonce": 0,
+        "chainId": 84532,
+        "gas": 100000,
+        "gasPrice": 1000000000,
+    }
+
+    return w3
+
+
+def test_transfer_fee_sent_success():
+    """allowance 十分 + tx success → status='sent', tx_hash 設定。"""
+    svc = FeeTransferService(BASE_SEPOLIA_CFG)
+    mock_w3 = _make_w3_mock(allowance=100_000_000)  # 100 USDC allowance
+
+    with patch.object(svc, "_get_w3", return_value=mock_w3):
+        result = svc.transfer_fee(
+            user_id=10,
+            user_wallet=USER_WALLET,
+            fee_amount_jpy=Decimal("1500"),  # 1500 JPY = 10 USD @ 150
+            subscription_amount_jpy=Decimal("0"),
+            yield_excess_jpy=Decimal("0"),
+            usd_jpy_rate=Decimal("150"),
+        )
+
+    assert result.status == "sent"
+    assert result.tx_hash is not None
+    assert result.fee_usd == Decimal("10.000000")
+    assert result.atoken_units == 10_000_000  # 10 USDC × 10^6
+
+
+def test_transfer_fee_no_allowance():
+    """allowance 不足 → status='no_allowance'、送金しない。"""
+    svc = FeeTransferService(BASE_SEPOLIA_CFG)
+    mock_w3 = _make_w3_mock(allowance=0)  # allowance ゼロ
+
+    with patch.object(svc, "_get_w3", return_value=mock_w3):
+        result = svc.transfer_fee(
+            user_id=11,
+            user_wallet=USER_WALLET,
+            fee_amount_jpy=Decimal("1500"),
+            subscription_amount_jpy=Decimal("0"),
+            yield_excess_jpy=Decimal("0"),
+            usd_jpy_rate=Decimal("150"),
+        )
+
+    assert result.status == "no_allowance"
+    assert result.tx_hash is None
+
+
+def test_transfer_fee_tx_reverted():
+    """tx status=0 (revert) → status='failed'。"""
+    svc = FeeTransferService(BASE_SEPOLIA_CFG)
+    mock_w3 = _make_w3_mock(allowance=100_000_000, tx_receipt_status=0)
+
+    with patch.object(svc, "_get_w3", return_value=mock_w3):
+        result = svc.transfer_fee(
+            user_id=12,
+            user_wallet=USER_WALLET,
+            fee_amount_jpy=Decimal("1500"),
+            subscription_amount_jpy=Decimal("0"),
+            yield_excess_jpy=Decimal("0"),
+            usd_jpy_rate=Decimal("150"),
+        )
+
+    assert result.status == "failed"
+    assert "reverted" in (result.error or "")
+
+
+def test_transfer_fee_web3_exception():
+    """Web3 例外 → status='failed'。"""
+    svc = FeeTransferService(BASE_SEPOLIA_CFG)
+    mock_w3 = MagicMock()
+    mock_w3.to_checksum_address.side_effect = lambda x: x
+    mock_w3.eth.contract.side_effect = RuntimeError("RPC error")
+
+    with patch.object(svc, "_get_w3", return_value=mock_w3):
+        result = svc.transfer_fee(
+            user_id=13,
+            user_wallet=USER_WALLET,
+            fee_amount_jpy=Decimal("1500"),
+            subscription_amount_jpy=Decimal("0"),
+            yield_excess_jpy=Decimal("0"),
+            usd_jpy_rate=Decimal("150"),
+        )
+
+    assert result.status == "failed"
+    assert result.tx_hash is None
+
+
+# ---------------------------------------------------------------------------
+# check_allowance
+# ---------------------------------------------------------------------------
+
+
+def test_check_allowance_returns_usd_amount():
+    """allowance 5_000_000 raw (6 decimals) = 5 USD。"""
+    svc = FeeTransferService(BASE_SEPOLIA_CFG)
+    mock_w3 = _make_w3_mock(allowance=5_000_000, decimals=6)
+
+    with patch.object(svc, "_get_w3", return_value=mock_w3):
+        allowance_usd = svc.check_allowance(USER_WALLET)
+
+    assert allowance_usd == Decimal("5")
+
+
+def test_check_allowance_disabled_config_returns_zero():
+    """OPERATOR_FEE_WALLET_ADDRESS 未設定 → 0。"""
+    svc = FeeTransferService(DISABLED_CFG)
+    allowance_usd = svc.check_allowance(USER_WALLET)
+    assert allowance_usd == Decimal("0")
+
+
+# ---------------------------------------------------------------------------
+# fee_usd 計算ロジック
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fee_jpy,sub_jpy,excess_jpy,rate,expected_usd",
+    [
+        (Decimal("15000"), Decimal("3000"), Decimal("2000"), Decimal("150"), Decimal("133.333333")),
+        (Decimal("0"), Decimal("0"), Decimal("0"), Decimal("150"), None),  # low_fee
+        (Decimal("300"), Decimal("0"), Decimal("0"), Decimal("150"), Decimal("2.000000")),
+    ],
+)
+def test_fee_usd_calculation(fee_jpy, sub_jpy, excess_jpy, rate, expected_usd):
+    """fee_usd = (fee + sub + excess) / rate の変換確認。"""
+    svc = FeeTransferService(BASE_SEPOLIA_CFG)
+    mock_w3 = _make_w3_mock(allowance=1_000_000_000)
+
+    with patch.object(svc, "_get_w3", return_value=mock_w3):
+        result = svc.transfer_fee(
+            user_id=20,
+            user_wallet=USER_WALLET,
+            fee_amount_jpy=fee_jpy,
+            subscription_amount_jpy=sub_jpy,
+            yield_excess_jpy=excess_jpy,
+            usd_jpy_rate=rate,
+        )
+
+    if expected_usd is None:
+        assert result.status == "low_fee"
+    else:
+        assert result.status == "sent"
+        assert result.fee_usd == expected_usd


### PR DESCRIPTION
## Summary

F-S6 (Asana 1215272587496967): 月次手数料の on-chain 徴収を `FEE_TRANSFER_ENABLED` フラグで gate して実装。

- **FEE_TRANSFER_ENABLED=false (default)**: DB 記録のみ → 既存動作完全維持  
- **FEE_TRANSFER_ENABLED=true**: operator wallet が `aToken.transferFrom(user→operator, fee)` を実行

---

## Non-custodial 設計判断 (§14a — custodial 問題の再発防止)

| 項目 | 内容 |
|-----|------|
| **FROM** | user.wallet_address (Aave aToken がユーザー自身の wallet に存在) |
| **TO** | OPERATOR_FEE_WALLET_ADDRESS (operator 自身の wallet) |
| **HOW** | operator wallet が `aToken.transferFrom(user, operator, amount)` を実行 (ERC-20 pull model) |
| **KEY** | `OPERATOR_FEE_WALLET_KEY` = operator **自身の** 秘密鍵 |
| **≠** | ユーザー秘密鍵、サーバー共通鍵 (今日直した custodial 問題と同じ保護) |

**non-custodial 保護の根拠:**
- サーバーはユーザーの秘密鍵を一切持たない
- ユーザーが aToken に operator wallet への allowance を事前承認 (ERC-20 標準)
- Operator は承認された分のみ引き出し可能 — ユーザーはいつでも revoke 可能
- `OPERATOR_FEE_WALLET_KEY` は operator 自身の資金のみコントロール

---

## 変更ファイル

| ファイル | 変更種別 | 内容 |
|--------|---------|------|
| `backend/app/fees/fee_transfer_service.py` | NEW | FeeTransferService — on-chain transfer コア |
| `backend/app/fees/models.py` | MODIFY | FeeTransaction に transfer_status/transfer_tx_hash/usd_jpy_rate 追加 |
| `backend/app/api/v1/fees.py` | MODIFY | finalize_month_core に fee transfer フェーズ追加 |
| `backend/alembic/versions/j0k1l2m3n4o5_fee_transfer_columns.py` | NEW | DB migration (3カラム追加) |
| `backend/tests/test_fee_transfer_service.py` | NEW | 17 ユニットテスト |
| `backend/scripts/test_fee_transfer_staging.py` | NEW | staging 実 tx 検証スクリプト |

---

## 新規環境変数

| 変数 | デフォルト | 説明 |
|-----|-----------|------|
| `FEE_TRANSFER_ENABLED` | `false` | `false` = DB 記録のみ (現状維持) |
| `OPERATOR_FEE_WALLET_ADDRESS` | `""` | operator の on-chain wallet address |
| `OPERATOR_FEE_WALLET_KEY` | `""` | operator wallet の秘密鍵 (ユーザー鍵 ≠) |

---

## Gate 結果

- **Gate 1**: `ruff check` → ALL PASSED
- **Gate 2**: `ruff format --check` → ALL PASSED  
- **Gate 2b**: `mypy` → ALL PASSED
- **Gate 3**: `pytest tests/test_fee_transfer_service.py` → **17/17 PASSED**
  - disabled/skipped ケース (5件)
  - allowance 不足・tx revert・例外 (3件)
  - mock Web3 sent success (1件)
  - fee_usd 計算 (3件)
  - check_allowance (2件)
  - parametrize fee_usd (3件)
- **staging 実 tx**: 下記参照

---

## staging 実 tx 検証 (credentials 必要)

read-only 確認済み (dev VPS から実行):
```
aUSDC address on Base Sepolia: 0x10F1A9D11CDf50041f3f8cB7191CBE2f31750ACC
basescan: https://sepolia.basescan.org/token/0x10F1A9D11CDf50041f3f8cB7191CBE2f31750ACC
```

実 transferFrom tx 実行手順 (staging wallet で実施):
```bash
export ALCHEMY_RPC_URL_BASE_SEPOLIA="..."
export OPERATOR_FEE_WALLET_ADDRESS="0x..."   # operator wallet address
export OPERATOR_FEE_WALLET_KEY="0x..."       # operator 自身の鍵 (≠ユーザー鍵)
export TEST_USER_WALLET="0x..."              # aUSDC 所持 + allowance 付与済み
export TEST_USER_PRIVATE_KEY="0x..."         # allowance 付与用 (本番 = Privy browser 署名)
export FEE_TRANSFER_ENABLED="true"
cd backend && source .venv/bin/activate
python scripts/test_fee_transfer_staging.py
# → basescan で from/to/amount/aToken 帰属を確認
```

確認すべき項目:
1. `from`: user wallet address  
2. `to`: OPERATOR_FEE_WALLET_ADDRESS  
3. token: aUSDC (`0x10F1A9D11CDf50041f3f8cB7191CBE2f31750ACC`)  
4. amount: fee_usd × 10^6 raw units  
5. tx status: Success (1)  

---

## 本番適用条件

- `FEE_TRANSFER_ENABLED=true` への変更は **法務確認 (S-5 森先生) 完了後に人間が行う**
- `OPERATOR_FEE_WALLET_KEY` は `.env.production` に追加 (CLAUDE.md §鉄則1 準拠、平文コミット禁止)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)