### PR TITLE
feat(liff-confirm): オンボーディング重要事項確認 + user settings (#516)

### DIFF
--- a/backend/app/users/settings_router.py
+++ b/backend/app/users/settings_router.py
@@ -2,6 +2,8 @@
 # backend/app/users/settings_router.py
 """ユーザー設定API ルーター定義。"""
 
+import logging
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -16,15 +18,38 @@ from app.partner.allocation_schemas import MyAllocationResponse
 
 from .settings_schemas import UserSettingsResponse, UserSettingsUpdate
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/user", tags=["user-settings"])
+
+
+def _build_settings_response(user: User) -> UserSettingsResponse:
+    """User ORM オブジェクトから UserSettingsResponse を構築する。
+
+    terms_accepted_at → terms_agreed_at のフィールド名変換を行う。
+    """
+    return UserSettingsResponse(
+        id=user.id,
+        email=user.email,
+        username=user.username,
+        is_active=user.is_active,
+        notification_email=user.notification_email,
+        notification_frequency=user.notification_frequency,
+        max_single_trade_usd=user.max_single_trade_usd,
+        max_daily_trade_usd=user.max_daily_trade_usd,
+        user_mode=user.user_mode,
+        execution_policy=user.execution_policy,
+        line_monthly_opt_in=user.line_monthly_opt_in,
+        terms_agreed_at=user.terms_accepted_at,
+    )
 
 
 @router.get("/settings", response_model=UserSettingsResponse, summary="設定取得")
 def get_user_settings(
     current_user: User = Depends(require_active_user),
 ) -> UserSettingsResponse:
-    """現在のユーザー設定を返す。"""
-    return UserSettingsResponse.model_validate(current_user)
+    """現在のユーザー設定を返す。terms_agreed_at（= terms_accepted_at）を含む。"""
+    return _build_settings_response(current_user)
 
 
 @router.put("/settings", response_model=UserSettingsResponse, summary="設定更新")
@@ -89,7 +114,40 @@ def update_user_settings(
     db.add(current_user)
     db.commit()
     db.refresh(current_user)
-    return UserSettingsResponse.model_validate(current_user)
+    return _build_settings_response(current_user)
+
+
+@router.post("/terms-agree", summary="重要事項同意記録")
+def agree_to_terms(
+    current_user: User = Depends(require_active_user),
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    """重要事項への同意を記録する（LIFF オンボーディング用）。
+
+    既に同意済みの場合はそのまま返す（冪等）。
+    terms_accepted_at カラムに現在時刻を書き込み、terms_version="liff-v1" を設定する。
+    """
+    if current_user.terms_accepted_at is not None:
+        return {
+            "terms_agreed_at": current_user.terms_accepted_at.isoformat(),
+            "already_agreed": True,
+        }
+
+    now = datetime.now(timezone.utc)
+    current_user.terms_accepted_at = now
+    current_user.terms_version = "liff-v1"
+    db.add(current_user)
+    db.commit()
+    db.refresh(current_user)
+    logger.info(
+        "User %s agreed to LIFF terms at %s",
+        current_user.email,
+        now.isoformat(),
+    )
+    return {
+        "terms_agreed_at": now.isoformat(),
+        "already_agreed": False,
+    }
 
 
 @router.get(

--- a/backend/app/users/settings_schemas.py
+++ b/backend/app/users/settings_schemas.py
@@ -2,6 +2,7 @@
 # backend/app/users/settings_schemas.py
 """ユーザー設定APIのスキーマ定義。"""
 
+from datetime import datetime
 from decimal import Decimal
 from typing import Optional
 
@@ -22,6 +23,8 @@ class UserSettingsResponse(BaseModel):
     user_mode: str
     execution_policy: str
     line_monthly_opt_in: bool = False
+    # 重要事項確認同意日時（User.terms_accepted_at を公開）
+    terms_agreed_at: Optional[datetime] = None
 
 
 class UserSettingsUpdate(BaseModel):

--- a/backend/tests/test_user_settings_api.py
+++ b/backend/tests/test_user_settings_api.py
@@ -214,3 +214,58 @@ class TestUserSettingsAPI:
         me_r = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
         assert me_r.status_code == 200
         assert me_r.json()["execution_policy"] == "require_approval"
+
+    def test_terms_agreed_at_null_by_default(self, client: TestClient) -> None:
+        """GET /api/user/settings で terms_agreed_at が初期状態では null であること。"""
+        token = register_and_login(client)
+        r = client.get("/api/user/settings", headers={"Authorization": f"Bearer {token}"})
+        assert r.status_code == 200
+        data = r.json()
+        assert "terms_agreed_at" in data
+        # 新規ユーザーは同意未完了
+        assert data["terms_agreed_at"] is None
+
+    def test_terms_agree_records_timestamp(self, client: TestClient) -> None:
+        """POST /api/user/terms-agree で terms_agreed_at が記録されること。"""
+        token = register_and_login(client)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # 同意前: terms_agreed_at is null
+        settings_before = client.get("/api/user/settings", headers=headers)
+        assert settings_before.json()["terms_agreed_at"] is None
+
+        # 同意
+        r = client.post("/api/user/terms-agree", headers=headers)
+        assert r.status_code == 200
+        data = r.json()
+        assert "terms_agreed_at" in data
+        assert data["terms_agreed_at"] is not None
+        assert data["already_agreed"] is False
+
+        # 同意後: settings に terms_agreed_at が反映されること
+        settings_after = client.get("/api/user/settings", headers=headers)
+        assert settings_after.json()["terms_agreed_at"] is not None
+
+    def test_terms_agree_idempotent(self, client: TestClient) -> None:
+        """POST /api/user/terms-agree は冪等で、再実行しても already_agreed=True が返ること。"""
+        token = register_and_login(client)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # 1回目
+        r1 = client.post("/api/user/terms-agree", headers=headers)
+        assert r1.status_code == 200
+        assert r1.json()["already_agreed"] is False
+
+        # 2回目: 冪等
+        r2 = client.post("/api/user/terms-agree", headers=headers)
+        assert r2.status_code == 200
+        assert r2.json()["already_agreed"] is True
+        # タイムスタンプは 1 回目と同じ（秒レベルで一致）
+        ts1 = r1.json()["terms_agreed_at"][:19]  # "YYYY-MM-DDTHH:MM:SS"
+        ts2 = r2.json()["terms_agreed_at"][:19]
+        assert ts1 == ts2
+
+    def test_terms_agree_requires_auth(self, client: TestClient) -> None:
+        """POST /api/user/terms-agree は認証必須であること。"""
+        r = client.post("/api/user/terms-agree")
+        assert r.status_code == 401

--- a/frontend/app/(liff)/liff-confirm/page.tsx
+++ b/frontend/app/(liff)/liff-confirm/page.tsx
@@ -1,0 +1,243 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+// frontend/app/(liff)/liff-confirm/page.tsx
+"use client"
+
+import { useState, useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { CheckCircle, ChevronDown, ExternalLink } from "lucide-react"
+import { getStoredToken } from "@/lib/auth"
+
+const API_BASE = process.env.NEXT_PUBLIC_BACKEND_BASE_URL ?? ""
+
+const ITEMS = [
+  {
+    id: "self_custody",
+    title: "資産はユーザー自身が管理します",
+    detail:
+      "本サービスはノンカストディアル型です。秘密鍵はユーザーが管理し、弊社はウォレットにアクセスできません。",
+  },
+  {
+    id: "defi_risk",
+    title: "DeFi運用にはリスクがあります",
+    detail:
+      "スマートコントラクトのリスク、価格変動リスク、流動性リスクが存在します。投資は自己責任でお願いします。",
+  },
+  {
+    id: "user_responsibility",
+    title: "アカウント管理は利用者自身の責任です",
+    detail:
+      "ログイン情報の管理、不正アクセスへの対応はユーザーご自身の責任となります。弊社はアカウント損失に対して責任を負いません。",
+  },
+]
+
+export default function LiffConfirmPage() {
+  const router = useRouter()
+  const [checked, setChecked] = useState<Record<string, boolean>>({})
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({})
+  const [submitting, setSubmitting] = useState(false)
+  const [loading, setLoading] = useState(true)
+
+  const allChecked = ITEMS.every((item) => checked[item.id])
+  const checkedCount = Object.values(checked).filter(Boolean).length
+
+  // terms_agreed_at チェック: 既に同意済みなら /liff-chat へリダイレクト
+  useEffect(() => {
+    const token = getStoredToken()
+    if (!token) {
+      setLoading(false)
+      return
+    }
+
+    fetch(`${API_BASE}/api/user/settings`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: { terms_agreed_at?: string | null } | null) => {
+        if (data?.terms_agreed_at) {
+          router.replace("/liff-chat")
+        } else {
+          setLoading(false)
+        }
+      })
+      .catch(() => setLoading(false))
+  }, [router])
+
+  const handleSubmit = async () => {
+    if (!allChecked || submitting) return
+    setSubmitting(true)
+
+    const token = getStoredToken()
+
+    try {
+      const res = await fetch(`${API_BASE}/api/user/terms-agree`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token ?? ""}`,
+          "Content-Type": "application/json",
+        },
+      })
+      if (res.ok) {
+        router.replace("/liff-chat")
+      } else {
+        setSubmitting(false)
+      }
+    } catch {
+      setSubmitting(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="w-[375px] mx-auto h-dvh bg-zinc-950 flex items-center justify-center">
+        <div className="w-6 h-6 border-2 border-[#1D9E75] border-t-transparent rounded-full animate-spin" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="w-[375px] mx-auto h-dvh bg-zinc-950 text-zinc-100 flex flex-col overflow-hidden">
+      {/* ヘッダー */}
+      <div className="bg-[#1a3d2e] px-4 py-5 flex-shrink-0">
+        <h1 className="text-white font-bold text-lg">重要事項の確認</h1>
+        <p className="text-zinc-300 text-sm mt-1">運用開始前に以下をご確認ください</p>
+        {/* ステップドット */}
+        <div className="flex gap-1.5 mt-3">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className={`h-1.5 rounded-full transition-all duration-300 ${
+                i < checkedCount ? "bg-[#4ade9a] w-6" : "bg-zinc-700 w-4"
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* プログレスバー */}
+      <div className="px-4 py-3 border-b border-zinc-800 flex-shrink-0">
+        <div className="flex items-center justify-between text-sm mb-1.5">
+          <span className="text-zinc-400">確認状況</span>
+          <span className="text-[#4ade9a] font-semibold">{checkedCount} / 3</span>
+        </div>
+        <div className="h-1.5 bg-zinc-800 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-[#1D9E75] rounded-full transition-all duration-500 ease-out"
+            style={{ width: `${(checkedCount / 3) * 100}%` }}
+          />
+        </div>
+      </div>
+
+      {/* アコーディオンリスト */}
+      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
+        {ITEMS.map((item, idx) => {
+          const isChecked = checked[item.id]
+          const isExpanded = expanded[item.id]
+          return (
+            <div
+              key={item.id}
+              className={`rounded-xl border transition-all duration-200 ${
+                isChecked
+                  ? "border-[#1D9E75] bg-[#1D9E75]/5"
+                  : "border-zinc-800 bg-zinc-900"
+              }`}
+            >
+              <button
+                className="flex items-center w-full px-4 py-4 text-left"
+                onClick={() =>
+                  setExpanded((prev) => ({ ...prev, [item.id]: !prev[item.id] }))
+                }
+              >
+                <button
+                  className="mr-3 flex-shrink-0"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setChecked((prev) => ({ ...prev, [item.id]: !prev[item.id] }))
+                    if (!expanded[item.id]) {
+                      setExpanded((prev) => ({ ...prev, [item.id]: true }))
+                    }
+                  }}
+                >
+                  {isChecked ? (
+                    <CheckCircle className="w-6 h-6 text-[#4ade9a]" />
+                  ) : (
+                    <div className="w-6 h-6 rounded-full border-2 border-zinc-600 flex items-center justify-center">
+                      <span className="text-zinc-500 text-xs font-bold">{idx + 1}</span>
+                    </div>
+                  )}
+                </button>
+                <span
+                  className={`flex-1 text-sm font-medium ${
+                    isChecked ? "text-[#4ade9a]" : "text-white"
+                  }`}
+                >
+                  {item.title}
+                </span>
+                <ChevronDown
+                  className={`w-4 h-4 text-zinc-500 transition-transform ${
+                    isExpanded ? "rotate-180" : ""
+                  }`}
+                />
+              </button>
+              {isExpanded && (
+                <div className="px-4 pb-4">
+                  <p className="text-zinc-400 text-sm leading-relaxed">{item.detail}</p>
+                  {!isChecked && (
+                    <button
+                      onClick={() =>
+                        setChecked((prev) => ({ ...prev, [item.id]: true }))
+                      }
+                      className="mt-3 w-full py-2.5 rounded-lg bg-[#1D9E75]/20 text-[#4ade9a] text-sm font-medium border border-[#1D9E75]/30 hover:bg-[#1D9E75]/30 transition-colors"
+                    >
+                      確認しました
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      {/* 下部: リンク + ボタン */}
+      <div className="px-4 pb-8 pt-4 border-t border-zinc-800 flex-shrink-0 space-y-3">
+        <div className="flex gap-4 justify-center text-xs text-zinc-500">
+          <a
+            href="https://ultra-auto-trade.com/terms"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 hover:text-zinc-300"
+          >
+            利用規約 <ExternalLink className="w-3 h-3" />
+          </a>
+          <a
+            href="https://ultra-auto-trade.com/privacy"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 hover:text-zinc-300"
+          >
+            プライバシーポリシー <ExternalLink className="w-3 h-3" />
+          </a>
+        </div>
+        <button
+          disabled={!allChecked || submitting}
+          onClick={handleSubmit}
+          className={`w-full py-4 rounded-xl font-semibold text-base transition-all duration-200 ${
+            allChecked && !submitting
+              ? "bg-[#1D9E75] text-white hover:bg-[#1D9E75]/90 active:scale-95"
+              : "bg-zinc-800 text-zinc-600 cursor-not-allowed"
+          }`}
+        >
+          {submitting ? (
+            <span className="flex items-center justify-center gap-2">
+              <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+              保存中...
+            </span>
+          ) : (
+            "運用を開始する"
+          )}
+        </button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 目的
LIFF オンボーディング重要事項確認 UI (liff-confirm) + user settings API を main へ合流 (#516)。referral-campaign backend は batch merge で main 既収のため、本 PR の差分は liff-confirm page + user settings router/schema/test。

## 状態
- 最新 main (#534 merged) を merge 済み (コンフリクトなし)
- ruff check green / frontend `tsc --noEmit` exit 0 (ローカル検証)

CI green を確認後 merge。

🤖 Generated with [Claude Code](https://claude.com/claude-code)