### PR TITLE
feat(liff-chat): アカウント/ログアウトパネル実装（Phase 3）

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/HamburgerMenu.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/HamburgerMenu.tsx
@@ -1,0 +1,89 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import {
+  Wallet,
+  ArrowDownUp,
+  Users,
+  Settings2,
+  Clock,
+  FileText,
+  Bell,
+  User,
+  BookOpen,
+  ChevronRight,
+} from "lucide-react"
+
+interface HamburgerMenuProps {
+  open: boolean
+  onClose: () => void
+  onPanelOpen: (id: string) => void
+}
+
+const MENU_ITEMS = [
+  { id: "myWallet",     label: "MY WALLET",      sub: "ウォレットアドレス・QRコード",   icon: Wallet },
+  { id: "deposit",      label: "入金/出金",        sub: "USDCの入出金",                 icon: ArrowDownUp },
+  { id: "referral",     label: "紹介キャンペーン", sub: "お友達を紹介して報酬を獲得",    icon: Users },
+  { id: "opMode",       label: "運用モード切替",   sub: "おまかせ / アクティブ",         icon: Settings2 },
+  { id: "txHistory",    label: "取引履歴",         sub: "過去の取引を確認",              icon: Clock },
+  { id: "tax",          label: "TAX & REPORTS",   sub: "税務レポート・CSV出力",          icon: FileText },
+  { id: "notification", label: "通知設定",         sub: "LINE・プッシュ通知の設定",      icon: Bell },
+  { id: "account",      label: "アカウント",       sub: "プロフィール・ログアウト",       icon: User },
+  { id: "terms",        label: "利用規約",         sub: "利用規約・プライバシーポリシー", icon: BookOpen },
+]
+
+export function HamburgerMenu({ open, onClose, onPanelOpen }: HamburgerMenuProps) {
+  return (
+    <>
+      {/* バックドロップ */}
+      {open && (
+        <div
+          className="fixed inset-0 z-40 bg-black/60"
+          onClick={onClose}
+        />
+      )}
+
+      {/* サイドパネル本体 */}
+      <div
+        className={`fixed top-0 left-0 h-full z-50 w-72 bg-[#1a3d2e] flex flex-col
+                    transform transition-transform duration-300 ease-in-out
+                    ${open ? "translate-x-0" : "-translate-x-full"}`}
+      >
+        {/* ヘッダー */}
+        <div className="flex items-center justify-between px-4 py-4 border-b border-white/10">
+          <span className="text-[#4ade9a] font-bold text-lg">UAT</span>
+          <button
+            onClick={onClose}
+            className="text-white text-xl leading-none w-8 h-8 flex items-center justify-center hover:bg-white/10 rounded-full transition-colors"
+            aria-label="メニューを閉じる"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* メニュー項目 */}
+        <div className="flex-1 overflow-y-auto">
+          {MENU_ITEMS.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => { onPanelOpen(item.id); onClose() }}
+              className="flex items-center w-full px-4 py-4 border-b border-white/10 hover:bg-white/5 active:bg-white/10 transition-colors"
+            >
+              <item.icon className="w-5 h-5 text-[#4ade9a] mr-3 flex-shrink-0" />
+              <div className="flex-1 text-left">
+                <div className="text-white font-medium text-sm">{item.label}</div>
+                <div className="text-zinc-400 text-xs mt-0.5">{item.sub}</div>
+              </div>
+              <ChevronRight className="w-4 h-4 text-zinc-600 flex-shrink-0" />
+            </button>
+          ))}
+        </div>
+
+        {/* フッター */}
+        <div className="mt-auto px-4 py-4">
+          <p className="text-zinc-600 text-xs text-center">UAT App v1.0 | © 2026 UAT Co., Ltd.</p>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/SlideUpPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/SlideUpPanel.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { ChevronLeft } from "lucide-react"
+
+interface SlideUpPanelProps {
+  open: boolean
+  onClose: () => void
+  title: string
+  children: React.ReactNode
+  maxHeight?: string
+}
+
+export function SlideUpPanel({
+  open,
+  onClose,
+  title,
+  children,
+  maxHeight = "90vh",
+}: SlideUpPanelProps) {
+  if (!open) return null
+  return (
+    <>
+      {/* バックドロップ */}
+      <div className="fixed inset-0 z-40 bg-black/60" onClick={onClose} />
+      {/* パネル本体 */}
+      <div
+        style={{ maxHeight }}
+        className="fixed bottom-0 left-0 right-0 z-50
+                   bg-zinc-900 rounded-t-2xl border-t border-zinc-800
+                   overflow-y-auto
+                   animate-in slide-in-from-bottom duration-300"
+      >
+        {/* ドラッグハンドル + ヘッダー */}
+        <div className="sticky top-0 bg-zinc-900 pt-3 pb-0 px-4">
+          <div className="mx-auto mb-3 h-1 w-8 rounded-full bg-zinc-700" />
+          {/* パネルヘッダー */}
+          <div className="flex items-center bg-[#1a3d2e] -mx-4 px-4 py-3 mb-4">
+            <button onClick={onClose} className="text-white mr-2">
+              <ChevronLeft className="w-5 h-5" />
+            </button>
+            <h2 className="text-white font-semibold text-base">{title}</h2>
+          </div>
+        </div>
+        <div className="px-4 pb-8">{children}</div>
+      </div>
+    </>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { User } from "lucide-react"
+
+export function AccountPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <User className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
@@ -1,13 +1,409 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 "use client"
 
-import { User } from "lucide-react"
+import { useState, useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { usePrivy } from "@privy-io/react-auth"
+import { Copy, LogOut, Trash2, Building2, ChevronDown, Check } from "lucide-react"
+
+interface UserData {
+  id?: number
+  email?: string
+  username?: string
+  user_mode?: "managed" | "active" | "pro"
+  created_at?: string
+  wallet_address?: string
+  // corporate fields (frontend-only state — not yet in backend schema)
+}
+
+interface CorpForm {
+  name: string
+  number: string
+  rep: string
+  month: number
+}
+
+const API_BASE = process.env.NEXT_PUBLIC_BACKEND_BASE_URL ?? ""
 
 export function AccountPanel() {
+  const router = useRouter()
+  const { logout: privyLogout } = usePrivy()
+  const [userData, setUserData] = useState<UserData | null>(null)
+  const [corpExpanded, setCorpExpanded] = useState(false)
+  const [corpForm, setCorpForm] = useState<CorpForm>({ name: "", number: "", rep: "", month: 0 })
+  const [corpSaved, setCorpSaved] = useState(false)
+  const [deleteSheet, setDeleteSheet] = useState(false)
+  const [toastMsg, setToastMsg] = useState("")
+  const [copied, setCopied] = useState(false)
+
+  const showToast = (msg: string) => {
+    setToastMsg(msg)
+    setTimeout(() => setToastMsg(""), 2000)
+  }
+
+  // ユーザー設定を取得（/api/user/settings + /auth/me を併用）
+  useEffect(() => {
+    const token =
+      typeof window !== "undefined" ? (localStorage.getItem("auth_token") ?? "") : ""
+    if (!token) return
+
+    // settings エンドポイント（user_mode 等）
+    fetch(`${API_BASE}/api/user/settings`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: UserData | null) => {
+        if (data) setUserData((prev) => ({ ...prev, ...data }))
+      })
+      .catch(() => {})
+
+    // auth/me エンドポイント（created_at, wallet_address）
+    fetch(`${API_BASE}/auth/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then(
+        (
+          data: {
+            email?: string
+            created_at?: string
+            wallet_address?: string
+          } | null,
+        ) => {
+          if (data) {
+            setUserData((prev) => ({
+              ...prev,
+              ...(data.email && { email: data.email }),
+              ...(data.created_at && { created_at: data.created_at }),
+              ...(data.wallet_address && { wallet_address: data.wallet_address }),
+            }))
+          }
+        },
+      )
+      .catch(() => {})
+  }, [])
+
+  // 法人情報を localStorage から復元
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem("liff_corp_info")
+      if (saved) {
+        const parsed = JSON.parse(saved) as CorpForm
+        setCorpForm(parsed)
+      }
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  // イニシャル生成
+  const getInitial = () => {
+    if (userData?.username) return userData.username.charAt(0).toUpperCase()
+    if (userData?.email) return userData.email.charAt(0).toUpperCase()
+    return "U"
+  }
+
+  // 表示名（username か email の @ 前）
+  const getDisplayName = () => {
+    if (userData?.username) return userData.username
+    if (userData?.email) return userData.email.split("@")[0]
+    return "ユーザー"
+  }
+
+  // ウォレットアドレス短縮表示
+  const getShortAddress = () => {
+    const addr = userData?.wallet_address
+    if (!addr) return null
+    return `${addr.slice(0, 6)}…${addr.slice(-4)}`
+  }
+
+  // 運用開始日フォーマット
+  const getStartedAt = () => {
+    if (!userData?.created_at) return "—"
+    const d = new Date(userData.created_at)
+    return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`
+  }
+
+  // 運用モード表示
+  const getModeLabel = () => {
+    if (userData?.user_mode === "managed") return "完全おまかせ"
+    if (userData?.user_mode === "active") return "アクティブ"
+    return "—"
+  }
+
+  // ウォレットアドレスコピー
+  const handleCopyWallet = async () => {
+    const addr = userData?.wallet_address
+    if (!addr) return
+    try {
+      await navigator.clipboard.writeText(addr)
+      setCopied(true)
+      showToast("コピーしました")
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      showToast("コピーできませんでした")
+    }
+  }
+
+  // 法人情報保存（フロントエンドのみ保持 — backend 未実装のためローカル保存）
+  const handleCorpSave = () => {
+    // 将来バックエンドが corporate_* フィールドを実装した時点で PUT /api/user/settings に送る
+    // 現時点は localStorage に保存してフロント内で表示するのみ
+    try {
+      localStorage.setItem("liff_corp_info", JSON.stringify(corpForm))
+    } catch {
+      // ignore
+    }
+    setCorpSaved(true)
+    showToast("保存しました")
+    setTimeout(() => setCorpSaved(false), 2000)
+  }
+
+  // ログアウト
+  const handleLogout = async () => {
+    // 1. Privy ログアウト
+    try {
+      await privyLogout()
+    } catch {
+      // ignore
+    }
+
+    // 2. LINE LIFF ログアウト
+    try {
+      const { getLiff } = await import("@/lib/liff/init")
+      const liff = await getLiff()
+      if (liff.isLoggedIn()) liff.logout()
+    } catch {
+      // ignore
+    }
+
+    // 3. トークンクリア
+    if (typeof window !== "undefined") {
+      localStorage.removeItem("auth_token")
+    }
+
+    // 4. /liff-login へリダイレクト
+    router.replace("/liff-login")
+  }
+
+  // アカウント削除申請
+  const handleDeleteRequest = async () => {
+    const token =
+      typeof window !== "undefined" ? (localStorage.getItem("auth_token") ?? "") : ""
+
+    try {
+      const res = await fetch(`${API_BASE}/api/user/delete-request`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      })
+      if (res.ok) {
+        showToast("削除申請を受け付けました")
+        setDeleteSheet(false)
+      } else if (res.status === 404 || res.status === 405) {
+        showToast("サポートへお問い合わせください")
+        setDeleteSheet(false)
+      } else {
+        showToast("エラーが発生しました")
+      }
+    } catch {
+      showToast("サポートへお問い合わせください")
+      setDeleteSheet(false)
+    }
+  }
+
+  const shortAddress = getShortAddress()
+
   return (
-    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
-      <User className="w-8 h-8 mb-3 text-zinc-700" />
-      <p className="text-sm">実装中</p>
+    <div className="space-y-4">
+      {/* プロフィールカード */}
+      <div className="bg-[#1a3d2e] rounded-2xl p-4">
+        <div className="flex items-center gap-3">
+          {/* イニシャルアバター */}
+          <div className="w-14 h-14 rounded-full bg-[#1D9E75]/20 border border-[#1D9E75] flex items-center justify-center text-[#4ade9a] text-xl font-bold flex-shrink-0">
+            {getInitial()}
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-white font-semibold truncate">{getDisplayName()}</p>
+            {userData?.email && (
+              <p className="text-zinc-300 text-sm truncate">{userData.email}</p>
+            )}
+            {/* ログイン方法バッジ（LIFF = LINE ログイン） */}
+            <div className="flex flex-wrap gap-1 mt-1">
+              <span className="bg-zinc-800 text-zinc-300 text-xs px-2 py-0.5 rounded-full">
+                LINE
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 運用情報セクション */}
+      <div className="bg-zinc-900 rounded-xl overflow-hidden">
+        {/* 運用開始日 */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800">
+          <span className="text-zinc-400 text-sm">運用開始日</span>
+          <span className="text-white text-sm">{getStartedAt()}</span>
+        </div>
+
+        {/* 運用モード */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800">
+          <span className="text-zinc-400 text-sm">運用モード</span>
+          <span className="text-white text-sm">{getModeLabel()}</span>
+        </div>
+
+        {/* ウォレットアドレス */}
+        <div className="flex items-center justify-between px-4 py-3">
+          <span className="text-zinc-400 text-sm">ウォレット</span>
+          {shortAddress ? (
+            <button
+              onClick={handleCopyWallet}
+              className="flex items-center gap-1.5 text-zinc-300 text-sm"
+            >
+              <span className="font-mono text-xs">{shortAddress}</span>
+              {copied ? (
+                <Check className="w-3.5 h-3.5 text-[#4ade9a]" />
+              ) : (
+                <Copy className="w-3.5 h-3.5 text-zinc-500" />
+              )}
+            </button>
+          ) : (
+            <span className="text-zinc-600 text-sm">未連携</span>
+          )}
+        </div>
+      </div>
+
+      {/* 法人情報セクション（アコーディオン） */}
+      <div className="bg-zinc-900 rounded-xl overflow-hidden">
+        <button
+          onClick={() => setCorpExpanded((v) => !v)}
+          className="flex items-center justify-between w-full px-4 py-3.5"
+        >
+          <div className="flex items-center gap-2">
+            <Building2 className="w-4 h-4 text-zinc-400" />
+            <span className="text-zinc-300 text-sm font-medium">法人として使う</span>
+          </div>
+          <ChevronDown
+            className={`w-4 h-4 text-zinc-500 transition-transform duration-200 ${
+              corpExpanded ? "rotate-180" : ""
+            }`}
+          />
+        </button>
+
+        {corpExpanded && (
+          <div className="px-4 pb-4 space-y-3 border-t border-zinc-800 pt-3">
+            <input
+              placeholder="法人名"
+              value={corpForm.name}
+              onChange={(e) => setCorpForm((p) => ({ ...p, name: e.target.value }))}
+              className="w-full bg-zinc-800 text-white px-3 py-2.5 rounded-lg text-sm placeholder-zinc-500 outline-none focus:ring-1 focus:ring-[#1D9E75]"
+            />
+            <input
+              placeholder="法人番号（13桁）"
+              value={corpForm.number}
+              onChange={(e) => setCorpForm((p) => ({ ...p, number: e.target.value }))}
+              maxLength={13}
+              inputMode="numeric"
+              className="w-full bg-zinc-800 text-white px-3 py-2.5 rounded-lg text-sm placeholder-zinc-500 outline-none focus:ring-1 focus:ring-[#1D9E75]"
+            />
+            <input
+              placeholder="代表者名"
+              value={corpForm.rep}
+              onChange={(e) => setCorpForm((p) => ({ ...p, rep: e.target.value }))}
+              className="w-full bg-zinc-800 text-white px-3 py-2.5 rounded-lg text-sm placeholder-zinc-500 outline-none focus:ring-1 focus:ring-[#1D9E75]"
+            />
+
+            {/* 決算月グリッド */}
+            <div>
+              <p className="text-zinc-400 text-xs mb-2">決算月</p>
+              <div className="grid grid-cols-6 gap-1.5">
+                {Array.from({ length: 12 }, (_, i) => i + 1).map((m) => (
+                  <button
+                    key={m}
+                    onClick={() => setCorpForm((p) => ({ ...p, month: m }))}
+                    className={`py-2 rounded-lg text-sm font-medium transition-colors ${
+                      corpForm.month === m
+                        ? "bg-[#1D9E75] text-white"
+                        : "bg-zinc-800 text-zinc-400 hover:bg-zinc-700"
+                    }`}
+                  >
+                    {m}月
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <button
+              onClick={handleCorpSave}
+              disabled={!corpForm.name || !corpForm.number || !corpForm.rep || !corpForm.month}
+              className="w-full py-3 bg-[#1D9E75] text-white rounded-xl text-sm font-semibold disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
+            >
+              {corpSaved ? "保存しました ✓" : "保存する"}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* ログアウトボタン */}
+      <button
+        onClick={handleLogout}
+        className="flex items-center gap-3 w-full px-4 py-4 bg-zinc-900 rounded-xl hover:bg-zinc-800 transition-colors"
+      >
+        <LogOut className="w-5 h-5 text-red-400" />
+        <span className="text-red-400 font-medium">ログアウト</span>
+      </button>
+
+      {/* アカウント削除ボタン */}
+      <div className="flex justify-center pb-2">
+        <button
+          onClick={() => setDeleteSheet(true)}
+          className="flex items-center gap-2 px-4 py-2 text-zinc-600 hover:text-zinc-400 transition-colors"
+        >
+          <Trash2 className="w-4 h-4" />
+          <span className="text-xs">アカウントを削除</span>
+        </button>
+      </div>
+
+      {/* 削除確認ボトムシート */}
+      {deleteSheet && (
+        <>
+          <div
+            className="fixed inset-0 z-[60] bg-black/60"
+            onClick={() => setDeleteSheet(false)}
+          />
+          <div
+            className="fixed bottom-0 left-0 right-0 z-[70] bg-zinc-900 rounded-t-2xl px-4 pb-8 pt-4
+                        animate-in slide-in-from-bottom duration-300"
+          >
+            <div className="mx-auto mb-4 h-1 w-8 rounded-full bg-zinc-700" />
+            <h3 className="text-white font-semibold mb-2">アカウントを削除しますか？</h3>
+            <p className="text-zinc-400 text-sm mb-6">
+              残高がある場合、削除申請を受け付けられません。先に全額出金してください。
+            </p>
+            <button
+              onClick={handleDeleteRequest}
+              className="w-full py-3.5 bg-red-600/20 border border-red-600 text-red-400 rounded-xl font-medium mb-3"
+            >
+              削除を申請する
+            </button>
+            <button
+              onClick={() => setDeleteSheet(false)}
+              className="w-full py-3.5 border border-zinc-700 text-zinc-400 rounded-xl font-medium"
+            >
+              キャンセル
+            </button>
+          </div>
+        </>
+      )}
+
+      {/* トースト */}
+      {toastMsg && (
+        <div className="fixed bottom-24 left-1/2 -translate-x-1/2 z-[80] bg-zinc-700 text-white px-4 py-2 rounded-full text-sm whitespace-nowrap">
+          {toastMsg}
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { ArrowDownUp } from "lucide-react"
+
+export function DepositPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <ArrowDownUp className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Wallet } from "lucide-react"
+
+export function MyWalletPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Wallet className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/NotificationPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/NotificationPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Bell } from "lucide-react"
+
+export function NotificationPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Bell className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Settings2 } from "lucide-react"
+
+export function OpModePanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Settings2 className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Users } from "lucide-react"
+
+export function ReferralPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Users className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/TaxPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TaxPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { FileText } from "lucide-react"
+
+export function TaxPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <FileText className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/TermsPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TermsPanel.tsx
@@ -1,0 +1,29 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { ExternalLink } from "lucide-react"
+
+export function TermsPanel() {
+  return (
+    <div className="space-y-3 py-4">
+      <a
+        href="https://ultra-auto-trade.com/terms"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center justify-between w-full px-4 py-4 bg-zinc-800 rounded-xl hover:bg-zinc-700 transition-colors"
+      >
+        <span className="text-white text-sm font-medium">利用規約</span>
+        <ExternalLink className="w-4 h-4 text-zinc-400" />
+      </a>
+      <a
+        href="https://ultra-auto-trade.com/privacy"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center justify-between w-full px-4 py-4 bg-zinc-800 rounded-xl hover:bg-zinc-700 transition-colors"
+      >
+        <span className="text-white text-sm font-medium">プライバシーポリシー</span>
+        <ExternalLink className="w-4 h-4 text-zinc-400" />
+      </a>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/panels/TxHistoryPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TxHistoryPanel.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+"use client"
+
+import { Clock } from "lucide-react"
+
+export function TxHistoryPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+      <Clock className="w-8 h-8 mb-3 text-zinc-700" />
+      <p className="text-sm">実装中</p>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -1,0 +1,89 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// frontend/app/(liff)/liff-chat/page.tsx
+// LIFF チャット ホーム — /liff-chat
+"use client"
+
+import { useState } from "react"
+import { Menu, User } from "lucide-react"
+import { HamburgerMenu } from "./_components/HamburgerMenu"
+import { SlideUpPanel } from "./_components/SlideUpPanel"
+import { MyWalletPanel } from "./_components/panels/MyWalletPanel"
+import { DepositPanel } from "./_components/panels/DepositPanel"
+import { ReferralPanel } from "./_components/panels/ReferralPanel"
+import { OpModePanel } from "./_components/panels/OpModePanel"
+import { TxHistoryPanel } from "./_components/panels/TxHistoryPanel"
+import { TaxPanel } from "./_components/panels/TaxPanel"
+import { NotificationPanel } from "./_components/panels/NotificationPanel"
+import { AccountPanel } from "./_components/panels/AccountPanel"
+import { TermsPanel } from "./_components/panels/TermsPanel"
+
+const PANEL_TITLES: Record<string, string> = {
+  myWallet:     "MY WALLET",
+  deposit:      "入金/出金",
+  referral:     "紹介キャンペーン",
+  opMode:       "運用モード切替",
+  txHistory:    "取引履歴",
+  tax:          "TAX & REPORTS",
+  notification: "通知設定",
+  account:      "アカウント",
+  terms:        "利用規約",
+}
+
+export default function LiffChatPage() {
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [activePanel, setActivePanel] = useState<string | null>(null)
+
+  return (
+    <div className="w-[375px] mx-auto h-dvh bg-zinc-950 text-zinc-100 flex flex-col overflow-hidden relative">
+      {/* ヘッダー */}
+      <header className="h-14 bg-[#1a3d2e] flex items-center justify-between px-4 flex-shrink-0">
+        <button
+          onClick={() => setMenuOpen(true)}
+          className="text-white hover:bg-white/10 rounded-lg p-1 transition-colors"
+          aria-label="メニューを開く"
+        >
+          <Menu className="w-6 h-6" />
+        </button>
+        <span className="text-[#4ade9a] font-bold text-xl">UAT</span>
+        <button
+          className="text-white hover:bg-white/10 rounded-lg p-1 transition-colors"
+          aria-label="アカウント"
+        >
+          <User className="w-6 h-6" />
+        </button>
+      </header>
+
+      {/* メインコンテンツ（暫定） */}
+      <main className="flex-1 flex items-center justify-center">
+        <p className="text-zinc-600 text-sm">ホーム画面は別タスクで実装</p>
+      </main>
+
+      {/* ハンバーガーメニュー */}
+      <HamburgerMenu
+        open={menuOpen}
+        onClose={() => setMenuOpen(false)}
+        onPanelOpen={(id) => setActivePanel(id)}
+      />
+
+      {/* 各パネル */}
+      {Object.keys(PANEL_TITLES).map((id) => (
+        <SlideUpPanel
+          key={id}
+          open={activePanel === id}
+          onClose={() => setActivePanel(null)}
+          title={PANEL_TITLES[id]}
+        >
+          {id === "myWallet"     && <MyWalletPanel />}
+          {id === "deposit"      && <DepositPanel />}
+          {id === "referral"     && <ReferralPanel />}
+          {id === "opMode"       && <OpModePanel />}
+          {id === "txHistory"    && <TxHistoryPanel />}
+          {id === "tax"          && <TaxPanel />}
+          {id === "notification" && <NotificationPanel />}
+          {id === "account"      && <AccountPanel />}
+          {id === "terms"        && <TermsPanel />}
+        </SlideUpPanel>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## 概要
アカウント設定・ログアウトパネルの完全実装。

## 変更内容
- プロフィールカード（イニシャルアバター・メール・LINEログインバッジ）
- 運用情報（運用開始日・モード・ウォレットアドレスコピー）
- 法人情報アコーディオン（法人名・番号・代表者・決算月グリッド）→ localhost 保存（将来 PUT /api/user/settings に接続）
- ログアウト: Privy logout() + liff.logout() + localStorage クリア → /liff-login へ
- アカウント削除申請（残高ゼロ確認メッセージ付き）

## バックエンド調査結果
- `/api/user/settings` に `corporate_*` / `fiscal_*` フィールドは**未実装**
- `wallet_address` は `users` テーブルに存在するが `UserSettingsResponse` には未公開
  → `/auth/me` エンドポイントと 2 本同時取得で補完
- `started_at` フィールドは存在しない → `users.created_at` を代替使用
- `/api/user/delete-request` は未実装 → 404/405 時はトースト「サポートへお問い合わせください」
- 法人情報フィールド（corporate_name/number/representative/fiscal_month）はバックエンドに**なし**
  → フロントエンドのみ localStorage 保持（将来バックエンド実装後に PUT に接続するコメント記載済）

## DoD
- [x] プロフィール情報表示（/api/user/settings + /auth/me API 連携）
- [x] ウォレットアドレスコピー + トースト
- [x] 法人情報入力 + ローカル保存（バックエンド未実装のため）
- [x] Privy logout() + liff.logout() 実装
- [x] ログアウト後 /liff-login リダイレクト
- [x] 削除申請ボトムシート（残高ゼロ確認メッセージ）
- [x] TypeScript エラー 0（tsc --noEmit --skipLibCheck PASS）

## Asana
Closes GID: 1215359472487694