### PR TITLE
fix: /api/transactions/export エンドポイント実装 (#1215483809528338)

### DIFF
--- a/backend/app/transactions/router.py
+++ b/backend/app/transactions/router.py
@@ -2,17 +2,21 @@
 # backend/app/transactions/router.py
 """取引履歴API ルーター定義。"""
 
-from datetime import datetime
+import csv
+import io
+from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Optional
+from zoneinfo import ZoneInfo
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import select
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.auth.dependencies import require_active_user, require_admin, require_editor, require_viewer
 from app.auth.models import User
 from app.database import get_db
+from app.proposals.models import Proposal
 
 from .models import Transaction
 from .schemas import (
@@ -21,6 +25,8 @@ from .schemas import (
     TransactionResponse,
     TransactionStatsResponse,
 )
+
+_JST = ZoneInfo("Asia/Tokyo")
 
 router = APIRouter(prefix="/api/transactions", tags=["transactions"])
 admin_router = APIRouter(prefix="/api/admin/transactions", tags=["admin-transactions"])
@@ -84,6 +90,58 @@ def list_transactions(
         total=total,
         limit=limit,
         offset=offset,
+    )
+
+
+@router.get("/export", summary="取引一覧 CSV エクスポート")
+def export_transactions_csv(
+    year: Optional[int] = Query(None, description="絞り込む年 (例: 2026)。省略時は全件"),
+    current_user: User = Depends(require_viewer),
+    db: Session = Depends(get_db),
+) -> Response:
+    """実行済み提案 (status='executed') を CSV 形式でエクスポートする。
+
+    CSV カラム: 実行日時, 操作, 資産, 数量, USD金額, 手数料(USD), TxHash
+    - 実行日時: JST (UTC+9) 形式 YYYY/MM/DD HH:MM:SS
+    - 操作: SUPPLY / WITHDRAW / BORROW / REPAY
+    - 数量: トークン数量 (Decimal)
+    - USD金額: 実行時の USD 換算額
+    - 手数料(USD): fee_amount。NULL の場合は 0
+    """
+    stmt = select(Proposal).where(
+        Proposal.user_id == current_user.id,
+        Proposal.status == "executed",
+        Proposal.executed_at.is_not(None),
+    )
+    if year is not None:
+        stmt = stmt.where(func.extract("year", Proposal.executed_at) == year)
+    stmt = stmt.order_by(Proposal.executed_at.asc())
+    proposals = db.scalars(stmt).all()
+
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(["実行日時", "操作", "資産", "数量", "USD金額", "手数料(USD)", "TxHash"])
+
+    for p in proposals:
+        if p.executed_at is None:
+            continue
+        dt = p.executed_at
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        executed_jst = dt.astimezone(_JST)
+        timestamp = executed_jst.strftime("%Y/%m/%d %H:%M:%S")
+        fee = str(p.fee_amount) if p.fee_amount is not None else "0"
+        writer.writerow(
+            [timestamp, p.operation, p.asset, str(p.amount), str(p.amount_usd), fee, p.tx_hash or ""]
+        )
+
+    csv_bytes = buf.getvalue().encode("utf-8-sig")  # BOM付きUTF-8 (Excel対応)
+    year_suffix = f"_{year}" if year else ""
+    filename = f"transactions{year_suffix}.csv"
+    return Response(
+        content=csv_bytes,
+        media_type="text/csv; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
 
 

--- a/backend/app/transactions/router.py
+++ b/backend/app/transactions/router.py
@@ -132,7 +132,15 @@ def export_transactions_csv(
         timestamp = executed_jst.strftime("%Y/%m/%d %H:%M:%S")
         fee = str(p.fee_amount) if p.fee_amount is not None else "0"
         writer.writerow(
-            [timestamp, p.operation, p.asset, str(p.amount), str(p.amount_usd), fee, p.tx_hash or ""]
+            [
+                timestamp,
+                p.operation,
+                p.asset,
+                str(p.amount),
+                str(p.amount_usd),
+                fee,
+                p.tx_hash or "",
+            ]
         )
 
     csv_bytes = buf.getvalue().encode("utf-8-sig")  # BOM付きUTF-8 (Excel対応)

--- a/backend/tests/test_transactions_api.py
+++ b/backend/tests/test_transactions_api.py
@@ -2,8 +2,11 @@
 # backend/tests/test_transactions_api.py
 """取引履歴APIのテスト。"""
 
+import csv
+import io
 import os
 import tempfile
+from datetime import datetime, timezone
 from typing import Generator
 
 import pytest
@@ -218,3 +221,111 @@ class TestTransactionsAPI:
         )
         assert r.status_code == 200
         assert all(item["chain"] == "arbitrum_one" for item in r.json()["items"])
+
+
+class TestTransactionsExportCSV:
+    """GET /api/transactions/export のテスト。"""
+
+    def _insert_executed_proposal(self, test_db, user_id: int, year: int = 2026) -> None:
+        """テスト用の実行済み提案を DB に直接挿入する。"""
+        from app.proposals.models import Proposal
+
+        _, engine = test_db
+        from sqlalchemy.orm import Session
+
+        with Session(engine) as session:
+            proposal = Proposal(
+                user_id=user_id,
+                operation="SUPPLY",
+                asset="USDC",
+                amount="500.000000000000000000",
+                amount_usd="500.00",
+                reason="test export",
+                status="executed",
+                fee_amount="5.00",
+                tx_hash="0xabcdef1234567890",
+                executed_at=datetime(year, 6, 15, 10, 30, 0, tzinfo=timezone.utc),
+            )
+            session.add(proposal)
+            session.commit()
+
+    def test_export_requires_auth(self, client: TestClient) -> None:
+        r = client.get("/api/transactions/export")
+        assert r.status_code == 401
+
+    def test_export_empty(self, client: TestClient) -> None:
+        token = get_admin_token(client)
+        r = client.get(
+            "/api/transactions/export",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        assert "text/csv" in r.headers["content-type"]
+        reader = csv.DictReader(io.StringIO(r.content.decode("utf-8-sig")))
+        rows = list(reader)
+        assert rows == []
+
+    def test_export_returns_csv_with_executed_proposals(
+        self, client: TestClient, test_db
+    ) -> None:
+        token = get_admin_token(client)
+        self._insert_executed_proposal(test_db, user_id=1)
+        r = client.get(
+            "/api/transactions/export",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        assert "text/csv" in r.headers["content-type"]
+        assert "attachment" in r.headers["content-disposition"]
+        reader = csv.DictReader(io.StringIO(r.content.decode("utf-8-sig")))
+        rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0]["操作"] == "SUPPLY"
+        assert rows[0]["資産"] == "USDC"
+        assert rows[0]["手数料(USD)"] == "5.00"
+        assert rows[0]["TxHash"] == "0xabcdef1234567890"
+
+    def test_export_year_filter_matches(self, client: TestClient, test_db) -> None:
+        token = get_admin_token(client)
+        self._insert_executed_proposal(test_db, user_id=1, year=2026)
+        r = client.get(
+            "/api/transactions/export?year=2026",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        reader = csv.DictReader(io.StringIO(r.content.decode("utf-8-sig")))
+        assert len(list(reader)) == 1
+
+    def test_export_year_filter_no_match(self, client: TestClient, test_db) -> None:
+        token = get_admin_token(client)
+        self._insert_executed_proposal(test_db, user_id=1, year=2026)
+        r = client.get(
+            "/api/transactions/export?year=2025",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        reader = csv.DictReader(io.StringIO(r.content.decode("utf-8-sig")))
+        assert list(reader) == []
+
+    def test_export_filename_includes_year(self, client: TestClient) -> None:
+        token = get_admin_token(client)
+        r = client.get(
+            "/api/transactions/export?year=2026",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        assert 'filename="transactions_2026.csv"' in r.headers["content-disposition"]
+
+    def test_export_does_not_include_other_user_proposals(
+        self, client: TestClient, test_db
+    ) -> None:
+        token = get_admin_token(client)
+        # user_id=99 (別ユーザー) の proposal を挿入
+        self._insert_executed_proposal(test_db, user_id=99)
+        r = client.get(
+            "/api/transactions/export",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        reader = csv.DictReader(io.StringIO(r.content.decode("utf-8-sig")))
+        assert list(reader) == []

--- a/backend/tests/test_transactions_api.py
+++ b/backend/tests/test_transactions_api.py
@@ -265,9 +265,7 @@ class TestTransactionsExportCSV:
         rows = list(reader)
         assert rows == []
 
-    def test_export_returns_csv_with_executed_proposals(
-        self, client: TestClient, test_db
-    ) -> None:
+    def test_export_returns_csv_with_executed_proposals(self, client: TestClient, test_db) -> None:
         token = get_admin_token(client)
         self._insert_executed_proposal(test_db, user_id=1)
         r = client.get(

--- a/backend/tests/test_transactions_api.py
+++ b/backend/tests/test_transactions_api.py
@@ -245,6 +245,7 @@ class TestTransactionsExportCSV:
                 fee_amount="5.00",
                 tx_hash="0xabcdef1234567890",
                 executed_at=datetime(year, 6, 15, 10, 30, 0, tzinfo=timezone.utc),
+                expires_at=datetime(year, 6, 15, 11, 30, 0, tzinfo=timezone.utc),
             )
             session.add(proposal)
             session.commit()


### PR DESCRIPTION
## Summary

- `GET /api/transactions/export?year={year}` エンドポイントを `transactions` router に追加
- TaxPanel の「取引一覧 CSV」ボタンが 404 になっていた問題を修正
- データソース: ユーザーの `status='executed'` な Proposal レコード（Cryptact CSV と同じソース）
- 出力: BOM 付き UTF-8 CSV（Excel 対応）、カラム: 実行日時(JST), 操作, 資産, 数量, USD金額, 手数料(USD), TxHash

## 変更ファイル

- `backend/app/transactions/router.py` — `GET /export` エンドポイント追加（import追加含む）
- `backend/tests/test_transactions_api.py` — テスト 7 件追加

## テスト計画

- [ ] `test_export_requires_auth` — 未認証で 401
- [ ] `test_export_empty` — 実行済み提案なしで空 CSV（ヘッダのみ）
- [ ] `test_export_returns_csv_with_executed_proposals` — CSV 内容確認
- [ ] `test_export_year_filter_matches` — `?year=2026` でマッチ
- [ ] `test_export_year_filter_no_match` — `?year=2025` で空
- [ ] `test_export_filename_includes_year` — Content-Disposition に年付きファイル名
- [ ] `test_export_does_not_include_other_user_proposals` — 他ユーザーのデータを返さない

## Asana

GID: 1215483809528338

🤖 Generated with [Claude Code](https://claude.com/claude-code)