### PR TITLE
fix(launch-gate): L0_schema.sh が ENV_TARGET を尊重するよう修正

### DIFF
--- a/scripts/launch_gate/L0_schema.sh
+++ b/scripts/launch_gate/L0_schema.sh
@@ -27,6 +27,12 @@ PROJECT_ROOT="$(gate_project_root)"
 GAP_SCRIPT="${PROJECT_ROOT}/scripts/check_db_migration_gap.sh"
 LABEL="L0 schema"
 
+# ENV_TARGET が明示設定された場合はその1環境のみ、未指定時は staging / production 両方
+if [[ -n "${ENV_TARGET:-}" ]]; then
+  run_envs=("${ENV_TARGET}")
+else
+  run_envs=(staging production)
+fi
 ENV_TARGET="${ENV_TARGET:-staging}"
 
 if [[ ! -x "${GAP_SCRIPT}" && ! -f "${GAP_SCRIPT}" ]]; then
@@ -36,22 +42,21 @@ fi
 
 # dev VPS からは prod DB に届かないので skip-with-instructions
 if is_dev_vps; then
-  cat <<EOF
-[INFO] L0 schema: dev VPS のため prod / staging DB に直接アクセスできません。
-       prod VPS (77.42.46.155) で以下を順に実行し、両方 exit 0 を確認してください:
-
-         bash ${GAP_SCRIPT} --env=staging
-         bash ${GAP_SCRIPT} --env=production
-
-       両方 0 でない場合は alembic head に gap あり → launch 不可。
-EOF
-  gate_record SKIP "${LABEL}" "dev VPS のため手動実行 (prod VPS で check_db_migration_gap.sh --env={staging,production})"
+  echo "[INFO] L0 schema: dev VPS のため DB に直接アクセスできません。"
+  echo "       prod VPS (77.42.46.155) で以下を実行し、exit 0 を確認してください:"
+  echo ""
+  for env in "${run_envs[@]}"; do
+    echo "         bash ${GAP_SCRIPT} --env=${env}"
+  done
+  echo ""
+  echo "       0 でない場合は alembic head に gap あり → launch 不可。"
+  gate_record SKIP "${LABEL}" "dev VPS のため手動実行 (prod VPS で check_db_migration_gap.sh --env={${run_envs[*]}})"
   exit 0
 fi
 
 # prod / staging 側 (本物の VPS) で実行された場合
 fail_envs=()
-for env in staging production; do
+for env in "${run_envs[@]}"; do
   echo "--- L0 schema: ${env} ---"
   if bash "${GAP_SCRIPT}" --env="${env}"; then
     echo "  [ok] ${env}"
@@ -62,7 +67,7 @@ for env in staging production; do
 done
 
 if [[ "${#fail_envs[@]}" -eq 0 ]]; then
-  gate_record PASS "${LABEL}" "staging / production alembic gap なし"
+  gate_record PASS "${LABEL}" "${run_envs[*]} alembic gap なし"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

- `scripts/launch_gate/L0_schema.sh` の `for env in staging production` ループが `ENV_TARGET` を無視していた問題を修正
- `ENV_TARGET` が明示設定された場合はその1環境のみ検査し、未指定時は `staging / production` 両方を検査する

## Changes

| 箇所 | Before | After |
|---|---|---|
| ループ対象決定 | 常に `staging production` 両方 | `ENV_TARGET` 明示時は1環境のみ |
| dev VPS skip メッセージ | 常に両環境の実行例を表示 | `run_envs` に応じた環境のみ表示 |
| PASS メッセージ | "staging / production alembic gap なし" | 実際に検査した環境名を表示 |

## Behavior

```bash
# 明示時: staging のみ検査
ENV_TARGET=staging bash scripts/launch_gate/L0_schema.sh

# 明示時: production のみ検査  
ENV_TARGET=production bash scripts/launch_gate/L0_schema.sh

# 未指定時: staging + production 両方検査
bash scripts/launch_gate/L0_schema.sh
```

## Test plan

- [x] `bash -n scripts/launch_gate/L0_schema.sh` 構文チェック: PASS
- [x] Gate1 `ruff check .`: PASS (502 files, all checks passed)
- [x] Gate2 `ruff format --check .`: PASS (502 files already formatted)
- [x] Gate3 `mypy app/`: 既存 `reportlab` stubs 未インストール (8 errors in monthly_report.py) — 本 PR と無関係

🤖 Generated with [Claude Code](https://claude.com/claude-code)