### PR TITLE
test(aave): fix stale WBTC assertion breaking main CI (Base map removal follow-up)

### DIFF
--- a/backend/tests/test_aave_web3_client.py
+++ b/backend/tests/test_aave_web3_client.py
@@ -826,7 +826,9 @@ def test_make_aave_client_base_wires_token_addresses(mock_web3, mock_rpc_provide
     assert client.token_addresses.get("USDC") == _BASE_USDC
     # chain_config.tokens の他トークンも配線される
     assert "WETH" in client.token_addresses
-    assert "WBTC" in client.token_addresses
+    # WBTC/USDT/DAI は Base Aave V3 非上場のため map から除外済み (chains.py 参照)。
+    # 除外自体の回帰は test_aave_chains.py が担保する。
+    assert "WBTC" not in client.token_addresses
 
 
 @patch("app.aave.rpc_provider.RPCProvider")


### PR DESCRIPTION
## 背景
`347f7afb`（`fix(aave): remove unsupported tokens from Base chain map (USDT/DAI/WBTC)`）が `backend/app/aave/chains.py` と `test_aave_chains.py` は更新したものの、`test_aave_web3_client.py::test_make_aave_client_base_wires_token_addresses` の `assert "WBTC" in client.token_addresses`（:829）を更新し忘れていました。

このため **main HEAD 由来で、main を基点にする全 PR の `Test (pytest + coverage)` / `Ruff + Mypy + Pytest → PR Comment` が赤**になっています（1 failed, 3338 passed）。

## 変更
- WBTC は Base Aave V3 非上場のため map から除外済み（`chains.py`: 「非上場: WBTC, USDT, DAI は Base Aave V3 に存在しないため除外」）
- 該当アサーションを `assert "WBTC" not in client.token_addresses` に変更し、**除外の回帰ガード**に転用
- 「USDC 以外も配線される」点は既存の `assert "WETH" in ...` が引き続き担保
- テストファイル1行のみの変更（プロダクションコード・他テストへの影響なし）

## 検証
```
tests/test_aave_web3_client.py tests/test_aave_chains.py: 65 passed, 4 skipped
ruff: All checks passed
```

これを先に merge すると、PR #568（通知 test-push パス修正）含む main ベースの全 PR の CI が緑化します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)