### PR TITLE
fix(liff): degrade 黒画面の中央集権ガード + ブラウザ partner 承認成立 (#548 統合)

### DIFF
--- a/frontend/app/(liff)/_components/BrowserLoginPrompt.tsx
+++ b/frontend/app/(liff)/_components/BrowserLoginPrompt.tsx
@@ -1,0 +1,66 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// frontend/app/(liff)/_components/BrowserLoginPrompt.tsx
+//
+// ブラウザ PWA モード (LIFF degrade) で JWT が無いときに表示する優しいログイン導線。
+// partner の IT リテラシを前提に、専門用語を避け、エラーも次の行動が分かる文言にする。
+"use client";
+
+import { Loader2, Wallet } from "lucide-react";
+import { useLiffBrowserAuth } from "@/hooks/useLiffBrowserAuth";
+
+interface BrowserLoginPromptProps {
+  /** ログイン成功後の処理。未指定ならページをリロードして token を読み直す。 */
+  onSuccess?: () => void;
+}
+
+export function BrowserLoginPrompt({ onSuccess }: BrowserLoginPromptProps) {
+  const { signIn, signingIn, error } = useLiffBrowserAuth();
+
+  async function handleLogin() {
+    const ok = await signIn();
+    if (!ok) return;
+    if (onSuccess) {
+      onSuccess();
+    } else if (typeof window !== "undefined") {
+      window.location.reload();
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-dvh bg-zinc-950 px-6 text-center">
+      <Wallet className="h-10 w-10 text-green-500 mb-4" />
+      <h2 className="text-zinc-100 text-base font-semibold mb-2">
+        ログインが必要です
+      </h2>
+      <p className="text-zinc-400 text-sm mb-6 leading-relaxed">
+        ご自身のウォレットでログインすると、
+        <br />
+        提案の確認と承認ができます。
+      </p>
+
+      <button
+        onClick={handleLogin}
+        disabled={signingIn}
+        className="w-full max-w-xs flex items-center justify-center gap-2
+                   bg-green-600 hover:bg-green-500 disabled:opacity-50
+                   disabled:cursor-not-allowed text-white font-semibold
+                   py-3 rounded-xl transition-colors"
+      >
+        {signingIn ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Wallet className="h-4 w-4" />
+        )}
+        {signingIn ? "ログイン中..." : "ウォレットでログイン"}
+      </button>
+
+      {error && <p className="text-red-400 text-xs mt-3 max-w-xs">{error}</p>}
+
+      <p className="text-zinc-600 text-xs mt-6 leading-relaxed">
+        LINEアプリからご利用の場合は、
+        <br />
+        メニューから開き直してください。
+      </p>
+    </div>
+  );
+}

--- a/frontend/app/(liff)/layout.tsx
+++ b/frontend/app/(liff)/layout.tsx
@@ -1,13 +1,20 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 'use client'
 
+import { usePathname } from 'next/navigation'
 import { useLiff } from '@/hooks/useLiff'
 import { useLiffAutoReAuth } from '@/hooks/useLiffAutoReAuth'
 import { SessionExpiryBanner } from '@/components/SessionExpiryBanner'
 import { PrivyRootClient } from '@/lib/wallet/PrivyRootClient'
 
+// degrade ガードを適用しない経路。
+// - liff-login : ログイン導線そのもの (未ログインで来る前提)
+// - liff-sign-poc: 署名診断ページ (ログイン状態を意図的に表示する)
+const AUTH_GUARD_EXEMPT = ['/liff-login', '/liff-sign-poc']
+
 export default function LiffLayout({ children }: { children: React.ReactNode }) {
-  const { isInitialized, error, liffConfigured } = useLiff()
+  const { isInitialized, isLoggedIn, error, liffConfigured } = useLiff()
+  const pathname = usePathname()
   // ITP wipe で auth_token が消えた場合に、LINE 側 idToken を使って
   // 黙って /auth/line を叩き直し、ユーザー操作なしで session を復元する。
   // liff-login 以外の LIFF ページに直接遷移しても復帰できる。
@@ -36,6 +43,23 @@ export default function LiffLayout({ children }: { children: React.ReactNode }) 
     return (
       <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center">
         <p className="text-zinc-400">セッションを復元しています...</p>
+      </div>
+    )
+  }
+
+  // ── 中央集権 degrade ガード ──
+  // 各 LIFF ページが個別に if(!isLoggedIn) 黒画面を持つ取りこぼしを解消し、ここで一元化する。
+  // ブロックするのは「LIFF モード (liffConfigured=true) かつ LINE 未ログインかつ JWT も無い」場合のみ。
+  // ブラウザ PWA モード (liffConfigured=false) は isLoggedIn が常に false でもブロックせず、
+  // children を通常描画して degrade させる (ブラウザ承認導線はページ側で JWT を取得する)。
+  // この構造により、新規 LIFF ページは個別ガードを書かなくても自動で degrade 対応になる。
+  const token =
+    typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null
+  const isExempt = AUTH_GUARD_EXEMPT.includes(pathname ?? '')
+  if (liffConfigured && !isLoggedIn && !token && !isExempt) {
+    return (
+      <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center px-4">
+        <p className="text-zinc-400 text-sm">LINEアプリから開いてください</p>
       </div>
     )
   }

--- a/frontend/app/(liff)/liff-approve/_components/ApproveConfirmSheet.tsx
+++ b/frontend/app/(liff)/liff-approve/_components/ApproveConfirmSheet.tsx
@@ -5,14 +5,14 @@
 
 import { useState, useCallback } from "react";
 import { usePrivy, useWallets } from "@privy-io/react-auth";
+import { ethers } from "ethers";
 import { Loader2, Lock } from "lucide-react";
 import {
   TransactionStatus,
   type ProposalStatus,
 } from "@/app/user/approve/_components/TransactionStatus";
+import { buildPartnerTx, submitPartnerTx } from "@/lib/api/admin-proposals";
 import type { Proposal } from "./ProposalBubble";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 type SigningStatus = "idle" | "signing" | "confirming" | "success" | "error";
 
@@ -72,6 +72,7 @@ export function ApproveConfirmSheet({
     setSigningStatus("signing");
 
     try {
+      // embedded wallet (Privy TEE) のみ使用。外部 wallet は秘密鍵管理の懸念で除外。
       const wallet = wallets.find((w) => w.walletClientType === "privy");
       if (!wallet) {
         await login();
@@ -79,43 +80,92 @@ export function ApproveConfirmSheet({
         return;
       }
 
-      // Step 1: 未署名 tx 取得
-      const buildRes = await fetch(
-        `${API_BASE}/api/proposals/${proposal.id}/build-tx`,
-        { headers: { Authorization: `Bearer ${token}` } }
-      );
-      if (!buildRes.ok) throw new Error(`build-tx: HTTP ${buildRes.status}`);
-      const { unsigned_tx } = (await buildRes.json()) as { unsigned_tx: object };
+      // Step 1: サーバーから未署名 tx を取得。
+      // build-tx は onBehalfOf / to == partner 本人 wallet をサーバー側で検証して返す (§14a)。
+      const txData = await buildPartnerTx(proposal.id, token);
 
-      // Step 2: Privy embedded wallet で署名 + 送信
       const eip1193 = await wallet.getEthereumProvider();
-      const txHash = (await eip1193.request({
-        method: "eth_sendTransaction",
-        params: [unsigned_tx],
-      })) as string;
+      const ethProvider = new ethers.BrowserProvider(
+        eip1193 as unknown as ethers.Eip1193Provider
+      );
+
+      let finalTxHash: string;
+
+      if (
+        txData.operation === "SUPPLY" &&
+        txData.approve_tx &&
+        txData.supply_tx
+      ) {
+        // SUPPLY: approve → supply の順に partner 本人が署名・送信。
+        const approveTxHash = (await eip1193.request({
+          method: "eth_sendTransaction",
+          params: [
+            {
+              to: txData.approve_tx.to,
+              data: txData.approve_tx.data,
+              from: txData.approve_tx.from,
+              value: "0x0",
+            },
+          ],
+        })) as string;
+
+        // approve の確定を待ってから supply を送信する。
+        const approveReceipt =
+          await ethProvider.waitForTransaction(approveTxHash);
+        if (approveReceipt === null || approveReceipt.status === 0) {
+          throw new Error(
+            "approve トランザクションが revert しました。残高・ガス代を確認してください。"
+          );
+        }
+
+        setSigningStatus("confirming");
+        finalTxHash = (await eip1193.request({
+          method: "eth_sendTransaction",
+          params: [
+            {
+              to: txData.supply_tx.to,
+              data: txData.supply_tx.data,
+              from: txData.supply_tx.from,
+              value: "0x0",
+            },
+          ],
+        })) as string;
+      } else if (txData.operation === "WITHDRAW" && txData.withdraw_tx) {
+        finalTxHash = (await eip1193.request({
+          method: "eth_sendTransaction",
+          params: [
+            {
+              to: txData.withdraw_tx.to,
+              data: txData.withdraw_tx.data,
+              from: txData.withdraw_tx.from,
+              value: "0x0",
+            },
+          ],
+        })) as string;
+      } else {
+        throw new Error(`未対応の operation: ${txData.operation}`);
+      }
 
       setSigningStatus("confirming");
 
-      // Step 3: バックエンドに tx_hash を送信して approve 完了
-      const approveRes = await fetch(
-        `${API_BASE}/api/proposals/${proposal.id}/approve`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ tx_hash: txHash }),
-        }
+      // Step 3: submit-tx で最終 tx_hash を報告。
+      // サーバーが on-chain receipt を検証する (from == partner wallet / status == 1)。
+      // 旧実装は /approve に tx_hash を投げるだけで receipt 検証を飛ばしていた弱点を塞ぐ (§7)。
+      await submitPartnerTx(
+        proposal.id,
+        finalTxHash,
+        txData.wallet_address,
+        token
       );
-      if (!approveRes.ok) throw new Error(`approve: HTTP ${approveRes.status}`);
 
       setSigningStatus("success");
-      onApproved(txHash);
+      onApproved(finalTxHash);
     } catch (err) {
       setSigningStatus("error");
+      const msg =
+        err instanceof Error ? err.message : "署名処理に失敗しました";
       setError(
-        err instanceof Error ? err.message : "署名処理に失敗しました"
+        msg.includes("rejected") ? "署名がキャンセルされました" : msg
       );
     }
   }, [wallets, login, proposal.id, token, onApproved]);

--- a/frontend/app/(liff)/liff-approve/page.tsx
+++ b/frontend/app/(liff)/liff-approve/page.tsx
@@ -17,13 +17,14 @@ import { SystemDateSeparator } from "./_components/SystemDateSeparator";
 import { ActionBar, type ActionBarState } from "./_components/ActionBar";
 import { ApproveConfirmSheet } from "./_components/ApproveConfirmSheet";
 import { ChatLoadingSkeleton } from "./_components/ChatLoadingSkeleton";
+import { BrowserLoginPrompt } from "../_components/BrowserLoginPrompt";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 type SystemMsg = { id: string; text: string };
 
 export default function LiffApprovePage() {
-  const { isReady, isLoggedIn, error } = useLiff();
+  const { isReady, error, liffConfigured } = useLiff();
   const token =
     typeof window !== "undefined" ? localStorage.getItem("auth_token") : null;
 
@@ -41,7 +42,9 @@ export default function LiffApprovePage() {
 
   // ---------- data fetch ----------
   useEffect(() => {
-    if (!isReady || !isLoggedIn || !token) return;
+    // 認証は JWT (token) の有無で判定する。ブラウザ degrade モードでは isLoggedIn は
+    // 常に false だが、token があれば取得を続行する (LINE 非依存)。
+    if (!isReady || !token) return;
 
     setLoading(true);
     setFetchError(null);
@@ -71,7 +74,7 @@ export default function LiffApprovePage() {
     ])
       .catch(() => setFetchError("データ取得に失敗しました"))
       .finally(() => setLoading(false));
-  }, [isReady, isLoggedIn, token]);
+  }, [isReady, token]);
 
   // scroll to bottom when proposal appears
   useEffect(() => {
@@ -132,7 +135,8 @@ export default function LiffApprovePage() {
     );
   }
 
-  if (error) {
+  // error 画面は LIFF モードの実 init 失敗時のみ。ブラウザ degrade では error は立たない。
+  if (liffConfigured && error) {
     return (
       <div className="flex items-center justify-center min-h-dvh bg-zinc-950 px-4">
         <p className="text-red-400 text-sm text-center">
@@ -142,23 +146,22 @@ export default function LiffApprovePage() {
     );
   }
 
-  if (!isLoggedIn) {
-    return (
-      <div className="flex items-center justify-center min-h-dvh bg-zinc-950 px-4">
-        <p className="text-zinc-400 text-sm">LINEアプリから開いてください</p>
-      </div>
-    );
-  }
-
+  // 黒画面の if(!isLoggedIn) ガードは (liff)/layout.tsx の中央集権 degrade ガードへ移譲済み。
+  // ここでは JWT (token) の有無だけを見る。
   if (!token) {
-    if (typeof window !== "undefined") {
-      window.location.replace("/liff-login");
+    // LIFF モード: LINE idToken から JWT を発行するため liff-login へ。
+    if (liffConfigured) {
+      if (typeof window !== "undefined") {
+        window.location.replace("/liff-login");
+      }
+      return (
+        <div className="flex items-center justify-center min-h-dvh bg-zinc-950 px-4">
+          <p className="text-zinc-400 text-sm">再認証中...</p>
+        </div>
+      );
     }
-    return (
-      <div className="flex items-center justify-center min-h-dvh bg-zinc-950 px-4">
-        <p className="text-zinc-400 text-sm">再認証中...</p>
-      </div>
-    );
+    // ブラウザ degrade モード: LINE 非依存で Privy wallet 署名により JWT を取得する。
+    return <BrowserLoginPrompt />;
   }
 
   const actionBarState: ActionBarState = proposal ? actionState : "empty";

--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -158,6 +158,7 @@ export default function LiffChatPage() {
         </button>
         <span className="text-[#4ade9a] font-bold text-xl tracking-wider">UAT</span>
         <button
+          onClick={() => setActivePanel("account")}
           className="text-white p-1 hover:bg-white/10 rounded-lg transition-colors"
           aria-label="アカウント"
         >

--- a/frontend/app/(liff)/liff-fee-approve/page.tsx
+++ b/frontend/app/(liff)/liff-fee-approve/page.tsx
@@ -8,9 +8,10 @@
 
 import { useLiff } from '@/hooks/useLiff'
 import { FeeApproveCard } from '@/components/user/FeeApproveCard'
+import { BrowserLoginPrompt } from '../_components/BrowserLoginPrompt'
 
 export default function LiffFeeApprovePage() {
-  const { isReady, isLoggedIn, error } = useLiff()
+  const { isReady, error, liffConfigured } = useLiff()
 
   if (!isReady) {
     return (
@@ -20,7 +21,8 @@ export default function LiffFeeApprovePage() {
     )
   }
 
-  if (error) {
+  // error 画面は LIFF モードの実 init 失敗時のみ。ブラウザ degrade では error は立たない。
+  if (liffConfigured && error) {
     return (
       <div className="flex items-center justify-center min-h-screen bg-zinc-950 px-4">
         <p className="text-red-400 text-sm text-center">
@@ -30,26 +32,24 @@ export default function LiffFeeApprovePage() {
     )
   }
 
-  if (!isLoggedIn) {
-    return (
-      <div className="flex items-center justify-center min-h-screen bg-zinc-950 px-4">
-        <p className="text-zinc-400 text-sm">LINEアプリから開いてください</p>
-      </div>
-    )
-  }
-
+  // 黒画面の if(!isLoggedIn) ガードは (liff)/layout.tsx の中央集権 degrade ガードへ移譲済み。
   const token =
     typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null
 
   if (!token) {
-    if (typeof window !== 'undefined') {
-      window.location.replace('/liff-login')
+    // LIFF モード: LINE idToken から JWT を発行するため liff-login へ。
+    if (liffConfigured) {
+      if (typeof window !== 'undefined') {
+        window.location.replace('/liff-login')
+      }
+      return (
+        <div className="flex items-center justify-center min-h-screen bg-zinc-950 px-4">
+          <p className="text-zinc-400 text-sm">再認証中...</p>
+        </div>
+      )
     }
-    return (
-      <div className="flex items-center justify-center min-h-screen bg-zinc-950 px-4">
-        <p className="text-zinc-400 text-sm">再認証中...</p>
-      </div>
-    )
+    // ブラウザ degrade モード: Privy wallet 署名で JWT を取得する。
+    return <BrowserLoginPrompt />
   }
 
   return (

--- a/frontend/app/(liff)/liff-history/page.tsx
+++ b/frontend/app/(liff)/liff-history/page.tsx
@@ -6,6 +6,7 @@
 
 import { useEffect, useState } from "react";
 import { useLiff } from "@/hooks/useLiff";
+import { BrowserLoginPrompt } from "../_components/BrowserLoginPrompt";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 const PAGE_SIZE = 20;
@@ -29,7 +30,7 @@ type DecisionListResponse = {
 };
 
 export default function LiffHistoryPage() {
-  const { isReady, isLoggedIn, error } = useLiff();
+  const { isReady, error, liffConfigured } = useLiff();
   const [items, setItems] = useState<Decision[]>([]);
   const [total, setTotal] = useState(0);
   const [offset, setOffset] = useState(0);
@@ -40,7 +41,8 @@ export default function LiffHistoryPage() {
     typeof window !== "undefined" ? localStorage.getItem("auth_token") : null;
 
   useEffect(() => {
-    if (!isReady || !isLoggedIn || !token) return;
+    // 認証は JWT (token) の有無で判定する (ブラウザ degrade モードでも token があれば続行)。
+    if (!isReady || !token) return;
 
     setLoading(true);
     setFetchError(null);
@@ -67,7 +69,7 @@ export default function LiffHistoryPage() {
         )
       )
       .finally(() => setLoading(false));
-  }, [isReady, isLoggedIn, token, offset]);
+  }, [isReady, token, offset]);
 
   // --- Loading state ---
   if (!isReady) {
@@ -78,8 +80,8 @@ export default function LiffHistoryPage() {
     );
   }
 
-  // --- LIFF error ---
-  if (error) {
+  // --- LIFF error (LIFF モードの実 init 失敗時のみ。ブラウザ degrade では立たない) ---
+  if (liffConfigured && error) {
     return (
       <div className="flex items-center justify-center min-h-screen bg-zinc-950 px-4">
         <p className="text-red-400 text-sm text-center">
@@ -89,25 +91,22 @@ export default function LiffHistoryPage() {
     );
   }
 
-  // --- Not logged in ---
-  if (!isLoggedIn) {
-    return (
-      <div className="flex items-center justify-center min-h-screen bg-zinc-950 px-4">
-        <p className="text-zinc-400 text-sm">LINEアプリから開いてください</p>
-      </div>
-    );
-  }
-
-  // --- Auth token missing (ITP によるセッション消去を含む) ---
+  // 黒画面の if(!isLoggedIn) ガードは (liff)/layout.tsx の中央集権 degrade ガードへ移譲済み。
+  // (#548 の liff-history 個別 degrade は本対策で supersede)
   if (!token) {
-    if (typeof window !== 'undefined') {
-      window.location.replace('/liff-login')
+    // LIFF モード: LINE idToken から JWT を発行するため liff-login へ (ITP セッション消去含む)。
+    if (liffConfigured) {
+      if (typeof window !== 'undefined') {
+        window.location.replace('/liff-login')
+      }
+      return (
+        <div className="flex items-center justify-center min-h-screen bg-zinc-950 px-4">
+          <p className="text-zinc-400 text-sm">再認証中...</p>
+        </div>
+      );
     }
-    return (
-      <div className="flex items-center justify-center min-h-screen bg-zinc-950 px-4">
-        <p className="text-zinc-400 text-sm">再認証中...</p>
-      </div>
-    );
+    // ブラウザ degrade モード: Privy wallet 署名で JWT を取得する。
+    return <BrowserLoginPrompt />;
   }
 
   const hasPrev = offset > 0;

--- a/frontend/app/(liff)/liff-login/page.tsx
+++ b/frontend/app/(liff)/liff-login/page.tsx
@@ -24,9 +24,20 @@ export default function LiffLoginPage() {
       }),
     })
       .then((r) => r.json())
-      .then((data: { access_token?: string }) => {
+      .then((data: { access_token?: string; expires_in?: number }) => {
         if (data.access_token) {
+          // token key 橋渡し (GID 1215441139765963 で ultra_auth_token に一本化予定):
+          // LIFF read key (auth_token) と canonical key (ultra_auth_token) の両方へ
+          // 同一 JWT を書き込む。LINE 経路もこれで ultra_auth_token を満たすため、
+          // 一本化 PR は auth_token を一律に除去できる。
           localStorage.setItem("auth_token", data.access_token);
+          localStorage.setItem("ultra_auth_token", data.access_token);
+          if (data.expires_in) {
+            localStorage.setItem(
+              "ultra_auth_token_expires",
+              String(Date.now() + data.expires_in * 1000)
+            );
+          }
           // LIFFなのでLINEアプリ内で完結 — ウィンドウクローズorリダイレクト
           window.location.href = "/";
         }

--- a/frontend/hooks/useLiffBrowserAuth.ts
+++ b/frontend/hooks/useLiffBrowserAuth.ts
@@ -1,0 +1,95 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+// frontend/hooks/useLiffBrowserAuth.ts
+//
+// ブラウザ PWA モード (NEXT_PUBLIC_LIFF_ID 未設定 = LIFF degrade) で、LINE idToken に
+// 依存せず JWT を取得するためのフック。partner 本人の Privy embedded wallet で
+// SIWE 風メッセージに署名し、POST /auth/wallet/connect で JWT を発行する。
+// 署名・onBehalfOf は build-tx 側でサーバー強制されるため、本フックは「認証」のみを担う。
+"use client";
+
+import { useCallback, useState } from "react";
+import { usePrivy, useWallets } from "@privy-io/react-auth";
+import { ethers } from "ethers";
+import { walletConnect } from "@/lib/api/auth";
+
+// ── token key 橋渡し (2 PR 整合: GID 1215441139765963 で ultra_auth_token に一本化予定) ──
+// 本 PR: LIFF ページの read key (auth_token) と canonical key (ultra_auth_token) の両方へ
+//        同一 JWT を書き込む (dual-write)。
+// 一本化 PR: LIFF ページの read を ultra_auth_token に移行し、auth_token 書き込みを除去する。
+//            両キーは常に同値のため、移行に伴う localStorage 不整合・gap は発生しない。
+// 必ず「本 PR を先に merge → 一本化 PR」を守ること (順序逆転すると LIFF read key が空になる)。
+const LIFF_TOKEN_KEY = "auth_token";
+const CANONICAL_TOKEN_KEY = "ultra_auth_token";
+const CANONICAL_EXPIRES_KEY = "ultra_auth_token_expires";
+
+// lib/auth.ts loginWithWallet と完全同一のメッセージ (バックエンド署名検証と一致させる)。
+function siweMessage(address: string): string {
+  return `Sign in to Ultra AutoTrade\nAddress: ${address}`;
+}
+
+export interface LiffBrowserAuthResult {
+  /** Privy wallet で署名し JWT を発行・保存する。成功時 true。Privy 未ログイン時は login() を開いて false。 */
+  signIn: () => Promise<boolean>;
+  signingIn: boolean;
+  error: string | null;
+}
+
+export function useLiffBrowserAuth(): LiffBrowserAuthResult {
+  const { login } = usePrivy();
+  const { wallets } = useWallets();
+  const [signingIn, setSigningIn] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const signIn = useCallback(async (): Promise<boolean> => {
+    setError(null);
+    setSigningIn(true);
+    try {
+      // embedded wallet (Privy TEE) のみ使用。外部 wallet は秘密鍵管理の懸念で除外。
+      const wallet = wallets.find((w) => w.walletClientType === "privy");
+      if (!wallet) {
+        // Privy 未ログイン → メールログイン用モーダルを開く。完了後ユーザーが再度ボタンを押す。
+        await login();
+        return false;
+      }
+
+      const address = wallet.address;
+      const eip1193 = await wallet.getEthereumProvider();
+      const ethProvider = new ethers.BrowserProvider(
+        eip1193 as unknown as ethers.Eip1193Provider
+      );
+      const signer = await ethProvider.getSigner();
+      const message = siweMessage(address);
+      const signature = await signer.signMessage(message);
+
+      const res = await walletConnect({
+        wallet_address: address,
+        message,
+        signature,
+      });
+
+      // dual-write (上記コメント参照)
+      localStorage.setItem(CANONICAL_TOKEN_KEY, res.access_token);
+      localStorage.setItem(
+        CANONICAL_EXPIRES_KEY,
+        String(Date.now() + res.expires_in * 1000)
+      );
+      localStorage.setItem(LIFF_TOKEN_KEY, res.access_token);
+      return true;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("User rejected") || msg.includes("user rejected")) {
+        setError("署名がキャンセルされました。もう一度お試しください。");
+      } else {
+        setError(
+          "ログインに失敗しました。通信環境を確認して、もう一度お試しください。"
+        );
+      }
+      return false;
+    } finally {
+      setSigningIn(false);
+    }
+  }, [wallets, login]);
+
+  return { signIn, signingIn, error };
+}


### PR DESCRIPTION
## 概要
LIFF degrade 黒画面の**根本対策**(中央集権ガード)と、**partner 承認のブラウザ成立**(LINE 非依存)。Tier S(proposal 承認の money 経路に触る)。

`#548` を本 PR に統合・supersede(commit1 アイコン修正は取り込み、commit2 liff-history 個別 degrade は中央ガードで代替)。

## 真因
`useLiff.liffConfigured`(#539, 6/4)は実在するが、`liff-approve`/`liff-fee-approve`/`liff-history` が個別に `if(!isLoggedIn)` 黒画面を持ち degrade を考慮せず、ブラウザ PWA で「LINEアプリから開いてください」黒画面になっていた。各ページが個別ガードを再実装する構造が取りこぼしの温床。

## 変更(frontend のみ / **backend 認証は無変更**)
| # | 変更 | ファイル |
|---|---|---|
| 1 | 中央集権 degrade ガード新設。LIFFモード&LINE未ログイン&JWT無&非除外時のみブロック。browser degrade は通常描画。除外=`/liff-login`,`/liff-sign-poc`。新規ページ自動 degrade | `(liff)/layout.tsx` |
| 2 | 3画面の個別 `if(!isLoggedIn)` 黒画面を撤去 → JWT(token)ベース判定へ統一 | `liff-approve`/`liff-fee-approve`/`liff-history` |
| 3 | ブラウザ JWT 取得を新設。Privy wallet で `/auth/wallet/connect` 署名認証 → JWT。優しい文言 | `useLiffBrowserAuth.ts` / `BrowserLoginPrompt.tsx` |
| 4 | `ApproveConfirmSheet` を canonical `build-tx → 2段 Privy 署名 → submit-tx` に修正。receipt 検証(from==partner/status==1)スキップの弱点を解消 | `ApproveConfirmSheet.tsx` |
| 5 | liff-chat ヘッダー account icon の onClick 未設定修正(#548 commit1) | `liff-chat/page.tsx` |

## 認証経路の変更点(明示)
- **backend: 無変更**。`/api/proposals/{id}/approve|build-tx|submit-tx` は元から `require_partner`(JWT + role)のみで **idToken 非依存**。onBehalfOf=partner はサーバー側 calldata 検証(`verify_supply_onbehalf`/`verify_withdraw_to`)で担保。
- **frontend**: ブラウザ(idToken 無し)では `/auth/wallet/connect`(Privy 署名)で JWT を発行し `auth_token` に橋渡し。LINE 経路(liff-login)は従来どおり `/auth/line`。

## token key 整合(2 PR / GID 1215441139765963 一本化 PR)
- 本 PR: `auth_token`(LIFF read)と `ultra_auth_token`(canonical)へ JWT を **dual-write**(liff-login の LINE 経路 / useLiffBrowserAuth のブラウザ経路 双方)。
- 一本化 PR: **本 PR の後に merge**。LIFF read を `ultra_auth_token` に移行 + `auth_token` 書き込み除去。両キー同値のため gap なし。
- **merge 順序厳守**: 本 PR → 一本化 PR(逆転すると LIFF read key が空になる)。

## Gate
- `tsc --noEmit`: ✅ pass
- `eslint`(変更ファイル): ✅ 0 errors(warning は既存の直接 fetch パターンのみ)
- `next build`: ✅ pass(全ルート / `(liff)` 含む)
- **money 実機検証(§7/§14a): ⛔ hkobayashi 実行待ち**(下記手順)

## ★ money 実機検証手順(staging / hkobayashi 実行・自己申告/mock 不可)
ブラウザ(LIFF_ID 未設定 or 非 LINE)で liff-approve から承認 → 実 tx を取得し partner 署名・onBehalfOf=partner を裏取り。

```bash
# 1) staging の partner wallet を確認 (<PARTNER_USER_ID> = 山本 or 橋口)
docker exec ultra-autotrade-postgres-staging-new psql -U postgres -d ultra_autotrade -c \
  "SELECT id, email, role, wallet_address FROM users WHERE id = <PARTNER_USER_ID>;"

# 2) ブラウザで /liff-approve を開き「ウォレットでログイン」→ 提案を承認(approve→supply 署名)
#    → 画面 or ネットワークタブから finalTxHash を取得

# 3) proposal が executed + tx_hash 記録を確認
docker exec ultra-autotrade-postgres-staging-new psql -U postgres -d ultra_autotrade -c \
  "SELECT id, user_id, status, tx_hash, expected_from, expected_to, approved_at, executed_at
   FROM proposals WHERE id = <PROPOSAL_ID>;"
#   期待: status='executed' / expected_from == 上記 wallet_address(partner) / tx_hash 一致

# 4) on-chain receipt で from==partner / status==1 を裏取り (Base Sepolia)
#    basescan(sepolia) で <TX_HASH> を開く、または:
cast receipt <TX_HASH> --rpc-url "$AAVE_RPC_URL_BASE_SEPOLIA" | grep -E "from|status|to"
#   期待: from == partner wallet_address / status == 1 (success)

# 5) supply の onBehalfOf がサーバー検証を通っていること (build-tx ログ)
docker logs ultra-autotrade-backend-blue-staging-new 2>&1 | grep -E "build-tx onBehalfOf|submit-tx: proposal <PROPOSAL_ID>" | tail -5
#   期待: "onBehalfOf 検証失敗" が出ていない + "receipt verified on-chain" が出る
```

合格条件: ③status=executed & expected_from=partner / ④on-chain from=partner & status=1 / ⑤onBehalfOf 検証 pass。1つでも欠けたら money ゲート不合格。

## マージ
PR 止まり。**merge は hkobayashi**(money 実機検証 ④⑤ の裏取り後)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
