### PR TITLE
fix(aave): ETH_USD_FALLBACK_PRICE $4000→$2100 に更新 + env 変数化 [Tier B]

### DIFF
--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -86,6 +86,11 @@ DATABASE_ECHO=false
 # ⚠️ 本番資金が入ったウォレットを使用するため、秘密鍵の管理は最重要
 # ⚠️ staging のウォレット秘密鍵を流用しないこと
 
+# ETH/USD フォールバック価格（Chainlink price feed 取得失敗時に使用）
+# デフォルト: 2100.00。実勢価格と大幅に乖離したら更新すること。
+# 過大設定だとガス代 USD 推定が実態より高く見積もられ is_gas_cost_acceptable が誤拒否する。
+ETH_USD_FALLBACK_PRICE=2100.00
+
 # 有効チェーン（カンマ区切り。production は arbitrum を使用）
 # テストネット使用時は base_sepolia を指定可（staging/shadow mode 専用）
 AAVE_ACTIVE_CHAINS=arbitrum

--- a/backend/app/aave/gas_estimator.py
+++ b/backend/app/aave/gas_estimator.py
@@ -15,13 +15,15 @@
 from __future__ import annotations
 
 import logging
+import os
 from decimal import Decimal
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# ETH/USD フォールバック価格（API失敗時に使用する保守的な高め設定）
-ETH_USD_FALLBACK_PRICE = Decimal("4000.00")
+# ETH/USD フォールバック価格（API失敗時に使用。ENV: ETH_USD_FALLBACK_PRICE）
+# デフォルトは現実値付近の $2100。実勢価格が大きく乖離した場合は env を更新する。
+ETH_USD_FALLBACK_PRICE = Decimal(os.environ.get("ETH_USD_FALLBACK_PRICE", "2100.00"))
 
 # デフォルトフォールバックガス値（estimate_gas失敗時）
 DEFAULT_FALLBACK_GAS_APPROVE = 100000


### PR DESCRIPTION
## Summary

- `ETH_USD_FALLBACK_PRICE` を `$4000.00` → デフォルト `$2100.00` に変更
- `os.environ.get("ETH_USD_FALLBACK_PRICE", "2100.00")` で環境変数上書き可能化
- `backend/.env.production.example` に `ETH_USD_FALLBACK_PRICE=2100.00` を追記

## Why

実勢 ETH/USD 価格は ~$2086 なのに fallback が $4000 だったため、
Chainlink price feed 取得失敗時にガス代 USD 推定が約2倍になり
`is_gas_cost_acceptable()` が有効取引を誤拒否するリスクがあった。

また `wallet_balance_service.py` も同定数を使うため、
ETH 残高 USD 表示が 2× 過大評価されていた。

Asana: 1215158953960527 ([Tier B] due 2026-06-02)

## Test plan

- [x] `python3 -c "import os; os.environ['ETH_USD_FALLBACK_PRICE']='2100.00'; from app.aave.gas_estimator import ETH_USD_FALLBACK_PRICE; assert str(ETH_USD_FALLBACK_PRICE)=='2100.00'"` → OK
- [ ] staging の `ETH_USD_FALLBACK_PRICE` 未設定→ デフォルト 2100.00 で動作することを人間が確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)