### PR TITLE
feat(reports): 月次レポートEP実データ化 + Viewer 権限対応 (Lane K)

### DIFF
--- a/backend/app/reports/monthly_report.py
+++ b/backend/app/reports/monthly_report.py
@@ -11,6 +11,12 @@ import csv
 import io
 import logging
 from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +35,75 @@ class MonthlyReportData:
     annual_yield_pct: float
 
 
+def build_monthly_report_data(
+    db: Session,
+    year: int,
+    month: int,
+    user_id: int | None = None,
+) -> MonthlyReportData:
+    """DB から実データを集計して MonthlyReportData を構築する。
+
+    Args:
+        db: SQLAlchemy セッション
+        year: 対象年
+        month: 対象月
+        user_id: 集計対象ユーザー ID。None の場合は全ユーザー集計。
+    """
+    from app.fees.models import FeeTransaction
+    from app.proposals.models import Proposal
+
+    period_str = f"{year}年{month}月"
+
+    start_dt = datetime(year, month, 1, tzinfo=timezone.utc)
+    if month == 12:
+        end_dt = datetime(year + 1, 1, 1, tzinfo=timezone.utc)
+    else:
+        end_dt = datetime(year, month + 1, 1, tzinfo=timezone.utc)
+
+    # --- proposals 集計 ---
+    q = db.query(Proposal).filter(
+        Proposal.created_at >= start_dt,
+        Proposal.created_at < end_dt,
+    )
+    if user_id is not None:
+        q = q.filter(Proposal.user_id == user_id)
+
+    proposals = q.all()
+    total_proposals = len(proposals)
+    positive_results = sum(1 for p in proposals if p.status == "executed")
+    win_rate = (positive_results / total_proposals * 100.0) if total_proposals > 0 else 0.0
+
+    # --- fee_transactions 集計 (JPY ベース) ---
+    calc_month = date(year, month, 1)
+    ft_q = db.query(FeeTransaction).filter(FeeTransaction.calculation_month == calc_month)
+    if user_id is not None:
+        ft_q = ft_q.filter(FeeTransaction.user_id == user_id)
+
+    fee_txs = ft_q.all()
+
+    total_gain_jpy = int(sum(ft.net_profit_jpy for ft in fee_txs))
+    total_fees_jpy = int(sum(ft.fee_amount_jpy for ft in fee_txs))
+    avg_gain_per_trade_jpy = (total_gain_jpy // total_proposals) if total_proposals > 0 else 0
+
+    # 年率換算: (月次利益 / 預け入れ元本) * 12 * 100
+    deposit_total = sum(ft.deposit_amount_jpy for ft in fee_txs)
+    annual_yield_pct = 0.0
+    if deposit_total > 0:
+        monthly_yield = Decimal(str(total_gain_jpy)) / deposit_total
+        annual_yield_pct = round(float(monthly_yield) * 12 * 100, 2)
+
+    return MonthlyReportData(
+        period=period_str,
+        total_proposals=total_proposals,
+        positive_results=positive_results,
+        win_rate=round(win_rate, 1),
+        total_gain_jpy=total_gain_jpy,
+        avg_gain_per_trade_jpy=avg_gain_per_trade_jpy,
+        total_fees_jpy=total_fees_jpy,
+        annual_yield_pct=annual_yield_pct,
+    )
+
+
 def _fmt_yen(amount: int) -> str:
     """円額を ¥1,234,567 形式にフォーマットする。"""
     return f"¥{amount:,}"
@@ -36,13 +111,13 @@ def _fmt_yen(amount: int) -> str:
 
 def _generate_pdf(data: MonthlyReportData) -> bytes:
     """reportlab で PDF バイトを生成する。"""
-    from reportlab.lib import colors  # type: ignore[import-untyped]
-    from reportlab.lib.pagesizes import A4  # type: ignore[import-untyped]
-    from reportlab.lib.styles import getSampleStyleSheet  # type: ignore[import-untyped]
-    from reportlab.lib.units import mm  # type: ignore[import-untyped]
-    from reportlab.pdfbase import pdfmetrics  # type: ignore[import-untyped]
-    from reportlab.pdfbase.ttfonts import TTFont  # type: ignore[import-untyped]
-    from reportlab.platypus import (  # type: ignore[import-untyped]
+    from reportlab.lib import colors
+    from reportlab.lib.pagesizes import A4
+    from reportlab.lib.styles import getSampleStyleSheet
+    from reportlab.lib.units import mm
+    from reportlab.pdfbase import pdfmetrics
+    from reportlab.pdfbase.ttfonts import TTFont
+    from reportlab.platypus import (
         Paragraph,
         SimpleDocTemplate,
         Spacer,
@@ -153,7 +228,7 @@ def generate_monthly_report_pdf(data: MonthlyReportData) -> tuple[bytes, str]:
         (bytes, content_type) のタプル
     """
     try:
-        import reportlab  # type: ignore[import-untyped]  # noqa: F401
+        import reportlab  # noqa: F401
 
         return _generate_pdf(data), "application/pdf"
     except ImportError:

--- a/backend/app/reports/router.py
+++ b/backend/app/reports/router.py
@@ -3,20 +3,23 @@
 """Reports Router — GET /api/reports/monthly
 
 月次レポートを PDF (reportlab 利用可) または CSV でダウンロードする。
-Admin または Editor ロールのみアクセス可。
+- Admin: 全ユーザー集計、または ?user_id= で特定ユーザーの集計を取得可能。
+- Viewer (一般ユーザー): 自分のデータのみ取得可能。
 """
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session
 
-from app.auth.dependencies import require_editor
-from app.auth.models import User
+from app.auth.dependencies import require_active_user
+from app.auth.models import User, UserRole
+from app.database import get_db
 
-from .monthly_report import MonthlyReportData, generate_monthly_report_pdf
+from .monthly_report import build_monthly_report_data, generate_monthly_report_pdf
 
 router = APIRouter(tags=["reports"])
 
@@ -25,35 +28,41 @@ router = APIRouter(tags=["reports"])
 def download_monthly_report(
     year: int | None = None,
     month: int | None = None,
-    _user: User = Depends(require_editor),
+    user_id: int | None = None,
+    current_user: User = Depends(require_active_user),
+    db: Session = Depends(get_db),
 ) -> StreamingResponse:
     """月次レポートをダウンロードする。
 
     Query params:
-        year:  対象年 (デフォルト: 今月)
-        month: 対象月 (デフォルト: 今月)
+        year:    対象年 (デフォルト: 今月)
+        month:   対象月 (デフォルト: 今月)
+        user_id: Admin のみ有効。指定ユーザーのレポートを取得。
+                 省略時は Admin なら全ユーザー集計、Viewer なら自分のみ。
 
     Auth:
-        Bearer トークン必須 (Admin または Editor ロール)
+        Bearer トークン必須 (全ロール)。
+        Viewer が他ユーザーの user_id を指定すると 403。
     """
     now = datetime.now(timezone.utc)
     target_year = year if year is not None else now.year
     target_month = month if month is not None else now.month
 
-    period = f"{target_year}年{target_month}月"
+    is_admin = current_user.role == UserRole.ADMIN.value
 
-    # モックデータ（実運用では DB から集計する）
-    data = MonthlyReportData(
-        period=period,
-        total_proposals=120,
-        positive_results=84,
-        win_rate=70.0,
-        total_gain_jpy=345_000,
-        avg_gain_per_trade_jpy=4_107,
-        total_fees_jpy=12_500,
-        annual_yield_pct=18.5,
-    )
+    if is_admin:
+        # Admin: user_id 指定があればそのユーザー、なければ全ユーザー集計
+        target_user_id = user_id
+    else:
+        # Viewer 系: 他ユーザーへのアクセスを拒否
+        if user_id is not None and user_id != current_user.id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="他のユーザーのレポートにはアクセスできません。",
+            )
+        target_user_id = current_user.id
 
+    data = build_monthly_report_data(db, target_year, target_month, target_user_id)
     content, content_type = generate_monthly_report_pdf(data)
 
     ext = "pdf" if content_type == "application/pdf" else "csv"

--- a/backend/tests/reports/test_monthly_report.py
+++ b/backend/tests/reports/test_monthly_report.py
@@ -4,7 +4,27 @@
 
 from __future__ import annotations
 
-from app.reports.monthly_report import MonthlyReportData, generate_monthly_report_pdf
+import os
+import tempfile
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-monthly-report")
+
+from app.database import Base  # noqa: E402
+from app.reports.monthly_report import (  # noqa: E402
+    MonthlyReportData,
+    build_monthly_report_data,
+    generate_monthly_report_pdf,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 def _make_data(**kwargs: object) -> MonthlyReportData:
@@ -22,6 +42,28 @@ def _make_data(**kwargs: object) -> MonthlyReportData:
     return MonthlyReportData(**defaults)  # type: ignore[arg-type]
 
 
+@pytest.fixture()
+def sqlite_db():
+    """テスト用の一時的な SQLite データベースを作成する。"""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+    Base.metadata.drop_all(bind=engine)
+    os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# 既存ユニットテスト (MonthlyReportData / generate_monthly_report_pdf)
+# ---------------------------------------------------------------------------
+
+
 def test_generate_report_returns_bytes() -> None:
     """レポート生成が bytes を返すことを確認する。"""
     data = _make_data()
@@ -37,7 +79,6 @@ def test_report_contains_period_text() -> None:
     data = _make_data(period="2026年3月")
     content, content_type = generate_monthly_report_pdf(data)
 
-    # PDF の場合は文字列をそのまま含むことが多い; CSV は確実
     assert b"2026" in content
 
 
@@ -57,3 +98,197 @@ def test_win_rate_calculation() -> None:
     content, _ = generate_monthly_report_pdf(data)
     assert isinstance(content, bytes)
     assert len(content) > 0
+
+
+# ---------------------------------------------------------------------------
+# build_monthly_report_data テスト
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMonthlyReportData:
+    """build_monthly_report_data の DB 集計テスト。"""
+
+    def test_empty_db_returns_zeros(self, sqlite_db) -> None:
+        """データが存在しない場合はゼロ値が返る。"""
+        result = build_monthly_report_data(sqlite_db, 2026, 3)
+
+        assert result.period == "2026年3月"
+        assert result.total_proposals == 0
+        assert result.positive_results == 0
+        assert result.win_rate == 0.0
+        assert result.total_gain_jpy == 0
+        assert result.total_fees_jpy == 0
+        assert result.annual_yield_pct == 0.0
+
+    def test_proposals_counted_in_month(self, sqlite_db) -> None:
+        """対象月のプロポーザルが正しく集計される。"""
+
+        _insert_proposal(sqlite_db, user_id=1, status="executed", year=2026, month=3)
+        _insert_proposal(sqlite_db, user_id=1, status="rejected", year=2026, month=3)
+        _insert_proposal(sqlite_db, user_id=1, status="executed", year=2026, month=4)
+
+        result = build_monthly_report_data(sqlite_db, 2026, 3)
+
+        assert result.total_proposals == 2
+        assert result.positive_results == 1
+        assert result.win_rate == 50.0
+
+    def test_proposals_filtered_by_user_id(self, sqlite_db) -> None:
+        """user_id 指定時は自ユーザーのデータのみ集計される。"""
+        _insert_proposal(sqlite_db, user_id=1, status="executed", year=2026, month=3)
+        _insert_proposal(sqlite_db, user_id=2, status="executed", year=2026, month=3)
+        _insert_proposal(sqlite_db, user_id=2, status="executed", year=2026, month=3)
+
+        result_user1 = build_monthly_report_data(sqlite_db, 2026, 3, user_id=1)
+        result_user2 = build_monthly_report_data(sqlite_db, 2026, 3, user_id=2)
+
+        assert result_user1.total_proposals == 1
+        assert result_user2.total_proposals == 2
+
+    def test_fee_transactions_aggregated(self, sqlite_db) -> None:
+        """fee_transactions から JPY 金額が集計される。"""
+        _insert_fee_tx(
+            sqlite_db,
+            user_id=1,
+            year=2026,
+            month=3,
+            net_profit_jpy=Decimal("50000"),
+            fee_amount_jpy=Decimal("5000"),
+            deposit_amount_jpy=Decimal("1000000"),
+        )
+        _insert_fee_tx(
+            sqlite_db,
+            user_id=2,
+            year=2026,
+            month=3,
+            net_profit_jpy=Decimal("30000"),
+            fee_amount_jpy=Decimal("3000"),
+            deposit_amount_jpy=Decimal("500000"),
+        )
+
+        # 全ユーザー集計
+        result = build_monthly_report_data(sqlite_db, 2026, 3)
+        assert result.total_gain_jpy == 80000
+        assert result.total_fees_jpy == 8000
+
+    def test_fee_transactions_filtered_by_user(self, sqlite_db) -> None:
+        """user_id 指定時は該当ユーザーの fee_transactions のみ集計される。"""
+        _insert_fee_tx(
+            sqlite_db,
+            user_id=1,
+            year=2026,
+            month=3,
+            net_profit_jpy=Decimal("50000"),
+            fee_amount_jpy=Decimal("5000"),
+            deposit_amount_jpy=Decimal("1000000"),
+        )
+        _insert_fee_tx(
+            sqlite_db,
+            user_id=2,
+            year=2026,
+            month=3,
+            net_profit_jpy=Decimal("30000"),
+            fee_amount_jpy=Decimal("3000"),
+            deposit_amount_jpy=Decimal("500000"),
+        )
+
+        result = build_monthly_report_data(sqlite_db, 2026, 3, user_id=1)
+        assert result.total_gain_jpy == 50000
+        assert result.total_fees_jpy == 5000
+
+    def test_annual_yield_calculated_from_fee_tx(self, sqlite_db) -> None:
+        """年率換算利回りが fee_transactions から計算される。"""
+        # 月次利益 = 10,000円 / 元本 100万円 = 月次利率 1% → 年率 12%
+        _insert_fee_tx(
+            sqlite_db,
+            user_id=1,
+            year=2026,
+            month=3,
+            net_profit_jpy=Decimal("10000"),
+            fee_amount_jpy=Decimal("1000"),
+            deposit_amount_jpy=Decimal("1000000"),
+        )
+
+        result = build_monthly_report_data(sqlite_db, 2026, 3, user_id=1)
+        assert result.annual_yield_pct == pytest.approx(12.0, rel=1e-3)
+
+    def test_avg_gain_per_trade_calculated(self, sqlite_db) -> None:
+        """平均損益/回が total_gain / total_proposals で計算される。"""
+        _insert_proposal(sqlite_db, user_id=1, status="executed", year=2026, month=3)
+        _insert_proposal(sqlite_db, user_id=1, status="executed", year=2026, month=3)
+        _insert_fee_tx(
+            sqlite_db,
+            user_id=1,
+            year=2026,
+            month=3,
+            net_profit_jpy=Decimal("10000"),
+            fee_amount_jpy=Decimal("1000"),
+            deposit_amount_jpy=Decimal("1000000"),
+        )
+
+        result = build_monthly_report_data(sqlite_db, 2026, 3, user_id=1)
+        assert result.avg_gain_per_trade_jpy == 5000  # 10000 // 2
+
+    def test_december_month_boundary(self, sqlite_db) -> None:
+        """12月指定で翌1月にまたがる提案が含まれないことを確認する。"""
+        _insert_proposal(sqlite_db, user_id=1, status="executed", year=2026, month=12)
+        _insert_proposal(sqlite_db, user_id=1, status="executed", year=2027, month=1)
+
+        result = build_monthly_report_data(sqlite_db, 2026, 12, user_id=1)
+        assert result.total_proposals == 1
+
+
+# ---------------------------------------------------------------------------
+# ヘルパー: テストデータ挿入
+# ---------------------------------------------------------------------------
+
+
+def _insert_proposal(db, *, user_id: int, status: str, year: int, month: int) -> None:
+    """テスト用プロポーザルを挿入する。"""
+    from app.proposals.models import Proposal
+
+    created_at = datetime(year, month, 15, 12, 0, 0, tzinfo=timezone.utc)
+    expires_at = datetime(year, month, 16, 12, 0, 0, tzinfo=timezone.utc)
+    p = Proposal(
+        user_id=user_id,
+        operation="SUPPLY",
+        asset="USDC",
+        amount=Decimal("100"),
+        amount_usd=Decimal("100"),
+        reason="test",
+        status=status,
+        expires_at=expires_at,
+        created_at=created_at,
+        updated_at=created_at,
+    )
+    db.add(p)
+    db.commit()
+
+
+def _insert_fee_tx(
+    db,
+    *,
+    user_id: int,
+    year: int,
+    month: int,
+    net_profit_jpy: Decimal,
+    fee_amount_jpy: Decimal,
+    deposit_amount_jpy: Decimal,
+) -> None:
+    """テスト用 fee_transaction を挿入する。"""
+    import datetime as dt
+
+    from app.fees.models import FeeTransaction
+
+    ft = FeeTransaction(
+        user_id=user_id,
+        calculation_month=dt.date(year, month, 1),
+        tier="LOWER",
+        risk_mode="conservative",
+        deposit_amount_jpy=deposit_amount_jpy,
+        net_profit_jpy=net_profit_jpy,
+        fee_amount_jpy=fee_amount_jpy,
+        gross_profit_jpy=net_profit_jpy + fee_amount_jpy,
+    )
+    db.add(ft)
+    db.commit()

--- a/backend/tests/reports/test_monthly_report_router.py
+++ b/backend/tests/reports/test_monthly_report_router.py
@@ -1,0 +1,210 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""月次レポート EP の RBAC 統合テスト。
+
+GET /api/reports/monthly の権限ルール:
+- 未認証 → 401
+- Viewer → 自分のデータのみ (200)
+- Viewer が他 user_id 指定 → 403
+- Admin → 全ユーザー集計 (200)
+- Admin が user_id 指定 → 指定ユーザー集計 (200)
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-report-router")
+os.environ.setdefault("JWT_ALGORITHM", "HS256")
+os.environ.setdefault("JWT_ACCESS_TOKEN_EXPIRE_MINUTES", "30")
+
+_ADMIN_EMAIL = "admin_report@example.com"
+_ADMIN_PASSWORD = "adminpassword123"
+_VIEWER_EMAIL = "viewer_report@example.com"
+_VIEWER_PASSWORD = "viewerpassword123"
+
+os.environ["INITIAL_ADMIN_EMAIL"] = _ADMIN_EMAIL
+
+from app.database import Base, get_db  # noqa: E402
+from app.main import create_app  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def test_db():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db() -> Generator:
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    yield override_get_db, engine
+    Base.metadata.drop_all(bind=engine)
+    os.unlink(path)
+
+
+@pytest.fixture()
+def client(test_db) -> TestClient:
+    override_get_db, _ = test_db
+    app = create_app()
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app)
+
+
+def _register_admin(client: TestClient) -> str:
+    client.post(
+        "/auth/register",
+        json={"email": _ADMIN_EMAIL, "username": "admin_report", "password": _ADMIN_PASSWORD},
+    )
+    r = client.post("/auth/login", json={"email": _ADMIN_EMAIL, "password": _ADMIN_PASSWORD})
+    assert r.status_code == 200, f"admin login failed: {r.text}"
+    return r.json()["access_token"]
+
+
+def _create_viewer_and_login(client: TestClient, admin_token: str) -> tuple[str, int]:
+    r = client.post(
+        "/users",
+        json={
+            "email": _VIEWER_EMAIL,
+            "username": "viewer_report",
+            "password": _VIEWER_PASSWORD,
+            "role": "viewer",
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code in (200, 201), f"create viewer failed: {r.text}"
+    viewer_id: int = r.json()["id"]
+    r2 = client.post("/auth/login", json={"email": _VIEWER_EMAIL, "password": _VIEWER_PASSWORD})
+    assert r2.status_code == 200, f"viewer login failed: {r2.text}"
+    return r2.json()["access_token"], viewer_id
+
+
+# ---------------------------------------------------------------------------
+# テスト
+# ---------------------------------------------------------------------------
+
+
+class TestMonthlyReportAuth:
+    """認証・認可の基本テスト。"""
+
+    def test_unauthenticated_returns_401(self, client: TestClient) -> None:
+        """未認証リクエストは 401 を返す。"""
+        r = client.get("/api/reports/monthly")
+        assert r.status_code == 401
+
+    def test_viewer_can_access_own_report(self, client: TestClient) -> None:
+        """Viewer は自分のレポートにアクセスできる (200)。"""
+        admin_token = _register_admin(client)
+        viewer_token, viewer_id = _create_viewer_and_login(client, admin_token)
+
+        r = client.get(
+            "/api/reports/monthly?year=2026&month=1",
+            headers={"Authorization": f"Bearer {viewer_token}"},
+        )
+        assert r.status_code == 200
+
+    def test_viewer_can_specify_own_user_id(self, client: TestClient) -> None:
+        """Viewer が自分の user_id を明示指定した場合も 200。"""
+        admin_token = _register_admin(client)
+        viewer_token, viewer_id = _create_viewer_and_login(client, admin_token)
+
+        r = client.get(
+            f"/api/reports/monthly?year=2026&month=1&user_id={viewer_id}",
+            headers={"Authorization": f"Bearer {viewer_token}"},
+        )
+        assert r.status_code == 200
+
+    def test_viewer_cannot_access_other_user(self, client: TestClient) -> None:
+        """Viewer が他ユーザーの user_id を指定すると 403。"""
+        admin_token = _register_admin(client)
+        viewer_token, viewer_id = _create_viewer_and_login(client, admin_token)
+
+        other_user_id = viewer_id + 999
+        r = client.get(
+            f"/api/reports/monthly?year=2026&month=1&user_id={other_user_id}",
+            headers={"Authorization": f"Bearer {viewer_token}"},
+        )
+        assert r.status_code == 403
+
+    def test_admin_can_access_without_user_id(self, client: TestClient) -> None:
+        """Admin は user_id なしで全ユーザー集計を取得できる (200)。"""
+        admin_token = _register_admin(client)
+
+        r = client.get(
+            "/api/reports/monthly?year=2026&month=1",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert r.status_code == 200
+
+    def test_admin_can_specify_any_user_id(self, client: TestClient) -> None:
+        """Admin は任意の user_id を指定してレポートを取得できる (200)。"""
+        admin_token = _register_admin(client)
+        _, viewer_id = _create_viewer_and_login(client, admin_token)
+
+        r = client.get(
+            f"/api/reports/monthly?year=2026&month=1&user_id={viewer_id}",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert r.status_code == 200
+
+
+class TestMonthlyReportContent:
+    """レスポンスコンテンツのテスト。"""
+
+    def test_response_has_content_disposition(self, client: TestClient) -> None:
+        """レスポンスに Content-Disposition ヘッダーが含まれる。"""
+        admin_token = _register_admin(client)
+
+        r = client.get(
+            "/api/reports/monthly?year=2026&month=3",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert r.status_code == 200
+        assert "content-disposition" in r.headers
+        assert "monthly_report_2026_03" in r.headers["content-disposition"]
+
+    def test_response_content_type_is_csv_or_pdf(self, client: TestClient) -> None:
+        """レスポンスの Content-Type が CSV または PDF である。"""
+        admin_token = _register_admin(client)
+
+        r = client.get(
+            "/api/reports/monthly?year=2026&month=3",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert r.status_code == 200
+        assert r.headers["content-type"] in (
+            "text/csv; charset=utf-8",
+            "application/pdf",
+        )
+
+    def test_default_year_month_uses_current(self, client: TestClient) -> None:
+        """year/month 未指定時は今月のファイル名が返る。"""
+        from datetime import datetime, timezone
+
+        admin_token = _register_admin(client)
+
+        r = client.get(
+            "/api/reports/monthly",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert r.status_code == 200
+        now = datetime.now(timezone.utc)
+        expected_filename = f"monthly_report_{now.year}_{now.month:02d}"
+        assert expected_filename in r.headers["content-disposition"]


### PR DESCRIPTION
## Summary

- **モックデータを実DB集計に置換**: `build_monthly_report_data()` 関数を `monthly_report.py` に追加。`proposals` テーブルから月次件数・勝率、`fee_transactions` から損益・手数料・年率換算利回りを集計。
- **権限を緩和**: `require_editor` → `require_active_user` (Viewer 含む全ロール)。Admin は `?user_id=` で任意ユーザーのレポートを取得可能。Viewer は自分のデータのみ (他ユーザー指定は 403)。
- **テスト追加**: `test_monthly_report.py` に DB 集計ユニットテスト 8 件、`test_monthly_report_router.py` に RBAC 統合テスト 9 件を新規追加 (合計 20/20 PASS)。

## Gate Results

- Gate 1: `ruff check` → PASS (0 errors)
- Gate 2: `ruff format --check` → PASS
- Gate 3: `mypy app/reports/` → PASS (0 errors、pre-existing unused-ignore も修正)
- pytest `tests/reports/` → **20/20 PASS**

## Test plan

- [ ] `pytest tests/reports/ -v` で 20 件全 PASS を確認
- [ ] Viewer トークンで `/api/reports/monthly` にアクセス → 200 (自分のデータ)
- [ ] Viewer で `?user_id=<他人のID>` → 403
- [ ] Admin で `?user_id=<任意>` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)