### PR TITLE
fix(liff-chat): アカウント名前変更を backend で永続化 + 偽装成功フォールバック撤廃 (Asana 1215466836714200)

### DIFF
--- a/backend/app/users/settings_router.py
+++ b/backend/app/users/settings_router.py
@@ -114,6 +114,21 @@ def update_user_settings(
         current_user.execution_policy = request.execution_policy
     if request.line_monthly_opt_in is not None:
         current_user.line_monthly_opt_in = request.line_monthly_opt_in
+    if request.username is not None:
+        # スキーマ側で形式検証 + 小文字化済み。本人による表示名変更（role 制限なし）。
+        new_username = request.username
+        if new_username != current_user.username:
+            existing = (
+                db.query(User)
+                .filter(User.username == new_username, User.id != current_user.id)
+                .first()
+            )
+            if existing is not None:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="このユーザー名は既に使用されています",
+                )
+            current_user.username = new_username
     db.add(current_user)
     db.commit()
     db.refresh(current_user)

--- a/backend/app/users/settings_schemas.py
+++ b/backend/app/users/settings_schemas.py
@@ -2,11 +2,12 @@
 # backend/app/users/settings_schemas.py
 """ユーザー設定APIのスキーマ定義。"""
 
+import re
 from datetime import datetime
 from decimal import Decimal
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class UserSettingsResponse(BaseModel):
@@ -37,3 +38,20 @@ class UserSettingsUpdate(BaseModel):
     user_mode: Optional[str] = None
     execution_policy: Optional[str] = None
     line_monthly_opt_in: Optional[bool] = None
+    # ユーザー名（本人による表示名変更）。auth/schemas.py の登録時 validator と同一規則。
+    username: Optional[str] = Field(default=None, min_length=3, max_length=50)
+
+    @field_validator("username")
+    @classmethod
+    def validate_username(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        if not v.strip():
+            raise ValueError("ユーザー名は空白のみにできません")
+        if not (v[0].isalpha() or v[0].isdigit()):
+            raise ValueError(
+                "ユーザー名は文字か数字で始まる必要があります (must start with a letter or number)"
+            )
+        if not re.match(r"^[\w\s\-]+$", v):
+            raise ValueError("ユーザー名には文字・数字・スペース・_・- のみ使用できます")
+        return v.lower()

--- a/backend/tests/test_user_settings_api.py
+++ b/backend/tests/test_user_settings_api.py
@@ -118,6 +118,61 @@ class TestUserSettingsAPI:
         )
         assert r.status_code == 422
 
+    def test_update_username(self, client: TestClient) -> None:
+        token = register_and_login(client)
+        r = client.put(
+            "/api/user/settings",
+            json={"username": "newname"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        assert r.json()["username"] == "newname"
+        # GET でも永続していること（リロード後に戻らない）
+        r2 = client.get("/api/user/settings", headers={"Authorization": f"Bearer {token}"})
+        assert r2.json()["username"] == "newname"
+
+    def test_update_username_conflict_returns_409(self, client: TestClient) -> None:
+        # register は bootstrap admin のみ。2人目は admin が POST /users で作る作法。
+        admin_token = register_and_login(client)  # username="testuser"（admin）
+        rc = client.post(
+            "/users",
+            json={
+                "email": "alice@example.com",
+                "username": "alice",
+                "password": "password123",
+                "role": "viewer",
+            },
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert rc.status_code in (200, 201), rc.text
+        # admin(testuser) が既存の alice へ改名 → 409
+        r = client.put(
+            "/api/user/settings",
+            json={"username": "alice"},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert r.status_code == 409
+
+    def test_update_username_invalid_too_short(self, client: TestClient) -> None:
+        token = register_and_login(client)
+        r = client.put(
+            "/api/user/settings",
+            json={"username": "ab"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 422
+
+    def test_update_username_same_value_noop(self, client: TestClient) -> None:
+        # 自分と同じ名前への変更は衝突扱いにしない（409 にならず 200）
+        token = register_and_login(client)  # username="testuser"
+        r = client.put(
+            "/api/user/settings",
+            json={"username": "testuser"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        assert r.json()["username"] == "testuser"
+
     def test_pause_user(self, client: TestClient) -> None:
         token = register_and_login(client)
         r = client.post("/api/user/pause", headers={"Authorization": f"Bearer {token}"})

--- a/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
@@ -230,17 +230,21 @@ export function AccountPanel() {
         body: JSON.stringify({ username: next }),
       })
       if (res.ok) {
-        setUserData((prev) => ({ ...prev, username: next }))
+        // backend が永続化した実値を反映（validator で小文字化される場合がある）
+        const updated = (await res.json().catch(() => null)) as {
+          username?: string
+        } | null
+        setUserData((prev) => ({ ...prev, username: updated?.username ?? next }))
         setEditingName(false)
         showToast("名前を変更しました")
-      } else if (res.status === 404 || res.status === 405 || res.status === 422) {
-        // backend が username の更新に未対応の場合でもフロント表示は反映する
-        // TODO: backend が PUT /api/user/settings で username partial update を
-        //       受け付けるようになったら、この fallback を削除する
-        setUserData((prev) => ({ ...prev, username: next }))
-        setEditingName(false)
-        showToast("名前を変更しました")
+      } else if (res.status === 409) {
+        showToast("このユーザー名は既に使用されています")
+      } else if (res.status === 422) {
+        showToast("名前の形式が正しくありません（3〜50文字・先頭は英数字）")
+      } else if (res.status === 401) {
+        showToast("認証が切れています。再ログインしてください")
       } else {
+        // 偽装成功はしない（非永続をマスクしていた旧 fallback を撤廃）
         showToast("変更に失敗しました")
       }
     } catch {


### PR DESCRIPTION
## 概要

PR #561 デプロイ後に SIC が実機で発見した **アカウント名前変更が保存されない（API未発火）+ 再ログイン文言の誤表示**（Asana 1215466836714200 / Tier A）への修正。

## 根本原因（実コードで確定）

### 層2: backend が username 更新に非対応（本PRで修正）
`PUT /api/user/settings` の受理スキーマ `UserSettingsUpdate` に `username` フィールドが無く、送っても Pydantic が無視 → **200 を返しても永続しない**。frontend は 404/405/422 を「成功」と偽装するフォールバックで**非永続をマスク**していた。

### 層1: 名前保存✓で API 0本 + 「再ログイン」誤表示（別対応・live 確認待ち）
`handleSaveName` は `getAuthToken()` が空だと fetch 前に return しつつ「再ログインしてください」を出す。`getAuthToken` 自体は正しい（`auth_token`→`ultra_auth_token`）ため、**本番セッションで localStorage が空**が真因。なぜ空かは **実機 DevTools（Application/Network）での切り分けが必要**（DoD 準拠・推測断定しない）。本PRでは扱わず、SIC の live 確認結果で別途導線修正。

## 変更内容

**backend**
- `settings_schemas.py`: `UserSettingsUpdate.username: Optional[str]`（auth 登録時と同一 validator: 3〜50字 / 先頭英数字 / `[\w\s\-]` / 小文字化）。
- `settings_router.py`: `update_user_settings` で username を unique 衝突チェック（他ユーザーと重複→**409**）、本人同名は no-op。role 制限なし（本人の表示名変更）。

**frontend**
- `AccountPanel.tsx`: 404/405/422 の偽装成功フォールバックを撤廃。**200 で実永続値（小文字化反映）を表示** / 409=「使用されています」/ 422=形式エラー / 401=再ログイン を fail-visible 化。

**test**
- `test_user_settings_api.py`: username 更新+GET永続 / 409衝突 / 422不正 / 同名no-op の 4 ケース追加。

## ローカル検証（dev VPS）
- `ruff check` / `ruff format --check` / `mypy`: pass
- `pytest tests/test_user_settings_api.py`: **25 passed**（新規4 + 既存21）
- frontend tsc/build は dev VPS 環境要因（privy dts staleness / SIGBUS）で不可 → CI に委譲

## 安全性
money/withdraw 経路は不触（`app/users/settings` のみ）。withdraw gate と無関係。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
