### PR TITLE
fix(frontend): 規約/PP/リスク開示の「戻る」を来訪元復帰に統一 (useSmartBack)

### DIFF
--- a/frontend/app/(user)/privacy-policy/page.tsx
+++ b/frontend/app/(user)/privacy-policy/page.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 'use client'
 
-import { useRouter } from 'next/navigation'
 import { ArrowLeft } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { useSmartBack } from '@/hooks/useSmartBack'
 
 export default function PrivacyPolicyPage() {
-  const router = useRouter()
+  const goBack = useSmartBack()
 
   return (
     <div className="min-h-screen bg-zinc-950 text-zinc-100">
@@ -15,7 +15,7 @@ export default function PrivacyPolicyPage() {
           variant="ghost"
           size="sm"
           className="mb-6 text-zinc-400 hover:text-zinc-100"
-          onClick={() => router.push('/')}
+          onClick={goBack}
         >
           <ArrowLeft className="mr-2 h-4 w-4" />
           戻る

--- a/frontend/app/(user)/risk-disclosure/page.tsx
+++ b/frontend/app/(user)/risk-disclosure/page.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 'use client'
 
-import { useRouter } from 'next/navigation'
 import { ArrowLeft, AlertTriangle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { useSmartBack } from '@/hooks/useSmartBack'
 
 export default function RiskDisclosurePage() {
-  const router = useRouter()
+  const goBack = useSmartBack()
 
   return (
     <div className="min-h-screen bg-zinc-950 text-zinc-100">
@@ -15,7 +15,7 @@ export default function RiskDisclosurePage() {
           variant="ghost"
           size="sm"
           className="mb-6 text-zinc-400 hover:text-zinc-100"
-          onClick={() => router.push('/connect')}
+          onClick={goBack}
         >
           <ArrowLeft className="mr-2 h-4 w-4" />
           戻る

--- a/frontend/app/(user)/terms/page.tsx
+++ b/frontend/app/(user)/terms/page.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 'use client'
 
-import { useRouter } from 'next/navigation'
 import { ArrowLeft } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { useSmartBack } from '@/hooks/useSmartBack'
 
 export default function TermsPage() {
-  const router = useRouter()
+  const goBack = useSmartBack()
 
   return (
     <div className="min-h-screen bg-zinc-950 text-zinc-100">
@@ -15,7 +15,7 @@ export default function TermsPage() {
           variant="ghost"
           size="sm"
           className="mb-6 text-zinc-400 hover:text-zinc-100"
-          onClick={() => router.push('/connect')}
+          onClick={goBack}
         >
           <ArrowLeft className="mr-2 h-4 w-4" />
           戻る

--- a/frontend/e2e/smoke/legal-pages-back.spec.ts
+++ b/frontend/e2e/smoke/legal-pages-back.spec.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+import { test, expect } from '@playwright/test';
+
+// 法的文書ページ（利用規約 / プライバシーポリシー / リスク開示）の「戻る」挙動。
+//
+// 旧実装は遷移先がハードコードされていた（terms・risk → /connect、privacy → '/'）ため、
+// /signup など /connect 以外から開くと無関係なウォレット接続画面に飛ばされていた。
+// useSmartBack 導入後は「来訪元に戻る」(router.back) が基本で、履歴が無い場合
+// （別タブ target="_blank" / ブックマーク）のみ fallback（トップ '/' → 未認証は /login）。
+test.describe('法的文書ページの「戻る」挙動 (useSmartBack)', () => {
+  // 同一タブ遷移では来訪元に戻る（遷移先ハードコードではない）ことを、
+  // 旧挙動と区別できる入口で検証する。
+  //   - 旧: /terms 戻る → /connect 固定 / /privacy-policy 戻る → '/' 固定
+  //   - 新: いずれも「来訪元」へ
+  const cases = [
+    { referrer: '/risk-disclosure', open: '/terms' },          // 旧なら /connect に飛んでいた
+    { referrer: '/risk-disclosure', open: '/privacy-policy' },  // 旧なら '/'(→/login) に飛んでいた
+    { referrer: '/terms', open: '/risk-disclosure' },           // 旧なら /connect に飛んでいた
+  ];
+
+  for (const { referrer, open } of cases) {
+    test(`${referrer} から ${open} を開いて「戻る」→ 来訪元 ${referrer} に戻る`, async ({ page }) => {
+      await page.goto(referrer);
+      await page.goto(open); // 同一タブ遷移（履歴あり）
+
+      await page.getByRole('button', { name: '戻る' }).click();
+
+      await page.waitForURL(`**${referrer}`, { timeout: 8000 });
+      expect(page.url()).toContain(referrer);
+      expect(page.url()).not.toContain('/connect');
+    });
+  }
+
+  // 本番のリンクは target="_blank"（別タブ）。別タブは履歴が無いため、
+  // 「戻る」は来訪元に戻れず fallback（トップ '/' → 未認証は /login）へ遷移する。
+  test('別タブ(target="_blank")で開いた場合は履歴が無く fallback (→/login) へ', async ({ page, context }) => {
+    await page.goto('/login');
+    const base = new URL(page.url()).origin;
+    await page.setContent(
+      `<a id="legal" href="${base}/terms" target="_blank" rel="noopener noreferrer">利用規約</a>`
+    );
+
+    const [popup] = await Promise.all([
+      context.waitForEvent('page'),
+      page.click('#legal'),
+    ]);
+    await popup.waitForLoadState('domcontentloaded');
+
+    // 別タブは新規コンテキストでクライアントバンドルがコールドのため、
+    // React hydration 前に click すると onClick 未装着で無反応になりうる。
+    // ナビゲートが成立するまで再試行する（hydration 完了待ち）。
+    await expect(async () => {
+      await popup.getByRole('button', { name: '戻る' }).click();
+      await popup.waitForURL('**/login', { timeout: 3000 });
+    }).toPass({ timeout: 20000 });
+    expect(popup.url()).toContain('/login');
+  });
+});

--- a/frontend/hooks/useSmartBack.ts
+++ b/frontend/hooks/useSmartBack.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+'use client'
+
+import { useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+
+/**
+ * 「戻る」ボタン共通フック。
+ *
+ * 規約 / プライバシーポリシー / リスク開示など、複数の入口（/connect・/signup・
+ * 設定画面・LIFF webview 等）からリンクされる法的文書ページで使う。
+ *
+ * 挙動:
+ * - ブラウザ履歴がある場合（同一タブ遷移）は `router.back()` で「来訪元」に戻す。
+ *   これにより /signup から開いて戻ると /signup に、/connect から開いて戻ると
+ *   /connect に戻る（従来は遷移先が /connect 固定で、/signup 等から開くと
+ *   無関係なウォレット接続画面に飛ばされていた）。
+ * - 履歴が無い場合（`target="_blank"` で別タブが開かれた、ブックマーク等で直接
+ *   URL を開いた）は戻り先が存在しないため、安全な `fallback`（既定はトップ `/`）へ。
+ *
+ * @param fallback 履歴が無いときの遷移先（既定 `/`）
+ */
+export function useSmartBack(fallback = '/') {
+  const router = useRouter()
+  return useCallback(() => {
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      router.back()
+    } else {
+      router.push(fallback)
+    }
+  }, [router, fallback])
+}


### PR DESCRIPTION
## 背景 / ユーザー目線の不具合
一般ユーザーが `app.ultra-auto-trade.com/connect`(および新公開登録 `/signup`)で
利用規約・プライバシーポリシー・リスク開示文書を開き、表示画面の「戻る」を押すと、
**来訪元ではなく無関係な画面に飛ばされていた**。

「戻る」の遷移先が各ページにハードコードされていたのが原因:
| ページ | 旧「戻る」 |
|---|---|
| `/terms` | `router.push('/connect')` 固定 |
| `/risk-disclosure` | `router.push('/connect')` 固定 |
| `/privacy-policy` | `router.push('/')` 固定(他2つと不統一) |

→ `/signup`(メール+パスワード登録、成功時は `/user/dashboard`)から規約/PPを開いて
「戻る」を押すと、ウォレット接続画面 `/connect` に飛ばされる。一般ユーザーの登録導線が崩れていた。

## 変更
- 共通フック `frontend/hooks/useSmartBack.ts` を新規追加。
  - 履歴あり(同一タブ遷移)→ `router.back()` で**来訪元に戻る**。
  - 履歴なし(`target="_blank"` の別タブ / ブックマーク直アクセス)→ fallback `'/'`(未認証は `/login`)。
- `/terms`・`/privacy-policy`・`/risk-disclosure` の3ページを `useSmartBack` に統一。
- `/connect` から開いた場合も同一タブ back で `/connect` に戻るため**回帰なし**。

## 検証
- `tsc --noEmit`: 0 エラー(変更ファイル含む)
- `next lint`(対象4ファイル): clean
- Playwright E2E: **4/4 passed**(`e2e/smoke/legal-pages-back.spec.ts`, retries=0)
  - `/risk-disclosure` → `/terms` → 戻る → `/risk-disclosure`(/connect 固定でないこと)
  - `/risk-disclosure` → `/privacy-policy` → 戻る → `/risk-disclosure`
  - `/terms` → `/risk-disclosure` → 戻る → `/terms`
  - `target="_blank"` 別タブ → 戻る → fallback(→`/login`)

## 残課題(本PRスコープ外)
- production 反映後の実機確認(本番VPS担当)。
- `settings/_components/AppInfoCard.tsx` の `href="/privacy"`(=404、正は `/privacy-policy`)は
  別系統の PR #564 で修正中のため本PRでは触っていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)