### PR TITLE
[admin] /admin/users モック → 実API配線 (GET /api/admin/users)

### DIFF
--- a/backend/app/api/admin_users.py
+++ b/backend/app/api/admin_users.py
@@ -1,0 +1,263 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/api/admin_users.py
+"""管理者向けユーザー運用状況 API。
+
+GET   /api/admin/users              - 全ユーザー一覧（viewer ロール、運用データ付き）
+POST  /api/admin/users/{id}/pause   - ユーザー運用停止（is_active = False）
+POST  /api/admin/users/{id}/resume  - ユーザー運用再開（is_active = True）
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.ai.models import AIDecision
+from app.auth.dependencies import require_admin
+from app.auth.models import User, UserRole
+from app.database import get_db
+from app.portfolio.models import PortfolioSnapshot
+from app.transactions.models import Transaction
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/admin/users", tags=["admin-users"])
+
+
+# ─── Response schemas ─────────────────────────────────────────────────────────
+
+
+class PositionItem(BaseModel):
+    asset: str
+    supplied: float
+    borrowed: float
+    usdValue: float
+
+
+class HFPoint(BaseModel):
+    date: str
+    hf: float
+
+
+class RecentTrade(BaseModel):
+    id: str
+    type: str
+    asset: str
+    amount: float
+    timestamp: str
+
+
+class RecentDecision(BaseModel):
+    id: str
+    action: str
+    confidence: int
+    timestamp: str
+
+
+class AdminUserDetail(BaseModel):
+    id: str
+    address: str
+    registeredAt: str
+    aum: float
+    lastActivity: str
+    riskMode: str
+    status: str  # NORMAL | WARNING | DANGER
+    isPaused: bool
+    positions: List[PositionItem]
+    healthFactor: float
+    hfHistory: List[HFPoint]
+    recentTrades: List[RecentTrade]
+    recentDecisions: List[RecentDecision]
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _hf_status(hf: float) -> str:
+    if hf < 1.6:
+        return "DANGER"
+    if hf < 2.0:
+        return "WARNING"
+    return "NORMAL"
+
+
+def _parse_positions(positions_json: Any) -> List[PositionItem]:
+    if not positions_json or not isinstance(positions_json, list):
+        return []
+    result: List[PositionItem] = []
+    for p in positions_json:
+        if not isinstance(p, dict):
+            continue
+        result.append(
+            PositionItem(
+                asset=str(p.get("asset", "")),
+                supplied=float(p.get("supplied", 0) or 0),
+                borrowed=float(p.get("borrowed", 0) or 0),
+                usdValue=float(p.get("usdValue", p.get("usd_value", 0)) or 0),
+            )
+        )
+    return result
+
+
+def _build_hf_history(snapshots: List[PortfolioSnapshot]) -> List[HFPoint]:
+    """スナップショット（recorded_at DESC）から日別1点のHF履歴を古→新で返す。"""
+    seen_dates: set[str] = set()
+    points: List[HFPoint] = []
+    for snap in snapshots:
+        if snap.health_factor is None:
+            continue
+        d = snap.recorded_at.strftime("%Y-%m-%d")
+        if d in seen_dates:
+            continue
+        seen_dates.add(d)
+        points.append(HFPoint(date=d, hf=float(snap.health_factor)))
+    points.reverse()
+    return points
+
+
+def _build_detail(
+    user: User,
+    latest_snap: Optional[PortfolioSnapshot],
+    hf_snaps: List[PortfolioSnapshot],
+    trades: List[Transaction],
+    decisions: List[AIDecision],
+) -> AdminUserDetail:
+    aum = float(latest_snap.total_value_usd) if latest_snap else 0.0
+    hf = (
+        float(latest_snap.health_factor)
+        if (latest_snap and latest_snap.health_factor is not None)
+        else 0.0
+    )
+
+    timestamps: List[datetime] = [user.created_at]
+    if trades:
+        timestamps.append(trades[0].created_at)
+    if decisions:
+        timestamps.append(decisions[0].created_at)
+    last_activity = max(timestamps)
+
+    return AdminUserDetail(
+        id=str(user.id),
+        address=user.wallet_address or "",
+        registeredAt=user.created_at.isoformat(),
+        aum=aum,
+        lastActivity=last_activity.isoformat(),
+        riskMode=user.risk_mode or "conservative",
+        status=_hf_status(hf),
+        isPaused=not user.is_active,
+        positions=_parse_positions(latest_snap.positions_json if latest_snap else None),
+        healthFactor=hf,
+        hfHistory=_build_hf_history(hf_snaps),
+        recentTrades=[
+            RecentTrade(
+                id=str(t.id),
+                type=t.operation,
+                asset=t.asset,
+                amount=float(t.amount_usd),
+                timestamp=t.created_at.isoformat(),
+            )
+            for t in trades
+        ],
+        recentDecisions=[
+            RecentDecision(
+                id=str(d.id),
+                action=d.action,
+                confidence=d.confidence,
+                timestamp=d.created_at.isoformat(),
+            )
+            for d in decisions
+        ],
+    )
+
+
+# ─── Endpoints ────────────────────────────────────────────────────────────────
+
+
+@router.get("", response_model=List[AdminUserDetail], summary="管理者: ユーザー運用一覧")
+def list_admin_users(
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> List[AdminUserDetail]:
+    """全 viewer ユーザーの運用状況（ポートフォリオ・HF・取引・AI判定）を返す。"""
+    users = (
+        db.query(User)
+        .filter(User.role == UserRole.VIEWER.value)
+        .order_by(User.created_at.desc())
+        .all()
+    )
+
+    since_7d = datetime.now(timezone.utc) - timedelta(days=7)
+    result: List[AdminUserDetail] = []
+
+    for user in users:
+        latest_snap = (
+            db.query(PortfolioSnapshot)
+            .filter(PortfolioSnapshot.user_id == user.id)
+            .order_by(PortfolioSnapshot.recorded_at.desc())
+            .first()
+        )
+        hf_snaps = (
+            db.query(PortfolioSnapshot)
+            .filter(
+                PortfolioSnapshot.user_id == user.id,
+                PortfolioSnapshot.recorded_at >= since_7d,
+            )
+            .order_by(PortfolioSnapshot.recorded_at.desc())
+            .limit(50)
+            .all()
+        )
+        trades = (
+            db.query(Transaction)
+            .filter(Transaction.user_id == user.id)
+            .order_by(Transaction.created_at.desc())
+            .limit(5)
+            .all()
+        )
+        decisions = (
+            db.query(AIDecision)
+            .filter(AIDecision.user_id == user.id)
+            .order_by(AIDecision.created_at.desc())
+            .limit(5)
+            .all()
+        )
+        result.append(_build_detail(user, latest_snap, hf_snaps, trades, decisions))
+
+    return result
+
+
+@router.post("/{user_id}/pause", summary="管理者: ユーザー運用停止")
+def pause_user(
+    user_id: int,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> dict:
+    """指定ユーザーの自動取引を停止する（is_active = False）。"""
+    user = db.query(User).filter(User.id == user_id, User.role == UserRole.VIEWER.value).first()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    user.is_active = False
+    db.commit()
+    logger.info("Admin %s paused user %d", admin.email, user_id)
+    return {"message": "paused", "user_id": user_id, "isPaused": True}
+
+
+@router.post("/{user_id}/resume", summary="管理者: ユーザー運用再開")
+def resume_user(
+    user_id: int,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> dict:
+    """指定ユーザーの自動取引を再開する（is_active = True）。"""
+    user = db.query(User).filter(User.id == user_id, User.role == UserRole.VIEWER.value).first()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    user.is_active = True
+    db.commit()
+    logger.info("Admin %s resumed user %d", admin.email, user_id)
+    return {"message": "resumed", "user_id": user_id, "isPaused": False}

--- a/backend/app/api/admin_users.py
+++ b/backend/app/api/admin_users.py
@@ -236,7 +236,7 @@ def pause_user(
     user_id: int,
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
-) -> dict:
+) -> dict[str, Any]:
     """指定ユーザーの自動取引を停止する（is_active = False）。"""
     user = db.query(User).filter(User.id == user_id, User.role == UserRole.VIEWER.value).first()
     if user is None:
@@ -252,7 +252,7 @@ def resume_user(
     user_id: int,
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
-) -> dict:
+) -> dict[str, Any]:
     """指定ユーザーの自動取引を再開する（is_active = True）。"""
     user = db.query(User).filter(User.id == user_id, User.role == UserRole.VIEWER.value).first()
     if user is None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -39,6 +39,7 @@ from app.ai.decisions_router import router as ai_decisions_router
 from app.ai.feedback_router import router as ai_feedback_router
 from app.ai.optimizer.router import router as ai_optimizer_router
 from app.ai.router import router as ai_router
+from app.api.admin_users import router as admin_users_router
 from app.api.alias_router import router as alias_router
 from app.api.automation_dashboard import router as automation_dashboard_router
 from app.api.v1.fee_transfer import router as fee_transfer_router
@@ -271,6 +272,7 @@ def create_app() -> FastAPI:
     app.include_router(ai_optimizer_router)  # AI Optimizer (Phase 2 / ENB)
     app.include_router(transactions_router)  # Transactions API
     app.include_router(admin_transactions_router)  # Admin Transactions API
+    app.include_router(admin_users_router)  # Admin Users API
     app.include_router(proposals_router)  # Proposals API
     app.include_router(portfolio_router)  # Portfolio History API
     app.include_router(user_settings_router)  # User Settings API

--- a/docs/integration/backend_deps.md
+++ b/docs/integration/backend_deps.md
@@ -5,6 +5,19 @@
 
 ---
 
+## PR #581 (admin users API): admin_users_router 配線 (2026-06-08)
+
+### 変更: admin_users_router を main.py に include_router
+- **対象凍結ファイル**: `backend/app/main.py`
+- **変更内容**:
+  - `from app.api.admin_users import router as admin_users_router` を import 追加
+  - `app.include_router(admin_users_router)` を追加（`/admin/users` モック → 実 API 配線、`GET /api/admin/users`）
+- **理由**: フロントエンド `/admin/users` のモックを実 API に置き換えるため、admin 向けユーザー一覧/操作エンドポイントを配線する。
+- **影響範囲**: ルーター登録のみ。起動シーケンス・既存エンドポイントへの影響なし。エンドポイントは `require_admin` で RBAC ガード済み。
+- **承認**: feature/admin-users-api-wiring-20260608 → main の通常フロー経由（PR #581）
+
+---
+
 ## PR #563 (前提1): ENABLE_WITHDRAWALS flag で withdraw EP を default-off ガード (2026-06-06)
 
 ### 変更: include_router(user_withdrawals_router) を ENABLE_WITHDRAWALS フラグで条件化

--- a/frontend/app/(admin)/users/page.tsx
+++ b/frontend/app/(admin)/users/page.tsx
@@ -2,108 +2,91 @@
 // Copyright (c) 2026 Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { Users, Search } from 'lucide-react'
 import AuthGuard from '@/components/AuthGuard'
 import { UserTable, UserDetailPanel } from './_components'
 import type { UserDetail } from './_components/UserDetailPanel'
+import { fetchAdminUsers, pauseAdminUser, resumeAdminUser } from '@/lib/api/admin-users'
+import type { AdminUserDetail } from '@/lib/api/admin-users'
 
-// ─── Mock data ────────────────────────────────────────────────────────────────
-// TODO: Replace with GET /api/admin/users
+// ─── Adapter ──────────────────────────────────────────────────────────────────
 
-const MOCK_USERS: UserDetail[] = [
-  {
-    id: 'user-001',
-    address: '0x742d35Cc6634C0532925a3b844Bc9e7595f2bD28',
-    registeredAt: '2026-03-01T00:00:00Z',
-    aum: 15000,
-    lastActivity: '2026-03-21T14:30:00Z',
-    riskMode: 'conservative' as const,
-    status: 'NORMAL' as const,
-    isPaused: false,
-    positions: [
-      { asset: 'USDC', supplied: 10000, borrowed: 0, usdValue: 10000 },
-      { asset: 'WETH', supplied: 2.5, borrowed: 0, usdValue: 5000 },
-    ],
-    healthFactor: 2.1,
-    hfHistory: Array.from({ length: 7 }, (_, i) => ({
-      date: new Date(Date.now() - (6 - i) * 86400000).toISOString().slice(0, 10),
-      hf: 2.0 + Math.random() * 0.5,
+function toUserDetail(u: AdminUserDetail): UserDetail {
+  return {
+    id: u.id,
+    address: u.address,
+    registeredAt: u.registeredAt,
+    aum: u.aum,
+    lastActivity: u.lastActivity,
+    riskMode: u.riskMode,
+    status: u.status,
+    isPaused: u.isPaused,
+    positions: u.positions,
+    healthFactor: u.healthFactor,
+    hfHistory: u.hfHistory,
+    recentTrades: u.recentTrades.map((t) => ({
+      id: t.id,
+      type: t.type as 'SUPPLY' | 'WITHDRAW' | 'BORROW',
+      asset: t.asset,
+      amount: t.amount,
+      timestamp: t.timestamp,
     })),
-    recentTrades: Array.from({ length: 5 }, (_, i) => ({
-      id: `trade-${i}`,
-      type: (['SUPPLY', 'WITHDRAW', 'BORROW'] as const)[i % 3],
-      asset: 'USDC',
-      amount: 1000 + i * 100,
-      timestamp: new Date(Date.now() - i * 3600000).toISOString(),
+    recentDecisions: u.recentDecisions.map((d) => ({
+      id: d.id,
+      action: d.action as 'BUY' | 'SELL' | 'HOLD',
+      confidence: d.confidence,
+      timestamp: d.timestamp,
     })),
-    recentDecisions: Array.from({ length: 5 }, (_, i) => ({
-      id: `dec-${i}`,
-      action: (['BUY', 'SELL', 'HOLD'] as const)[i % 3],
-      confidence: 60 + i * 5,
-      timestamp: new Date(Date.now() - i * 7200000).toISOString(),
-    })),
-  },
-  {
-    id: 'user-002',
-    address: '0xAbcD1234EfGh5678IjKl9012MnOp3456QrSt7890',
-    registeredAt: '2026-03-10T00:00:00Z',
-    aum: 8500,
-    lastActivity: '2026-03-20T09:15:00Z',
-    riskMode: 'balanced' as const,
-    status: 'WARNING' as const,
-    isPaused: false,
-    positions: [{ asset: 'USDT', supplied: 8500, borrowed: 0, usdValue: 8500 }],
-    healthFactor: 1.9,
-    hfHistory: Array.from({ length: 7 }, (_, i) => ({
-      date: new Date(Date.now() - (6 - i) * 86400000).toISOString().slice(0, 10),
-      hf: 1.8 + Math.random() * 0.3,
-    })),
-    recentTrades: [],
-    recentDecisions: [],
-  },
-  {
-    id: 'user-003',
-    address: '0x1111222233334444555566667777888899990000',
-    registeredAt: '2026-03-15T00:00:00Z',
-    aum: 3200,
-    lastActivity: '2026-03-19T22:00:00Z',
-    riskMode: 'aggressive' as const,
-    status: 'NORMAL' as const,
-    isPaused: true,
-    positions: [{ asset: 'WBTC', supplied: 0.1, borrowed: 0, usdValue: 3200 }],
-    healthFactor: 3.5,
-    hfHistory: Array.from({ length: 7 }, (_, i) => ({
-      date: new Date(Date.now() - (6 - i) * 86400000).toISOString().slice(0, 10),
-      hf: 3.0 + Math.random() * 0.8,
-    })),
-    recentTrades: [],
-    recentDecisions: [],
-  },
-]
+  }
+}
 
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function UsersPage() {
-  const [users, setUsers] = useState<UserDetail[]>(MOCK_USERS)
+  const [users, setUsers] = useState<UserDetail[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
   const [selectedUser, setSelectedUser] = useState<UserDetail | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
 
-  // Filter by wallet address partial match
+  useEffect(() => {
+    fetchAdminUsers()
+      .then((data) => {
+        setUsers(data.map(toUserDetail))
+        setLoading(false)
+      })
+      .catch((err) => {
+        setError(err?.message ?? 'データの取得に失敗しました')
+        setLoading(false)
+      })
+  }, [])
+
   const filteredUsers = useMemo(() => {
     const q = searchQuery.trim().toLowerCase()
     if (!q) return users
     return users.filter((u) => u.address.toLowerCase().includes(q))
   }, [users, searchQuery])
 
-  function handleTogglePause(userId: string, pause: boolean) {
-    setUsers((prev) =>
-      prev.map((u) => (u.id === userId ? { ...u, isPaused: pause } : u))
-    )
-    // Sync selectedUser state
-    setSelectedUser((prev) =>
-      prev && prev.id === userId ? { ...prev, isPaused: pause } : prev
-    )
+  async function handleTogglePause(userId: string, pause: boolean) {
+    try {
+      if (pause) {
+        await pauseAdminUser(userId)
+      } else {
+        await resumeAdminUser(userId)
+      }
+      setUsers((prev) =>
+        prev.map((u) => (u.id === userId ? { ...u, isPaused: pause } : u))
+      )
+      setSelectedUser((prev) =>
+        prev && prev.id === userId ? { ...prev, isPaused: pause } : prev
+      )
+    } catch {
+      // エラー時は再取得してリセット
+      fetchAdminUsers()
+        .then((data) => setUsers(data.map(toUserDetail)))
+        .catch(() => {})
+    }
   }
 
   const totalAUM = users.reduce((sum, u) => sum + u.aum, 0)
@@ -122,13 +105,17 @@ export default function UsersPage() {
           <div>
             <div className="flex items-center gap-2">
               <h1 className="text-xl font-bold text-gray-100">ユーザー管理</h1>
-              <span className="inline-flex items-center rounded-full bg-blue-900/50 border border-blue-800 px-2.5 py-0.5 text-xs font-semibold text-blue-300">
-                {users.length}人
-              </span>
+              {!loading && (
+                <span className="inline-flex items-center rounded-full bg-blue-900/50 border border-blue-800 px-2.5 py-0.5 text-xs font-semibold text-blue-300">
+                  {users.length}人
+                </span>
+              )}
             </div>
-            <p className="text-xs text-gray-500 mt-0.5">
-              総AUM: ${totalAUM.toLocaleString('ja-JP')}
-            </p>
+            {!loading && (
+              <p className="text-xs text-gray-500 mt-0.5">
+                総AUM: ${totalAUM.toLocaleString('ja-JP')}
+              </p>
+            )}
           </div>
         </div>
 
@@ -145,21 +132,33 @@ export default function UsersPage() {
         </div>
       </div>
 
-      {/* Mock data banner */}
-      <div className="mb-4 rounded-lg border border-amber-800 bg-amber-950/50 px-4 py-2 text-xs text-amber-300">
-        準備中: ユーザー管理APIは現在実装中です。以下はサンプルデータです。
-      </div>
-
-      {/* ── User table ───────────────────────────────────────────────────── */}
-      {filteredUsers.length === 0 ? (
-        <EmptyState hasQuery={searchQuery.length > 0} />
-      ) : (
-        <UserTable users={filteredUsers} onSelectUser={setSelectedUser} />
+      {/* ── States ───────────────────────────────────────────────────────── */}
+      {loading && (
+        <div className="flex items-center justify-center rounded-xl border border-gray-800 bg-gray-900/50 py-16">
+          <div className="h-6 w-6 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />
+          <span className="ml-3 text-sm text-gray-400">読み込み中...</span>
+        </div>
       )}
 
-      <p className="mt-2 text-xs text-gray-600">
-        ※ 行をクリックするとユーザー詳細が表示されます。
-      </p>
+      {!loading && error && (
+        <div className="rounded-lg border border-red-800 bg-red-950/50 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      {/* ── User table ───────────────────────────────────────────────────── */}
+      {!loading && !error && (
+        <>
+          {filteredUsers.length === 0 ? (
+            <EmptyState hasQuery={searchQuery.length > 0} />
+          ) : (
+            <UserTable users={filteredUsers} onSelectUser={setSelectedUser} />
+          )}
+          <p className="mt-2 text-xs text-gray-600">
+            ※ 行をクリックするとユーザー詳細が表示されます。
+          </p>
+        </>
+      )}
 
       {/* ── Detail panel ─────────────────────────────────────────────────── */}
       <UserDetailPanel

--- a/frontend/lib/api/admin-users.ts
+++ b/frontend/lib/api/admin-users.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+// frontend/lib/api/admin-users.ts
+/**
+ * 管理者向けユーザー運用状況 API クライアント。
+ * GET  /api/admin/users
+ * POST /api/admin/users/{id}/pause
+ * POST /api/admin/users/{id}/resume
+ */
+
+import { apiFetch, apiPost } from './client'
+
+export interface AdminUserPosition {
+  asset: string
+  supplied: number
+  borrowed: number
+  usdValue: number
+}
+
+export interface AdminUserHFPoint {
+  date: string
+  hf: number
+}
+
+export interface AdminUserRecentTrade {
+  id: string
+  type: string
+  asset: string
+  amount: number
+  timestamp: string
+}
+
+export interface AdminUserRecentDecision {
+  id: string
+  action: string
+  confidence: number
+  timestamp: string
+}
+
+export interface AdminUserDetail {
+  id: string
+  address: string
+  registeredAt: string
+  aum: number
+  lastActivity: string
+  riskMode: 'conservative' | 'balanced' | 'aggressive'
+  status: 'NORMAL' | 'WARNING' | 'DANGER'
+  isPaused: boolean
+  positions: AdminUserPosition[]
+  healthFactor: number
+  hfHistory: AdminUserHFPoint[]
+  recentTrades: AdminUserRecentTrade[]
+  recentDecisions: AdminUserRecentDecision[]
+}
+
+export async function fetchAdminUsers(): Promise<AdminUserDetail[]> {
+  return apiFetch<AdminUserDetail[]>('/api/admin/users')
+}
+
+export async function pauseAdminUser(userId: string): Promise<void> {
+  await apiPost<unknown>(`/api/admin/users/${userId}/pause`, null)
+}
+
+export async function resumeAdminUser(userId: string): Promise<void> {
+  await apiPost<unknown>(`/api/admin/users/${userId}/resume`, null)
+}


### PR DESCRIPTION
## Summary

- **backend**: `GET /api/admin/users` を新規実装 — viewer ロール全ユーザーの運用状況（AUM・HF・7日間HF履歴・直近5取引・直近5AI判定）を一括返却
- **backend**: `POST /api/admin/users/{id}/pause` / `resume` — admin による is_active 切替
- **frontend**: `lib/api/admin-users.ts` — API クライアント新規作成
- **frontend**: `/admin/users/page.tsx` — モックデータ・「準備中」バナーを削除し、useEffect で実 API 呼び出しに変更。ローディング/エラー状態も追加

## Test plan

- [ ] `GET /api/admin/users` に admin トークンで curl → viewer ユーザーリストが返る
- [ ] `POST /api/admin/users/{id}/pause` → DB の is_active が False に変わる / 再度 GET で isPaused=true
- [ ] `/admin/users` 画面でリアルデータが表示される（ローディングスピナー → 表示）
- [ ] ユーザー詳細パネルの「停止」ボタンが実際に停止・再開できる
- [ ] viewer ユーザーが 0 人のとき「登録ユーザーがいません」表示になる

## Codex セルフチェック

- dry_run 関係なし ✅
- admin ガード (`require_admin`) 配線済み ✅
- main.py に `include_router(admin_users_router)` 登録済み ✅
- migration 不要（新規テーブルなし、既存テーブルの read + is_active write のみ）✅
- 後方互換: 既存 `/users` ルーターと prefix 重複なし（`/api/admin/users` vs `/users`）✅

関連 Asana: 1215477326469976

🤖 Generated with [Claude Code](https://claude.com/claude-code)