### PR TITLE
feat(liff): liff-confirm 遷移配線 + 規約ver03対応 (GID 1215360586206558)

### DIFF
--- a/backend/app/auth/line.py
+++ b/backend/app/auth/line.py
@@ -6,7 +6,6 @@
 LINE idTokenを検証してユーザーを取得または作成する。
 """
 
-import datetime
 import logging
 import os
 import secrets
@@ -70,14 +69,13 @@ def get_or_create_line_user(db: Session, line_user_id: str, display_name: str) -
         return user
 
     # 新規ユーザー作成（パスワードなし — ランダムハッシュでログイン不可化）
+    # terms_accepted_at は liff-confirm での同意後に設定するため初期値 None
     user = User(
         email=pseudo_email,
         username=f"line_{line_user_id[:8]}",  # 先頭8文字
         hashed_password=secrets.token_hex(32),  # ランダム（ログイン不可パスワード）
         role=UserRole.VIEWER.value,
         is_active=True,
-        terms_version="2.0",
-        terms_accepted_at=datetime.datetime.now(datetime.timezone.utc),
     )
     db.add(user)
     db.commit()

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -61,6 +61,9 @@ limiter = Limiter(key_func=get_remote_address)
 LOGIN_RATE_LIMIT = os.getenv("LOGIN_RATE_LIMIT", "5/minute")
 
 CURRENT_TERMS_VERSION = "2.0"
+# LIFF 固有の同意バージョン（liff-confirm 経由での同意）も accepted として扱う
+_LIFF_TERMS_VERSION = "liff-v3"
+_ACCEPTED_TERMS_VERSIONS = frozenset([CURRENT_TERMS_VERSION, _LIFF_TERMS_VERSION])
 
 logger = logging.getLogger(__name__)
 
@@ -396,12 +399,13 @@ def get_terms_status(
     user: User = Depends(require_active_user),
 ) -> TermsStatusResponse:
     """Check whether the current user has accepted the latest terms of service."""
+    accepted = user.terms_version in _ACCEPTED_TERMS_VERSIONS
     return TermsStatusResponse(
-        accepted=user.terms_version == CURRENT_TERMS_VERSION,
+        accepted=accepted,
         terms_version=user.terms_version,
         terms_accepted_at=user.terms_accepted_at,
         current_version=CURRENT_TERMS_VERSION,
-        needs_acceptance=user.terms_version != CURRENT_TERMS_VERSION,
+        needs_acceptance=not accepted,
     )
 
 
@@ -674,7 +678,7 @@ def wallet_connect(
         role=user.role,
     )
 
-    needs_terms_acceptance = user.terms_version != CURRENT_TERMS_VERSION
+    needs_terms_acceptance = user.terms_version not in _ACCEPTED_TERMS_VERSIONS
 
     logger.info(
         "Wallet connect: %s...%s (new=%s)",

--- a/backend/app/users/settings_router.py
+++ b/backend/app/users/settings_router.py
@@ -20,6 +20,8 @@ from .settings_schemas import UserSettingsResponse, UserSettingsUpdate
 
 logger = logging.getLogger(__name__)
 
+LIFF_TERMS_VERSION = "liff-v3"
+
 router = APIRouter(prefix="/api/user", tags=["user-settings"])
 
 
@@ -41,6 +43,7 @@ def _build_settings_response(user: User) -> UserSettingsResponse:
         execution_policy=user.execution_policy,
         line_monthly_opt_in=user.line_monthly_opt_in,
         terms_agreed_at=user.terms_accepted_at,
+        terms_version=user.terms_version,
     )
 
 
@@ -125,9 +128,14 @@ def agree_to_terms(
     """重要事項への同意を記録する（LIFF オンボーディング用）。
 
     既に同意済みの場合はそのまま返す（冪等）。
-    terms_accepted_at カラムに現在時刻を書き込み、terms_version="liff-v1" を設定する。
+    terms_accepted_at カラムに現在時刻を書き込み、terms_version="liff-v3" を設定する。
     """
-    if current_user.terms_accepted_at is not None:
+    # terms_version が liff-v3 の場合のみ同意済みとして扱う
+    # — 旧バージョン (liff-v1, 2.0 等) で同意済みのユーザーは再同意を求める
+    if (
+        current_user.terms_accepted_at is not None
+        and current_user.terms_version == LIFF_TERMS_VERSION
+    ):
         return {
             "terms_agreed_at": current_user.terms_accepted_at.isoformat(),
             "already_agreed": True,
@@ -135,7 +143,7 @@ def agree_to_terms(
 
     now = datetime.now(timezone.utc)
     current_user.terms_accepted_at = now
-    current_user.terms_version = "liff-v1"
+    current_user.terms_version = LIFF_TERMS_VERSION
     db.add(current_user)
     db.commit()
     db.refresh(current_user)

--- a/backend/app/users/settings_schemas.py
+++ b/backend/app/users/settings_schemas.py
@@ -25,6 +25,8 @@ class UserSettingsResponse(BaseModel):
     line_monthly_opt_in: bool = False
     # 重要事項確認同意日時（User.terms_accepted_at を公開）
     terms_agreed_at: Optional[datetime] = None
+    # 同意時の規約バージョン（フロントエンドの再同意判定に使用）
+    terms_version: Optional[str] = None
 
 
 class UserSettingsUpdate(BaseModel):

--- a/frontend/app/(liff)/liff-confirm/page.tsx
+++ b/frontend/app/(liff)/liff-confirm/page.tsx
@@ -6,28 +6,37 @@
 import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { CheckCircle, ChevronDown, ExternalLink } from "lucide-react"
-import { getStoredToken } from "@/lib/auth"
+
+const getToken = () =>
+  typeof window !== "undefined" ? (localStorage.getItem("auth_token") ?? "") : ""
 
 const API_BASE = process.env.NEXT_PUBLIC_BACKEND_BASE_URL ?? ""
 
+// 規約 ver03 — 2026-06 本番運用開始に合わせ改訂
 const ITEMS = [
   {
     id: "self_custody",
     title: "資産はユーザー自身が管理します",
     detail:
-      "本サービスはノンカストディアル型です。秘密鍵はユーザーが管理し、弊社はウォレットにアクセスできません。",
+      "本サービスはノンカストディアル型です。お客様のウォレット秘密鍵は弊社サーバーに保存されません。ウォレットおよびLINEアカウントの管理責任はお客様ご自身にあります。",
   },
   {
     id: "defi_risk",
     title: "DeFi運用にはリスクがあります",
     detail:
-      "スマートコントラクトのリスク、価格変動リスク、流動性リスクが存在します。投資は自己責任でお願いします。",
+      "スマートコントラクトのリスク、価格変動リスク、流動性リスク、清算リスクが存在します。元本を失う可能性があります。本サービスは投資助言ではなく、運用はすべて自己責任となります。",
   },
   {
     id: "user_responsibility",
     title: "アカウント管理は利用者自身の責任です",
     detail:
-      "ログイン情報の管理、不正アクセスへの対応はユーザーご自身の責任となります。弊社はアカウント損失に対して責任を負いません。",
+      "LINEアカウントの管理、不正アクセスへの対応はユーザーご自身の責任となります。弊社はアカウント損失・不正利用による損害に対して責任を負いません。",
+  },
+  {
+    id: "age_confirm",
+    title: "18歳以上であることを確認します",
+    detail:
+      "本サービスのご利用には18歳以上であることが必要です。18歳未満の方はご利用いただけません。",
   },
 ]
 
@@ -43,7 +52,7 @@ export default function LiffConfirmPage() {
 
   // terms_agreed_at チェック: 既に同意済みなら /liff-chat へリダイレクト
   useEffect(() => {
-    const token = getStoredToken()
+    const token = getToken()
     if (!token) {
       setLoading(false)
       return
@@ -53,8 +62,9 @@ export default function LiffConfirmPage() {
       headers: { Authorization: `Bearer ${token}` },
     })
       .then((r) => (r.ok ? r.json() : null))
-      .then((data: { terms_agreed_at?: string | null } | null) => {
-        if (data?.terms_agreed_at) {
+      .then((data: { terms_agreed_at?: string | null; terms_version?: string | null } | null) => {
+        // liff-v3 で同意済みの場合のみスキップ (旧バージョン同意者は再同意を求める)
+        if (data?.terms_agreed_at && data?.terms_version === "liff-v3") {
           router.replace("/liff-chat")
         } else {
           setLoading(false)
@@ -67,7 +77,7 @@ export default function LiffConfirmPage() {
     if (!allChecked || submitting) return
     setSubmitting(true)
 
-    const token = getStoredToken()
+    const token = getToken()
 
     try {
       const res = await fetch(`${API_BASE}/api/user/terms-agree`, {
@@ -101,9 +111,9 @@ export default function LiffConfirmPage() {
       <div className="bg-[#1a3d2e] px-4 py-5 flex-shrink-0">
         <h1 className="text-white font-bold text-lg">重要事項の確認</h1>
         <p className="text-zinc-300 text-sm mt-1">運用開始前に以下をご確認ください</p>
-        {/* ステップドット */}
+        {/* ステップドット (ver03: 4 items) */}
         <div className="flex gap-1.5 mt-3">
-          {[0, 1, 2].map((i) => (
+          {Array.from({ length: ITEMS.length }, (_, i) => i).map((i) => (
             <div
               key={i}
               className={`h-1.5 rounded-full transition-all duration-300 ${
@@ -118,12 +128,12 @@ export default function LiffConfirmPage() {
       <div className="px-4 py-3 border-b border-zinc-800 flex-shrink-0">
         <div className="flex items-center justify-between text-sm mb-1.5">
           <span className="text-zinc-400">確認状況</span>
-          <span className="text-[#4ade9a] font-semibold">{checkedCount} / 3</span>
+          <span className="text-[#4ade9a] font-semibold">{checkedCount} / {ITEMS.length}</span>
         </div>
         <div className="h-1.5 bg-zinc-800 rounded-full overflow-hidden">
           <div
             className="h-full bg-[#1D9E75] rounded-full transition-all duration-500 ease-out"
-            style={{ width: `${(checkedCount / 3) * 100}%` }}
+            style={{ width: `${(checkedCount / ITEMS.length) * 100}%` }}
           />
         </div>
       </div>

--- a/frontend/app/(liff)/liff-login/page.tsx
+++ b/frontend/app/(liff)/liff-login/page.tsx
@@ -38,8 +38,8 @@ export default function LiffLoginPage() {
               String(Date.now() + data.expires_in * 1000)
             );
           }
-          // LIFFなのでLINEアプリ内で完結 — ウィンドウクローズorリダイレクト
-          window.location.href = "/";
+          // 重要事項確認 (liff-confirm) を経由してから liff-chat へ
+          window.location.href = "/liff-confirm";
         }
       })
       .catch(console.error);


### PR DESCRIPTION
## Summary

- **liff-login → liff-confirm 遷移配線**: LINE ログイン後のリダイレクト先を `/` から `/liff-confirm` に変更。未同意ユーザーが必ず重要事項確認を通過するよう強制。
- **規約 ver03 文言改訂** (4項目): ノンカストディアル型説明 / DeFi運用リスク / アカウント管理責任 / **18歳以上確認** (LINE miniapp ガイドライン必須)
- **既存ユーザーの旧バージョン同意バイパス修正**: `terms_version == "liff-v3"` の確認を冪等ガードと redirect スキップ条件の両方に追加。旧同意ユーザー (liff-v1, 2.0) も再同意を求める。
- **`UserSettingsResponse` に `terms_version` 追加**: フロントの再同意判定に使用
- **`_ACCEPTED_TERMS_VERSIONS` frozenset**: `"2.0"` と `"liff-v3"` の両バージョンを accepted 扱いに統一 (wallet/admin フロー非破壊)
- **新規 LINE ユーザーの terms_accepted_at 自動設定を削除**: liff-confirm 経由での明示的同意を必須化

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `frontend/app/(liff)/liff-login/page.tsx` | redirect `/` → `/liff-confirm` |
| `frontend/app/(liff)/liff-confirm/page.tsx` | ver03 文言 4 項目、terms_version チェック追加、dots dynamic化 |
| `backend/app/auth/line.py` | 新規ユーザー terms_accepted_at 自動設定削除 |
| `backend/app/auth/router.py` | _ACCEPTED_TERMS_VERSIONS frozenset 追加 |
| `backend/app/users/settings_router.py` | LIFF_TERMS_VERSION 定数、冪等ガード強化、terms_version expose |
| `backend/app/users/settings_schemas.py` | UserSettingsResponse に terms_version 追加 |

## 法務コンプライアンス確認ポイント

- [ ] 18歳確認項目 (`age_confirm`) が4番目に表示されること
- [ ] 全4項目チェック完了まで「運用を開始する」ボタンが非活性のこと
- [ ] 既存ユーザーが旧バージョン (`liff-v1`, `2.0`) で同意済みでも再同意画面が表示されること

## Test plan

- [ ] `GET /api/user/settings` レスポンスに `terms_version` フィールドが含まれること
- [ ] 新規 LINE ユーザー作成後に `terms_accepted_at=null`, `terms_version=null` であること
- [ ] `POST /api/user/terms-agree` で `terms_version="liff-v3"` に更新されること
- [ ] `liff-v3` で同意済みユーザーが `/liff-confirm` にアクセスすると `/liff-chat` へリダイレクトされること
- [ ] `liff-v1` または `2.0` で同意済みユーザーが `/liff-confirm` にアクセスすると同意フォームが表示されること
- [ ] liff-login ログイン後に `/liff-confirm` へ遷移すること

Closes #GID-1215360586206558

🤖 Generated with [Claude Code](https://claude.com/claude-code)