### PR TITLE
fix(liff): 未ログイン時に AccountPanel の「ログアウト/削除」を非表示にガード

### DIFF
--- a/CLAUDE.lessons.md
+++ b/CLAUDE.lessons.md
@@ -1158,3 +1158,16 @@ deploy_staging.sh)が稼働中だった。ps の ELAPSED は MM:SS 表記、誤�
 **何が起きたか**: fund_partner_test_wallet.py (ETH_TO_SEND=0.02 ETH) を 2 回実行したことで AAVE_WALLET の Base Sepolia ETH が ~0.001 ETH まで減少した。
 
 **再発防止**: E2E 実行前に `AAVE_WALLET_ADDRESS` の Base Sepolia ETH 残高を確認する。0.05 ETH 未満なら faucet (https://www.alchemy.com/faucets/base-sepolia) で補充。
+
+---
+
+## 2026-06-09 認証ガードの「新コンポーネントへのポート漏れ」(未ログインでログアウト表示の再発)
+
+**何が起きたか**: staging UI テストで LIFF v3 `/liff-chat` → ハンバーガー →「アカウント」を未ログイン状態で開くと「ログアウト」ボタンが表示された。同種バグは旧 Web UI で過去に修正済み (commit `5c42868`「未ログイン時にログアウトボタンが表示されるバグを修正」/ `frontend/components/user/UserHeader.tsx` を `{(user || token) && (…ログアウト…)}` でガード、main マージ済み)。しかし新規実装した LIFF v3 `AccountPanel.tsx` (Phase3, `9ca996d`) に同ガードがポートされておらず、618-625 行目でログアウトボタンを**無条件描画**していた (usePrivy() から logout のみ destructure、authenticated 未参照)。
+
+**なぜ未ログインで描画されたか**: staging はブラウザ PWA degrade モード (`NEXT_PUBLIC_LIFF_ID` 未設定)。`(liff)/layout.tsx` の中央 degrade ガードは `liffConfigured && !isLoggedIn && !token` の時のみブロックするため、degrade (`liffConfigured=false`) では意図的に素通しし children を描画する。AccountPanel 側にガードが無いとログアウトが露出する。`liffFetch` の 401→`/liff-login` リダイレクトは API 応答後のため、ボタンが先に見える。
+
+**再発防止ルール**:
+- 認証状態で表示が変わる要素 (ログアウト/削除/設定等の操作系) は、未ログイン時の表示を**コンポーネント自身で必ずガード**する。中央レイアウトの degrade ガードは「素通し」設計なので、これに依存しない。
+- **既存コンポーネントにあるガードは新コンポーネントへ必ずポートする**。「同じ画面・同じ部品の作り直し」時はバグ修正コミット (例 `5c42868`) を `git log -- <旧ファイル>` で確認し踏襲する。
+- CLAUDE.md §標準チェックリスト(UI) に同趣旨の項目を追加済み (毎実装でチェック)。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -802,6 +802,7 @@ claude.ai が Step 0 をスキップして §9 を実行した場合、それは
 ### UI / フロントエンド
 - [ ] 全テキストが日本語（英語ハードコード禁止。ja.jsonにキーがあればそちらを使用）
 - [ ] admin / partner / viewer(tester) の権限分離（role === "admin" で操作系の表示/非表示）
+- [ ] 認証状態で表示が変わる要素（ログアウト/削除/設定等の操作系）は未ログイン時に必ずガード（`{(authenticated || token) && …}`）。新コンポーネントは既存コンポーネントの認証ガードをポートする（例: UserHeader 5c42868 の logout gate を AccountPanel に踏襲。ポート漏れ＝未ログインで「ログアウト」表示の再発要因）
 - [ ] ダミー/ハードコードデータがないこと（value={5.2} のような固定値禁止。データ未取得時は「データなし」表示）
 - [ ] Decimal型（バックエンドからの文字列）→ Number() ラップしてから .toFixed() 等を呼ぶ
 - [ ] recharts → 別ファイルに分離 + dynamic(() => import('./XxxRecharts'), { ssr: false })

--- a/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
@@ -46,7 +46,13 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ""
 
 export function AccountPanel() {
   const router = useRouter()
-  const { logout: privyLogout } = usePrivy()
+  const { logout: privyLogout, authenticated } = usePrivy()
+  // 認証状態。未ログイン時に「ログアウト」/「アカウント削除」等の操作系を出さないためのガード。
+  // backend JWT (getAuthToken) か Privy authenticated のどちらかがあれば「ログイン済み」とみなす
+  // (UserHeader.tsx の {(user||token)&&…} ガード = commit 5c42868 を LIFF v3 にポート)。
+  // token は localStorage 依存で SSR 不可のため、hydration mismatch を避けて useEffect で取得する。
+  const [hasToken, setHasToken] = useState(false)
+  const isAuthed = authenticated || hasToken
   const [userData, setUserData] = useState<UserData | null>(null)
   const [corpExpanded, setCorpExpanded] = useState(false)
   const [corpForm, setCorpForm] = useState<CorpForm>({ name: "", number: "", rep: "", month: 0 })
@@ -69,6 +75,11 @@ export function AccountPanel() {
     setToastMsg(msg)
     setTimeout(() => setToastMsg(""), 2000)
   }
+
+  // backend JWT の有無を client 側で確定（SSR では localStorage 不可）
+  useEffect(() => {
+    setHasToken(!!getAuthToken())
+  }, [])
 
   // ユーザー設定を取得（/api/user/settings + /auth/me を併用）
   useEffect(() => {
@@ -615,25 +626,30 @@ export function AccountPanel() {
         )}
       </div>
 
-      {/* ログアウトボタン */}
-      <button
-        onClick={handleLogout}
-        className="flex items-center gap-3 w-full px-4 py-4 bg-zinc-900 rounded-xl hover:bg-zinc-800 transition-colors"
-      >
-        <LogOut className="w-5 h-5 text-red-400" />
-        <span className="text-red-400 font-medium">ログアウト</span>
-      </button>
+      {/* ログアウト / 削除は認証済みのみ表示（未ログイン時の誤表示を防ぐ） */}
+      {isAuthed && (
+        <>
+          {/* ログアウトボタン */}
+          <button
+            onClick={handleLogout}
+            className="flex items-center gap-3 w-full px-4 py-4 bg-zinc-900 rounded-xl hover:bg-zinc-800 transition-colors"
+          >
+            <LogOut className="w-5 h-5 text-red-400" />
+            <span className="text-red-400 font-medium">ログアウト</span>
+          </button>
 
-      {/* アカウント削除ボタン */}
-      <div className="flex justify-center pb-2">
-        <button
-          onClick={() => setDeleteSheet(true)}
-          className="flex items-center gap-2 px-4 py-2 text-zinc-600 hover:text-zinc-400 transition-colors"
-        >
-          <Trash2 className="w-4 h-4" />
-          <span className="text-xs">アカウントを削除</span>
-        </button>
-      </div>
+          {/* アカウント削除ボタン */}
+          <div className="flex justify-center pb-2">
+            <button
+              onClick={() => setDeleteSheet(true)}
+              className="flex items-center gap-2 px-4 py-2 text-zinc-600 hover:text-zinc-400 transition-colors"
+            >
+              <Trash2 className="w-4 h-4" />
+              <span className="text-xs">アカウントを削除</span>
+            </button>
+          </div>
+        </>
+      )}
 
       {/* 削除確認ボトムシート */}
       {deleteSheet && (

--- a/frontend/e2e/liff-chat-account.spec.ts
+++ b/frontend/e2e/liff-chat-account.spec.ts
@@ -46,6 +46,46 @@ async function openAccountPanel(page: Page): Promise<boolean> {
   return true
 }
 
+// /api/user/settings と /auth/me を 200 で固定する。これにより
+//   - liffFetch の 401→/liff-login リダイレクトを抑止
+//   - 重要事項同意ゲート（terms_version="liff-v3" 一致で accepted）の /liff-confirm リダイレクト抑止
+// が成立し、認証あり/なしのどちらでも AccountPanel を決定的に開ける。
+async function mockUserApis(page: Page): Promise<void> {
+  const settingsBody = JSON.stringify({
+    user_mode: 'managed',
+    terms_version: 'liff-v3',
+    corporate_fiscal_month: null,
+    created_at: '2026-01-01T00:00:00Z',
+    email: 'e2e@example.com',
+    wallet_address: '0x0000000000000000000000000000000000000000',
+  })
+  await page.route('**/api/user/settings*', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: settingsBody }),
+  )
+  await page.route('**/auth/me*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        email: 'e2e@example.com',
+        created_at: '2026-01-01T00:00:00Z',
+        wallet_address: '0x0000000000000000000000000000000000000000',
+      }),
+    }),
+  )
+}
+
+// backend JWT を localStorage に seed し、AccountPanel を「ログイン済み」状態にする。
+async function seedAuthToken(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    try {
+      window.localStorage.setItem('auth_token', 'e2e-fake-jwt')
+    } catch {
+      /* localStorage 不可環境は無視 */
+    }
+  })
+}
+
 test.describe('liff-chat AccountPanel', () => {
   test('アカウントパネルが開きプロフィール/運用情報が表示される', async ({ page }) => {
     const opened = await openAccountPanel(page)
@@ -90,6 +130,9 @@ test.describe('liff-chat AccountPanel', () => {
   })
 
   test('アカウント削除フロー（ボトムシート文言 + 申請/キャンセル）', async ({ page }) => {
+    // 削除は認証済みのみ表示されるため、ログイン状態を seed して開く
+    await mockUserApis(page)
+    await seedAuthToken(page)
     const opened = await openAccountPanel(page)
     test.skip(!opened, 'AccountPanel に到達できない環境')
 
@@ -116,10 +159,27 @@ test.describe('liff-chat AccountPanel', () => {
     await expect(page.getByText('アカウントを削除しますか？')).toBeHidden()
   })
 
-  test('ログアウトボタンが存在する（既存挙動を壊していない）', async ({ page }) => {
+  test('認証済みではログアウト/削除が表示される', async ({ page }) => {
+    await mockUserApis(page)
+    await seedAuthToken(page)
     const opened = await openAccountPanel(page)
     test.skip(!opened, 'AccountPanel に到達できない環境')
 
     await expect(page.getByRole('button', { name: 'ログアウト' })).toBeVisible()
+    await expect(page.getByText('アカウントを削除', { exact: true })).toBeVisible()
+  })
+
+  // 回帰防止: 未ログイン時に「ログアウト」/「アカウント削除」が表示されない
+  // （staging browser PWA degrade で未認証でも表示されたバグ。UserHeader 5c42868 ガードの
+  //  AccountPanel へのポート。Asana 1215522469898102）。
+  test('未認証ではログアウト/削除が表示されない（回帰防止）', async ({ page }) => {
+    // token を seed しない（未ログイン）。API は 200 固定でリダイレクトを抑止し、
+    // パネル自体は開ける状態にしたうえで操作系が出ないことを検証する。
+    await mockUserApis(page)
+    const opened = await openAccountPanel(page)
+    test.skip(!opened, 'AccountPanel に到達できない環境')
+
+    await expect(page.getByRole('button', { name: 'ログアウト' })).toHaveCount(0)
+    await expect(page.getByText('アカウントを削除', { exact: true })).toHaveCount(0)
   })
 })


### PR DESCRIPTION
## 概要
LIFF v3 `/liff-chat` のアカウントパネル（`AccountPanel.tsx`）が、**未ログイン状態（browser PWA degrade）でも「ログアウト」「アカウントを削除」を無条件表示**していたバグを修正する。staging UI テストで発見（2026-06-09）。

## 根本原因
- `AccountPanel.tsx` にはログアウト/削除ボタンの認証ガードが無く、無条件描画していた（`usePrivy()` から `logout` のみ取得、`authenticated` 未参照）。
- 中央 degrade ガード（`(liff)/layout.tsx`）は `liffConfigured && !isLoggedIn && !token` の時のみブロックする設計。staging は browser PWA degrade（`NEXT_PUBLIC_LIFF_ID` 未設定 → `liffConfigured=false`）のため**意図的に素通し**し、ページ側で認証導線を持つ前提。よってコンポーネント自身のガードが必要。
- 同種バグは旧 Web UI で過去に修正済み（commit `5c42868`「未ログイン時にログアウトボタンが表示されるバグを修正」/ `UserHeader.tsx` を `{(user || token) && …}` でガード、main マージ済み）。**新規 LIFF v3 `AccountPanel`（Phase3, `9ca996d`）に同ガードが未ポート**だったための再発（drift）。

## 変更内容
- **`AccountPanel.tsx`**: `isAuthed = Privy authenticated || backend JWT(getAuthToken)` を導入し、「ログアウト」「アカウントを削除」を `{isAuthed && …}` でガード。`token` は localStorage 依存で SSR 不可のため `useEffect` で取得し hydration mismatch を回避。
- **`e2e/liff-chat-account.spec.ts`**: `/api/user/settings` + `/auth/me` を 200 固定して 401／重要事項同意ゲートのリダイレクトを抑止し、**認証あり=表示／認証なし=非表示**を決定的に検証するテストを追加（回帰防止）。既存の削除フローテストにも認証 seed を付与。
- **`CLAUDE.md` 標準チェックリスト(UI)** / **`CLAUDE.lessons.md`**: 「認証状態で表示が変わる要素は未ログイン時に必ずガード／新コンポーネントは既存ガードをポートする」教訓を追記。

## 検証
- [x] `tsc --noEmit` 通過（exit 0）
- [x] `eslint`（変更ファイル）通過（exit 0）
- [ ] **staging 実機**（人間担当 / dev からは staging=prod VPS 同居で不可）: 未ログイン（browser PWA）で `/liff-chat` → ハンバーガー → アカウント を開き、「ログアウト/アカウント削除」が出ないことを Network tab・画面で裏取り
- [ ] PR→main→staging 反映後に再確認

## 関連
- Asana: https://app.asana.com/1/817733952351708/project/1213916581114014/task/1215522469898102

🤖 Generated with [Claude Code](https://claude.com/claude-code)
