### PR TITLE
fix(test): aave Base map から WBTC 除外済みに合わせ stale assert を修正

### DIFF
--- a/backend/tests/test_aave_web3_client.py
+++ b/backend/tests/test_aave_web3_client.py
@@ -826,7 +826,8 @@ def test_make_aave_client_base_wires_token_addresses(mock_web3, mock_rpc_provide
     assert client.token_addresses.get("USDC") == _BASE_USDC
     # chain_config.tokens の他トークンも配線される
     assert "WETH" in client.token_addresses
-    assert "WBTC" in client.token_addresses
+    # WBTC / USDT / DAI は Base Aave V3 非上場のため chain map から除外済み (347f7afb)
+    assert "WBTC" not in client.token_addresses
 
 
 @patch("app.aave.rpc_provider.RPCProvider")


### PR DESCRIPTION
## 概要
main の HEAD コミット `347f7afb` (fix(aave): remove unsupported tokens from Base chain map (USDT/DAI/WBTC)) が WBTC/USDT/DAI を Base Aave V3 非上場として `aave/chains.py` の Base map から削除した際、`test_aave_web3_client.py::test_make_aave_client_base_wires_token_addresses` の `"WBTC" in token_addresses` assert を更新し忘れていた。

このため **main を base にする全 PR の `Test (pytest + coverage)` が赤**になっていた (PR #566 の CI 調査で発見)。referral 等の無関係な変更とは独立した既存 breakage。

## 変更
- `assert "WBTC" in client.token_addresses` → `assert "WBTC" not in client.token_addresses` (347f7afb の除外意図に整合)

## テスト
- `pytest tests/test_aave_web3_client.py tests/test_aave_chains.py` → **65 passed, 4 skipped**
- ruff format/check クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)