### PR TITLE
fix(test): Base Aave WBTC 除外にテスト追従 (CI merge gate 復旧)

### DIFF
--- a/backend/tests/test_aave_web3_client.py
+++ b/backend/tests/test_aave_web3_client.py
@@ -826,7 +826,10 @@ def test_make_aave_client_base_wires_token_addresses(mock_web3, mock_rpc_provide
     assert client.token_addresses.get("USDC") == _BASE_USDC
     # chain_config.tokens の他トークンも配線される
     assert "WETH" in client.token_addresses
-    assert "WBTC" in client.token_addresses
+    # WBTC は Base Aave V3 非上場のため chains.py から除外済み (commit 347f7afb)。
+    # Base 上場の BTC 系 cbBTC で配線を確認し、WBTC が無いことも明示する。
+    assert "cbBTC" in client.token_addresses
+    assert "WBTC" not in client.token_addresses
 
 
 @patch("app.aave.rpc_provider.RPCProvider")


### PR DESCRIPTION
## 概要
`test_aave_web3_client.py::test_make_aave_client_base_wires_token_addresses` が現在 main 由来の**全PRで失敗**し、pytest merge gate を塞いでいるのを修正。

## 根本原因
commit `347f7afb fix(aave): remove unsupported tokens from Base chain map (USDT/DAI/WBTC)` が Base Aave V3 非上場の WBTC/USDT/DAI を `chains.py` から除外した際、`test_aave_chains.py` は更新したが **`test_aave_web3_client.py:829` の `assert "WBTC" in client.token_addresses` を更新し忘れた**。結果、Base クライアントの token_addresses に WBTC が無くなり当該テストが赤に。

## 変更
- `assert "WBTC" in ...` → Base 上場の **cbBTC** で配線を確認 + `assert "WBTC" not in ...` で除外を明示。
- テストの本来の意図(USDC/WETH 以外のトークンも配線される回帰確認)は維持。

## 検証
\`\`\`
pytest tests/test_aave_web3_client.py::test_make_aave_client_base_wires_token_addresses \
       ::test_make_aave_client_base_sepolia_wires_token_addresses
→ 2 passed
ruff check / format --check → All checks passed
\`\`\`

## 補足
これは本日のオンボーディング系PR (#564 / #565) の pytest gate を赤にしていた原因。本PR merge で解消。frontend PR とは無関係の独立修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)