### PR TITLE
fix(opmode): 運用モード切替を viewer 等エンドユーザーにセルフサービス開放

### DIFF
--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -24,7 +24,6 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from web3 import Web3
 
-from .constants import ExecutionPolicy
 from .models import User, UserRole
 from .schemas import (
     OpenRegisterRequest,
@@ -220,26 +219,6 @@ class AuthService:
             return None
         return user
 
-    @staticmethod
-    def _validate_viewer_no_autoexec(role: str, execution_policy: str) -> None:
-        """viewer ロールに auto_execute を設定しようとした場合に ValueError を送出する。
-
-        viewer は自動執行の権限を持たない設計のため、role=viewer かつ
-        execution_policy=auto_execute の組み合わせは app 層で拒否する。
-
-        Args:
-            role: 設定しようとするロール文字列
-            execution_policy: 設定しようとする (または現在の) execution_policy 文字列
-
-        Raises:
-            ValueError: viewer ロールに auto_execute が指定された場合
-        """
-        if role == UserRole.VIEWER.value and execution_policy == ExecutionPolicy.AUTO_EXECUTE.value:
-            raise ValueError(
-                "viewer role cannot have auto_execute execution_policy. "
-                "Use require_approval or proposal_only instead."
-            )
-
     @classmethod
     def create_user(
         cls,
@@ -263,7 +242,6 @@ class AuthService:
 
         Raises:
             ValueError: メールまたはユーザー名が既に使用されている場合
-            ValueError: viewer ロールに auto_execute を設定しようとした場合
         """
         # 重複チェック
         if cls.get_user_by_email(db, request.email):
@@ -274,14 +252,6 @@ class AuthService:
         # UserCreateRequest の場合はロールを取得
         if isinstance(request, UserCreateRequest):
             role = request.role.value
-
-        # viewer + auto_execute の組み合わせを拒否 (防御的チェック)。
-        # UserCreateRequest に execution_policy フィールドは存在しないため、
-        # 作成時に auto_execute が渡ってくることはない。将来フィールド追加に備え、
-        # また P3-1 (default を require_approval に変更) 後の安全確保のため明示チェック。
-        # 作成経路では require_approval を安全側 effective_policy として評価する。
-        effective_policy = ExecutionPolicy.REQUIRE_APPROVAL.value
-        cls._validate_viewer_no_autoexec(role, effective_policy)
 
         user = User(
             email=request.email,
@@ -325,7 +295,6 @@ class AuthService:
 
         Raises:
             ValueError: メールまたはユーザー名が既に使用されている場合
-            ValueError: viewer ロールへの変更時にユーザーの execution_policy が auto_execute の場合
         """
         if email and email != user.email:
             if cls.get_user_by_email(db, email):
@@ -341,10 +310,6 @@ class AuthService:
             user.hashed_password = cls.hash_password(password)
 
         if role is not None:
-            # viewer ロールへの変更時は auto_execute を禁止する。
-            # 降格後も execution_policy が auto_execute のままだと設計違反になるため拒否。
-            # 管理者側は先に execution_policy を変更してから role を変更すること。
-            cls._validate_viewer_no_autoexec(role, user.execution_policy)
             user.role = role
 
         if is_active is not None:

--- a/backend/app/users/settings_router.py
+++ b/backend/app/users/settings_router.py
@@ -92,12 +92,9 @@ def update_user_settings(
                 detail="max_daily_trade_usd must be positive",
             )
         current_user.max_daily_trade_usd = request.max_daily_trade_usd
-    if request.user_mode is not None or request.execution_policy is not None:
-        if current_user.role not in (UserRole.ADMIN.value, UserRole.PARTNER.value):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="execution policy change is not allowed for this role",
-            )
+    # user_mode は本人によるセルフサービス変更（role 制限なし）。
+    # LIFF 運用モード画面でエンドユーザー（viewer）が自分の運用モードを
+    # 「完全おまかせ(managed)/アクティブ(active)」で切り替えられるようにする。
     if request.user_mode is not None:
         if request.user_mode not in _USER_MODE_TO_POLICY:
             raise HTTPException(
@@ -106,7 +103,13 @@ def update_user_settings(
             )
         current_user.user_mode = request.user_mode
         current_user.execution_policy = _USER_MODE_TO_POLICY[request.user_mode]
+    # execution_policy の直接指定は admin/partner のみ（低レベル操作のため温存）。
     if request.execution_policy is not None:
+        if current_user.role not in (UserRole.ADMIN.value, UserRole.PARTNER.value):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="execution policy change is not allowed for this role",
+            )
         if request.execution_policy not in ExecutionPolicy.values():
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/backend/tests/test_user_settings_role_auth.py
+++ b/backend/tests/test_user_settings_role_auth.py
@@ -117,18 +117,35 @@ def test_partner_can_revert_to_active(client: TestClient) -> None:
     assert r.json()["execution_policy"] == "require_approval"
 
 
-def test_viewer_cannot_update_user_mode(client: TestClient) -> None:
-    """viewerロールは user_mode 変更が 403 になること。"""
+def test_viewer_can_update_user_mode(client: TestClient) -> None:
+    """viewerロールも user_mode を本人セルフサービスで変更できること。
+
+    LIFF 運用モード画面でエンドユーザー（viewer）が「完全おまかせ(managed)/
+    アクティブ(active)」を自分で切り替えられる必要があるため、user_mode 変更は
+    role 制限なし。execution_policy も user_mode に追従して更新される。
+    """
     admin_token = _register_admin(client)
     token = _create_user_with_role(client, admin_token, "viewer_mode@example.com", "viewer")
 
+    # active へ切替
+    r = client.put(
+        "/api/user/settings",
+        json={"user_mode": "active"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["user_mode"] == "active"
+    assert data["execution_policy"] == "require_approval"
+
+    # managed（完全おまかせ = auto_execute）へも切替可能
     r = client.put(
         "/api/user/settings",
         json={"user_mode": "managed"},
         headers={"Authorization": f"Bearer {token}"},
     )
-    assert r.status_code == 403
-    assert "execution policy" in r.json()["detail"].lower()
+    assert r.status_code == 200, r.text
+    assert r.json()["execution_policy"] == "auto_execute"
 
 
 def test_viewer_cannot_update_execution_policy_directly(client: TestClient) -> None:

--- a/backend/tests/test_viewer_no_autoexec_guard.py
+++ b/backend/tests/test_viewer_no_autoexec_guard.py
@@ -1,12 +1,16 @@
 # Copyright (c) Ultra AutoTrade. All rights reserved.
 # backend/tests/test_viewer_no_autoexec_guard.py
-"""P3-2: viewer ロール + auto_execute 組み合わせ拒否ガードのテスト。
+"""viewer ロール + auto_execute の許可テスト。
 
-GID 1214993061793196 (P0) 対応。
-- viewer + auto_execute → 拒否 (400)
-- admin/partner + auto_execute → 許可
-- viewer + require_approval / proposal_only → 許可
-- 既存ユーザーを viewer に降格する際に auto_execute のままなら拒否 (400)
+旧 P3-2 (GID 1214993061793196) では viewer + auto_execute を拒否していたが、
+LIFF 運用モード画面でエンドユーザー（viewer）が自分で「完全おまかせ(managed =
+auto_execute)/アクティブ(active)」を切り替えられるようにする方針変更に伴い、
+viewer + auto_execute 拒否ガードは撤廃した。
+
+現仕様:
+- viewer も user_mode 変更（auto_execute を含む）を本人セルフサービスで実行可能
+- viewer/admin/partner いずれの作成も成功
+- auto_execute を持つユーザーを viewer に降格しても許可される
 """
 
 import os
@@ -94,71 +98,22 @@ def _login(client: TestClient, email: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# _validate_viewer_no_autoexec 単体テスト（service layer）
-# ---------------------------------------------------------------------------
-
-
-class TestValidateViewerNoAutoexec:
-    """AuthService._validate_viewer_no_autoexec の直接テスト。"""
-
-    def test_viewer_auto_execute_raises(self) -> None:
-        """viewer + auto_execute → ValueError。"""
-        from app.auth.service import AuthService
-
-        with pytest.raises(ValueError, match="auto_execute"):
-            AuthService._validate_viewer_no_autoexec("viewer", "auto_execute")
-
-    def test_viewer_require_approval_ok(self) -> None:
-        """viewer + require_approval → 正常。"""
-        from app.auth.service import AuthService
-
-        AuthService._validate_viewer_no_autoexec("viewer", "require_approval")  # no raise
-
-    def test_viewer_proposal_only_ok(self) -> None:
-        """viewer + proposal_only → 正常。"""
-        from app.auth.service import AuthService
-
-        AuthService._validate_viewer_no_autoexec("viewer", "proposal_only")  # no raise
-
-    def test_admin_auto_execute_ok(self) -> None:
-        """admin + auto_execute → 正常。"""
-        from app.auth.service import AuthService
-
-        AuthService._validate_viewer_no_autoexec("admin", "auto_execute")  # no raise
-
-    def test_partner_auto_execute_ok(self) -> None:
-        """partner + auto_execute → 正常。"""
-        from app.auth.service import AuthService
-
-        AuthService._validate_viewer_no_autoexec("partner", "auto_execute")  # no raise
-
-    def test_editor_auto_execute_ok(self) -> None:
-        """editor + auto_execute → 正常。"""
-        from app.auth.service import AuthService
-
-        AuthService._validate_viewer_no_autoexec("editor", "auto_execute")  # no raise
-
-
-# ---------------------------------------------------------------------------
 # API integration tests: ユーザー作成
 # ---------------------------------------------------------------------------
 
 
-class TestCreateUserGuard:
+class TestCreateUser:
     def test_create_viewer_gets_require_approval_default(self, client: TestClient) -> None:
-        """viewer ユーザー作成時、デフォルトで require_approval になること。"""
+        """viewer ユーザー作成時、デフォルトで require_approval になること。
+
+        既定値は安全側の require_approval のまま（auto_execute はユーザーが
+        運用モード画面で能動的に「完全おまかせ」を選んだ場合のみ）。
+        """
         admin_token = _register_admin(client)
         r = _create_user(client, admin_token, "viewer_create@example.com", "viewer")
         assert r.status_code in (200, 201), f"Expected 200/201, got {r.status_code}: {r.text}"
-        # DB デフォルト (require_approval) が適用される
         data = r.json()
-        assert (
-            data["execution_policy"]
-            in (
-                "require_approval",
-                "auto_execute",  # DB側のdefaultが古い環境では auto_execute の可能性もあるが P3-1 後は require_approval
-            )
-        )
+        assert data["execution_policy"] in ("require_approval", "auto_execute")
 
     def test_create_admin_succeeds(self, client: TestClient) -> None:
         """admin ユーザー作成は常に成功すること。"""
@@ -174,21 +129,43 @@ class TestCreateUserGuard:
 
 
 # ---------------------------------------------------------------------------
-# API integration tests: ユーザーロール更新（降格ガード）
+# API integration tests: viewer の auto_execute セルフサービス
 # ---------------------------------------------------------------------------
 
 
-class TestUpdateUserRoleGuard:
-    def test_demote_admin_with_auto_execute_to_viewer_rejected(self, client: TestClient) -> None:
-        """auto_execute を持つ admin を viewer に降格しようとすると 400 になること。"""
+class TestViewerAutoExecuteAllowed:
+    def test_viewer_can_set_managed_auto_execute(self, client: TestClient) -> None:
+        """viewer が運用モードを managed（= auto_execute）に切り替えられること。"""
+        admin_token = _register_admin(client)
+        r = _create_user(client, admin_token, "viewer_autoexec@example.com", "viewer")
+        assert r.status_code in (200, 201)
+
+        token = _login(client, "viewer_autoexec@example.com")
+        r = client.put(
+            "/api/user/settings",
+            json={"user_mode": "managed"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["user_mode"] == "managed"
+        assert data["execution_policy"] == "auto_execute"
+
+
+# ---------------------------------------------------------------------------
+# API integration tests: ユーザーロール更新（降格は auto_execute でも許可）
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateUserRole:
+    def test_demote_admin_with_auto_execute_to_viewer_allowed(self, client: TestClient) -> None:
+        """auto_execute を持つ admin を viewer に降格しても許可されること（ガード撤廃後）。"""
         admin_token = _register_admin(client)
 
-        # 新しい admin ユーザーを作成（admin は auto_execute がデフォルト設定可能）
         r = _create_user(client, admin_token, "admin_to_demote@example.com", "admin")
         assert r.status_code in (200, 201)
         user_id = r.json()["id"]
 
-        # admin の execution_policy を auto_execute に設定
         target_token = _login(client, "admin_to_demote@example.com")
         r = client.put(
             "/api/user/settings",
@@ -198,16 +175,16 @@ class TestUpdateUserRoleGuard:
         assert r.status_code == 200
         assert r.json()["execution_policy"] == "auto_execute"
 
-        # admin → viewer に降格を試みる → 400 になるべき
+        # admin → viewer に降格 → 許可される
         r = client.put(
             f"/users/{user_id}",
             json={"role": "viewer"},
             headers={"Authorization": f"Bearer {admin_token}"},
         )
-        assert r.status_code == 400, (
-            f"Expected 400 (viewer+auto_execute guard), got {r.status_code}: {r.text}"
+        assert r.status_code == 200, (
+            f"Expected 200 (guard removed), got {r.status_code}: {r.text}"
         )
-        assert "auto_execute" in r.json()["detail"].lower()
+        assert r.json()["role"] == "viewer"
 
     def test_demote_admin_with_require_approval_to_viewer_allowed(self, client: TestClient) -> None:
         """require_approval を持つ admin を viewer に降格すると成功すること。"""
@@ -217,7 +194,6 @@ class TestUpdateUserRoleGuard:
         assert r.status_code in (200, 201)
         user_id = r.json()["id"]
 
-        # execution_policy を require_approval に設定してから降格
         target_token = _login(client, "admin_to_demote2@example.com")
         r = client.put(
             "/api/user/settings",
@@ -227,7 +203,6 @@ class TestUpdateUserRoleGuard:
         assert r.status_code == 200
         assert r.json()["execution_policy"] == "require_approval"
 
-        # admin → viewer に降格 → 成功
         r = client.put(
             f"/users/{user_id}",
             json={"role": "viewer"},
@@ -246,7 +221,6 @@ class TestUpdateUserRoleGuard:
         assert r.status_code in (200, 201)
         user_id = r.json()["id"]
 
-        # email のみ更新（role 変更なし）
         r = client.put(
             f"/users/{user_id}",
             json={"email": "viewer_noupdate_new@example.com"},
@@ -254,15 +228,14 @@ class TestUpdateUserRoleGuard:
         )
         assert r.status_code == 200
 
-    def test_update_partner_to_viewer_with_auto_execute_rejected(self, client: TestClient) -> None:
-        """auto_execute を持つ partner を viewer に降格しようとすると 400 になること。"""
+    def test_update_partner_to_viewer_with_auto_execute_allowed(self, client: TestClient) -> None:
+        """auto_execute を持つ partner を viewer に降格しても許可されること（ガード撤廃後）。"""
         admin_token = _register_admin(client)
 
         r = _create_user(client, admin_token, "partner_to_viewer@example.com", "partner")
         assert r.status_code in (200, 201)
         user_id = r.json()["id"]
 
-        # partner の execution_policy を auto_execute に設定
         target_token = _login(client, "partner_to_viewer@example.com")
         r = client.put(
             "/api/user/settings",
@@ -272,13 +245,12 @@ class TestUpdateUserRoleGuard:
         assert r.status_code == 200
         assert r.json()["execution_policy"] == "auto_execute"
 
-        # partner → viewer に降格を試みる → 400
         r = client.put(
             f"/users/{user_id}",
             json={"role": "viewer"},
             headers={"Authorization": f"Bearer {admin_token}"},
         )
-        assert r.status_code == 400, (
-            f"Expected 400 (viewer+auto_execute guard), got {r.status_code}: {r.text}"
+        assert r.status_code == 200, (
+            f"Expected 200 (guard removed), got {r.status_code}: {r.text}"
         )
-        assert "auto_execute" in r.json()["detail"].lower()
+        assert r.json()["role"] == "viewer"

--- a/backend/tests/test_viewer_no_autoexec_guard.py
+++ b/backend/tests/test_viewer_no_autoexec_guard.py
@@ -181,9 +181,7 @@ class TestUpdateUserRole:
             json={"role": "viewer"},
             headers={"Authorization": f"Bearer {admin_token}"},
         )
-        assert r.status_code == 200, (
-            f"Expected 200 (guard removed), got {r.status_code}: {r.text}"
-        )
+        assert r.status_code == 200, f"Expected 200 (guard removed), got {r.status_code}: {r.text}"
         assert r.json()["role"] == "viewer"
 
     def test_demote_admin_with_require_approval_to_viewer_allowed(self, client: TestClient) -> None:
@@ -250,7 +248,5 @@ class TestUpdateUserRole:
             json={"role": "viewer"},
             headers={"Authorization": f"Bearer {admin_token}"},
         )
-        assert r.status_code == 200, (
-            f"Expected 200 (guard removed), got {r.status_code}: {r.text}"
-        )
+        assert r.status_code == 200, f"Expected 200 (guard removed), got {r.status_code}: {r.text}"
         assert r.json()["role"] == "viewer"


### PR DESCRIPTION
## 概要
staging UI テストで「運用モード切替画面で**アクティブ**にしても反映されず、**完全おまかせ**のみになる」不具合の修正。

## 真因
`PUT /api/user/settings` が **admin/partner 以外の role に対し `user_mode` 変更を 403 で拒否**していた（`settings_router.py`、`test_viewer_cannot_update_user_mode` で意図的にテストされていた挙動）。
LIFF の `OpModePanel` は楽観的更新 → PUT 失敗時に既定値 `managed`（完全おまかせ）へロールバックするため、選択が常に巻き戻っていた。

LIFF/LINE オンボードのエンドユーザーは**全員 `role=viewer`**（`auth/line.py:77` ほか）のため、これは一部アカウントではなく**全エンドユーザーで再現する構造バグ**だった。

## 変更
- **`backend/app/users/settings_router.py`**: `user_mode` 変更の role ゲートを撤廃しセルフサービス化。`execution_policy` の**直接指定**だけ admin/partner 限定で温存。
- **`backend/app/auth/service.py`**: viewer+auto_execute 拒否ガード `_validate_viewer_no_autoexec` を撤廃（viewer も「完全おまかせ=auto_execute」を選択可能に）。create_user / update_user_role の呼び出しと未使用 import を除去。
- **テスト**: `test_user_settings_role_auth.py` / `test_viewer_no_autoexec_guard.py` を新仕様（viewer も両モード切替可・auto_execute 保持ユーザーの viewer 降格も許可）に更新。

## 方針判断
オーナー確認のうえ「viewer に両モード許可（user_mode はセルフサービス、execution_policy 直接指定のみ admin/partner、viewer+auto_execute ガード撤廃）」を採用。

## テスト
- `test_user_settings_role_auth.py` + `test_viewer_no_autoexec_guard.py`: 14 passed
- 関連 auth/user 回帰: `test_user_mode` / `test_user_settings_api` / `test_execution_policy_enum`（49 passed）、`test_auth` / `test_auth_rbac` / `test_open_registration` / `test_auth_register_with_referral` / `test_invitations`（69 passed, 12 skipped）
- ruff: All checks passed

## 補足
- バックエンド変更のため、**staging 実機 UI 確認にはデプロイが必要**（本 PR では未検証）。
- Web 側 `OperationModeCard` は role ゲートなし（`disabled={isStopped}` のみ）のため、本修正で LIFF・Web 両方が機能する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
