### PR TITLE
feat(auth): Admin向けウォレット解除API追加 DELETE /auth/wallet/{user_id}

### DIFF
--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm import Session
 from app.database import get_db
 from app.referral import service as referral_service
 
-from .dependencies import require_active_user
+from .dependencies import require_active_user, require_admin
 from .models import (
     PHASE_1_ALLOWED_RISK_MODES,
     RISK_MODE_JP_LABELS,
@@ -773,6 +773,53 @@ def wallet_link(
         wallet_address=address_lower,
         linked_at=linked_at,
     )
+
+
+class WalletUnlinkResponse(BaseModel):
+    ok: bool
+    user_id: int
+    unlinked_address: str
+
+
+@router.delete(
+    "/wallet/{user_id}",
+    response_model=WalletUnlinkResponse,
+    summary="Admin: ユーザーのウォレットリンクを解除",
+)
+def wallet_unlink(
+    user_id: int,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> WalletUnlinkResponse:
+    """
+    Admin のみ実行可能。対象ユーザーの wallet_address を NULL にする。
+    解除後は /auth/wallet/link で別アドレスを再リンク可能。
+
+    レスポンス:
+    - 200: 解除成功
+    - 400: 既に wallet_address が未設定
+    - 403: Admin 以外 (require_admin が返す)
+    - 404: 対象ユーザーが存在しない
+    """
+    user = db.get(User, user_id)
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="user not found")
+
+    if user.wallet_address is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="wallet not linked")
+
+    unlinked_address = user.wallet_address
+    user.wallet_address = None
+    db.commit()
+
+    logger.info(
+        "Wallet unlinked by admin: admin_id=%d target_user_id=%d wallet=%s...%s",
+        admin.id,
+        user.id,
+        unlinked_address[:10],
+        unlinked_address[-4:],
+    )
+    return WalletUnlinkResponse(ok=True, user_id=user.id, unlinked_address=unlinked_address)
 
 
 # ── LINE LIFF認証 ────────────────────────────────────────────────────────────

--- a/backend/tests/test_auth_wallet_link.py
+++ b/backend/tests/test_auth_wallet_link.py
@@ -224,7 +224,9 @@ class TestWalletLink:
         )
 
 
-def _make_admin(SessionLocal, *, email: str = "admin@example.com", username: str = "admin1") -> tuple[int, str]:
+def _make_admin(
+    SessionLocal, *, email: str = "admin@example.com", username: str = "admin1"
+) -> tuple[int, str]:
     """Admin ユーザーを作成し、(user_id, jwt_token) を返す。"""
     with SessionLocal() as session:
         user = User(
@@ -296,9 +298,7 @@ class TestWalletUnlink:
     # ── 404 ────────────────────────────────────────────────────────────────
     def test_404_nonexistent_user(self, client: TestClient, test_db):
         _, SessionLocal = test_db
-        _, admin_token = _make_admin(
-            SessionLocal, email="admin2@example.com", username="admin2"
-        )
+        _, admin_token = _make_admin(SessionLocal, email="admin2@example.com", username="admin2")
 
         response = client.delete(
             "/auth/wallet/99999",
@@ -310,9 +310,7 @@ class TestWalletUnlink:
     # ── 400 ────────────────────────────────────────────────────────────────
     def test_400_wallet_already_null(self, client: TestClient, test_db):
         _, SessionLocal = test_db
-        _, admin_token = _make_admin(
-            SessionLocal, email="admin3@example.com", username="admin3"
-        )
+        _, admin_token = _make_admin(SessionLocal, email="admin3@example.com", username="admin3")
         user_id, _ = _make_user(
             SessionLocal,
             email="nowallet@example.com",

--- a/backend/tests/test_auth_wallet_link.py
+++ b/backend/tests/test_auth_wallet_link.py
@@ -222,3 +222,106 @@ class TestWalletLink:
             "privy_did" in response.json()["detail"].lower()
             or "match" in response.json()["detail"].lower()
         )
+
+
+def _make_admin(SessionLocal, *, email: str = "admin@example.com", username: str = "admin1") -> tuple[int, str]:
+    """Admin ユーザーを作成し、(user_id, jwt_token) を返す。"""
+    with SessionLocal() as session:
+        user = User(
+            email=email,
+            username=username,
+            hashed_password=AuthService.hash_password("test-password-123"),
+            role=UserRole.ADMIN.value,
+        )
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+        token, _ = AuthService.create_access_token(
+            user_id=user.id, email=user.email, role=user.role
+        )
+        return user.id, token
+
+
+class TestWalletUnlink:
+    """DELETE /auth/wallet/{user_id} の 4 ケース。"""
+
+    # ── 200 ────────────────────────────────────────────────────────────────
+    def test_200_admin_unlinks_wallet(self, client: TestClient, test_db):
+        _, SessionLocal = test_db
+        _, admin_token = _make_admin(SessionLocal)
+        user_id, _ = _make_user(
+            SessionLocal,
+            email="target@example.com",
+            username="target1",
+            wallet_address=TEST_WALLET_ADDRESS,
+        )
+
+        response = client.delete(
+            f"/auth/wallet/{user_id}",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+        assert response.status_code == 200, response.json()
+        data = response.json()
+        assert data["ok"] is True
+        assert data["user_id"] == user_id
+        assert data["unlinked_address"] == TEST_WALLET_ADDRESS.lower()
+
+        with SessionLocal() as session:
+            updated = session.query(User).filter(User.id == user_id).first()
+            assert updated is not None
+            assert updated.wallet_address is None
+
+    # ── 403 ────────────────────────────────────────────────────────────────
+    def test_403_non_admin_returns_forbidden(self, client: TestClient, test_db):
+        _, SessionLocal = test_db
+        target_id, _ = _make_user(
+            SessionLocal,
+            email="target2@example.com",
+            username="target2",
+            wallet_address=TEST_WALLET_ADDRESS,
+        )
+        _, viewer_token = _make_user(
+            SessionLocal,
+            email="viewer2@example.com",
+            username="viewer2",
+        )
+
+        response = client.delete(
+            f"/auth/wallet/{target_id}",
+            headers={"Authorization": f"Bearer {viewer_token}"},
+        )
+        assert response.status_code == 403, response.json()
+
+    # ── 404 ────────────────────────────────────────────────────────────────
+    def test_404_nonexistent_user(self, client: TestClient, test_db):
+        _, SessionLocal = test_db
+        _, admin_token = _make_admin(
+            SessionLocal, email="admin2@example.com", username="admin2"
+        )
+
+        response = client.delete(
+            "/auth/wallet/99999",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 404, response.json()
+        assert "not found" in response.json()["detail"].lower()
+
+    # ── 400 ────────────────────────────────────────────────────────────────
+    def test_400_wallet_already_null(self, client: TestClient, test_db):
+        _, SessionLocal = test_db
+        _, admin_token = _make_admin(
+            SessionLocal, email="admin3@example.com", username="admin3"
+        )
+        user_id, _ = _make_user(
+            SessionLocal,
+            email="nowallet@example.com",
+            username="nowallet1",
+        )
+
+        response = client.delete(
+            f"/auth/wallet/{user_id}",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 400, response.json()
+        assert "not linked" in response.json()["detail"].lower()


### PR DESCRIPTION
## Summary

- `DELETE /auth/wallet/{user_id}` エンドポイントを追加（Admin限定）
- 対象ユーザーの `wallet_address` を NULL にセット。解除後は `/auth/wallet/link` で別アドレスを再リンク可能
- 既存の `require_admin` dependency を流用、新規ガード不要

## Test plan

- [ ] 200: Admin がウォレット解除 → `wallet_address = NULL` に更新されること
- [ ] 403: 非Admin（VIEWER）が呼び出す → 403 Forbidden
- [ ] 404: 存在しない `user_id` → 404 Not Found
- [ ] 400: 既に `wallet_address = NULL` のユーザーに対して呼び出す → 400 Bad Request
- [ ] `pytest tests/test_auth_wallet_link.py` 9件全パス確認済み

## 関連

- Asana: https://app.asana.com/1/817733952351708/project/1213814438308045/task/1215476562063168
- 元の `POST /auth/wallet/link` (router.py:703) と対になるエンドポイント

🤖 Generated with [Claude Code](https://claude.com/claude-code)