### PR TITLE
feat(liff): 重要事項同意を入口非依存で強制するゲートを追加

### DIFF
--- a/frontend/app/(liff)/layout.tsx
+++ b/frontend/app/(liff)/layout.tsx
@@ -1,9 +1,11 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 'use client'
 
-import { usePathname } from 'next/navigation'
+import { useEffect } from 'react'
+import { usePathname, useRouter } from 'next/navigation'
 import { useLiff } from '@/hooks/useLiff'
 import { useLiffAutoReAuth } from '@/hooks/useLiffAutoReAuth'
+import { useLiffTermsGate } from '@/hooks/useLiffTermsGate'
 import { SessionExpiryBanner } from '@/components/SessionExpiryBanner'
 import { PrivyRootClient } from '@/lib/wallet/PrivyRootClient'
 import { getAuthToken } from '@/lib/auth/token-key'
@@ -13,13 +15,33 @@ import { getAuthToken } from '@/lib/auth/token-key'
 // - liff-sign-poc: 署名診断ページ (ログイン状態を意図的に表示する)
 const AUTH_GUARD_EXEMPT = ['/liff-login', '/liff-sign-poc']
 
+// 重要事項同意 (terms_version="liff-v3") を入口非依存で強制する BtoC 消費者ページ。
+// リッチメニュー / ブックマーク等で直接アクセスされても、未同意なら /liff-confirm へ
+// 誘導する (法的同意の 1 経路依存を解消; Asana 1215360586206558)。
+// パートナー承認系 (liff-approve / liff-fee-approve 等) は別系統のため対象外。
+const TERMS_GATE_PATHS = ['/liff-chat']
+
 export default function LiffLayout({ children }: { children: React.ReactNode }) {
   const { isInitialized, isLoggedIn, error, liffConfigured } = useLiff()
   const pathname = usePathname()
+  const router = useRouter()
   // ITP wipe で auth_token が消えた場合に、LINE 側 idToken を使って
   // 黙って /auth/line を叩き直し、ユーザー操作なしで session を復元する。
   // liff-login 以外の LIFF ページに直接遷移しても復帰できる。
   const reauth = useLiffAutoReAuth()
+
+  // ── 重要事項同意ガード (入口非依存) ──
+  // token を持つ消費者が TERMS_GATE_PATHS に直接来た場合に、liff-v3 未同意なら
+  // /liff-confirm へ送る。token が無い場合は下の auth guard 側に委ねる。
+  const token = getAuthToken()
+  const needsTermsGate =
+    !!token && TERMS_GATE_PATHS.some((p) => (pathname ?? '').startsWith(p))
+  const termsState = useLiffTermsGate(needsTermsGate)
+  useEffect(() => {
+    if (needsTermsGate && termsState === 'not-accepted') {
+      router.replace('/liff-confirm')
+    }
+  }, [needsTermsGate, termsState, router])
 
   // error 画面は「LIFF モードかつ実際の liff.init 失敗時」のみ表示する。
   // NEXT_PUBLIC_LIFF_ID 未設定（ブラウザ PWA モード）は error にせず、
@@ -54,12 +76,22 @@ export default function LiffLayout({ children }: { children: React.ReactNode }) 
   // ブラウザ PWA モード (liffConfigured=false) は isLoggedIn が常に false でもブロックせず、
   // children を通常描画して degrade させる (ブラウザ承認導線はページ側で JWT を取得する)。
   // この構造により、新規 LIFF ページは個別ガードを書かなくても自動で degrade 対応になる。
-  const token = getAuthToken()
   const isExempt = AUTH_GUARD_EXEMPT.includes(pathname ?? '')
   if (liffConfigured && !isLoggedIn && !token && !isExempt) {
     return (
       <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center px-4">
         <p className="text-zinc-400 text-sm">LINEアプリから開いてください</p>
+      </div>
+    )
+  }
+
+  // ── 重要事項同意ガード (render) ──
+  // 同意未確定 (loading / not-accepted) の間は children を描画せず、上の useEffect が
+  // /liff-confirm へ遷移するまで読み込み表示でブロックする (未同意ホームの一瞬の表示も防ぐ)。
+  if (needsTermsGate && termsState !== 'accepted') {
+    return (
+      <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center">
+        <p className="text-zinc-400">読み込み中...</p>
       </div>
     )
   }

--- a/frontend/hooks/useLiffTermsGate.ts
+++ b/frontend/hooks/useLiffTermsGate.ts
@@ -1,0 +1,78 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+// frontend/hooks/useLiffTermsGate.ts
+//
+// LIFF (BtoC 消費者) の重要事項同意 (terms_version="liff-v3") を入口非依存で
+// 強制するためのゲート判定フック。
+//
+// 背景 (Asana 1215360586206558):
+//   同意の強制は従来 /liff-login → /liff-confirm の 1 経路にしか無く、
+//   リッチメニュー / ブックマーク等で /liff-chat に直接アクセスすると
+//   重要事項確認を一度も通らずホームが描画されていた。非カストディアル・
+//   元本喪失・鍵喪失の法的同意としては入口非依存で強制する必要がある。
+//   本フックを (liff)/layout.tsx から呼び、未同意なら /liff-confirm へ誘導する。
+//
+// fail-closed: settings 取得失敗時は "not-accepted" を返し同意画面へ送る。
+//   /liff-confirm 側が再度 settings を確認し、同意済みなら /liff-chat へ戻すため
+//   already-agreed ユーザーがロックされることはない (再同意は冪等)。
+
+"use client"
+
+import { useEffect, useState } from "react"
+
+import { getAuthToken } from "@/lib/auth/token-key"
+
+/** liff-confirm / settings_router (LIFF_TERMS_VERSION) と一致させること。 */
+const LIFF_TERMS_VERSION = "liff-v3"
+
+export type LiffTermsGateState = "loading" | "accepted" | "not-accepted"
+
+/**
+ * 重要事項同意 (liff-v3) の状態を返す。
+ * @param enabled false の間はゲートを無効化し常に "accepted" を返す
+ *                (除外ページ / 未認証時に呼び出し側が無効化する)。
+ */
+export function useLiffTermsGate(enabled: boolean): LiffTermsGateState {
+  const [state, setState] = useState<LiffTermsGateState>("loading")
+
+  useEffect(() => {
+    if (!enabled) {
+      setState("accepted")
+      return
+    }
+
+    const token = getAuthToken()
+    if (!token) {
+      // 認証は別ガード (auth guard) が担保。token 無しでは同意判定不能のため
+      // ここでは pass-through し、auth guard 側に委ねる。
+      setState("accepted")
+      return
+    }
+
+    const apiBase = process.env.NEXT_PUBLIC_API_URL ?? ""
+    let cancelled = false
+    setState("loading")
+
+    fetch(`${apiBase}/api/user/settings`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: { terms_version?: string | null } | null) => {
+        if (cancelled) return
+        setState(
+          data?.terms_version === LIFF_TERMS_VERSION ? "accepted" : "not-accepted"
+        )
+      })
+      .catch(() => {
+        if (cancelled) return
+        // 法的同意ガード: 不確定時は同意画面へ誘導 (fail-closed)。
+        setState("not-accepted")
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [enabled])
+
+  return state
+}


### PR DESCRIPTION
## 概要
LIFF (BtoC) の**重要事項同意 (terms_version=\"liff-v3\") を入口非依存で強制**するゲートを `(liff)/layout.tsx` に追加。

## 背景 (なぜ必要か)
同意の強制は従来 **`/liff-login` → `/liff-confirm` の1経路にしか無かった**。`(liff)/layout.tsx` の既存ガードは**認証**のみで `terms_accepted_at` を見ていないため:

- リッチメニュー / ブックマーク等で **`/liff-chat` に直接アクセス**
- `useLiffAutoReAuth` がトークンを黙って復元

した未同意ユーザーが、**重要事項確認を一度も通らずにホームへ到達できた**。非カストディアル・元本喪失・鍵喪失の**法的同意画面**としては、単一経路依存は不適切。

## 変更
- **`hooks/useLiffTermsGate.ts`** (新規): `GET /api/user/settings` で `terms_version` を確認し `loading | accepted | not-accepted` を返す。**fail-closed**(取得失敗時は `not-accepted` → 同意画面へ)。
- **`(liff)/layout.tsx`**: token を持つ消費者が `/liff-chat` に来た際、`liff-v3` 未同意なら `/liff-confirm` へ `router.replace`。同意確定まで children を描画せず読み込み表示でブロック(未同意ホームの一瞬の表示も防止)。

## スコープ / 安全性
- 対象は `TERMS_GATE_PATHS = ['/liff-chat']` のみ。**パートナー承認系**(`liff-approve` / `liff-fee-approve` 等)は別系統のため**対象外**(誤バウンス防止)。
- `/liff-confirm` 自身は対象外 → **無限ループしない**。confirm 側は同意済みなら `/liff-chat` へ戻すため already-agreed ユーザーはロックされない。
- 全 React hooks は early return より前で呼出(hooks order 安全)。

## 検証
- 変更2ファイルとも **tsc 型エラー 0**(全体32件は既存の ethers/@privy 依存型欠落でベースライン、変更ファイルは無関係)。
- ⚠️ **実機 LIFF での新規ユーザー踏破は未実施** — staging LIFF 未構成(NEXT_PUBLIC_LIFF_ID 未設定 / GID 1215312700483149)でブロック中。LIFF ID + LINE 実機投入後に「直接 /liff-chat → /liff-confirm 強制遷移」を踏破確認が必要。

Refs: Asana 1215360586206558

🤖 Generated with [Claude Code](https://claude.com/claude-code)