### PR TITLE
fix(liff): AI JUDGMENT「なぜ?」reason 導線を配線 (BUY/SELL/HOLD)

### DIFF
--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -86,6 +86,7 @@ export default function LiffChatPage() {
   const [graphOpen, setGraphOpen] = useState(false)
   const [chatOpen, setChatOpen] = useState(false)
   const [unreadCount] = useState(0)
+  const [reasonOpen, setReasonOpen] = useState(false)
 
   // ── データ取得
   useEffect(() => {
@@ -252,11 +253,18 @@ export default function LiffChatPage() {
             </div>
           )}
 
-          {/* HOLD 時: なぜ HOLD？リンク */}
-          {!isBuy && !isSell && (
-            <button className="mt-2 text-zinc-500 text-xs underline">
-              なぜHOLD？
-            </button>
+          {/* なぜ{action}？理由トグル（BUY/SELL/HOLD 共通） */}
+          <button
+            onClick={() => setReasonOpen((v) => !v)}
+            className="mt-2 text-zinc-500 text-xs underline"
+            aria-expanded={reasonOpen}
+          >
+            なぜ{action}？
+          </button>
+          {reasonOpen && (
+            <p className="mt-2 text-zinc-400 text-xs leading-relaxed whitespace-pre-wrap">
+              {aiJudgment?.reason ?? "理由データがありません"}
+            </p>
           )}
         </div>
 


### PR DESCRIPTION
## 現象
トップ画面 `/liff-chat` の AI JUDGMENT カードで:
- HOLD 時の「なぜHOLD？」が **リンク切れ**（`onClick` 無しの dead button）
- BUY/SELL 時は「なぜBUY？/なぜSELL？」相当の導線が **そもそも無い**

## 真因（調査）
- 「なぜHOLD？」は underline でリンク風だが `onClick` 無し（`page.tsx:255-260`）
- 表示すべき `reason`（AI判定理由）は取得済みなのに未描画
- データは end-to-end で生きている（backend修正不要）:
  - DB `ai_decisions.reason` 列 → `AIDecisionResponse.reason`（`decisions_schemas.py:36`）→ frontend 型 `AiJudgment.reason?`（`page.tsx:46`）→ fetch `/api/ai/decisions?limit=1` で state 格納済（`page.tsx:116-119`）
  - 欠落 = `aiJudgment.reason` の描画 + ボタンの onClick

## 修正（フロントのみ・低リスク）
- アクション非依存の「なぜ{action}？」トグルに統一（BUY/SELL/HOLD 共通）
- 押下で `aiJudgment.reason` をカード下にインライン開閉表示。null 時は「理由データがありません」
- ルーティング不要・browser PWA / LIFF 両対応

## 検証
- `tsc --noEmit` エラーなし
- backend 変更なし

Closes Asana 1215521431934769

🤖 Generated with [Claude Code](https://claude.com/claude-code)