### PR TITLE
fix(alembic): add missing invitations create migration + prove prod upgrade safety

### DIFF
--- a/backend/alembic/versions/b3invtbl9k0z_create_invitations_table.py
+++ b/backend/alembic/versions/b3invtbl9k0z_create_invitations_table.py
@@ -1,0 +1,73 @@
+"""create_invitations_table (pre-j0k1 baseline)
+
+invitations テーブルの create migration を補完する。
+
+背景:
+  invitations モデル (app/invitations/models.py) は本番では手動 DDL / create_all で
+  作成されてきた (§12 / 2026-04-05 教訓「DB マイグレーションは手動 ALTER TABLE 方式」)。
+  そのため create migration が alembic chain に存在せず、後続の
+  j0k1l2m3n4o5 (add_invitation_type) が ALTER 対象テーブル不在で fresh DB upgrade を
+  止めていた。本 migration を j0k1 の直前に挿入し chain を自己完結させる。
+
+本番影響:
+  本番 alembic_version は o5p6q7r8s9t0 で stamp 済み。本 revision はその祖先
+  (i9j0k1l2m3n4 と j0k1l2m3n4o5 の間) のため、本番 `alembic upgrade head` では
+  適用済み扱いとなり実行されない (安全)。fresh DB / 本番相当 DB 構築時のみ実行される。
+
+スキーマは j0k1 適用「前」の状態 (type 列なし / partner_id NOT NULL)。
+j0k1 が後段で type 追加 + partner_id nullable 化を行う。
+
+冪等: 既存テーブルがある環境でも安全なよう has_table で存在確認してから作成する。
+
+Revision ID: b3invtbl9k0z
+Revises: i9j0k1l2m3n4
+Create Date: 2026-06-04
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+from alembic import op
+
+revision: str = "b3invtbl9k0z"
+down_revision: Union[str, Sequence[str], None] = "i9j0k1l2m3n4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if inspect(bind).has_table("invitations"):
+        # 本番 / 既存環境では手動 DDL / create_all で既に存在する。再作成しない。
+        return
+    op.create_table(
+        "invitations",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("code", sa.String(length=16), nullable=False),
+        sa.Column(
+            "partner_id",
+            sa.Integer(),
+            nullable=False,  # j0k1l2m3n4o5 で nullable 化される (open registration)
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("max_uses", sa.Integer(), nullable=False),
+        sa.Column("used_count", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("invited_user_id", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["partner_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["invited_user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_invitations_code", "invitations", ["code"], unique=True)
+    op.create_index("ix_invitations_partner_id", "invitations", ["partner_id"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if not inspect(bind).has_table("invitations"):
+        return
+    op.drop_index("ix_invitations_partner_id", table_name="invitations")
+    op.drop_index("ix_invitations_code", table_name="invitations")
+    op.drop_table("invitations")

--- a/backend/alembic/versions/j0k1l2m3n4o5_add_invitation_type.py
+++ b/backend/alembic/versions/j0k1l2m3n4o5_add_invitation_type.py
@@ -5,7 +5,7 @@ invitations テーブルへの変更（open registration mode 対応）:
   - partner_id を nullable 変更: open 登録時は partner 不要
 
 Revision ID: j0k1l2m3n4o5
-Revises: i9j0k1l2m3n4
+Revises: b3invtbl9k0z
 Create Date: 2026-06-01 00:00:00.000000
 
 既存 invitations レコードは type='invite' (server_default) で自動補完されるため後方互換。
@@ -17,7 +17,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "j0k1l2m3n4o5"
-down_revision = "i9j0k1l2m3n4"
+down_revision = "b3invtbl9k0z"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## 結論
**本番 deploy で `alembic upgrade head` は安全に通る = YES。要追加対応なし**（apply-chain は既に冪等）。本 PR は fresh DB / 本番相当 DB の chain 自己完結化 + 実証。

## invitations 真因（確定）
- **カテゴリ (a): 既存本番テーブル / create migration は別管理（手動 DDL）**。
- §12 / 2026-04-05 教訓「本番は手動 ALTER TABLE 方式、compose に alembic 無し」のため invitations は手動 DDL / create_all で作成され、alembic chain に create が存在しなかった。`j0k1l2m3n4o5` が ALTER 対象不在で fresh DB upgrade を停止させていた。
- 修正: `b3invtbl9k0z_create_invitations_table.py` を `i9j0k1l2m3n4`↔`j0k1l2m3n4o5` 間に挿入（j0k1 適用前 schema: type 列なし / partner_id NOT NULL、has_table guard で冪等）。j0k1 の down_revision を張り替え。

## 本番 alembic 整合（実機: head=o5p6q7r8s9t0, alembic_version 有）
本番は **既に stamp 済み**（§12 の「alembic_version 無し」は解消済み）。本 revision は stamp(o5p6) の**祖先**のため本番 upgrade では適用されない（安全）。

## apply-chain o5p6q7r8s9t0 → head(s9t0u1v2w3x4) 全突合
| migration | 操作 | 本番現状 | 判定 |
|---|---|---|---|
| `p6q7r8s9t0u1` | referral_campaigns / uat_wallet_ledger 作成 | 不明（手動の可能性） | `CREATE TABLE IF NOT EXISTS` → 冪等安全 |
| `q7r8s9t0u1v2` | proposals.execution_route 等追加 | 不明 | `ADD COLUMN IF NOT EXISTS` → 冪等安全 |
| `r8s9t0u1v2w3` | tos_consents / tos_user_actions 作成 | **無**（実機確認済） | 新規作成 = 正常 |
| `s9t0u1v2w3x4` | proposals.expiry_reminder_sent_at 追加 | 不明（o5p6 bundling の可能性） | `ADD COLUMN IF NOT EXISTS` → 冪等安全 |

- **user_actions**: 本番 schema = `id,user_id,action_type,target_type,target_id,clicked_at,session_id,context_json` = **ai版(context_json)**、main 定義と一致。apply-chain は user_actions を触らない → alter 不要。

## 実証（本番相当 DB / scratch pgvector）
1. `base→o5p6` 構築 → 本番実機と一致（invitations✓ / user_actions✓(ai) / tos_consents✗ / alembic_version=o5p6q7r8s9t0）。
2. `o5p6→head` upgrade クリーン完走（停止なし、head=s9t0u1v2w3x4、tos_consents 新規作成）。
3. **本番 manual-DDL 想定**で execution_route / expiry_reminder_sent_at / referral_campaigns を事前注入 → upgrade head で IF NOT EXISTS により "already exists" 衝突ゼロ。
4. 往復（downgrade→upgrade）クリーン。単一 head・重複 revision なし。

## 残注意（deploy 手順反映）
- `r8s9` の tos_consents/tos_user_actions は plain create（IF NOT EXISTS 無し）。本番に両テーブル無を実機確認済のため安全だが、deploy 直前に再度 read-only で `to_regclass('public.tos_consents')` が NULL であることを確認推奨。
- IF NOT EXISTS は「既存テーブルの schema 互換」を前提とする。本番の referral_campaigns 等が手動作成済の場合、列構成が migration 期待と一致するか deploy 前に確認推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)