### PR TITLE
chore(env): FEE_TRANSFER_ENABLED + OPERATOR_FEE_WALLET_KEY を .env*.example に追記

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -111,6 +111,15 @@ NEXT_PUBLIC_DEFAULT_CHAIN_ID=8453
 NEXT_PUBLIC_BASE_MAINNET_RPC=https://base-mainnet.g.alchemy.com/v2/YOUR_KEY
 
 # =============================================================================
+# Fee Transfer (Non-Custodial / Operator Fee)
+# FEE_TRANSFER_ENABLED: false = 手数料送金無効 (デフォルト), true = 有効
+# OPERATOR_FEE_WALLET_KEY: オペレーター手数料受取ウォレットの秘密鍵
+#   実値は絶対にここに記載しない — .env.production のみに設定すること (§13)
+# =============================================================================
+FEE_TRANSFER_ENABLED=false
+OPERATOR_FEE_WALLET_KEY=0xYOUR_OPERATOR_FEE_WALLET_PRIVATE_KEY_HERE
+
+# =============================================================================
 # Cloudflare
 # =============================================================================
 CLOUDFLARE_TUNNEL_TOKEN=

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -104,6 +104,16 @@ NEXT_PUBLIC_DEFAULT_CHAIN_ID=84532
 NEXT_PUBLIC_BASE_SEPOLIA_RPC=https://base-sepolia.g.alchemy.com/v2/YOUR_KEY
 
 # =============================================================================
+# Fee Transfer (Non-Custodial / Operator Fee)
+# FEE_TRANSFER_ENABLED: false = 手数料送金無効 (デフォルト), true = 有効
+# OPERATOR_FEE_WALLET_KEY: オペレーター手数料受取ウォレットの秘密鍵
+#   実値は絶対にここに記載しない — .env.staging のみに設定すること (§13)
+#   staging ではテストネット専用ウォレットの秘密鍵を使用すること
+# =============================================================================
+FEE_TRANSFER_ENABLED=false
+OPERATOR_FEE_WALLET_KEY=0xYOUR_STAGING_OPERATOR_FEE_WALLET_PRIVATE_KEY_HERE
+
+# =============================================================================
 # Cloudflare
 # CLOUDFLARE_TUNNEL_TOKEN は Phase 4 で staging 専用トンネルを作成後に設定
 # =============================================================================


### PR DESCRIPTION
## Summary

- `.env.production.example` と `.env.staging.example` に Fee Transfer 関連の 2 キーを追加
- `FEE_TRANSFER_ENABLED=false` — デフォルト無効。`true` にすると手数料送金が有効化される
- `OPERATOR_FEE_WALLET_KEY=0xYOUR_..._PRIVATE_KEY_HERE` — ダミープレースホルダーのみ。実値は example に記載しない (§13)
- staging 用には「テストネット専用ウォレットの秘密鍵を使用すること」のコメントを追加

## Closes

Asana GID: 1215273648350780

## Gate 結果

| Gate | 結果 |
|---|---|
| Gate 1-3 (verify.sh) | n/a — .env*.example のみ変更、Python/TS コードなし |
| Gate 4 (E2E) | n/a |
| Gate 5 (孤立コード) | n/a |
| Gate 6 (Codex) | n/a |
| Gate 7 (chrome) | n/a |

## セキュリティ確認

- `OPERATOR_FEE_WALLET_KEY` の値はプレースホルダー `0xYOUR_..._PRIVATE_KEY_HERE` のみ
- 実値は `.env.production` / `.env.staging` (git 管理外) にのみ設定する設計

🤖 Generated with [Claude Code](https://claude.com/claude-code)