### PR TITLE
fix(liff): /liff-login を PWA degrade 対応にし LINE 行き止まりを解消 (v3 PWA blocker)

### DIFF
--- a/frontend/app/(liff)/liff-login/page.tsx
+++ b/frontend/app/(liff)/liff-login/page.tsx
@@ -5,11 +5,13 @@
 
 import { useEffect } from "react";
 import { useLiff } from "@/hooks/useLiff";
+import { BrowserLoginPrompt } from "../_components/BrowserLoginPrompt";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 export default function LiffLoginPage() {
-  const { isReady, isLoggedIn, profile, idToken, error } = useLiff();
+  const { isReady, isLoggedIn, profile, idToken, error, liffConfigured } =
+    useLiff();
 
   useEffect(() => {
     if (!isReady || !isLoggedIn || !idToken || !profile) return;
@@ -50,6 +52,22 @@ export default function LiffLoginPage() {
       <div className="flex items-center justify-center min-h-screen">
         <p className="text-muted-foreground">Loading...</p>
       </div>
+    );
+  }
+
+  // ブラウザ PWA モード (NEXT_PUBLIC_LIFF_ID 未設定 = liffConfigured=false / v3 の本番形態)。
+  // LINE 文脈が無いため idToken ログインは不可。代わりに Privy passwordless の
+  // BrowserLoginPrompt を出す。これにより liffFetch 401 / TaxPanel / TxHistoryPanel /
+  // SessionExpiryBanner 等から /liff-login へ送られたユーザーが、行き止まり
+  // (「LINEアプリから開いてください」) ではなく実際にログインできる入口に着地する。
+  // LINE モード (liffConfigured=true / v4) では従来どおり下の idToken 経路を使う。
+  if (!liffConfigured) {
+    return (
+      <BrowserLoginPrompt
+        onSuccess={() => {
+          window.location.href = "/liff-confirm";
+        }}
+      />
     );
   }
 


### PR DESCRIPTION
## 背景 (v3 PWA launch ブロッカー)

v3 は **PWA 配布**（LINE 申請は v4 / v4 審査落ちなら PWA 継続）のため、`NEXT_PUBLIC_LIFF_ID` 未設定 = `liffConfigured=false`（Privy passwordless）が **v3 の本番モード**。

ところが認証失敗時に複数箇所が LINE 専用の `/liff-login` へ送る：
- `lib/liff/liff-fetch.ts:22` 401→`/liff-login`（無条件）→ これを使う AccountPanel / NotificationPanel / OpModePanel
- `liff-chat/_components/panels/TaxPanel.tsx:49`（DL時401）
- `liff-chat/_components/panels/TxHistoryPanel.tsx:267`（「再ログイン」）
- `(liff)/layout.tsx:101` `SessionExpiryBanner loginHref="/liff-login"`

`/liff-login` は LINE 専用で、PWA では「LINEアプリから開いてください」の**行き止まり**。実テストユーザーが認証要パネルを開いた瞬間に詰む（手動 UAT で発見：`/liff-chat → アカウント → /liff-login → CF Access 行き止まり`）。

## 修正（最小・全件一括）

各パネル/liffFetch を個別に触らず、**`/liff-login` ページ自体を degrade 対応**にする：
- PWA モード（`!liffConfigured`）では `<BrowserLoginPrompt>`（Privy passwordless）を描画し、成功後 `/liff-confirm` へ。
- これにより上記**全ての `/liff-login` 行きリダイレクトが、PWA では実際にログインできる Privy 入口に着地**する。
- LINE モード（`liffConfigured=true` / v4）の idToken 経路は**従来どおり温存**。

approve/history/fee の3ページは既に `if(liffConfigured)?/liff-login:<BrowserLoginPrompt>` でガード済み（修正不要）。本 PR は残りの「無条件 /liff-login 行き」を `/liff-login` ページ側で一括救済する。

## 検証
- `tsc --noEmit` 0 error
- `eslint` 該当ファイル 0 error（既存の useEffect fetch 警告のみ・本変更起因ではない）

## DoD（デプロイ後）
- staging へ `deploy_staging.sh --frontend-only` 反映
- PWA で `/liff-chat → アカウント等` を開いて `/liff-login` 行き止まりにならず Privy「ウォレットでログイン」が出る
- Privy passwordless ログイン → `/liff-confirm` → `/liff-chat` で全パネル表示
- LINE モード（将来 LIFF_ID 投入時）の idToken 経路が壊れていないことをコードレビューで確認

## follow-up（別タスク）
- v3 ホーム `/liff-chat` に初回 Privy サインアップ CTA（現状はパネルを開けば 401→Privy に到達はする）
- ReferralPanel `shareTargetPicker` / TermsPanel `openWindow` の PWA fallback 実挙動確認

Asana: https://app.asana.com/1/817733952351708/project/1213741124336104/task/1215522827291466

🤖 Generated with [Claude Code](https://claude.com/claude-code)