### PR TITLE
feat(liff-chat): ハンバーガーメニューシェル（Phase 1）

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/HamburgerMenu.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/HamburgerMenu.tsx
@@ -1,0 +1,89 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import {
+  Wallet,
+  ArrowDownUp,
+  Users,
+  Settings2,
+  Clock,
+  FileText,
+  Bell,
+  User,
+  BookOpen,
+  ChevronRight,
+} from "lucide-react"
+
+interface HamburgerMenuProps {
+  open: boolean
+  onClose: () => void
+  onPanelOpen: (id: string) => void
+}
+
+const MENU_ITEMS = [
+  { id: "myWallet",     label: "MY WALLET",      sub: "ウォレットアドレス・QRコード",   icon: Wallet },
+  { id: "deposit",      label: "入金/出金",        sub: "USDCの入出金",                 icon: ArrowDownUp },
+  { id: "referral",     label: "紹介キャンペーン", sub: "お友達を紹介して報酬を獲得",    icon: Users },
+  { id: "opMode",       label: "運用モード切替",   sub: "おまかせ / アクティブ",         icon: Settings2 },
+  { id: "txHistory",    label: "取引履歴",         sub: "過去の取引を確認",              icon: Clock },
+  { id: "tax",          label: "TAX & REPORTS",   sub: "税務レポート・CSV出力",          icon: FileText },
+  { id: "notification", label: "通知設定",         sub: "LINE・プッシュ通知の設定",      icon: Bell },
+  { id: "account",      label: "アカウント",       sub: "プロフィール・ログアウト",       icon: User },
+  { id: "terms",        label: "利用規約",         sub: "利用規約・プライバシーポリシー", icon: BookOpen },
+]
+
+export function HamburgerMenu({ open, onClose, onPanelOpen }: HamburgerMenuProps) {
+  return (
+    <>
+      {/* バックドロップ */}
+      {open && (
+        <div
+          className="fixed inset-0 z-40 bg-black/60"
+          onClick={onClose}
+        />
+      )}
+
+      {/* サイドパネル本体 */}
+      <div
+        className={`fixed top-0 left-0 h-full z-50 w-72 bg-[#1a3d2e] flex flex-col
+                    transform transition-transform duration-300 ease-in-out
+                    ${open ? "translate-x-0" : "-translate-x-full"}`}
+      >
+        {/* ヘッダー */}
+        <div className="flex items-center justify-between px-4 py-4 border-b border-white/10">
+          <span className="text-[#4ade9a] font-bold text-lg">UAT</span>
+          <button
+            onClick={onClose}
+            className="text-white text-xl leading-none w-8 h-8 flex items-center justify-center hover:bg-white/10 rounded-full transition-colors"
+            aria-label="メニューを閉じる"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* メニュー項目 */}
+        <div className="flex-1 overflow-y-auto">
+          {MENU_ITEMS.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => { onPanelOpen(item.id); onClose() }}
+              className="flex items-center w-full px-4 py-4 border-b border-white/10 hover:bg-white/5 active:bg-white/10 transition-colors"
+            >
+              <item.icon className="w-5 h-5 text-[#4ade9a] mr-3 flex-shrink-0" />
+              <div className="flex-1 text-left">
+                <div className="text-white font-medium text-sm">{item.label}</div>
+                <div className="text-zinc-400 text-xs mt-0.5">{item.sub}</div>
+              </div>
+              <ChevronRight className="w-4 h-4 text-zinc-600 flex-shrink-0" />
+            </button>
+          ))}
+        </div>
+
+        {/* フッター */}
+        <div className="mt-auto px-4 py-4">
+          <p className="text-zinc-600 text-xs text-center">UAT App v1.0 | © 2026 UAT Co., Ltd.</p>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/SlideUpPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/SlideUpPanel.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { ChevronLeft } from "lucide-react"
+
+interface SlideUpPanelProps {
+  open: boolean
+  onClose: () => void
+  title: string
+  children: React.ReactNode
+  maxHeight?: string
+}
+
+export function SlideUpPanel({
+  open,
+  onClose,
+  title,
+  children,
+  maxHeight = "90vh",
+}: SlideUpPanelProps) {
+  if (!open) return null
+  return (
+    <>
+      {/* バックドロップ */}
+      <div className="fixed inset-0 z-40 bg-black/60" onClick={onClose} />
+      {/* パネル本体 */}
+      <div
+        style={{ maxHeight }}
+        className="fixed bottom-0 left-0 right-0 z-50
+                   bg-zinc-900 rounded-t-2xl border-t border-zinc-800
+                   overflow-y-auto
+                   animate-in slide-in-from-bottom duration-300"
+      >
+        {/* ドラッグハンドル + ヘッダー */}
+        <div className="sticky top-0 bg-zinc-900 pt-3 pb-0 px-4">
+          <div className="mx-auto mb-3 h-1 w-8 rounded-full bg-zinc-700" />
+          {/* パネルヘッダー */}
+          <div className="flex items-center bg-[#1a3d2e] -mx-4 px-4 py-3 mb-4">
+            <button onClick={onClose} className="text-white mr-2">
+              <ChevronLeft className="w-5 h-5" />
+            </button>
+            <h2 className="text-white font-semibold text-base">{title}</h2>
+          </div>
+        </div>
+        <div className="px-4 pb-8">{children}</div>
+      </div>
+    </>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { User } from "lucide-react"
+
+export function AccountPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <User className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { ArrowDownUp } from "lucide-react"
+
+export function DepositPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <ArrowDownUp className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Wallet } from "lucide-react"
+
+export function MyWalletPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Wallet className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/NotificationPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/NotificationPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Bell } from "lucide-react"
+
+export function NotificationPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Bell className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Settings2 } from "lucide-react"
+
+export function OpModePanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Settings2 className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Users } from "lucide-react"
+
+export function ReferralPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Users className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/TaxPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TaxPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { FileText } from "lucide-react"
+
+export function TaxPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <FileText className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/TermsPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TermsPanel.tsx
@@ -1,0 +1,29 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { ExternalLink } from "lucide-react"
+
+export function TermsPanel() {
+  return (
+    <div className="space-y-3 py-4">
+      <a
+        href="https://ultra-auto-trade.com/terms"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center justify-between w-full px-4 py-4 bg-zinc-800 rounded-xl hover:bg-zinc-700 transition-colors"
+      >
+        <span className="text-white text-sm font-medium">利用規約</span>
+        <ExternalLink className="w-4 h-4 text-zinc-400" />
+      </a>
+      <a
+        href="https://ultra-auto-trade.com/privacy"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center justify-between w-full px-4 py-4 bg-zinc-800 rounded-xl hover:bg-zinc-700 transition-colors"
+      >
+        <span className="text-white text-sm font-medium">プライバシーポリシー</span>
+        <ExternalLink className="w-4 h-4 text-zinc-400" />
+      </a>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/TxHistoryPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TxHistoryPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Clock } from "lucide-react"
+
+export function TxHistoryPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Clock className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -1,0 +1,89 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// frontend/app/(liff)/liff-chat/page.tsx
+// LIFF チャット ホーム — /liff-chat
+"use client"
+
+import { useState } from "react"
+import { Menu, User } from "lucide-react"
+import { HamburgerMenu } from "./_components/HamburgerMenu"
+import { SlideUpPanel } from "./_components/SlideUpPanel"
+import { MyWalletPanel } from "./_components/panels/MyWalletPanel"
+import { DepositPanel } from "./_components/panels/DepositPanel"
+import { ReferralPanel } from "./_components/panels/ReferralPanel"
+import { OpModePanel } from "./_components/panels/OpModePanel"
+import { TxHistoryPanel } from "./_components/panels/TxHistoryPanel"
+import { TaxPanel } from "./_components/panels/TaxPanel"
+import { NotificationPanel } from "./_components/panels/NotificationPanel"
+import { AccountPanel } from "./_components/panels/AccountPanel"
+import { TermsPanel } from "./_components/panels/TermsPanel"
+
+const PANEL_TITLES: Record<string, string> = {
+  myWallet:     "MY WALLET",
+  deposit:      "入金/出金",
+  referral:     "紹介キャンペーン",
+  opMode:       "運用モード切替",
+  txHistory:    "取引履歴",
+  tax:          "TAX & REPORTS",
+  notification: "通知設定",
+  account:      "アカウント",
+  terms:        "利用規約",
+}
+
+export default function LiffChatPage() {
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [activePanel, setActivePanel] = useState<string | null>(null)
+
+  return (
+    <div className="w-[375px] mx-auto h-dvh bg-zinc-950 text-zinc-100 flex flex-col overflow-hidden relative">
+      {/* ヘッダー */}
+      <header className="h-14 bg-[#1a3d2e] flex items-center justify-between px-4 flex-shrink-0">
+        <button
+          onClick={() => setMenuOpen(true)}
+          className="text-white hover:bg-white/10 rounded-lg p-1 transition-colors"
+          aria-label="メニューを開く"
+        >
+          <Menu className="w-6 h-6" />
+        </button>
+        <span className="text-[#4ade9a] font-bold text-xl">UAT</span>
+        <button
+          className="text-white hover:bg-white/10 rounded-lg p-1 transition-colors"
+          aria-label="アカウント"
+        >
+          <User className="w-6 h-6" />
+        </button>
+      </header>
+
+      {/* メインコンテンツ（暫定） */}
+      <main className="flex-1 flex items-center justify-center">
+        <p className="text-zinc-600 text-sm">ホーム画面は別タスクで実装</p>
+      </main>
+
+      {/* ハンバーガーメニュー */}
+      <HamburgerMenu
+        open={menuOpen}
+        onClose={() => setMenuOpen(false)}
+        onPanelOpen={(id) => setActivePanel(id)}
+      />
+
+      {/* 各パネル */}
+      {Object.keys(PANEL_TITLES).map((id) => (
+        <SlideUpPanel
+          key={id}
+          open={activePanel === id}
+          onClose={() => setActivePanel(null)}
+          title={PANEL_TITLES[id]}
+        >
+          {id === "myWallet"     && <MyWalletPanel />}
+          {id === "deposit"      && <DepositPanel />}
+          {id === "referral"     && <ReferralPanel />}
+          {id === "opMode"       && <OpModePanel />}
+          {id === "txHistory"    && <TxHistoryPanel />}
+          {id === "tax"          && <TaxPanel />}
+          {id === "notification" && <NotificationPanel />}
+          {id === "account"      && <AccountPanel />}
+          {id === "terms"        && <TermsPanel />}
+        </SlideUpPanel>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## 概要
/liff-chat ページの新規作成とハンバーガーメニューシェルの実装。

## 変更内容
- `frontend/app/(liff)/liff-chat/page.tsx` — メインページ（ヘッダー + ≡ボタン）
- `_components/HamburgerMenu.tsx` — 左スライドインサイドパネル（9項目）
- `_components/SlideUpPanel.tsx` — 再利用可能スライドアップパネル基底
- `_components/panels/*.tsx` — 各メニュー項目スタブ（Phase 2 で実装）

## DoD
- [x] ≡ボタンでサイドパネル開閉
- [x] 9項目リスト表示（MY WALLET / 入金出金 / 紹介キャンペーン / 運用モード切替 / 取引履歴 / TAX&REPORTS / 通知設定 / アカウント / 利用規約）
- [x] 各項目タップでスライドアップパネル表示（スタブ）
- [x] TypeScript エラー 0

## Asana
Closes GID: 1215359469381716