### PR TITLE
feat(proposals): CEX/on-chain Aave 経路分岐 immutable + 誤執行ガード (P0-2)

### DIFF
--- a/backend/alembic/versions/q7r8s9t0u1v2_add_proposals_execution_route.py
+++ b/backend/alembic/versions/q7r8s9t0u1v2_add_proposals_execution_route.py
@@ -1,0 +1,102 @@
+"""add_proposals_execution_route
+
+Add execution route branching columns to proposals (P0-2, 2026-06-03):
+- execution_route (NOT NULL, default 'onchain_aave'): CEX 本線 / on-chain Aave opt-in
+- cex_order_id / cex_response: CEX 経路の執行証跡 (order_id = tx_id, 生レスポンス)
+- CHECK 制約 ck_proposals_execution_route: ExecutionRoute.values() を文字通り使用
+
+背景 (Asana 1215364069502631):
+- proposal ごとに執行経路を作成時に確定し immutable 保持する。経路と執行証跡の
+  食い違い (誤執行) を構造的に防ぐ。
+
+CHECK 制約 enum は app.proposals.execution_route.ExecutionRoute を唯一の真実源とし、
+本 migration は import して値を文字通り埋め込む (CLAUDE.md「CHECK制約と migration の
+二重管理ルール」遵守 / 独自 enum 定義禁止)。
+
+Idempotent:
+- postgresql: ADD COLUMN IF NOT EXISTS。CHECK 制約は存在確認後に追加。
+- sqlite (テスト): batch_alter_table。CHECK は models.py の __table_args__ が
+  create_all 時に付与するため、本 migration では列追加のみ。
+
+Revision ID: q7r8s9t0u1v2
+Revises: p6q7r8s9t0u1
+Create Date: 2026-06-03 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+from app.proposals.execution_route import DEFAULT_EXECUTION_ROUTE, ExecutionRoute
+
+# revision identifiers, used by Alembic.
+revision: str = "q7r8s9t0u1v2"
+down_revision: Union[str, Sequence[str], None] = "p6q7r8s9t0u1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_CHECK_NAME = "ck_proposals_execution_route"
+_CHECK_SQL = "execution_route IN (" + ", ".join(f"'{v}'" for v in ExecutionRoute.values()) + ")"
+
+
+def upgrade() -> None:
+    """Add execution_route / cex_order_id / cex_response columns (idempotent)."""
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute(
+            "ALTER TABLE proposals ADD COLUMN IF NOT EXISTS execution_route "
+            f"VARCHAR(20) NOT NULL DEFAULT '{DEFAULT_EXECUTION_ROUTE}'"
+        )
+        op.execute("ALTER TABLE proposals ADD COLUMN IF NOT EXISTS cex_order_id VARCHAR(100)")
+        op.execute("ALTER TABLE proposals ADD COLUMN IF NOT EXISTS cex_response TEXT")
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS ix_proposals_execution_route ON proposals (execution_route)"
+        )
+        # CHECK 制約は IF NOT EXISTS が無いので存在確認してから追加する。
+        op.execute(
+            f"""
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint WHERE conname = '{_CHECK_NAME}'
+                ) THEN
+                    ALTER TABLE proposals ADD CONSTRAINT {_CHECK_NAME}
+                        CHECK ({_CHECK_SQL});
+                END IF;
+            END $$;
+            """
+        )
+    else:
+        # SQLite (テスト fallback): 列追加のみ。CHECK は models.py __table_args__ が付与。
+        with op.batch_alter_table("proposals") as batch_op:
+            batch_op.add_column(
+                sa.Column(
+                    "execution_route",
+                    sa.String(length=20),
+                    nullable=False,
+                    server_default=DEFAULT_EXECUTION_ROUTE,
+                )
+            )
+            batch_op.add_column(sa.Column("cex_order_id", sa.String(length=100), nullable=True))
+            batch_op.add_column(sa.Column("cex_response", sa.Text(), nullable=True))
+        op.create_index("ix_proposals_execution_route", "proposals", ["execution_route"])
+
+
+def downgrade() -> None:
+    """Remove execution route columns from proposals table."""
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute(f"ALTER TABLE proposals DROP CONSTRAINT IF EXISTS {_CHECK_NAME}")
+        op.execute("DROP INDEX IF EXISTS ix_proposals_execution_route")
+        op.execute("ALTER TABLE proposals DROP COLUMN IF EXISTS cex_response")
+        op.execute("ALTER TABLE proposals DROP COLUMN IF EXISTS cex_order_id")
+        op.execute("ALTER TABLE proposals DROP COLUMN IF EXISTS execution_route")
+    else:
+        op.drop_index("ix_proposals_execution_route", table_name="proposals")
+        with op.batch_alter_table("proposals") as batch_op:
+            batch_op.drop_column("cex_response")
+            batch_op.drop_column("cex_order_id")
+            batch_op.drop_column("execution_route")

--- a/backend/app/proposals/execution_route.py
+++ b/backend/app/proposals/execution_route.py
@@ -1,0 +1,174 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/app/proposals/execution_route.py
+"""提案の執行経路 (CEX 本線 / on-chain Aave opt-in) の定義と誤執行ガード。
+
+P0-2 (Asana 1215364069502631) で導入。
+
+§14a 同型の「どの経路で誰の資産が動くか」取り違えリスクを構造的に防ぐ:
+  - proposal ごとに execution_route を作成時に確定し immutable に保持する
+    (immutability は models.py の SQLAlchemy set イベントで強制する)。
+  - CEX 経路は CEX API レスポンス + order_id を DB 記録し、on-chain tx_hash は
+    一切持たない (basescan に現れない = 正常)。
+  - on-chain 経路は P0-1 同様 tx_hash / from / to を receipt 検証し、
+    proposal_id ↔ tx_hash を DB に紐付ける。
+  - 経路と執行証跡が食い違った場合 (on-chain 選択 proposal が CEX 経路で執行、
+    逆も) は即時 EMERGENCY アラート + 例外送出で自動進行を止め、手動介入を必須化する。
+
+値リネーム禁止: DB proposals.execution_route カラムに直接保存され、API で文字列
+として往復し、CHECK 制約 / migration が値を直参照する (auth/constants.py の
+ExecutionPolicy と同じ規律)。
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import Enum
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:  # pragma: no cover - 型補完用
+    from .models import Proposal
+
+logger = logging.getLogger(__name__)
+
+
+class ExecutionRoute(str, Enum):
+    """proposal の執行経路。
+
+    値:
+      - ONCHAIN_AAVE: on-chain Aave V3 経路 (opt-in)。partner wallet が署名し
+        basescan に tx_hash が現れる。
+      - CEX: CEX (Bybit 等) 経路 (本線)。CEX API で発注し order_id / レスポンスを
+        記録する。basescan には一切現れない。
+
+    値リネーム禁止 (DB 永続化値・API 互換性のため)。
+    """
+
+    ONCHAIN_AAVE = "onchain_aave"
+    CEX = "cex"
+
+    @classmethod
+    def values(cls) -> list[str]:
+        """全ての有効値を文字列リストで返す (CheckConstraint / バリデーション用)。"""
+        return [member.value for member in cls]
+
+
+# proposals.execution_route のデフォルト。既存運用は Aave 単独だったため
+# 後方互換 (既存行 / 経路未指定の新規行) は on-chain Aave とみなす。
+DEFAULT_EXECUTION_ROUTE: str = ExecutionRoute.ONCHAIN_AAVE.value
+
+
+class RouteMismatchError(Exception):
+    """proposal の execution_route と実際の執行証跡が食い違った時に送出する。
+
+    誤執行 (別経路で執行された) を意味し、自動進行を止めて手動介入を必須化する。
+    """
+
+
+def detect_route_mismatch(
+    route: str,
+    *,
+    has_onchain_tx: bool,
+    has_cex_order: bool,
+) -> Optional[str]:
+    """execution_route と執行証跡の不整合を検出する。
+
+    :param route: proposal.execution_route の値
+    :param has_onchain_tx: on-chain tx_hash (basescan 証跡) が存在するか
+    :param has_cex_order: CEX order_id / レスポンスが存在するか
+    :returns: 不整合があれば人間可読な説明文字列、無ければ None
+
+    判定:
+      - CEX 経路なのに on-chain tx_hash がある → 誤執行 (本来 basescan に現れない)
+      - ONCHAIN_AAVE 経路なのに CEX order がある → 誤執行 (本来 CEX を使わない)
+    """
+    if route == ExecutionRoute.CEX.value and has_onchain_tx:
+        return (
+            "CEX 経路の proposal に on-chain tx_hash (basescan 証跡) が記録された。"
+            "CEX 経路は basescan に一切現れないのが正常 (誤執行の疑い)。"
+        )
+    if route == ExecutionRoute.ONCHAIN_AAVE.value and has_cex_order:
+        return (
+            "on-chain Aave 経路の proposal に CEX order/レスポンスが記録された。"
+            "on-chain 経路は CEX API を使わないのが正常 (誤執行の疑い)。"
+        )
+    return None
+
+
+def notify_route_mismatch(proposal_id: int, route: str, detail: str) -> None:
+    """誤執行を管理者へ即時 EMERGENCY 通知する (通知失敗で本処理を止めない)。
+
+    手動介入必須を明示する文面を含める。
+    """
+    try:
+        from app.notifications.factory import get_notification_service  # noqa: PLC0415
+        from app.notifications.schemas import (  # noqa: PLC0415
+            NotificationChannel,
+            NotificationMessage,
+            NotificationSeverity,
+        )
+
+        message = NotificationMessage(
+            channel=NotificationChannel.SLACK,
+            severity=NotificationSeverity.EMERGENCY,
+            title=f"🚨 誤執行検出 (proposal #{proposal_id})",
+            body=(
+                f"proposal_id: {proposal_id}\n"
+                f"execution_route: {route}\n"
+                f"detail: {detail}\n"
+                "action: 自動進行を停止しました。手動介入必須 "
+                "(資産が別経路/別 partner wallet で動いた可能性、即時確認)。"
+            ),
+        )
+        get_notification_service().send(message)
+    except Exception:  # noqa: BLE001 — 通知失敗で本処理を止めない
+        logger.exception(
+            "proposal %d: failed to send route-mismatch EMERGENCY notification", proposal_id
+        )
+
+
+def assert_route(
+    proposal: "Proposal",
+    expected: ExecutionRoute,
+) -> None:
+    """proposal がこれから執行しようとする経路 (expected) と一致するか確認する。
+
+    一致しなければ誤執行とみなし、即時 EMERGENCY 通知 + RouteMismatchError 送出で
+    自動進行を止める (手動介入必須)。
+
+    submit-tx (on-chain) / record_cex_execution (CEX) の入口で呼び、
+    「on-chain 選択 proposal を CEX 経路で執行」「逆」を構造的に弾く。
+    """
+    route = proposal.execution_route or DEFAULT_EXECUTION_ROUTE
+    if route == expected.value:
+        return
+    detail = f"proposal.execution_route={route} だが {expected.value} 経路で執行されようとした"
+    notify_route_mismatch(proposal.id, route, detail)
+    raise RouteMismatchError(detail)
+
+
+def record_cex_execution(
+    proposal: "Proposal",
+    *,
+    cex_order_id: str,
+    cex_response: str,
+) -> None:
+    """CEX 経路の執行完了を proposal に記録する。
+
+    - execution_route が CEX であることを assert_route で確認 (違えば誤執行アラート + 例外)。
+    - CEX API レスポンス + order_id (tx_id) を DB に記録する。
+    - on-chain tx_hash は設定しない (basescan に現れないのが正常)。
+
+    呼び出し元が db.commit() を行う責務を持つ。
+    """
+    from datetime import datetime, timezone  # noqa: PLC0415
+
+    assert_route(proposal, ExecutionRoute.CEX)
+    proposal.cex_order_id = cex_order_id
+    proposal.cex_response = cex_response
+    proposal.status = "executed"
+    proposal.executed_at = datetime.now(timezone.utc)
+    logger.info(
+        "proposal %d: CEX execution recorded order_id=%s (no on-chain tx, basescan clean)",
+        proposal.id,
+        cex_order_id,
+    )

--- a/backend/app/proposals/models.py
+++ b/backend/app/proposals/models.py
@@ -15,16 +15,27 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Optional
 
-from sqlalchemy import DateTime, Integer, Numeric, String, Text
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import CheckConstraint, DateTime, Integer, Numeric, String, Text, event
+from sqlalchemy.orm import NO_VALUE, Mapped, mapped_column
 
 from app.database import Base
+
+from .execution_route import DEFAULT_EXECUTION_ROUTE, ExecutionRoute
 
 
 class Proposal(Base):
     """提案テーブル。"""
 
     __tablename__ = "proposals"
+    # execution_route の有効値は ExecutionRoute (models.py が唯一の真実源)。
+    # migration / DB CHECK 制約は本 enum の values() を文字通り使う
+    # (CLAUDE.md「CHECK制約と migration の二重管理ルール」遵守)。
+    __table_args__ = (
+        CheckConstraint(
+            "execution_route IN (" + ", ".join(f"'{v}'" for v in ExecutionRoute.values()) + ")",
+            name="ck_proposals_execution_route",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     user_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
@@ -60,6 +71,20 @@ class Proposal(Base):
     # submit-tx receipt 検証: partner が送信した tx の from/to アドレスを保存して照合する
     expected_from: Mapped[Optional[str]] = mapped_column(String(42), nullable=True)
     expected_to: Mapped[Optional[str]] = mapped_column(String(42), nullable=True)
+    # P0-2 (2026-06-03): 執行経路分岐 (CEX 本線 / on-chain Aave opt-in)。
+    # 作成時に確定し immutable (下部 _prevent_execution_route_mutation で強制)。
+    # 値の正は app.proposals.execution_route.ExecutionRoute。
+    execution_route: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default=DEFAULT_EXECUTION_ROUTE,
+        server_default=DEFAULT_EXECUTION_ROUTE,
+        index=True,
+    )
+    # CEX 経路の執行証跡: CEX API order_id (= tx_id) と生レスポンス。
+    # on-chain 経路では NULL のまま (basescan の tx_hash 側に記録される)。
+    cex_order_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    cex_response: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
@@ -72,3 +97,25 @@ class Proposal(Base):
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
     )
+
+
+@event.listens_for(Proposal.execution_route, "set", propagate=True)
+def _prevent_execution_route_mutation(
+    target: Proposal, value: object, oldvalue: object, initiator: object
+) -> object:
+    """execution_route の作成後変更を構造的に禁止する (P0-2 DoD: immutable)。
+
+    初回設定 (oldvalue が未設定 / None) は許可。以後、別値への変更は ValueError。
+    同値の再代入 (db.refresh 等) は no-op で許可する。
+
+    「経路の後から変更を許す実装」は P0-2 で明示的に禁止されているため、
+    application 層で物理的に弾く。
+    """
+    if oldvalue is NO_VALUE or oldvalue is None:
+        return value
+    if value != oldvalue:
+        raise ValueError(
+            f"execution_route is immutable (proposal id={getattr(target, 'id', None)}): "
+            f"cannot change {oldvalue!r} -> {value!r}"
+        )
+    return value

--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -219,6 +219,18 @@ def _execute_aave_for_proposal(proposal: Proposal, db: Session) -> None:
     from app.ai.schemas import TradeAction  # noqa: PLC0415
     from app.transactions.models import Transaction  # noqa: PLC0415
 
+    from .execution_route import ExecutionRoute, RouteMismatchError, assert_route
+
+    # P0-2 誤執行ガード: Aave 自動実行は on-chain 経路専用。
+    # CEX 選択 proposal がこの経路に入った場合は即時 EMERGENCY アラート + 例外で停止する
+    # (呼び出し元 approve_proposal が 409 に変換し、手動介入必須)。
+    try:
+        assert_route(proposal, ExecutionRoute.ONCHAIN_AAVE)
+    except RouteMismatchError:
+        proposal.status = "failed"
+        proposal.error_message = "route mismatch: CEX proposal entered on-chain execution path"
+        raise
+
     op_map: dict[str, TradeAction] = {
         "SUPPLY": TradeAction.BUY,
         "WITHDRAW": TradeAction.SELL,
@@ -585,7 +597,16 @@ def approve_proposal(
     # AAVE_WALLET_PRIVATE_KEY が署名する経路はこのフラグで完全に無効化される。
     auto_execution_enabled = os.getenv("AUTO_EXECUTION_ENABLED", "false").lower() == "true"
     if auto_execution_enabled:
-        _execute_aave_for_proposal(proposal, db)
+        from .execution_route import RouteMismatchError  # noqa: PLC0415
+
+        try:
+            _execute_aave_for_proposal(proposal, db)
+        except RouteMismatchError as exc:
+            db.commit()  # status='failed' / error_message を永続化
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"誤執行検出: {exc} (手動介入必須)",
+            ) from exc
         db.commit()
         db.refresh(proposal)
     else:
@@ -799,6 +820,8 @@ def submit_partner_tx(
     """
     from app.transactions.models import Transaction  # noqa: PLC0415
 
+    from .execution_route import ExecutionRoute, RouteMismatchError, assert_route
+
     stmt = select(Proposal).where(Proposal.id == proposal_id)
     proposal = db.scalars(stmt).first()
     if proposal is None:
@@ -812,6 +835,17 @@ def submit_partner_tx(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Cannot submit tx for proposal with status '{proposal.status}'",
         )
+
+    # P0-2 誤執行ガード: submit-tx は on-chain Aave 経路専用。
+    # CEX 選択 proposal が on-chain (basescan) tx で執行されようとした場合は
+    # 即時 EMERGENCY アラート + 409 で自動進行を止め、手動介入を必須化する。
+    try:
+        assert_route(proposal, ExecutionRoute.ONCHAIN_AAVE)
+    except RouteMismatchError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"誤執行検出: {exc} (手動介入必須)",
+        ) from exc
 
     # tx_hash 形式チェック (0x + 64 hex chars)
     import re  # noqa: PLC0415
@@ -926,7 +960,16 @@ def create_proposal(
     db: Session = Depends(get_db),
 ) -> ProposalResponse:
     """提案を作成する（内部呼び出し用）。"""
+    from .execution_route import DEFAULT_EXECUTION_ROUTE, ExecutionRoute  # noqa: PLC0415
+
     expires_at = request.expires_at or (datetime.now(timezone.utc) + timedelta(hours=72))
+    # P0-2: 執行経路を作成時に確定 (以後 immutable)。未指定時は on-chain Aave (後方互換)。
+    execution_route = request.execution_route or DEFAULT_EXECUTION_ROUTE
+    if execution_route not in ExecutionRoute.values():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid execution_route '{execution_route}'",
+        )
     proposal = Proposal(
         user_id=request.user_id,
         ai_decision_id=request.ai_decision_id,
@@ -938,6 +981,7 @@ def create_proposal(
         expected_hf_after=request.expected_hf_after,
         estimated_gas_usd=request.estimated_gas_usd,
         expires_at=expires_at,
+        execution_route=execution_route,
     )
     db.add(proposal)
     db.commit()

--- a/backend/app/proposals/schemas.py
+++ b/backend/app/proposals/schemas.py
@@ -22,6 +22,9 @@ class ProposalCreate(BaseModel):
     fee_rate: Optional[Decimal] = None
     fee_amount: Optional[Decimal] = None
     expires_at: Optional[datetime] = None
+    # P0-2: 執行経路 (cex / onchain_aave)。未指定時は on-chain Aave (後方互換)。
+    # 作成時のみ指定可、以後 immutable。
+    execution_route: Optional[str] = None
 
 
 class ProposalResponse(BaseModel):
@@ -47,6 +50,10 @@ class ProposalResponse(BaseModel):
     tx_hash: Optional[str]
     expected_from: Optional[str] = None
     expected_to: Optional[str] = None
+    # P0-2: 執行経路 + CEX 経路の証跡 (on-chain 経路では NULL)。
+    execution_route: str = "onchain_aave"
+    cex_order_id: Optional[str] = None
+    cex_response: Optional[str] = None
     error_message: Optional[str] = None
     expires_at: datetime
     created_at: datetime

--- a/backend/ruff.toml
+++ b/backend/ruff.toml
@@ -27,4 +27,6 @@ known-first-party = ["app"]
 [lint.per-file-ignores]
 # テストファイルではassert, 仮パスワード, tmpファイル使用は許容する
 "tests/**/*.py" = ["S101", "S105", "S106", "S107", "S108"]
+# migration は定数のみで構成されたテンプレート SQL のため S608 (SQL injection) は false positive
+"alembic/versions/**/*.py" = ["S608"]
 

--- a/backend/tests/test_proposal_execution_route.py
+++ b/backend/tests/test_proposal_execution_route.py
@@ -1,0 +1,278 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_proposal_execution_route.py
+"""P0-2: CEX(本線) / on-chain Aave(opt-in) 経路分岐の統合テスト。
+
+Asana 1215364069502631 DoD を担保する:
+- proposal 単位で execution_route を作成時に確定し変更不可 (immutable)
+- CEX 経路: 執行後に CEX API レスポンス + order_id(tx_id) を DB 記録、tx_hash は持たない
+  (basescan に一切現れない = 正常)
+- on-chain 経路: tx_hash 記録 + proposal_id ↔ tx_hash 紐付け + 他 partner 非混在
+- 誤執行: on-chain 選択 proposal を CEX 経路で執行 (逆も) した場合に即時アラート +
+  例外で自動進行停止 (手動介入必須)。統合テスト + 模擬執行で担保。
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-exec-route")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "exec_route_admin@example.com")
+
+from app.database import Base  # noqa: E402
+from app.proposals.execution_route import (  # noqa: E402
+    DEFAULT_EXECUTION_ROUTE,
+    ExecutionRoute,
+    RouteMismatchError,
+    assert_route,
+    detect_route_mismatch,
+    record_cex_execution,
+)
+from app.proposals.models import Proposal  # noqa: E402
+
+
+@pytest.fixture()
+def db_session() -> Generator[Session, None, None]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestSession()
+    try:
+        yield db
+    finally:
+        db.close()
+    Base.metadata.drop_all(bind=engine)
+    os.unlink(path)
+
+
+def _make_proposal(
+    db: Session,
+    *,
+    execution_route: str = ExecutionRoute.ONCHAIN_AAVE.value,
+    status: str = "approved",
+    user_id: int = 1,
+) -> Proposal:
+    p = Proposal(
+        user_id=user_id,
+        operation="SUPPLY",
+        asset="USDC",
+        amount=Decimal("100.000000000000000000"),
+        amount_usd=Decimal("100.00"),
+        reason="test",
+        status=status,
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        execution_route=execution_route,
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# ExecutionRoute enum / detect_route_mismatch
+# ---------------------------------------------------------------------------
+
+
+def test_execution_route_values() -> None:
+    assert ExecutionRoute.values() == ["onchain_aave", "cex"]
+    assert DEFAULT_EXECUTION_ROUTE == ExecutionRoute.ONCHAIN_AAVE.value
+
+
+@pytest.mark.parametrize(
+    ("route", "has_onchain_tx", "has_cex_order", "expect_mismatch"),
+    [
+        # 正常: 経路と証跡が一致
+        (ExecutionRoute.ONCHAIN_AAVE.value, True, False, False),
+        (ExecutionRoute.CEX.value, False, True, False),
+        # 証跡なし (執行前): 不整合なし
+        (ExecutionRoute.ONCHAIN_AAVE.value, False, False, False),
+        (ExecutionRoute.CEX.value, False, False, False),
+        # 誤執行: CEX 経路に on-chain tx
+        (ExecutionRoute.CEX.value, True, False, True),
+        # 誤執行: on-chain 経路に CEX order
+        (ExecutionRoute.ONCHAIN_AAVE.value, False, True, True),
+    ],
+)
+def test_detect_route_mismatch_matrix(
+    route: str, has_onchain_tx: bool, has_cex_order: bool, expect_mismatch: bool
+) -> None:
+    result = detect_route_mismatch(
+        route, has_onchain_tx=has_onchain_tx, has_cex_order=has_cex_order
+    )
+    assert (result is not None) == expect_mismatch
+
+
+# ---------------------------------------------------------------------------
+# DoD: immutability
+# ---------------------------------------------------------------------------
+
+
+def test_execution_route_immutable_after_creation(db_session: Session) -> None:
+    """作成後に execution_route を別値へ変更すると ValueError (immutable)。"""
+    p = _make_proposal(db_session, execution_route=ExecutionRoute.ONCHAIN_AAVE.value)
+    with pytest.raises(ValueError, match="immutable"):
+        p.execution_route = ExecutionRoute.CEX.value
+
+
+def test_execution_route_same_value_reassign_allowed(db_session: Session) -> None:
+    """同値の再代入 (db.refresh 相当) は許可される。"""
+    p = _make_proposal(db_session, execution_route=ExecutionRoute.CEX.value)
+    p.execution_route = ExecutionRoute.CEX.value  # no-op、例外にならない
+    db_session.refresh(p)
+    assert p.execution_route == ExecutionRoute.CEX.value
+
+
+def test_execution_route_default_is_onchain(db_session: Session) -> None:
+    """経路未指定で作成すると後方互換で on-chain Aave になる。"""
+    p = Proposal(
+        user_id=1,
+        operation="SUPPLY",
+        asset="USDC",
+        amount=Decimal("1"),
+        amount_usd=Decimal("1"),
+        reason="default-route",
+        status="pending",
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    db_session.add(p)
+    db_session.commit()
+    db_session.refresh(p)
+    assert p.execution_route == ExecutionRoute.ONCHAIN_AAVE.value
+
+
+# ---------------------------------------------------------------------------
+# DoD: CEX 経路の完了記録
+# ---------------------------------------------------------------------------
+
+
+def test_record_cex_execution_sets_evidence_without_tx_hash(db_session: Session) -> None:
+    """CEX 経路: order_id + レスポンスを記録し、tx_hash は付けない (basescan clean)。"""
+    p = _make_proposal(db_session, execution_route=ExecutionRoute.CEX.value)
+    record_cex_execution(
+        p,
+        cex_order_id="bybit-order-12345",
+        cex_response='{"orderId": "bybit-order-12345", "status": "Filled"}',
+    )
+    db_session.commit()
+    db_session.refresh(p)
+    assert p.status == "executed"
+    assert p.cex_order_id == "bybit-order-12345"
+    assert p.cex_response is not None
+    assert p.executed_at is not None
+    # basescan に現れないのが正常: on-chain tx_hash は記録されない
+    assert p.tx_hash is None
+
+
+def test_record_cex_execution_on_onchain_proposal_raises_and_alerts(db_session: Session) -> None:
+    """誤執行: on-chain 選択 proposal を CEX 経路で執行 → 即時アラート + 例外。"""
+    p = _make_proposal(db_session, execution_route=ExecutionRoute.ONCHAIN_AAVE.value)
+    with patch("app.proposals.execution_route.notify_route_mismatch") as mock_notify:
+        with pytest.raises(RouteMismatchError):
+            record_cex_execution(p, cex_order_id="x", cex_response="{}")
+    mock_notify.assert_called_once()
+    # 自動進行は止まる: executed にならない
+    assert p.status != "executed"
+    assert p.cex_order_id is None
+
+
+def test_assert_route_consistent_noop(db_session: Session) -> None:
+    p = _make_proposal(db_session, execution_route=ExecutionRoute.ONCHAIN_AAVE.value)
+    # 一致時は例外を出さない
+    assert_route(p, ExecutionRoute.ONCHAIN_AAVE)
+
+
+# ---------------------------------------------------------------------------
+# DoD: 誤執行ガード (submit-tx = on-chain 経路) を _execute / assert_route で担保
+# ---------------------------------------------------------------------------
+
+
+def test_assert_route_cex_proposal_onchain_execution_raises(db_session: Session) -> None:
+    """誤執行: CEX 選択 proposal が on-chain 経路で執行 → 即時アラート + 例外。"""
+    p = _make_proposal(db_session, execution_route=ExecutionRoute.CEX.value)
+    with patch("app.proposals.execution_route.notify_route_mismatch") as mock_notify:
+        with pytest.raises(RouteMismatchError):
+            assert_route(p, ExecutionRoute.ONCHAIN_AAVE)
+    mock_notify.assert_called_once()
+
+
+def test_execute_aave_blocks_cex_proposal(db_session: Session) -> None:
+    """模擬執行: CEX proposal が Aave 自動実行経路に入ると failed + 例外 (実 Aave 呼ばず)。"""
+    from app.proposals.router import _execute_aave_for_proposal
+
+    p = _make_proposal(db_session, execution_route=ExecutionRoute.CEX.value)
+    with patch("app.proposals.execution_route.notify_route_mismatch") as mock_notify:
+        with pytest.raises(RouteMismatchError):
+            _execute_aave_for_proposal(p, db_session)
+    mock_notify.assert_called_once()
+    assert p.status == "failed"
+    assert "route mismatch" in (p.error_message or "")
+    # on-chain tx は立たない
+    assert p.tx_hash is None
+
+
+# ---------------------------------------------------------------------------
+# DoD: on-chain 経路 — proposal_id ↔ tx_hash 紐付け + 他 partner 非混在
+# ---------------------------------------------------------------------------
+
+
+def test_onchain_execution_links_proposal_id_to_tx_hash(db_session: Session) -> None:
+    """on-chain 経路の正常執行: proposal_id ↔ tx_hash が DB に紐付く。"""
+    from app.proposals.router import _execute_aave_for_proposal
+
+    p = _make_proposal(db_session, execution_route=ExecutionRoute.ONCHAIN_AAVE.value)
+    fake_result = MagicMock()
+    fake_result.tx_hash = "0x" + "ab" * 32
+    fake_result.status = "success"
+
+    with patch.dict(os.environ, {"AAVE_ACTIVE_CHAINS": "base"}):
+        with patch("app.aave.service.MultiChainAaveService") as mock_svc:
+            mock_svc.return_value.execute_rebalance.return_value = fake_result
+            _execute_aave_for_proposal(p, db_session)
+
+    db_session.commit()
+    db_session.refresh(p)
+    assert p.status == "executed"
+    assert p.tx_hash == "0x" + "ab" * 32
+    # DB 上で proposal_id から tx_hash が引ける (紐付け存在)
+    fetched = db_session.scalars(select(Proposal).where(Proposal.id == p.id)).first()
+    assert fetched is not None
+    assert fetched.tx_hash == "0x" + "ab" * 32
+    assert fetched.cex_order_id is None  # on-chain 経路は CEX 証跡を持たない
+
+
+def test_onchain_partners_not_mixed(db_session: Session) -> None:
+    """他 partner の tx と非混在: 各 proposal の tx_hash は own proposal_id に紐付く。"""
+    from app.proposals.router import _execute_aave_for_proposal
+
+    p1 = _make_proposal(db_session, user_id=11, execution_route=ExecutionRoute.ONCHAIN_AAVE.value)
+    p2 = _make_proposal(db_session, user_id=22, execution_route=ExecutionRoute.ONCHAIN_AAVE.value)
+
+    def _fake_exec(proposal_user_tx: str):
+        r = MagicMock()
+        r.tx_hash = proposal_user_tx
+        r.status = "success"
+        return r
+
+    with patch.dict(os.environ, {"AAVE_ACTIVE_CHAINS": "base"}):
+        with patch("app.aave.service.MultiChainAaveService") as mock_svc:
+            mock_svc.return_value.execute_rebalance.return_value = _fake_exec("0x" + "11" * 32)
+            _execute_aave_for_proposal(p1, db_session)
+            mock_svc.return_value.execute_rebalance.return_value = _fake_exec("0x" + "22" * 32)
+            _execute_aave_for_proposal(p2, db_session)
+    db_session.commit()
+
+    assert p1.tx_hash == "0x" + "11" * 32
+    assert p2.tx_hash == "0x" + "22" * 32
+    assert p1.user_id != p2.user_id
+    assert p1.tx_hash != p2.tx_hash


### PR DESCRIPTION
## 概要
Asana [1215364069502631](https://app.asana.com/1/817733952351708/project/1213916581114014/task/1215364069502631) (P0-2 / Tier S)。proposal ごとに執行経路 (CEX 本線 / on-chain Aave opt-in) を確定し、別経路・別 partner wallet での誤執行を構造的に防ぐ。

Closes Asana 1215364069502631

## DoD 対応
- [x] **immutable 経路保持**: `proposals.execution_route` (cex / onchain_aave) を作成時に確定。SQLAlchemy `set` イベントで以後の変更を `ValueError` で物理的に禁止 (「後から変更を許す実装」禁止条項を遵守)。
- [x] **CEX 経路の完了条件**: `record_cex_execution` が `cex_order_id`(=tx_id) + `cex_response` を DB 記録。on-chain `tx_hash` は付けない (basescan に一切現れない = 正常)。
- [x] **on-chain 経路の完了条件**: P0-1 の receipt 検証 (from/to/status) を維持。`proposal_id ↔ tx_hash` 紐付け + 他 partner 非混在をテストで担保。
- [x] **誤執行アラート**: `assert_route` が経路不一致時に即時 EMERGENCY Slack 通知 + `RouteMismatchError` 送出。`submit-tx` / `approve`(auto-exec) は 409 に変換し自動進行を停止、手動介入を必須化。統合テスト + 模擬執行で担保。

## 一切しないこと (遵守確認)
- 経路の後から変更を許す実装 → immutable ガードで禁止
- CEX 側ロジックの仕様変更 → `exchange/service.py` 未編集

## 変更
| ファイル | 内容 |
|---|---|
| `app/proposals/execution_route.py` (新規) | ExecutionRoute enum / detect_route_mismatch / assert_route / record_cex_execution / notify_route_mismatch |
| `app/proposals/models.py` | execution_route / cex_order_id / cex_response カラム + CHECK 制約 + immutability イベント |
| `app/proposals/router.py` | submit-tx / approve(auto-exec) / create に経路ガード配線 |
| `app/proposals/schemas.py` | ProposalCreate/Response に経路フィールド |
| `alembic/versions/q7r8s9t0u1v2_*.py` (新規) | カラム + CHECK 追加 (idempotent pg/sqlite)。CHECK enum は ExecutionRoute.values() を唯一の真実源として埋め込み |
| `tests/test_proposal_execution_route.py` (新規) | 統合テスト 17 件 |

## Gate
- 自レーン新規テスト: **17 passed** (enum / mismatch matrix / immutable / CEX 記録 / 模擬誤執行アラート / on-chain 紐付け / partner 非混在)
- proposal 系既存テスト: **80 passed** (回帰なし)
- 対象ファイル ruff check / format / mypy / ruff S: **green**
- alembic: 単一 linear head (`q7r8s9t0u1v2`)、migration upgrade/downgrade 往復 OK
- 既知 red (referral/service.py mypy, aave/client.py 等の lint/format) は origin/main baseline 由来で本 PR 範囲外 (#0 対応中)

🤖 Generated with [Claude Code](https://claude.com/claude-code)