### PR TITLE
fix(aave): wire chain_config.tokens into multichain client (non-custodial build-tx launch blocker)

### DIFF
--- a/backend/app/aave/client.py
+++ b/backend/app/aave/client.py
@@ -427,6 +427,7 @@ class Web3AaveClient(AaveClientBase):
         pool_address: Optional[str] = None,
         settings: Optional[AaveSettings] = None,
         flashbots_rpc_url: Optional[str] = None,
+        token_addresses: Optional[dict[str, str]] = None,
     ) -> None:
         # 2026-05-01: pool_address のデフォルトを Sepolia hardcode から None に変更。
         # 旧デフォルトは mainnet 切替後に silent regression (testnet pool に書き込み) を
@@ -514,6 +515,17 @@ class Web3AaveClient(AaveClientBase):
                 raise AaveClientError(
                     "eth-account package is required. Install with: pip install eth-account"
                 ) from exc
+
+        # マルチチェーン経路（settings 無し）での token_addresses 配線。
+        # make_aave_client(chain_name=...) が chains.py の chain_config.tokens を渡す。
+        # これが無いと build_deposit_txs / build_withdraw_tx が hasattr ガードで
+        # "Unknown asset" を投げ、non-custodial partner 署名フロー (build-tx) が
+        # 500 になる（2026-06-02 launch ブロッカー修正）。
+        # settings 経路が既に self.token_addresses を設定済みの場合は上書きしない。
+        if token_addresses and not hasattr(self, "token_addresses"):
+            self.token_addresses = {
+                symbol: Web3.to_checksum_address(addr) for symbol, addr in token_addresses.items()
+            }
 
         logger.info(
             "Web3AaveClient 初期化完了 (pool=%s...%s)",
@@ -1137,6 +1149,9 @@ def make_aave_client(
     if client_type == "dummy":
         return DummyAaveClient()
     if client_type == "web3":
+        # chain_config.tokens を client に配線するためのマップ（chain_name 経路のみ）。
+        # 未配線だと build_deposit_txs / build_withdraw_tx が "Unknown asset" を投げる。
+        token_addresses: Optional[dict[str, str]] = None
         if chain_name is not None:
             from .chains import get_chain_config, get_rpc_url_for_chain
 
@@ -1148,6 +1163,7 @@ def make_aave_client(
                 if chain_config.flashbots_rpc_env_var is not None
                 else None
             )
+            token_addresses = chain_config.tokens
         if not rpc_url:
             raise ValueError("AAVE_CLIENT_TYPE=web3 の場合は AAVE_RPC_URL が必須です")
 
@@ -1169,6 +1185,7 @@ def make_aave_client(
             rpc_url=rpc_url,
             pool_address=pool_address,
             flashbots_rpc_url=flashbots_rpc_url,
+            token_addresses=token_addresses,
         )
     raise ValueError(f"不明な AAVE_CLIENT_TYPE: {client_type!r} (dummy | web3)")
 

--- a/backend/tests/test_aave_web3_client.py
+++ b/backend/tests/test_aave_web3_client.py
@@ -721,3 +721,129 @@ def test_withdraw_uses_partner_wallet_as_to(mock_web3, mock_rpc_provider_cls, mo
         f"to={to_address} はパートナー wallet であるべき (={partner_wallet})"
     )
     assert to_address != server_account.address
+
+
+# ==============================================================================
+# 回帰テスト: マルチチェーン client の token_addresses 配線
+# (2026-06-02 launch ブロッカー: make_aave_client(chain_name=...) が
+#  chain_config.tokens を Web3AaveClient に渡さず、build_deposit_txs /
+#  build_withdraw_tx が "Unknown asset" で 500 になっていた)
+# ==============================================================================
+
+_BASE_USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+_BASE_SEPOLIA_USDC = "0xba50cd2a20f6da35d788639e581bca8d0b5d4d5f"
+
+
+def _mock_multichain_client(mock_web3, mock_rpc_provider_cls, chain_name):
+    """settings 無し（マルチチェーン経路）で make_aave_client を実行するヘルパー。"""
+    mock_rpc_provider_instance = MagicMock()
+    mock_w3 = MagicMock()
+    mock_w3.eth.chain_id = 8453 if chain_name == "base" else 84532
+    mock_rpc_provider_instance.get_web3.return_value = mock_w3
+    mock_rpc_provider_cls.return_value = mock_rpc_provider_instance
+
+    mock_web3.HTTPProvider = MagicMock()
+    mock_web3.to_checksum_address = lambda x: x
+
+    mock_pool = MagicMock()
+    mock_pool.address = "0xPOOL"
+    mock_pool.functions.decimals.return_value.call.return_value = 6
+    mock_pool.encodeABI.return_value = "0xdeadbeef"
+    mock_w3.eth.contract.return_value = mock_pool
+
+    client = make_aave_client(client_type="web3", chain_name=chain_name)
+    return client, mock_pool
+
+
+@patch("app.aave.rpc_provider.RPCProvider")
+@patch("app.aave.client.Web3")
+def test_make_aave_client_base_wires_token_addresses(mock_web3, mock_rpc_provider_cls):
+    """
+    回帰: make_aave_client(chain_name="base") が chain_config.tokens を client に配線し、
+    token_addresses 属性が存在して USDC が解決できること。
+    (配線漏れだと hasattr=False → build_deposit_txs が "Unknown asset")
+    """
+    with patch.dict(os.environ, {"AAVE_RPC_URL_BASE": "https://base.example"}):
+        client, _pool = _mock_multichain_client(mock_web3, mock_rpc_provider_cls, "base")
+
+    assert hasattr(client, "token_addresses"), "token_addresses 未配線 (Unknown asset の原因)"
+    assert client.token_addresses.get("USDC") == _BASE_USDC
+    # chain_config.tokens の他トークンも配線される
+    assert "WETH" in client.token_addresses
+    assert "WBTC" in client.token_addresses
+
+
+@patch("app.aave.rpc_provider.RPCProvider")
+@patch("app.aave.client.Web3")
+def test_make_aave_client_base_sepolia_wires_token_addresses(mock_web3, mock_rpc_provider_cls):
+    """回帰: base_sepolia でも token_addresses が配線される (staging proof 経路)。"""
+    with patch.dict(os.environ, {"ALCHEMY_RPC_URL_BASE_SEPOLIA": "https://sepolia.base.org"}):
+        client, _pool = _mock_multichain_client(mock_web3, mock_rpc_provider_cls, "base_sepolia")
+
+    assert hasattr(client, "token_addresses")
+    assert client.token_addresses.get("USDC") == _BASE_SEPOLIA_USDC
+
+
+@patch("app.aave.rpc_provider.RPCProvider")
+@patch("app.aave.client.Web3")
+def test_build_deposit_txs_multichain_no_unknown_asset(mock_web3, mock_rpc_provider_cls):
+    """
+    回帰 (本丸): マルチチェーン経路で生成した client の build_deposit_txs("USDC") が
+    "Unknown asset" を投げず、approve_tx / supply_tx を返すこと。
+    onBehalfOf/from は partner wallet (build_deposit_txs は checksum_wallet を from に使う)。
+    """
+    partner_wallet = "0x" + "d" * 40
+    with patch.dict(os.environ, {"AAVE_RPC_URL_BASE": "https://base.example"}):
+        client, _pool = _mock_multichain_client(mock_web3, mock_rpc_provider_cls, "base")
+
+        result = client.build_deposit_txs(
+            asset_symbol="USDC",
+            amount=Decimal("1.0"),
+            wallet_address=partner_wallet,
+        )
+
+    assert "approve_tx" in result and "supply_tx" in result
+    # non-custodial: 両 tx の from は partner wallet
+    assert result["approve_tx"]["from"] == partner_wallet
+    assert result["supply_tx"]["from"] == partner_wallet
+
+
+@patch("app.aave.rpc_provider.RPCProvider")
+@patch("app.aave.client.Web3")
+def test_build_withdraw_tx_multichain_no_unknown_asset(mock_web3, mock_rpc_provider_cls):
+    """回帰 (withdraw): マルチチェーン経路で build_withdraw_tx も Unknown asset を出さない。"""
+    partner_wallet = "0x" + "d" * 40
+    with patch.dict(os.environ, {"AAVE_RPC_URL_BASE": "https://base.example"}):
+        client, _pool = _mock_multichain_client(mock_web3, mock_rpc_provider_cls, "base")
+
+        result = client.build_withdraw_tx(
+            asset_symbol="USDC",
+            amount=Decimal("1.0"),
+            wallet_address=partner_wallet,
+        )
+
+    assert "withdraw_tx" in result
+    assert result["withdraw_tx"]["from"] == partner_wallet
+
+
+@patch("app.aave.rpc_provider.RPCProvider")
+@patch("app.aave.client.Web3")
+def test_web3client_token_addresses_param_sets_attr(mock_web3, mock_rpc_provider_cls):
+    """
+    回帰: Web3AaveClient(settings=None, token_addresses=...) で token_addresses が設定され、
+    checksum 化されること。
+    """
+    mock_rpc_provider_instance = MagicMock()
+    mock_rpc_provider_instance.get_web3.return_value = MagicMock()
+    mock_rpc_provider_cls.return_value = mock_rpc_provider_instance
+    mock_web3.HTTPProvider = MagicMock()
+    mock_web3.to_checksum_address = lambda x: x.upper()  # checksum 化が呼ばれることを確認
+
+    client = Web3AaveClient(
+        rpc_url="https://base.example",
+        pool_address="0xpool",
+        token_addresses={"USDC": _BASE_USDC},
+    )
+
+    assert hasattr(client, "token_addresses")
+    assert client.token_addresses["USDC"] == _BASE_USDC.upper()

--- a/docs/ops/orphan_detection.md
+++ b/docs/ops/orphan_detection.md
@@ -21,3 +21,23 @@ UIテスト（/chrome）やpytestでは検出できない。2026-04-01に Stress
 - P0: 安全装置系の孤立 → 即修正（workflow.pyやscheduled_tasks.pyに配線）
 - P1: リスク管理系の孤立 → 1-2日以内に修正
 - P2: ユーティリティ系の孤立 → 将来使用予定なら許容、不要なら削除
+
+## 追加パターン: 部分配線欠陥（factory が constructor 引数を供給しない）
+2026-06-02: 「関数は呼ばれているが、生成 factory が必要な属性を供給しない」型の欠陥が
+launch ブロッカーになった。`make_aave_client(chain_name=...)`（マルチチェーン経路）が
+`Web3AaveClient` に `token_addresses` を渡さず（設定は `if settings is not None:` 経路のみ）、
+`build_deposit_txs` / `build_withdraw_tx` が `hasattr(self,"token_addresses")` ガードで
+`Unknown asset` を投げ、non-custodial partner build-tx が staging/production とも 500 だった。
+
+**なぜ5ゲートをすり抜けたか（1行）**: unit test は settings 経路 client か mock を使い
+マルチチェーン経路の token_addresses 欠落を一度も実行せず、E2E は build-tx 実経路に到達せず、
+孤立検出は「参照0件」のみ見て「constructor 引数の供給漏れ」を見ないため、全ゲートが runtime-only
+の配線欠陥を検出できなかった。
+
+**検出観点の追加（grep だけでは出ない）**:
+- 同一クラスに複数の生成経路（`make_*` factory / `settings` 経路 / 直接 new）がある場合、
+  **全経路が同じ必須属性（例: `token_addresses`）を設定するか**を突き合わせる。
+- `hasattr(self, "...")` ガードで分岐するメソッドは、その属性を**設定しない生成経路**が
+  存在しないか確認（設定箇所と生成箇所の数が一致するか）。
+- 重点: `backend/app/aave/client.py` の `make_aave_client` / `make_multi_chain_clients` /
+  `get_default_aave_client` が `Web3AaveClient` に同じ属性群を渡しているか。


### PR DESCRIPTION
## 概要
非カストディ build-tx (`GET /api/proposals/{id}/build-tx` → `build_partner_tx`) が **staging / production とも HTTP 500 `Unknown asset: USDC`** になっていた **launch ブロッカー**の修正。6/3 partner 実売買（Privy 署名フロー）の前提。

## 真因（実コードで確定）
`Web3AaveClient.token_addresses` は `__init__` の `if settings is not None:` 経路でのみ設定される。だが build-tx の経路は settings を渡さない:
```
build_partner_tx → MultiChainAaveService.get_service(chain)._client
  → make_multi_chain_clients → make_aave_client(chain_name=...)   # settings 無しで Web3AaveClient 生成
```
→ `token_addresses` 属性が作られず、`build_deposit_txs`/`build_withdraw_tx` の `hasattr(self,"token_addresses")` ガードで `Unknown asset`。`chains.py` に正しい USDC アドレス（base `0x833589…2913` / base_sepolia `0xba50…d5f`）は既存だが client に**配線されていなかった**（部分配線欠陥）。

production (`backend-green`, image 6/1 10:54 JST) でも実コード grep で同欠陥を確認済み。

## 修正（最小・配線追加のみ）
- `Web3AaveClient.__init__` に `token_addresses` 引数を追加。settings 無し経路で受け取ったマップを checksum 化して `self.token_addresses` に設定（settings 経路が既に設定済みなら非上書き）。
- `make_aave_client` の `chain_name` 分岐で `chain_config.tokens` を client に渡す。

## テスト（`backend/tests/test_aave_web3_client.py` +5）
- `make_aave_client(chain_name="base"/"base_sepolia")` が `token_addresses` を配線
- `build_deposit_txs` / `build_withdraw_tx` がマルチチェーン経路で `Unknown asset` を投げず、`from=partner` の未署名 tx を返す（non-custodial）
- `token_addresses` 引数の checksum 化

## DoD
- `ruff check` / `ruff format --check`: pass（line-length 100）
- `mypy app/aave/client.py`: Success
- `pytest`（aave suite 7 ファイル）: **145 passed, 4 skipped**（新規 5 件含む、回帰なし）
- **defi-aave-review**: HF / Decimal / emergency-stop / auth 非介入、`build_deposit_txs`/`build_withdraw_tx` はサーバー鍵で署名せず未署名 tx を返す設計を維持、approve+supply 回帰なし

## 再発防止
`docs/ops/orphan_detection.md` に「**部分配線欠陥**（factory が constructor 引数を供給しない）」パターン + 検出観点を追記（なぜ5ゲートをすり抜けたか: unit test は settings 経路/mock のみ、E2E は build-tx 実経路未到達、孤立検出は「参照0件」のみ見て引数供給漏れを見ない）。

## デプロイ影響 ⚠️
本修正は **production の非カストディ build-tx も同欠陥**のため、staging/production 両方への deploy が 6/3 partner 実売買の前提。**production deploy は 3 段プロトコル（ローカル merge → Hetzner `git pull` → `deploy_production.sh`）経由**。

## 検証メモ（staging proof）
staging では本欠陥の手前で解消済みのドリフト2件あり（proposals.expected_from/to ALTER、AAVE_ACTIVE_CHAINS=base_sepolia env）。これらは staging 固有の設定 drift で production は parity 済み。詳細は本修正後の staging build-tx 再検証で 200 / onBehalfOf=partner / サーバー鍵不在 を確認予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)