### PR TITLE
fix(liff): 入金/出金パネルの残高スピナー無限ループを解消 (apiFetch→liffFetch)

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect, useCallback } from "react"
 import { AlertTriangle, Loader2 } from "lucide-react"
 import { useFundWallet, useWallets } from "@privy-io/react-auth"
 import { base } from "viem/chains"
-import { apiFetch, apiPost } from "@/lib/api/client"
+import { liffFetch } from "@/lib/liff/liff-fetch"
 
 // ---- 型定義 ---------------------------------------------------------------
 
@@ -116,9 +116,18 @@ export function DepositPanel() {
   const fetchBalance = useCallback(async () => {
     setBalanceLoading(true)
     try {
-      const res = await apiFetch<UserSettingsResponse>("/api/user/settings")
-      setBalance(res.balance != null ? Number(res.balance) : null)
-      setWalletAddress(res.wallet_address ?? null)
+      // (liff) パネルは liffFetch を使う。apiFetch は (user) 側 AuthProvider が
+      // resolve する authReadyPromise を待つが、(liff) ツリーには AuthProvider が
+      // 無く永久 pending → リクエストがハングして残高スピナーが止まらない
+      // (Asana 1215524979521648)。兄弟パネルと同じ liffFetch に統一する。
+      const res = await liffFetch("/api/user/settings")
+      if (res.ok) {
+        const data = (await res.json()) as UserSettingsResponse
+        setBalance(data.balance != null ? Number(data.balance) : null)
+        setWalletAddress(data.wallet_address ?? null)
+      } else {
+        setBalance(null)
+      }
     } catch {
       setBalance(null)
     } finally {
@@ -204,9 +213,14 @@ export function DepositPanel() {
     setConfirmBusy(true)
     setConfirmError(null)
     try {
-      await apiPost<{ status: string }>("/api/transactions/withdraw", {
-        amount_usdc: withdrawNum,
+      const res = await liffFetch("/api/transactions/withdraw", {
+        method: "POST",
+        body: JSON.stringify({ amount_usdc: withdrawNum }),
       })
+      if (!res.ok) {
+        const detail = (await res.json().catch(() => null)) as { detail?: string } | null
+        throw new Error(detail?.detail ?? "出金処理に失敗しました")
+      }
       setConfirmOpen(false)
       setSuccessMsg("出金リクエストを送信しました。反映まで少々お待ちください。")
       setWithdrawAmount("")


### PR DESCRIPTION
## 現象
staging UI テストで、入金/出金画面 (liff-chat DepositPanel) の「現在の残高 / 出金可能残高」が「取得中...」スピナーのまま**永遠に回り続ける**。

## 真因（origin/main 実コード）
インフラ起因ではなく**コードのフェッチャ取り違え**。
- `DepositPanel` は `(liff)` 配下なのに **(user) 向けの `apiFetch`** (`@/lib/api/client`) を使用。
- `apiFetch` は本リクエスト前に **`await authReadyPromise`** (client.ts:49-50)。
- `authReadyPromise` は `AuthProvider` 内の `resolveAuthReady()` (auth.ts:106) でしか解決されないが、**`(liff)` ツリーには `AuthProvider` が無い** (grep 0件) → 永久 pending。
- → `getJson` すら呼ばれずハング → `fetchBalance` の `finally` に到達せず `balanceLoading=true` のまま = スピナーが止まらない。
- 兄弟パネル (AccountPanel / NotificationPanel / OpModePanel) は `liffFetch` 使用のため正常。**DepositPanel だけがフェッチャを誤用**していた。

## 修正（フロントのみ・1ファイル）
- `fetchBalance` / `handleWithdrawConfirm` を `apiFetch`/`apiPost` → **`liffFetch`** に置換（兄弟パネルと統一）。
- `liffFetch` は生 `Response` を返すため `res.ok` 判定 + `json()` パースを明示。
- 他の `(liff)` 配下に `apiFetch` 使用箇所が無いことを grep で確認（同型バグの水平展開なし）。

## 既知の残課題（別対応・このPRの範囲外）
ハング解消後、残高は当面 **`---`** 表示になる。理由: `DepositPanel` が読む `/api/user/settings` は `balance`/`wallet_address` を返さない（`UserSettingsResponse` に該当フィールド無し）。一般ユーザー向け残高エンドポイントが未整備（partner の `/api/partner/wallet-balance` は `require_partner` かつ Base mainnet 固定で流用不可）。**残高の実数表示は後続タスク**（一般ユーザー残高 API 新設 or フロントで Privy ウォレットの on-chain 残高直読み）。

## DoD
- [ ] staging 実機: 入金/出金画面で残高がスピナーで固まらない（`---` または実値）ことを確認
- [ ] tsc/CI green
- [ ] 残高実数表示は別タスクで追跡

Refs Asana 1215524979521648

🤖 Generated with [Claude Code](https://claude.com/claude-code)