### PR TITLE
feat(referral): 紹介報酬を「紹介友達の実受取利益×10%」に修正し一般ユーザー利用可能に (Asana 1215467015333283)

### DIFF
--- a/backend/alembic/sql/045_fee_v10_tables.sql
+++ b/backend/alembic/sql/045_fee_v10_tables.sql
@@ -38,7 +38,7 @@ CREATE TABLE fee_configs (
   subscription_rates JSONB NOT NULL,
   expense_markup_enabled BOOLEAN NOT NULL DEFAULT FALSE,
   expense_markup_rate NUMERIC(6, 4) NOT NULL DEFAULT 0,
-  affiliate_rate NUMERIC(6, 4) NOT NULL DEFAULT 0.30,
+  affiliate_rate NUMERIC(6, 4) NOT NULL DEFAULT 0.10,  -- 紹介報酬=紹介友達の実受取利益×10% (Asana 1215467015333283)
   is_active BOOLEAN NOT NULL DEFAULT FALSE,
   effective_from TIMESTAMP WITH TIME ZONE NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),

--- a/backend/alembic/versions/v2w3x4y5z6a7_affiliate_rate_default_010.py
+++ b/backend/alembic/versions/v2w3x4y5z6a7_affiliate_rate_default_010.py
@@ -1,0 +1,37 @@
+"""fee_configs.affiliate_rate column DEFAULT 0.30 -> 0.10
+
+紹介報酬仕様 (Asana 1215467015333283 / 2026-06-06 確定) の確定により、affiliate_rate は
+「紹介友達の月次 user_takehome_jpy の 10%」を意味する。列 DEFAULT が旧 0.30 (サブスク料基準
+時代の値) のままだと、新規 fee_configs INSERT が誤った 0.30 で作られ得るため 0.10 に揃える。
+
+- 本 migration は **列 DEFAULT (今後の INSERT 用) のみ** を変更する。
+- 既存行 (現行 active config) の値是正は ops 子タスク 1215466962382625 (人間) が担当。
+- model 側 (FeeConfigV10.affiliate_rate.server_default) は既に 0.10 でドリフトしていたのを解消。
+
+Revision ID: v2w3x4y5z6a7
+Revises: u1v2w3x4y5z6
+Create Date: 2026-06-07 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "v2w3x4y5z6a7"
+down_revision: Union[str, Sequence[str], None] = "u1v2w3x4y5z6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    # SQLite (テスト) は ALTER COLUMN ... SET DEFAULT 非対応 + そもそも model server_default
+    # =0.10 を使うため no-op。PostgreSQL のみ列 DEFAULT を是正する。
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TABLE fee_configs ALTER COLUMN affiliate_rate SET DEFAULT 0.10")
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TABLE fee_configs ALTER COLUMN affiliate_rate SET DEFAULT 0.30")

--- a/backend/app/fees/calculator.py
+++ b/backend/app/fees/calculator.py
@@ -13,7 +13,7 @@ I/O / 外部 API / DB 接続は一切行わない。
     Step 3: サブスク保護 (net_profit < subscription なら全額 UATa, fee 0, takehome 0)
     Step 4: tier-based fee = max(0, net_profit - subscription) * fee_rate
     Step 5: monthly_yield_cap (provisional_takehome > cap_amount なら excess→UATa)
-    Step 6: affiliate = subscription * affiliate_rate (subscription>0 のみ)
+    Step 6: affiliate = user_takehome * affiliate_rate (紹介報酬, takehome>0 のみ)
 
 関連:
 - 入力源 ``FeeConfigV10`` (F-1 + F-4 seed)
@@ -216,18 +216,26 @@ class FeeCalculator:
                 f"step5 yield ok: provisional({provisional_takehome}) <= cap({cap_amount})"
             )
 
-        # === Step 6: affiliate ===
-        if payload.affiliate_id is not None and sub_amount > Decimal("0"):
-            affiliate_amount = self._round_jpy(sub_amount * self._affiliate_rate())
+        # === Step 6: affiliate (紹介報酬) ===
+        # 仕様 (Asana 1215467015333283 / 2026-06-06 確定): 紹介報酬は「最新紹介友達の
+        # 月次 user_takehome_jpy (手数料・サブスク控除後の実受取利益) × affiliate_rate(=10%)」。
+        # サブスク有無に依らず takehome>0 なら発生する (コンサバ運用=サブスク0でも対象)。
+        # affiliate_id は finalize_month が「当月有効な紹介ウィンドウ (シングルスロット・
+        # ローリング)」のパートナー id を渡す。subscription_protected の早期 return では
+        # user_takehome=0 のため affiliate も自動的に 0 になる。
+        if payload.affiliate_id is not None and user_takehome > Decimal("0"):
+            affiliate_amount = self._round_jpy(user_takehome * self._affiliate_rate())
             affiliate_id_out: int | None = payload.affiliate_id
             debug.append(
-                f"step6 affiliate: sub({sub_amount}) * rate({self._affiliate_rate()}) "
+                f"step6 affiliate: takehome({user_takehome}) * rate({self._affiliate_rate()}) "
                 f"= {affiliate_amount}"
             )
         else:
             affiliate_amount = Decimal("0")
             affiliate_id_out = None
-            debug.append(f"step6 affiliate skipped: id={payload.affiliate_id}, sub={sub_amount}")
+            debug.append(
+                f"step6 affiliate skipped: id={payload.affiliate_id}, takehome={user_takehome}"
+            )
 
         return FeeCalculationResult(
             user_id=payload.user_id,

--- a/backend/app/referral/service.py
+++ b/backend/app/referral/service.py
@@ -130,8 +130,8 @@ def mask_email(email: str) -> str:
 def handle_new_referral(db: Session, partner_id: int, referree_id: int) -> ReferralCampaign:
     """新規紹介登録時に紹介キャンペーン ウィンドウを更新する。
 
-    1. 同一パートナーの既存アクティブ ウィンドウを今月で終了。
-    2. 新しい 12ヶ月ウィンドウを作成 (来月スタート)。
+    1. 同一パートナーの既存アクティブ ウィンドウを今月で終了 (シングルスロット・ローリング)。
+    2. 新しいウィンドウを作成 (来月スタート、末 = 最後に紹介した月 + 13ヶ月)。
 
     Args:
         db: DB セッション (呼び出し元が commit を担当)。
@@ -161,9 +161,10 @@ def handle_new_referral(db: Session, partner_id: int, referree_id: int) -> Refer
             current_month,
         )
 
-    # 新ウィンドウ: 来月スタート、12ヶ月間
+    # 新ウィンドウ: 来月スタート、末 = 最後に紹介した月(current_month) + 13ヶ月。
+    # reward_start_month = current_month + 1、expires = start + 12 (= current_month + 13)。
     reward_start_month = _add_months(current_month, 1)
-    reward_expires_month = _add_months(reward_start_month, 11)
+    reward_expires_month = _add_months(reward_start_month, 12)
 
     campaign = ReferralCampaign(
         partner_id=partner_id,
@@ -232,9 +233,10 @@ def get_referral_earnings(db: Session, partner_id: int) -> dict[str, str | int |
         .order_by(FeeConfigV10.effective_from.desc())
         .first()
     )
-    # affiliate_rate の正本: 045_fee_v10_tables.sql DEFAULT 0.30 / seed_runbook 0.30
-    # calculator Step6: affiliate = subscription * affiliate_rate → 「サブスク料の30%」
-    campaign_rate = active_config.affiliate_rate if active_config else Decimal("0.30")
+    # affiliate_rate の正本 = 製品仕様 (Asana 1215467015333283 / 2026-06-06 確定):
+    # 紹介友達の月次 user_takehome_jpy の 10%。calculator Step6 が takehome×rate で算定する。
+    # active fee_config が無い場合の fallback は 0.10 (FeeConfigV10.affiliate_rate server_default と一致)。
+    campaign_rate = active_config.affiliate_rate if active_config else Decimal("0.10")
 
     # アクティブ ウィンドウを探して期限月を返す
     active_campaign = db.scalar(
@@ -262,7 +264,9 @@ def get_api_referral_info(db: Session, user: User) -> dict[str, object]:
     """LIFF 紹介パネル用: /api/referral/earnings のデータを組み立てる。
 
     partner 専用の ``get_referral_earnings`` と異なり、全 active user が対象。
-    ``reward_jpy`` は ¥1,500 bonus 計算が別タスクのため常に "0"。
+    紹介報酬は「紹介友達の実受取利益 × affiliate_rate(10%)」で、当月分は
+    ``current_month_reward_jpy`` / 累計は ``total_payout_jpy`` に集約する。
+    友達ごとの内訳 ``reward_jpy`` は未集計のため "0" を返す (集計は別タスク)。
 
     Args:
         db: DB セッション。
@@ -326,7 +330,7 @@ def get_api_referral_info(db: Session, user: User) -> dict[str, object]:
         .order_by(FeeConfigV10.effective_from.desc())
         .first()
     )
-    campaign_rate = active_config.affiliate_rate if active_config else Decimal("0.30")
+    campaign_rate = active_config.affiliate_rate if active_config else Decimal("0.10")
 
     return {
         "referral_count": referral_count,

--- a/backend/tests/helpers/fee_config_factory.py
+++ b/backend/tests/helpers/fee_config_factory.py
@@ -11,7 +11,7 @@ values は v10 spec §1 と一致 (PR #125 で staging-new 投入確認済み):
 - tier_fee_rates:          [0.30, 0.25, 0.20]
 - tier_monthly_yield_caps: [0.018, 0.023, 0.030]
 - subscription_rates:      {"conservative": 0.0, "balanced": 0.003, "aggressive": 0.01}
-- affiliate_rate:          0.30
+- affiliate_rate:          0.10  (紹介報酬 = 紹介友達の実受取利益 × 10%, Asana 1215467015333283 / seed と一致)
 """
 
 from __future__ import annotations
@@ -42,7 +42,7 @@ def make_v10_default_config() -> FeeConfigV10:
         },
         expense_markup_enabled=False,
         expense_markup_rate=Decimal("0"),
-        affiliate_rate=Decimal("0.30"),
+        affiliate_rate=Decimal("0.10"),
         is_active=True,
         effective_from=datetime(2026, 5, 1, tzinfo=_JST),
     )

--- a/backend/tests/test_api_v1_fees.py
+++ b/backend/tests/test_api_v1_fees.py
@@ -265,8 +265,8 @@ class TestFeeConfigEndpoint:
         assert body["tier_fee_rates"] == [0.30, 0.25, 0.20]
         assert body["subscription_rates"]["conservative"] == 0.0
         assert body["subscription_rates"]["balanced"] == 0.003
-        # Numeric(6,4) のため "0.3000" として返る
-        assert Decimal(body["affiliate_rate"]) == Decimal("0.30")
+        # Numeric(6,4) のため "0.1000" として返る (紹介報酬 = 紹介友達の実受取利益 × 10%)
+        assert Decimal(body["affiliate_rate"]) == Decimal("0.10")
         assert body["is_active"] is True
 
 

--- a/backend/tests/test_fee_calculator.py
+++ b/backend/tests/test_fee_calculator.py
@@ -329,9 +329,9 @@ class TestAffiliate:
         assert result.affiliate_id == 99
         assert result.affiliate_amount_jpy == Decimal("490")
         # 仕様の関係式 (takehome × rate) を明示的に確認
-        assert result.affiliate_amount_jpy == (
-            result.user_takehome_jpy * Decimal("0.10")
-        ).quantize(Decimal("1"))
+        assert result.affiliate_amount_jpy == (result.user_takehome_jpy * Decimal("0.10")).quantize(
+            Decimal("1")
+        )
 
     def test_affiliate_fires_when_subscription_zero(self, calculator: FeeCalculator) -> None:
         # conservative (sub=0) でも takehome>0 なら紹介報酬は発火する (新仕様)。

--- a/backend/tests/test_fee_calculator.py
+++ b/backend/tests/test_fee_calculator.py
@@ -307,11 +307,16 @@ class TestMonthlyYieldCap:
 
 
 class TestAffiliate:
-    """affiliate_id あり + sub > 0 で 30% 発動。"""
+    """紹介報酬 = 紹介友達の user_takehome × affiliate_rate(0.10)。
 
-    def test_affiliate_when_subscription_active(self, calculator: FeeCalculator) -> None:
-        # balanced, deposit 1000000 → sub = 3000
-        # affiliate = 3000 * 0.30 = 900
+    仕様 (Asana 1215467015333283 / 2026-06-06 確定): サブスク有無に依らず
+    takehome>0 なら発火し、takehome=0 (subscription_protected 等) では発火しない。
+    """
+
+    def test_affiliate_is_takehome_times_rate(self, calculator: FeeCalculator) -> None:
+        # balanced, deposit 1000000, gross 10000 →
+        # sub=3000, fee=(10000-3000)*0.30=2100, takehome=10000-3000-2100=4900
+        # affiliate = 4900 * 0.10 = 490
         result = calculator.calculate_monthly(
             _make_input(
                 deposit=Decimal("1000000"),
@@ -320,11 +325,17 @@ class TestAffiliate:
                 affiliate_id=99,
             )
         )
+        assert result.user_takehome_jpy == Decimal("4900")
         assert result.affiliate_id == 99
-        assert result.affiliate_amount_jpy == Decimal("900")
+        assert result.affiliate_amount_jpy == Decimal("490")
+        # 仕様の関係式 (takehome × rate) を明示的に確認
+        assert result.affiliate_amount_jpy == (
+            result.user_takehome_jpy * Decimal("0.10")
+        ).quantize(Decimal("1"))
 
-    def test_affiliate_skipped_when_subscription_zero(self, calculator: FeeCalculator) -> None:
-        # conservative (sub=0) では affiliate 発動しない
+    def test_affiliate_fires_when_subscription_zero(self, calculator: FeeCalculator) -> None:
+        # conservative (sub=0) でも takehome>0 なら紹介報酬は発火する (新仕様)。
+        # net=10000, fee=10000*0.30=3000, takehome=7000, affiliate=7000*0.10=700
         result = calculator.calculate_monthly(
             _make_input(
                 deposit=Decimal("1000000"),
@@ -333,6 +344,23 @@ class TestAffiliate:
                 affiliate_id=99,
             )
         )
+        assert result.subscription_amount_jpy == Decimal("0")
+        assert result.user_takehome_jpy == Decimal("7000")
+        assert result.affiliate_id == 99
+        assert result.affiliate_amount_jpy == Decimal("700")
+
+    def test_affiliate_zero_when_takehome_zero(self, calculator: FeeCalculator) -> None:
+        # subscription_protected (net < sub) で takehome=0 → 紹介報酬も 0。
+        result = calculator.calculate_monthly(
+            _make_input(
+                deposit=Decimal("1000000"),
+                gross=Decimal("1000"),  # net=1000 < sub=3000 → 保護発動
+                risk=RiskMode.BALANCED,
+                affiliate_id=99,
+            )
+        )
+        assert result.subscription_protected is True
+        assert result.user_takehome_jpy == Decimal("0")
         assert result.affiliate_id is None
         assert result.affiliate_amount_jpy == Decimal("0")
 

--- a/backend/tests/test_proposals_fee_wiring.py
+++ b/backend/tests/test_proposals_fee_wiring.py
@@ -71,7 +71,7 @@ def _insert_fee_config(db: Session, *, is_active: bool = True) -> FeeConfigV10:
         subscription_rates={"conservative": 0.0, "balanced": 0.003, "aggressive": 0.01},
         expense_markup_enabled=False,
         expense_markup_rate=Decimal("0"),
-        affiliate_rate=Decimal("0.30"),
+        affiliate_rate=Decimal("0.10"),
         is_active=is_active,
         effective_from=datetime(2026, 5, 1, tzinfo=_JST),
     )

--- a/backend/tests/test_referral_campaign_window.py
+++ b/backend/tests/test_referral_campaign_window.py
@@ -1,0 +1,100 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/test_referral_campaign_window.py
+"""紹介キャンペーン ウィンドウ (handle_new_referral) のユニットテスト。
+
+仕様 (Asana 1215467015333283 / 2026-06-06 確定):
+- 報酬ウィンドウ末 = 最後に紹介した月 + 13ヶ月 (= reward_start_month + 12)。
+- シングルスロット・ローリング: 新規紹介で同一パートナーの旧ウィンドウを今月で打ち切り、
+  最新友達ベースの新ウィンドウを開く。
+
+handle_new_referral は users 行を参照せず partner_id / referree_id を整数として扱うため、
+本テストは ReferralCampaign のみで完結する (sqlite, FK 未強制)。
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Generator
+from datetime import date
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-referral-window")
+
+from app.database import Base  # noqa: E402
+from app.fees.models import ReferralCampaign  # noqa: E402
+from app.referral.service import _add_months, handle_new_referral  # noqa: E402
+
+
+@pytest.fixture()
+def db() -> Generator[Session, None, None]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = factory()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+        os.unlink(path)
+
+
+def _months_between(start: date, end: date) -> int:
+    return (end.year - start.year) * 12 + (end.month - start.month)
+
+
+def test_window_end_is_referral_month_plus_13(db: Session) -> None:
+    today = date.today()
+    current_month = date(today.year, today.month, 1)
+
+    campaign = handle_new_referral(db, partner_id=1, referree_id=2)
+    db.commit()
+
+    # 来月スタート
+    assert campaign.reward_start_month == _add_months(current_month, 1)
+    # 末 = start + 12ヶ月
+    assert campaign.reward_expires_month == _add_months(campaign.reward_start_month, 12)
+    assert _months_between(campaign.reward_start_month, campaign.reward_expires_month) == 12
+    # = 最後に紹介した月 (current_month) + 13ヶ月
+    assert _months_between(current_month, campaign.reward_expires_month) == 13
+    assert campaign.ended_early_month is None
+
+
+def test_new_referral_rolls_single_slot(db: Session) -> None:
+    today = date.today()
+    current_month = date(today.year, today.month, 1)
+
+    first = handle_new_referral(db, partner_id=1, referree_id=2)
+    db.commit()
+    first_id = first.id
+
+    # 同一パートナーが別の友達を新規紹介 → 旧ウィンドウは今月で打ち切り、新ウィンドウ開設
+    second = handle_new_referral(db, partner_id=1, referree_id=3)
+    db.commit()
+
+    db.refresh(first)
+    assert first.ended_early_month == current_month, "旧ウィンドウは今月で ended_early"
+    assert second.id != first_id
+    assert second.referree_id == 3
+    assert second.ended_early_month is None
+    # 新ウィンドウも +13ヶ月仕様
+    assert _months_between(current_month, second.reward_expires_month) == 13
+
+    # アクティブ (ended_early=None) は最新の1件のみ = シングルスロット
+    active = (
+        db.query(ReferralCampaign)
+        .filter(
+            ReferralCampaign.partner_id == 1,
+            ReferralCampaign.ended_early_month.is_(None),
+        )
+        .all()
+    )
+    assert len(active) == 1
+    assert active[0].referree_id == 3

--- a/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
@@ -18,7 +18,7 @@ function getToken(): string {
 }
 
 function buildShareText(code: string): string {
-  return `【UATaのご紹介】\nAIが自動で資産運用してくれるサービスです。\n紹介コード「${code}」を使って登録すると特典があります。\n▼ アカウント開設はこちら\n${SIGNUP_URL}?ref=${code}`
+  return `【UATaのご紹介】\nAIが自動で資産運用してくれるサービスです。\n紹介コード「${code}」を使ってアカウント登録できます。\n▼ アカウント開設はこちら\n${SIGNUP_URL}?ref=${code}`
 }
 
 /** フォールバック用のスケルトンデータ（ローディング中 or エラー時） */
@@ -26,7 +26,7 @@ const EMPTY_INFO: ReferralInfo = {
   referral_count: 0,
   current_month_reward_jpy: "0",
   total_payout_jpy: "0",
-  campaign_rate: "30",
+  campaign_rate: "0.10",
   referral_code: "",
   referred_users: [],
 }
@@ -276,12 +276,12 @@ export function ReferralPanel() {
           />
           <HowItWorksStep
             step={2}
-            text="友達が登録・運用開始"
-            reward="¥1,500 もらえる"
+            text="友達が登録して資産運用を開始"
           />
           <HowItWorksStep
             step={3}
-            text="毎月サブスク料の 30% が加算"
+            text="紹介した友達の毎月の実受取利益（手数料控除後）の 10% を、翌月末にあなたへ自動でお支払い"
+            reward="紹介し続ける限り継続"
           />
         </div>
       </div>

--- a/frontend/app/(partner)/partner/referral/page.tsx
+++ b/frontend/app/(partner)/partner/referral/page.tsx
@@ -130,7 +130,7 @@ export default function PartnerReferralPage() {
               今月の報酬
               {earnings && (
                 <span className="ml-1 text-xs font-normal">
-                  (サブスク{formatRate(earnings.campaign_rate)})
+                  (紹介友達の実受取利益の{formatRate(earnings.campaign_rate)})
                 </span>
               )}
             </CardTitle>


### PR DESCRIPTION
## 概要
確定仕様 (Asana [1215467015333283](https://app.asana.com/0/0/1215467015333283), 2026-06-06 sic.nozawa 確定) が実コードに未着地だったため、紹介キャンペーンを一般ユーザーが正しく使える状態まで実装。

旧コードは「サブスク料の30%」基準・12ヶ月ウィンドウ・frontend に「¥1,500」「サブスク30%」が残存していた。

## 変更
### backend
- **calculator Step6**: `affiliate = subscription × rate` → **`user_takehome × rate`**。ゲートを `sub>0` → `takehome>0` に (コンサバ運用=サブスク0でも実受取利益の10%が発生する正しい挙動)
- **referral/service.py**: 報酬ウィンドウ末を **+12 (= 最後に紹介した月+13ヶ月)** に。`affiliate_rate` fallback を `0.30 → 0.10` に統一、誤コメント訂正
- **率ドリフト解消**: 新規 alembic migration で `fee_configs.affiliate_rate` 列 DEFAULT を `0.10` に (single head `u1v2w3x4y5z6` 接続 / postgres限定 / downgrade有)。045 SQL・test factory も 0.10 に統一。**既存行の是正は ops 子タスク [1215466962382625](https://app.asana.com/0/0/1215466962382625) 担当**

### frontend
- **ReferralPanel** (liff, 一般ユーザー): 廃止済み「¥1,500 もらえる」「毎月サブスク料の30%」を撤廃 →「紹介した友達の毎月の実受取利益(手数料控除後)の10%を翌月末に自動でお支払い」。EMPTY_INFO・招待文も修正
- **partner referral page**: 「サブスク○%」ラベルを「紹介友達の実受取利益の○%」に修正

## テスト
- `test_fee_calculator` TestAffiliate: takehome×10% / サブスク0でも発火 / takehome=0で0
- 新規 `test_referral_campaign_window`: ウィンドウ末=紹介月+13、シングルスロット・ローリング
- 影響テスト (api_v1_fees / proposals_fee_wiring / factory) を 0.10 に追従
- **backend: 99 + 27 passed** (`pytest tests/test_fee_calculator.py test_referral_campaign_window.py test_api_v1_fees.py test_proposals_fee_wiring.py test_seed_fee_config_v10.py test_referral_router.py test_api_referral_router.py test_auth_register_with_referral.py`)
- frontend: 編集ファイルに新規型エラーなし (既存の privy/ethers 型欠落は本PR対象外)

## 対象外 (既存子タスクのまま)
- operator→紹介者 **on-chain 送金 executor** ([1215466962331679](https://app.asana.com/0/0/1215466962331679)) — `FEE_TRANSFER_ENABLED` ゲート据え置き / 法務OKまで false。本PRでは報酬は `uat_wallet_ledger` debit 記帳まで (一般ユーザーには表示される)
- 本番・staging active `fee_config.affiliate_rate=0.10` 是正確認 ([1215466962382625](https://app.asana.com/0/0/1215466962382625))

## 残検証
実機 LIFF での表示確認は staging LIFF 未構成のため人間確認待ち (オンボーディング系と同じ env ブロッカー)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)