### PR TITLE
feat(frontend): 一般公開 open registration フロント配線 (signup + registerOpen)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -109,6 +109,10 @@ NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=
 NEXT_PUBLIC_DEFAULT_CHAIN=base-mainnet
 NEXT_PUBLIC_DEFAULT_CHAIN_ID=8453
 NEXT_PUBLIC_BASE_MAINNET_RPC=https://base-mainnet.g.alchemy.com/v2/YOUR_KEY
+# 一般公開（partner 招待不要の自己登録 /signup）の有効化フラグ。
+# false = 一般登録 UI 非表示（デフォルト）, true = 有効。build-time 埋め込みのため変更時は frontend 再ビルド必須。
+# 実公開は 法務(non-custodial S-5) / LINE 審査 / KYC ベンダー判断 が揃ってから true にする。
+NEXT_PUBLIC_PUBLIC_REGISTRATION_ENABLED=false
 
 # =============================================================================
 # Fee Transfer (Non-Custodial / Operator Fee)

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -102,6 +102,10 @@ NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=
 NEXT_PUBLIC_DEFAULT_CHAIN=base-sepolia
 NEXT_PUBLIC_DEFAULT_CHAIN_ID=84532
 NEXT_PUBLIC_BASE_SEPOLIA_RPC=https://base-sepolia.g.alchemy.com/v2/YOUR_KEY
+# 一般公開（partner 招待不要の自己登録 /signup）の有効化フラグ。
+# false = 一般登録 UI 非表示（デフォルト）, true = 有効。build-time 埋め込みのため変更時は frontend 再ビルド必須。
+# staging で一般登録フローを実機検証する際は true にして frontend 再ビルド。
+NEXT_PUBLIC_PUBLIC_REGISTRATION_ENABLED=false
 
 # =============================================================================
 # Fee Transfer (Non-Custodial / Operator Fee)

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -12,6 +12,7 @@ import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle } from "lucide-react";
+import { isPublicRegistrationEnabled } from "@/lib/flags";
 
 /**
  * リダイレクト先を検証し、安全なパスのみ許可する。
@@ -138,9 +139,18 @@ function LoginForm() {
             </Button>
           </form>
 
-          <p className="mt-6 text-center text-xs text-muted-foreground">
-            初期設定が必要な場合は管理者にお問い合わせください。
-          </p>
+          {isPublicRegistrationEnabled() ? (
+            <p className="mt-6 text-center text-xs text-muted-foreground">
+              アカウントをお持ちでない方は
+              <a href="/signup" className="underline underline-offset-4 hover:text-primary ml-1">
+                新規登録
+              </a>
+            </p>
+          ) : (
+            <p className="mt-6 text-center text-xs text-muted-foreground">
+              初期設定が必要な場合は管理者にお問い合わせください。
+            </p>
+          )}
         </CardContent>
       </Card>
     </main>

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -1,0 +1,190 @@
+'use client'
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+
+// frontend/app/signup/page.tsx
+// 一般公開ユーザー登録ページ（partner 招待・紹介コード不要）。
+// backend POST /auth/register-open に対応。
+// 公開は NEXT_PUBLIC_PUBLIC_REGISTRATION_ENABLED フラグで gate（既定 false）。
+import { useRouter } from 'next/navigation'
+import { useState, FormEvent } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { AlertCircle } from 'lucide-react'
+import { registerOpen } from '@/lib/api/auth'
+import { isPublicRegistrationEnabled } from '@/lib/flags'
+
+function SignupForm() {
+  const router = useRouter()
+
+  const [email, setEmail] = useState('')
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [consent, setConsent] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    if (!consent) {
+      setError('利用規約・プライバシーポリシーへの同意が必要です')
+      return
+    }
+    setError(null)
+    setSubmitting(true)
+    try {
+      const result = await registerOpen({
+        email,
+        username,
+        password,
+        terms_consent: true,
+      })
+      localStorage.setItem('ultra_auth_token', result.access_token)
+      localStorage.setItem('ultra_auth_expires', String(Date.now() + result.expires_in * 1000))
+      router.replace('/user/dashboard')
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === 'object' && 'message' in err
+          ? String((err as { message: string }).message)
+          : '登録に失敗しました'
+      setError(message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-muted/40 p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">Ultra AutoTrade</CardTitle>
+          <CardDescription>新規アカウント登録</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={(e) => { void handleSubmit(e) }} className="space-y-4">
+            {error && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <div className="space-y-1.5">
+              <Label htmlFor="email">メールアドレス</Label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoComplete="email"
+                disabled={submitting}
+                placeholder="you@example.com"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="username">表示名</Label>
+              <Input
+                id="username"
+                type="text"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                required
+                autoComplete="username"
+                disabled={submitting}
+                placeholder="山田太郎"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="password">パスワード</Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                minLength={8}
+                autoComplete="new-password"
+                disabled={submitting}
+              />
+              <p className="text-xs text-muted-foreground">8文字以上で入力してください</p>
+            </div>
+
+            {/* 利用規約・プライバシーポリシー同意 */}
+            <div className="flex items-start gap-2 rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950/20">
+              <input
+                id="consent"
+                type="checkbox"
+                checked={consent}
+                onChange={(e) => setConsent(e.target.checked)}
+                required
+                disabled={submitting}
+                className="mt-0.5 h-4 w-4 shrink-0 accent-blue-600"
+              />
+              <Label htmlFor="consent" className="text-xs leading-relaxed cursor-pointer">
+                <a href="/terms" target="_blank" rel="noopener noreferrer" className="underline underline-offset-4 hover:text-primary">
+                  利用規約
+                </a>
+                および
+                <a href="/privacy-policy" target="_blank" rel="noopener noreferrer" className="underline underline-offset-4 hover:text-primary">
+                  プライバシーポリシー
+                </a>
+                に同意します
+              </Label>
+            </div>
+
+            <Button type="submit" className="w-full" disabled={submitting || !consent}>
+              {submitting ? '登録中...' : 'アカウントを作成'}
+            </Button>
+          </form>
+
+          <p className="mt-6 text-center text-xs text-muted-foreground">
+            すでにアカウントをお持ちの方は
+            <a href="/login" className="underline underline-offset-4 hover:text-primary ml-1">
+              ログイン
+            </a>
+          </p>
+        </CardContent>
+      </Card>
+    </main>
+  )
+}
+
+function ComingSoon() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-muted/40 p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">Ultra AutoTrade</CardTitle>
+          <CardDescription>新規アカウント登録</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Alert>
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>
+              一般登録は現在準備中です。招待をお持ちの方は招待リンクからご登録ください。
+            </AlertDescription>
+          </Alert>
+          <Button variant="outline" className="w-full" onClick={() => { window.location.href = '/login' }}>
+            ログインへ
+          </Button>
+        </CardContent>
+      </Card>
+    </main>
+  )
+}
+
+export default function SignupPage() {
+  const enabled = isPublicRegistrationEnabled()
+  return (
+    <>
+      <title>新規登録 - Ultra AutoTrade</title>
+      {enabled ? <SignupForm /> : <ComingSoon />}
+    </>
+  )
+}

--- a/frontend/lib/api/auth.ts
+++ b/frontend/lib/api/auth.ts
@@ -18,6 +18,28 @@ export interface RegisterRequest {
   password: string;
 }
 
+export interface OpenRegisterRequest {
+  email: string;
+  username: string;
+  password: string;
+  terms_consent: boolean;
+}
+
+/**
+ * 一般登録（open registration）レスポンス。
+ * backend RegisterResponse = UserResponse + access_token + expires_in に対応。
+ */
+export interface OpenRegisterResponse {
+  id: number;
+  email: string;
+  username: string;
+  role: string;
+  is_active: boolean;
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+}
+
 export interface TokenResponse {
   access_token: string;
   token_type: string;
@@ -49,6 +71,19 @@ export interface PasswordChangeRequest {
  */
 export async function register(request: RegisterRequest): Promise<UserResponse> {
   return await postJson<UserResponse>("/auth/register", request);
+}
+
+/**
+ * 一般登録（partner 招待不要の自己申請 / POST /auth/register-open）。
+ *
+ * terms_consent === true が必須（backend 側で 422 になる）。成功時は
+ * RegisterResponse（ユーザー情報 + access_token + expires_in）を返す。
+ * フロント側の到達経路は isPublicRegistrationEnabled() フラグで gate する。
+ */
+export async function registerOpen(
+  request: OpenRegisterRequest
+): Promise<OpenRegisterResponse> {
+  return await postJson<OpenRegisterResponse>("/auth/register-open", request);
 }
 
 /**

--- a/frontend/lib/flags.ts
+++ b/frontend/lib/flags.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+/**
+ * ビルド時フィーチャーフラグ。
+ *
+ * NEXT_PUBLIC_* は build-time inline なので、値を変えたら frontend 再ビルドが必須。
+ */
+
+/**
+ * 一般公開（partner 招待不要の自己登録）が有効か。
+ *
+ * 既定 false。実公開は法務（non-custodial S-5）・LINE 審査・KYC ベンダー判断が
+ * 揃ってからフラグを true にして再ビルドする（code-ready-behind-flag）。
+ * backend POST /auth/register-open 自体は常時実装済だが、フロント側の到達経路を
+ * このフラグで gate する。
+ */
+export function isPublicRegistrationEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_PUBLIC_REGISTRATION_ENABLED === 'true'
+}


### PR DESCRIPTION
## 目的
V3 一般公開で**一般ユーザーが自力でアカウント開設**するためのフロント経路を実装。
backend `POST /auth/register-open` は実装済 (#482) だが、フロント側に到達経路が無かった（`grep registerOpen` = 0件、`/signup` 等のページ無し）。一般ユーザーは UI から登録できない状態だった。

法務（non-custodial S-5）・LINE 審査・KYC ベンダー判断には**依存しない「コードで完結する配線」のみ**を対象。実公開は build-time フラグ1つで gate する `code-ready-behind-flag` 方式（`FEE_TRANSFER_ENABLED` と同型）。

## 変更
- `frontend/lib/flags.ts`（新規）— `isPublicRegistrationEnabled()`
- `frontend/lib/api/auth.ts` — `registerOpen()` + 型（`POST /auth/register-open`）
- `frontend/app/signup/page.tsx`（新規）— 一般登録フォーム（email/username/password + 利用規約・プライバシーポリシー同意）。フラグ off は「準備中」表示
- `frontend/app/login/page.tsx` — フラグ on 時のみ「新規登録」導線
- `.env.{production,staging}.example` — `NEXT_PUBLIC_PUBLIC_REGISTRATION_ENABLED=false` 追記

## 安全性
- フラグ off（既定）の現状は**既存挙動不変＝回帰なし**（`/signup` は「準備中」、login 導線も非表示）
- 実公開は法務/LINE/KYC 承認後に `NEXT_PUBLIC_PUBLIC_REGISTRATION_ENABLED=true` + frontend 再ビルド
- backend KYC ゲート接続点（`router.py:259` コメント）は据え置き＝別 Lane / ベンダー判断

## 検証
- `tsc --noEmit` / `next lint`（変更4ファイル）/ `next build`（flag off・on 両方）: **PASS**
- 実機 HTTP: `/signup` flag off→「準備中」(200) / flag on→フォーム全項目(200)
- **実ブラウザ E2E（Playwright chromium、flag on build）17/17 PASS**:
  - フォーム描画（全入力・同意 checkbox・作成ボタン・利用規約/PPリンク）
  - 同意前ボタン disabled → 同意後 enabled
  - 送信 → `POST /auth/register-open`（payload `terms_consent=true` + email/username）
  - 201 受領（network mock）→ token を localStorage 保存 → `/user/dashboard` 遷移
  - `/login`（未認証クリーンコンテキスト）に「新規登録」→ `/signup` 導線
- **残（この PR では未取得）**: 実 backend 接続での 201/DB（user・open invitation レコード）確認。staging（フラグ true ビルド）+ 人間検証が必要。E2E Smoke の Playwright fail は mock backend 起因の構造問題（Asana 1215186241897655）で merge gate にしない。

## Asana
- 親: https://app.asana.com/1/817733952351708/project/1213916581114014/task/1215470228567873

🤖 Generated with [Claude Code](https://claude.com/claude-code)