### PR TITLE
fix(notifications): add /api/notifications/push/test alias for liff-chat test button

### DIFF
--- a/backend/app/notifications/router.py
+++ b/backend/app/notifications/router.py
@@ -166,13 +166,11 @@ def get_vapid_key() -> dict[str, Any]:
     return {"publicKey": config.public_key}
 
 
-@router.post("/push/test", status_code=status.HTTP_200_OK)
-def send_test_push(
-    req: TestPushRequest = TestPushRequest(),
-    store: InMemorySubscriptionStore = Depends(get_subscription_store),
-    _current_user: User = Depends(require_active_user),
+def _do_full_test_push(
+    req: TestPushRequest,
+    store: InMemorySubscriptionStore,
 ) -> dict[str, Any]:
-    """テスト通知を送信する。認証必須。"""
+    """Web Push + LINE のテスト通知を送信して結果を返す。"""
     from app.notifications.config import get_notification_settings
 
     result = _do_test_push(req.title, req.body, store)
@@ -193,16 +191,38 @@ def send_test_push(
     return result
 
 
-@api_router.post("/test-push", status_code=status.HTTP_200_OK)
-def api_test_push(
-    req: TestPushRequest,
+@router.post("/push/test", status_code=status.HTTP_200_OK)
+def send_test_push(
+    req: TestPushRequest = TestPushRequest(),
     store: InMemorySubscriptionStore = Depends(get_subscription_store),
     _current_user: User = Depends(require_active_user),
 ) -> dict[str, Any]:
-    """テスト通知を送信する（/api/notifications/test-push エイリアス）。認証必須。"""
-    result = _do_test_push(req.title, req.body, store)
-    result["status"] = "ok"
-    return result
+    """テスト通知を送信する。認証必須。"""
+    return _do_full_test_push(req, store)
+
+
+@api_router.post("/push/test", status_code=status.HTTP_200_OK)
+def api_test_push_canonical(
+    req: TestPushRequest = TestPushRequest(),
+    store: InMemorySubscriptionStore = Depends(get_subscription_store),
+    _current_user: User = Depends(require_active_user),
+) -> dict[str, Any]:
+    """テスト通知を送信する（/api/notifications/push/test エイリアス）。
+
+    liff-chat NotificationPanel の「テスト通知」ボタンはこのパスへ body 無しで
+    POST する。req を省略可能にし、Web Push + LINE の完全版ロジックを呼ぶ。認証必須。
+    """
+    return _do_full_test_push(req, store)
+
+
+@api_router.post("/test-push", status_code=status.HTTP_200_OK)
+def api_test_push(
+    req: TestPushRequest = TestPushRequest(),
+    store: InMemorySubscriptionStore = Depends(get_subscription_store),
+    _current_user: User = Depends(require_active_user),
+) -> dict[str, Any]:
+    """テスト通知を送信する（/api/notifications/test-push 後方互換エイリアス）。認証必須。"""
+    return _do_full_test_push(req, store)
 
 
 @router.get("/push/count", status_code=status.HTTP_200_OK)

--- a/backend/tests/test_notification_settings_api.py
+++ b/backend/tests/test_notification_settings_api.py
@@ -171,3 +171,38 @@ class TestPutNotificationSettings:
         self._override_deps(user, db)
         res = self.client.put("/api/notifications/settings", json={"line_enabled": "not_a_bool"})
         assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /api/notifications/push/test (liff-chat「テスト通知」ボタンのパス)
+# ---------------------------------------------------------------------------
+
+
+class TestTestPushAliasPaths:
+    """NotificationPanel の「テスト通知」ボタンは body 無しで
+    POST /api/notifications/push/test を叩く。frontend と完全一致のパス +
+    後方互換 /api/notifications/test-push が body 無しで 200 を返すこと。
+    VAPID 未設定 + LINE 未設定の既定環境では送信 0 件・200 を期待。"""
+
+    def setup_method(self):
+        self.app = _make_app()
+        self.client = TestClient(self.app)
+        from app.auth.dependencies import require_active_user
+
+        self.app.dependency_overrides[require_active_user] = lambda: _make_user(None)
+
+    def test_canonical_api_path_no_body_returns_200(self):
+        # frontend NotificationPanel.handleTestNotification が叩く正確なパス
+        res = self.client.post("/api/notifications/push/test")
+        assert res.status_code == 200, res.text
+        assert res.json()["status"] == "ok"
+
+    def test_legacy_test_push_path_no_body_returns_200(self):
+        res = self.client.post("/api/notifications/test-push")
+        assert res.status_code == 200, res.text
+        assert res.json()["status"] == "ok"
+
+    def test_non_api_push_test_path_no_body_returns_200(self):
+        res = self.client.post("/notifications/push/test")
+        assert res.status_code == 200, res.text
+        assert res.json()["status"] == "ok"


### PR DESCRIPTION
## 背景 / 真因
liff-chat 通知設定の 404 (Asana 1215466859114764) を調査した結果、設定 EP (GET/PUT `/api/notifications/settings`) は #553 で実装済み・main に存在し、404 の主因は **backend 未 deploy**（frontend #561 のみ本番反映）でした。

さらに調査中に、**deploy しても直らない独立した実バグ**を発見:

- frontend `NotificationPanel.handleTestNotification` は body 無しで `POST /api/notifications/push/test` を叩く
- しかし backend には `/api/notifications/test-push`（api_router）と `/notifications/push/test`（非api）しか無く、**`/api/notifications/push/test` は未登録**
- → backend を deploy しても「テスト通知」ボタンは 404 のまま

frontend は既に本番反映済みのため、追加 frontend deploy を不要にすべく **backend 側にエイリアスを追加**して解消します。

## 変更
- `_do_full_test_push()` を抽出（Web Push + LINE + `status:ok`）
- `@api_router.post("/push/test")` を新設 = frontend の正確なパス、body 省略可
- 既存 `/push/test`・`/test-push` も同 helper に統一（`/test-push` は body 省略可に緩和）
- 後方互換維持: 既存2パスは引き続き 200
- 回帰テスト3件追加（3パス × body 無し → 200）

## 検証
- 通知テスト **87 passed** + 追加3件 pass、ruff クリーン、alembic head 単一
- ルーティング表（`ENABLE_WITHDRAWALS` OFF）: 通知3パス登録 ✅ / withdraw route 不在 ✅
- full-app TestClient: `GET /api/notifications/settings` → 200

## deploy 注記
- 通知 router は `ENABLE_WITHDRAWALS` フラグと独立に無条件登録。本 PR は #391 money gate と無関係に安全に deploy 可能（フラグ未設定なら `/api/users/withdrawals` は 404 のまま）。
- 一般ユーザー利用には本 PR merge 後の **origin/main backend 本番 deploy（migration `u1v2w3x4y5z6` 適用）** が必要。実機 DevTools 200 確認まで完了としないこと。

Closes 部分対応: Asana 1215466859114764

🤖 Generated with [Claude Code](https://claude.com/claude-code)