### PR TITLE
feat(liff): degrade V3 (liff) screens to browser PWA when LIFF_ID unset

### DIFF
--- a/frontend/app/(liff)/layout.tsx
+++ b/frontend/app/(liff)/layout.tsx
@@ -7,13 +7,16 @@ import { SessionExpiryBanner } from '@/components/SessionExpiryBanner'
 import { PrivyRootClient } from '@/lib/wallet/PrivyRootClient'
 
 export default function LiffLayout({ children }: { children: React.ReactNode }) {
-  const { isInitialized, error } = useLiff()
+  const { isInitialized, error, liffConfigured } = useLiff()
   // ITP wipe で auth_token が消えた場合に、LINE 側 idToken を使って
   // 黙って /auth/line を叩き直し、ユーザー操作なしで session を復元する。
   // liff-login 以外の LIFF ページに直接遷移しても復帰できる。
   const reauth = useLiffAutoReAuth()
 
-  if (error) {
+  // error 画面は「LIFF モードかつ実際の liff.init 失敗時」のみ表示する。
+  // NEXT_PUBLIC_LIFF_ID 未設定（ブラウザ PWA モード）は error にせず、
+  // 下の通常描画にフォールスルーして children をブラウザで表示する（degrade）。
+  if (liffConfigured && error) {
     return (
       <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center">
         <p className="text-red-400">LIFF初期化エラー: {error}</p>

--- a/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
@@ -161,6 +161,9 @@ export function AccountPanel() {
 
   // ログアウト
   const handleLogout = async () => {
+    const { getLiff, isLiffConfigured } = await import("@/lib/liff/init")
+    const liffMode = isLiffConfigured()
+
     // 1. Privy ログアウト
     try {
       await privyLogout()
@@ -168,13 +171,14 @@ export function AccountPanel() {
       // ignore
     }
 
-    // 2. LINE LIFF ログアウト
-    try {
-      const { getLiff } = await import("@/lib/liff/init")
-      const liff = await getLiff()
-      if (liff.isLoggedIn()) liff.logout()
-    } catch {
-      // ignore
+    // 2. LINE LIFF ログアウト（LIFF モードのみ。ブラウザ PWA モードでは skip）
+    if (liffMode) {
+      try {
+        const liff = await getLiff()
+        if (liff.isLoggedIn()) liff.logout()
+      } catch {
+        // ignore
+      }
     }
 
     // 3. トークンクリア
@@ -182,8 +186,8 @@ export function AccountPanel() {
       localStorage.removeItem("auth_token")
     }
 
-    // 4. /liff-login へリダイレクト
-    router.replace("/liff-login")
+    // 4. リダイレクト（LIFF モードは /liff-login、ブラウザは /login）
+    router.replace(liffMode ? "/liff-login" : "/login")
   }
 
   // アカウント削除申請

--- a/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
@@ -97,9 +97,10 @@ export function ReferralPanel() {
     if (!code) return
     const shareText = buildShareText(code)
     try {
-      const { getLiff } = await import("@/lib/liff/init")
-      const liff = await getLiff()
-      if (liff.isApiAvailable("shareTargetPicker")) {
+      const { getLiff, isLiffConfigured } = await import("@/lib/liff/init")
+      // ブラウザ PWA モード（LIFF 未設定）は SDK を触らずクリップボードへ degrade。
+      const liff = isLiffConfigured() ? await getLiff() : null
+      if (liff && liff.isApiAvailable("shareTargetPicker")) {
         await liff.shareTargetPicker([{ type: "text", text: shareText }])
       } else {
         await navigator.clipboard.writeText(shareText)

--- a/frontend/hooks/useLiff.ts
+++ b/frontend/hooks/useLiff.ts
@@ -21,6 +21,12 @@ export type LiffState = {
   profile: LiffProfile | null;
   idToken: string | null;
   error: string | null;
+  /**
+   * NEXT_PUBLIC_LIFF_ID が設定されているか。
+   * false = ブラウザ PWA モード（LIFF SDK は初期化されず、error は LIFF 未設定では立たない）。
+   * true  = LIFF モード（error は実際の liff.init 失敗時のみ立つ）。
+   */
+  liffConfigured: boolean;
 };
 
 export function useLiff(): LiffState {
@@ -32,6 +38,7 @@ export function useLiff(): LiffState {
     profile: null,
     idToken: null,
     error: null,
+    liffConfigured: true,
   });
 
   useEffect(() => {
@@ -39,7 +46,28 @@ export function useLiff(): LiffState {
 
     async function init() {
       try {
-        const { initLiff, getLiff } = await import("@/lib/liff/init");
+        const { initLiff, getLiff, isLiffConfigured } = await import(
+          "@/lib/liff/init"
+        );
+
+        // ブラウザ PWA モード: LIFF_ID 未設定なら SDK を読み込まず degrade。
+        // 画面はブラウザで描画され、LIFF 専用機能（profile/idToken 等）は無効。
+        if (!isLiffConfigured()) {
+          if (!cancelled) {
+            setState({
+              isReady: true,
+              isInitialized: true,
+              isLoggedIn: false,
+              isInClient: false,
+              profile: null,
+              idToken: null,
+              error: null,
+              liffConfigured: false,
+            });
+          }
+          return;
+        }
+
         await initLiff();
         const liff = await getLiff();
 
@@ -76,6 +104,7 @@ export function useLiff(): LiffState {
           },
           idToken,
           error: null,
+          liffConfigured: true,
         });
       } catch (err) {
         if (!cancelled) {

--- a/frontend/lib/liff/init.ts
+++ b/frontend/lib/liff/init.ts
@@ -4,16 +4,26 @@
 /**
  * LIFF SDK初期化ヘルパー。
  * クライアントサイドのみで使用すること（useEffect内）。
+ *
+ * NEXT_PUBLIC_LIFF_ID が未設定の場合は「ブラウザ PWA モード」として degrade する:
+ * initLiff() は何もせず return し、画面はブラウザで描画される（LIFF 専用機能のみ無効）。
+ * 将来 NEXT_PUBLIC_LIFF_ID を投入すれば従来どおり LIFF モードへ自動的に戻る。
  */
 
 let _initialized = false;
+
+/** NEXT_PUBLIC_LIFF_ID が設定されているか（= LIFF モードで動かすか）。 */
+export function isLiffConfigured(): boolean {
+  return !!process.env.NEXT_PUBLIC_LIFF_ID;
+}
 
 export async function initLiff(): Promise<void> {
   if (_initialized) return;
 
   const liffId = process.env.NEXT_PUBLIC_LIFF_ID;
   if (!liffId) {
-    throw new Error("NEXT_PUBLIC_LIFF_ID is not set");
+    // ブラウザ PWA モード: LIFF 未設定。throw せず no-op（初期化スキップ）。
+    return;
   }
 
   const liff = (await import("@line/liff")).default;


### PR DESCRIPTION
## 目的
NEXT_PUBLIC_LIFF_ID 未設定（ブラウザ PWA）でも V3 の `(liff)` 画面（liff-chat home v3 / 全パネル / liff-confirm）を描画できるよう degrade。**LIFF_ID 設定時は従来どおり LIFF モード（回帰なし）**、将来 LIFF_ID 投入で自動的に LIFF へ戻る設計（LIFF を捨てない）。

## 変更（frontend 5 ファイル）
- **`lib/liff/init.ts`**: 空 LIFF_ID で `throw` せず no-op return。`isLiffConfigured()` 追加。
- **`hooks/useLiff.ts`**: 未設定時は SDK を読み込まず browser-mode state（`isInitialized:true / isLoggedIn:false / error:null / liffConfigured:false`）を返す。実 LIFF_ID 時は従来 init→profile パス維持。
- **`(liff)/layout.tsx`**: error 画面は `liffConfigured && error`（= 実 init 失敗）時のみ。未設定は children を描画（degrade）。本物の init エラーと区別。
- **`AccountPanel` / `ReferralPanel`**: LIFF 専用機能（logout / shareTargetPicker）を `isLiffConfigured()` で guard。ブラウザは logout→`/login`、share→クリップボードへ degrade（throw しない）。

## 検証（空 LIFF_ID）
| 項目 | 結果 |
|---|---|
| `npm run build` | **green**（/liff-chat /liff-confirm /liff-login prerender ○） |
| `tsc --noEmit` | **exit 0** |
| headless chromium `/liff-chat` | 「LIFF初期化エラー」なし・V3 描画（CURRENT ASSET / AI JUDGMENT / MY WALLET）✓ |
| headless chromium `/liff-confirm` | 重要事項確認 UI 描画 ✓ |

LIFF モードは init.ts/useLiff の configured パスが byte 不変のため回帰なし（実機 LINE 検証は別途）。

## ルート導線（DoD 4）
`/` は role 別 dashboard redirect、V3 は `/liff-chat` 直リンク（middleware は i18n のみ＝URL 到達可）。ブラウザ公開メニューへの導線追加は別 UX 判断のため本 PR では未追加（degrade スコープに限定）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)