### PR TITLE
fix(liff): add liffFetch wrapper for 401 redirect [HR3]

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
@@ -16,6 +16,7 @@ import {
   X,
 } from "lucide-react"
 import { getAuthToken, clearAuthToken } from "@/lib/auth/token-key"
+import { liffFetch } from "@/lib/liff/liff-fetch"
 
 interface UserData {
   id?: number
@@ -71,13 +72,8 @@ export function AccountPanel() {
 
   // ユーザー設定を取得（/api/user/settings + /auth/me を併用）
   useEffect(() => {
-    const token = getAuthToken() ?? ""
-    if (!token) return
-
     // settings エンドポイント（user_mode 等）
-    fetch(`${API_BASE}/api/user/settings`, {
-      headers: { Authorization: `Bearer ${token}` },
-    })
+    liffFetch("/api/user/settings")
       .then((r) => (r.ok ? r.json() : null))
       .then((data: UserData | null) => {
         if (data) {
@@ -91,9 +87,7 @@ export function AccountPanel() {
       .catch(() => {})
 
     // auth/me エンドポイント（created_at, wallet_address）
-    fetch(`${API_BASE}/auth/me`, {
-      headers: { Authorization: `Bearer ${token}` },
-    })
+    liffFetch("/auth/me")
       .then((r) => (r.ok ? r.json() : null))
       .then(
         (

--- a/frontend/app/(liff)/liff-chat/_components/panels/NotificationPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/NotificationPanel.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useState } from "react"
 import { MessageCircle, Bell, AlertTriangle, ShieldAlert, FileText, Info } from "lucide-react"
 import { getAuthToken } from "@/lib/auth/token-key"
+import { liffFetch } from "@/lib/liff/liff-fetch"
 
 // ---------------------------------------------------------------------------
 // 型定義
@@ -150,10 +151,7 @@ export function NotificationPanel() {
 
   // 設定を取得
   useEffect(() => {
-    const token = getToken()
-    fetch(`${API_BASE}/api/notifications/settings`, {
-      headers: { Authorization: `Bearer ${token}` },
-    })
+    liffFetch("/api/notifications/settings")
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`)
         return res.json() as Promise<NotificationSettings>
@@ -162,7 +160,7 @@ export function NotificationPanel() {
       .catch(() => {
         // API が存在しない場合はデフォルト状態を保持
       })
-  }, [API_BASE])
+  }, [])
 
   // 設定を保存
   async function saveSettings(next: NotificationSettings) {

--- a/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useState } from "react"
 import { Bot, MousePointer2 } from "lucide-react"
 import { getAuthToken } from "@/lib/auth/token-key"
+import { liffFetch } from "@/lib/liff/liff-fetch"
 
 type UserMode = "managed" | "active"
 
@@ -52,14 +53,7 @@ export function OpModePanel() {
 
   // 初回ロード: GET /api/user/settings
   useEffect(() => {
-    const token = getAuthToken()
-    if (!token) {
-      setLoading(false)
-      return
-    }
-    fetch(`${API_BASE}/api/user/settings`, {
-      headers: { Authorization: `Bearer ${token}` },
-    })
+    liffFetch("/api/user/settings")
       .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
       .then((data: { user_mode: UserMode }) => {
         setCurrentMode(data.user_mode)

--- a/frontend/lib/liff/liff-fetch.ts
+++ b/frontend/lib/liff/liff-fetch.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// liffFetch: LIFF パネル用の fetch ラッパー。
+// 401 レスポンス時に /liff-login へリダイレクトし、サイレント無視を防ぐ。
+import { getAuthToken } from "@/lib/auth/token-key"
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ""
+
+export async function liffFetch(
+  path: string,
+  options?: RequestInit,
+): Promise<Response> {
+  const token = getAuthToken()
+  const res = await fetch(API_BASE + path, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + (token ?? ""),
+      ...options?.headers,
+    },
+  })
+  if (res.status === 401 && typeof window !== "undefined") {
+    window.location.href = "/liff-login"
+  }
+  return res
+}


### PR DESCRIPTION
HR3: LIFFパネルの401サイレント無視を修正。セッション切れ時に/liff-loginへ誘導。

## 変更内容

- `frontend/lib/liff/liff-fetch.ts` 新規作成: 共通fetchラッパー。401レスポンス時に `window.location.href = "/liff-login"` へリダイレクト
- `NotificationPanel.tsx`: マウント時GET (`/api/notifications/settings`) を `liffFetch` に切り替え
- `OpModePanel.tsx`: マウント時GET (`/api/user/settings`) を `liffFetch` に切り替え
- `AccountPanel.tsx`: マウント時GET 2本 (`/api/user/settings`, `/auth/me`) を `liffFetch` に切り替え
- `ReferralPanel.tsx`: `getReferralInfo()` はlib経由のため変更不要

## 参考

TxHistoryPanel の既存401ハンドリングパターン（`setAuthExpired(true)` + 再ログインUI）を確認済み。liffFetchはシンプルなリダイレクト方式を採用（マウント時fetchの共通化）。

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>