### PR TITLE
fix(i18n): BUY/SELL ラベルをユーザー向け日本語に統一

### DIFF
--- a/backend/app/notifications/templates.py
+++ b/backend/app/notifications/templates.py
@@ -12,6 +12,12 @@ from typing import Any
 
 from .schemas import NotificationChannel, NotificationMessage, NotificationSeverity
 
+# action 文字列 → ユーザー向け日本語ラベル
+_ACTION_LABEL_JA: dict[str, str] = {
+    "BUY": "購入する",
+    "SELL": "売る",
+}
+
 # severity 文字列 → LINE Flex ヘッダー色
 _SEVERITY_COLOR: dict[str, str] = {
     "emergency": "#FF0000",
@@ -127,9 +133,10 @@ def ai_proposal_notification(
     confidence: int,
 ) -> NotificationPayload:
     """AI取引提案通知。"""
+    op_label = _ACTION_LABEL_JA.get(operation, operation)
     title = "💡 新しいAI取引提案"
     body = (
-        f"{operation} {amount} {asset}（信頼度: {confidence}%）。アプリで確認・承認してください。"
+        f"{op_label} {amount} {asset}（信頼度: {confidence}%）。アプリで確認・承認してください。"
     )
     return _build_payload(title, body, "warning")
 
@@ -141,8 +148,9 @@ def trade_executed_notification(
     tx_hash: str,
 ) -> NotificationPayload:
     """取引実行完了通知。"""
+    op_label = _ACTION_LABEL_JA.get(operation, operation)
     title = "✅ 取引実行完了"
-    body = f"{operation} {amount} {asset} が完了しました。Tx: {tx_hash[:10]}..."
+    body = f"{op_label} {amount} {asset} が完了しました。Tx: {tx_hash[:10]}..."
     return _build_payload(title, body, "info")
 
 
@@ -153,8 +161,9 @@ def trade_failed_notification(
     error: str,
 ) -> NotificationPayload:
     """取引失敗通知。"""
+    op_label = _ACTION_LABEL_JA.get(operation, operation)
     title = "❌ 取引失敗"
-    body = f"{operation} {amount} {asset} が失敗しました。エラー: {error[:100]}"
+    body = f"{op_label} {amount} {asset} が失敗しました。エラー: {error[:100]}"
     return _build_payload(title, body, "alert")
 
 
@@ -164,8 +173,9 @@ def approval_timeout_notification(
     timeout_minutes: int = 60,
 ) -> NotificationPayload:
     """承認タイムアウト通知。"""
+    op_label = _ACTION_LABEL_JA.get(operation, operation)
     title = "⏰ 承認タイムアウト"
     body = (
-        f"{operation} {asset} の提案が {timeout_minutes} 分以内に承認されず、キャンセルしました。"
+        f"{op_label} {asset} の提案が {timeout_minutes} 分以内に承認されず、キャンセルしました。"
     )
     return _build_payload(title, body, "info")

--- a/backend/app/notifications/templates.py
+++ b/backend/app/notifications/templates.py
@@ -135,9 +135,7 @@ def ai_proposal_notification(
     """AI取引提案通知。"""
     op_label = _ACTION_LABEL_JA.get(operation, operation)
     title = "💡 新しいAI取引提案"
-    body = (
-        f"{op_label} {amount} {asset}（信頼度: {confidence}%）。アプリで確認・承認してください。"
-    )
+    body = f"{op_label} {amount} {asset}（信頼度: {confidence}%）。アプリで確認・承認してください。"
     return _build_payload(title, body, "warning")
 
 
@@ -175,7 +173,5 @@ def approval_timeout_notification(
     """承認タイムアウト通知。"""
     op_label = _ACTION_LABEL_JA.get(operation, operation)
     title = "⏰ 承認タイムアウト"
-    body = (
-        f"{op_label} {asset} の提案が {timeout_minutes} 分以内に承認されず、キャンセルしました。"
-    )
+    body = f"{op_label} {asset} の提案が {timeout_minutes} 分以内に承認されず、キャンセルしました。"
     return _build_payload(title, body, "info")

--- a/frontend/components/shared/TradeActionBadge.tsx
+++ b/frontend/components/shared/TradeActionBadge.tsx
@@ -12,12 +12,12 @@ export interface TradeActionBadgeProps {
 
 const actionConfig = {
   BUY: {
-    label: 'BUY',
+    label: '購入する',
     icon: TrendingUp,
     className: 'bg-green-100 text-green-800 border-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800',
   },
   SELL: {
-    label: 'SELL',
+    label: '売る',
     icon: TrendingDown,
     className: 'bg-red-100 text-red-800 border-red-200 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800',
   },

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -106,8 +106,8 @@
     "disagreed": "不一致",
     "noDecisions": "AI判定履歴がありません",
     "filterAll": "すべて",
-    "filterBuy": "BUY",
-    "filterSell": "SELL",
+    "filterBuy": "購入する",
+    "filterSell": "売る",
     "filterHold": "HOLD",
     "fetchError": "データを取得できません"
   },
@@ -240,8 +240,8 @@
     "aiDecisions": {
       "title": "AI判定モニター",
       "totalDecisions": "総判定数",
-      "buyCount": "BUY",
-      "sellCount": "SELL",
+      "buyCount": "購入する",
+      "sellCount": "売る",
       "holdCount": "HOLD",
       "avgConfidence": "平均確信度",
       "action": "判定",


### PR DESCRIPTION
## Summary
- `TradeActionBadge.tsx`: バッジの BUY/SELL ラベルを「購入する」/「売る」に変更
- `messages/ja.json`: filterBuy/filterSell/buyCount/sellCount を日本語化
- `notifications/templates.py`: LINE/Push 通知 4テンプレート（提案・実行完了・失敗・タイムアウト）の operation ラベルを日本語化（`_ACTION_LABEL_JA` マッピング追加）

オート・マニュアル両モードで統一。SUPPLY/WITHDRAW など他の operation 値はフォールバックでそのまま表示。

## Test plan
- [ ] TradeActionBadge が「購入する」/「売る」と表示されることをフロントエンドで確認
- [ ] LINE 通知 body に「購入する」/「売る」が入ることを確認（ai_proposal_notification）
- [ ] `pytest tests/test_notifications.py` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)