### PR TITLE
feat: ENABLE_WITHDRAWALS flag で withdraw EP を default-off ガード (#391 money gate 前提)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -274,7 +274,12 @@ def create_app() -> FastAPI:
     app.include_router(proposals_router)  # Proposals API
     app.include_router(portfolio_router)  # Portfolio History API
     app.include_router(user_settings_router)  # User Settings API
-    app.include_router(user_withdrawals_router)  # P4: user withdrawals (non-custodial)
+    # P4 withdraw EP は money を動かす経路のため default-off で配線ガードする。
+    # ENABLE_WITHDRAWALS=1/true のときのみ route 登録。未登録時 POST /api/users/withdrawals=404
+    # （shadow 的な「登録するが実行しない」ではなく route 自体を出さない）。
+    # ★#391 money gate (staging Sepolia 6項目) を通すまで本番 .env で true にしないこと。
+    if os.getenv("ENABLE_WITHDRAWALS", "false").lower() in ("1", "true", "yes"):
+        app.include_router(user_withdrawals_router)  # P4: user withdrawals (non-custodial)
     app.include_router(alias_router)  # API aliases (/api/safety-score etc.)
     app.include_router(notification_router)  # Notifications (Phase PWA)
     app.include_router(notification_api_router)  # Notifications /api/* alias (Phase PWA)

--- a/backend/tests/test_withdrawals_flag.py
+++ b/backend/tests/test_withdrawals_flag.py
@@ -1,0 +1,47 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_withdrawals_flag.py
+"""ENABLE_WITHDRAWALS による withdraw EP 配線ガードのテスト。
+
+money を動かす経路のため default-off。
+- flag 未設定 / false → route 未登録 → POST /api/users/withdrawals = 404
+- flag on (1/true) のときのみ route 登録 → 認証前段に到達 (404 ではない)
+
+★ #391 money gate (staging Sepolia 6 項目) を通すまで本番 .env で true にしないこと。
+"""
+
+import os
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-withdrawals-flag")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from app.main import create_app  # noqa: E402
+
+_WITHDRAW_PATH = "/api/users/withdrawals"
+
+
+def test_withdraw_route_404_when_flag_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 既定 (env 未設定) では withdraw EP は配線されない → 404
+    monkeypatch.delenv("ENABLE_WITHDRAWALS", raising=False)
+    client = TestClient(create_app())
+    r = client.post(_WITHDRAW_PATH, json={})
+    assert r.status_code == 404
+
+
+def test_withdraw_route_404_when_flag_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENABLE_WITHDRAWALS", "false")
+    client = TestClient(create_app())
+    r = client.post(_WITHDRAW_PATH, json={})
+    assert r.status_code == 404
+
+
+def test_withdraw_route_registered_when_flag_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    # ENABLE_WITHDRAWALS=1 のときのみ route が登録される。
+    # 認証なしの POST は route 存在 → 認証/検証前段に到達するため 404 ではない。
+    monkeypatch.setenv("ENABLE_WITHDRAWALS", "1")
+    client = TestClient(create_app())
+    r = client.post(_WITHDRAW_PATH, json={})
+    assert r.status_code != 404
+    assert r.status_code in (401, 403, 422)

--- a/docs/integration/backend_deps.md
+++ b/docs/integration/backend_deps.md
@@ -5,6 +5,20 @@
 
 ---
 
+## PR #563 (前提1): ENABLE_WITHDRAWALS flag で withdraw EP を default-off ガード (2026-06-06)
+
+### 変更: include_router(user_withdrawals_router) を ENABLE_WITHDRAWALS フラグで条件化
+- **対象凍結ファイル**: `backend/app/main.py`
+- **変更内容**:
+  - PR #560 で無条件配線された `app.include_router(user_withdrawals_router)` を
+    `if os.getenv("ENABLE_WITHDRAWALS", "false").lower() in ("1", "true", "yes"):` で囲む（既定 false）。
+  - import 行（副作用なし）は残し、include のみ条件化。通知 router(279/280) は無条件のまま不触。
+- **理由**: money を動かす `/api/users/withdrawals` が無条件配線だったため、backend deploy で通知/名前保存/TAX 等を出す際に withdraw 経路を構造的に開かないよう default-off で配線ガードする（Asana 1215466937993772 前提1）。「閉じる」= route 未登録 = 404（shadow 的な登録するが実行しない、ではない）。
+- **影響範囲**: ルーター登録の条件化のみ。withdraw ロジック・起動シーケンス・他エンドポイントへの影響なし。★#391 money gate（staging Sepolia 6 項目）を通すまで本番 `.env` で `ENABLE_WITHDRAWALS=true` にしないこと。
+- **承認**: feat/enable-withdrawals-flag-20260606 → main の通常フロー経由（PR #563）
+
+---
+
 ## PR #560 (P4): /api/users/withdrawals user_withdrawals_router 配線 (2026-06-06)
 
 ### 変更: user_withdrawals_router を main.py に include_router


### PR DESCRIPTION
## 概要

money を動かす `POST /api/users/withdrawals` が `main.py:277` で **無条件 `include_router`** されており（env による無効化フラグ無し・実コードで確認済）、backend deploy すると withdraw 経路が即有効化される。これを **default-off の env フラグ `ENABLE_WITHDRAWALS`** で配線ガードし、backend deploy で通知/名前保存/TAX 等を出しても **withdraw 経路を構造的に開かない**ようにする。

Asana 1215466937993772（backend deploy 解禁 前提1）。設計は SIC 確定（変更不可）に準拠。

## 変更（スコープ厳守）

- `backend/app/main.py`: `app.include_router(user_withdrawals_router)` を
  `if os.getenv("ENABLE_WITHDRAWALS", "false").lower() in ("1","true","yes"):` で囲む。
  - **既定 false**。codebase の既存 flag パターン（`os.getenv("ENABLE_X","0")=="1"` が main.py に7例、中央 pydantic Settings は無い）に踏襲。
  - **「閉じる」= route 未登録 = 404**（shadow 的な「登録するが実行しない」ではない）。
  - import 行（副作用なし）は残し、**include だけ条件化**。
  - **通知 router(279/280) は無条件のまま（触らない）**。
- `backend/tests/test_withdrawals_flag.py`（新規）: flag 未設定/false → 404、flag on(monkeypatch) → route 登録（非404=認証前段 401/403/422）の 3 ケース。

withdraw のロジック自体は不変（配線ガードのみ）。**`.env.production` は不触**。

## 検証（dev VPS）
- `ruff check` / `ruff format` / `mypy app/main.py`: pass（CI 基準 `mypy app/` clean）
- `pytest tests/test_withdrawals_flag.py`: **3 passed**
- frontend 無変更 → tsc/build 影響なし

## ★運用の固定事項
**#391 money gate（staging Sepolia 6項目: tx.from=partner / USDC Transfer.from=partner / AAVE_WALLET不在 / status=1 / backend記録）を通すまで、本番 `.env` で `ENABLE_WITHDRAWALS=true` にしないこと。** 既定 false で閉じたまま。コード comment + テストで固定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
