### PR TITLE
feat(liff-chat): 入金/出金パネル実装

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/HamburgerMenu.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/HamburgerMenu.tsx
@@ -1,0 +1,89 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import {
+  Wallet,
+  ArrowDownUp,
+  Users,
+  Settings2,
+  Clock,
+  FileText,
+  Bell,
+  User,
+  BookOpen,
+  ChevronRight,
+} from "lucide-react"
+
+interface HamburgerMenuProps {
+  open: boolean
+  onClose: () => void
+  onPanelOpen: (id: string) => void
+}
+
+const MENU_ITEMS = [
+  { id: "myWallet",     label: "MY WALLET",      sub: "ウォレットアドレス・QRコード",   icon: Wallet },
+  { id: "deposit",      label: "入金/出金",        sub: "USDCの入出金",                 icon: ArrowDownUp },
+  { id: "referral",     label: "紹介キャンペーン", sub: "お友達を紹介して報酬を獲得",    icon: Users },
+  { id: "opMode",       label: "運用モード切替",   sub: "おまかせ / アクティブ",         icon: Settings2 },
+  { id: "txHistory",    label: "取引履歴",         sub: "過去の取引を確認",              icon: Clock },
+  { id: "tax",          label: "TAX & REPORTS",   sub: "税務レポート・CSV出力",          icon: FileText },
+  { id: "notification", label: "通知設定",         sub: "LINE・プッシュ通知の設定",      icon: Bell },
+  { id: "account",      label: "アカウント",       sub: "プロフィール・ログアウト",       icon: User },
+  { id: "terms",        label: "利用規約",         sub: "利用規約・プライバシーポリシー", icon: BookOpen },
+]
+
+export function HamburgerMenu({ open, onClose, onPanelOpen }: HamburgerMenuProps) {
+  return (
+    <>
+      {/* バックドロップ */}
+      {open && (
+        <div
+          className="fixed inset-0 z-40 bg-black/60"
+          onClick={onClose}
+        />
+      )}
+
+      {/* サイドパネル本体 */}
+      <div
+        className={`fixed top-0 left-0 h-full z-50 w-72 bg-[#1a3d2e] flex flex-col
+                    transform transition-transform duration-300 ease-in-out
+                    ${open ? "translate-x-0" : "-translate-x-full"}`}
+      >
+        {/* ヘッダー */}
+        <div className="flex items-center justify-between px-4 py-4 border-b border-white/10">
+          <span className="text-[#4ade9a] font-bold text-lg">UAT</span>
+          <button
+            onClick={onClose}
+            className="text-white text-xl leading-none w-8 h-8 flex items-center justify-center hover:bg-white/10 rounded-full transition-colors"
+            aria-label="メニューを閉じる"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* メニュー項目 */}
+        <div className="flex-1 overflow-y-auto">
+          {MENU_ITEMS.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => { onPanelOpen(item.id); onClose() }}
+              className="flex items-center w-full px-4 py-4 border-b border-white/10 hover:bg-white/5 active:bg-white/10 transition-colors"
+            >
+              <item.icon className="w-5 h-5 text-[#4ade9a] mr-3 flex-shrink-0" />
+              <div className="flex-1 text-left">
+                <div className="text-white font-medium text-sm">{item.label}</div>
+                <div className="text-zinc-400 text-xs mt-0.5">{item.sub}</div>
+              </div>
+              <ChevronRight className="w-4 h-4 text-zinc-600 flex-shrink-0" />
+            </button>
+          ))}
+        </div>
+
+        {/* フッター */}
+        <div className="mt-auto px-4 py-4">
+          <p className="text-zinc-600 text-xs text-center">UAT App v1.0 | © 2026 UAT Co., Ltd.</p>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/SlideUpPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/SlideUpPanel.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { ChevronLeft } from "lucide-react"
+
+interface SlideUpPanelProps {
+  open: boolean
+  onClose: () => void
+  title: string
+  children: React.ReactNode
+  maxHeight?: string
+}
+
+export function SlideUpPanel({
+  open,
+  onClose,
+  title,
+  children,
+  maxHeight = "90vh",
+}: SlideUpPanelProps) {
+  if (!open) return null
+  return (
+    <>
+      {/* バックドロップ */}
+      <div className="fixed inset-0 z-40 bg-black/60" onClick={onClose} />
+      {/* パネル本体 */}
+      <div
+        style={{ maxHeight }}
+        className="fixed bottom-0 left-0 right-0 z-50
+                   bg-zinc-900 rounded-t-2xl border-t border-zinc-800
+                   overflow-y-auto
+                   animate-in slide-in-from-bottom duration-300"
+      >
+        {/* ドラッグハンドル + ヘッダー */}
+        <div className="sticky top-0 bg-zinc-900 pt-3 pb-0 px-4">
+          <div className="mx-auto mb-3 h-1 w-8 rounded-full bg-zinc-700" />
+          {/* パネルヘッダー */}
+          <div className="flex items-center bg-[#1a3d2e] -mx-4 px-4 py-3 mb-4">
+            <button onClick={onClose} className="text-white mr-2">
+              <ChevronLeft className="w-5 h-5" />
+            </button>
+            <h2 className="text-white font-semibold text-base">{title}</h2>
+          </div>
+        </div>
+        <div className="px-4 pb-8">{children}</div>
+      </div>
+    </>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { User } from "lucide-react"
+
+export function AccountPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <User className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { ArrowDownUp } from "lucide-react"
+
+export function DepositPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <ArrowDownUp className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
@@ -1,13 +1,469 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 "use client"
 
-import { ArrowDownUp } from "lucide-react"
+import { useState, useEffect, useCallback } from "react"
+import { AlertTriangle, Loader2 } from "lucide-react"
+import { useFundWallet, useWallets } from "@privy-io/react-auth"
+import { base } from "viem/chains"
+import { apiFetch, apiPost } from "@/lib/api/client"
+
+// ---- 型定義 ---------------------------------------------------------------
+
+interface UserSettingsResponse {
+  balance?: string | number | null
+  wallet_address?: string | null
+}
+
+type Tab = "deposit" | "withdraw"
+type PaymentMethod = "card" | "apple" | "google"
+
+// 入金用 JPY → USDC 変換レート（固定近似値）
+const JPY_PER_USDC = 155
+
+// 出金ネットワーク手数料概算 (USDC)
+const WITHDRAW_FEE = 0.08
+
+// ---- 確認シート ------------------------------------------------------------
+
+interface ConfirmSheetProps {
+  open: boolean
+  title: string
+  rows: { label: string; value: string }[]
+  onConfirm: () => void | Promise<void>
+  onCancel: () => void
+  busy: boolean
+  error: string | null
+}
+
+function ConfirmSheet({ open, title, rows, onConfirm, onCancel, busy, error }: ConfirmSheetProps) {
+  if (!open) return null
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-[60] bg-black/60"
+        onClick={!busy ? onCancel : undefined}
+      />
+      <div className="fixed bottom-0 left-0 right-0 z-[70] bg-zinc-900 rounded-t-2xl border-t border-zinc-800 px-4 pb-8 pt-3 animate-in slide-in-from-bottom duration-300">
+        <div className="mx-auto mb-4 h-1 w-8 rounded-full bg-zinc-700" />
+        <h2 className="text-base font-semibold text-zinc-100 mb-4">{title}</h2>
+        <div className="space-y-3 mb-6">
+          {rows.map((r) => (
+            <div key={r.label} className="flex justify-between items-baseline gap-2">
+              <span className="text-xs text-zinc-500 shrink-0">{r.label}</span>
+              <span className="text-sm text-zinc-100 text-right">{r.value}</span>
+            </div>
+          ))}
+        </div>
+        {error && (
+          <div className="flex items-start gap-2 mb-3 text-red-400 text-xs">
+            <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
+            <span>{error}</span>
+          </div>
+        )}
+        <button
+          onClick={() => { void onConfirm() }}
+          disabled={busy}
+          className="w-full flex items-center justify-center gap-2 bg-[#1D9E75] hover:bg-[#1a8f6a]
+                     disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold
+                     py-3 rounded-xl transition-colors"
+        >
+          {busy && <Loader2 className="w-4 h-4 animate-spin" />}
+          実行する
+        </button>
+        <button
+          onClick={onCancel}
+          disabled={busy}
+          className="mt-2 w-full py-3 rounded-xl border border-zinc-600 text-zinc-300
+                     hover:bg-zinc-800 disabled:opacity-50 disabled:cursor-not-allowed
+                     text-sm font-medium transition-colors"
+        >
+          キャンセル
+        </button>
+      </div>
+    </>
+  )
+}
+
+// ---- メインコンポーネント ---------------------------------------------------
 
 export function DepositPanel() {
+  const [tab, setTab] = useState<Tab>("deposit")
+
+  // 残高
+  const [balance, setBalance] = useState<number | null>(null)
+  const [walletAddress, setWalletAddress] = useState<string | null>(null)
+  const [balanceLoading, setBalanceLoading] = useState(true)
+
+  // 入金フォーム
+  const [depositAmount, setDepositAmount] = useState("")
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>("card")
+
+  // 出金フォーム
+  const [withdrawAmount, setWithdrawAmount] = useState("")
+
+  // 確認シート
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [confirmBusy, setConfirmBusy] = useState(false)
+  const [confirmError, setConfirmError] = useState<string | null>(null)
+  const [successMsg, setSuccessMsg] = useState<string | null>(null)
+
+  // Privy
+  const { fundWallet } = useFundWallet()
+  const { wallets } = useWallets()
+
+  // ---- 残高取得 ------------------------------------------------------------
+
+  const fetchBalance = useCallback(async () => {
+    setBalanceLoading(true)
+    try {
+      const res = await apiFetch<UserSettingsResponse>("/api/user/settings")
+      setBalance(res.balance != null ? Number(res.balance) : null)
+      setWalletAddress(res.wallet_address ?? null)
+    } catch {
+      setBalance(null)
+    } finally {
+      setBalanceLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void fetchBalance()
+  }, [fetchBalance])
+
+  // ---- 出金可能額上限（全額ボタン用） ----------------------------------------
+
+  const maxWithdraw = balance ?? 0
+
+  // ---- 受取予定額計算 -------------------------------------------------------
+
+  const withdrawNum = parseFloat(withdrawAmount) || 0
+  const receiveAmount = Math.max(0, withdrawNum - WITHDRAW_FEE)
+
+  // ---- タブ切替 ------------------------------------------------------------
+
+  const handleTabChange = (t: Tab) => {
+    setTab(t)
+    setConfirmOpen(false)
+    setConfirmError(null)
+    setSuccessMsg(null)
+  }
+
+  // ---- 入金確認シート -------------------------------------------------------
+
+  const depositNum = parseFloat(depositAmount) || 0
+  const estimatedUsdc = depositNum > 0 ? (depositNum / JPY_PER_USDC).toFixed(2) : "0"
+
+  const depositRows = [
+    { label: "金額", value: `¥${depositNum.toLocaleString("ja-JP")}` },
+    { label: "概算 USDC", value: `≈ $${estimatedUsdc} USDC` },
+    { label: "支払い方法", value: paymentMethod === "card" ? "クレジット/デビット" : paymentMethod === "apple" ? "Apple Pay" : "Google Pay" },
+    { label: "ネットワーク", value: "Base Mainnet" },
+  ]
+
+  const handleDepositConfirm = useCallback(async () => {
+    setConfirmBusy(true)
+    setConfirmError(null)
+    try {
+      // Privy useFundWallet でオンランプ起動
+      const wallet = wallets.find((w) => w.walletClientType === "privy")
+      const address = wallet?.address ?? walletAddress ?? ""
+      if (!address) throw new Error("ウォレットアドレスが見つかりません")
+      await fundWallet({
+        address,
+        options: {
+          chain: base,
+          asset: "USDC",
+          amount: estimatedUsdc,
+        },
+      })
+      setConfirmOpen(false)
+      setSuccessMsg("入金フローを開始しました。完了後に残高が更新されます。")
+      void fetchBalance()
+    } catch (e) {
+      if (e instanceof Error && e.message.toLowerCase().includes("exit")) {
+        // ユーザーが途中でキャンセル — エラー扱いしない
+        setConfirmOpen(false)
+      } else {
+        setConfirmError(e instanceof Error ? e.message : "入金処理に失敗しました")
+      }
+    } finally {
+      setConfirmBusy(false)
+    }
+  }, [wallets, walletAddress, fundWallet, estimatedUsdc, fetchBalance])
+
+  // ---- 出金確認シート -------------------------------------------------------
+
+  const withdrawRows = [
+    { label: "出金額", value: `$${withdrawNum.toFixed(2)} USDC` },
+    { label: "ネットワーク手数料", value: `≈ $${WITHDRAW_FEE.toFixed(2)}` },
+    { label: "受取予定額", value: `$${receiveAmount.toFixed(2)} USDC` },
+    { label: "出金先", value: walletAddress ? `${walletAddress.slice(0, 6)}...${walletAddress.slice(-4)}` : "ウォレット" },
+  ]
+
+  const handleWithdrawConfirm = useCallback(async () => {
+    setConfirmBusy(true)
+    setConfirmError(null)
+    try {
+      await apiPost<{ status: string }>("/api/transactions/withdraw", {
+        amount_usdc: withdrawNum,
+      })
+      setConfirmOpen(false)
+      setSuccessMsg("出金リクエストを送信しました。反映まで少々お待ちください。")
+      setWithdrawAmount("")
+      void fetchBalance()
+    } catch (e) {
+      setConfirmError(e instanceof Error ? e.message : "出金処理に失敗しました")
+    } finally {
+      setConfirmBusy(false)
+    }
+  }, [withdrawNum, fetchBalance])
+
+  // ---- 残高ラベル（タブ依存） -----------------------------------------------
+
+  const balanceLabel = tab === "deposit" ? "現在の残高" : "出金可能残高"
+
+  // ---- レンダリング --------------------------------------------------------
+
   return (
-    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
-      <ArrowDownUp className="w-8 h-8 mb-3 text-zinc-700" />
-      <p className="text-sm">実装中</p>
+    <div className="pb-2">
+      {/* タブ */}
+      <div className="flex border-b border-zinc-800 mb-4">
+        {(["deposit", "withdraw"] as Tab[]).map((t) => (
+          <button
+            key={t}
+            onClick={() => handleTabChange(t)}
+            className={[
+              "flex-1 py-2 text-sm font-medium transition-colors",
+              tab === t
+                ? "border-b-2 border-[#1D9E75] text-[#1D9E75]"
+                : "text-zinc-400",
+            ].join(" ")}
+          >
+            {t === "deposit" ? "入金" : "出金"}
+          </button>
+        ))}
+      </div>
+
+      {/* 残高カード */}
+      <div className="bg-[#1a3d2e] rounded-xl px-4 py-4 mb-4">
+        <p className="text-xs text-zinc-400 mb-1">{balanceLabel}</p>
+        {balanceLoading ? (
+          <div className="flex items-center gap-2">
+            <Loader2 className="w-4 h-4 animate-spin text-zinc-400" />
+            <span className="text-zinc-400 text-sm">取得中...</span>
+          </div>
+        ) : (
+          <p className="text-2xl font-bold text-white">
+            {balance != null ? `$${balance.toFixed(2)}` : "---"}
+            <span className="text-sm font-normal text-zinc-400 ml-2">USDC</span>
+          </p>
+        )}
+        <p className="text-xs text-zinc-500 mt-1">USDC · Base Mainnet</p>
+      </div>
+
+      {/* 成功メッセージ */}
+      {successMsg && (
+        <div className="bg-[#1a3d2e] border border-[#1D9E75] rounded-xl px-4 py-3 mb-4 text-sm text-[#4ade9a]">
+          {successMsg}
+        </div>
+      )}
+
+      {/* ====== 入金タブ ====== */}
+      {tab === "deposit" && (
+        <div className="space-y-4">
+          {/* 金額入力 */}
+          <div>
+            <label className="block text-xs text-zinc-400 mb-1">金額を入力（円）</label>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400 text-sm">¥</span>
+              <input
+                type="number"
+                min="0"
+                placeholder="金額を入力"
+                value={depositAmount}
+                onChange={(e) => setDepositAmount(e.target.value)}
+                className="w-full bg-zinc-800 text-white text-lg pl-7 pr-4 py-3 rounded-xl
+                           border border-zinc-700 focus:border-[#1D9E75] focus:outline-none
+                           placeholder-zinc-600"
+              />
+            </div>
+            {depositNum > 0 && (
+              <p className="text-xs text-zinc-500 mt-1">
+                ≈ ${(depositNum / JPY_PER_USDC).toFixed(2)} USDC
+              </p>
+            )}
+          </div>
+
+          {/* クイックボタン */}
+          <div className="grid grid-cols-4 gap-2">
+            {[10000, 30000, 50000, 100000].map((amt) => (
+              <button
+                key={amt}
+                onClick={() => setDepositAmount(String(amt))}
+                className="bg-zinc-800 hover:bg-zinc-700 text-zinc-200 text-xs py-2 rounded-lg
+                           border border-zinc-700 transition-colors"
+              >
+                ¥{(amt / 10000).toFixed(0)}万
+              </button>
+            ))}
+          </div>
+
+          {/* 支払い方法 */}
+          <div>
+            <label className="block text-xs text-zinc-400 mb-2">支払い方法</label>
+            <div className="space-y-2">
+              {(
+                [
+                  { id: "card" as PaymentMethod, label: "クレジット/デビット" },
+                  { id: "apple" as PaymentMethod, label: "Apple Pay" },
+                  { id: "google" as PaymentMethod, label: "Google Pay" },
+                ] as { id: PaymentMethod; label: string }[]
+              ).map(({ id, label }) => (
+                <label
+                  key={id}
+                  className={[
+                    "flex items-center gap-3 px-3 py-3 rounded-xl border cursor-pointer transition-colors",
+                    paymentMethod === id
+                      ? "border-[#1D9E75] bg-[#1a3d2e]"
+                      : "border-zinc-700 bg-zinc-800",
+                  ].join(" ")}
+                >
+                  <input
+                    type="radio"
+                    name="payment"
+                    value={id}
+                    checked={paymentMethod === id}
+                    onChange={() => setPaymentMethod(id)}
+                    className="accent-[#1D9E75]"
+                  />
+                  <span className="text-sm text-zinc-200">{label}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* 入金ボタン */}
+          <button
+            disabled={!depositAmount || depositNum <= 0}
+            onClick={() => {
+              setConfirmError(null)
+              setSuccessMsg(null)
+              setConfirmOpen(true)
+            }}
+            className="w-full bg-[#1D9E75] hover:bg-[#1a8f6a]
+                       disabled:opacity-40 disabled:cursor-not-allowed
+                       text-white font-semibold py-3 rounded-xl transition-colors"
+          >
+            入金する
+          </button>
+        </div>
+      )}
+
+      {/* ====== 出金タブ ====== */}
+      {tab === "withdraw" && (
+        <div className="space-y-4">
+          {/* 金額入力 */}
+          <div>
+            <label className="block text-xs text-zinc-400 mb-1">金額を入力（USDC）</label>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400 text-sm">$</span>
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                placeholder="金額を入力"
+                value={withdrawAmount}
+                onChange={(e) => setWithdrawAmount(e.target.value)}
+                className="w-full bg-zinc-800 text-white text-lg pl-7 pr-4 py-3 rounded-xl
+                           border border-zinc-700 focus:border-[#1D9E75] focus:outline-none
+                           placeholder-zinc-600"
+              />
+            </div>
+          </div>
+
+          {/* クイックボタン */}
+          <div className="grid grid-cols-4 gap-2">
+            {[100, 500, 1000].map((amt) => (
+              <button
+                key={amt}
+                onClick={() => setWithdrawAmount(String(amt))}
+                className="bg-zinc-800 hover:bg-zinc-700 text-zinc-200 text-xs py-2 rounded-lg
+                           border border-zinc-700 transition-colors"
+              >
+                ${amt}
+              </button>
+            ))}
+            <button
+              onClick={() => setWithdrawAmount(maxWithdraw > 0 ? maxWithdraw.toFixed(2) : "")}
+              className="bg-zinc-800 hover:bg-zinc-700 text-zinc-200 text-xs py-2 rounded-lg
+                         border border-zinc-700 transition-colors"
+            >
+              全額
+            </button>
+          </div>
+
+          {/* 出金先（変更不可） */}
+          <div>
+            <label className="block text-xs text-zinc-400 mb-1">出金先</label>
+            <div className="bg-zinc-800 border border-zinc-700 rounded-xl px-4 py-3">
+              <p className="text-sm text-zinc-300 font-mono">
+                {walletAddress
+                  ? `${walletAddress.slice(0, 6)}...${walletAddress.slice(-4)}`
+                  : "自分のウォレット"}
+              </p>
+              <p className="text-xs text-zinc-500 mt-0.5">変更不可</p>
+            </div>
+          </div>
+
+          {/* 手数料・受取予定額 */}
+          <div className="bg-zinc-800 border border-zinc-700 rounded-xl px-4 py-3 space-y-2">
+            <div className="flex justify-between text-xs text-zinc-400">
+              <span>ネットワーク手数料</span>
+              <span>≈ ${WITHDRAW_FEE.toFixed(2)}</span>
+            </div>
+            <div className="flex justify-between text-sm font-semibold">
+              <span className="text-zinc-300">受取予定額</span>
+              <span className="text-white">
+                {withdrawNum > 0 ? `$${receiveAmount.toFixed(2)} USDC` : "---"}
+              </span>
+            </div>
+          </div>
+
+          {/* 警告 */}
+          <div className="flex items-start gap-2 text-yellow-400 text-xs">
+            <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
+            <p>
+              出金後の資産はAave運用から外れます。再入金まで利回りは発生しません。
+            </p>
+          </div>
+
+          {/* 出金ボタン */}
+          <button
+            disabled={!withdrawAmount || withdrawNum <= 0}
+            onClick={() => {
+              setConfirmError(null)
+              setSuccessMsg(null)
+              setConfirmOpen(true)
+            }}
+            className="w-full bg-[#1D9E75] hover:bg-[#1a8f6a]
+                       disabled:opacity-40 disabled:cursor-not-allowed
+                       text-white font-semibold py-3 rounded-xl transition-colors"
+          >
+            出金する
+          </button>
+        </div>
+      )}
+
+      {/* 確認シート */}
+      <ConfirmSheet
+        open={confirmOpen}
+        title={tab === "deposit" ? "入金内容の確認" : "出金内容の確認"}
+        rows={tab === "deposit" ? depositRows : withdrawRows}
+        onConfirm={tab === "deposit" ? handleDepositConfirm : handleWithdrawConfirm}
+        onCancel={() => setConfirmOpen(false)}
+        busy={confirmBusy}
+        error={confirmError}
+      />
     </div>
   )
 }

--- a/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Wallet } from "lucide-react"
+
+export function MyWalletPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Wallet className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/NotificationPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/NotificationPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Bell } from "lucide-react"
+
+export function NotificationPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Bell className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Settings2 } from "lucide-react"
+
+export function OpModePanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Settings2 className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Users } from "lucide-react"
+
+export function ReferralPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Users className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/TaxPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TaxPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { FileText } from "lucide-react"
+
+export function TaxPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <FileText className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/TermsPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TermsPanel.tsx
@@ -1,0 +1,29 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { ExternalLink } from "lucide-react"
+
+export function TermsPanel() {
+  return (
+    <div className="space-y-3 py-4">
+      <a
+        href="https://ultra-auto-trade.com/terms"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center justify-between w-full px-4 py-4 bg-zinc-800 rounded-xl hover:bg-zinc-700 transition-colors"
+      >
+        <span className="text-white text-sm font-medium">利用規約</span>
+        <ExternalLink className="w-4 h-4 text-zinc-400" />
+      </a>
+      <a
+        href="https://ultra-auto-trade.com/privacy"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center justify-between w-full px-4 py-4 bg-zinc-800 rounded-xl hover:bg-zinc-700 transition-colors"
+      >
+        <span className="text-white text-sm font-medium">プライバシーポリシー</span>
+        <ExternalLink className="w-4 h-4 text-zinc-400" />
+      </a>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/TxHistoryPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TxHistoryPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Clock } from "lucide-react"
+
+export function TxHistoryPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Clock className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -1,0 +1,89 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// frontend/app/(liff)/liff-chat/page.tsx
+// LIFF チャット ホーム — /liff-chat
+"use client"
+
+import { useState } from "react"
+import { Menu, User } from "lucide-react"
+import { HamburgerMenu } from "./_components/HamburgerMenu"
+import { SlideUpPanel } from "./_components/SlideUpPanel"
+import { MyWalletPanel } from "./_components/panels/MyWalletPanel"
+import { DepositPanel } from "./_components/panels/DepositPanel"
+import { ReferralPanel } from "./_components/panels/ReferralPanel"
+import { OpModePanel } from "./_components/panels/OpModePanel"
+import { TxHistoryPanel } from "./_components/panels/TxHistoryPanel"
+import { TaxPanel } from "./_components/panels/TaxPanel"
+import { NotificationPanel } from "./_components/panels/NotificationPanel"
+import { AccountPanel } from "./_components/panels/AccountPanel"
+import { TermsPanel } from "./_components/panels/TermsPanel"
+
+const PANEL_TITLES: Record<string, string> = {
+  myWallet:     "MY WALLET",
+  deposit:      "入金/出金",
+  referral:     "紹介キャンペーン",
+  opMode:       "運用モード切替",
+  txHistory:    "取引履歴",
+  tax:          "TAX & REPORTS",
+  notification: "通知設定",
+  account:      "アカウント",
+  terms:        "利用規約",
+}
+
+export default function LiffChatPage() {
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [activePanel, setActivePanel] = useState<string | null>(null)
+
+  return (
+    <div className="w-[375px] mx-auto h-dvh bg-zinc-950 text-zinc-100 flex flex-col overflow-hidden relative">
+      {/* ヘッダー */}
+      <header className="h-14 bg-[#1a3d2e] flex items-center justify-between px-4 flex-shrink-0">
+        <button
+          onClick={() => setMenuOpen(true)}
+          className="text-white hover:bg-white/10 rounded-lg p-1 transition-colors"
+          aria-label="メニューを開く"
+        >
+          <Menu className="w-6 h-6" />
+        </button>
+        <span className="text-[#4ade9a] font-bold text-xl">UAT</span>
+        <button
+          className="text-white hover:bg-white/10 rounded-lg p-1 transition-colors"
+          aria-label="アカウント"
+        >
+          <User className="w-6 h-6" />
+        </button>
+      </header>
+
+      {/* メインコンテンツ（暫定） */}
+      <main className="flex-1 flex items-center justify-center">
+        <p className="text-zinc-600 text-sm">ホーム画面は別タスクで実装</p>
+      </main>
+
+      {/* ハンバーガーメニュー */}
+      <HamburgerMenu
+        open={menuOpen}
+        onClose={() => setMenuOpen(false)}
+        onPanelOpen={(id) => setActivePanel(id)}
+      />
+
+      {/* 各パネル */}
+      {Object.keys(PANEL_TITLES).map((id) => (
+        <SlideUpPanel
+          key={id}
+          open={activePanel === id}
+          onClose={() => setActivePanel(null)}
+          title={PANEL_TITLES[id]}
+        >
+          {id === "myWallet"     && <MyWalletPanel />}
+          {id === "deposit"      && <DepositPanel />}
+          {id === "referral"     && <ReferralPanel />}
+          {id === "opMode"       && <OpModePanel />}
+          {id === "txHistory"    && <TxHistoryPanel />}
+          {id === "tax"          && <TaxPanel />}
+          {id === "notification" && <NotificationPanel />}
+          {id === "account"      && <AccountPanel />}
+          {id === "terms"        && <TermsPanel />}
+        </SlideUpPanel>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- `DepositPanel.tsx` を stub から本実装に置き換え
- 入金タブ: JPY建て金額入力 + クイックボタン (¥1万/3万/5万/10万) + 支払い方法ラジオ (クレカ/Apple Pay/Google Pay) → 確認シート → Privy `useFundWallet` 起動
- 出金タブ: USDC建て金額入力 + クイックボタン ($100/$500/$1000/全額) + 受取予定額リアルタイム計算 (入力額 - $0.08) + 出金後警告テキスト → 確認シート → POST /api/transactions/withdraw
- 共通: `GET /api/user/settings` から残高 + ウォレットアドレス取得、確認シート (実行する bg-[#1D9E75] / キャンセル border border-zinc-600)

## Test plan

- [ ] 入金タブ: 金額未入力時に「入金する」ボタンが disabled になること
- [ ] 入金タブ: クイックボタン押下で金額フィールドに入力されること
- [ ] 入金タブ: 確認シート表示 → 実行でPrivy fundWallet フローが起動すること
- [ ] 出金タブ: 金額入力中に受取予定額がリアルタイム更新されること
- [ ] 出金タブ: 全額ボタンで balance がセットされること
- [ ] 出金タブ: 確認シート → 実行で POST /api/transactions/withdraw が呼ばれること
- [ ] 残高カード: GET /api/user/settings の balance フィールドが表示されること

Asana GID: 1215359346096050

🤖 Generated with [Claude Code](https://claude.com/claude-code)