### PR TITLE
fix(referral): share URL /register -> /auth/register [B6]

### DIFF
--- a/backend/app/referral/service.py
+++ b/backend/app/referral/service.py
@@ -70,7 +70,7 @@ def get_or_create_code(db: Session, user: User) -> str:
 
 def build_share_url(referral_code: str) -> str:
     """紹介コードから招待 URL を組み立てる。"""
-    return f"{_share_base_url()}/register?ref={referral_code}"
+    return f"{_share_base_url()}/auth/register?ref={referral_code}"
 
 
 def list_referred_users(db: Session, partner_id: int) -> list[User]:

--- a/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
@@ -9,7 +9,7 @@ import { getAuthToken } from "@/lib/auth/token-key"
 // SIGNUP URL: 専用の env/定数が無いため、sibling パネル (TermsPanel 等) と同じ
 // app.ultra-auto-trade.com 系ドメインへハードコードでフォールバックする。
 // NEXT_PUBLIC_LIFF_APP_URL が定義されればそちらを優先する。
-const SIGNUP_URL = process.env.NEXT_PUBLIC_LIFF_APP_URL ?? "https://app.ultra-auto-trade.com/register"
+const SIGNUP_URL = process.env.NEXT_PUBLIC_LIFF_APP_URL ?? "https://app.ultra-auto-trade.com/auth/register"
 
 function getToken(): string {
   // 統一済み auth token getter (Asana 1215441139765963)。


### PR DESCRIPTION
B6: 紹介共有URLの遷移先を修正。/auth/registerは?ref=を読む正しいページ。

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>