### PR TITLE
fix(pwa): start_url を /liff-login に整合し初回オンボーディングを確実化

### DIFF
--- a/frontend/app/(liff)/liff-login/page.tsx
+++ b/frontend/app/(liff)/liff-login/page.tsx
@@ -6,6 +6,7 @@
 import { useEffect } from "react";
 import { useLiff } from "@/hooks/useLiff";
 import { BrowserLoginPrompt } from "../_components/BrowserLoginPrompt";
+import { getAuthToken } from "@/lib/auth/token-key";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -47,6 +48,19 @@ export default function LiffLoginPage() {
       .catch(console.error);
   }, [isReady, isLoggedIn, idToken, profile]);
 
+  // ブラウザ PWA モード (v3 本番形態) で既に JWT を持つ再訪ユーザーは、毎回
+  // ログイン催促 (BrowserLoginPrompt) を出さずに /liff-chat へ即転送する。
+  // PWA の start_url を /liff-login にしたため、再訪ユーザーが起動するたびに
+  // ここを通る。同意確認は (liff)/layout の terms gate が担保する
+  // (未同意なら /liff-confirm へ誘導)。新規 (token 無し) は下の
+  // BrowserLoginPrompt に着地させ、Privy 登録 → /liff-confirm へ進ませる。
+  useEffect(() => {
+    if (!isReady || liffConfigured) return;
+    if (getAuthToken()) {
+      window.location.href = "/liff-chat";
+    }
+  }, [isReady, liffConfigured]);
+
   if (!isReady) {
     return (
       <div className="flex items-center justify-center min-h-screen">
@@ -62,6 +76,15 @@ export default function LiffLoginPage() {
   // (「LINEアプリから開いてください」) ではなく実際にログインできる入口に着地する。
   // LINE モード (liffConfigured=true / v4) では従来どおり下の idToken 経路を使う。
   if (!liffConfigured) {
+    // 既認証の再訪ユーザーは上の useEffect が /liff-chat へ転送する。
+    // 転送が走るまでの一瞬、ログイン催促を見せないようローディングを出す。
+    if (getAuthToken()) {
+      return (
+        <div className="flex items-center justify-center min-h-screen">
+          <p className="text-muted-foreground">読み込み中...</p>
+        </div>
+      );
+    }
     return (
       <BrowserLoginPrompt
         onSuccess={() => {

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ultra AutoTrade",
   "short_name": "UAT",
   "description": "Automated DeFi trading platform",
-  "start_url": "/",
+  "start_url": "/liff-login",
   "scope": "/",
   "display": "standalone",
   "orientation": "portrait",


### PR DESCRIPTION
## 背景 / 現象
v3 は **PWA のみ**（LIFF/LINE は v4）。初回ユーザーが URL/QR で来訪したとき、想定フローは **Privy 登録（ウォレット作成）→ 利用規約・重要事項チェック → ホーム** で、これは `(liff)` 経路（`/liff-login` → `/liff-confirm` → `/liff-chat`）に実装済み。

しかし **PWA manifest の `start_url` が `"/"`** だったため、インストール済み PWA をホーム画面から起動すると `root → /login`（Web ログイン）へ落ち、`(liff)` 側の初回オンボーディングを通らなかった。

- `/connect`（Privy+規約の別実装）は `UserProviders.tsx:49` の認証ガードで `/login` に弾かれ入口に使えない
- `(liff)/layout.tsx` の auth guard は `liffConfigured && !isLoggedIn && !token` の時のみブロック＝**ブラウザ PWA モード（v3）では未認証でもブロックせず degrade 描画**。terms gate も `!!token` 前提で未認証では発火しない
- → `start_url="/"` のままでは、**新規ユーザーが Privy 登録も法的同意も踏まずにホーム到達し得る**

## 修正（フロントのみ・低リスク / 2ファイル）
- **manifest.json**: `start_url` `"/"` → `"/liff-login"`（`scope` は `"/"` 維持）
- **liff-login/page.tsx**（ブラウザ PWA 分岐）: 既に JWT を持つ**再訪ユーザーは `/liff-chat` へ即転送**し、毎回のログイン催促を回避。**新規（token 無し）のみ `BrowserLoginPrompt`** → `/liff-confirm`（重要事項同意）へ。同意確認は `(liff)/layout` の terms gate が担保

これで PWA 起動時:
- 新規 → `/liff-login` → Privy 登録 → `/liff-confirm`（同意）→ `/liff-chat`（**同意を確実に取得**）
- 再訪（認証済）→ `/liff-chat` 直行（同意未済なら terms gate が `/liff-confirm` へ）

## 検証メモ（正直な但し書き）
- fresh worktree のため**ローカル tsc/build は未実行**。`getAuthToken` の import パス（`@/lib/auth/token-key`）は export 実在を確認済み。型チェックは CI に委ねる
- **実機確認は未**：PWA を再インストール/起動し、新規アカウントで Privy→同意→ホーム、再訪でホーム直行を踏むのが DoD。staging 反映後に要踏破

🤖 Generated with [Claude Code](https://claude.com/claude-code)