### PR TITLE
fix(liff): 規約/プライバシーリンクを現オリジン基準にしてstaging→prod誤遷移を解消

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/TermsPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TermsPanel.tsx
@@ -8,7 +8,13 @@ import { ExternalLink, FileText, Shield } from "lucide-react"
 // /liff-approve (パートナートップ) に戻ってしまうため、target=_blank の
 // 素の <a> ではなく liff.openWindow({external:true}) を優先して使用する。
 // liff が無い (通常ブラウザ等) 場合は window.open へフォールバック。
-function openExternal(url: string) {
+//
+// path は同一オリジン相対 ("/terms" 等) で保持し、openExternal で
+// window.location.origin を前置して絶対 URL 化する。prod ドメインを
+// ハードコードすると staging で開いても本番 (app.ultra-auto-trade.com) に
+// 飛んでしまうため (環境跨ぎバグ)、必ず現在のオリジン基準で解決する。
+function openExternal(path: string) {
+  const url = typeof window !== "undefined" ? `${window.location.origin}${path}` : path
   if (
     typeof window !== "undefined" &&
     (window as Window & { liff?: { openWindow: (opts: { url: string; external: boolean }) => void } }).liff
@@ -22,7 +28,7 @@ function openExternal(url: string) {
 export function TermsPanel() {
   const links = [
     {
-      href: "https://app.ultra-auto-trade.com/terms",
+      href: "/terms",
       label: "利用規約",
       desc: "サービス利用条件・免責事項",
       icon: FileText,
@@ -30,7 +36,7 @@ export function TermsPanel() {
     {
       // 実ルートは /privacy-policy (frontend/app/(user)/privacy-policy/page.tsx)。
       // 旧 href ".../privacy" は 404 のため修正。
-      href: "https://app.ultra-auto-trade.com/privacy-policy",
+      href: "/privacy-policy",
       label: "プライバシーポリシー",
       desc: "個人情報の取り扱い",
       icon: Shield,

--- a/frontend/app/(liff)/liff-confirm/page.tsx
+++ b/frontend/app/(liff)/liff-confirm/page.tsx
@@ -213,7 +213,7 @@ export default function LiffConfirmPage() {
       <div className="px-4 pb-8 pt-4 border-t border-zinc-800 flex-shrink-0 space-y-3">
         <div className="flex gap-4 justify-center text-xs text-zinc-500">
           <a
-            href="https://app.ultra-auto-trade.com/terms"
+            href="/terms"
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center gap-1 hover:text-zinc-300"
@@ -221,7 +221,7 @@ export default function LiffConfirmPage() {
             利用規約 <ExternalLink className="w-3 h-3" />
           </a>
           <a
-            href="https://app.ultra-auto-trade.com/privacy-policy"
+            href="/privacy-policy"
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center gap-1 hover:text-zinc-300"


### PR DESCRIPTION
## 現象
staging の UI テスト中、`/liff-chat` の規約パネル（および `liff-confirm`）で「利用規約」「プライバシーポリシー」を開くと、staging のはずが本番ドメイン `https://app.ultra-auto-trade.com/terms` / `.../privacy-policy` に飛ぶ。環境跨ぎバグ。

## 真因
LIFF 系2ファイルが本番ドメインを絶対URLで**ハードコード**していたため、staging で開いても必ず prod に遷移していた。
- `frontend/app/(liff)/liff-chat/_components/panels/TermsPanel.tsx`
- `frontend/app/(liff)/liff-confirm/page.tsx`

`/terms`・`/privacy-policy` のルート自体は存在する（`app/(user)/terms`, `app/(user)/privacy-policy`）。他の規約リンク（signup / connect / settings）は相対パスで正しく、本PR対象外。

## 修正（フロントのみ・低リスク）
- **TermsPanel.tsx**: href を相対 `/terms`・`/privacy-policy` で保持し、`openExternal` 内で `window.location.origin` を前置して絶対URL化（liff.openWindow は絶対URL必須のため）。同 repo の `partner/referral/page.tsx:88` と同じ既存パターン。
- **liff-confirm/page.tsx**: `<a href>` を相対化して同オリジン解決。

修正後、prod ドメインの規約/プライバシーリンクの残存は grep で 0 件を確認済み。

## DoD（デプロイ後に実機確認）
- [ ] staging で規約/プライバシーを開くと `staging.ultra-auto-trade.com/...` になる（LIFF実機 + browser PWA 両方）
- [ ] `deploy_staging.sh --frontend-only` 再ビルド後に確認
- [ ] production へは P1 デプロイ（Asana 1215521760437320）に同梱

Closes Asana 1215522504201384

🤖 Generated with [Claude Code](https://claude.com/claude-code)