### PR TITLE
feat(aave): build-tx の onBehalfOf 本人一致をサーバー固定 + 署名前 calldata 再検証 (P0-3)

### DIFF
--- a/backend/app/aave/client.py
+++ b/backend/app/aave/client.py
@@ -1266,3 +1266,73 @@ def make_multi_chain_clients(
             chain_name=chain.chain_name,
         )
     return result
+
+
+# ==============================================================================
+# build-tx 本人一致 検証 (P0-3 / Asana 1215364095372268)
+#
+# Privy Policy Engine は onBehalfOf == msg.sender の動的自己参照比較を未サポート
+# (value は静的リテラルのみ) のため、本人一致は build-tx 側固定 + 署名前 calldata
+# 再検証で担保する。以下はサーバーが生成済み calldata を実デコードして
+# onBehalfOf / to が本人 wallet であることを確認する純粋関数 (RPC 不要)。
+#
+# build_partner_tx エンドポイントが署名前 hook (補完層) として呼び、
+# 不一致なら未署名 tx をフロントに返さず reject する。
+# ==============================================================================
+
+
+class OnBehalfMismatchError(AaveClientError):
+    """生成済み calldata の onBehalfOf / to が本人 wallet と不一致のとき送出。"""
+
+
+def _decode_pool_calldata(calldata: str) -> "tuple[str, dict[str, Any]]":
+    """Aave V3 Pool の calldata を実デコードして (関数名, 引数 dict) を返す。
+
+    provider 不要 (ABI デコードはオフライン処理)。web3 未インストール時は
+    AaveClientError を送出する。
+    """
+    if Web3 is None:
+        raise AaveClientError("web3 package is required")
+    # provider 無し Web3 インスタンスでも decode_function_input は動作する
+    pool = Web3().eth.contract(abi=_POOL_ABI_MINIMAL)
+    func, params = pool.decode_function_input(calldata)
+    return func.fn_name, dict(params)
+
+
+def verify_supply_onbehalf(supply_calldata: str, expected_wallet: str) -> bool:
+    """supply calldata の onBehalfOf が expected_wallet と一致するか検証する。
+
+    一致時のみ True。関数が supply でない / onBehalfOf 不一致 / デコード不能なら
+    False (fail-closed)。比較は checksum 正規化して大文字小文字非依存。
+    expected_wallet の値の中身には依存しない (常に渡された本人 wallet と照合)。
+    """
+    try:
+        fn_name, params = _decode_pool_calldata(supply_calldata)
+    except Exception:
+        return False
+    if fn_name != "supply":
+        return False
+    on_behalf = params.get("onBehalfOf")
+    if not on_behalf:
+        return False
+    try:
+        return Web3.to_checksum_address(on_behalf) == Web3.to_checksum_address(expected_wallet)
+    except Exception:
+        return False
+
+
+def verify_withdraw_to(withdraw_calldata: str, expected_wallet: str) -> bool:
+    """withdraw calldata の to が expected_wallet と一致するか検証する (fail-closed)。"""
+    try:
+        fn_name, params = _decode_pool_calldata(withdraw_calldata)
+    except Exception:
+        return False
+    if fn_name != "withdraw":
+        return False
+    to_addr = params.get("to")
+    if not to_addr:
+        return False
+    try:
+        return Web3.to_checksum_address(to_addr) == Web3.to_checksum_address(expected_wallet)
+    except Exception:
+        return False

--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -639,6 +639,7 @@ def build_partner_tx(
     approve_proposal の代わりにこのエンドポイントを呼び、フロントエンドで
     Privy sendTransaction() 経由でパートナー本人が署名・送信する。
     """
+    from app.aave.client import verify_supply_onbehalf, verify_withdraw_to  # noqa: PLC0415
     from app.aave.service import MultiChainAaveService  # noqa: PLC0415
 
     stmt = select(Proposal).where(Proposal.id == proposal_id)
@@ -683,30 +684,60 @@ def build_partner_tx(
                 amount=Decimal(str(proposal.amount_usd)),
                 wallet_address=wallet_address,
             )
-            return PartnerUnsignedTxs(
-                proposal_id=proposal_id,
-                operation=proposal.operation,
-                wallet_address=wallet_address,
-                approve_tx=UnsignedTx.model_validate(txs["approve_tx"]),
-                supply_tx=UnsignedTx.model_validate(txs["supply_tx"]),
-            )
         else:  # WITHDRAW
             txs = service._client.build_withdraw_tx(
                 asset_symbol=asset_symbol,
                 amount=Decimal(str(proposal.amount_usd)),
                 wallet_address=wallet_address,
             )
-            return PartnerUnsignedTxs(
-                proposal_id=proposal_id,
-                operation=proposal.operation,
-                wallet_address=wallet_address,
-                withdraw_tx=UnsignedTx.model_validate(txs["withdraw_tx"]),
-            )
     except Exception as exc:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"tx 構築失敗: {exc}",
         ) from exc
+
+    # 署名前 hook (補完層): サーバーが生成済み calldata を実デコードし、
+    # onBehalfOf (supply) / to (withdraw) が本人 wallet でなければ未署名 tx を
+    # 返さず reject する。build-tx 側固定 (主担保) の二重チェックであり、
+    # 万一 encode 経路に欠陥が混入しても他人宛て tx を組ませない。
+    # (P0-3 / Asana 1215364095372268)
+    if proposal.operation == "SUPPLY":
+        if not verify_supply_onbehalf(txs["supply_tx"]["data"], wallet_address):
+            logger.error(
+                "build-tx onBehalfOf 検証失敗: proposal=%s wallet=%s...%s",
+                proposal_id,
+                wallet_address[:6],
+                wallet_address[-4:],
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="onBehalfOf 検証失敗: supply tx の onBehalfOf が本人 wallet と不一致",
+            )
+        return PartnerUnsignedTxs(
+            proposal_id=proposal_id,
+            operation=proposal.operation,
+            wallet_address=wallet_address,
+            approve_tx=UnsignedTx.model_validate(txs["approve_tx"]),
+            supply_tx=UnsignedTx.model_validate(txs["supply_tx"]),
+        )
+    else:  # WITHDRAW
+        if not verify_withdraw_to(txs["withdraw_tx"]["data"], wallet_address):
+            logger.error(
+                "build-tx withdraw to 検証失敗: proposal=%s wallet=%s...%s",
+                proposal_id,
+                wallet_address[:6],
+                wallet_address[-4:],
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="to 検証失敗: withdraw tx の to が本人 wallet と不一致",
+            )
+        return PartnerUnsignedTxs(
+            proposal_id=proposal_id,
+            operation=proposal.operation,
+            wallet_address=wallet_address,
+            withdraw_tx=UnsignedTx.model_validate(txs["withdraw_tx"]),
+        )
 
 
 def _verify_on_chain_receipt(

--- a/backend/tests/test_build_tx_onbehalf_server_fixed.py
+++ b/backend/tests/test_build_tx_onbehalf_server_fixed.py
@@ -1,0 +1,126 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_build_tx_onbehalf_server_fixed.py
+"""
+P0-3: onBehalfOf 本人一致を build-tx 側でサーバー固定 (Asana 1215364095372268)
+
+DoD 検証: build-tx が組む未署名 supply tx の calldata を **実デコード** し、
+onBehalfOf が本人 wallet であることを確認する。Privy Policy Engine は
+onBehalfOf == msg.sender の動的比較を未サポートのため、本人一致は
+build-tx 側固定 (主担保) + 署名前 calldata 再検証 (補完層) で担保する。
+
+本テストは mock を使わず、Web3 の実 ABI エンコーダで supply/withdraw calldata を
+組み立て、本番と同じ `verify_supply_onbehalf` / `verify_withdraw_to` で実デコード
+検証する。値の中身に依存しない (複数の wallet で常に本人一致を確認する)。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# web3 が無い環境では本テスト群を skip (mypy/型のみの CI を壊さない)
+web3 = pytest.importorskip("web3")
+from web3 import Web3  # noqa: E402
+
+from app.aave.client import (  # noqa: E402
+    _POOL_ABI_MINIMAL,
+    verify_supply_onbehalf,
+    verify_withdraw_to,
+)
+
+# Aave V3 Pool / USDC ダミーアドレス (checksum 化済)
+_ASSET = Web3.to_checksum_address("0x" + "a1" * 20)
+_SERVER_WALLET = Web3.to_checksum_address("0x" + "11" * 20)
+
+# 値の中身に非依存であることを示すため複数 partner wallet を用意
+_PARTNER_WALLETS = [
+    Web3.to_checksum_address("0x" + "7f" * 20),
+    Web3.to_checksum_address("0x" + "ab" * 20),
+    Web3.to_checksum_address("0xdEAD" + "00" * 18),
+]
+
+
+def _build_supply_calldata(on_behalf_of: str, amount_wei: int = 1_000_000) -> str:
+    """build_deposit_txs と同一の encode_abi 呼び出しで supply calldata を生成する。"""
+    pool = Web3().eth.contract(abi=_POOL_ABI_MINIMAL)
+    return pool.encode_abi("supply", args=[_ASSET, amount_wei, on_behalf_of, 0])
+
+
+def _build_withdraw_calldata(to_addr: str, amount_wei: int = 1_000_000) -> str:
+    pool = Web3().eth.contract(abi=_POOL_ABI_MINIMAL)
+    return pool.encode_abi("withdraw", args=[_ASSET, amount_wei, to_addr])
+
+
+# ---------------------------------------------------------------------------
+# 主担保: build-tx が固定した onBehalfOf を実デコードで確認
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("partner_wallet", _PARTNER_WALLETS)
+def test_supply_calldata_onbehalf_is_partner(partner_wallet: str) -> None:
+    """supply calldata を実デコードすると onBehalfOf が本人 wallet と一致する。"""
+    calldata = _build_supply_calldata(partner_wallet)
+
+    # 実デコード (本番 verify と独立に decode して値を直接確認)
+    pool = Web3().eth.contract(abi=_POOL_ABI_MINIMAL)
+    func, params = pool.decode_function_input(calldata)
+    assert func.fn_name == "supply"
+    assert Web3.to_checksum_address(params["onBehalfOf"]) == partner_wallet
+
+    # 本番の署名前 hook 関数でも True
+    assert verify_supply_onbehalf(calldata, partner_wallet) is True
+
+
+def test_supply_onbehalf_is_value_independent() -> None:
+    """値の中身に非依存: どの wallet でも decode 後の onBehalfOf は渡した本人 wallet。"""
+    for w in _PARTNER_WALLETS:
+        calldata = _build_supply_calldata(w)
+        pool = Web3().eth.contract(abi=_POOL_ABI_MINIMAL)
+        _, params = pool.decode_function_input(calldata)
+        assert Web3.to_checksum_address(params["onBehalfOf"]) == w
+
+
+def test_supply_checksum_insensitive_match() -> None:
+    """小文字 wallet を渡しても checksum 正規化して一致判定される。"""
+    partner = _PARTNER_WALLETS[0]
+    calldata = _build_supply_calldata(partner)
+    assert verify_supply_onbehalf(calldata, partner.lower()) is True
+
+
+# ---------------------------------------------------------------------------
+# 署名前 hook (補完層): 他人宛て / 改竄を fail-closed で拒否
+# ---------------------------------------------------------------------------
+def test_supply_rejects_server_wallet_substitution() -> None:
+    """onBehalfOf がサーバー wallet 等の他人宛てなら verify は False (reject)。"""
+    # 万一 encode 経路がサーバー wallet を onBehalfOf に入れてしまった場合を模す
+    calldata = _build_supply_calldata(_SERVER_WALLET)
+    partner = _PARTNER_WALLETS[0]
+    assert verify_supply_onbehalf(calldata, partner) is False
+
+
+def test_supply_rejects_wrong_function() -> None:
+    """supply 以外 (withdraw) の calldata を渡したら supply 検証は False。"""
+    partner = _PARTNER_WALLETS[0]
+    withdraw_calldata = _build_withdraw_calldata(partner)
+    assert verify_supply_onbehalf(withdraw_calldata, partner) is False
+
+
+def test_supply_rejects_garbage_calldata() -> None:
+    """デコード不能な calldata は fail-closed で False (例外を投げない)。"""
+    assert verify_supply_onbehalf("0xdeadbeef", _PARTNER_WALLETS[0]) is False
+    assert verify_supply_onbehalf("not-hex", _PARTNER_WALLETS[0]) is False
+
+
+# ---------------------------------------------------------------------------
+# withdraw: to も同様に本人固定
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("partner_wallet", _PARTNER_WALLETS)
+def test_withdraw_calldata_to_is_partner(partner_wallet: str) -> None:
+    calldata = _build_withdraw_calldata(partner_wallet)
+    pool = Web3().eth.contract(abi=_POOL_ABI_MINIMAL)
+    func, params = pool.decode_function_input(calldata)
+    assert func.fn_name == "withdraw"
+    assert Web3.to_checksum_address(params["to"]) == partner_wallet
+    assert verify_withdraw_to(calldata, partner_wallet) is True
+
+
+def test_withdraw_rejects_other_recipient() -> None:
+    calldata = _build_withdraw_calldata(_SERVER_WALLET)
+    assert verify_withdraw_to(calldata, _PARTNER_WALLETS[0]) is False


### PR DESCRIPTION
## 概要
P0-3 (Asana 1215364095372268). Aave supply の `onBehalfOf` が必ず当該 partner wallet になることを、ユーザーが上書きできない構造で担保する。

Privy Policy Engine は `ethereum_calldata` のデコードと**静的値比較**は可能だが、`onBehalfOf == msg.sender` の**動的自己参照比較は未サポート** (value は静的リテラルのみ、`$from` 等の変数参照なし)。よって本人一致は policy 単体では強制できず、**build-tx 側固定 + 署名前 calldata 再検証**が標準。

## 変更 (DoD の担保層)
**1. build-tx (主担保) — 既存挙動を維持・明文化**
- `build_partner_tx` は `user.wallet_address` を DB から解決して `onBehalfOf` に固定。エンドポイントはユーザー入力の wallet を一切受け取らない (path の `proposal_id` + 認証 user のみ) → 上書き不可・値の中身に非依存。

**2. 署名前 hook (補完) — 新規**
- 生成済み `supply` / `withdraw` calldata をサーバーが**実デコード**し、`onBehalfOf` (supply) / `to` (withdraw) が本人 wallet でなければ未署名 tx を返さず `500` で reject。
- `verify_supply_onbehalf` / `verify_withdraw_to` を `app/aave/client.py` に追加 (RPC 不要・fail-closed・checksum 非依存比較)。万一 encode 経路に欠陥が混入しても他人宛て tx を組ませない二重チェック。

**3. Policy Engine (補完) — 既存**
- `app/policy/engine.py` が asset whitelist (USDC) / operation (SUPPLY・WITHDRAW) / position・velocity cap を既に担保。

## 検証 (DoD: calldata 実デコードで onBehalfOf=partner を確認)
新規テスト `backend/tests/test_build_tx_onbehalf_server_fixed.py` (mock 無し・Web3 実エンコード/デコード):
- supply calldata を実デコードし `onBehalfOf` == partner wallet を確認 (3 wallet で parametrize)
- 値非依存: どの wallet でも decode 後の `onBehalfOf` は渡した本人 wallet
- 他人 (サーバー wallet) 宛て / 関数違い / デコード不能 calldata を fail-closed で reject
- withdraw の `to` も同様
- **12 passed**

## Gate
- 新規テスト: 12 passed
- 既存回帰: `test_aave_web3_client` / `test_aave_multi_chain_service` / `test_aave_service` 73 passed + 4 skipped、`test_proposals_api` / `test_integration_proposals` / `test_proposal_wallet_propagation` 26 passed
- `ruff check` / `ruff format --check`: 変更3ファイル pass
- `mypy app/aave/client.py app/proposals/router.py`: 変更ファイルにエラー 0 (既存の `app/referral/service.py:187` [type-arg] は base main 360e1bf 由来の pre-existing red、自レーン外)

## 一切しないこと (notes 準拠)
policy 単体で `onBehalfOf` 本人一致を強制する実装 (不可能) は行わない。

Closes Asana 1215364095372268

🤖 Generated with [Claude Code](https://claude.com/claude-code)