### PR TITLE
feat(billing): F-7 subscription billing engine + vendor-agnostic adapter (stub)

### DIFF
--- a/backend/alembic/sql/047_fee_tx_vendor_ref.sql
+++ b/backend/alembic/sql/047_fee_tx_vendor_ref.sql
@@ -1,6 +1,6 @@
 -- 047_fee_tx_vendor_ref.sql
 -- Add vendor_reference_id and charged_at to fee_transactions (F-7 vendor-agnostic adapter)
--- Corresponds to alembic revision: k1l2m3n4o5p6
+-- Corresponds to alembic revision: l2m3n4o5p6q7
 
 ALTER TABLE fee_transactions
     ADD COLUMN IF NOT EXISTS vendor_reference_id VARCHAR(128),

--- a/backend/alembic/sql/047_fee_tx_vendor_ref.sql
+++ b/backend/alembic/sql/047_fee_tx_vendor_ref.sql
@@ -1,0 +1,11 @@
+-- 047_fee_tx_vendor_ref.sql
+-- Add vendor_reference_id and charged_at to fee_transactions (F-7 vendor-agnostic adapter)
+-- Corresponds to alembic revision: k1l2m3n4o5p6
+
+ALTER TABLE fee_transactions
+    ADD COLUMN IF NOT EXISTS vendor_reference_id VARCHAR(128),
+    ADD COLUMN IF NOT EXISTS charged_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_fee_tx_vendor_ref
+    ON fee_transactions (vendor_reference_id)
+    WHERE vendor_reference_id IS NOT NULL;

--- a/backend/alembic/versions/k1l2m3n4o5p6_add_fee_tx_vendor_ref.py
+++ b/backend/alembic/versions/k1l2m3n4o5p6_add_fee_tx_vendor_ref.py
@@ -1,0 +1,49 @@
+"""add_fee_tx_vendor_ref
+
+Add vendor_reference_id and charged_at columns to fee_transactions.
+Enables vendor-agnostic billing adapter result persistence (F-7).
+
+Equivalent raw SQL: backend/alembic/sql/047_fee_tx_vendor_ref.sql
+
+Revision ID: k1l2m3n4o5p6
+Revises: i9j0k1l2m3n4
+Create Date: 2026-06-02 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "k1l2m3n4o5p6"
+down_revision: Union[str, Sequence[str], None] = "i9j0k1l2m3n4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add vendor_reference_id and charged_at to fee_transactions."""
+    op.add_column(
+        "fee_transactions",
+        sa.Column("vendor_reference_id", sa.String(128), nullable=True),
+    )
+    op.add_column(
+        "fee_transactions",
+        sa.Column("charged_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "idx_fee_tx_vendor_ref",
+        "fee_transactions",
+        ["vendor_reference_id"],
+        postgresql_where=sa.text("vendor_reference_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Remove vendor_reference_id and charged_at from fee_transactions."""
+    op.drop_index("idx_fee_tx_vendor_ref", table_name="fee_transactions")
+    op.drop_column("fee_transactions", "charged_at")
+    op.drop_column("fee_transactions", "vendor_reference_id")

--- a/backend/alembic/versions/l2m3n4o5p6q7_add_fee_tx_vendor_ref.py
+++ b/backend/alembic/versions/l2m3n4o5p6q7_add_fee_tx_vendor_ref.py
@@ -5,8 +5,8 @@ Enables vendor-agnostic billing adapter result persistence (F-7).
 
 Equivalent raw SQL: backend/alembic/sql/047_fee_tx_vendor_ref.sql
 
-Revision ID: k1l2m3n4o5p6
-Revises: i9j0k1l2m3n4
+Revision ID: l2m3n4o5p6q7
+Revises: k1l2m3n4o5p6
 Create Date: 2026-06-02 00:00:00.000000
 
 """
@@ -18,8 +18,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "k1l2m3n4o5p6"
-down_revision: Union[str, Sequence[str], None] = "i9j0k1l2m3n4"
+revision: str = "l2m3n4o5p6q7"
+down_revision: Union[str, Sequence[str], None] = "k1l2m3n4o5p6"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/app/api/v1/fees.py
+++ b/backend/app/api/v1/fees.py
@@ -45,6 +45,7 @@ from app.auth.dependencies import require_active_user, require_admin
 from app.auth.models import InvestmentTier, RiskMode, User
 from app.database import get_db
 from app.fees import FeeCalculationInput, FeeCalculator
+from app.fees.billing_adapter import BillingVendorAdapter, ChargeRequest
 from app.fees.fee_transfer_service import (
     FeeTransferConfig,
     FeeTransferService,
@@ -211,6 +212,10 @@ class FinalizeMonthResponse(BaseModel):
     transfer_sent: int = 0
     transfer_skipped: int = 0
     transfer_failed: int = 0
+    #: vendor adapter 経由で課金を試みたユーザー数 (subscription_amount > 0)
+    vendor_charges_attempted: int = 0
+    #: vendor adapter が success=True を返したユーザー数
+    vendor_charges_succeeded: int = 0
 
 
 # ===========================================================================
@@ -255,6 +260,7 @@ def finalize_month_core(
     usd_jpy_rate: Decimal,
     *,
     dry_run: bool = False,
+    vendor_adapter: BillingVendorAdapter | None = None,
 ) -> FinalizeMonthResponse:
     """月次手数料バッチのコアロジック (API endpoint / 定期実行タスク 共通)。
 
@@ -262,6 +268,10 @@ def finalize_month_core(
     FeeCalculator で手数料を計算して fee_transactions に書き込む。
     dry_run=True の場合は計算のみ行い DB 書込はしない。
     expense_jpy は当月の完了トレード件数 × TRADE_FIXED_COST_USD × usd_jpy_rate で算出 (F-9)。
+
+    vendor_adapter が指定された場合、サブスク課金額 > 0 かつ subscription_protected=False の
+    ユーザーに対して charge_subscription() を呼び出す (課金ベンダー差込点)。
+    dry_run=True のとき vendor_adapter は呼ばれない。
     """
     next_month = _next_month_start(month_start)
     dt_from = datetime(month_start.year, month_start.month, 1, tzinfo=timezone.utc)
@@ -276,6 +286,8 @@ def finalize_month_core(
     total_fee = Decimal("0")
     total_sub = Decimal("0")
     total_takehome = Decimal("0")
+    vendor_charges_attempted = 0
+    vendor_charges_succeeded = 0
 
     for user in active_users:
         first_snap = db.scalar(
@@ -403,14 +415,68 @@ def finalize_month_core(
     if not dry_run:
         db.commit()
 
+        # --- 課金ベンダー差込点 (vendor_adapter が指定された場合のみ実行) ---
+        # subscription_amount_jpy > 0 かつ subscription_protected=False のユーザーに対し
+        # サブスク課金を実行する。DB への vendor_reference_id 書込後に再 commit。
+        if vendor_adapter is not None:
+            written_ids: list[int] = []
+            stmt_uncharged = select(FeeTransaction).where(
+                FeeTransaction.calculation_month == month_start,
+                FeeTransaction.subscription_amount_jpy > Decimal("0"),
+                FeeTransaction.subscription_protected.is_(False),
+                FeeTransaction.vendor_reference_id.is_(None),
+            )
+            pending_txs = db.execute(stmt_uncharged).scalars().all()
+            for fee_tx in pending_txs:
+                vendor_charges_attempted += 1
+                try:
+                    charge_req = ChargeRequest(
+                        user_id=fee_tx.user_id,
+                        fee_transaction_id=fee_tx.id,
+                        subscription_amount_jpy=Decimal(str(fee_tx.subscription_amount_jpy)),
+                        calculation_month=fee_tx.calculation_month,
+                        description=f"サブスク月額 {fee_tx.calculation_month}",
+                    )
+                    charge_res = vendor_adapter.charge_subscription(charge_req)
+                    if charge_res.success:
+                        fee_tx.vendor_reference_id = charge_res.vendor_reference_id
+                        fee_tx.charged_at = datetime.now(timezone.utc)
+                        vendor_charges_succeeded += 1
+                        written_ids.append(fee_tx.id)
+                    else:
+                        logger.warning(
+                            "vendor charge failed: user_id=%d fee_tx_id=%d err=%s",
+                            fee_tx.user_id,
+                            fee_tx.id,
+                            charge_res.error_message,
+                        )
+                except Exception as exc:  # noqa: BLE001
+                    logger.error(
+                        "vendor charge exception: user_id=%d fee_tx_id=%d exc=%s",
+                        fee_tx.user_id,
+                        fee_tx.id,
+                        exc,
+                    )
+            if written_ids:
+                db.commit()
+                logger.info(
+                    "finalize_month vendor charges: month=%s attempted=%d succeeded=%d ids=%s",
+                    month_start,
+                    vendor_charges_attempted,
+                    vendor_charges_succeeded,
+                    written_ids,
+                )
+
     logger.info(
         "finalize_month: month=%s processed=%d skipped_no_snap=%d skipped_finalized=%d"
-        " total_fee=%s dry_run=%s",
+        " total_fee=%s vendor_charges=%d/%d dry_run=%s",
         month_start,
         processed,
         skipped_no_snapshot,
         skipped_finalized,
         total_fee,
+        vendor_charges_succeeded,
+        vendor_charges_attempted,
         dry_run,
     )
 
@@ -495,6 +561,8 @@ def finalize_month_core(
         transfer_sent=transfer_sent,
         transfer_skipped=transfer_skipped,
         transfer_failed=transfer_failed,
+        vendor_charges_attempted=vendor_charges_attempted,
+        vendor_charges_succeeded=vendor_charges_succeeded,
     )
 
 

--- a/backend/app/automation/scheduled_tasks.py
+++ b/backend/app/automation/scheduled_tasks.py
@@ -168,6 +168,7 @@ def _monthly_fee_batch_sync(calculation_month: date, usd_jpy_rate: Decimal) -> N
     from sqlalchemy import select as _select  # noqa: PLC0415
 
     from app.api.v1.fees import finalize_month_core  # noqa: PLC0415
+    from app.fees.billing_adapter import StubBillingAdapter  # noqa: PLC0415
     from app.fees.models import FeeConfigV10  # noqa: PLC0415
 
     with SessionLocal() as db:
@@ -183,15 +184,20 @@ def _monthly_fee_batch_sync(calculation_month: date, usd_jpy_rate: Decimal) -> N
                 calculation_month,
             )
             return
-        result = finalize_month_core(db, config, calculation_month, usd_jpy_rate)
+        vendor = StubBillingAdapter()
+        result = finalize_month_core(
+            db, config, calculation_month, usd_jpy_rate, vendor_adapter=vendor
+        )
         logger.info(
             "monthly_fee_batch done: month=%s processed=%d skipped_no_snap=%d"
-            " skipped_finalized=%d total_fee=%s",
+            " skipped_finalized=%d total_fee=%s vendor_charges=%d/%d",
             calculation_month,
             result.users_processed,
             result.users_skipped_no_snapshot,
             result.users_skipped_already_finalized,
             result.total_fee_jpy,
+            result.vendor_charges_succeeded,
+            result.vendor_charges_attempted,
         )
 
 

--- a/backend/app/fees/__init__.py
+++ b/backend/app/fees/__init__.py
@@ -12,8 +12,18 @@
 - ``JPY_QUANTIZE``           : 円未満切り捨て用 Decimal 単位
 - ``MarketFeeResult``        : トレードゲート判定結果 (§4)
 - ``calculate_fee_by_market``: §4 トレードゲート (予想利益 > 経費チェック)
+- ``BillingVendorAdapter``   : 課金ベンダー抽象プロトコル (F-7 vendor-agnostic)
+- ``ChargeRequest``          : 課金リクエスト dataclass
+- ``ChargeResult``           : 課金結果 dataclass
+- ``StubBillingAdapter``     : ベンダー未定期間スタブ (ログのみ)
 """
 
+from .billing_adapter import (
+    BillingVendorAdapter,
+    ChargeRequest,
+    ChargeResult,
+    StubBillingAdapter,
+)
 from .calculator import (
     JPY_QUANTIZE,
     FeeCalculationInput,
@@ -26,6 +36,10 @@ from .trade_gate import (
 )
 
 __all__ = [
+    "BillingVendorAdapter",
+    "ChargeRequest",
+    "ChargeResult",
+    "StubBillingAdapter",
     "JPY_QUANTIZE",
     "FeeCalculationInput",
     "FeeCalculationResult",

--- a/backend/app/fees/billing_adapter.py
+++ b/backend/app/fees/billing_adapter.py
@@ -1,0 +1,104 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/fees/billing_adapter.py
+"""課金ベンダー vendor-agnostic adapter (F-7)。
+
+ベンダー未決定期間は ``StubBillingAdapter`` を使用し、ログのみ記録する。
+課金ベンダー (Stripe / Paidy 等) が確定した時点で ``BillingVendorAdapter``
+プロトコルを実装した adapter class を差し替えるだけで切り替え完了。
+
+差込点: ``app.api.v1.fees.finalize_month_core(..., vendor_adapter=...)``
+
+関連:
+- ``app.fees.calculator`` (月次手数料計算エンジン、F-5)
+- ``app.api.v1.fees.finalize_month_core`` (月次 finalize、F-7)
+- ``docs/45_fee_model_v10_migration_plan.md`` §4 F-7 行
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ChargeRequest:
+    """課金リクエスト。``finalize_month_core`` から vendor adapter へ渡す。
+
+    subscription_amount_jpy は Step 2 で確定した額。
+    subscription_protected=True の月は ``finalize_month_core`` がリクエストを
+    生成しないため、本 dataclass は subscription_protected=False のケースのみ受け取る。
+    """
+
+    user_id: int
+    fee_transaction_id: int
+    subscription_amount_jpy: Decimal
+    calculation_month: date
+    description: str = ""
+
+
+@dataclass
+class ChargeResult:
+    """課金結果。vendor adapter から ``finalize_month_core`` へ返す。
+
+    ``vendor_reference_id`` は DBに ``fee_transactions.vendor_reference_id`` として保存し、
+    ベンダー側との突合に使う。
+    """
+
+    user_id: int
+    fee_transaction_id: int
+    success: bool
+    vendor_reference_id: str | None = None
+    error_message: str | None = None
+
+
+@runtime_checkable
+class BillingVendorAdapter(Protocol):
+    """課金ベンダー抽象プロトコル (F-7 vendor-agnostic 差込点)。
+
+    実装を swap するだけでベンダーを切り替えられる::
+
+        finalize_month_core(..., vendor_adapter=StubBillingAdapter())
+        finalize_month_core(..., vendor_adapter=StripeBillingAdapter(api_key=...))
+        finalize_month_core(..., vendor_adapter=PaidyBillingAdapter(api_key=...))
+    """
+
+    def charge_subscription(self, request: ChargeRequest) -> ChargeResult:
+        """サブスク月額料金を課金する。
+
+        Args:
+            request: 課金対象ユーザー・金額・月。
+
+        Returns:
+            成否 + ベンダー参照 ID (突合用)。
+        """
+        ...
+
+
+class StubBillingAdapter:
+    """ベンダー未定期間のスタブ実装。実課金は行わない (ログのみ)。
+
+    課金ベンダーが確定した際は本クラスを本物の adapter に差し替える。
+    差込点は ``finalize_month_core(..., vendor_adapter=StubBillingAdapter())``。
+    """
+
+    def charge_subscription(self, request: ChargeRequest) -> ChargeResult:
+        logger.info(
+            "BillingStub.charge_subscription: user_id=%d fee_tx_id=%d "
+            "amount_jpy=%s month=%s [NO-OP: billing vendor not yet configured]",
+            request.user_id,
+            request.fee_transaction_id,
+            request.subscription_amount_jpy,
+            request.calculation_month,
+        )
+        return ChargeResult(
+            user_id=request.user_id,
+            fee_transaction_id=request.fee_transaction_id,
+            success=True,
+            vendor_reference_id=f"stub-{request.calculation_month}-u{request.user_id}",
+        )

--- a/backend/app/fees/models.py
+++ b/backend/app/fees/models.py
@@ -160,6 +160,14 @@ class FeeTransaction(Base):
     affiliate_amount_jpy: Mapped[Decimal] = mapped_column(
         Numeric(18, 2), nullable=False, server_default=text("0")
     )
+    #: 課金ベンダーが返した参照 ID (Stripe charge_id / Paidy payment_id 等)。
+    #: ベンダー未定期間は StubBillingAdapter が "stub-YYYY-MM-uN" を格納。
+    #: NULL = 課金未実行 (dry_run / vendor_adapter=None)。
+    vendor_reference_id: Mapped[Optional[str]] = mapped_column(
+        String(128), nullable=True, index=True
+    )
+    #: 課金ベンダーが subscription を処理した日時。NULL = 未課金。
+    charged_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     calculated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/backend/tests/billing/test_subscription_billing.py
+++ b/backend/tests/billing/test_subscription_billing.py
@@ -1,0 +1,469 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/billing/test_subscription_billing.py
+"""サブスク定期請求エンジン統合テスト (F-7 vendor-agnostic adapter)。
+
+テスト対象:
+- ``StubBillingAdapter`` の動作検証
+- ``finalize_month_core`` へ vendor_adapter を渡したときの課金フロー
+- サブスク保護 (subscription_protected=True → 課金スキップ)
+- 月次利回りキャップ超過 → UATa 振替
+- dry_run=True → vendor adapter 不呼出
+- vendor adapter エラー → ログのみ (fail-open)
+
+DB は SQLite テスト DB (in-memory)。
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Generator
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-billing")
+os.environ.setdefault("JWT_ALGORITHM", "HS256")
+os.environ.setdefault("JWT_ACCESS_TOKEN_EXPIRE_MINUTES", "30")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "billing_test@example.com")
+
+from app.auth.models import InvestmentTier, RiskMode, User  # noqa: E402
+from app.database import Base  # noqa: E402
+from app.fees.billing_adapter import (  # noqa: E402
+    BillingVendorAdapter,
+    ChargeRequest,
+    ChargeResult,
+    StubBillingAdapter,
+)
+from app.fees.models import FeeConfigV10, FeeTransaction  # noqa: E402
+from app.portfolio.models import PortfolioSnapshot  # noqa: E402
+from tests.helpers.fee_config_factory import make_v10_default_config  # noqa: E402
+
+_JST = timezone(timedelta(hours=9))
+_MONTH = date(2026, 5, 1)
+_NEXT_MONTH = date(2026, 6, 1)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db() -> Generator[Session, None, None]:
+    """In-memory SQLite DB。各テストで独立。"""
+    fd, path = tempfile.mkstemp(suffix=".billing_test.db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = SessionLocal()
+    yield session
+    session.close()
+    Base.metadata.drop_all(bind=engine)
+    os.unlink(path)
+
+
+@pytest.fixture()
+def active_config(db: Session) -> FeeConfigV10:
+    cfg = make_v10_default_config()
+    db.add(cfg)
+    db.commit()
+    db.refresh(cfg)
+    return cfg
+
+
+def _add_user(
+    db: Session,
+    *,
+    user_id: int = 1,
+    risk_mode: str = "balanced",
+    tier: str = "LOWER",
+    created_days_ago: int = 60,
+) -> User:
+    """テスト用アクティブユーザーを作成して返す。"""
+    u = User(
+        id=user_id,
+        email=f"user{user_id}@test.com",
+        username=f"user{user_id}",
+        hashed_password="x",
+        is_active=True,
+        risk_mode=risk_mode,
+        tier=tier,
+        created_at=datetime.now(timezone.utc) - timedelta(days=created_days_ago),
+    )
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _add_snapshots(
+    db: Session,
+    user_id: int,
+    *,
+    start_usd: Decimal,
+    end_usd: Decimal,
+) -> None:
+    """月初 / 月末スナップショットを追加。"""
+    dt_start = datetime(_MONTH.year, _MONTH.month, 1, tzinfo=timezone.utc)
+    dt_end = datetime(_NEXT_MONTH.year, _NEXT_MONTH.month, 1, tzinfo=timezone.utc) - timedelta(
+        seconds=1
+    )
+    db.add(
+        PortfolioSnapshot(
+            user_id=user_id,
+            total_value_usd=start_usd,
+            total_supply_usd=start_usd,
+            total_borrow_usd=Decimal("0"),
+            recorded_at=dt_start,
+        )
+    )
+    db.add(
+        PortfolioSnapshot(
+            user_id=user_id,
+            total_value_usd=end_usd,
+            total_supply_usd=end_usd,
+            total_borrow_usd=Decimal("0"),
+            recorded_at=dt_end,
+        )
+    )
+    db.flush()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: StubBillingAdapter
+# ---------------------------------------------------------------------------
+
+
+class TestStubBillingAdapter:
+    def test_returns_success(self) -> None:
+        adapter = StubBillingAdapter()
+        req = ChargeRequest(
+            user_id=1,
+            fee_transaction_id=42,
+            subscription_amount_jpy=Decimal("300"),
+            calculation_month=_MONTH,
+        )
+        result = adapter.charge_subscription(req)
+        assert result.success is True
+        assert result.vendor_reference_id is not None
+        assert "stub" in result.vendor_reference_id
+        assert result.error_message is None
+
+    def test_vendor_ref_contains_month_and_user(self) -> None:
+        adapter = StubBillingAdapter()
+        req = ChargeRequest(
+            user_id=7,
+            fee_transaction_id=99,
+            subscription_amount_jpy=Decimal("1000"),
+            calculation_month=date(2026, 5, 1),
+        )
+        result = adapter.charge_subscription(req)
+        assert "2026-05-01" in (result.vendor_reference_id or "")
+        assert "u7" in (result.vendor_reference_id or "")
+
+    def test_protocol_conformance(self) -> None:
+        """StubBillingAdapter は BillingVendorAdapter プロトコルを満たす。"""
+        adapter = StubBillingAdapter()
+        assert isinstance(adapter, BillingVendorAdapter)
+
+    def test_zero_amount_still_succeeds(self) -> None:
+        adapter = StubBillingAdapter()
+        req = ChargeRequest(
+            user_id=1,
+            fee_transaction_id=1,
+            subscription_amount_jpy=Decimal("0"),
+            calculation_month=_MONTH,
+        )
+        result = adapter.charge_subscription(req)
+        assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: finalize_month_core + vendor_adapter
+# ---------------------------------------------------------------------------
+
+
+class TestFinalizeMonthWithVendorAdapter:
+    def _import_core(self):  # type: ignore[no-untyped-def]
+        from app.api.v1.fees import finalize_month_core  # noqa: PLC0415
+
+        return finalize_month_core
+
+    def test_stub_adapter_charges_balanced_user(
+        self, db: Session, active_config: FeeConfigV10
+    ) -> None:
+        """balanced (0.3%) ユーザーは subscription_amount > 0 → stub が呼ばれる。"""
+        _add_user(db, user_id=1, risk_mode="balanced", tier="LOWER")
+        _add_snapshots(db, 1, start_usd=Decimal("1000"), end_usd=Decimal("1020"))
+        db.commit()
+
+        finalize_month_core = self._import_core()
+        stub = StubBillingAdapter()
+
+        resp = finalize_month_core(db, active_config, _MONTH, Decimal("150"), vendor_adapter=stub)
+        assert resp.users_processed == 1
+        assert resp.vendor_charges_attempted == 1
+        assert resp.vendor_charges_succeeded == 1
+
+        fee_tx = db.scalar(select(FeeTransaction).where(FeeTransaction.user_id == 1))
+        assert fee_tx is not None
+        assert fee_tx.vendor_reference_id is not None
+        assert "stub" in fee_tx.vendor_reference_id
+        assert fee_tx.charged_at is not None
+
+    def test_conservative_user_no_charge(self, db: Session, active_config: FeeConfigV10) -> None:
+        """conservative (0%) ユーザーは subscription_rate=0 → 課金不要 (attempts=0)。"""
+        _add_user(db, user_id=2, risk_mode="conservative", tier="LOWER")
+        _add_snapshots(db, 2, start_usd=Decimal("1000"), end_usd=Decimal("1020"))
+        db.commit()
+
+        finalize_month_core = self._import_core()
+        stub = StubBillingAdapter()
+
+        resp = finalize_month_core(db, active_config, _MONTH, Decimal("150"), vendor_adapter=stub)
+        assert resp.users_processed == 1
+        assert resp.vendor_charges_attempted == 0
+        assert resp.vendor_charges_succeeded == 0
+
+        fee_tx = db.scalar(select(FeeTransaction).where(FeeTransaction.user_id == 2))
+        assert fee_tx is not None
+        assert fee_tx.vendor_reference_id is None
+
+    def test_subscription_protected_skips_vendor_charge(
+        self, db: Session, active_config: FeeConfigV10
+    ) -> None:
+        """サブスク保護発動 (net_profit < subscription) → subscription_protected=True → 課金スキップ。
+
+        balanced 0.3%: deposit=1,500,000 JPY → subscription=4,500 JPY/月
+        gross_profit_jpy=0 → net_profit=0 < 4,500 → サブスク保護発動
+        subscription_amount_jpy は DB に 0 として保存される (Step 3 early-return)。
+        vendor adapter は呼ばれない。
+        """
+        _add_user(db, user_id=3, risk_mode="balanced", tier="LOWER")
+        deposit_usd = Decimal("10000")  # 150万円
+        _add_snapshots(db, 3, start_usd=deposit_usd, end_usd=deposit_usd)
+        db.commit()
+
+        finalize_month_core = self._import_core()
+        stub = StubBillingAdapter()
+
+        resp = finalize_month_core(db, active_config, _MONTH, Decimal("150"), vendor_adapter=stub)
+        assert resp.users_processed == 1
+        assert resp.vendor_charges_attempted == 0
+
+        fee_tx = db.scalar(select(FeeTransaction).where(FeeTransaction.user_id == 3))
+        assert fee_tx is not None
+        assert fee_tx.subscription_protected is True
+        assert fee_tx.vendor_reference_id is None
+
+    def test_dry_run_skips_vendor_adapter(self, db: Session, active_config: FeeConfigV10) -> None:
+        """dry_run=True のとき vendor adapter は呼ばれない。"""
+        _add_user(db, user_id=4, risk_mode="balanced", tier="LOWER")
+        _add_snapshots(db, 4, start_usd=Decimal("1000"), end_usd=Decimal("1050"))
+        db.commit()
+
+        called: list[ChargeRequest] = []
+
+        class SpyAdapter:
+            def charge_subscription(self, req: ChargeRequest) -> ChargeResult:
+                called.append(req)
+                return ChargeResult(
+                    user_id=req.user_id,
+                    fee_transaction_id=req.fee_transaction_id,
+                    success=True,
+                    vendor_reference_id="spy-ref",
+                )
+
+        finalize_month_core = self._import_core()
+        resp = finalize_month_core(
+            db, active_config, _MONTH, Decimal("150"), dry_run=True, vendor_adapter=SpyAdapter()
+        )
+        assert resp.dry_run is True
+        assert len(called) == 0
+
+    def test_vendor_charge_error_does_not_abort_batch(
+        self, db: Session, active_config: FeeConfigV10
+    ) -> None:
+        """vendor adapter が例外を投げてもバッチ全体は fail-open で続行する。"""
+        _add_user(db, user_id=5, risk_mode="balanced", tier="LOWER")
+        _add_snapshots(db, 5, start_usd=Decimal("1000"), end_usd=Decimal("1030"))
+        db.commit()
+
+        class FailingAdapter:
+            def charge_subscription(self, req: ChargeRequest) -> ChargeResult:
+                raise RuntimeError("vendor API timeout")
+
+        finalize_month_core = self._import_core()
+        # 例外が外に伝播しないことを確認
+        resp = finalize_month_core(
+            db,
+            active_config,
+            _MONTH,
+            Decimal("150"),
+            vendor_adapter=FailingAdapter(),
+        )
+        assert resp.users_processed == 1
+        assert resp.vendor_charges_attempted == 1
+        assert resp.vendor_charges_succeeded == 0
+
+    def test_no_vendor_adapter_leaves_vendor_ref_null(
+        self, db: Session, active_config: FeeConfigV10
+    ) -> None:
+        """vendor_adapter=None (デフォルト) のとき vendor_reference_id は NULL。"""
+        _add_user(db, user_id=6, risk_mode="aggressive", tier="MIDDLE")
+        _add_snapshots(db, 6, start_usd=Decimal("2000"), end_usd=Decimal("2100"))
+        db.commit()
+
+        finalize_month_core = self._import_core()
+        resp = finalize_month_core(db, active_config, _MONTH, Decimal("150"))
+        assert resp.vendor_charges_attempted == 0
+
+        fee_tx = db.scalar(select(FeeTransaction).where(FeeTransaction.user_id == 6))
+        assert fee_tx is not None
+        assert fee_tx.vendor_reference_id is None
+
+
+# ---------------------------------------------------------------------------
+# Unit: subscription protection boundary
+# ---------------------------------------------------------------------------
+
+
+class TestSubscriptionProtectionBoundary:
+    """サブスク保護の境界値テスト (pure calculator 経由)。"""
+
+    def test_mid_risk_sub_rate_is_0_3pct(self) -> None:
+        """balanced (ミドルリスク) の subscription_rate = 0.003 (0.3%/月)。"""
+        from app.fees import FeeCalculationInput, FeeCalculator  # noqa: PLC0415
+
+        cfg = make_v10_default_config()
+        calc = FeeCalculator(cfg)
+        result = calc.calculate_monthly(
+            FeeCalculationInput(
+                user_id=1,
+                calculation_month=_MONTH,
+                deposit_jpy=Decimal("1000000"),
+                gross_profit_jpy=Decimal("5000"),
+                expense_jpy=Decimal("0"),
+                user_tier=InvestmentTier.LOWER,
+                user_risk_mode=RiskMode.BALANCED,
+            )
+        )
+        # subscription = 1,000,000 * 0.003 = 3,000 JPY
+        assert result.subscription_rate_applied == Decimal("0.003")
+        assert result.subscription_amount_jpy == Decimal("3000")
+        assert result.subscription_protected is False
+
+    def test_high_risk_sub_rate_is_1_0pct(self) -> None:
+        """aggressive (ハイリスク) の subscription_rate = 0.01 (1.0%/月)。"""
+        from app.fees import FeeCalculationInput, FeeCalculator  # noqa: PLC0415
+
+        cfg = make_v10_default_config()
+        calc = FeeCalculator(cfg)
+        result = calc.calculate_monthly(
+            FeeCalculationInput(
+                user_id=2,
+                calculation_month=_MONTH,
+                deposit_jpy=Decimal("1000000"),
+                gross_profit_jpy=Decimal("20000"),
+                expense_jpy=Decimal("0"),
+                user_tier=InvestmentTier.LOWER,
+                user_risk_mode=RiskMode.AGGRESSIVE,
+            )
+        )
+        # subscription = 1,000,000 * 0.01 = 10,000 JPY
+        assert result.subscription_rate_applied == Decimal("0.01")
+        assert result.subscription_amount_jpy == Decimal("10000")
+
+    def test_protection_triggers_when_net_lt_subscription(self) -> None:
+        """net_profit < subscription → subscription_protected=True、profit 全額 UATa。"""
+        from app.fees import FeeCalculationInput, FeeCalculator  # noqa: PLC0415
+
+        cfg = make_v10_default_config()
+        calc = FeeCalculator(cfg)
+        # deposit=1,000,000、balanced → sub=3,000。gross=2,000 → net=2,000 < 3,000
+        result = calc.calculate_monthly(
+            FeeCalculationInput(
+                user_id=3,
+                calculation_month=_MONTH,
+                deposit_jpy=Decimal("1000000"),
+                gross_profit_jpy=Decimal("2000"),
+                expense_jpy=Decimal("0"),
+                user_tier=InvestmentTier.LOWER,
+                user_risk_mode=RiskMode.BALANCED,
+            )
+        )
+        assert result.subscription_protected is True
+        assert result.subscription_amount_jpy == Decimal("0")
+        assert result.fee_amount_jpy == Decimal("0")
+        assert result.user_takehome_jpy == Decimal("0")
+        # net_profit 全額が UATa (yield_excess_to_uata)
+        assert result.yield_excess_to_uata_jpy == Decimal("2000")
+
+    def test_first_month_no_subscription(self) -> None:
+        """初月 (is_first_month=True) はサブスク料金 0。"""
+        from app.fees import FeeCalculationInput, FeeCalculator  # noqa: PLC0415
+
+        cfg = make_v10_default_config()
+        calc = FeeCalculator(cfg)
+        result = calc.calculate_monthly(
+            FeeCalculationInput(
+                user_id=4,
+                calculation_month=_MONTH,
+                deposit_jpy=Decimal("1000000"),
+                gross_profit_jpy=Decimal("5000"),
+                expense_jpy=Decimal("0"),
+                user_tier=InvestmentTier.LOWER,
+                user_risk_mode=RiskMode.BALANCED,
+                is_first_month=True,
+            )
+        )
+        assert result.subscription_amount_jpy == Decimal("0")
+        assert result.subscription_rate_applied == Decimal("0")
+
+    def test_yield_cap_excess_to_uata(self) -> None:
+        """月次利回りキャップ超過分は UATa に振替される。
+
+        LOWER tier: cap=1.8%/月。deposit=1,000,000 → cap=18,000 JPY
+        net_profit=20,000 (cap 超)、sub=0 (conservative) → provisional=20,000 > 18,000
+        → yield_excess = 2,000 → UATa
+        """
+        from app.fees import FeeCalculationInput, FeeCalculator  # noqa: PLC0415
+
+        cfg = make_v10_default_config()
+        calc = FeeCalculator(cfg)
+        result = calc.calculate_monthly(
+            FeeCalculationInput(
+                user_id=5,
+                calculation_month=_MONTH,
+                deposit_jpy=Decimal("1000000"),
+                gross_profit_jpy=Decimal("20000"),
+                expense_jpy=Decimal("0"),
+                user_tier=InvestmentTier.LOWER,
+                user_risk_mode=RiskMode.CONSERVATIVE,
+            )
+        )
+        # conservative → sub=0, fee_rate=0.30
+        # net=20,000, fee=floor(20,000*0.30)=6,000
+        # provisional_takehome = 20,000 - 0 - 6,000 = 14,000
+        # cap = 1,000,000 * 0.018 = 18,000 → 14,000 <= 18,000 → no excess
+        assert result.yield_excess_to_uata_jpy == Decimal("0")
+
+        # cap 超えケース: gross=50,000 → net=50,000, fee=15,000, provisional=35,000 > 18,000
+        result2 = calc.calculate_monthly(
+            FeeCalculationInput(
+                user_id=5,
+                calculation_month=_MONTH,
+                deposit_jpy=Decimal("1000000"),
+                gross_profit_jpy=Decimal("50000"),
+                expense_jpy=Decimal("0"),
+                user_tier=InvestmentTier.LOWER,
+                user_risk_mode=RiskMode.CONSERVATIVE,
+            )
+        )
+        assert result2.yield_excess_to_uata_jpy == Decimal("17000")  # 35,000 - 18,000
+        assert result2.user_takehome_jpy == Decimal("18000")


### PR DESCRIPTION
## Summary

- **BillingVendorAdapter プロトコル + StubBillingAdapter 実装** (`backend/app/fees/billing_adapter.py` 新規)
  - 課金ベンダー差込点: `StubBillingAdapter` → `StripeBillingAdapter` / `PaidyBillingAdapter` にスワップするだけで切り替え完了
  - `charge_subscription(ChargeRequest) → ChargeResult` プロトコル
- **`finalize_month_core` に `vendor_adapter` パラメータを追加** (`api/v1/fees.py`)
  - `subscription_amount_jpy > 0` かつ `subscription_protected=False` のユーザーを課金対象に
  - `dry_run=True` → adapter 不呼出 (DB 書込なしと同様に安全)
  - vendor adapter 例外 → fail-open (ログのみ・バッチ継続)
  - `FinalizeMonthResponse` に `vendor_charges_attempted` / `vendor_charges_succeeded` 追加
- **`_monthly_fee_batch_sync` に `StubBillingAdapter` を wire** (`scheduled_tasks.py` 最小変更)
- **`fee_transactions` に `vendor_reference_id` + `charged_at` 列を追加** (`models.py`)
- **Alembic migration `k1l2m3n4o5p6`**: `i9j0k1l2m3n4` (origin/main HEAD) から chain
- **テスト 15 件新規** (`tests/billing/test_subscription_billing.py`): StubBillingAdapter 単体 4 件 + finalize_month_core 統合 6 件 + サブスク保護境界値 5 件

## 関連 Asana

- MVP-P0-13 / MVP-P0-18 (GID 未確認のためコメントで補完)

## テスト計画

- [x] Gate 1-3: ruff check / ruff format / mypy / pytest 15/15 pass
- [ ] Gate 4: Playwright E2E (UI 変更なし → n/a)
- [ ] Gate 5: 孤立コード検出 (新規モジュール billing_adapter.py → 要確認)
- [ ] Gate 6: Codex Review
- [ ] Gate 7: chrome (UI 変更なし → n/a)

## 課金ベンダー差込点 (How to swap)

```python
# 現在: StubBillingAdapter (ログのみ)
vendor = StubBillingAdapter()

# Stripe 実装時:
from app.fees.billing_adapter import BillingVendorAdapter
class StripeBillingAdapter:
    def charge_subscription(self, req: ChargeRequest) -> ChargeResult:
        # stripe.Charge.create(amount=int(req.subscription_amount_jpy), currency="jpy", ...)
        ...

vendor = StripeBillingAdapter(api_key=os.getenv("STRIPE_API_KEY"))

# 差込: finalize_month_core(..., vendor_adapter=vendor)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)