### PR TITLE
fix(test): main CI 赤を解消 — Base 配線回帰テスト WBTC→cbBTC (chains.py と整合)

### DIFF
--- a/backend/tests/test_aave_web3_client.py
+++ b/backend/tests/test_aave_web3_client.py
@@ -824,9 +824,12 @@ def test_make_aave_client_base_wires_token_addresses(mock_web3, mock_rpc_provide
 
     assert hasattr(client, "token_addresses"), "token_addresses 未配線 (Unknown asset の原因)"
     assert client.token_addresses.get("USDC") == _BASE_USDC
-    # chain_config.tokens の他トークンも配線される
+    # chain_config.tokens の他トークンも配線される。
+    # NOTE: WBTC は Base Aave V3 に非上場のため chains.py から除外済み
+    # (347f7af "remove unsupported tokens from Base chain map")。
+    # Base の BTC 資産は cbBTC なので、配線回帰の検証には cbBTC を使う。
     assert "WETH" in client.token_addresses
-    assert "WBTC" in client.token_addresses
+    assert "cbBTC" in client.token_addresses
 
 
 @patch("app.aave.rpc_provider.RPCProvider")


### PR DESCRIPTION
## 問題
main CI が赤（pytest 1 failed / 3335 passed）。最新 main（347f7af）も同一テストで failure。

- 失敗: `tests/test_aave_web3_client.py::test_make_aave_client_base_wires_token_addresses`
- `AssertionError: assert 'WBTC' in client.token_addresses`

## 真因
コミット `347f7af "remove unsupported tokens from Base chain map (USDT/DAI/WBTC)"` が `chains.py` の Base token map から **WBTC を正しく除外**した（Base Aave V3 に WBTC は非上場、BTC 資産は cbBTC）。しかし回帰テストの `assert "WBTC" in client.token_addresses` が更新されず、stale なアサーションが残って CI が赤に。

→ **プロダクション（chains.py の WBTC 除外）は正しい。テスト側が陳腐化していた。**

## 修正
- 当該テストの `assert "WBTC" in ...` を Base 実在の BTC 資産 `assert "cbBTC" in ...` に差し替え（WBTC の代替）
- USDC / WETH のアサーションは Base map に存在するため維持
- `test_aave_chains.py`（「Base は WBTC/USDT/DAI を含まない」を検証）とも整合
- 変更は **テスト1ファイルのみ**、プロダクションコード不変

## 検証
- 変更は1アサーション（WBTC→cbBTC）。`chains.py` Base map に `cbBTC` 実在を確認、`WBTC` は意図的除外を確認。
- **注記**: dev セッションで `pip install` 不可のためローカル pytest は未実行 → CI（Test pytest+coverage）で確認。
- 影響: この赤は全 PR の merge ゲートをブロックしていた（例: #567 フロント PR も巻き込まれて赤）。本 PR merge で解消。

## Asana
- https://app.asana.com/1/817733952351708/project/1213916581114014/task/1215470443062373

🤖 Generated with [Claude Code](https://claude.com/claude-code)