### PR TITLE
fix(liff): ReferralPanel の register URL に app. サブドメインを追加 (GID 1215441383624332)

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
@@ -6,7 +6,7 @@ import { Copy, Mail, Share2, CheckCircle, Users, Gift, TrendingUp, ChevronRight 
 import { getReferralInfo, createReferralCode, type ReferralInfo } from "@/lib/api/referral"
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ""
-const SIGNUP_URL = process.env.NEXT_PUBLIC_LIFF_APP_URL ?? "https://ultra-auto-trade.com/register"
+const SIGNUP_URL = process.env.NEXT_PUBLIC_LIFF_APP_URL ?? "https://app.ultra-auto-trade.com/register"
 
 function getToken(): string {
   return typeof window !== "undefined" ? (localStorage.getItem("ultra_auth_token") ?? "") : ""


### PR DESCRIPTION
## Summary
- `ReferralPanel.tsx` のフォールバック URL 1 行のみを修正
- `https://ultra-auto-trade.com/register` → `https://app.ultra-auto-trade.com/register`

## 背景
旧 PR #558 (`fix/contract-url-app-prefix`) は #556 の referral backend コミット (`backend/app/main.py` / `withdrawals_router.py` 混入) が混入しており Tier B スコープ超過。#558 を close し、main から新ブランチで切り直し。

TermsPanel・liff-confirm の terms/privacy URL は #553/#555 の merge 時に main 取込済みのため本 PR では対象外。

## 変更ファイル
- `frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx` (1 行)

## Path Access Control
凍結ファイル (`backend/app/main.py` 等) に触れていないため Path AC は最初から PASS。

## Test plan
- [ ] CI 全 ✓ (Lint / E2E / Test / Path AC)
- [ ] staging で規約ページ・登録ページのリンク先が `app.ultra-auto-trade.com` に遷移することを確認

Refs: GID 1215441383624332 / closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)