### PR TITLE
fix(infra): entrypoint で named volume chown 恒久修正 (Lane L)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && apt-get upgrade -y --no-install-recommends \
     && apt-get install -y --no-install-recommends \
     libpq5 \
     curl \
+    gosu \
     && rm -rf /var/lib/apt/lists/*
 
 # builder の wheel をコピーしてインストール（ネットワーク不要）
@@ -54,18 +55,25 @@ RUN if [ "$BUILD_MODE" = "production" ]; then \
       find backend/app/ai -name "*.py" ! -name "__init__.py" ! -name "schemas.py" ! -name "router.py" ! -name "decisions_router.py" ! -name "decisions_schemas.py" ! -name "models.py" -delete; \
     fi
 
-# 非 root ユーザーで実行（docs/13_security_design.md）
-# UID/GID は 10001 で固定。docker-compose の ultra-state-init が同じ UID で
-# named volume (/var/run/ultra) を chown するためここと値が一致している必要がある。
+# 非 root ユーザーを作成（docs/13_security_design.md）
+# UID/GID は 10001 で固定。docker-compose の backend-volume-init と
+# entrypoint.sh の chown 対象 UID と一致させる必要がある。
 RUN groupadd --gid 10001 appuser \
     && useradd --no-create-home --shell /bin/false --uid 10001 --gid 10001 appuser
+# イメージ層でもディレクトリを作成しておく（新規 volume の初回 population 時に
+# chown 済み状態でコピーされる）。
 RUN mkdir -p /var/log/ultra-autotrade /var/run/ultra \
     && chown appuser:appuser /var/log/ultra-autotrade /var/run/ultra
-USER appuser
+
+# entrypoint: root で起動 → named volume を chown → gosu で appuser に降格して CMD を exec
+# USER appuser は設定しない（entrypoint が権限降格を担う）
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 EXPOSE 8000
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# Named Docker volumes are created as root:root on first mount, making them
+# unwritable by appuser (UID=10001). This entrypoint runs as root and corrects
+# ownership before dropping privileges — covers both first-deploy and any
+# docker-compose restart / docker restart scenario where the compose-level
+# backend-volume-init init-container does not re-run.
+mkdir -p /var/run/ultra /var/log/ultra-autotrade
+chown -R 10001:10001 /var/run/ultra /var/log/ultra-autotrade
+
+exec gosu appuser "$@"


### PR DESCRIPTION
## 問題

production/staging で `/var/run/ultra/state.json` および `/var/log/ultra-autotrade` に対して
`Permission denied` が発生し fallback 動作（§21/§24a）が継続している。

**根本原因**: Docker named volume は初回マウント時に `root:root` で作成される。
`dbe1233` で追加した `backend-volume-init` init container は `docker compose up` 時のみ
実行され、`docker compose restart` や `docker restart` では再実行されない。
このため VPS 再起動後などに権限が root:root に戻るリスクがある。

## 修正

`docker/entrypoint.sh` を追加し、コンテナ起動の**都度** named volume を chown する。

```
[root] entrypoint.sh
  → mkdir -p /var/run/ultra /var/log/ultra-autotrade
  → chown -R 10001:10001 (両ディレクトリ)
  → exec gosu appuser "$@"  ← ここから appuser で uvicorn が起動
```

既存の `backend-volume-init` (docker-compose レベル) は残す（ベルトサスペンダー）。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `docker/entrypoint.sh` | 新規追加: root→appuser 権限降格 + chown |
| `Dockerfile` | `gosu` apt 追加、`USER appuser` 削除、`ENTRYPOINT` 追加 |

## 検証（dev ローカル）

```
Test 1: runs as appuser
uid=10001(appuser) gid=10001(appuser) groups=10001(appuser) ✅

Test 2: root:root volume → chowned
drwxr-xr-x 2 appuser appuser ... /var/run/ultra ✅
drwxr-xr-x 2 appuser appuser ... /var/log/ultra-autotrade ✅

Test 3: write state.json after chown
appuser:appuser /var/run/ultra
write OK ✅
```

## staging 確認手順（人間が実施）

```bash
# 1. deploy
scripts/deploy_staging.sh

# 2. fallback ログが出ないことを確認
docker logs ultra-autotrade-backend-blue-staging-new 2>&1 | grep -E "Permission denied|fallback|in-memory"
# → 0件であること

# 3. state.json が書き込まれていることを確認
docker exec ultra-autotrade-backend-blue-staging-new ls -la /var/run/ultra/
# → -rw------- 1 appuser appuser ... state.json
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)