### PR TITLE
feat(proposals): AI判定提案にガス代設定・承認画面で合計金額表示

### DIFF
--- a/backend/app/aave/gas_estimator.py
+++ b/backend/app/aave/gas_estimator.py
@@ -30,6 +30,39 @@ DEFAULT_FALLBACK_GAS_APPROVE = 100000
 DEFAULT_FALLBACK_GAS_SUPPLY = 300000
 DEFAULT_FALLBACK_GAS_WITHDRAW = 300000
 
+# フォールバックガス価格（wei単位、提案生成時など web3 なしの概算用。ENV: ETH_GAS_PRICE_GWEI_FALLBACK）
+DEFAULT_GAS_PRICE_WEI = Decimal(os.environ.get("ETH_GAS_PRICE_GWEI_FALLBACK", "30")) * Decimal(
+    "1000000000"
+)  # デフォルト 30 gwei
+
+
+def estimate_static_gas_cost_usd(
+    operation: str,
+    eth_usd_price: Decimal | None = None,
+    gas_price_wei: Decimal | None = None,
+) -> Decimal:
+    """Web3接続なしのフォールバックガス代見積もり（提案生成時用）。
+
+    実際のガス価格は実行時に変わるため、これはあくまで表示用概算値。
+    """
+    gas_units = (
+        DEFAULT_FALLBACK_GAS_WITHDRAW
+        if operation.upper() == "WITHDRAW"
+        else DEFAULT_FALLBACK_GAS_SUPPLY
+    )
+    price = eth_usd_price if eth_usd_price is not None else ETH_USD_FALLBACK_PRICE
+    g_price = gas_price_wei if gas_price_wei is not None else DEFAULT_GAS_PRICE_WEI
+    gas_cost_eth = Decimal(str(gas_units)) * g_price / Decimal("1000000000000000000")
+    cost_usd = gas_cost_eth * price
+    logger.debug(
+        "静的ガス概算(%s): %d units × %s wei = $%s USD",
+        operation,
+        gas_units,
+        g_price,
+        cost_usd,
+    )
+    return cost_usd
+
 
 class GasEstimator:
     """動的ガス見積もり + 上限キャップ"""

--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -26,6 +26,7 @@ from app.ai.schemas import CrossValidationResult, RAGContext, TradeAction
 from app.ai.service import AIService
 from app.auth.constants import ExecutionPolicy
 from app.auth.models import InvestmentTier, User, normalize_tier
+from app.aave.gas_estimator import estimate_static_gas_cost_usd
 from app.automation.aave_data_fetcher import AaveMarketData, fetch_aave_market_data_safe
 from app.data_feeds.context import MarketContext, build_market_context
 from app.database import SessionLocal
@@ -446,6 +447,7 @@ def _create_proposals_for_users(
                     )
                     continue
 
+                estimated_gas_usd = estimate_static_gas_cost_usd(operation)
                 proposal = Proposal(
                     user_id=user.id,
                     ai_decision_id=decision.id,
@@ -457,6 +459,7 @@ def _create_proposals_for_users(
                     expires_at=expires_at,
                     fee_rate=market_fee.fee_rate,
                     fee_amount=market_fee.fee_amount,
+                    estimated_gas_usd=estimated_gas_usd,
                 )
                 db.add(proposal)
                 user.last_judgment_at = now

--- a/backend/tests/test_ai_judgment_scheduler.py
+++ b/backend/tests/test_ai_judgment_scheduler.py
@@ -243,6 +243,8 @@ def test_run_job_buy_creates_proposals(db_session):
         assert p.asset == "USDC"
         assert p.amount == Decimal("1000")
         assert p.amount_usd == Decimal("1000.00")
+        assert p.estimated_gas_usd is not None
+        assert p.estimated_gas_usd > Decimal("0")
 
 
 def test_run_job_saves_to_ai_decisions(db_session):
@@ -287,6 +289,8 @@ def test_run_job_sell_creates_withdraw_proposals(db_session):
     proposals = db_session.scalars(select(Proposal)).all()
     assert len(proposals) == 1
     assert proposals[0].operation == "WITHDRAW"
+    assert proposals[0].estimated_gas_usd is not None
+    assert proposals[0].estimated_gas_usd > Decimal("0")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_gas_estimator.py
+++ b/backend/tests/test_gas_estimator.py
@@ -7,8 +7,12 @@ from unittest.mock import MagicMock
 
 from app.aave.gas_estimator import (
     DEFAULT_FALLBACK_GAS_APPROVE,
+    DEFAULT_FALLBACK_GAS_SUPPLY,
+    DEFAULT_FALLBACK_GAS_WITHDRAW,
+    DEFAULT_GAS_PRICE_WEI,
     ETH_USD_FALLBACK_PRICE,
     GasEstimator,
+    estimate_static_gas_cost_usd,
 )
 
 
@@ -114,3 +118,47 @@ class TestIsProfitable:
             )
             is False
         )
+
+
+class TestEstimateStaticGasCostUsd:
+    def test_supply_uses_supply_fallback_gas(self) -> None:
+        """SUPPLY は DEFAULT_FALLBACK_GAS_SUPPLY を使うこと"""
+        eth_price = Decimal("2000.00")
+        cost = estimate_static_gas_cost_usd(
+            "SUPPLY", eth_usd_price=eth_price, gas_price_wei=Decimal("20000000000")
+        )
+        # 300000 * 20 Gwei = 0.006 ETH * $2000 = $12.00
+        expected = Decimal(str(DEFAULT_FALLBACK_GAS_SUPPLY)) * Decimal("20000000000") / Decimal("1e18") * eth_price
+        assert cost == expected
+
+    def test_withdraw_uses_withdraw_fallback_gas(self) -> None:
+        """WITHDRAW は DEFAULT_FALLBACK_GAS_WITHDRAW を使うこと"""
+        eth_price = Decimal("2000.00")
+        cost = estimate_static_gas_cost_usd(
+            "WITHDRAW", eth_usd_price=eth_price, gas_price_wei=Decimal("20000000000")
+        )
+        expected = Decimal(str(DEFAULT_FALLBACK_GAS_WITHDRAW)) * Decimal("20000000000") / Decimal("1e18") * eth_price
+        assert cost == expected
+
+    def test_uses_fallback_eth_price_when_none(self) -> None:
+        """eth_usd_price=None のとき ETH_USD_FALLBACK_PRICE を使うこと"""
+        cost_none = estimate_static_gas_cost_usd("SUPPLY", eth_usd_price=None)
+        cost_explicit = estimate_static_gas_cost_usd("SUPPLY", eth_usd_price=ETH_USD_FALLBACK_PRICE)
+        assert cost_none == cost_explicit
+
+    def test_uses_default_gas_price_when_none(self) -> None:
+        """gas_price_wei=None のとき DEFAULT_GAS_PRICE_WEI を使うこと"""
+        cost_none = estimate_static_gas_cost_usd("SUPPLY", gas_price_wei=None)
+        cost_explicit = estimate_static_gas_cost_usd("SUPPLY", gas_price_wei=DEFAULT_GAS_PRICE_WEI)
+        assert cost_none == cost_explicit
+
+    def test_returns_decimal(self) -> None:
+        """返り値が Decimal であること（float禁止）"""
+        cost = estimate_static_gas_cost_usd("SUPPLY")
+        assert isinstance(cost, Decimal)
+
+    def test_operation_case_insensitive(self) -> None:
+        """operation は大文字小文字を問わず動作すること"""
+        cost_upper = estimate_static_gas_cost_usd("SUPPLY")
+        cost_lower = estimate_static_gas_cost_usd("supply")
+        assert cost_upper == cost_lower

--- a/frontend/app/(liff)/liff-approve/_components/ProposalBubble.tsx
+++ b/frontend/app/(liff)/liff-approve/_components/ProposalBubble.tsx
@@ -61,6 +61,15 @@ export function ProposalBubble({ proposal }: ProposalBubbleProps) {
     ? `~$${Number(proposal.estimated_gas_usd).toFixed(2)}`
     : null;
 
+  const totalUsd =
+    proposal.estimated_gas_usd
+      ? (Number(proposal.amount_usd) + Number(proposal.estimated_gas_usd)).toLocaleString("ja-JP", {
+          style: "currency",
+          currency: "USD",
+          maximumFractionDigits: 2,
+        })
+      : null;
+
   return (
     <div className="flex flex-col items-start px-3 py-2">
       {/* bubble */}
@@ -130,9 +139,14 @@ export function ProposalBubble({ proposal }: ProposalBubbleProps) {
           </p>
         )}
 
-        {/* gas */}
+        {/* gas + total */}
         {gasUsd && (
-          <p className="text-xs text-zinc-600">ガス概算: {gasUsd}</p>
+          <div className="space-y-0.5">
+            <p className="text-xs text-zinc-600">ガス概算: {gasUsd}</p>
+            {totalUsd && (
+              <p className="text-xs text-zinc-400 font-medium">合計（ガス込み）: {totalUsd}</p>
+            )}
+          </div>
         )}
       </div>
 

--- a/frontend/app/(user)/approve/_components/ProposalCard.tsx
+++ b/frontend/app/(user)/approve/_components/ProposalCard.tsx
@@ -81,6 +81,7 @@ export function ProposalCard({
 
   const isProcessing = status === 'approving' || status === 'confirming'
   const isDone = status === 'success' || status === 'failed'
+  const totalCostUSD = proposal.amountUSD + proposal.estimatedGas
 
   return (
     <Card className="w-full dark:bg-gray-900 border-border">
@@ -109,6 +110,11 @@ export function ProposalCard({
               <p className="text-sm text-muted-foreground">
                 ≈ ${proposal.amountUSD.toLocaleString('ja-JP', { maximumFractionDigits: 2 })}
               </p>
+              {proposal.estimatedGas > 0 && (
+                <p className="text-xs text-muted-foreground">
+                  合計（ガス込み）: ${totalCostUSD.toLocaleString('ja-JP', { maximumFractionDigits: 2 })}
+                </p>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 概要

AI判定スケジューラーが提案生成時に `estimated_gas_usd` をセットしていなかったため、ユーザーの承認画面でガス代が常に $0.00 になっていた問題を修正。合わせてガス代込み合計金額の表示を追加。

Asana: https://app.asana.com/1/817733952351708/project/1213814438308045/task/1215355590743506

## 変更内容

### バックエンド

- `gas_estimator.py`: `estimate_static_gas_cost_usd(operation)` を追加
  - web3 接続不要のフォールバック概算関数（提案生成時用）
  - デフォルト 30 gwei × 300,000 gas × $2100 ETH ≈ $18.90
  - ENV `ETH_GAS_PRICE_GWEI_FALLBACK` / `ETH_USD_FALLBACK_PRICE` で調整可能
- `ai_judgment_scheduler.py`: Proposal 生成時に `estimated_gas_usd=estimate_static_gas_cost_usd(operation)` をセット

### フロントエンド

- `ProposalCard.tsx`（ユーザー承認画面）: ガス代 > 0 の場合に「合計（ガス込み）: $XXX」を表示
- `ProposalBubble.tsx`（LIFF）: ガス概算の下に「合計（ガス込み）: $XXX」を追加表示

### テスト

- `test_gas_estimator.py`: `TestEstimateStaticGasCostUsd` クラスを追加（6ケース）
  - SUPPLY/WITHDRAW の gas_units 分岐、フォールバック動作、Decimal 型、大文字小文字の正規化
- `test_ai_judgment_scheduler.py`: BUY/SELL 判定で生成される Proposal に `estimated_gas_usd > 0` がセットされることを確認

## テスト結果

```
tests/test_gas_estimator.py::TestEstimateStaticGasCostUsd 6 passed
tests/test_ai_judgment_scheduler.py::test_run_job_buy_creates_proposals PASSED
tests/test_ai_judgment_scheduler.py::test_run_job_sell_creates_withdraw_proposals PASSED
```

## Test plan

- [ ] staging でスケジューラーを実行し、生成された Proposal の `estimated_gas_usd` が NULL でないことを DB で確認
- [ ] ユーザー承認画面（`/approve`）でガス代と合計金額が表示されることを目視確認
- [ ] LIFF の提案バブルで合計金額が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)