### PR TITLE
feat(referral): アフィリエイト → 紹介キャンペーン仕様変更

### DIFF
--- a/backend/alembic/versions/p6q7r8s9t0u1_referral_campaign.py
+++ b/backend/alembic/versions/p6q7r8s9t0u1_referral_campaign.py
@@ -1,0 +1,129 @@
+"""referral_campaign and uat_wallet_ledger tables
+
+紹介キャンペーン仕様変更に伴い 2 テーブルを追加:
+- referral_campaigns : パートナーごとの紹介ウィンドウ (最新1件が有効)
+- uat_wallet_ledger  : UAT 収支台帳 (月次バッチで credit/debit を記録)
+
+Revision ID: p6q7r8s9t0u1
+Revises: o5p6q7r8s9t0
+Create Date: 2026-06-03 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "p6q7r8s9t0u1"
+down_revision: Union[str, Sequence[str], None] = "o5p6q7r8s9t0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    is_pg = bind.dialect.name == "postgresql"
+
+    if is_pg:
+        op.execute("""
+            CREATE TABLE IF NOT EXISTS referral_campaigns (
+                id BIGSERIAL PRIMARY KEY,
+                partner_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                referree_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                reward_start_month DATE NOT NULL,
+                reward_expires_month DATE NOT NULL,
+                ended_early_month DATE,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+        """)
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS idx_rc_referree_month "
+            "ON referral_campaigns (referree_id, reward_start_month, reward_expires_month)"
+        )
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS idx_rc_partner "
+            "ON referral_campaigns (partner_id)"
+        )
+
+        op.execute("""
+            CREATE TABLE IF NOT EXISTS uat_wallet_ledger (
+                id BIGSERIAL PRIMARY KEY,
+                entry_type VARCHAR(16) NOT NULL,
+                amount_jpy NUMERIC(18,2) NOT NULL,
+                reason VARCHAR(64) NOT NULL,
+                reference_fee_tx_id BIGINT REFERENCES fee_transactions(id) ON DELETE SET NULL,
+                month DATE,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                CONSTRAINT chk_uwl_entry_type CHECK (entry_type IN ('credit', 'debit')),
+                CONSTRAINT chk_uwl_amount CHECK (amount_jpy >= 0)
+            )
+        """)
+        op.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_uwl_fee_tx_type_reason "
+            "ON uat_wallet_ledger (reference_fee_tx_id, entry_type, reason) "
+            "WHERE reference_fee_tx_id IS NOT NULL"
+        )
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS idx_uwl_month "
+            "ON uat_wallet_ledger (month)"
+        )
+    else:
+        # SQLite (テスト環境)
+        op.create_table(
+            "referral_campaigns",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column(
+                "partner_id",
+                sa.Integer(),
+                sa.ForeignKey("users.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "referree_id",
+                sa.Integer(),
+                sa.ForeignKey("users.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("reward_start_month", sa.Date(), nullable=False),
+            sa.Column("reward_expires_month", sa.Date(), nullable=False),
+            sa.Column("ended_early_month", sa.Date(), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+            ),
+        )
+        op.create_table(
+            "uat_wallet_ledger",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("entry_type", sa.String(16), nullable=False),
+            sa.Column("amount_jpy", sa.Numeric(18, 2), nullable=False),
+            sa.Column("reason", sa.String(64), nullable=False),
+            sa.Column(
+                "reference_fee_tx_id",
+                sa.Integer(),
+                sa.ForeignKey("fee_transactions.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("month", sa.Date(), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+            ),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    is_pg = bind.dialect.name == "postgresql"
+
+    if is_pg:
+        op.execute("DROP TABLE IF EXISTS uat_wallet_ledger")
+        op.execute("DROP TABLE IF EXISTS referral_campaigns")
+    else:
+        op.drop_table("uat_wallet_ledger")
+        op.drop_table("referral_campaigns")

--- a/backend/app/api/v1/fees.py
+++ b/backend/app/api/v1/fees.py
@@ -51,7 +51,7 @@ from app.fees.fee_transfer_service import (
     FeeTransferService,
     is_fee_transfer_enabled,
 )
-from app.fees.models import FeeConfigV10, FeeTransaction
+from app.fees.models import FeeConfigV10, FeeTransaction, ReferralCampaign, UatWalletLedger
 from app.portfolio.models import PortfolioSnapshot
 from app.transactions.models import Transaction
 
@@ -253,6 +253,29 @@ def _next_month_start(d: date) -> date:
     return date(d.year, d.month + 1, 1)
 
 
+def _get_active_campaign_partner_id(db: Session, referree_id: int, month: date) -> int | None:
+    """指定月に有効な紹介キャンペーン ウィンドウのパートナー ID を返す。
+
+    有効条件:
+        reward_start_month <= month <= reward_expires_month
+        AND (ended_early_month IS NULL OR ended_early_month >= month)
+    """
+    from sqlalchemy import or_
+
+    campaign = db.scalar(
+        select(ReferralCampaign).where(
+            ReferralCampaign.referree_id == referree_id,
+            ReferralCampaign.reward_start_month <= month,
+            ReferralCampaign.reward_expires_month >= month,
+            or_(
+                ReferralCampaign.ended_early_month.is_(None),
+                ReferralCampaign.ended_early_month >= month,
+            ),
+        )
+    )
+    return campaign.partner_id if campaign else None
+
+
 def finalize_month_core(
     db: Session,
     config: FeeConfigV10,
@@ -349,6 +372,8 @@ def finalize_month_core(
         )
         expense_jpy = (fixed_cost_usd * trade_count * usd_jpy_rate).quantize(Decimal("1"))
 
+        campaign_partner_id = _get_active_campaign_partner_id(db, user.id, month_start)
+
         payload = FeeCalculationInput(
             user_id=user.id,
             calculation_month=month_start,
@@ -357,7 +382,7 @@ def finalize_month_core(
             expense_jpy=expense_jpy,
             user_tier=user_tier,
             user_risk_mode=user_risk_mode,
-            affiliate_id=user.invited_by,
+            affiliate_id=campaign_partner_id,
             is_first_month=is_first_month,
         )
 
@@ -414,6 +439,72 @@ def finalize_month_core(
 
     if not dry_run:
         db.commit()
+
+        # --- UAT ウォレット台帳 記録 (冪等: 同月再実行でも重複しない) ---
+        fee_txs_this_month = (
+            db.execute(
+                select(FeeTransaction).where(
+                    FeeTransaction.calculation_month == month_start
+                )
+            )
+            .scalars()
+            .all()
+        )
+        wallet_entries_added = 0
+        for fee_tx in fee_txs_this_month:
+            uat_income = (
+                (fee_tx.subscription_amount_jpy or Decimal("0"))
+                + (fee_tx.fee_amount_jpy or Decimal("0"))
+                + (fee_tx.yield_excess_to_uata_jpy or Decimal("0"))
+            )
+            if uat_income > Decimal("0"):
+                already = db.scalar(
+                    select(UatWalletLedger).where(
+                        UatWalletLedger.reference_fee_tx_id == fee_tx.id,
+                        UatWalletLedger.entry_type == "credit",
+                        UatWalletLedger.reason == "uat_monthly_income",
+                    )
+                )
+                if already is None:
+                    db.add(
+                        UatWalletLedger(
+                            entry_type="credit",
+                            amount_jpy=uat_income,
+                            reason="uat_monthly_income",
+                            reference_fee_tx_id=fee_tx.id,
+                            month=month_start,
+                        )
+                    )
+                    wallet_entries_added += 1
+
+            affiliate_amt = fee_tx.affiliate_amount_jpy or Decimal("0")
+            if affiliate_amt > Decimal("0"):
+                already_debit = db.scalar(
+                    select(UatWalletLedger).where(
+                        UatWalletLedger.reference_fee_tx_id == fee_tx.id,
+                        UatWalletLedger.entry_type == "debit",
+                        UatWalletLedger.reason == "referral_campaign",
+                    )
+                )
+                if already_debit is None:
+                    db.add(
+                        UatWalletLedger(
+                            entry_type="debit",
+                            amount_jpy=affiliate_amt,
+                            reason="referral_campaign",
+                            reference_fee_tx_id=fee_tx.id,
+                            month=month_start,
+                        )
+                    )
+                    wallet_entries_added += 1
+
+        if wallet_entries_added:
+            db.commit()
+            logger.info(
+                "uat_wallet_ledger: month=%s entries_added=%d",
+                month_start,
+                wallet_entries_added,
+            )
 
         # --- 課金ベンダー差込点 (vendor_adapter が指定された場合のみ実行) ---
         # subscription_amount_jpy > 0 かつ subscription_protected=False のユーザーに対し

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -54,6 +54,7 @@ from .schemas import (
     WalletLinkResponse,
 )
 from .service import AuthService
+from app.referral import service as referral_service
 
 limiter = Limiter(key_func=get_remote_address)
 
@@ -199,9 +200,10 @@ def register_with_referral(
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
-    # Step 6: set referral fields
+    # Step 6: set referral fields + 紹介キャンペーン ウィンドウ作成
     user.referrer_id = referrer.id
     user.referred_consent_at = datetime.now(timezone.utc)
+    referral_service.handle_new_referral(db, partner_id=referrer.id, referree_id=user.id)
     db.commit()
     db.refresh(user)
 

--- a/backend/app/fees/models.py
+++ b/backend/app/fees/models.py
@@ -4,8 +4,10 @@
 """Fee Model v10 SQLAlchemy ORM 定義。
 
 テーブル:
-- fee_configs      : v10 設定 (tier × risk_mode の手数料率マトリクス)
-- fee_transactions : 月次手数料計算結果
+- fee_configs         : v10 設定 (tier × risk_mode の手数料率マトリクス)
+- fee_transactions    : 月次手数料計算結果
+- referral_campaigns  : 紹介キャンペーン ウィンドウ管理 (パートナーごとの最新1件が有効)
+- uat_wallet_ledger   : UAT 収支台帳 (月次バッチで credit/debit を記録)
 
 DDL の真実の源: backend/alembic/sql/045_fee_v10_tables.sql
 """
@@ -37,6 +39,8 @@ from sqlalchemy.orm import Mapped, mapped_column
 from app.database import Base
 
 #: PostgreSQL では JSONB、それ以外 (SQLite テスト等) では JSON を使う型 alias。
+# (module-level で一度だけ定義 — 下の FeeConfigV10 でも参照するため上に移動)
+
 _JSONB_OR_JSON = JSONB().with_variant(JSON(), "sqlite")
 
 
@@ -66,7 +70,7 @@ class FeeConfigV10(Base):
         Numeric(6, 4), nullable=False, server_default=text("0")
     )
     affiliate_rate: Mapped[Decimal] = mapped_column(
-        Numeric(6, 4), nullable=False, server_default=text("0.30")
+        Numeric(6, 4), nullable=False, server_default=text("0.10")
     )
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("FALSE"))
     effective_from: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
@@ -217,4 +221,114 @@ class FeeTransaction(Base):
             f"<FeeTransaction(id={self.id}, user_id={self.user_id}, "
             f"month={self.calculation_month}, tier={self.tier}, "
             f"risk_mode={self.risk_mode}, total={self.fee_amount_jpy})>"
+        )
+
+
+class ReferralCampaign(Base):
+    """紹介キャンペーン ウィンドウ管理。
+
+    パートナーが新規紹介をするたびに 1 レコードを追加する。
+    同一パートナーの有効ウィンドウは最大 1 件 (新規紹介時に前のレコードの
+    ended_early_month を更新して閉じる)。
+
+    有効条件 (月 M に対して):
+        reward_start_month <= M <= reward_expires_month
+        AND (ended_early_month IS NULL OR ended_early_month >= M)
+    """
+
+    __tablename__ = "referral_campaigns"
+
+    id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer(), "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    )
+    partner_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    referree_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    #: 報酬開始月 (紹介翌月の月初 date)。
+    reward_start_month: Mapped[date] = mapped_column(Date, nullable=False)
+    #: 報酬終了月 (reward_start_month + 11ヶ月、この月を含む)。
+    reward_expires_month: Mapped[date] = mapped_column(Date, nullable=False)
+    #: 新規紹介で早期終了した場合、終了した最終報酬月 (NULL = まだ有効)。
+    ended_early_month: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=text("NOW()"),
+    )
+
+    __table_args__ = (
+        Index(
+            "idx_rc_referree_month",
+            "referree_id",
+            "reward_start_month",
+            "reward_expires_month",
+        ),
+        Index("idx_rc_partner", "partner_id"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<ReferralCampaign(id={self.id}, partner={self.partner_id}, "
+            f"referree={self.referree_id}, "
+            f"start={self.reward_start_month}, expires={self.reward_expires_month})>"
+        )
+
+
+class UatWalletLedger(Base):
+    """UAT 収支台帳。
+
+    月次確定バッチで以下を記録:
+    - credit / reason='uat_monthly_income' : 手数料 + サブスク + yield_excess の合計
+    - debit  / reason='referral_campaign'  : 紹介キャンペーン報酬支出
+
+    UNIQUE (reference_fee_tx_id, entry_type, reason) により冪等性を保証。
+    """
+
+    __tablename__ = "uat_wallet_ledger"
+
+    id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer(), "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    )
+    #: 'credit' or 'debit'
+    entry_type: Mapped[str] = mapped_column(String(16), nullable=False)
+    amount_jpy: Mapped[Decimal] = mapped_column(Numeric(18, 2), nullable=False)
+    #: 'uat_monthly_income', 'referral_campaign', etc.
+    reason: Mapped[str] = mapped_column(String(64), nullable=False)
+    #: 紐づく fee_transaction (NULL の場合は手動エントリー等)。
+    reference_fee_tx_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger().with_variant(Integer(), "sqlite"),
+        ForeignKey("fee_transactions.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    #: 対象月 (月初 date)。バッチ処理では calculation_month と一致。
+    month: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=text("NOW()"),
+    )
+
+    __table_args__ = (
+        CheckConstraint("entry_type IN ('credit', 'debit')", name="chk_uwl_entry_type"),
+        CheckConstraint("amount_jpy >= 0", name="chk_uwl_amount"),
+        Index("idx_uwl_month", "month"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<UatWalletLedger(id={self.id}, type={self.entry_type}, "
+            f"amount={self.amount_jpy}, reason={self.reason!r}, month={self.month})>"
         )

--- a/backend/app/referral/router.py
+++ b/backend/app/referral/router.py
@@ -66,13 +66,13 @@ def post_referral_code(
 @router.get(
     "/earnings",
     response_model=ReferralEarningsResponse,
-    summary="アフィリエイター収益サマリー (partner 専用)",
+    summary="紹介キャンペーン収益サマリー (partner 専用)",
 )
 def get_referral_earnings(
     current_user: User = Depends(require_partner_only),
     db: Session = Depends(get_db),
 ) -> ReferralEarningsResponse:
-    """紹介数・今月報酬・累計 payout を返す。"""
+    """紹介数・今月報酬・累計 payout・キャンペーン期限を返す。"""
     data = service.get_referral_earnings(db, current_user.id)
     return ReferralEarningsResponse(**data)
 

--- a/backend/app/referral/schemas.py
+++ b/backend/app/referral/schemas.py
@@ -46,7 +46,7 @@ class ReferralTransactionResponse(BaseModel):
 
 
 class ReferralEarningsResponse(BaseModel):
-    """アフィリエイター収益サマリー。
+    """紹介キャンペーン収益サマリー。
 
     金額は Decimal を文字列で返却 (CLAUDE.md §21)。
     """
@@ -54,4 +54,5 @@ class ReferralEarningsResponse(BaseModel):
     referral_count: int
     current_month_reward_jpy: str
     total_payout_jpy: str
-    affiliate_rate: str  # e.g. "0.3000"
+    campaign_rate: str  # e.g. "0.1000" (10%)
+    campaign_expires_month: str | None  # "2027-01-01" 形式 or None

--- a/backend/app/referral/service.py
+++ b/backend/app/referral/service.py
@@ -7,6 +7,7 @@ partner ロール用に以下を提供する:
   - 紹介コードの取得 / 自動発行
   - 紹介経由で登録された配下ユーザー一覧
   - 配下ユーザーの取引履歴 (deposit / withdraw / borrow / repay のみ、wallet/tx は除外)
+  - 紹介キャンペーン ウィンドウ管理 (新規紹介時のウィンドウ開閉)
 """
 
 from __future__ import annotations
@@ -18,10 +19,10 @@ from decimal import Decimal
 from typing import TYPE_CHECKING
 
 from fastapi import HTTPException, status
-from sqlalchemy import func
+from sqlalchemy import func, select
 
 from app.auth.models import User
-from app.fees.models import FeeConfigV10, FeeTransaction
+from app.fees.models import FeeConfigV10, FeeTransaction, ReferralCampaign
 from app.transactions.models import Transaction
 
 from .code_generator import generate_referral_code
@@ -120,13 +121,77 @@ def mask_email(email: str) -> str:
     return f"{local[0]}***@{domain}"
 
 
+def handle_new_referral(db: Session, partner_id: int, referree_id: int) -> ReferralCampaign:
+    """新規紹介登録時に紹介キャンペーン ウィンドウを更新する。
+
+    1. 同一パートナーの既存アクティブ ウィンドウを今月で終了。
+    2. 新しい 12ヶ月ウィンドウを作成 (来月スタート)。
+
+    Args:
+        db: DB セッション (呼び出し元が commit を担当)。
+        partner_id: 紹介したパートナーの user id。
+        referree_id: 新規登録したユーザーの user id。
+
+    Returns:
+        作成した ReferralCampaign レコード。
+    """
+    today = date.today()
+    current_month = date(today.year, today.month, 1)
+
+    # 既存のアクティブ ウィンドウを今月で閉じる
+    existing_active = db.scalars(
+        select(ReferralCampaign).where(
+            ReferralCampaign.partner_id == partner_id,
+            ReferralCampaign.ended_early_month.is_(None),
+            ReferralCampaign.reward_expires_month >= current_month,
+        )
+    ).all()
+    for old_campaign in existing_active:
+        old_campaign.ended_early_month = current_month
+        logger.info(
+            "Closed referral campaign id=%d partner=%d (new referral in month=%s)",
+            old_campaign.id,
+            partner_id,
+            current_month,
+        )
+
+    # 新ウィンドウ: 来月スタート、12ヶ月間
+    reward_start_month = _add_months(current_month, 1)
+    reward_expires_month = _add_months(reward_start_month, 11)
+
+    campaign = ReferralCampaign(
+        partner_id=partner_id,
+        referree_id=referree_id,
+        reward_start_month=reward_start_month,
+        reward_expires_month=reward_expires_month,
+    )
+    db.add(campaign)
+    logger.info(
+        "Created referral campaign partner=%d referree=%d start=%s expires=%s",
+        partner_id,
+        referree_id,
+        reward_start_month,
+        reward_expires_month,
+    )
+    return campaign
+
+
+def _add_months(d: date, months: int) -> date:
+    """月初 date に n ヶ月を加算して月初 date を返す (日は常に 1 日)。"""
+    total = d.month - 1 + months
+    year = d.year + total // 12
+    month = total % 12 + 1
+    return date(year, month, 1)
+
+
 def get_referral_earnings(db: Session, partner_id: int) -> dict:
-    """アフィリエイター収益サマリーを返す。
+    """紹介キャンペーン収益サマリーを返す。
 
     - referral_count: referrer_id == partner_id のユーザー数
     - current_month_reward_jpy: 今月の affiliate_amount_jpy 合計
     - total_payout_jpy: finalized 済みの affiliate_amount_jpy 累計
-    - affiliate_rate: active FeeConfigV10 の affiliate_rate (デフォルト 0.30)
+    - campaign_rate: active FeeConfigV10 の affiliate_rate (デフォルト 0.10)
+    - campaign_expires_month: アクティブ ウィンドウの reward_expires_month (None = ウィンドウなし)
     """
     referral_count: int = (
         db.query(func.count(User.id)).filter(User.referrer_id == partner_id).scalar() or 0
@@ -161,11 +226,25 @@ def get_referral_earnings(db: Session, partner_id: int) -> dict:
         .order_by(FeeConfigV10.effective_from.desc())
         .first()
     )
-    affiliate_rate = active_config.affiliate_rate if active_config else Decimal("0.30")
+    campaign_rate = active_config.affiliate_rate if active_config else Decimal("0.10")
+
+    # アクティブ ウィンドウを探して期限月を返す
+    active_campaign = db.scalar(
+        select(ReferralCampaign).where(
+            ReferralCampaign.partner_id == partner_id,
+            ReferralCampaign.ended_early_month.is_(None),
+            ReferralCampaign.reward_expires_month >= current_month,
+            ReferralCampaign.reward_start_month <= current_month,
+        )
+    )
+    campaign_expires_month: str | None = (
+        str(active_campaign.reward_expires_month) if active_campaign else None
+    )
 
     return {
         "referral_count": referral_count,
         "current_month_reward_jpy": str(current_month_reward),
         "total_payout_jpy": str(total_payout),
-        "affiliate_rate": str(affiliate_rate),
+        "campaign_rate": str(campaign_rate),
+        "campaign_expires_month": campaign_expires_month,
     }

--- a/backend/scripts/seed_fee_config_v10.py
+++ b/backend/scripts/seed_fee_config_v10.py
@@ -79,7 +79,7 @@ def build_v10_default_config() -> dict[str, object]:
         # → {"conservative": 0.0, "balanced": 0.003, "aggressive": 0.01}
         "expense_markup_enabled": False,
         "expense_markup_rate": Decimal("0"),
-        "affiliate_rate": Decimal("0.30"),
+        "affiliate_rate": Decimal("0.10"),
         "is_active": True,
         "effective_from": V10_DEFAULT_EFFECTIVE_FROM,
     }

--- a/backend/tests/test_seed_fee_config_v10.py
+++ b/backend/tests/test_seed_fee_config_v10.py
@@ -85,7 +85,7 @@ class TestBuildV10DefaultConfig:
 
     def test_affiliate_rate_is_decimal(self) -> None:
         config = build_v10_default_config()
-        assert config["affiliate_rate"] == Decimal("0.30")
+        assert config["affiliate_rate"] == Decimal("0.10")
         assert isinstance(config["affiliate_rate"], Decimal)
 
     def test_expense_markup_disabled_by_default(self) -> None:
@@ -220,4 +220,4 @@ class TestSeededRowMatchesSpec:
         seed(v10_db)
         row = v10_db.query(FeeConfigV10).one()
         # SQLite では NUMERIC が文字列として返ることがあるため Decimal 比較
-        assert Decimal(str(row.affiliate_rate)) == Decimal("0.30")
+        assert Decimal(str(row.affiliate_rate)) == Decimal("0.10")

--- a/frontend/app/(admin)/settings/_components/FeeConfigCard.tsx
+++ b/frontend/app/(admin)/settings/_components/FeeConfigCard.tsx
@@ -118,7 +118,7 @@ export function FeeConfigCard() {
               </div>
             </div>
 
-            {/* 経費マークアップ / アフィリエイト */}
+            {/* 経費マークアップ / 紹介キャンペーン */}
             <div>
               <h3 className="text-xs font-semibold text-zinc-400 uppercase tracking-wide mb-2">
                 その他レート
@@ -133,7 +133,7 @@ export function FeeConfigCard() {
                   </p>
                 </div>
                 <div className="rounded-lg bg-zinc-800/60 px-3 py-2">
-                  <p className="text-xs text-zinc-500">アフィリエイト報酬率</p>
+                  <p className="text-xs text-zinc-500">紹介キャンペーン報酬率</p>
                   <p className="text-sm font-medium text-zinc-100 mt-0.5">
                     {`${(Number(config.affiliate_rate) * 100).toFixed(1)}%`}
                   </p>

--- a/frontend/app/(partner)/partner/referral/page.tsx
+++ b/frontend/app/(partner)/partner/referral/page.tsx
@@ -101,7 +101,7 @@ export default function PartnerReferralPage() {
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
-      <h1 className="text-2xl font-bold">紹介プログラム</h1>
+      <h1 className="text-2xl font-bold">紹介キャンペーン</h1>
 
       {/* Earnings summary */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
@@ -130,7 +130,7 @@ export default function PartnerReferralPage() {
               今月の報酬
               {earnings && (
                 <span className="ml-1 text-xs font-normal">
-                  (サブスク{formatRate(earnings.affiliate_rate)})
+                  (サブスク{formatRate(earnings.campaign_rate)})
                 </span>
               )}
             </CardTitle>
@@ -163,6 +163,14 @@ export default function PartnerReferralPage() {
           </CardContent>
         </Card>
       </div>
+
+      {/* キャンペーン期限バナー */}
+      {!earningsLoading && earnings?.campaign_expires_month && (
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-400">
+          キャンペーン有効期限: <span className="font-medium">{earnings.campaign_expires_month.slice(0, 7)}</span> まで
+          （新規紹介をするとさらに1年延長されます）
+        </div>
+      )}
 
       {/* Referral code card */}
       <Card>

--- a/frontend/lib/api/referral.ts
+++ b/frontend/lib/api/referral.ts
@@ -24,7 +24,8 @@ export interface ReferralEarnings {
   referral_count: number
   current_month_reward_jpy: string
   total_payout_jpy: string
-  affiliate_rate: string
+  campaign_rate: string
+  campaign_expires_month: string | null
 }
 
 export interface RegisterWithReferralPayload {


### PR DESCRIPTION
## 概要

アフィリエイト機能を「紹介キャンペーン」として仕様変更・再実装。

## 仕様変更

| 項目 | 旧仕様 | 新仕様 |
|------|-------|-------|
| 名称 | アフィリエイト | 紹介キャンペーン |
| 報酬率 | 30%/月 | 10%/月 |
| 支払元 | サブスク収益から按分 | UAT ウォレットから支出 |
| 報酬期間 | 無期限 | 紹介翌月から12ヶ月 |
| 複数紹介 | 全員に永続 | 最新1名のみ有効（新規紹介で前の報酬終了・1年延長） |

## ウィンドウロジック

- 1月紹介 → 2月〜翌1月（12ヶ月）報酬
- 4月に新規紹介 → 1人目の報酬は4月終了、5月〜翌4月（12ヶ月）で2人目スタート

## 変更ファイル

### DB / Migration
- `backend/alembic/versions/p6q7r8s9t0u1_referral_campaign.py` — 新規テーブル2件
  - `referral_campaigns`: ウィンドウ管理（partner_id / referree_id / reward_start_month / reward_expires_month / ended_early_month）
  - `uat_wallet_ledger`: UAT 収支台帳（credit/debit 台帳、冪等インデックス付き）

### バックエンド
- `fees/models.py` — `ReferralCampaign`, `UatWalletLedger` モデル追加。`affiliate_rate` デフォルト 0.30→0.10
- `referral/service.py` — `handle_new_referral`（ウィンドウ開閉）、`_add_months` 追加。`get_referral_earnings` を `campaign_rate` / `campaign_expires_month` 対応に更新
- `auth/router.py` — `register_with_referral` に `handle_new_referral` 呼び出しを追加
- `api/v1/fees.py` — `_get_active_campaign_partner_id` ヘルパー、UAT ウォレット記録フェーズ（Phase 2.5、冪等）を `finalize_month_core` に追加
- `scripts/seed_fee_config_v10.py` — `affiliate_rate` 0.30→0.10
- `referral/schemas.py` — `ReferralEarningsResponse` を新フィールドに更新
- `referral/router.py` — summary 文言更新

### フロントエンド
- `lib/api/referral.ts` — `ReferralEarnings` 型を `campaign_rate` / `campaign_expires_month` に更新
- `app/(partner)/partner/referral/page.tsx` — タイトル変更・フィールド差し替え・キャンペーン期限バナー追加
- `app/(admin)/settings/_components/FeeConfigCard.tsx` — ラベル「紹介キャンペーン報酬率」に変更

### テスト
- `tests/test_seed_fee_config_v10.py` — affiliate_rate アサーション 0.30→0.10 に更新

## テスト結果

```
126 passed, 0 failed
対象: test_fee_calculator, test_api_v1_fees, test_referral_router,
      test_auth_register_with_referral, test_seed_fee_config_v10,
      test_qa_fee_calculator, test_fee_service
```

## デプロイ手順（staging）

1. Migration 適用: `alembic upgrade head`
2. Seed 更新: 既存 `v10_default` がある場合は `docs/48 §4` 手順（新 config_name で INSERT → スイッチ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)