### PR TITLE
fix: 利用規約・プライバシーURLのapp.サブドメイン欠落を修正

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/TermsPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TermsPanel.tsx
@@ -6,13 +6,13 @@ import { ExternalLink, FileText, Shield } from "lucide-react"
 export function TermsPanel() {
   const links = [
     {
-      href: "https://ultra-auto-trade.com/terms",
+      href: "https://app.ultra-auto-trade.com/terms",
       label: "利用規約",
       desc: "サービス利用条件・免責事項",
       icon: FileText,
     },
     {
-      href: "https://ultra-auto-trade.com/privacy",
+      href: "https://app.ultra-auto-trade.com/privacy",
       label: "プライバシーポリシー",
       desc: "個人情報の取り扱い",
       icon: Shield,

--- a/frontend/app/(liff)/liff-confirm/page.tsx
+++ b/frontend/app/(liff)/liff-confirm/page.tsx
@@ -203,7 +203,7 @@ export default function LiffConfirmPage() {
       <div className="px-4 pb-8 pt-4 border-t border-zinc-800 flex-shrink-0 space-y-3">
         <div className="flex gap-4 justify-center text-xs text-zinc-500">
           <a
-            href="https://ultra-auto-trade.com/terms"
+            href="https://app.ultra-auto-trade.com/terms"
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center gap-1 hover:text-zinc-300"
@@ -211,7 +211,7 @@ export default function LiffConfirmPage() {
             利用規約 <ExternalLink className="w-3 h-3" />
           </a>
           <a
-            href="https://ultra-auto-trade.com/privacy"
+            href="https://app.ultra-auto-trade.com/privacy"
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center gap-1 hover:text-zinc-300"


### PR DESCRIPTION
## Summary

- `liff-chat` の TermsPanel と `liff-confirm` 画面で利用規約・プライバシーポリシーのリンクURLが `app.` サブドメイン欠落になっていた
- `https://ultra-auto-trade.com/terms` → `https://app.ultra-auto-trade.com/terms`
- `https://ultra-auto-trade.com/privacy` → `https://app.ultra-auto-trade.com/privacy`
- 変更ファイル: `TermsPanel.tsx` / `liff-confirm/page.tsx` の計2ファイル、4行のみ

## 影響範囲

リンク先URLの文字列のみ。UIロジック・API・DB変更なし。

## verify.sh 結果

| Gate | 結果 |
|------|------|
| [0] Chain Config | ⚠ skip (.env.production 未設置、CI環境) |
| [1] ruff check | ✅ |
| [2] ruff format | ✅ |
| [3] mypy | ✅ |
| [4] pytest (coverage 85.3%) | ✅ |
| [5] ruff security | ✅ |
| [6] tsc --noEmit | ✅ (0 errors) |
| [7] npm run build | ❌ dev VPS OOM (RAM空き775MB・swap全使用の環境制約、コード無関係) |

## Asana

https://app.asana.com/1/817733952351708/project/1213916581114014/task/1215441383624332

🤖 Generated with [Claude Code](https://claude.com/claude-code)