### PR TITLE
feat(tax): 法人決算月backend + 設定UX + corporate CSV を501ガード (corporate-CSV 2/4,3/4)

### DIFF
--- a/backend/alembic/versions/cfm1corp2month_add_corporate_fiscal_month.py
+++ b/backend/alembic/versions/cfm1corp2month_add_corporate_fiscal_month.py
@@ -1,0 +1,41 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""add_corporate_fiscal_month
+
+users テーブルに corporate_fiscal_month カラムを追加する (corporate-CSV [2/4])。
+
+法人決算月 (1-12) を保持し、TAX & REPORTS の法人モード (freee/弥生 CSV)
+アンロック条件に用いる。NULL = 個人ユーザー (法人モード未設定)。
+
+Revision ID: cfm1corp2month
+Revises: u1v2w3x4y5z6
+Create Date: 2026-06-07 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "cfm1corp2month"
+down_revision: Union[str, None] = "u1v2w3x4y5z6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "corporate_fiscal_month",
+            sa.SmallInteger(),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "corporate_fiscal_month")

--- a/backend/app/auth/models.py
+++ b/backend/app/auth/models.py
@@ -35,6 +35,9 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS referred_consent_at TIMESTAMP WITH TI
 
 -- Lane P: LINE 月次レポート通知 opt-in
 ALTER TABLE users ADD COLUMN IF NOT EXISTS line_monthly_opt_in BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- corporate-CSV [2/4]: 法人決算月 (1-12, NULL=個人)。TAX & REPORTS 法人モードのアンロック条件。
+ALTER TABLE users ADD COLUMN IF NOT EXISTS corporate_fiscal_month SMALLINT NULL;
 """
 
 import logging
@@ -43,7 +46,16 @@ from decimal import Decimal
 from enum import Enum
 from typing import Optional
 
-from sqlalchemy import Boolean, CheckConstraint, DateTime, ForeignKey, Integer, Numeric, String
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Numeric,
+    SmallInteger,
+    String,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.auth.constants import ExecutionPolicy
@@ -276,6 +288,12 @@ class User(Base):
     # ALTER TABLE users ADD COLUMN IF NOT EXISTS notification_settings_json TEXT NULL;
     notification_settings_json: Mapped[Optional[str]] = mapped_column(
         String, nullable=True, default=None
+    )
+    # corporate_fiscal_month: 法人決算月 (1-12)。NULL=個人ユーザー(法人モード未設定)。
+    # TAX & REPORTS の法人モード (freee/弥生 CSV) のアンロック条件に使用する。
+    # ALTER TABLE users ADD COLUMN IF NOT EXISTS corporate_fiscal_month SMALLINT NULL;
+    corporate_fiscal_month: Mapped[Optional[int]] = mapped_column(
+        SmallInteger, nullable=True, default=None
     )
 
     def __repr__(self) -> str:

--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -520,6 +520,10 @@ _OPERATION_TO_CRYPTACT_ACTION: dict[str, str] = {
 @router.get("/tax/cryptact-csv", summary="Cryptact無料版フォーマットCSVダウンロード")
 def download_cryptact_csv(
     year: Optional[int] = Query(None, description="絞り込む年 (例: 2026)。省略時は全件"),
+    type: str = Query(
+        "individual",
+        description="出力モード: individual (個人=Cryptact) / corporate (法人=freee/弥生)",
+    ),
     current_user: User = Depends(require_viewer),
     db: Session = Depends(get_db),
 ) -> Response:
@@ -536,7 +540,21 @@ def download_cryptact_csv(
     - Counter: USD
     - Fee: 手数料 USD (fee_amount。NULL の場合は 0)
     - FeeCcy: USD
+
+    type=corporate (法人 freee/弥生) は corporate-CSV [4/4] で実装予定。
+    会計マッピング(勘定科目・税区分)の税理士承認が適用されるまでは、個人データを
+    法人フォーマットと偽って返さないよう 501 で明示的に拒否する (silent-wrong-data 防止)。
+    円建ての基礎データ源は月次 fee_transactions (net_profit_jpy 等) を用いる方針で確定済み。
     """
+    if type == "corporate":
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail=(
+                "法人モード (freee/弥生 CSV) は準備中です。"
+                "税理士承認の仕訳マッピング適用後に提供されます。"
+            ),
+        )
+
     stmt = select(Proposal).where(
         Proposal.user_id == current_user.id,
         Proposal.status == "executed",

--- a/backend/app/users/settings_router.py
+++ b/backend/app/users/settings_router.py
@@ -44,6 +44,7 @@ def _build_settings_response(user: User) -> UserSettingsResponse:
         line_monthly_opt_in=user.line_monthly_opt_in,
         terms_agreed_at=user.terms_accepted_at,
         terms_version=user.terms_version,
+        corporate_fiscal_month=user.corporate_fiscal_month,
     )
 
 
@@ -114,6 +115,9 @@ def update_user_settings(
         current_user.execution_policy = request.execution_policy
     if request.line_monthly_opt_in is not None:
         current_user.line_monthly_opt_in = request.line_monthly_opt_in
+    if request.corporate_fiscal_month is not None:
+        # スキーマ側で 1-12 を検証済み。設定すると TAX & REPORTS 法人モードが解放される。
+        current_user.corporate_fiscal_month = request.corporate_fiscal_month
     if request.username is not None:
         # スキーマ側で形式検証 + 小文字化済み。本人による表示名変更（role 制限なし）。
         new_username = request.username

--- a/backend/app/users/settings_schemas.py
+++ b/backend/app/users/settings_schemas.py
@@ -28,6 +28,8 @@ class UserSettingsResponse(BaseModel):
     terms_agreed_at: Optional[datetime] = None
     # 同意時の規約バージョン（フロントエンドの再同意判定に使用）
     terms_version: Optional[str] = None
+    # 法人決算月 (1-12)。NULL=個人ユーザー。設定済みで TAX & REPORTS 法人モードを解放する。
+    corporate_fiscal_month: Optional[int] = None
 
 
 class UserSettingsUpdate(BaseModel):
@@ -38,8 +40,19 @@ class UserSettingsUpdate(BaseModel):
     user_mode: Optional[str] = None
     execution_policy: Optional[str] = None
     line_monthly_opt_in: Optional[bool] = None
+    # 法人決算月 (1-12)。設定すると TAX & REPORTS 法人モードが解放される。
+    corporate_fiscal_month: Optional[int] = None
     # ユーザー名（本人による表示名変更）。auth/schemas.py の登録時 validator と同一規則。
     username: Optional[str] = Field(default=None, min_length=3, max_length=50)
+
+    @field_validator("corporate_fiscal_month")
+    @classmethod
+    def validate_corporate_fiscal_month(cls, v: Optional[int]) -> Optional[int]:
+        if v is None:
+            return v
+        if not (1 <= v <= 12):
+            raise ValueError("corporate_fiscal_month は 1〜12 の整数で指定してください")
+        return v
 
     @field_validator("username")
     @classmethod

--- a/backend/tests/test_aave_web3_client.py
+++ b/backend/tests/test_aave_web3_client.py
@@ -826,7 +826,8 @@ def test_make_aave_client_base_wires_token_addresses(mock_web3, mock_rpc_provide
     assert client.token_addresses.get("USDC") == _BASE_USDC
     # chain_config.tokens の他トークンも配線される
     assert "WETH" in client.token_addresses
-    assert "WBTC" in client.token_addresses
+    # WBTC は Base Aave V3 非上場のため除外済 (chains.py)。BTC 系は cbBTC で配線確認する。
+    assert "cbBTC" in client.token_addresses
 
 
 @patch("app.aave.rpc_provider.RPCProvider")

--- a/backend/tests/test_cryptact_csv.py
+++ b/backend/tests/test_cryptact_csv.py
@@ -128,6 +128,27 @@ class TestCryptactCsvEndpoint:
         assert r.status_code == 200
         assert "text/csv" in r.headers["content-type"]
 
+    def test_type_individual_explicit_still_csv(self, client_with_proposals: TestClient) -> None:
+        """type=individual を明示しても従来どおり CSV を返すこと（後方互換）。"""
+        token = _get_admin_token(client_with_proposals)
+        r = client_with_proposals.get(
+            "/api/proposals/tax/cryptact-csv?type=individual",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        assert "text/csv" in r.headers["content-type"]
+
+    def test_type_corporate_not_yet_implemented(self, client_with_proposals: TestClient) -> None:
+        """type=corporate は仕訳マッピング適用前は 501 で拒否し、個人データを返さないこと。"""
+        token = _get_admin_token(client_with_proposals)
+        r = client_with_proposals.get(
+            "/api/proposals/tax/cryptact-csv?type=corporate",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 501
+        # 個人 CSV を法人と偽って返していないこと
+        assert "text/csv" not in r.headers.get("content-type", "")
+
     def test_csv_header_row(self, client_with_proposals: TestClient) -> None:
         token = _get_admin_token(client_with_proposals)
         r = client_with_proposals.get(

--- a/backend/tests/test_user_settings_api.py
+++ b/backend/tests/test_user_settings_api.py
@@ -324,3 +324,40 @@ class TestUserSettingsAPI:
         """POST /api/user/terms-agree は認証必須であること。"""
         r = client.post("/api/user/terms-agree")
         assert r.status_code == 401
+
+    # --- corporate-CSV [2/4]: corporate_fiscal_month ---
+
+    def test_corporate_fiscal_month_default_none(self, client: TestClient) -> None:
+        """新規ユーザーは corporate_fiscal_month が None（個人扱い）であること。"""
+        token = register_and_login(client)
+        r = client.get("/api/user/settings", headers={"Authorization": f"Bearer {token}"})
+        assert r.status_code == 200
+        assert r.json()["corporate_fiscal_month"] is None
+
+    def test_set_corporate_fiscal_month(self, client: TestClient) -> None:
+        """決算月を設定すると GET でも反映され、法人モードが解放されること。"""
+        token = register_and_login(client)
+        headers = {"Authorization": f"Bearer {token}"}
+        r = client.put(
+            "/api/user/settings",
+            json={"corporate_fiscal_month": 3},
+            headers=headers,
+        )
+        assert r.status_code == 200
+        assert r.json()["corporate_fiscal_month"] == 3
+        # GET でも永続化されていること
+        g = client.get("/api/user/settings", headers=headers)
+        assert g.json()["corporate_fiscal_month"] == 3
+
+    @pytest.mark.parametrize("bad", [0, 13, -1, 100])
+    def test_corporate_fiscal_month_out_of_range_rejected(
+        self, client: TestClient, bad: int
+    ) -> None:
+        """1〜12 の範囲外の決算月は 422 で拒否されること。"""
+        token = register_and_login(client)
+        r = client.put(
+            "/api/user/settings",
+            json={"corporate_fiscal_month": bad},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 422

--- a/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
@@ -25,7 +25,8 @@ interface UserData {
   created_at?: string
   wallet_address?: string
   avatar_url?: string
-  // corporate fields (frontend-only state — not yet in backend schema)
+  // 法人決算月 (1-12)。backend /api/user/settings で永続化される。
+  corporate_fiscal_month?: number | null
 }
 
 // アバター画像のローカル保持キー（backend に avatar upload エンドポイントが
@@ -79,7 +80,13 @@ export function AccountPanel() {
     })
       .then((r) => (r.ok ? r.json() : null))
       .then((data: UserData | null) => {
-        if (data) setUserData((prev) => ({ ...prev, ...data }))
+        if (data) {
+          setUserData((prev) => ({ ...prev, ...data }))
+          // 決算月は backend を正本とする（localStorage の同期復元より後に解決するため勝つ）。
+          if (typeof data.corporate_fiscal_month === "number") {
+            setCorpForm((p) => ({ ...p, month: data.corporate_fiscal_month as number }))
+          }
+        }
       })
       .catch(() => {})
 
@@ -181,15 +188,49 @@ export function AccountPanel() {
     }
   }
 
-  // 法人情報保存（フロントエンドのみ保持 — backend 未実装のためローカル保存）
-  const handleCorpSave = () => {
-    // 将来バックエンドが corporate_* フィールドを実装した時点で PUT /api/user/settings に送る
-    // 現時点は localStorage に保存してフロント内で表示するのみ
+  // 法人情報保存。決算月 (month) は backend に永続化し（TAX & REPORTS 法人モードの
+  // アンロック条件）、name/number/rep は backend に対応カラムが無いため localStorage 保持。
+  const handleCorpSave = async () => {
+    // name/number/rep は引き続きローカル保持
     try {
       localStorage.setItem("liff_corp_info", JSON.stringify(corpForm))
     } catch {
       // ignore
     }
+
+    // 決算月を backend に PUT（corporate_fiscal_month）。既存 settings の partial PUT を踏襲。
+    const token = getAuthToken() ?? ""
+    if (token && corpForm.month >= 1 && corpForm.month <= 12) {
+      try {
+        const res = await fetch(`${API_BASE}/api/user/settings`, {
+          method: "PUT",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ corporate_fiscal_month: corpForm.month }),
+        })
+        if (res.ok) {
+          const updated = (await res.json().catch(() => null)) as {
+            corporate_fiscal_month?: number | null
+          } | null
+          setUserData((prev) => ({
+            ...prev,
+            corporate_fiscal_month: updated?.corporate_fiscal_month ?? corpForm.month,
+          }))
+        } else if (res.status === 401) {
+          showToast("認証が切れています。再ログインしてください")
+          return
+        } else {
+          showToast("決算月の保存に失敗しました")
+          return
+        }
+      } catch {
+        showToast("通信エラーが発生しました")
+        return
+      }
+    }
+
     setCorpSaved(true)
     showToast("保存しました")
     setTimeout(() => setCorpSaved(false), 2000)

--- a/frontend/app/(liff)/liff-chat/_components/panels/TaxPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TaxPanel.tsx
@@ -118,14 +118,7 @@ export function TaxPanel() {
       )}
 
       {activeTab === "法人" && settings?.corporate_fiscal_month && (
-        <CorporateTabContent
-          fiscalMonth={settings.corporate_fiscal_month}
-          selectedYear={selectedYear}
-          onYearChange={setSelectedYear}
-          currentYear={currentYear}
-          buildDownloadUrl={buildDownloadUrl}
-          downloadFile={downloadFile}
-        />
+        <CorporateTabContent fiscalMonth={settings.corporate_fiscal_month} />
       )}
 
       {/* 注意書き */}
@@ -245,21 +238,9 @@ function PersonalTabContent({
 
 interface CorporateTabContentProps {
   fiscalMonth: number
-  selectedYear: number
-  onYearChange: (year: number) => void
-  currentYear: number
-  buildDownloadUrl: (path: string) => string
-  downloadFile: (url: string, filename: string) => void
 }
 
-function CorporateTabContent({
-  fiscalMonth,
-  selectedYear,
-  onYearChange,
-  currentYear,
-  buildDownloadUrl,
-  downloadFile,
-}: CorporateTabContentProps) {
+function CorporateTabContent({ fiscalMonth }: CorporateTabContentProps) {
   return (
     <div className="space-y-3">
       {/* 決算月表示 */}
@@ -268,32 +249,18 @@ function CorporateTabContent({
         <span className="text-white text-sm font-semibold">{fiscalMonth}月</span>
       </div>
 
-      <YearSelector
-        selectedYear={selectedYear}
-        onYearChange={onYearChange}
-        currentYear={currentYear}
-      />
-
-      <DownloadButton
-        label="法人向け Cryptact CSV"
-        description="法人決算対応フォーマット"
-        onClick={() => {
-          const url = buildDownloadUrl(
-            `/api/proposals/tax/cryptact-csv?year=${selectedYear}&type=corporate`
-          )
-          downloadFile(url, `cryptact_corporate_${selectedYear}.csv`)
-        }}
-      />
-      <DownloadButton
-        label="取引一覧 CSV（法人用）"
-        description="全取引データのエクスポート"
-        onClick={() => {
-          const url = buildDownloadUrl(
-            `/api/transactions/export?year=${selectedYear}&type=corporate`
-          )
-          downloadFile(url, `transactions_corporate_${selectedYear}.csv`)
-        }}
-      />
+      {/* 準備中: freee/弥生 CSV は税理士承認の仕訳マッピング適用後に提供する。
+          個人データを法人フォーマットと偽って返さないため、ここでは DL を出さない。 */}
+      <div className="flex items-start gap-2 bg-zinc-800/60 border border-zinc-700 rounded-xl px-4 py-3 text-sm">
+        <AlertCircle className="w-4 h-4 text-[#1D9E75] flex-shrink-0 mt-0.5" />
+        <div className="text-zinc-300 leading-relaxed">
+          <p className="font-medium text-white mb-1">法人向け CSV は準備中です</p>
+          <p className="text-zinc-400 text-xs">
+            freee / 弥生 形式の仕訳 CSV は、税理士監修の会計マッピング適用後に提供します。
+            決算月の設定は保存済みです。
+          </p>
+        </div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## 概要
TAX & REPORTS 法人モードの基盤を実装。税理士OKを受けたが**承認マッピング現物は「後日貼付」のため、マッピング非依存の範囲のみ**を対象とし、推測実装はしない。

Asana: 親 1215466861141650 配下の [2/4] 1215467018253320 / [3/4] 1215480750097558。

## 変更点

### [2/4] 決算月 backend
- `User.corporate_fiscal_month` (SmallInteger, NULL=個人) + alembic migration (head=`cfm1corp2month`, 単一head確認済) + models.py ALTERコメント
- `UserSettingsResponse`/`UserSettingsUpdate` に追加（**1–12 validator**）、`settings_router` の GET/PUT 配線
- `test_user_settings_api` に7件追加

### [3/4] 設定UX
- `AccountPanel`: 既存の法人フォームの決算月を `PUT /api/user/settings` で**永続化** + 起動時hydrate（backend正本）
- `TaxPanel` 法人タブ: 壊れた/偽装DLボタンを**「準備中（税理士監修マッピング適用後に提供）」表示**へ差替え

### silent-wrong-data 修正（Asanaタスクの核心）
- `download_cryptact_csv` に `type` param 追加、`type=corporate` は **501** で拒否 → 個人データを「法人決算対応」と偽って返す挙動を停止
- `test_cryptact_csv` に2件追加（501 corporate / individual 後方互換）

## 検証
- ruff: All checks passed
- pytest: proposal+cryptact **166 passed** / settings **31 passed**（新規7）/ cryptact **13 passed**（新規2）
- frontend: tsc 変更ファイルに新規エラー0 / eslint **0 errors**
- alembic 単一head確認

## スコープ外（別途報告）
- `/api/transactions/export` は**実在しない** → 個人タブの「取引一覧CSV」も404。本PR対象外。

## 残り = [4/4]
freee/弥生 CSV 本体は、承認された**取引種別→勘定科目/税区分 対応表**（後日貼付）と **freee 公式列テンプレ**（列順 support 403 で未取得）が揃えば、501解除込みで実装。円建て源は**月次 fee_transactions**（net_profit_jpy 等）で確定。

## デプロイ注意
backend 変更を含む。deploy 解禁設計 GID 1215466937993772 の対象。

🤖 Generated with [Claude Code](https://claude.com/claude-code)