### PR TITLE
feat(deploy): alembic upgrade head をゼロダウンタイムデプロイに統合 (CP-2)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,6 +23,7 @@ pydantic[email]>=2.0.0
 asyncpg>=0.29.0
 psycopg2-binary>=2.9.9
 pgvector>=0.2.0
+alembic>=1.13,<2.0
 
 # Exchange (PoC Pivot)
 ccxt>=4.0.0

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -231,6 +231,16 @@ deploy_backend_zero_downtime() {
   log "backend-${inactive_slot} を起動..."
   ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" up -d --no-deps "backend-${inactive_slot}"
 
+  # 2a. DB マイグレーション (swap 前に実行、失敗時は abort)
+  ALEMBIC_CONT="ultra-autotrade-backend-${inactive_slot}-production"
+  log "alembic upgrade head を実行 (コンテナ: ${ALEMBIC_CONT})..."
+  if ! docker exec "${ALEMBIC_CONT}" alembic upgrade head; then
+    err "alembic upgrade head 失敗。切替を中止し新コンテナを停止します"
+    ${DC} -f "${COMPOSE_FILE}" stop "backend-${inactive_slot}" 2>/dev/null || true
+    exit 1
+  fi
+  log "✅ alembic upgrade head 完了"
+
   # 3. 新コンテナのヘルスチェック (ホスト側ポート直打ち)
   if ! wait_healthy "http://127.0.0.1:${inactive_port}/health" "backend-${inactive_slot}"; then
     err "新コンテナのヘルスチェック失敗。切替を中止し新コンテナを停止します"


### PR DESCRIPTION
## Summary

- `backend/requirements.txt` に `alembic>=1.13,<2.0` を追加
- `scripts/deploy_production.sh` の `deploy_backend_zero_downtime()` に alembic マイグレーションステップを挿入：新コンテナ起動直後・`wait_healthy` 前に `docker exec ultra-autotrade-backend-${inactive_slot}-production alembic upgrade head` を実行
- 失敗時は新コンテナを停止して `exit 1` で swap 前 abort（nginx 切替前に安全停止）

## 変更詳細

### `backend/requirements.txt`
```
alembic>=1.13,<2.0
```

### `scripts/deploy_production.sh` — `deploy_backend_zero_downtime()` 内
```bash
# 2a. DB マイグレーション (swap 前に実行、失敗時は abort)
ALEMBIC_CONT="ultra-autotrade-backend-${inactive_slot}-production"
log "alembic upgrade head を実行 (コンテナ: ${ALEMBIC_CONT})..."
if ! docker exec "${ALEMBIC_CONT}" alembic upgrade head; then
  err "alembic upgrade head 失敗。切替を中止し新コンテナを停止します"
  ${DC} -f "${COMPOSE_FILE}" stop "backend-${inactive_slot}" 2>/dev/null || true
  exit 1
fi
log "✅ alembic upgrade head 完了"
```

## Gate 結果

| Gate | 結果 | 備考 |
|------|------|------|
| Gate 1 ruff check | ✅ PASS | |
| Gate 2 ruff format | ✅ PASS | |
| Gate 3 mypy | ❌ 既存失敗 | `monthly_report.py` reportlab stubs 不足 — 本 PR の変更と無関係（shell script + requirements.txt のみ変更） |
| Gate 4 E2E | N/A | デプロイスクリプト変更のみ |

## 注意事項

- 本 PR は CP-0 PR（alembic env.py/migrations/初期化関連）とは別ファイルを触るため並行可能
- `ALEMBIC_CONT` のコンテナ名は本番 compose の `container_name: ultra-autotrade-backend-blue-production` / `...-green-production` と一致する設計
- merge はしない（CP-0 と合わせて確認後に merge）

🤖 Generated with [Claude Code](https://claude.com/claude-code)