### PR TITLE
feat(deposit): Privy SDK 3.29.2 + Deposit address 入金フロー対応(日本対応)

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
@@ -15,7 +15,6 @@ interface UserSettingsResponse {
 }
 
 type Tab = "deposit" | "withdraw"
-type PaymentMethod = "card" | "apple" | "google"
 
 // 入金用 JPY → USDC 変換レート（固定近似値）
 const JPY_PER_USDC = 155
@@ -96,7 +95,6 @@ export function DepositPanel() {
 
   // 入金フォーム
   const [depositAmount, setDepositAmount] = useState("")
-  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>("card")
 
   // 出金フォーム
   const [withdrawAmount, setWithdrawAmount] = useState("")
@@ -163,10 +161,10 @@ export function DepositPanel() {
   const estimatedUsdc = depositNum > 0 ? (depositNum / JPY_PER_USDC).toFixed(2) : "0"
 
   const depositRows = [
-    { label: "金額", value: `¥${depositNum.toLocaleString("ja-JP")}` },
+    { label: "入金目安額", value: `¥${depositNum.toLocaleString("ja-JP")}` },
     { label: "概算 USDC", value: `≈ $${estimatedUsdc} USDC` },
-    { label: "支払い方法", value: paymentMethod === "card" ? "クレジット/デビット" : paymentMethod === "apple" ? "Apple Pay" : "Google Pay" },
-    { label: "ネットワーク", value: "Base Mainnet" },
+    { label: "入金方法", value: "取引所・ウォレットから送金" },
+    { label: "着金先ネットワーク", value: "Base Mainnet（自動変換）" },
   ]
 
   const handleDepositConfirm = useCallback(async () => {
@@ -186,7 +184,7 @@ export function DepositPanel() {
         },
       })
       setConfirmOpen(false)
-      setSuccessMsg("入金フローを開始しました。完了後に残高が更新されます。")
+      setSuccessMsg("入金用アドレスを表示しました。送金の着金後に残高が反映されます。")
       void fetchBalance()
     } catch (e) {
       if (e instanceof Error && e.message.toLowerCase().includes("exit")) {
@@ -322,38 +320,18 @@ export function DepositPanel() {
             ))}
           </div>
 
-          {/* 支払い方法 */}
-          <div>
-            <label className="block text-xs text-zinc-400 mb-2">支払い方法</label>
-            <div className="space-y-2">
-              {(
-                [
-                  { id: "card" as PaymentMethod, label: "クレジット/デビット" },
-                  { id: "apple" as PaymentMethod, label: "Apple Pay" },
-                  { id: "google" as PaymentMethod, label: "Google Pay" },
-                ] as { id: PaymentMethod; label: string }[]
-              ).map(({ id, label }) => (
-                <label
-                  key={id}
-                  className={[
-                    "flex items-center gap-3 px-3 py-3 rounded-xl border cursor-pointer transition-colors",
-                    paymentMethod === id
-                      ? "border-[#1D9E75] bg-[#1a3d2e]"
-                      : "border-zinc-700 bg-zinc-800",
-                  ].join(" ")}
-                >
-                  <input
-                    type="radio"
-                    name="payment"
-                    value={id}
-                    checked={paymentMethod === id}
-                    onChange={() => setPaymentMethod(id)}
-                    className="accent-[#1D9E75]"
-                  />
-                  <span className="text-sm text-zinc-200">{label}</span>
-                </label>
-              ))}
-            </div>
+          {/* 入金方法の案内（Privy Deposit address） */}
+          <div className="bg-zinc-800 border border-zinc-700 rounded-xl px-4 py-3 space-y-2">
+            <p className="text-xs font-medium text-zinc-300">入金方法</p>
+            <p className="text-xs text-zinc-400 leading-relaxed">
+              「入金する」を押すと入金用アドレスが表示されます。取引所（例: SBI VCトレード）や
+              お持ちのウォレットから USDC を送金してください。
+            </p>
+            <ul className="text-xs text-zinc-500 leading-relaxed space-y-0.5 list-disc list-inside">
+              <li>Ethereum など別ネットワークの USDC も自動で Base に変換されて着金します</li>
+              <li>少額すぎると送金できない場合があります（目安: 数十ドル以上）</li>
+              <li>入力した金額は送金額の目安です（実際の送金額はご自身で指定します）</li>
+            </ul>
           </div>
 
           {/* 入金ボタン */}

--- a/frontend/app/user/deposit/DepositContent.tsx
+++ b/frontend/app/user/deposit/DepositContent.tsx
@@ -179,13 +179,13 @@ export function DepositContent() {
         </CardHeader>
         <CardContent className="space-y-3">
           <p className="text-sm text-muted-foreground">
-            クレジットカードや銀行振込でUSDCを直接あなたのウォレットに入金できます。
+            取引所（例: SBI VCトレード）やお持ちのウォレットから USDC を送金して入金できます。
             資産はサーバーには預けられず、あなたのウォレットに直接届きます。
           </p>
           <div className="rounded-lg bg-muted/50 px-3 py-2 text-xs text-muted-foreground space-y-1">
             <p>・入金先: あなた自身のウォレット（ノンカストディアル）</p>
             <p>・推奨金額: ${DEPOSIT_GATE_USD} USDC 以上</p>
-            <p>・対応チェーン: {chain?.name ?? 'Base'}</p>
+            <p>・着金チェーン: {chain?.name ?? 'Base'}（別ネットワークの USDC も自動変換）</p>
           </div>
           <Button
             className="w-full"
@@ -201,7 +201,7 @@ export function DepositContent() {
             ) : (
               <>
                 <ArrowDownToLine className="mr-2 h-4 w-4" />
-                入金する（Privy）
+                入金アドレスを表示
               </>
             )}
           </Button>
@@ -217,8 +217,8 @@ export function DepositContent() {
       </Card>
 
       <p className="text-center text-xs text-muted-foreground px-4">
-        入金はPrivyの安全なオンランプ経由で処理されます。
-        手数料はProviderにより異なります。
+        入金はPrivyの入金アドレス経由で処理され、別チェーンの USDC は自動でブリッジされます。
+        ネットワーク・ブリッジ手数料がかかる場合があります。
       </p>
     </div>
   )

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -67,10 +67,13 @@ const nextConfig = {
     };
     // Privy の optional な Solana / Farcaster 依存をスタブ（未使用）
     // porto は package.json から削除済み。wagmi/connectors 内部参照をスタブ化
+    // @stripe/crypto は react-auth 3.29 の FiatOnrampScreen(Stripe Bridge onramp)用の
+    // optional peer dep。日本は Deposit address 方式で Stripe Bridge は未使用のためスタブ化。
     config.resolve.alias = {
       ...config.resolve.alias,
       '@solana/wallet-adapter-react': false,
       '@farcaster/miniapp-sdk': false,
+      '@stripe/crypto': false,
       'porto': false,
       'porto/internal': false,
     };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@farcaster/mini-app-solana": "^2.0.0",
         "@line/liff": "^2.28.0",
-        "@privy-io/react-auth": "^3.21.0",
+        "@privy-io/react-auth": "^3.29.2",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -4817,9 +4817,9 @@
       }
     },
     "node_modules/@privy-io/api-base": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@privy-io/api-base/-/api-base-1.8.3.tgz",
-      "integrity": "sha512-wMOtQZBN/j+jufy4FxR9iHMx/DpxhJIRyFFIKOFPsL+ueGyI2GDhDldkOlTpfldGNL1VDgdgJGRDD82hTUrZ2w==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@privy-io/api-base/-/api-base-1.9.0.tgz",
+      "integrity": "sha512-8OJ2chadFcgUwr+Kqim0z5paIdadEdMH8pW94WJz0O3s2X4aX7vhN1eqiNZqcdgSIk9FHm8c3A+/epJUwiTYuQ==",
       "dependencies": {
         "zod": "^3.24.3"
       }
@@ -4834,181 +4834,67 @@
       }
     },
     "node_modules/@privy-io/api-types": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@privy-io/api-types/-/api-types-0.8.0.tgz",
-      "integrity": "sha512-+4qHNYRlekl6DZAwLB6ARiZJzpMBwmjQxAjdQ2zrhWnK2SL2pUGub17N7wQL5h5AZXzkVKaFmFc0I3ckNn+/NQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@privy-io/api-types/-/api-types-0.15.0.tgz",
+      "integrity": "sha512-VT5/Wau37+ZRaVZ8CPa224z5qcJTeaQtamq6TfOcPJSdV6cNyX+Phlaeg13xFLjj3dIGkqibZvr0f45VT6PX3A==",
       "license": "Apache-2.0"
     },
     "node_modules/@privy-io/are-addresses-equal": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@privy-io/are-addresses-equal/-/are-addresses-equal-0.0.3.tgz",
-      "integrity": "sha512-1nR9Rb5qYETTFKGrkYVVPuBQNnInaBkzPk38yzQ5okw/IwOQdfQIyU+xs5X0B0E/9SJxJrnqypamuaeH95NFZA==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@privy-io/are-addresses-equal/-/are-addresses-equal-0.0.8.tgz",
+      "integrity": "sha512-KbRu4jGE47edxz1xAmpA5e9wMOxT1bnhgu1kVhLyr7AY1shAkEb7GMteyPTB6iis9AXGuMd/JtQk4yfdHqWp5g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "viem": "2.47.4"
-      }
-    },
-    "node_modules/@privy-io/are-addresses-equal/node_modules/@adraffy/ens-normalize": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
-      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
-      "license": "MIT"
-    },
-    "node_modules/@privy-io/are-addresses-equal/node_modules/@noble/curves": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
-      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@privy-io/are-addresses-equal/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@privy-io/are-addresses-equal/node_modules/ox": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.5.tgz",
-      "integrity": "sha512-HgmHmBveYO40H/R3K6TMrwYtHsx/u6TAB+GpZlgJCoW0Sq5Ttpjih0IZZiwGQw7T6vdW4IAyobYrE2mdAvyF8Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "^1.11.0",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "1.9.1",
-        "@noble/hashes": "^1.8.0",
-        "@scure/bip32": "^1.7.0",
-        "@scure/bip39": "^1.6.0",
-        "abitype": "^1.2.3",
-        "eventemitter3": "5.0.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@privy-io/are-addresses-equal/node_modules/viem": {
-      "version": "2.47.4",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.4.tgz",
-      "integrity": "sha512-h0Wp/SYmJO/HB4B/em1OZ3W1LaKrmr7jzaN7talSlZpo0LCn0V6rZ5g923j6sf4VUSrqp/gUuWuHFc7UcoIp8A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "1.9.1",
-        "@noble/hashes": "1.8.0",
-        "@scure/bip32": "1.7.0",
-        "@scure/bip39": "1.6.0",
-        "abitype": "1.2.3",
-        "isows": "1.0.7",
-        "ox": "0.14.5",
-        "ws": "8.18.3"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@privy-io/are-addresses-equal/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+        "viem": "2.52.0"
       }
     },
     "node_modules/@privy-io/chains": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@privy-io/chains/-/chains-0.1.4.tgz",
-      "integrity": "sha512-wdZchhDE9cpqDevgJL8DFimdb5s68kjz53mmAPgFR/gy7KAtk6rDV+1xRNee9zAUNJ0cCbHgneRsvPXgbwHVig==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@privy-io/chains/-/chains-0.3.0.tgz",
+      "integrity": "sha512-27dTj94S4PbyiJuknRuqXzYZSqbk62y2Ht/8ppSNlsaIswxrso9uE8w5PKX82zNyz7crHRULfxDPv2xM2ZXHTg==",
       "license": "Apache-2.0"
     },
     "node_modules/@privy-io/encoding": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@privy-io/encoding/-/encoding-0.1.2.tgz",
-      "integrity": "sha512-gCGVP5IRqCAmPJgHxWsrxNLcgN2nYUjLqa0TxbZ8I77hY5wKUgpleZJnWqayRjp1BZok0zdttYCN4l0NwNWfKA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@privy-io/encoding/-/encoding-0.1.3.tgz",
+      "integrity": "sha512-tvSuC0umDmkfmdKe339P/IZzqh04y7WQ7fOB5iU0aQoxdEivjO0hAD4GHxNOTdn9be9hS2WfIp7u/q6h7ZvvTg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.2.6"
       }
     },
     "node_modules/@privy-io/ethereum": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@privy-io/ethereum/-/ethereum-0.0.10.tgz",
-      "integrity": "sha512-aJX0+1D3rp33x5wn1+Relio4v6j9s2MJ9ApC+FRvyLYu3ClQ4Kj6jRsM/qO2MQsUXS2HqK+UAZPIWA4UtzwtaA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@privy-io/ethereum/-/ethereum-0.1.4.tgz",
+      "integrity": "sha512-YuxGO18eY9miw2CyyxOugOOSoFnsg0uM3KU3/bUwRZmIdOQzzyOuSV2ZoOJmZs2H4u5ofuI4vunjgqw1wOM3ng==",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "viem": "2.47.4"
+        "viem": "2.52.0"
       }
     },
     "node_modules/@privy-io/js-sdk-core": {
-      "version": "0.60.8",
-      "resolved": "https://registry.npmjs.org/@privy-io/js-sdk-core/-/js-sdk-core-0.60.8.tgz",
-      "integrity": "sha512-InRybWnVHD4IM6sXaWw9ZeYqnKhSk7EQNholprTR8mJFId3mwWrf0FtlrhR/2i55pqX7klCLACAS5NC6YAgbOA==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@privy-io/js-sdk-core/-/js-sdk-core-0.67.0.tgz",
+      "integrity": "sha512-v9QI/hnucgCHykQutkQd807/bm6NvqNnzf+9fBUwVO1QNFoyOd7aGQ9jDCK441hp5Ecl1EzLs2LARihauJ4RCQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@privy-io/api-base": "1.8.3",
-        "@privy-io/api-types": "0.8.0",
-        "@privy-io/chains": "0.1.4",
-        "@privy-io/ethereum": "0.0.10",
-        "@privy-io/routes": "0.0.10",
+        "@privy-io/api-base": "1.9.0",
+        "@privy-io/api-types": "0.15.0",
+        "@privy-io/chains": "0.3.0",
+        "@privy-io/encoding": "0.1.3",
+        "@privy-io/ethereum": "0.1.4",
+        "@privy-io/routes": "0.2.4",
         "canonicalize": "^2.0.0",
         "eventemitter3": "^5.0.1",
         "fetch-retry": "^6.0.0",
         "jose": "^4.15.5",
         "js-cookie": "^3.0.5",
         "libphonenumber-js": "^1.10.44",
-        "set-cookie-parser": "^2.6.0",
-        "uuid": ">=8 <10"
+        "set-cookie-parser": "^2.6.0"
       },
       "peerDependencies": {
         "permissionless": "^0.2.47",
-        "viem": "2.47.4"
+        "viem": "2.52.0"
       },
       "peerDependenciesMeta": {
         "permissionless": {
@@ -5020,15 +4906,15 @@
       }
     },
     "node_modules/@privy-io/popup": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@privy-io/popup/-/popup-0.0.3.tgz",
-      "integrity": "sha512-wmh0uv87pRre832JFaVjbaJlzA4ogoz8sTrvGjpUa3ye/1ZJzR2W4qAJieXXPeHubaak9k45JfWwu4uVMIkKLw==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@privy-io/popup/-/popup-0.0.4.tgz",
+      "integrity": "sha512-Lk5BqB//F9naVOR9tkHbrcGs55fM4ILS50tdsgIQ76Kr9i7Og4Ob5IRGIKb75P11f5hXTwAjMezRmWM/7uAsrw==",
       "license": "Apache-2.0"
     },
     "node_modules/@privy-io/react-auth": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@privy-io/react-auth/-/react-auth-3.21.0.tgz",
-      "integrity": "sha512-bO+e5owmOEUPasxDqZNiA7KQZNzF4AHW3iKyIw22ZYSWlEDqKbiW/2K1qmk1h0nAcNcXmmaSLUtE5/WwFjy/sA==",
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@privy-io/react-auth/-/react-auth-3.29.2.tgz",
+      "integrity": "sha512-ADvifcZaIeXfLOTc+JvTAti0uYx2bMrjMGLlfwQWmkwuKw+KG9mUHzq43uf7vIebIweZG/Z82HRkKc+g0Oksfg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@base-org/account": "^1.1.0",
@@ -5038,15 +4924,15 @@
         "@headlessui/react": "^2.2.0",
         "@heroicons/react": "^2.1.1",
         "@marsidev/react-turnstile": "^1.3.1",
-        "@privy-io/api-base": "1.8.3",
-        "@privy-io/api-types": "0.8.0",
-        "@privy-io/are-addresses-equal": "0.0.3",
-        "@privy-io/chains": "0.1.4",
-        "@privy-io/encoding": "0.1.2",
-        "@privy-io/ethereum": "0.0.10",
-        "@privy-io/js-sdk-core": "0.60.8",
-        "@privy-io/popup": "0.0.3",
-        "@privy-io/routes": "0.0.10",
+        "@privy-io/api-base": "1.9.0",
+        "@privy-io/api-types": "0.15.0",
+        "@privy-io/are-addresses-equal": "0.0.8",
+        "@privy-io/chains": "0.3.0",
+        "@privy-io/encoding": "0.1.3",
+        "@privy-io/ethereum": "0.1.4",
+        "@privy-io/js-sdk-core": "0.67.0",
+        "@privy-io/popup": "0.0.4",
+        "@privy-io/routes": "0.2.4",
         "@privy-io/urls": "0.0.4",
         "@scure/base": "^1.2.5",
         "@simplewebauthn/browser": "^13.2.2",
@@ -5068,10 +4954,9 @@
         "styled-components": "^6.1.13",
         "stylis": "^4.3.4",
         "tinycolor2": "^1.6.0",
-        "uuid": ">=8 <10",
-        "viem": "2.47.4",
+        "viem": "2.52.0",
         "x402": "^0.7.1",
-        "zustand": "^5.0.0"
+        "zustand": "^5.0.4"
       },
       "peerDependencies": {
         "@abstract-foundation/agw-client": "^1.0.0",
@@ -5080,6 +4965,7 @@
         "@solana-program/system": ">=0.8.0",
         "@solana-program/token": ">=0.6.0",
         "@solana/kit": ">=3.0.3",
+        "@stripe/crypto": ">=0.1.0",
         "permissionless": "^0.2.47",
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19"
@@ -5101,6 +4987,9 @@
           "optional": true
         },
         "@solana/kit": {
+          "optional": true
+        },
+        "@stripe/crypto": {
           "optional": true
         },
         "permissionless": {
@@ -5420,121 +5309,42 @@
         "multiformats": "^9.4.2"
       }
     },
-    "node_modules/@privy-io/react-auth/node_modules/viem": {
-      "version": "2.47.4",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.4.tgz",
-      "integrity": "sha512-h0Wp/SYmJO/HB4B/em1OZ3W1LaKrmr7jzaN7talSlZpo0LCn0V6rZ5g923j6sf4VUSrqp/gUuWuHFc7UcoIp8A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "1.9.1",
-        "@noble/hashes": "1.8.0",
-        "@scure/bip32": "1.7.0",
-        "@scure/bip39": "1.6.0",
-        "abitype": "1.2.3",
-        "isows": "1.0.7",
-        "ox": "0.14.5",
-        "ws": "8.18.3"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@privy-io/react-auth/node_modules/viem/node_modules/@noble/curves": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
-      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@privy-io/react-auth/node_modules/viem/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+    "node_modules/@privy-io/react-auth/node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
       "license": "MIT",
       "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@privy-io/react-auth/node_modules/viem/node_modules/ox": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.5.tgz",
-      "integrity": "sha512-HgmHmBveYO40H/R3K6TMrwYtHsx/u6TAB+GpZlgJCoW0Sq5Ttpjih0IZZiwGQw7T6vdW4IAyobYrE2mdAvyF8Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "^1.11.0",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "1.9.1",
-        "@noble/hashes": "^1.8.0",
-        "@scure/bip32": "^1.7.0",
-        "@scure/bip39": "^1.6.0",
-        "abitype": "^1.2.3",
-        "eventemitter3": "5.0.1"
+        "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "typescript": ">=5.4.0"
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
       },
       "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@privy-io/react-auth/node_modules/viem/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
+        "@types/react": {
           "optional": true
         },
-        "utf-8-validate": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
           "optional": true
         }
       }
     },
     "node_modules/@privy-io/routes": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@privy-io/routes/-/routes-0.0.10.tgz",
-      "integrity": "sha512-tJXhDEm1pkU4lW1AfOjjSIbaWFnA2Le624n5hlhjj5M61U4Xo7afIuuYOn3scXjq773T3ZTJd+hAgfCTOw6yEA==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@privy-io/routes/-/routes-0.2.4.tgz",
+      "integrity": "sha512-rPb9z8q7gYSp4ip9I9wuISzf6oo4rTcu3VLmNvRmU4hXfEDzZ2qZhBIwLwwPPvxH+P2pAyaVhlKwV7jOKaeS7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@privy-io/api-types": "0.8.0"
+        "@privy-io/api-types": "0.15.0"
       }
     },
     "node_modules/@privy-io/urls": {
@@ -16323,13 +16133,10 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "license": "MIT"
     },
     "node_modules/js-sha3": {
       "version": "0.8.0",
@@ -16563,9 +16370,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.12.41",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.41.tgz",
-      "integrity": "sha512-lsmMmGXBxXIK/VMLEj0kL6MtUs1kBGj1nTCzi6zgQoG1DEwqwt2DQyHxcLykceIxAnfE3hya7NuIh6PpC6S3fA==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.6.tgz",
+      "integrity": "sha512-NdB6O6QvlGMCoG003m0YIKG2+Xw7DjmCZhmc1RH+K6HncADUbRf8TZeLegxBBN1VFyPHcNpPTKpIhYLXzJVy1Q==",
       "license": "MIT"
     },
     "node_modules/lilconfig": {
@@ -20563,9 +20370,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.47.6",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.6.tgz",
-      "integrity": "sha512-zExmbI99NGvMdYa7fmqSTLgkwh48dmhgEqFrUgkpL4kfG4XkVefZ8dZqIKVUhZo6Uhf0FrrEXOsHm9LUyIvI2Q==",
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.52.0.tgz",
+      "integrity": "sha512-py2QPYe9e1f4DmPJCsXF7zHmyZ0PkJrBxdQZ5dvNXvzy3UzWkUn7dNfC0TMeNm6Qv1tKw3b6qXXExpx6L0oMbw==",
       "funding": [
         {
           "type": "github",
@@ -20580,8 +20387,8 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.7",
-        "ws": "8.18.3"
+        "ox": "0.14.27",
+        "ws": "8.20.1"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -20626,9 +20433,9 @@
       }
     },
     "node_modules/viem/node_modules/ox": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.7.tgz",
-      "integrity": "sha512-zSQ/cfBdolj7U4++NAvH7sI+VG0T3pEohITCgcQj8KlawvTDY4vGVhDT64Atsm0d6adWfIYHDpu88iUBMMp+AQ==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.27.tgz",
+      "integrity": "sha512-+xhLHo/f+f4BH121/1Pomm/1vgBBda1wYiFpTvjSo8o5OcEj76Pf1hGPJiepoYMTQoTm2SKdSBvWkFWk5l07PA==",
       "funding": [
         {
           "type": "github",
@@ -20656,9 +20463,9 @@
       }
     },
     "node_modules/viem/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@farcaster/mini-app-solana": "^2.0.0",
     "@line/liff": "^2.28.0",
-    "@privy-io/react-auth": "^3.21.0",
+    "@privy-io/react-auth": "^3.29.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",


### PR DESCRIPTION
## 背景
staging UI テストで `/liff-chat` の入金がカード/Apple Pay/Google Pay で `Wallet funding is not enabled` になる件の根本対応。調査の結論:

- Privy のカード onramp は **MoonPay / Coinbase の2社のみ**で、**両方とも日本(JP)を除外**(Coinbase 公式FAQ「available in all countries which Coinbase operates except Japan」)。→ 日本ではカード入金は構造的に不可能。
- **Meld** はインストール版 3.21.0 でも最新 3.29.2 でも **react-auth に未実装**(バンドルに meld 文字列なし)。SDK 経由では使えない。
- **Deposit address**(任意取引所/ウォレットから USDC 送付 → Privy が Base へ自動ブリッジ)は **3.29.2 で新規実装**(`DepositAddressScreen` / `use-deposit-address` / method=`manual`)。3.21.0 には無いため有効化しても throw していた。→ **日本で動く唯一の現実解**。SBI VC Trade の Ethereum USDC も自動で Base 化されて救済される。

## 変更
- `@privy-io/react-auth` `^3.21.0` → `^3.29.2`（Deposit address 対応版）。lockfile 更新。
- `next.config.js`: `@stripe/crypto`（3.29 の Stripe Bridge onramp 用 optional peer dep・日本では未使用）を既存スタブ群に追加。初回ビルドの `Module not found` を解消。
- `DepositPanel.tsx`(LIFF) / `DepositContent.tsx`(/user/deposit): JP 非対応の支払い方法（card/Apple Pay/Google Pay）セレクタを撤去し、取引所/ウォレットからの USDC 送金 + 自動ブリッジの案内へ差し替え（現状 paymentMethod は MoonPay に渡されておらず見た目だけだった）。

## 検証
- `tsc --noEmit` 通過（SDK 3.21→3.29 で既存 `useFundWallet`/`useWallets` API 破壊なし）
- `next build` 成功

## 残（このPR外 / 人間・デプロイ側）
- staging デプロイ（`deploy_staging.sh` 経由）
- Privy ダッシュボードで Deposit address 有効化（済）/ MoonPay OFF のまま
- **通常 Safari で `/liff-chat` 実機テスト**（DepositAddressScreen 描画・ネットワーク/トークン選択→入金アドレス+QR→着金まで）= 最終 E2E
- バックエンド連動は別チケット [BE] 1215576083312226（Privy webhook 受信・deposit transaction 記録・$200 gate サーバ判定・tier/referral 連動）

Asana: [FE] https://app.asana.com/1/817733952351708/project/1213916581114014/task/1215582493593845

🤖 Generated with [Claude Code](https://claude.com/claude-code)