### PR TITLE
fix(session): last_seen を write primitive で hasActiveToken ガード（incognito 誤バナー根治）

### DIFF
--- a/frontend/hooks/useITPGuard.ts
+++ b/frontend/hooks/useITPGuard.ts
@@ -37,7 +37,9 @@ export function useITPGuard(): ITPGuardResult {
   const [hoursUntilExpiry, setHoursUntilExpiry] = useState<number | null>(null)
 
   useEffect(() => {
-    updateLastSeen()
+    // 認証済みのみ last_seen を更新 (未認証で書くと初回 incognito で wiped 誤判定)。
+    // updateLastSeen 自体も内部で hasActiveToken ガード済 (二重防御)。
+    if (isAuthenticated) updateLastSeen()
 
     function refresh() {
       setSessionState(computeState(isAuthenticated))
@@ -48,7 +50,7 @@ export function useITPGuard(): ITPGuardResult {
 
     function onVisibilityChange() {
       if (document.visibilityState === 'visible') {
-        updateLastSeen()
+        if (isAuthenticated) updateLastSeen()
         refresh()
       }
     }

--- a/frontend/lib/auth/session-monitor.ts
+++ b/frontend/lib/auth/session-monitor.ts
@@ -105,9 +105,16 @@ export function hasActiveToken(): boolean {
  * 現在時刻を last_seen として記録する。
  * AuthProvider / LIFF layout のマウント時と、`visibilitychange` で呼び出すこと。
  *
- * @returns 書き込みに成功したか (Private モードでは false)
+ * 不変条件: last_seen は「認証済みセッションの活動時刻」のみを表す。
+ * 未認証 (有効な token なし) の場合は **書き込まない**。これにより
+ *   - 初回 incognito / 未ログイン訪問で ultra_last_seen が作られず never_seen を維持
+ *   - 「last_seen 有 + token 無」= 過去に認証済みだった証拠 = 真の wipe (#424) と確定
+ * を保証する。呼び出し側のガード漏れに対する最終防壁 (write primitive level)。
+ *
+ * @returns 書き込みに成功したか (未認証 / Private モードでは false)
  */
 export function recordLastSeen(now: number = Date.now()): boolean {
+  if (!hasActiveToken()) return false;
   return safeSetItem(LAST_SEEN_KEY, String(now));
 }
 

--- a/frontend/lib/session/itp-guard.ts
+++ b/frontend/lib/session/itp-guard.ts
@@ -11,12 +11,18 @@
 //   2. 6日経過で「もうすぐ期限切れ」警告 → 再認証を促す
 //   3. 7日経過で ITP によるセッション消去とみなす
 
+import { hasActiveToken } from '@/lib/auth/session-monitor'
+
 export const LAST_SEEN_KEY = 'ultra_last_seen'
 
 const ITP_EXPIRE_MS  = 7 * 24 * 60 * 60 * 1000  // 7 days — ITP threshold
 const ITP_WARNING_MS = 6 * 24 * 60 * 60 * 1000  // 6 days — warn before expiry
 
 export function updateLastSeen(): void {
+  // 不変条件: last_seen は認証済みセッションの活動時刻のみ。未認証では書かない。
+  // (ultra_last_seen は session-monitor の wiped 判定と共有のため、未認証で書くと
+  //  初回 incognito で誤って「セッションが切れました」バナーが出る。)
+  if (!hasActiveToken()) return
   try {
     localStorage.setItem(LAST_SEEN_KEY, String(Date.now()))
   } catch {


### PR DESCRIPTION
## 真因（#541 のガード漏れ経路）
incognito 実機で `ultra_last_seen` が書かれ続けるのは、`ultra_last_seen` を書く経路が **2 系統**あり #541 は片方しか塞いでいなかったため:
1. `lib/auth/session-monitor.ts` `recordLastSeen()` ← #541 で呼び出し3箇所をガード済
2. **`lib/session/itp-guard.ts` `updateLastSeen()`** ← 同じ `ultra_last_seen` キーへ直接 `setItem`、**未ガード**。呼び出し元 `hooks/useITPGuard.ts` は現状 dead code だが、配線/将来利用で未認証でも書き、session-monitor の wiped 判定を汚染して赤バナーが復活する。

## 根治（write primitive level でガード統一）
「`last_seen` は認証済みセッションの活動時刻のみ」という不変条件を**書き込み関数の入口**で強制（呼び出し側のガード漏れに非依存）:
- `recordLastSeen()`: 先頭で `!hasActiveToken()` なら no-op
- `updateLastSeen()`: 同上（`hasActiveToken` を import）
- `useITPGuard`: 呼び出し側も `isAuthenticated` ガード（二重防御）

→ 「`ultra_last_seen` 存在 ⟺ 過去に認証済み」が常に成立。`detectSessionState` の `wiped`（last_seen 有 + token 無）は真の wipe のみを表す。

## describeSessionState 側の保険（検討した上で敢えて入れない）
token-key 存在チェック等を足すと #424 の「ITP で token が消えても last_seen 残存 → wipe 検知」を壊す。primitive guard で不変条件を保証する方が安全かつ十分なため、`detectSessionState` ロジックは変更せず不変条件をコメントで明文化。

## 実機 headless 検証（空 LIFF_ID build）
| シナリオ | ultra_last_seen | banner | V3 |
|---|---|---|---|
| clean incognito `/liff-chat` | **null（未書込）** | **0 件** | CURRENT ASSET 描画 ✓ |
| token 期限切れ + 過去 last_seen | — | **1 件 (wiped)** | #424 維持 ✓ |

tsc exit 0 / npm run build green。

## 補足
実機で #541 後も書かれていたのは、当該環境が **#541 未デプロイ or PWA service worker の旧 JS キャッシュ**の可能性が高い。本 PR は経路レベルで再発不能化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)