### PR TITLE
feat(aave): Aaveプール利用率チェック実装（WITHDRAW実行前ガード）

### DIFF
--- a/backend/app/aave/client.py
+++ b/backend/app/aave/client.py
@@ -82,6 +82,50 @@ _POOL_ABI_MINIMAL = [
         "stateMutability": "nonpayable",
         "type": "function",
     },
+    {
+        "name": "getReserveData",
+        "type": "function",
+        "stateMutability": "view",
+        "inputs": [{"name": "asset", "type": "address"}],
+        "outputs": [
+            {
+                "name": "",
+                "type": "tuple",
+                "components": [
+                    {
+                        "name": "configuration",
+                        "type": "tuple",
+                        "components": [{"name": "data", "type": "uint256"}],
+                    },
+                    {"name": "liquidityIndex", "type": "uint128"},
+                    {"name": "currentLiquidityRate", "type": "uint128"},
+                    {"name": "variableBorrowIndex", "type": "uint128"},
+                    {"name": "currentVariableBorrowRate", "type": "uint128"},
+                    {"name": "currentStableBorrowRate", "type": "uint128"},
+                    {"name": "lastUpdateTimestamp", "type": "uint40"},
+                    {"name": "id", "type": "uint16"},
+                    {"name": "aTokenAddress", "type": "address"},
+                    {"name": "stableDebtTokenAddress", "type": "address"},
+                    {"name": "variableDebtTokenAddress", "type": "address"},
+                    {"name": "interestRateStrategyAddress", "type": "address"},
+                    {"name": "accruedToTreasury", "type": "uint128"},
+                    {"name": "unbacked", "type": "uint128"},
+                    {"name": "isolationModeTotalDebt", "type": "uint128"},
+                ],
+            }
+        ],
+    },
+]
+
+# ERC-20 totalSupply ABI（利用率計算用）
+_ERC20_TOTAL_SUPPLY_ABI = [
+    {
+        "name": "totalSupply",
+        "type": "function",
+        "stateMutability": "view",
+        "inputs": [],
+        "outputs": [{"name": "", "type": "uint256"}],
+    }
 ]
 
 # ERC-20 ABI（approve + decimals — 最小限）
@@ -258,6 +302,13 @@ class AaveClientBase(ABC):
     @abstractmethod
     def get_account_data(self, wallet_address: str) -> AccountData: ...
 
+    def get_pool_utilization(self, asset_symbol: str) -> Optional[Decimal]:
+        """プール利用率 (0-100) を返す。取得不可の場合は None。
+
+        サブクラスがオーバーライドしない場合は None を返す（fail-open）。
+        """
+        return None
+
 
 class AaveClientError(Exception):
     """Aave クライアントの基底例外。"""
@@ -297,6 +348,9 @@ class AaveClient(Protocol):
 
     def get_account_data(self, wallet_address: str) -> "AccountData":
         """Aave V3 Pool のアカウントデータを取得する。"""
+
+    def get_pool_utilization(self, asset_symbol: str) -> Optional[Decimal]:
+        """プール利用率 (0-100) を返す。取得不可の場合は None。"""
 
 
 class DummyAaveClient(AaveClientBase):
@@ -1133,6 +1187,67 @@ class Web3AaveClient(AaveClientBase):
                 "value": "0x0",
             }
         }
+
+    def get_pool_utilization(self, asset_symbol: str) -> Optional[Decimal]:
+        """Aave V3 プールの現在利用率 (0-100) を返す。
+
+        getReserveData → aToken.totalSupply / vDebtToken.totalSupply で計算。
+        RPC失敗・アドレス未設定の場合は None を返す（fail-open）。
+        """
+        if Web3 is None:
+            return None
+        if not hasattr(self, "token_addresses"):
+            logger.warning("get_pool_utilization: token_addresses not set; skipping check")
+            return None
+        asset_addr = self.token_addresses.get(asset_symbol)
+        if not asset_addr:
+            logger.warning(
+                "get_pool_utilization: unknown asset_symbol=%s; skipping check", asset_symbol
+            )
+            return None
+        try:
+            reserve_data = self._pool.functions.getReserveData(
+                Web3.to_checksum_address(asset_addr)
+            ).call()
+            atoken_addr: str = reserve_data[8]
+            sdebt_addr: str = reserve_data[9]
+            vdebt_addr: str = reserve_data[10]
+
+            atoken_contract = self._w3.eth.contract(
+                address=Web3.to_checksum_address(atoken_addr),
+                abi=_ERC20_TOTAL_SUPPLY_ABI,
+            )
+            atoken_total = int(atoken_contract.functions.totalSupply().call())
+
+            vdebt_contract = self._w3.eth.contract(
+                address=Web3.to_checksum_address(vdebt_addr),
+                abi=_ERC20_TOTAL_SUPPLY_ABI,
+            )
+            vdebt_total = int(vdebt_contract.functions.totalSupply().call())
+
+            # V3.3+ でstable debt は廃止済み。ゼロアドレスの場合はcallしない
+            if int(sdebt_addr, 16) == 0:
+                sdebt_total = 0
+            else:
+                sdebt_contract = self._w3.eth.contract(
+                    address=Web3.to_checksum_address(sdebt_addr),
+                    abi=_ERC20_TOTAL_SUPPLY_ABI,
+                )
+                sdebt_total = int(sdebt_contract.functions.totalSupply().call())
+
+            total_debt = vdebt_total + sdebt_total
+            if atoken_total <= 0:
+                return Decimal("0")
+            utilization_pct = Decimal(total_debt) / Decimal(atoken_total) * Decimal(100)
+            logger.debug(
+                "get_pool_utilization: %s utilization=%.2f%%",
+                asset_symbol,
+                float(utilization_pct),
+            )
+            return utilization_pct
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("get_pool_utilization: RPC failed for %s: %s", asset_symbol, exc)
+            return None
 
     # 後方互換: 旧 Web3AaveClient が持っていたユーティリティメソッド
     def _to_wei(self, amount: Decimal, decimals: int) -> int:

--- a/backend/app/aave/rebalance_config.py
+++ b/backend/app/aave/rebalance_config.py
@@ -43,7 +43,7 @@ class RebalanceSettings:
     confirmation_token_secret: str
     check_interval_seconds: int
     shadow_mode: bool
-    pool_utilization_block_pct: Decimal
+    pool_utilization_block_pct: Decimal = Decimal("95")
 
 
 def _get_env_int(name: str, default: int) -> int:

--- a/backend/app/aave/rebalance_config.py
+++ b/backend/app/aave/rebalance_config.py
@@ -43,6 +43,7 @@ class RebalanceSettings:
     confirmation_token_secret: str
     check_interval_seconds: int
     shadow_mode: bool
+    pool_utilization_block_pct: Decimal
 
 
 def _get_env_int(name: str, default: int) -> int:
@@ -178,6 +179,10 @@ def get_rebalance_settings() -> RebalanceSettings:
         "REBALANCE_SHADOW_MODE",
         default=True,  # 安全のためデフォルトは shadow (dry-run) モード
     )
+    pool_utilization_block_pct = _get_env_decimal(
+        "REBALANCE_POOL_UTILIZATION_BLOCK_PCT",
+        default="95",  # 95% 超でWITHDRAW停止（流動性枯渇防止）
+    )
 
     return RebalanceSettings(
         target_allocations=target_allocations,
@@ -189,4 +194,5 @@ def get_rebalance_settings() -> RebalanceSettings:
         confirmation_token_secret=confirmation_token_secret,
         check_interval_seconds=check_interval_seconds,
         shadow_mode=shadow_mode,
+        pool_utilization_block_pct=pool_utilization_block_pct,
     )

--- a/backend/app/aave/rebalance_service.py
+++ b/backend/app/aave/rebalance_service.py
@@ -469,6 +469,38 @@ class RebalanceService:
 
         return reasons
 
+    def _check_pool_liquidity(self, operations: list[ProposedOperation]) -> list[str]:
+        """WITHDRAW操作に対してプール利用率をライブチェックする。
+
+        utilization >= pool_utilization_block_pct の場合に rejection reason を返す。
+        RPC失敗時は fail-open（None → スキップ）。
+        """
+        reasons: list[str] = []
+        threshold = self._rb_settings.pool_utilization_block_pct
+        for op in operations:
+            if op.operation != AaveOperationType.WITHDRAW:
+                continue
+            utilization = self._client.get_pool_utilization(op.asset_symbol)
+            if utilization is None:
+                logger.warning(
+                    "_check_pool_liquidity: utilization fetch failed for %s; skipping check (fail-open)",
+                    op.asset_symbol,
+                )
+                continue
+            if utilization >= threshold:
+                reasons.append(
+                    f"Pool utilization for {op.asset_symbol} is {utilization:.1f}% "
+                    f"(>= {threshold}%); WITHDRAW blocked to protect pool liquidity"
+                )
+            else:
+                logger.debug(
+                    "_check_pool_liquidity: %s utilization=%.1f%% < threshold=%.1f%% OK",
+                    op.asset_symbol,
+                    float(utilization),
+                    float(threshold),
+                )
+        return reasons
+
     # ---- Public methods --------------------------------------------------
 
     def get_current_status(self) -> RebalanceStatusResponse:
@@ -770,6 +802,16 @@ class RebalanceService:
                 re_check_reasons,
             )
             raise RebalanceSafetyError(f"Safety constraints failed on re-check: {re_check_reasons}")
+
+        # 3b. Pool liquidity check (WITHDRAW のみ対象)
+        liquidity_reasons = self._check_pool_liquidity(list(proposal.operations))
+        if liquidity_reasons:
+            logger.warning(
+                "execute: pool liquidity check failed for proposal_id=%s: %s",
+                proposal_id,
+                liquidity_reasons,
+            )
+            raise RebalanceSafetyError(f"Pool liquidity check failed: {liquidity_reasons}")
 
         health_factor_before = current_hf
 

--- a/backend/tests/test_rebalance_service.py
+++ b/backend/tests/test_rebalance_service.py
@@ -57,11 +57,13 @@ class FakeAaveClientWithPositions:
         total_collateral: Decimal = Decimal("10000"),
         positions: Optional[dict[str, Decimal]] = None,
         raise_on_get_account_data: Optional[Exception] = None,
+        pool_utilization: Optional[Decimal] = None,
     ) -> None:
         self.hf = health_factor
         self.total_collateral = total_collateral
         self.positions = positions or {"USDC": Decimal("7000"), "WETH": Decimal("3000")}
         self.raise_on_get_account_data = raise_on_get_account_data
+        self._pool_utilization = pool_utilization  # None = RPC失敗(fail-open)
 
         self.deposit_calls: list[dict] = []
         self.withdraw_calls: list[dict] = []
@@ -70,6 +72,9 @@ class FakeAaveClientWithPositions:
 
     def get_health_factor(self, wallet_address: str = "") -> Decimal:
         return self.hf
+
+    def get_pool_utilization(self, asset_symbol: str) -> Optional[Decimal]:
+        return self._pool_utilization
 
     def get_account_data(self, wallet_address: str) -> AccountData:
         if self.raise_on_get_account_data is not None:
@@ -196,6 +201,7 @@ def _make_rebalance_settings(
     confirmation_token_ttl_seconds: int = 300,
     confirmation_token_secret: str = "test-secret-key-for-tests",
     shadow_mode: bool = True,
+    pool_utilization_block_pct: str = "95",
 ) -> RebalanceSettings:
     return RebalanceSettings(
         target_allocations=target_allocations
@@ -211,6 +217,7 @@ def _make_rebalance_settings(
         confirmation_token_secret=confirmation_token_secret,
         check_interval_seconds=14400,
         shadow_mode=shadow_mode,
+        pool_utilization_block_pct=Decimal(pool_utilization_block_pct),
     )
 
 
@@ -252,12 +259,15 @@ def _make_service(
     min_health_factor_post: str = "1.8",
     cooldown_seconds: int = 3600,
     raise_on_get_account_data: Optional[Exception] = None,
+    pool_utilization: Optional[Decimal] = Decimal("50"),
+    pool_utilization_block_pct: str = "95",
 ) -> tuple[RebalanceService, FakeAaveClientWithPositions, FakeAaveService]:
     """テスト用の RebalanceService インスタンスを生成するヘルパー。"""
     fake_client = FakeAaveClientWithPositions(
         health_factor=health_factor,
         total_collateral=total_collateral,
         raise_on_get_account_data=raise_on_get_account_data,
+        pool_utilization=pool_utilization,
     )
     fake_aave_service = FakeAaveService(results=aave_service_results)
     state_manager = FakeStateManager(
@@ -274,6 +284,7 @@ def _make_service(
         max_rebalance_pct=max_rebalance_pct,
         min_health_factor_post=min_health_factor_post,
         cooldown_seconds=cooldown_seconds,
+        pool_utilization_block_pct=pool_utilization_block_pct,
     )
     aave_cfg = aave_settings or _make_aave_settings()
 
@@ -1085,3 +1096,94 @@ class TestTokenVerification:
 
         with pytest.raises(RebalanceTokenError, match="Invalid token format"):
             _verify_confirmation_token("nodot_token_here", "some-id", "secret")
+
+
+class TestPoolLiquidityCheck:
+    """_check_pool_liquidity / execute() のプール利用率チェックのテスト。"""
+
+    def _inject_withdraw_proposal(self, service: RebalanceService) -> tuple[str, str]:
+        """WITHDRAW操作を含む proposal を直接 _pending_proposals に注入してIDとtokenを返す。
+
+        simulate() は risk_mode チェックを含むため、ここでは直接注入してバイパスする。
+        """
+        import uuid
+        from datetime import timezone
+
+        from app.aave.rebalance_schemas import AssetAllocation, ProposedOperation, RebalanceProposal
+        from app.aave.rebalance_service import _make_confirmation_token
+
+        proposal_id = str(uuid.uuid4())
+        exp_ts = (datetime.now(timezone.utc) + timedelta(seconds=300)).timestamp()
+        secret = service._rb_settings.confirmation_token_secret  # noqa: SLF001
+        token = _make_confirmation_token(proposal_id, exp_ts, secret)
+
+        proposal = RebalanceProposal(
+            proposal_id=proposal_id,
+            created_at=datetime.now(timezone.utc),
+            health_factor_before=Decimal("2.5"),
+            total_value_usd=Decimal("10000"),
+            allocations=[
+                AssetAllocation(
+                    asset_symbol="USDC",
+                    current_amount_usd=Decimal("7000"),
+                    current_pct=Decimal("70"),
+                    target_pct=Decimal("60"),
+                    deviation_pct=Decimal("10"),
+                )
+            ],
+            operations=[
+                ProposedOperation(
+                    asset_symbol="USDC",
+                    operation=AaveOperationType.WITHDRAW,
+                    amount_usd=Decimal("500"),
+                    reason="test withdraw",
+                )
+            ],
+            estimated_health_factor_after=Decimal("2.3"),
+            max_single_trade_pct=Decimal("10"),
+            confirmation_token=token,
+            is_executable=True,
+            rejection_reasons=[],
+        )
+        service._pending_proposals[proposal_id] = proposal  # noqa: SLF001
+        return proposal_id, token
+
+    def test_execute_blocks_when_utilization_at_threshold(self) -> None:
+        """利用率が閾値(95%)以上のとき execute が RebalanceSafetyError を raise すること。"""
+        service, _, _ = _make_service(
+            pool_utilization=Decimal("95"),
+            pool_utilization_block_pct="95",
+        )
+        proposal_id, token = self._inject_withdraw_proposal(service)
+        with pytest.raises(RebalanceSafetyError, match="Pool liquidity check failed"):
+            service.execute(proposal_id=proposal_id, confirmation_token=token)
+
+    def test_execute_blocks_when_utilization_above_threshold(self) -> None:
+        """利用率が閾値(95%)超のとき execute が RebalanceSafetyError を raise すること。"""
+        service, _, _ = _make_service(
+            pool_utilization=Decimal("98.5"),
+            pool_utilization_block_pct="95",
+        )
+        proposal_id, token = self._inject_withdraw_proposal(service)
+        with pytest.raises(RebalanceSafetyError, match="Pool liquidity check failed"):
+            service.execute(proposal_id=proposal_id, confirmation_token=token)
+
+    def test_execute_allows_when_utilization_below_threshold(self) -> None:
+        """利用率が閾値(95%)未満のとき execute が正常に通過すること。"""
+        service, _, _ = _make_service(
+            pool_utilization=Decimal("94"),
+            pool_utilization_block_pct="95",
+        )
+        proposal_id, token = self._inject_withdraw_proposal(service)
+        result = service.execute(proposal_id=proposal_id, confirmation_token=token)
+        assert result is not None
+
+    def test_execute_allows_when_utilization_fetch_fails(self) -> None:
+        """RPC失敗(utilization=None)のとき fail-open で execute が通過すること。"""
+        service, _, _ = _make_service(
+            pool_utilization=None,  # RPC失敗をシミュレート
+            pool_utilization_block_pct="95",
+        )
+        proposal_id, token = self._inject_withdraw_proposal(service)
+        result = service.execute(proposal_id=proposal_id, confirmation_token=token)
+        assert result is not None


### PR DESCRIPTION
## Summary

- 1000人規模の一斉SELL時、Aaveプールの流動性不足でWITHDRAW txがrevertするリスクに対処
- `execute()` 直前に利用率をライブ取得し、≥95% の場合のみWITHDRAWをブロック
- AI判定層（`ai/agents.py`）には触れないためBUY/SELL判定頻度への影響はなし
- RPC失敗時はfail-open（監視障害でWITHDRAW全停止を防ぐ）

## 変更ファイル

| ファイル | 内容 |
|---------|------|
| `client.py` | `getReserveData` ABI追加 + `get_pool_utilization()` を `Web3AaveClient` に実装 |
| `rebalance_config.py` | `pool_utilization_block_pct` フィールド追加（デフォルト95%、env: `REBALANCE_POOL_UTILIZATION_BLOCK_PCT`） |
| `rebalance_service.py` | `_check_pool_liquidity()` + `execute()` safety re-check直後に組み込み |
| `tests/test_rebalance_service.py` | `TestPoolLiquidityCheck` 4ケース追加 |

## Test plan

- [x] `ruff check` / `ruff format` 全通過
- [x] `mypy` 型エラーなし
- [x] `pytest tests/test_rebalance_service.py tests/test_daily_trade_limit.py` 全通過
- [x] 新規テスト4ケース: 利用率95%ブロック / 98.5%ブロック / 94%通過 / RPC失敗→fail-open通過

## Asana

Closes #1215484881270365

🤖 Generated with [Claude Code](https://claude.com/claude-code)