### PR TITLE
fix(ci): restore main CI to green (lint blocker + 2 test systems)

### DIFF
--- a/backend/alembic/versions/p6q7r8s9t0u1_referral_campaign.py
+++ b/backend/alembic/versions/p6q7r8s9t0u1_referral_campaign.py
@@ -41,10 +41,7 @@ def upgrade() -> None:
             "CREATE INDEX IF NOT EXISTS idx_rc_referree_month "
             "ON referral_campaigns (referree_id, reward_start_month, reward_expires_month)"
         )
-        op.execute(
-            "CREATE INDEX IF NOT EXISTS idx_rc_partner "
-            "ON referral_campaigns (partner_id)"
-        )
+        op.execute("CREATE INDEX IF NOT EXISTS idx_rc_partner ON referral_campaigns (partner_id)")
 
         op.execute("""
             CREATE TABLE IF NOT EXISTS uat_wallet_ledger (
@@ -64,10 +61,7 @@ def upgrade() -> None:
             "ON uat_wallet_ledger (reference_fee_tx_id, entry_type, reason) "
             "WHERE reference_fee_tx_id IS NOT NULL"
         )
-        op.execute(
-            "CREATE INDEX IF NOT EXISTS idx_uwl_month "
-            "ON uat_wallet_ledger (month)"
-        )
+        op.execute("CREATE INDEX IF NOT EXISTS idx_uwl_month ON uat_wallet_ledger (month)")
     else:
         # SQLite (テスト環境)
         op.create_table(

--- a/backend/app/aave/client.py
+++ b/backend/app/aave/client.py
@@ -1193,8 +1193,7 @@ def make_aave_client(
         # build_deposit_txs / build_withdraw_tx が "Unknown asset" で失敗する (method2 バグ修正)。
         if token_addresses and not hasattr(client, "token_addresses"):
             client.token_addresses = {
-                sym: Web3.to_checksum_address(addr)
-                for sym, addr in token_addresses.items()
+                sym: Web3.to_checksum_address(addr) for sym, addr in token_addresses.items()
             }
         return client
     raise ValueError(f"不明な AAVE_CLIENT_TYPE: {client_type!r} (dummy | web3)")

--- a/backend/app/api/v1/fees.py
+++ b/backend/app/api/v1/fees.py
@@ -443,9 +443,7 @@ def finalize_month_core(
         # --- UAT ウォレット台帳 記録 (冪等: 同月再実行でも重複しない) ---
         fee_txs_this_month = (
             db.execute(
-                select(FeeTransaction).where(
-                    FeeTransaction.calculation_month == month_start
-                )
+                select(FeeTransaction).where(FeeTransaction.calculation_month == month_start)
             )
             .scalars()
             .all()

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -23,6 +23,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.database import get_db
+from app.referral import service as referral_service
 
 from .dependencies import require_active_user
 from .models import (
@@ -54,7 +55,6 @@ from .schemas import (
     WalletLinkResponse,
 )
 from .service import AuthService
-from app.referral import service as referral_service
 
 limiter = Limiter(key_func=get_remote_address)
 

--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -20,13 +20,13 @@ from typing import Any, Callable, Optional
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from app.aave.gas_estimator import estimate_static_gas_cost_usd
 from app.ai.judgment_log import get_judgment_logger
 from app.ai.models import AIDecision, AiDecisionFeature
 from app.ai.schemas import CrossValidationResult, RAGContext, TradeAction
 from app.ai.service import AIService
 from app.auth.constants import ExecutionPolicy
 from app.auth.models import InvestmentTier, User, normalize_tier
-from app.aave.gas_estimator import estimate_static_gas_cost_usd
 from app.automation.aave_data_fetcher import AaveMarketData, fetch_aave_market_data_safe
 from app.data_feeds.context import MarketContext, build_market_context
 from app.database import SessionLocal

--- a/backend/app/referral/service.py
+++ b/backend/app/referral/service.py
@@ -184,7 +184,7 @@ def _add_months(d: date, months: int) -> date:
     return date(year, month, 1)
 
 
-def get_referral_earnings(db: Session, partner_id: int) -> dict:
+def get_referral_earnings(db: Session, partner_id: int) -> dict[str, str | int | None]:
     """紹介キャンペーン収益サマリーを返す。
 
     - referral_count: referrer_id == partner_id のユーザー数

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,10 @@ pytest-asyncio>=0.23.0
 web3>=6.15.1
 eth-account>=0.11.0
 python-dotenv>=1.0.0
+# aiohttp は web3/ccxt 経由の transitive dep。3.14.0 で AsyncStreamReaderMixin が
+# 削除され、vcrpy(<=8.1.1) のテスト記録が壊れる (upstream Issue #995 / PR #996 未リリース)。
+# 上流が対応するまで <3.14 に固定し、CI と prod で同一版を保証する。
+aiohttp<3.14
 
 # Authentication & Database (Phase 12)
 sqlalchemy>=2.0.0

--- a/backend/tests/reports/test_monthly_report_router.py
+++ b/backend/tests/reports/test_monthly_report_router.py
@@ -69,6 +69,10 @@ def client(test_db) -> TestClient:
 
 
 def _register_admin(client: TestClient) -> str:
+    # フルスイート実行時、他テスト (test_risk_mode.py / test_e2e_approve_flow.py 等) が
+    # fixture 実行時に INITIAL_ADMIN_EMAIL を上書きするため、register 直前に再セットする。
+    # これを怠ると /auth/register が email 不一致で 403 を返す (module-level の set では不足)。
+    os.environ["INITIAL_ADMIN_EMAIL"] = _ADMIN_EMAIL
     client.post(
         "/auth/register",
         json={"email": _ADMIN_EMAIL, "username": "admin_report", "password": _ADMIN_PASSWORD},

--- a/backend/tests/test_cryptact_csv.py
+++ b/backend/tests/test_cryptact_csv.py
@@ -137,7 +137,15 @@ class TestCryptactCsvEndpoint:
         content = r.content.decode("utf-8-sig")
         reader = csv.DictReader(io.StringIO(content))
         assert reader.fieldnames == [
-            "Timestamp", "Action", "Source", "Base", "Volume", "Price", "Counter", "Fee", "FeeCcy"
+            "Timestamp",
+            "Action",
+            "Source",
+            "Base",
+            "Volume",
+            "Price",
+            "Counter",
+            "Fee",
+            "FeeCcy",
         ]
 
     def test_only_executed_proposals_included(self, client_with_proposals: TestClient) -> None:
@@ -161,7 +169,9 @@ class TestCryptactCsvEndpoint:
         content = r.content.decode("utf-8-sig")
         reader = csv.DictReader(io.StringIO(content))
         rows = list(reader)
-        supply_row = next(row for row in rows if row["Base"] == "USDC" and row["Action"] == "LENDING")
+        supply_row = next(
+            row for row in rows if row["Base"] == "USDC" and row["Action"] == "LENDING"
+        )
         assert supply_row["Action"] == "LENDING"
         assert supply_row["Source"] == "AAVE_V3"
         assert supply_row["Counter"] == "USD"

--- a/backend/tests/test_fee_transfer_service.py
+++ b/backend/tests/test_fee_transfer_service.py
@@ -378,7 +378,8 @@ def test_fee_usd_calculation(fee_jpy, sub_jpy, excess_jpy, rate, expected_usd):
 # Lane R: transfer_service / AllowanceService (EIP-2612 新インタフェース)
 # ===========================================================================
 
-from app.fees.transfer_service import FeeTransferResult, FeeTransferService as NewFeeTransferService  # noqa: E402
+from app.fees.transfer_service import FeeTransferResult  # noqa: E402
+from app.fees.transfer_service import FeeTransferService as NewFeeTransferService  # noqa: E402
 
 
 class TestFeeTransferServiceDisabled:

--- a/backend/tests/test_gas_estimator.py
+++ b/backend/tests/test_gas_estimator.py
@@ -128,7 +128,12 @@ class TestEstimateStaticGasCostUsd:
             "SUPPLY", eth_usd_price=eth_price, gas_price_wei=Decimal("20000000000")
         )
         # 300000 * 20 Gwei = 0.006 ETH * $2000 = $12.00
-        expected = Decimal(str(DEFAULT_FALLBACK_GAS_SUPPLY)) * Decimal("20000000000") / Decimal("1e18") * eth_price
+        expected = (
+            Decimal(str(DEFAULT_FALLBACK_GAS_SUPPLY))
+            * Decimal("20000000000")
+            / Decimal("1e18")
+            * eth_price
+        )
         assert cost == expected
 
     def test_withdraw_uses_withdraw_fallback_gas(self) -> None:
@@ -137,7 +142,12 @@ class TestEstimateStaticGasCostUsd:
         cost = estimate_static_gas_cost_usd(
             "WITHDRAW", eth_usd_price=eth_price, gas_price_wei=Decimal("20000000000")
         )
-        expected = Decimal(str(DEFAULT_FALLBACK_GAS_WITHDRAW)) * Decimal("20000000000") / Decimal("1e18") * eth_price
+        expected = (
+            Decimal(str(DEFAULT_FALLBACK_GAS_WITHDRAW))
+            * Decimal("20000000000")
+            / Decimal("1e18")
+            * eth_price
+        )
         assert cost == expected
 
     def test_uses_fallback_eth_price_when_none(self) -> None:

--- a/backend/tests/test_line_messaging.py
+++ b/backend/tests/test_line_messaging.py
@@ -13,7 +13,6 @@ from app.notifications.line_messaging import (
     build_monthly_report_flex_bubble,
 )
 
-
 # ── build_monthly_report_flex_bubble ──────────────────────────────────────────
 
 

--- a/docs/integration/backend_deps.md
+++ b/docs/integration/backend_deps.md
@@ -157,6 +157,17 @@
 
 ## backend/requirements.txt
 
+### 変更 #3: aiohttp<3.14 固定（vcrpy 非互換 / CI green 回復）(PR #529 / 2026-06-04)
+- **コミット範囲**: `a300118` (fix/main-ci-green)
+- **変更内容**: `aiohttp<3.14` を requirements.txt に追加
+- **理由**: aiohttp 3.14.0 で `AsyncStreamReaderMixin` が削除され、vcrpy<=8.1.1 の cassette 再生が
+  `ERROR` になり CI の `test_judge_with_rag_vcr` が2件 failing（upstream Issue #995 / PR #996 未リリース）。
+  aiohttp は web3/ccxt 経由の transitive **runtime** dep のため requirements.txt 側で pin し、
+  CI と prod で同一版（3.13.x）を保証。upstream が対応次第 (`vcrpy>8.1.1` + `aiohttp>=3.14`) に更新する。
+- **影響範囲**: aiohttp の upper cap 追加のみ。web3 (`>=3.7.4`) / ccxt (`>=3.10.11`) との両立を
+  `pip check` で確認済み。アプリケーションロジックへの影響なし。
+- **承認**: fix/main-ci-green → main (PR #529)
+
 ### 変更 #2: PyJWT[crypto] extra 追加（Privy ID Token 検証対応）(PR #155 / 2026-04-27)
 - **コミット範囲**: `c88dfd2` – `41f77d7` (feature/privy-did-storage)
 - **変更内容**: `PyJWT>=2.9.0` → `PyJWT[crypto]>=2.9.0`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ module = [
     "tiktoken.*",
     "jose.*",
     "feedparser.*",
+    "reportlab.*",
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
## 目的
main CI を green に戻す（全 PR の関門）。red はいずれも既存 main 由来で #523 とは無関係。

## 真因（実機で裏取り済み）
CI の `Lint (ruff + mypy)` job が **`ruff check` で停止**しており、`Test` job は `needs: lint` で未実行（run 26872934094 で確認）。よって報告の test 2系統だけ直しても CI は赤のまま。lint も同時に解消する。

### Gate1 `ruff check`（実際の CI ブロッカー）
- 4× `I001`（import 未ソート）を auto-fix: `auth/router.py`, `automation/ai_judgment_scheduler.py`, `tests/test_fee_transfer_service.py`, `tests/test_line_messaging.py`
- isort が結合 import を2行に分割 → 2行目の `# noqa: E402` を復元

### Gate2 `ruff format --check`
- drift していた5ファイルを整形（空白のみ・意味変更なし）

### Gate3 `mypy app/`
- `reportlab.*` を missing-stubs ignore に追加（upstream 型スタブ無し）
- `get_referral_earnings -> dict[str, str | int | None]` に型付け

### Test系統1 — `test_judge_with_rag_vcr`（2 ERROR）
aiohttp 3.14.0 で `AsyncStreamReaderMixin` が削除され vcrpy(<=8.1.1) が壊れる（upstream [Issue #995](https://github.com/kevin1024/vcrpy/issues/995) / [PR #996](https://github.com/kevin1024/vcrpy/pull/996) 未リリース）。aiohttp は web3/ccxt 経由の **transitive runtime dep** のため `requirements.txt` に `aiohttp<3.14` を固定し CI と prod で同一版を保証。3.13.5 で green 確認。

### Test系統2 — `test_monthly_report_router`（8 FAILED）
register 制限（`INITIAL_ADMIN_EMAIL`）は仕様が正。フルスイートでは他テスト（`test_risk_mode.py` 等）が fixture 実行時に同 env を上書きするため、module-level の set が本テスト実行前に潰され `/auth/register` が **403**。`_register_admin` 内で POST 直前に env を再セット（`test_risk_mode.py` と同パターン）。

## ローカル検証
- `ruff check .` → All checks passed
- `ruff format --check .` → 515 files already formatted
- `mypy app/` → Success: no issues found in 249 source files
- 系統2: `test_risk_mode.py` 先行 + 修正なしで **8 failed** を再現 → 修正後 **33 passed**
- 系統1: vcr 2件 **2 passed**（aiohttp 3.13.5）
- 依存解決: web3 `aiohttp>=3.7.4` / ccxt `>=3.10.11` と `<3.14` は両立

> Note: フル `pytest`（Gate4）は postgres+pgvector が必要なため CI 側で最終確認。lint が通ることで初めて Test job が走る点に留意。

🤖 Generated with [Claude Code](https://claude.com/claude-code)