### PR TITLE
ci: add frontend (tsc + build) required check + branch protection draft

### DIFF
--- a/.github/branch-protection-setup.md
+++ b/.github/branch-protection-setup.md
@@ -119,6 +119,123 @@ feature/*
 
 ---
 
+## gh api コマンド草案 (hkobayashi 確認後に実行)
+
+> **注意:** 以下コマンドは `admin:repo` 権限が必要。実行前に hkobayashi が確認・承認すること。
+> `required_status_checks` に指定するチェック名は `CI / {job_name}` 形式 (GitHub Actions の場合)。
+> 新ジョブは少なくとも 1 回 CI 実行後でないと GitHub 側にコンテキストが登録されない。
+
+### main ブランチ
+
+```bash
+gh api \
+  --method PUT \
+  -H "Accept: application/vnd.github+json" \
+  /repos/milechy/ultra-autotrade-project/branches/main/protection \
+  --input - << 'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "checks": [
+      {"context": "CI / Lint (ruff + mypy)",        "app_id": -1},
+      {"context": "CI / Test (pytest + coverage)",  "app_id": -1},
+      {"context": "CI / Security Check",            "app_id": -1},
+      {"context": "CI / Frontend (tsc + build)",    "app_id": -1}
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 2,
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": true
+}
+EOF
+```
+
+### staging ブランチ
+
+```bash
+gh api \
+  --method PUT \
+  -H "Accept: application/vnd.github+json" \
+  /repos/milechy/ultra-autotrade-project/branches/staging/protection \
+  --input - << 'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "checks": [
+      {"context": "CI / Lint (ruff + mypy)",        "app_id": -1},
+      {"context": "CI / Test (pytest + coverage)",  "app_id": -1},
+      {"context": "CI / Security Check",            "app_id": -1},
+      {"context": "CI / Frontend (tsc + build)",    "app_id": -1}
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": false
+}
+EOF
+```
+
+### dev ブランチ
+
+```bash
+gh api \
+  --method PUT \
+  -H "Accept: application/vnd.github+json" \
+  /repos/milechy/ultra-autotrade-project/branches/dev/protection \
+  --input - << 'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "checks": [
+      {"context": "CI / Lint (ruff + mypy)",       "app_id": -1},
+      {"context": "CI / Test (pytest + coverage)", "app_id": -1},
+      {"context": "CI / Frontend (tsc + build)",   "app_id": -1}
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": false
+}
+EOF
+```
+
+### 設定確認コマンド
+
+```bash
+# 設定後の確認 (各ブランチ)
+gh api /repos/milechy/ultra-autotrade-project/branches/main/protection \
+  | python3 -m json.tool | grep -A30 required_status
+
+gh api /repos/milechy/ultra-autotrade-project/branches/dev/protection \
+  | python3 -m json.tool | grep -A30 required_status
+
+gh api /repos/milechy/ultra-autotrade-project/branches/staging/protection \
+  | python3 -m json.tool | grep -A30 required_status
+```
+
+---
+
 ## 緊急時の手順 (Break-glass)
 
 本番障害など緊急時に直接 main へ push が必要な場合:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,37 @@ jobs:
           name: coverage-report
           path: backend/coverage.xml
 
+  frontend:
+    name: Frontend (tsc + build)
+    runs-on: ubuntu-latest
+    needs: lint
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0  # v2.12.0
+        continue-on-error: true
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps
+
+      - name: TypeScript check
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: npm run build
+
   security-check:
     name: Security Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- **新 CI ジョブ追加**: `Frontend (tsc + build)` — `npx tsc --noEmit` + `npm run build` を必須チェックとして追加
- **branch protection 草案**: `gh api` PUT コマンドを `.github/branch-protection-setup.md` に追記（main / staging / dev）
- **トグル未実施**: 実際の branch protection 有効化は hkobayashi 確認後

## 変更詳細

### ci.yml
```
frontend job (needs: lint)
  - actions/setup-node@v4.4.0 (pinned SHA) + Node 22
  - npm install --legacy-peer-deps
  - npx tsc --noEmit        ← TypeScript 型エラーを CI で検出
  - npm run build           ← Next.js production build 確認
```

### branch-protection-setup.md
`gh api` コマンド草案を追加。

**required checks (main / staging):**
- `CI / Lint (ruff + mypy)` — ruff + mypy
- `CI / Test (pytest + coverage)` — pytest
- `CI / Security Check`
- `CI / Frontend (tsc + build)` — tsc + build (新規)

**required checks (dev):**
- Lint + Test + Frontend (security-check 除く)

## 注意事項

- `required_status_checks` に指定するコンテキスト名は `CI / {job name}` 形式
- 新ジョブが少なくとも 1 回 CI を通過してから branch protection を有効化すること
- `app_id: -1` = any app (GitHub Actions 共通)

## Test plan

- [ ] このPRの CI で `Frontend (tsc + build)` ジョブが緑になることを確認
- [ ] hkobayashi が gh api コマンドを確認・実行

GID: 1215428893181908

🤖 Generated with [Claude Code](https://claude.com/claude-code)