### PR TITLE
docs(fee-runbook): affiliate_rate 0.30 → 0.10 (紹介報酬=実受取利益×10%)

### DIFF
--- a/docs/48_fee_config_seed_runbook.md
+++ b/docs/48_fee_config_seed_runbook.md
@@ -109,7 +109,7 @@ docker exec -w /app/backend ultra-autotrade-backend-blue-staging-new \
   'subscription_rates': {'conservative': 0.0, 'balanced': 0.003, 'aggressive': 0.01},
   'expense_markup_enabled': False,
   'expense_markup_rate': Decimal('0'),
-  'affiliate_rate': Decimal('0.30'),
+  'affiliate_rate': Decimal('0.10'),
   'is_active': True,
   'effective_from': datetime(2026, 5, 1, 0, 0, tzinfo=...)
 }
@@ -161,7 +161,7 @@ WHERE config_name = 'v10_default';
 | tier_thresholds_jpy | `[1000000, 10000000]` |
 | tier_fee_rates | `[0.30, 0.25, 0.20]` |
 | tier_monthly_yield_caps | `[0.018, 0.023, 0.030]` |
-| affiliate_rate | `0.3000` |
+| affiliate_rate | `0.1000` |
 | effective_from | `2026-04-30 15:00:00+00` |
 
 ```bash
@@ -294,7 +294,7 @@ FROM fee_configs;
 | tier_thresholds_jpy | `[1000000, 10000000]` |
 | tier_fee_rates | `[0.30, 0.25, 0.20]` |
 | tier_monthly_yield_caps | `[0.018, 0.023, 0.030]` |
-| affiliate_rate | `0.30` |
+| affiliate_rate | `0.10` |
 | effective_from | `2026-04-30 15:00:00+00` (= 2026-05-01 00:00 JST) |
 
 ```bash


### PR DESCRIPTION
## 概要
紹介報酬の確定仕様 (Asana [1215467015333283](https://app.asana.com/0/0/1215467015333283) / PR #566 main マージ済) では `affiliate_rate` = 紹介友達の月次 `user_takehome` の **10%**。`docs/48_fee_config_seed_runbook.md` に旧サブスク基準時代の `0.30` が期待値として 3 箇所残っており、**再 seed すると 0.30 が復活してドリフトする**ため 0.10 に更新する。

## 変更 (3 箇所、いずれも affiliate_rate)
- L112: seed 出力例 `Decimal('0.30')` → `Decimal('0.10')`
- L164: 検証表 `0.3000` → `0.1000`
- L297: 検証表 `0.30` → `0.10`

※ `tier_fee_rates [0.30, 0.25, 0.20]` は別フィールドなので変更なし。

## 補足
コード側 (model server_default / seed_fee_config_v10.py / test factory / 045 SQL / migration v2w3x4y5z6a7) は #566 で 0.10 統一済み。本 PR はドキュメントのドリフト解消のみ (ドキュメント変更につき低リスク)。本番 active config 値の是正は別タスク [1215466962382625](https://app.asana.com/0/0/1215466962382625)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)