### PR TITLE
feat(liff-chat): 紹介キャンペーンパネル実装

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/HamburgerMenu.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/HamburgerMenu.tsx
@@ -1,0 +1,89 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import {
+  Wallet,
+  ArrowDownUp,
+  Users,
+  Settings2,
+  Clock,
+  FileText,
+  Bell,
+  User,
+  BookOpen,
+  ChevronRight,
+} from "lucide-react"
+
+interface HamburgerMenuProps {
+  open: boolean
+  onClose: () => void
+  onPanelOpen: (id: string) => void
+}
+
+const MENU_ITEMS = [
+  { id: "myWallet",     label: "MY WALLET",      sub: "ウォレットアドレス・QRコード",   icon: Wallet },
+  { id: "deposit",      label: "入金/出金",        sub: "USDCの入出金",                 icon: ArrowDownUp },
+  { id: "referral",     label: "紹介キャンペーン", sub: "お友達を紹介して報酬を獲得",    icon: Users },
+  { id: "opMode",       label: "運用モード切替",   sub: "おまかせ / アクティブ",         icon: Settings2 },
+  { id: "txHistory",    label: "取引履歴",         sub: "過去の取引を確認",              icon: Clock },
+  { id: "tax",          label: "TAX & REPORTS",   sub: "税務レポート・CSV出力",          icon: FileText },
+  { id: "notification", label: "通知設定",         sub: "LINE・プッシュ通知の設定",      icon: Bell },
+  { id: "account",      label: "アカウント",       sub: "プロフィール・ログアウト",       icon: User },
+  { id: "terms",        label: "利用規約",         sub: "利用規約・プライバシーポリシー", icon: BookOpen },
+]
+
+export function HamburgerMenu({ open, onClose, onPanelOpen }: HamburgerMenuProps) {
+  return (
+    <>
+      {/* バックドロップ */}
+      {open && (
+        <div
+          className="fixed inset-0 z-40 bg-black/60"
+          onClick={onClose}
+        />
+      )}
+
+      {/* サイドパネル本体 */}
+      <div
+        className={`fixed top-0 left-0 h-full z-50 w-72 bg-[#1a3d2e] flex flex-col
+                    transform transition-transform duration-300 ease-in-out
+                    ${open ? "translate-x-0" : "-translate-x-full"}`}
+      >
+        {/* ヘッダー */}
+        <div className="flex items-center justify-between px-4 py-4 border-b border-white/10">
+          <span className="text-[#4ade9a] font-bold text-lg">UAT</span>
+          <button
+            onClick={onClose}
+            className="text-white text-xl leading-none w-8 h-8 flex items-center justify-center hover:bg-white/10 rounded-full transition-colors"
+            aria-label="メニューを閉じる"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* メニュー項目 */}
+        <div className="flex-1 overflow-y-auto">
+          {MENU_ITEMS.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => { onPanelOpen(item.id); onClose() }}
+              className="flex items-center w-full px-4 py-4 border-b border-white/10 hover:bg-white/5 active:bg-white/10 transition-colors"
+            >
+              <item.icon className="w-5 h-5 text-[#4ade9a] mr-3 flex-shrink-0" />
+              <div className="flex-1 text-left">
+                <div className="text-white font-medium text-sm">{item.label}</div>
+                <div className="text-zinc-400 text-xs mt-0.5">{item.sub}</div>
+              </div>
+              <ChevronRight className="w-4 h-4 text-zinc-600 flex-shrink-0" />
+            </button>
+          ))}
+        </div>
+
+        {/* フッター */}
+        <div className="mt-auto px-4 py-4">
+          <p className="text-zinc-600 text-xs text-center">UAT App v1.0 | © 2026 UAT Co., Ltd.</p>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/SlideUpPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/SlideUpPanel.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { ChevronLeft } from "lucide-react"
+
+interface SlideUpPanelProps {
+  open: boolean
+  onClose: () => void
+  title: string
+  children: React.ReactNode
+  maxHeight?: string
+}
+
+export function SlideUpPanel({
+  open,
+  onClose,
+  title,
+  children,
+  maxHeight = "90vh",
+}: SlideUpPanelProps) {
+  if (!open) return null
+  return (
+    <>
+      {/* バックドロップ */}
+      <div className="fixed inset-0 z-40 bg-black/60" onClick={onClose} />
+      {/* パネル本体 */}
+      <div
+        style={{ maxHeight }}
+        className="fixed bottom-0 left-0 right-0 z-50
+                   bg-zinc-900 rounded-t-2xl border-t border-zinc-800
+                   overflow-y-auto
+                   animate-in slide-in-from-bottom duration-300"
+      >
+        {/* ドラッグハンドル + ヘッダー */}
+        <div className="sticky top-0 bg-zinc-900 pt-3 pb-0 px-4">
+          <div className="mx-auto mb-3 h-1 w-8 rounded-full bg-zinc-700" />
+          {/* パネルヘッダー */}
+          <div className="flex items-center bg-[#1a3d2e] -mx-4 px-4 py-3 mb-4">
+            <button onClick={onClose} className="text-white mr-2">
+              <ChevronLeft className="w-5 h-5" />
+            </button>
+            <h2 className="text-white font-semibold text-base">{title}</h2>
+          </div>
+        </div>
+        <div className="px-4 pb-8">{children}</div>
+      </div>
+    </>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { User } from "lucide-react"
+
+export function AccountPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <User className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { ArrowDownUp } from "lucide-react"
+
+export function DepositPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <ArrowDownUp className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Wallet } from "lucide-react"
+
+export function MyWalletPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Wallet className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/NotificationPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/NotificationPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Bell } from "lucide-react"
+
+export function NotificationPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Bell className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Settings2 } from "lucide-react"
+
+export function OpModePanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Settings2 className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Users } from "lucide-react"
+
+export function ReferralPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Users className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
@@ -1,13 +1,385 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 "use client"
 
-import { Users } from "lucide-react"
+import { useEffect, useState, useCallback } from "react"
+import { Copy, Mail, Share2, CheckCircle, Users, Gift, TrendingUp, ChevronRight } from "lucide-react"
+import { getReferralInfo, createReferralCode, type ReferralInfo } from "@/lib/api/referral"
+
+const API_BASE = process.env.NEXT_PUBLIC_BACKEND_BASE_URL ?? ""
+const SIGNUP_URL = process.env.NEXT_PUBLIC_LIFF_APP_URL ?? "https://ultra-auto-trade.com/register"
+
+function getToken(): string {
+  return typeof window !== "undefined" ? (localStorage.getItem("ultra_auth_token") ?? "") : ""
+}
+
+function buildShareText(code: string): string {
+  return `【UATaのご紹介】\nAIが自動で資産運用してくれるサービスです。\n紹介コード「${code}」を使って登録すると特典があります。\n▼ アカウント開設はこちら\n${SIGNUP_URL}?ref=${code}`
+}
+
+/** フォールバック用のスケルトンデータ（ローディング中 or エラー時） */
+const EMPTY_INFO: ReferralInfo = {
+  referral_count: 0,
+  current_month_reward_jpy: "0",
+  total_payout_jpy: "0",
+  campaign_rate: "30",
+  referral_code: "",
+  referred_users: [],
+}
 
 export function ReferralPanel() {
+  const [info, setInfo] = useState<ReferralInfo | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [toast, setToast] = useState<string | null>(null)
+  const [creatingCode, setCreatingCode] = useState(false)
+
+  const showToast = useCallback((msg: string) => {
+    setToast(msg)
+    setTimeout(() => setToast(null), 2500)
+  }, [])
+
+  useEffect(() => {
+    const token = getToken()
+    setLoading(true)
+    getReferralInfo(token)
+      .then((data) => {
+        setInfo(data)
+        setError(null)
+      })
+      .catch(() => {
+        setError("データを取得できませんでした")
+        setInfo(EMPTY_INFO)
+      })
+      .finally(() => setLoading(false))
+  }, [])
+
+  const handleCreateCode = useCallback(async () => {
+    const token = getToken()
+    setCreatingCode(true)
+    try {
+      const res = await createReferralCode(token)
+      setInfo((prev) =>
+        prev ? { ...prev, referral_code: res.referral_code } : null
+      )
+      showToast("紹介コードを発行しました")
+    } catch {
+      showToast("コードの発行に失敗しました")
+    } finally {
+      setCreatingCode(false)
+    }
+  }, [showToast])
+
+  const handleCopyCode = useCallback(async () => {
+    const code = info?.referral_code
+    if (!code) return
+    try {
+      await navigator.clipboard.writeText(code)
+      showToast("コードをコピーしました")
+    } catch {
+      showToast("コピーに失敗しました")
+    }
+  }, [info?.referral_code, showToast])
+
+  const handleCopyLink = useCallback(async () => {
+    const code = info?.referral_code
+    if (!code) return
+    const url = `${SIGNUP_URL}?ref=${code}`
+    try {
+      await navigator.clipboard.writeText(url)
+      showToast("リンクをコピーしました")
+    } catch {
+      showToast("コピーに失敗しました")
+    }
+  }, [info?.referral_code, showToast])
+
+  const handleLineShare = useCallback(async () => {
+    const code = info?.referral_code
+    if (!code) return
+    const shareText = buildShareText(code)
+    try {
+      const { getLiff } = await import("@/lib/liff/init")
+      const liff = await getLiff()
+      if (liff.isApiAvailable("shareTargetPicker")) {
+        await liff.shareTargetPicker([{ type: "text", text: shareText }])
+      } else {
+        await navigator.clipboard.writeText(shareText)
+        showToast("LINEシェア非対応環境 — テキストをコピーしました")
+      }
+    } catch {
+      showToast("シェアに失敗しました")
+    }
+  }, [info?.referral_code, showToast])
+
+  const handleMailShare = useCallback(() => {
+    const code = info?.referral_code
+    if (!code) return
+    const subject = encodeURIComponent("【UATaのご紹介】AI自動資産運用サービス")
+    const body = encodeURIComponent(buildShareText(code))
+    window.location.href = `mailto:?subject=${subject}&body=${body}`
+  }, [info?.referral_code])
+
+  const displayInfo = info ?? EMPTY_INFO
+
+  const totalReward = Number(displayInfo.total_payout_jpy).toLocaleString("ja-JP")
+  const monthlyReward = Number(displayInfo.current_month_reward_jpy).toLocaleString("ja-JP")
+
+  const operatingCount = displayInfo.referred_users.filter(
+    (u) => u.status === "運用中"
+  ).length
+
   return (
-    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
-      <Users className="w-8 h-8 mb-3 text-zinc-700" />
-      <p className="text-sm">実装中</p>
+    <div className="space-y-4 pb-4">
+      {/* トースト */}
+      {toast && (
+        <div className="fixed top-16 left-1/2 -translate-x-1/2 z-[60]
+                        flex items-center gap-2 bg-zinc-800 border border-zinc-700
+                        text-zinc-100 text-sm px-4 py-2 rounded-xl shadow-lg
+                        animate-in fade-in duration-200">
+          <CheckCircle className="w-4 h-4 text-[#4ade9a]" />
+          {toast}
+        </div>
+      )}
+
+      {/* エラーバナー */}
+      {error && (
+        <div className="text-xs text-amber-400 bg-amber-400/10 border border-amber-400/30
+                        rounded-xl px-3 py-2">
+          {error}（オフライン表示中）
+        </div>
+      )}
+
+      {/* 報酬サマリーカード */}
+      <div className="bg-[#1a3d2e] rounded-2xl p-5">
+        {loading ? (
+          <div className="h-20 flex items-center justify-center">
+            <div className="w-6 h-6 border-2 border-[#4ade9a] border-t-transparent rounded-full animate-spin" />
+          </div>
+        ) : (
+          <>
+            <p className="text-zinc-400 text-xs mb-1">合計報酬</p>
+            <p className="text-[#4ade9a] text-3xl font-bold mb-1">
+              ¥{totalReward}
+            </p>
+            <p className="text-zinc-400 text-xs mb-5">
+              {displayInfo.referral_count}名の紹介から獲得
+            </p>
+
+            {/* 統計 3つ */}
+            <div className="grid grid-cols-3 gap-2 pt-4 border-t border-white/10">
+              <StatCard
+                icon={<Users className="w-4 h-4" />}
+                label="紹介人数"
+                value={`${displayInfo.referral_count}名`}
+              />
+              <StatCard
+                icon={<TrendingUp className="w-4 h-4" />}
+                label="運用開始済み"
+                value={`${operatingCount}名`}
+              />
+              <StatCard
+                icon={<Gift className="w-4 h-4" />}
+                label="今月の報酬"
+                value={`¥${monthlyReward}`}
+              />
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* 紹介コード */}
+      <div className="space-y-2">
+        <p className="text-zinc-400 text-xs font-medium px-1">紹介コード</p>
+        {displayInfo.referral_code ? (
+          <div className="flex items-center gap-2">
+            <div className="flex-1 bg-zinc-800 rounded-xl px-4 py-3 flex items-center">
+              <span className="text-white font-mono text-2xl tracking-widest">
+                {displayInfo.referral_code}
+              </span>
+            </div>
+            <button
+              onClick={handleCopyCode}
+              className="flex items-center gap-1.5 bg-[#1D9E75] hover:bg-[#17855f]
+                         text-white text-sm font-semibold px-4 py-3 rounded-xl
+                         transition-colors whitespace-nowrap"
+            >
+              <Copy className="w-4 h-4" />
+              コピー
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={handleCreateCode}
+            disabled={creatingCode || loading}
+            className="w-full bg-[#1D9E75] hover:bg-[#17855f] disabled:opacity-50
+                       text-white text-sm font-semibold py-3 rounded-xl
+                       transition-colors"
+          >
+            {creatingCode ? "発行中..." : "紹介コードを発行する"}
+          </button>
+        )}
+      </div>
+
+      {/* シェアボタン */}
+      {displayInfo.referral_code && (
+        <div className="space-y-2">
+          <p className="text-zinc-400 text-xs font-medium px-1">友達に送る</p>
+          <div className="space-y-2">
+            <button
+              onClick={handleLineShare}
+              className="w-full flex items-center gap-3 bg-[#06C755] hover:bg-[#05a848]
+                         text-white font-semibold py-3 px-4 rounded-xl
+                         transition-colors"
+            >
+              <Share2 className="w-5 h-5" />
+              <span className="flex-1 text-left">LINEで送る</span>
+              <ChevronRight className="w-4 h-4 opacity-60" />
+            </button>
+
+            <button
+              onClick={handleMailShare}
+              className="w-full flex items-center gap-3 bg-blue-600 hover:bg-blue-500
+                         text-white font-semibold py-3 px-4 rounded-xl
+                         transition-colors"
+            >
+              <Mail className="w-5 h-5" />
+              <span className="flex-1 text-left">メールで送る</span>
+              <ChevronRight className="w-4 h-4 opacity-60" />
+            </button>
+
+            <button
+              onClick={handleCopyLink}
+              className="w-full flex items-center gap-3 bg-zinc-700 hover:bg-zinc-600
+                         text-white font-semibold py-3 px-4 rounded-xl
+                         transition-colors"
+            >
+              <Copy className="w-5 h-5" />
+              <span className="flex-1 text-left">リンクをコピー</span>
+              <ChevronRight className="w-4 h-4 opacity-60" />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* 報酬の仕組み */}
+      <div className="space-y-2">
+        <p className="text-zinc-400 text-xs font-medium px-1">報酬の仕組み</p>
+        <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-4 space-y-4">
+          <HowItWorksStep
+            step={1}
+            text="友達に紹介コードを送る"
+          />
+          <HowItWorksStep
+            step={2}
+            text="友達が登録・運用開始"
+            reward="¥1,500 もらえる"
+          />
+          <HowItWorksStep
+            step={3}
+            text="毎月サブスク料の 30% が加算"
+          />
+        </div>
+      </div>
+
+      {/* 紹介した友達リスト */}
+      {displayInfo.referred_users.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-zinc-400 text-xs font-medium px-1">紹介した友達</p>
+          <div className="space-y-2">
+            {displayInfo.referred_users.map((user, i) => (
+              <ReferredUserRow key={i} user={user} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {!loading && displayInfo.referred_users.length === 0 && displayInfo.referral_code && (
+        <div className="text-center py-8 text-zinc-600 text-sm">
+          まだ紹介した友達がいません。<br />
+          コードを友達に送ってみましょう！
+        </div>
+      )}
+    </div>
+  )
+}
+
+function StatCard({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: string
+}) {
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <div className="text-[#4ade9a]">{icon}</div>
+      <p className="text-white font-semibold text-sm">{value}</p>
+      <p className="text-zinc-500 text-[10px]">{label}</p>
+    </div>
+  )
+}
+
+function HowItWorksStep({
+  step,
+  text,
+  reward,
+}: {
+  step: number
+  text: string
+  reward?: string
+}) {
+  return (
+    <div className="flex items-start gap-3">
+      <div className="w-6 h-6 rounded-full bg-[#1a3d2e] border border-[#1D9E75]
+                      flex items-center justify-center flex-shrink-0 mt-0.5">
+        <span className="text-[#4ade9a] text-xs font-bold">{step}</span>
+      </div>
+      <div className="flex-1">
+        <p className="text-white text-sm">{text}</p>
+        {reward && (
+          <p className="text-[#4ade9a] text-xs font-semibold mt-0.5">
+            → {reward}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ReferredUserRow({ user }: { user: { name: string; joined_at: string; status: string; reward_jpy: string } }) {
+  const isActive = user.status === "運用中"
+  const initial = user.name ? user.name.charAt(0).toUpperCase() : "?"
+  const joinedDate = user.joined_at ? user.joined_at.slice(0, 10) : ""
+  const rewardJpy = Number(user.reward_jpy).toLocaleString("ja-JP")
+
+  return (
+    <div className="flex items-center gap-3 bg-zinc-900 border border-zinc-800 rounded-xl px-4 py-3">
+      {/* アバター */}
+      <div className="w-9 h-9 rounded-full bg-[#1a3d2e] border border-[#1D9E75]
+                      flex items-center justify-center flex-shrink-0">
+        <span className="text-[#4ade9a] text-sm font-bold">{initial}</span>
+      </div>
+
+      {/* 名前・日付 */}
+      <div className="flex-1 min-w-0">
+        <p className="text-white text-sm font-medium truncate">{user.name}</p>
+        <p className="text-zinc-500 text-xs mt-0.5">登録日: {joinedDate}</p>
+      </div>
+
+      {/* ステータス・報酬 */}
+      <div className="flex flex-col items-end gap-1">
+        <span
+          className={`text-xs border rounded-full px-2 py-0.5 ${
+            isActive
+              ? "text-[#4ade9a] border-[#1D9E75]"
+              : "text-zinc-400 border-zinc-700"
+          }`}
+        >
+          {user.status}
+        </span>
+        <span className="text-zinc-300 text-xs">¥{rewardJpy}</span>
+      </div>
     </div>
   )
 }

--- a/frontend/app/(liff)/liff-chat/_components/panels/TaxPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TaxPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { FileText } from "lucide-react"
+
+export function TaxPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <FileText className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/TermsPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TermsPanel.tsx
@@ -1,0 +1,29 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { ExternalLink } from "lucide-react"
+
+export function TermsPanel() {
+  return (
+    <div className="space-y-3 py-4">
+      <a
+        href="https://ultra-auto-trade.com/terms"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center justify-between w-full px-4 py-4 bg-zinc-800 rounded-xl hover:bg-zinc-700 transition-colors"
+      >
+        <span className="text-white text-sm font-medium">利用規約</span>
+        <ExternalLink className="w-4 h-4 text-zinc-400" />
+      </a>
+      <a
+        href="https://ultra-auto-trade.com/privacy"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center justify-between w-full px-4 py-4 bg-zinc-800 rounded-xl hover:bg-zinc-700 transition-colors"
+      >
+        <span className="text-white text-sm font-medium">プライバシーポリシー</span>
+        <ExternalLink className="w-4 h-4 text-zinc-400" />
+      </a>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/TxHistoryPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TxHistoryPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Clock } from "lucide-react"
+
+export function TxHistoryPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Clock className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -1,0 +1,89 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// frontend/app/(liff)/liff-chat/page.tsx
+// LIFF チャット ホーム — /liff-chat
+"use client"
+
+import { useState } from "react"
+import { Menu, User } from "lucide-react"
+import { HamburgerMenu } from "./_components/HamburgerMenu"
+import { SlideUpPanel } from "./_components/SlideUpPanel"
+import { MyWalletPanel } from "./_components/panels/MyWalletPanel"
+import { DepositPanel } from "./_components/panels/DepositPanel"
+import { ReferralPanel } from "./_components/panels/ReferralPanel"
+import { OpModePanel } from "./_components/panels/OpModePanel"
+import { TxHistoryPanel } from "./_components/panels/TxHistoryPanel"
+import { TaxPanel } from "./_components/panels/TaxPanel"
+import { NotificationPanel } from "./_components/panels/NotificationPanel"
+import { AccountPanel } from "./_components/panels/AccountPanel"
+import { TermsPanel } from "./_components/panels/TermsPanel"
+
+const PANEL_TITLES: Record<string, string> = {
+  myWallet:     "MY WALLET",
+  deposit:      "入金/出金",
+  referral:     "紹介キャンペーン",
+  opMode:       "運用モード切替",
+  txHistory:    "取引履歴",
+  tax:          "TAX & REPORTS",
+  notification: "通知設定",
+  account:      "アカウント",
+  terms:        "利用規約",
+}
+
+export default function LiffChatPage() {
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [activePanel, setActivePanel] = useState<string | null>(null)
+
+  return (
+    <div className="w-[375px] mx-auto h-dvh bg-zinc-950 text-zinc-100 flex flex-col overflow-hidden relative">
+      {/* ヘッダー */}
+      <header className="h-14 bg-[#1a3d2e] flex items-center justify-between px-4 flex-shrink-0">
+        <button
+          onClick={() => setMenuOpen(true)}
+          className="text-white hover:bg-white/10 rounded-lg p-1 transition-colors"
+          aria-label="メニューを開く"
+        >
+          <Menu className="w-6 h-6" />
+        </button>
+        <span className="text-[#4ade9a] font-bold text-xl">UAT</span>
+        <button
+          className="text-white hover:bg-white/10 rounded-lg p-1 transition-colors"
+          aria-label="アカウント"
+        >
+          <User className="w-6 h-6" />
+        </button>
+      </header>
+
+      {/* メインコンテンツ（暫定） */}
+      <main className="flex-1 flex items-center justify-center">
+        <p className="text-zinc-600 text-sm">ホーム画面は別タスクで実装</p>
+      </main>
+
+      {/* ハンバーガーメニュー */}
+      <HamburgerMenu
+        open={menuOpen}
+        onClose={() => setMenuOpen(false)}
+        onPanelOpen={(id) => setActivePanel(id)}
+      />
+
+      {/* 各パネル */}
+      {Object.keys(PANEL_TITLES).map((id) => (
+        <SlideUpPanel
+          key={id}
+          open={activePanel === id}
+          onClose={() => setActivePanel(null)}
+          title={PANEL_TITLES[id]}
+        >
+          {id === "myWallet"     && <MyWalletPanel />}
+          {id === "deposit"      && <DepositPanel />}
+          {id === "referral"     && <ReferralPanel />}
+          {id === "opMode"       && <OpModePanel />}
+          {id === "txHistory"    && <TxHistoryPanel />}
+          {id === "tax"          && <TaxPanel />}
+          {id === "notification" && <NotificationPanel />}
+          {id === "account"      && <AccountPanel />}
+          {id === "terms"        && <TermsPanel />}
+        </SlideUpPanel>
+      ))}
+    </div>
+  )
+}

--- a/frontend/lib/api/referral.ts
+++ b/frontend/lib/api/referral.ts
@@ -28,6 +28,35 @@ export interface ReferralEarnings {
   campaign_expires_month: string | null
 }
 
+/** LIFF チャット 紹介パネル用 */
+export interface ReferredUserDetail {
+  name: string
+  joined_at: string
+  status: string
+  reward_jpy: string
+}
+
+export interface ReferralInfo {
+  referral_count: number
+  current_month_reward_jpy: string
+  total_payout_jpy: string
+  campaign_rate: string
+  referral_code: string
+  referred_users: ReferredUserDetail[]
+}
+
+export async function getReferralInfo(token: string): Promise<ReferralInfo> {
+  return getJson<ReferralInfo>('/api/referral/earnings', {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
+export async function createReferralCode(token: string): Promise<ReferralCodeResponse> {
+  return postJson<ReferralCodeResponse>('/api/referral/code', {}, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
 export interface RegisterWithReferralPayload {
   email: string
   password: string


### PR DESCRIPTION
## Summary

- `ReferralPanel.tsx` を実装に置き換え（スケルトン → 完全実装）
- 報酬サマリーカード（合計報酬 / 統計 3 項目：紹介人数・運用開始済み・今月の報酬）
- 紹介コード表示（mono フォント）＋コピーボタン
- シェア 3 ボタン: LINE shareTargetPicker / メール (mailto) / リンクコピー（クリップボード）
- 報酬の仕組み 3 ステップ説明
- 紹介した友達リスト（アバター・ステータスバッジ・報酬額）
- `referral.ts` に `ReferralInfo` / `ReferredUserDetail` インターフェースと `getReferralInfo` / `createReferralCode` 関数を追加（既存関数・型は保持）
- API エラー時はオフライン表示でフォールバック（fail-open 設計）

## Asana

GID: 1215359468868668

## Test plan

- [ ] ハンバーガーメニュー → 「紹介キャンペーン」タップ → パネルが開く
- [ ] loading 中スピナー表示 → データ取得後カード / コード表示
- [ ] 紹介コードがない場合は「発行する」ボタン → POST して表示
- [ ] コードコピーボタン → トーストが表示され 2.5 秒で消える
- [ ] LINE シェアボタン → liff.shareTargetPicker 呼び出し（LIFF 環境外はクリップボード fallback）
- [ ] メールボタン → mailto: が開く
- [ ] リンクコピー → `${SIGNUP_URL}?ref={CODE}` がクリップボードに入る
- [ ] referred_users が空の場合「まだ紹介した友達がいません」が表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)