### PR TITLE
fix(session): 初回 incognito の「セッションが切れました」誤バナーを抑止

### DIFF
--- a/frontend/e2e/itp-wipe-reauth.spec.ts
+++ b/frontend/e2e/itp-wipe-reauth.spec.ts
@@ -102,15 +102,17 @@ test.describe('ITP 7日 wipe re-auth フロー (session-monitor)', () => {
     expect(result.neverSeen).toBe('never_seen')
   })
 
-  test('ページ訪問で last_seen が更新される', async ({ page }) => {
+  test('認証済みユーザーのページ訪問で last_seen が更新される', async ({ page }) => {
     const before = Date.now() - 2 * ONE_DAY_MS
     await seedStorage(page, {
       ultra_last_seen: String(before),
+      // last_seen は「認証済みセッションの活動時刻」。token がある場合のみ更新される。
+      ultra_auth_token: 'dummy.jwt.token',
+      ultra_auth_expires: String(Date.now() + 7 * ONE_DAY_MS),
     })
 
     await page.goto('/')
-    // useSessionMonitor がマウント時に recordLastSeen() を呼ぶ。
-    // 値が更新されているか確認 (少なくとも seed より大きい)。
+    // AuthProvider / useSessionMonitor がマウント時に (認証済みなので) recordLastSeen() を呼ぶ。
     await page.waitForFunction(
       (seed: number) => {
         const raw = window.localStorage.getItem('ultra_last_seen')
@@ -121,5 +123,30 @@ test.describe('ITP 7日 wipe re-auth フロー (session-monitor)', () => {
       before,
       { timeout: 5000 },
     )
+  })
+
+  test('未認証 (token 無し) の訪問では last_seen を記録しない (初回 incognito で wiped 誤検知を防ぐ)', async ({
+    page,
+  }) => {
+    // 真の初回相当: token も last_seen も無いクリーンな状態。
+    await seedStorage(page, {
+      ultra_auth_token: null,
+      ultra_auth_expires: null,
+      auth_token: null,
+      ultra_last_seen: null,
+    })
+
+    // /liff-chat は (liff) layout 配下で SessionExpiryBanner を mount する。
+    await page.goto('/liff-chat')
+
+    // useSessionMonitor が mount しても、未認証なので recordLastSeen() は呼ばれない。
+    // → last_seen は作られず never_seen のまま → バナーは出ない。
+    const banner = page.getByTestId('session-expiry-banner')
+    await expect(banner).toHaveCount(0)
+
+    const lastSeen = await page.evaluate(() =>
+      window.localStorage.getItem('ultra_last_seen'),
+    )
+    expect(lastSeen).toBeNull()
   })
 })

--- a/frontend/hooks/useSessionMonitor.ts
+++ b/frontend/hooks/useSessionMonitor.ts
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import {
   detectSessionState,
+  hasActiveToken,
   recordLastSeen,
   type SessionSnapshot,
 } from "@/lib/auth/session-monitor";
@@ -36,9 +37,15 @@ export function useSessionMonitor(): SessionSnapshot {
   }, []);
 
   useEffect(() => {
-    // マウント時に last_seen を更新し、即 state を再計算する。
-    // (last_seen 更新自体が detectSessionState の結果を fresh に倒すことに注意)
-    recordLastSeen();
+    // マウント時に「認証済みの場合のみ」last_seen を更新し、即 state を再計算する。
+    // last_seen は「認証済みセッションの活動時刻」を表す。未認証 (初回 incognito 等) で
+    // 記録すると never_seen が wiped に化け、一般ユーザーの初回訪問で誤って
+    // 「セッションが切れました」バナーが出てしまう (不適切な導線)。
+    // 認証済みユーザーの token 期限切れ/wipe 検知 (#424) は、過去の認証セッションで
+    // 記録済みの last_seen が残ることで従来どおり機能する。
+    if (hasActiveToken()) {
+      recordLastSeen();
+    }
     refresh();
 
     // 1 分ごとに再計算 (5/7 日境界跨ぎ検知用、軽量)
@@ -46,8 +53,10 @@ export function useSessionMonitor(): SessionSnapshot {
 
     const handleVisibility = () => {
       if (document.visibilityState === "visible") {
-        // 戻ってきたタイミングで last_seen を更新 + 即再計算
-        recordLastSeen();
+        // 戻ってきたタイミングで (認証済みのみ) last_seen を更新 + 即再計算
+        if (hasActiveToken()) {
+          recordLastSeen();
+        }
         refresh();
       }
     };

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -21,7 +21,7 @@
 import React, { createContext, useContext, useEffect, useState, useCallback } from "react";
 import { login as apiLogin, getMe, logout as apiLogout, walletConnect, type UserResponse, type TokenResponse } from "./api/auth";
 import { resolveAuthReady } from "./auth-state";
-import { recordLastSeen } from "./auth/session-monitor";
+import { hasActiveToken, recordLastSeen } from "./auth/session-monitor";
 
 const TOKEN_KEY = "ultra_auth_token";
 const TOKEN_EXPIRES_KEY = "ultra_auth_expires";
@@ -70,9 +70,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   // Restore token on initialization
   useEffect(() => {
-    // ITP wipe 検知用の last_seen を更新 (token の有無に関わらず常に記録)。
-    // 7日 ITP wipe で token が消えていても last_seen が残っていれば wipe を検知できる。
-    recordLastSeen();
+    // last_seen は「認証済みセッションの活動時刻」。認証済み (有効 token あり) の場合のみ更新する。
+    // 未認証 (初回 incognito 等) で記録すると never_seen が wiped に化け、一般ユーザーの
+    // 初回訪問で誤って「セッションが切れました」バナーが出てしまうため。
+    // 7日 ITP wipe / token 期限切れの検知 (#424) は、過去の認証セッションで記録済みの
+    // last_seen が残ることで従来どおり機能する。
+    if (hasActiveToken()) {
+      recordLastSeen();
+    }
 
     const storedToken = localStorage.getItem(TOKEN_KEY);
     const expiresStr = localStorage.getItem(TOKEN_EXPIRES_KEY);


### PR DESCRIPTION
## 症状
incognito（localStorage 完全クリーン・真の初回）で `/liff-chat` を開くと「セッションが切れました。再度ログインしてください」赤バナーが出る。

## 真因（実コード特定）
バナー発火元は `SessionExpiryBanner` → `useSessionMonitor` → `describeSessionState`。
`useSessionMonitor`(mount/visibilitychange) と `AuthProvider`(mount) が **token の有無に関わらず** `recordLastSeen()` を呼んでいた：
1. `recordLastSeen()` が `ultra_last_seen=now` を書き込む
2. `detectSessionState()` が `lastSeen=now` + `hasToken=false` を見て **`wiped`** 判定（`never_seen` ではなく）
3. `describeSessionState("wiped")` =「セッションが切れました」赤バナー表示

→ `auth.ts` の旧コメント「token の有無に関わらず常に記録」がこの誤判定の原因。

## 修正
`last_seen` =「**認証済みセッションの活動時刻**」という本来の意味に揃え、`recordLastSeen()` を **`hasActiveToken()` が true の場合のみ** 呼ぶ（3 箇所）:
- `hooks/useSessionMonitor.ts`（mount / visibilitychange）
- `lib/auth.ts`（AuthProvider mount）

## #424（7日 ITP wipe re-auth）は非回帰
認証済みユーザーが過去に記録した `last_seen` は残るため、token 期限切れ/wipe 後の再訪では「last_seen 有 + token 無」=`wiped` を従来どおり検知しバナーを出す。

## 実機 headless 検証（empty LIFF_ID build）
| シナリオ | banner | last_seen | 判定 |
|---|---|---|---|
| clean incognito | **0 件** | null | ✓ 出ない |
| token 期限切れ + 過去 last_seen | **1 件** (state=wiped) | — | ✓ #424 維持 |

## テスト
`e2e/itp-wipe-reauth.spec.ts`: 「ページ訪問で last_seen 更新」→「**認証済み**訪問で更新」に修正（token seed 追加）+ 新規回帰テスト「未認証訪問では last_seen を記録しない（初回 incognito で wiped 誤検知を防ぐ）」を追加。

## DoD
- tsc --noEmit exit 0 / npm run build green（空 LIFF_ID）/ headless 確認済
- CI（Lint/Test/E2E）green を確認後 merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)