### PR TITLE
fix(migration): 重複 revision j0k1l2m3n4o5 解消 (reminder を末尾接続)

### DIFF
--- a/backend/alembic/versions/o5p6q7r8s9t0_add_proposals_expiry_reminder_sent.py
+++ b/backend/alembic/versions/o5p6q7r8s9t0_add_proposals_expiry_reminder_sent.py
@@ -1,0 +1,49 @@
+"""add_proposals_expiry_reminder_sent
+
+expire 前再通知 rail (MVP-P0-10 延長): proposals.expiry_reminder_sent_at カラムを追加。
+pending な proposal が expires_at の N 分前に通知済みかを追跡し、重複通知を防ぐ。
+
+Revision ID: o5p6q7r8s9t0
+Revises: n4o5p6q7r8s9
+Create Date: 2026-06-03 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "o5p6q7r8s9t0"
+down_revision: Union[str, Sequence[str], None] = "n4o5p6q7r8s9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add expiry_reminder_sent_at column to proposals table (idempotent)."""
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute(
+            "ALTER TABLE proposals ADD COLUMN IF NOT EXISTS expiry_reminder_sent_at TIMESTAMPTZ"
+        )
+    else:
+        op.add_column(
+            "proposals",
+            sa.Column(
+                "expiry_reminder_sent_at",
+                sa.DateTime(timezone=True),
+                nullable=True,
+            ),
+        )
+
+
+def downgrade() -> None:
+    """Remove expiry_reminder_sent_at column from proposals table."""
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TABLE proposals DROP COLUMN IF EXISTS expiry_reminder_sent_at")
+    else:
+        with op.batch_alter_table("proposals") as batch_op:
+            batch_op.drop_column("expiry_reminder_sent_at")


### PR DESCRIPTION
## 概要

`j0k1l2m3n4o5` に 2 つの migration が割り当てられていた重複を解消。

- **正**: `j0k1l2m3n4o5_add_invitation_type.py` — invitation_type 列 + partner_id nullable 化（そのまま据え置き）
- **分離**: `proposals_expiry_reminder_sent` 機能を新 revision `o5p6q7r8s9t0` にリネームし、現 HEAD `n4o5p6q7r8s9` (fee_allowances) へ接続

## 確認済み事項

- `alembic history` で heads 単一・linear chain 確認済み
- `j0k1l2m3n4o5` = add_invitation_type のみ
- `o5p6q7r8s9t0` = add_proposals_expiry_reminder_sent、down_revision = n4o5p6q7r8s9

## 注意

- reminder 機能本実装（loop / モデル定義）は別タスク
- mypy 9 件の既存エラーは main ブランチ一致の既存問題（本 PR スコープ外）