### PR TITLE
fix(aave): web3 v7 encodeABI → encode_abi in build-tx (non-custodial launch blocker)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -947,6 +947,10 @@ claude.ai が Step 0 をスキップして §9 を実行した場合、それは
 - cognitive_state injection 漏れ
 - _validate_model_config() startup hook 配線漏れ
 - aave_data_fetcher.py V2→V3 API 移行漏れ
+- factory が constructor 引数を供給せず属性未配線（make_aave_client が Web3AaveClient に token_addresses を渡さず build-tx が "Unknown asset"。複数生成経路で必須属性の供給有無を突き合わせる。#500）
+
+### 依存 / ライブラリバージョン
+- web3.py メジャー更新時の API drift（v6→v7 で `Contract.encodeABI()`→`encode_abi()`、`fn_name=`→位置引数。旧 API は `# type: ignore[attr-defined]` で mypy 検出を抑止していたため build-tx が runtime 500 になるまで気づかなかった）。依存更新 PR では camelCase web3 API（encodeABI/buildTransaction/rawTransaction 等）の残存を grep し、`# type: ignore[attr-defined]` を安易に付けない
 
 該当しそうなものがあれば、修正してから完了宣言する。同種が出たら個別修正でなく
 `scripts/launch_gate.sh` / CI gate に追加して再発防止する。

--- a/backend/app/aave/client.py
+++ b/backend/app/aave/client.py
@@ -1039,11 +1039,11 @@ class Web3AaveClient(AaveClientBase):
         pool_address = self._pool.address
         chain_id = self._w3.eth.chain_id
 
-        approve_data = token_contract.encodeABI(  # type: ignore[attr-defined]
-            fn_name="approve", args=[pool_address, amount_wei]
-        )
-        supply_data = self._pool.encodeABI(  # type: ignore[attr-defined]
-            fn_name="supply",
+        # web3.py v7: Contract.encodeABI() は廃止され encode_abi() に改名
+        # (fn_name= キーワードも abi_element_identifier 位置引数に変更)。
+        approve_data = token_contract.encode_abi("approve", args=[pool_address, amount_wei])
+        supply_data = self._pool.encode_abi(
+            "supply",
             args=[Web3.to_checksum_address(asset_address), amount_wei, checksum_wallet, 0],
         )
 
@@ -1096,8 +1096,9 @@ class Web3AaveClient(AaveClientBase):
         checksum_wallet = Web3.to_checksum_address(wallet_address)
         chain_id = self._w3.eth.chain_id
 
-        withdraw_data = self._pool.encodeABI(  # type: ignore[attr-defined]
-            fn_name="withdraw",
+        # web3.py v7: encodeABI → encode_abi（fn_name= → 位置引数）
+        withdraw_data = self._pool.encode_abi(
+            "withdraw",
             args=[Web3.to_checksum_address(asset_address), amount_wei, checksum_wallet],
         )
 

--- a/backend/tests/test_aave_web3_client.py
+++ b/backend/tests/test_aave_web3_client.py
@@ -748,7 +748,8 @@ def _mock_multichain_client(mock_web3, mock_rpc_provider_cls, chain_name):
     mock_pool = MagicMock()
     mock_pool.address = "0xPOOL"
     mock_pool.functions.decimals.return_value.call.return_value = 6
-    mock_pool.encodeABI.return_value = "0xdeadbeef"
+    # web3 v7: Contract.encode_abi (encodeABI は v7 で廃止)
+    mock_pool.encode_abi.return_value = "0xdeadbeef"
     mock_w3.eth.contract.return_value = mock_pool
 
     client = make_aave_client(client_type="web3", chain_name=chain_name)
@@ -847,3 +848,75 @@ def test_web3client_token_addresses_param_sets_attr(mock_web3, mock_rpc_provider
 
     assert hasattr(client, "token_addresses")
     assert client.token_addresses["USDC"] == _BASE_USDC.upper()
+
+
+# ==============================================================================
+# 回帰テスト: web3.py v7 API (encode_abi) — encodeABI は v7 で廃止
+# (2026-06-02 launch ブロッカー: build_deposit_txs/build_withdraw_tx が
+#  廃止 API encodeABI を使い 'Contract' object has no attribute 'encodeABI' で 500。
+#  #500 の mock は MagicMock が任意メソッドに応答するため drift を検出できなかった)
+# ==============================================================================
+
+_APPROVE_ABI = [
+    {
+        "inputs": [
+            {"name": "spender", "type": "address"},
+            {"name": "amount", "type": "uint256"},
+        ],
+        "name": "approve",
+        "outputs": [{"name": "", "type": "bool"}],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    }
+]
+
+
+def test_web3_v7_contract_api_pin():
+    """
+    版ピン: インストール済み web3 の Contract は encode_abi を持ち encodeABI を持たない。
+    web3 メジャー更新 / ダウングレードで API drift したら検出する。
+    """
+    from web3 import Web3
+
+    w3 = Web3()  # provider 不要（ABI encode はオフライン）
+    contract = w3.eth.contract(abi=_APPROVE_ABI, address="0x" + "1" * 40)
+
+    assert hasattr(contract, "encode_abi"), "web3 v7 の encode_abi が無い (API drift)"
+    assert not hasattr(contract, "encodeABI"), "encodeABI は v7 で廃止のはず"
+
+    # 位置引数 + args= で encode できること（fn_name= は v7 で廃止）
+    data = contract.encode_abi("approve", args=["0x" + "2" * 40, 1000])
+    assert data.startswith("0x")
+
+
+@patch("app.aave.rpc_provider.RPCProvider")
+@patch("app.aave.client.Web3")
+def test_build_deposit_txs_uses_encode_abi_v7_api(mock_web3, mock_rpc_provider_cls):
+    """
+    回帰: build_deposit_txs が v7 API encode_abi を呼び、廃止 API encodeABI を呼ばないこと。
+    (旧コードに戻ると encode_abi が呼ばれず encodeABI が呼ばれてこのテストが落ちる)
+    """
+    partner_wallet = "0x" + "d" * 40
+    with patch.dict(os.environ, {"AAVE_RPC_URL_BASE": "https://base.example"}):
+        client, mock_pool = _mock_multichain_client(mock_web3, mock_rpc_provider_cls, "base")
+        client.build_deposit_txs(
+            asset_symbol="USDC", amount=Decimal("1.0"), wallet_address=partner_wallet
+        )
+
+    assert mock_pool.encode_abi.called, "v7 API encode_abi が呼ばれていない"
+    assert not mock_pool.encodeABI.called, "廃止 API encodeABI を呼んでいる (v7 で 500)"
+
+
+@patch("app.aave.rpc_provider.RPCProvider")
+@patch("app.aave.client.Web3")
+def test_build_withdraw_tx_uses_encode_abi_v7_api(mock_web3, mock_rpc_provider_cls):
+    """回帰 (withdraw): build_withdraw_tx も v7 API encode_abi を使うこと。"""
+    partner_wallet = "0x" + "d" * 40
+    with patch.dict(os.environ, {"AAVE_RPC_URL_BASE": "https://base.example"}):
+        client, mock_pool = _mock_multichain_client(mock_web3, mock_rpc_provider_cls, "base")
+        client.build_withdraw_tx(
+            asset_symbol="USDC", amount=Decimal("1.0"), wallet_address=partner_wallet
+        )
+
+    assert mock_pool.encode_abi.called
+    assert not mock_pool.encodeABI.called


### PR DESCRIPTION
## 概要
#500（token_addresses 配線）で `Unknown asset` を解消した後、build-tx が次のブロッカーで HTTP 500: `'Contract' object has no attribute 'encodeABI'`。**build-tx launch ブロッカーチェーンの最終コード修正**（6/3 partner 実売買の前提）。

## 真因
web3.py v7 で `Contract.encodeABI()` は廃止され `encode_abi()` に改名（キーワードも `fn_name=` → `abi_element_identifier` 位置引数）。`build_deposit_txs`/`build_withdraw_tx` の 3 箇所が旧 API を `# type: ignore[attr-defined]` 付きで使っており、mypy 検出を抑止していたためコンテナ web3=7.16.0 で runtime 500 になっていた。

## 修正
- `client.py` の `encodeABI` 3 箇所（approve/supply/withdraw）を `encode_abi` に置換、`fn_name=` を位置引数化、`# type: ignore[attr-defined]` 除去（mypy 再検出可能に）。
- `encode_abi` は `encodeABI` と同一 calldata（selector+args）を生成 → 機能等価。

## テスト（`test_aave_web3_client.py` +3）
- **版ピン**: 実 web3 Contract が `encode_abi` を持ち `encodeABI` を持たないこと（位置引数 encode 動作も確認）
- `build_deposit_txs`/`build_withdraw_tx` が `encode_abi` を呼び `encodeABI` を呼ばないこと
- #500 の mock を `encode_abi` に更新（MagicMock が任意メソッドに応答して drift を隠していた再発防止）

## DoD
- `ruff check` / `ruff format --check`: pass
- `mypy app/aave/client.py`: **Success**（`type: ignore` 除去後も通る = 今後の API drift を mypy で再検出可能）
- `pytest`（aave suite 6 ファイル）: **141 passed, 4 skipped**（新規 3 件含む、回帰なし）
- **defi-aave-review**: HF/Decimal/emergency-stop/auth 非介入、`build_deposit_txs`/`build_withdraw_tx` はサーバー鍵署名なしの未署名 tx を返す設計維持、calldata 等価

## 再発防止
`CLAUDE.md` ドリフト再発カタログに「**依存/ライブラリバージョン**: web3 メジャー更新時の API drift（encodeABI/encode_abi 等、`# type: ignore` による隠蔽）」+「factory が constructor 引数を供給せず属性未配線」を追記。

## デプロイ影響 ⚠️
production も同 web3 7.x のため、**#500 + 本修正の両方**が 6/3 partner 実売買の前提。staging では本 PR deploy 後に build-tx を再検証（200 / onBehalfOf=partner / サーバー鍵不在）。**production deploy は 3 段プロトコル経由**。

## build-tx ブロッカーチェーン（参考）
①proposals.expected_from/to（staging ALTER 済）→ ②AAVE_ACTIVE_CHAINS（staging env 済）→ ③Alchemy inactive（public RPC override で検証）→ ④token_addresses 未配線（#500）→ ⑤web3 v7 encodeABI（本 PR）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)