### PR TITLE
feat(liff-chat): 取引履歴パネル実装

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/HamburgerMenu.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/HamburgerMenu.tsx
@@ -1,0 +1,89 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import {
+  Wallet,
+  ArrowDownUp,
+  Users,
+  Settings2,
+  Clock,
+  FileText,
+  Bell,
+  User,
+  BookOpen,
+  ChevronRight,
+} from "lucide-react"
+
+interface HamburgerMenuProps {
+  open: boolean
+  onClose: () => void
+  onPanelOpen: (id: string) => void
+}
+
+const MENU_ITEMS = [
+  { id: "myWallet",     label: "MY WALLET",      sub: "ウォレットアドレス・QRコード",   icon: Wallet },
+  { id: "deposit",      label: "入金/出金",        sub: "USDCの入出金",                 icon: ArrowDownUp },
+  { id: "referral",     label: "紹介キャンペーン", sub: "お友達を紹介して報酬を獲得",    icon: Users },
+  { id: "opMode",       label: "運用モード切替",   sub: "おまかせ / アクティブ",         icon: Settings2 },
+  { id: "txHistory",    label: "取引履歴",         sub: "過去の取引を確認",              icon: Clock },
+  { id: "tax",          label: "TAX & REPORTS",   sub: "税務レポート・CSV出力",          icon: FileText },
+  { id: "notification", label: "通知設定",         sub: "LINE・プッシュ通知の設定",      icon: Bell },
+  { id: "account",      label: "アカウント",       sub: "プロフィール・ログアウト",       icon: User },
+  { id: "terms",        label: "利用規約",         sub: "利用規約・プライバシーポリシー", icon: BookOpen },
+]
+
+export function HamburgerMenu({ open, onClose, onPanelOpen }: HamburgerMenuProps) {
+  return (
+    <>
+      {/* バックドロップ */}
+      {open && (
+        <div
+          className="fixed inset-0 z-40 bg-black/60"
+          onClick={onClose}
+        />
+      )}
+
+      {/* サイドパネル本体 */}
+      <div
+        className={`fixed top-0 left-0 h-full z-50 w-72 bg-[#1a3d2e] flex flex-col
+                    transform transition-transform duration-300 ease-in-out
+                    ${open ? "translate-x-0" : "-translate-x-full"}`}
+      >
+        {/* ヘッダー */}
+        <div className="flex items-center justify-between px-4 py-4 border-b border-white/10">
+          <span className="text-[#4ade9a] font-bold text-lg">UAT</span>
+          <button
+            onClick={onClose}
+            className="text-white text-xl leading-none w-8 h-8 flex items-center justify-center hover:bg-white/10 rounded-full transition-colors"
+            aria-label="メニューを閉じる"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* メニュー項目 */}
+        <div className="flex-1 overflow-y-auto">
+          {MENU_ITEMS.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => { onPanelOpen(item.id); onClose() }}
+              className="flex items-center w-full px-4 py-4 border-b border-white/10 hover:bg-white/5 active:bg-white/10 transition-colors"
+            >
+              <item.icon className="w-5 h-5 text-[#4ade9a] mr-3 flex-shrink-0" />
+              <div className="flex-1 text-left">
+                <div className="text-white font-medium text-sm">{item.label}</div>
+                <div className="text-zinc-400 text-xs mt-0.5">{item.sub}</div>
+              </div>
+              <ChevronRight className="w-4 h-4 text-zinc-600 flex-shrink-0" />
+            </button>
+          ))}
+        </div>
+
+        {/* フッター */}
+        <div className="mt-auto px-4 py-4">
+          <p className="text-zinc-600 text-xs text-center">UAT App v1.0 | © 2026 UAT Co., Ltd.</p>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/SlideUpPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/SlideUpPanel.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { ChevronLeft } from "lucide-react"
+
+interface SlideUpPanelProps {
+  open: boolean
+  onClose: () => void
+  title: string
+  children: React.ReactNode
+  maxHeight?: string
+}
+
+export function SlideUpPanel({
+  open,
+  onClose,
+  title,
+  children,
+  maxHeight = "90vh",
+}: SlideUpPanelProps) {
+  if (!open) return null
+  return (
+    <>
+      {/* バックドロップ */}
+      <div className="fixed inset-0 z-40 bg-black/60" onClick={onClose} />
+      {/* パネル本体 */}
+      <div
+        style={{ maxHeight }}
+        className="fixed bottom-0 left-0 right-0 z-50
+                   bg-zinc-900 rounded-t-2xl border-t border-zinc-800
+                   overflow-y-auto
+                   animate-in slide-in-from-bottom duration-300"
+      >
+        {/* ドラッグハンドル + ヘッダー */}
+        <div className="sticky top-0 bg-zinc-900 pt-3 pb-0 px-4">
+          <div className="mx-auto mb-3 h-1 w-8 rounded-full bg-zinc-700" />
+          {/* パネルヘッダー */}
+          <div className="flex items-center bg-[#1a3d2e] -mx-4 px-4 py-3 mb-4">
+            <button onClick={onClose} className="text-white mr-2">
+              <ChevronLeft className="w-5 h-5" />
+            </button>
+            <h2 className="text-white font-semibold text-base">{title}</h2>
+          </div>
+        </div>
+        <div className="px-4 pb-8">{children}</div>
+      </div>
+    </>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { User } from "lucide-react"
+
+export function AccountPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <User className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { ArrowDownUp } from "lucide-react"
+
+export function DepositPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <ArrowDownUp className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Wallet } from "lucide-react"
+
+export function MyWalletPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Wallet className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/NotificationPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/NotificationPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Bell } from "lucide-react"
+
+export function NotificationPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Bell className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Settings2 } from "lucide-react"
+
+export function OpModePanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Settings2 className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Users } from "lucide-react"
+
+export function ReferralPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Users className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/TaxPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TaxPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { FileText } from "lucide-react"
+
+export function TaxPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <FileText className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/TermsPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TermsPanel.tsx
@@ -1,0 +1,29 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { ExternalLink } from "lucide-react"
+
+export function TermsPanel() {
+  return (
+    <div className="space-y-3 py-4">
+      <a
+        href="https://ultra-auto-trade.com/terms"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center justify-between w-full px-4 py-4 bg-zinc-800 rounded-xl hover:bg-zinc-700 transition-colors"
+      >
+        <span className="text-white text-sm font-medium">利用規約</span>
+        <ExternalLink className="w-4 h-4 text-zinc-400" />
+      </a>
+      <a
+        href="https://ultra-auto-trade.com/privacy"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center justify-between w-full px-4 py-4 bg-zinc-800 rounded-xl hover:bg-zinc-700 transition-colors"
+      >
+        <span className="text-white text-sm font-medium">プライバシーポリシー</span>
+        <ExternalLink className="w-4 h-4 text-zinc-400" />
+      </a>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/TxHistoryPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TxHistoryPanel.tsx
@@ -1,13 +1,354 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 "use client"
 
-import { Clock } from "lucide-react"
+import { useEffect, useState } from "react"
+import { ArrowDown, ArrowUp, ChevronLeft, Download, ExternalLink, Loader2 } from "lucide-react"
 
-export function TxHistoryPanel() {
+const API_BASE = process.env.NEXT_PUBLIC_BACKEND_BASE_URL ?? ""
+
+interface Transaction {
+  id: number
+  operation: "SUPPLY" | "WITHDRAW"
+  asset: string
+  amount_usd: string
+  tx_hash: string | null
+  status: string
+  created_at: string
+  protocol?: string
+  apy?: string
+  gas_fee_usd?: string
+  wallet_address?: string
+}
+
+interface CoinSummary {
+  asset: string
+  total_supply: string
+  total_withdraw: string
+}
+
+type FilterType = "all" | "SUPPLY" | "WITHDRAW" | "USDC" | "ETH"
+
+function getToken(): string {
+  if (typeof window === "undefined") return ""
+  return localStorage.getItem("auth_token") ?? ""
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  return d.toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+}
+
+function formatMonthHeader(iso: string): string {
+  const d = new Date(iso)
+  return d.toLocaleDateString("ja-JP", { year: "numeric", month: "long" })
+}
+
+function formatAmountUsd(amountUsd: string, operation: "SUPPLY" | "WITHDRAW"): string {
+  const num = Number(amountUsd)
+  const sign = operation === "SUPPLY" ? "+" : "-"
+  return `${sign}$${num.toFixed(2)}`
+}
+
+function buildCoinSummaries(txs: Transaction[]): CoinSummary[] {
+  const map = new Map<string, { supply: number; withdraw: number }>()
+  for (const tx of txs) {
+    const key = tx.asset
+    const existing = map.get(key) ?? { supply: 0, withdraw: 0 }
+    const amt = Number(tx.amount_usd)
+    if (tx.operation === "SUPPLY") {
+      existing.supply += amt
+    } else {
+      existing.withdraw += amt
+    }
+    map.set(key, existing)
+  }
+  return Array.from(map.entries()).map(([asset, { supply, withdraw }]) => ({
+    asset,
+    total_supply: supply.toFixed(2),
+    total_withdraw: withdraw.toFixed(2),
+  }))
+}
+
+function groupByMonth(txs: Transaction[]): Array<{ month: string; items: Transaction[] }> {
+  const groups = new Map<string, Transaction[]>()
+  for (const tx of txs) {
+    const key = formatMonthHeader(tx.created_at)
+    const arr = groups.get(key) ?? []
+    arr.push(tx)
+    groups.set(key, arr)
+  }
+  return Array.from(groups.entries()).map(([month, items]) => ({ month, items }))
+}
+
+function statusLabel(status: string): string {
+  if (status === "executed" || status === "completed") return "実行済み"
+  if (status === "pending") return "保留中"
+  if (status === "failed") return "失敗"
+  return status
+}
+
+// --- Detail Panel ---
+interface TxDetailPanelProps {
+  tx: Transaction
+  onClose: () => void
+}
+
+function TxDetailPanel({ tx, onClose }: TxDetailPanelProps) {
+  const isSupply = tx.operation === "SUPPLY"
+  const amountDisplay = formatAmountUsd(tx.amount_usd, tx.operation)
+
+  const detailRows: Array<{ label: string; value: string }> = [
+    { label: "操作", value: isSupply ? "SUPPLY (入金)" : "WITHDRAW (出金)" },
+    { label: "アセット", value: tx.asset },
+    { label: "日時", value: formatDate(tx.created_at) },
+    { label: "ステータス", value: statusLabel(tx.status) },
+  ]
+  if (tx.protocol) detailRows.push({ label: "プロトコル", value: tx.protocol })
+  if (tx.apy) detailRows.push({ label: "APY", value: `${tx.apy}%` })
+  if (tx.gas_fee_usd) detailRows.push({ label: "ガス代", value: `$${Number(tx.gas_fee_usd).toFixed(4)}` })
+  if (tx.wallet_address) detailRows.push({ label: "ウォレット", value: `${tx.wallet_address.slice(0, 6)}...${tx.wallet_address.slice(-4)}` })
+  if (tx.tx_hash) detailRows.push({ label: "Tx Hash", value: `${tx.tx_hash.slice(0, 8)}...${tx.tx_hash.slice(-6)}` })
+
   return (
-    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
-      <Clock className="w-8 h-8 mb-3 text-zinc-700" />
-      <p className="text-sm">実装中</p>
+    <div className="fixed inset-0 z-[60] bg-zinc-900 flex flex-col animate-in slide-in-from-right duration-200 w-[375px] mx-auto">
+      {/* ヘッダー */}
+      <div className="flex items-center bg-[#1a3d2e] px-4 py-3 flex-shrink-0">
+        <button onClick={onClose} className="text-white mr-2">
+          <ChevronLeft className="w-5 h-5" />
+        </button>
+        <h2 className="text-white font-semibold text-base">取引詳細</h2>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-4 pb-8">
+        {/* 金額カード */}
+        <div className="bg-[#1a3d2e] rounded-2xl p-4 mt-4 mb-6">
+          <div className={`text-3xl font-bold ${isSupply ? "text-[#4ade9a]" : "text-orange-400"}`}>
+            {amountDisplay}
+          </div>
+          <div className="text-zinc-300 text-sm mt-1">
+            {tx.operation} · {tx.asset}
+          </div>
+        </div>
+
+        {/* 詳細行 */}
+        <div className="space-y-0">
+          {detailRows.map((row) => (
+            <div key={row.label} className="flex justify-between items-start py-3 border-b border-zinc-800">
+              <span className="text-zinc-500 text-sm">{row.label}</span>
+              <span className="text-zinc-100 text-sm text-right max-w-[60%] break-all">{row.value}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* Basescan リンク */}
+        {tx.tx_hash && (
+          <a
+            href={`https://basescan.org/tx/${tx.tx_hash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-6 flex items-center justify-center gap-2 w-full py-3 rounded-xl border border-zinc-700 text-zinc-300 hover:bg-zinc-800 transition-colors text-sm"
+          >
+            <ExternalLink className="w-4 h-4" />
+            Basescanで確認する
+          </a>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// --- Main Panel ---
+export function TxHistoryPanel() {
+  const [txs, setTxs] = useState<Transaction[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [filter, setFilter] = useState<FilterType>("all")
+  const [selectedTx, setSelectedTx] = useState<Transaction | null>(null)
+
+  useEffect(() => {
+    const token = getToken()
+    setLoading(true)
+    setError(null)
+    fetch(`${API_BASE}/api/transactions?limit=50&offset=0`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`)
+        return r.json() as Promise<Transaction[] | { items: Transaction[] }>
+      })
+      .then((data) => {
+        const items = Array.isArray(data) ? data : data.items
+        setTxs(items)
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : "データ取得に失敗しました")
+      })
+      .finally(() => setLoading(false))
+  }, [])
+
+  const handleCsvDownload = () => {
+    const token = getToken()
+    const url = `${API_BASE}/api/proposals/tax/cryptact-csv`
+    const link = document.createElement("a")
+    // トークンをクエリに渡す（シンプルな download リンク用）
+    link.href = `${url}?token=${encodeURIComponent(token)}`
+    link.download = "uata_tax_report.csv"
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  }
+
+  // フィルタリング
+  const filteredTxs = txs.filter((tx) => {
+    if (filter === "all") return true
+    if (filter === "SUPPLY") return tx.operation === "SUPPLY"
+    if (filter === "WITHDRAW") return tx.operation === "WITHDRAW"
+    if (filter === "USDC") return tx.asset === "USDC"
+    if (filter === "ETH") return tx.asset === "ETH" || tx.asset === "WETH"
+    return true
+  })
+
+  const coinSummaries = buildCoinSummaries(txs)
+  const grouped = groupByMonth(filteredTxs)
+
+  const FILTERS: Array<{ id: FilterType; label: string }> = [
+    { id: "all", label: "すべて" },
+    { id: "SUPPLY", label: "SUPPLY" },
+    { id: "WITHDRAW", label: "WITHDRAW" },
+    { id: "USDC", label: "USDC" },
+    { id: "ETH", label: "ETH" },
+  ]
+
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+        <Loader2 className="w-6 h-6 mb-3 text-zinc-600 animate-spin" />
+        <p className="text-sm">読み込み中...</p>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+        <p className="text-sm text-red-400">{error}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* CSV ダウンロードボタン */}
+      <div className="flex justify-end">
+        <button
+          onClick={handleCsvDownload}
+          className="flex items-center gap-1.5 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-xs px-3 py-1.5 rounded-lg transition-colors"
+        >
+          <Download className="w-3.5 h-3.5" />
+          CSV
+        </button>
+      </div>
+
+      {/* コイン別サマリーバー */}
+      {coinSummaries.length > 0 && (
+        <div className="flex gap-2 overflow-x-auto pb-2 scrollbar-hide">
+          {coinSummaries.map((coin) => (
+            <div
+              key={coin.asset}
+              className="flex-shrink-0 bg-zinc-800 rounded-xl px-3 py-2 min-w-[100px]"
+            >
+              <div className="text-xs text-zinc-400 font-medium mb-0.5">{coin.asset}</div>
+              <div className="text-[#4ade9a] text-xs">+${coin.total_supply}</div>
+              <div className="text-orange-400 text-xs">-${coin.total_withdraw}</div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* フィルターバー */}
+      <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-hide">
+        {FILTERS.map((f) => (
+          <button
+            key={f.id}
+            onClick={() => setFilter(f.id)}
+            className={`flex-shrink-0 text-xs px-3 py-1.5 rounded-full transition-colors ${
+              filter === f.id
+                ? "bg-[#1D9E75] text-white"
+                : "bg-zinc-800 text-zinc-400 hover:bg-zinc-700"
+            }`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      {/* 取引リスト */}
+      {filteredTxs.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+          <p className="text-sm">取引履歴がありません</p>
+        </div>
+      ) : (
+        <div className="flex flex-col">
+          {grouped.map(({ month, items }) => (
+            <div key={month}>
+              {/* 月ヘッダー */}
+              <div className="text-zinc-500 text-xs font-semibold py-2 pt-4">
+                {month}
+              </div>
+              {/* 行 */}
+              {items.map((tx) => {
+                const isSupply = tx.operation === "SUPPLY"
+                return (
+                  <button
+                    key={tx.id}
+                    onClick={() => setSelectedTx(tx)}
+                    className="flex items-center w-full py-3 border-b border-zinc-800 text-left hover:bg-zinc-800/50 transition-colors -mx-1 px-1 rounded"
+                  >
+                    {/* 種別アイコン */}
+                    <div className="mr-3 w-8 h-8 rounded-full flex items-center justify-center bg-zinc-800 flex-shrink-0">
+                      {isSupply ? (
+                        <ArrowDown className="w-4 h-4 text-[#4ade9a]" />
+                      ) : (
+                        <ArrowUp className="w-4 h-4 text-orange-400" />
+                      )}
+                    </div>
+                    {/* 情報 */}
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-1.5">
+                        <span className="text-white text-sm font-medium">
+                          {tx.operation}
+                        </span>
+                        <span className="bg-zinc-700 text-zinc-300 text-xs px-1.5 py-0.5 rounded">
+                          {tx.asset}
+                        </span>
+                      </div>
+                      <div className="text-zinc-500 text-xs mt-0.5">{formatDate(tx.created_at)}</div>
+                    </div>
+                    {/* 金額 */}
+                    <div className="text-right flex-shrink-0 ml-2">
+                      <div className={`font-medium text-sm ${isSupply ? "text-[#4ade9a]" : "text-orange-400"}`}>
+                        {formatAmountUsd(tx.amount_usd, tx.operation)}
+                      </div>
+                      <div className="text-zinc-500 text-xs mt-0.5">{statusLabel(tx.status)}</div>
+                    </div>
+                  </button>
+                )
+              })}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* 詳細パネル */}
+      {selectedTx && (
+        <TxDetailPanel tx={selectedTx} onClose={() => setSelectedTx(null)} />
+      )}
     </div>
   )
 }

--- a/frontend/app/(liff)/liff-chat/_components/panels/TxHistoryPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TxHistoryPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Clock } from "lucide-react"
+
+export function TxHistoryPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Clock className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -1,0 +1,89 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// frontend/app/(liff)/liff-chat/page.tsx
+// LIFF チャット ホーム — /liff-chat
+"use client"
+
+import { useState } from "react"
+import { Menu, User } from "lucide-react"
+import { HamburgerMenu } from "./_components/HamburgerMenu"
+import { SlideUpPanel } from "./_components/SlideUpPanel"
+import { MyWalletPanel } from "./_components/panels/MyWalletPanel"
+import { DepositPanel } from "./_components/panels/DepositPanel"
+import { ReferralPanel } from "./_components/panels/ReferralPanel"
+import { OpModePanel } from "./_components/panels/OpModePanel"
+import { TxHistoryPanel } from "./_components/panels/TxHistoryPanel"
+import { TaxPanel } from "./_components/panels/TaxPanel"
+import { NotificationPanel } from "./_components/panels/NotificationPanel"
+import { AccountPanel } from "./_components/panels/AccountPanel"
+import { TermsPanel } from "./_components/panels/TermsPanel"
+
+const PANEL_TITLES: Record<string, string> = {
+  myWallet:     "MY WALLET",
+  deposit:      "入金/出金",
+  referral:     "紹介キャンペーン",
+  opMode:       "運用モード切替",
+  txHistory:    "取引履歴",
+  tax:          "TAX & REPORTS",
+  notification: "通知設定",
+  account:      "アカウント",
+  terms:        "利用規約",
+}
+
+export default function LiffChatPage() {
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [activePanel, setActivePanel] = useState<string | null>(null)
+
+  return (
+    <div className="w-[375px] mx-auto h-dvh bg-zinc-950 text-zinc-100 flex flex-col overflow-hidden relative">
+      {/* ヘッダー */}
+      <header className="h-14 bg-[#1a3d2e] flex items-center justify-between px-4 flex-shrink-0">
+        <button
+          onClick={() => setMenuOpen(true)}
+          className="text-white hover:bg-white/10 rounded-lg p-1 transition-colors"
+          aria-label="メニューを開く"
+        >
+          <Menu className="w-6 h-6" />
+        </button>
+        <span className="text-[#4ade9a] font-bold text-xl">UAT</span>
+        <button
+          className="text-white hover:bg-white/10 rounded-lg p-1 transition-colors"
+          aria-label="アカウント"
+        >
+          <User className="w-6 h-6" />
+        </button>
+      </header>
+
+      {/* メインコンテンツ（暫定） */}
+      <main className="flex-1 flex items-center justify-center">
+        <p className="text-zinc-600 text-sm">ホーム画面は別タスクで実装</p>
+      </main>
+
+      {/* ハンバーガーメニュー */}
+      <HamburgerMenu
+        open={menuOpen}
+        onClose={() => setMenuOpen(false)}
+        onPanelOpen={(id) => setActivePanel(id)}
+      />
+
+      {/* 各パネル */}
+      {Object.keys(PANEL_TITLES).map((id) => (
+        <SlideUpPanel
+          key={id}
+          open={activePanel === id}
+          onClose={() => setActivePanel(null)}
+          title={PANEL_TITLES[id]}
+        >
+          {id === "myWallet"     && <MyWalletPanel />}
+          {id === "deposit"      && <DepositPanel />}
+          {id === "referral"     && <ReferralPanel />}
+          {id === "opMode"       && <OpModePanel />}
+          {id === "txHistory"    && <TxHistoryPanel />}
+          {id === "tax"          && <TaxPanel />}
+          {id === "notification" && <NotificationPanel />}
+          {id === "account"      && <AccountPanel />}
+          {id === "terms"        && <TermsPanel />}
+        </SlideUpPanel>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## 概要

LIFF チャット UI の取引履歴パネル (`TxHistoryPanel`) をスタブから本実装に置き換えます。

Asana GID: 1215359346060215

## 変更内容

- `frontend/app/(liff)/liff-chat/_components/panels/TxHistoryPanel.tsx` を完全実装
- `GET /api/transactions?limit=50&offset=0` でデータ取得 (Bearer Token 認証)
- コイン別サマリーバー（横スクロール）: アセット名 / SUPPLY 合計 / WITHDRAW 合計
- フィルターバー（横スクロール）: すべて / SUPPLY / WITHDRAW / USDC / ETH
- 月別グルーピング取引リスト: ArrowDown(緑)=SUPPLY / ArrowUp(橙)=WITHDRAW アイコン
- 行タップで詳細パネルをスライドイン表示（`z-[60]`、右からスライドイン）
- 詳細パネル内 Basescan リンク（`tx_hash` 存在時のみ）
- CSV ダウンロードボタン（`/api/proposals/tax/cryptact-csv`）

## スタイル規約準拠

- ヘッダー背景: `bg-[#1a3d2e]`
- SUPPLY 金額: `text-[#4ade9a]` / WITHDRAW 金額: `text-orange-400`
- アクティブフィルター: `bg-[#1D9E75] text-white`
- カード背景: `bg-zinc-800` / `bg-zinc-900`

## テスト計画

- [ ] SlideUpPanel から取引履歴パネルが開けること
- [ ] API データ取得 → リスト表示
- [ ] フィルター切り替え動作
- [ ] 行タップ → 詳細パネルスライドイン
- [ ] 詳細パネルの戻るボタン
- [ ] CSV ダウンロードボタン
- [ ] tx_hash ありの場合 Basescan リンク表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)