### PR TITLE
fix(migration): 案A拡張 — multiple heads 解消・単一線形チェーン化

### DIFF
--- a/backend/alembic/versions/m3n4o5p6q7r8_add_line_monthly_opt_in.py
+++ b/backend/alembic/versions/m3n4o5p6q7r8_add_line_monthly_opt_in.py
@@ -5,7 +5,7 @@
 users テーブルに line_monthly_opt_in カラムを追加する (Lane P)。
 
 Revision ID: m3n4o5p6q7r8
-Revises: k1l2m3n4o5p6
+Revises: l2m3n4o5p6q7
 Create Date: 2026-06-02 00:00:00.000000
 
 """
@@ -18,7 +18,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "m3n4o5p6q7r8"
-down_revision: Union[str, None] = "k1l2m3n4o5p6"
+down_revision: Union[str, None] = "l2m3n4o5p6q7"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/n4o5p6q7r8s9_fee_allowances.py
+++ b/backend/alembic/versions/n4o5p6q7r8s9_fee_allowances.py
@@ -6,8 +6,8 @@ on_chain_tx_hash stores the tx hash after FEE_TRANSFER_ENABLED=true transfers.
 
 Asana: 1215272587496967 / 1215273755294098
 
-Revision ID: j0k1l2m3n4o5
-Revises: i9j0k1l2m3n4
+Revision ID: n4o5p6q7r8s9
+Revises: m3n4o5p6q7r8
 Create Date: 2026-06-02 00:00:00.000000
 """
 
@@ -17,8 +17,8 @@ import sqlalchemy as sa
 
 from alembic import op
 
-revision: str = "j0k1l2m3n4o5"
-down_revision: Union[str, Sequence[str], None] = "i9j0k1l2m3n4"
+revision: str = "n4o5p6q7r8s9"
+down_revision: Union[str, Sequence[str], None] = "m3n4o5p6q7r8"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary

- **#502** `fee_allowances` migration の revision を重複 `j0k1l2m3n4o5` → 一意の `n4o5p6q7r8s9` にリネーム
  - ファイル: `j0k1l2m3n4o5_fee_allowances.py` → `n4o5p6q7r8s9_fee_allowances.py`
  - `j0k1l2m3n4o5` は #482 `add_invitation_type` と重複していたため衝突解消
- **#499** `line_monthly_opt_in` の `down_revision` を `k1l2m3n4o5p6` → `l2m3n4o5p6q7` (#496 vendor_ref) に付け替え

## 結果チェーン（単一線形）

```
k1l2m3n4o5p6
  → l2m3n4o5p6q7  (#496 add_fee_tx_vendor_ref)
  → m3n4o5p6q7r8  (#499 add_line_monthly_opt_in)
  → n4o5p6q7r8s9  (#502 fee_allowances)   ← alembic head (単一)
```

## 検証

- `alembic heads` 静的解析: head = `n4o5p6q7r8s9` (1本のみ)
- duplicate revision `j0k1l2m3n4o5` 解消確認
- 機能コード (`upgrade()` / `downgrade()`) は無変更

## 変更ファイル

- `backend/alembic/versions/j0k1l2m3n4o5_fee_allowances.py` → `n4o5p6q7r8s9_fee_allowances.py` (rename + revision更新)
- `backend/alembic/versions/m3n4o5p6q7r8_add_line_monthly_opt_in.py` (down_revision付け替えのみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)