### PR TITLE
docs(terms): お任せモード・手動モードの説明を追記（実態との乖離修正）

### DIFF
--- a/frontend/app/(user)/terms/page.tsx
+++ b/frontend/app/(user)/terms/page.tsx
@@ -22,7 +22,7 @@ export default function TermsPage() {
         </Button>
 
         <h1 className="text-2xl font-bold mb-2">Ultra AutoTrade 利用規約</h1>
-        <p className="text-sm text-zinc-500 mb-8">最終更新日：2026年3月24日</p>
+        <p className="text-sm text-zinc-500 mb-8">最終更新日：2026年6月8日</p>
 
         <div className="space-y-8 text-sm text-zinc-300 leading-relaxed">
           <section>
@@ -46,32 +46,46 @@ export default function TermsPage() {
           </section>
 
           <section>
-            <h2 className="text-base font-semibold text-zinc-100 mb-2">5. 取引の承認</h2>
-            <p>本サービスでは、すべての取引においてお客様の明示的な承認が必要です。AIが提案した取引を自動執行することはありません。また、緊急停止機能により即座に運用を停止することができます。</p>
+            <h2 className="text-base font-semibold text-zinc-100 mb-2">5. 運用モードについて</h2>
+            <p>本サービスでは、以下の2つの運用モードをご利用いただけます。</p>
+            <ul className="mt-2 space-y-2 list-disc list-inside">
+              <li>
+                <span className="font-medium text-zinc-200">お任せモード（デフォルト）</span>：AIの判定に基づき、取引を自動的に執行します。お客様が個別の取引を承認する必要はありませんが、いつでもモードを変更または緊急停止することができます。
+              </li>
+              <li>
+                <span className="font-medium text-zinc-200">手動モード</span>：AIが提案した取引について、お客様の明示的な承認が必要です。承認なしに取引が執行されることはありません。
+              </li>
+            </ul>
+            <p className="mt-2">モードの切替は設定画面からいつでも変更可能です。また、緊急停止機能により即座に運用を停止することができます。</p>
           </section>
 
           <section>
-            <h2 className="text-base font-semibold text-zinc-100 mb-2">6. 手数料</h2>
+            <h2 className="text-base font-semibold text-zinc-100 mb-2">6. 取引の執行</h2>
+            <p>取引の執行方法は、選択された運用モードによって異なります。お任せモードでは、AIの判定に基づき自動的に取引が執行されます。手動モードでは、すべての取引においてお客様の明示的な承認が必要です。いずれのモードにおいても、当社のリスク管理基準を超える取引は執行されません。</p>
+          </section>
+
+          <section>
+            <h2 className="text-base font-semibold text-zinc-100 mb-2">7. 手数料</h2>
             <p>テスト期間中、本サービスの利用料は無料です。ただし、ブロックチェーンのガス代はお客様負担となります（テストネットのガス代は無料です）。</p>
           </section>
 
           <section>
-            <h2 className="text-base font-semibold text-zinc-100 mb-2">7. 免責事項</h2>
+            <h2 className="text-base font-semibold text-zinc-100 mb-2">8. 免責事項</h2>
             <p>本サービスは資産の値上がりを保証するものではありません。システム障害、ネットワーク障害、その他の要因によりサービスが中断する可能性があります。当社はこれらにより生じた損害について責任を負いません。</p>
           </section>
 
           <section>
-            <h2 className="text-base font-semibold text-zinc-100 mb-2">8. プライバシー</h2>
+            <h2 className="text-base font-semibold text-zinc-100 mb-2">9. プライバシー</h2>
             <p>本サービスが収集する情報はウォレットアドレスおよび取引履歴のみです。個人を特定できる情報は収集しません。</p>
           </section>
 
           <section>
-            <h2 className="text-base font-semibold text-zinc-100 mb-2">9. 禁止事項</h2>
+            <h2 className="text-base font-semibold text-zinc-100 mb-2">10. 禁止事項</h2>
             <p>本サービスのリバースエンジニアリング、不正アクセス、システムへの攻撃、または他のユーザーへの妨害行為を禁止します。</p>
           </section>
 
           <section>
-            <h2 className="text-base font-semibold text-zinc-100 mb-2">10. 規約の変更</h2>
+            <h2 className="text-base font-semibold text-zinc-100 mb-2">11. 規約の変更</h2>
             <p>本規約は事前通知のうえ変更されることがあります。変更後も本サービスを継続して利用された場合、変更後の規約に同意したものとみなします。</p>
           </section>
         </div>


### PR DESCRIPTION
## 変更概要

Asana GID: 1215483631226343

利用規約の内容がサービス実態と乖離していた問題を修正。

## 修正内容

- **最終更新日**：2026年3月24日 → 2026年6月8日
- **第5条「取引の承認」を改訂**：「AIが提案した取引を自動執行することはありません」という実態と矛盾する記述を削除し、「運用モードについて」として書き直し
  - お任せモード（デフォルト）：AIの判定に基づき自動執行
  - 手動モード：明示的な承認が必要
- **新設 第6条「取引の執行」**：モード別の執行フローとリスク管理基準を明記
- **第6〜10条を第7〜11条に繰り上げ**（番号調整）

## レビュー注意事項

⚠️ **法的リスクを考慮した人間レビューが必要です（Asana DoD より）**

本 PR の文言は実態との整合性を優先して作成していますが、法的観点からの最終確認を小林さんにお願いします。

## テスト計画

- [ ] 規約ページ `/terms` の表示確認（番号飛びなし、スタイル崩れなし）
- [ ] 法的文言の人間レビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)