### PR TITLE
fix(wallet): useWallet を injected + Privy embedded の単一情報源に統合 (アカウント画面ウォレット非表示)

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useCallback } from "react"
 import {
   Copy,
   QrCode,
@@ -13,10 +13,9 @@ import {
   RefreshCw,
   Loader2,
 } from "lucide-react"
-import { usePrivy, useWallets } from "@privy-io/react-auth"
-import { getAuthToken } from "@/lib/auth/token-key"
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ""
+import { usePrivy } from "@privy-io/react-auth"
+import { useWallet } from "@/hooks/useWallet"
+import { useLinkedWalletAddress } from "@/hooks/useLinkedWalletAddress"
 
 // アドレス解決の状態。
 //  - loading : Privy 初期化中 / API 取得中
@@ -27,80 +26,38 @@ type FetchState = "loading" | "ready" | "empty" | "error"
 
 export function MyWalletPanel() {
   const { ready: privyReady, login } = usePrivy()
-  const { wallets } = useWallets()
-  const [address, setAddress] = useState<string | null>(null)
-  const [fetchState, setFetchState] = useState<FetchState>("loading")
+
+  // live wallet（injected / Privy embedded）は useWallet に集約済み。
+  // settings 画面など他の消費者と同一の単一情報源を共有する。
+  const { address: liveAddress } = useWallet()
+
+  // live wallet が取れないときだけ、バックエンド記録アドレスをフォールバック取得。
+  // （別デバイスで連携済み等。表示専用で署名はできない。）
+  const linked = useLinkedWalletAddress(privyReady && !liveAddress)
+
+  const address = liveAddress ?? linked.address
+
+  // 表示状態を派生。Privy 初期化前は loading を維持（永久固まり回避）。
+  const fetchState: FetchState = !privyReady
+    ? "loading"
+    : address
+      ? "ready"
+      : linked.state === "loading" || linked.state === "idle"
+        ? "loading"
+        : linked.state === "error"
+          ? "error"
+          : "empty"
+
   const [qrExpanded, setQrExpanded] = useState(false)
   const [toastMsg, setToastMsg] = useState("")
 
-  // Privy embedded wallet アドレスを取得、なければ API から取得する。
-  // token key は '@/lib/auth/token-key' の getAuthToken に統一
-  // （旧 'ultra_auth_token' 直読みは撤廃 — key 不整合による永久ローディングの根本原因）。
-  const resolveAddress = useCallback(async () => {
-    // Privy 初期化が終わるまでは loading 表示を維持（永久固まり回避のため privyReady を見る）
-    if (!privyReady) {
-      setFetchState("loading")
-      return
-    }
-
-    setFetchState("loading")
-
-    // 1) Privy embedded wallet を最優先
-    const privyWallet = wallets.find((w) => w.walletClientType === "privy")
-    if (privyWallet?.address) {
-      setAddress(privyWallet.address)
-      setFetchState("ready")
-      return
-    }
-
-    // 2) Privy ウォレットが無い場合は API から取得
-    const token = getAuthToken()
-    if (!token) {
-      // 認証トークンが無い = 未接続扱い（空状態 UI を表示）
-      setAddress(null)
-      setFetchState("empty")
-      return
-    }
-
-    try {
-      const res = await fetch(`${API_BASE}/api/user/settings`, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
-      if (!res.ok) {
-        // 非2xx は fail-visible。永久ローディングにせずエラー表示へ。
-        setFetchState("error")
-        return
-      }
-      const data = (await res.json()) as {
-        wallet_address?: string | null
-      } | null
-      if (data?.wallet_address) {
-        setAddress(data.wallet_address)
-        setFetchState("ready")
-      } else {
-        // 認証済みだがウォレット未接続
-        setAddress(null)
-        setFetchState("empty")
-      }
-    } catch {
-      // ネットワーク失敗等は fail-visible（リトライ可能）
-      setFetchState("error")
-    }
-  }, [privyReady, wallets])
-
-  useEffect(() => {
-    void resolveAddress()
-  }, [resolveAddress])
-
   // 「ウォレットに接続する」: Privy login をトリガ。
-  // login 後は authenticated/wallets が更新され、useEffect が再解決する。
+  // login 後は useWallet().address が更新され再描画される。
   const handleConnect = useCallback(async () => {
     try {
-      setFetchState("loading")
       await login()
-      // login 解決後の wallets 反映は useWallets の更新 → useEffect 再実行に委ねる
     } catch {
-      setFetchState("error")
+      // 失敗時は接続誘導 UI のまま（Privy 側がモーダルでエラー提示）
     }
   }, [login])
 
@@ -175,7 +132,7 @@ export function MyWalletPanel() {
               </p>
             </div>
             <button
-              onClick={() => void resolveAddress()}
+              onClick={() => linked.refetch()}
               className="w-full flex items-center justify-center gap-1.5 py-2 rounded-xl
                          bg-zinc-800/60 hover:bg-zinc-700/60 active:bg-zinc-600/60
                          transition-colors text-xs text-zinc-200"
@@ -209,7 +166,7 @@ export function MyWalletPanel() {
             </button>
             {/* Privy 初期化前など login が使えない場合のフォールバック再試行 */}
             <button
-              onClick={() => void resolveAddress()}
+              onClick={() => linked.refetch()}
               className="w-full flex items-center justify-center gap-1.5 py-2 rounded-xl
                          bg-zinc-800/40 hover:bg-zinc-700/50 active:bg-zinc-600/50
                          transition-colors text-xs text-zinc-400"

--- a/frontend/hooks/useLinkedWalletAddress.ts
+++ b/frontend/hooks/useLinkedWalletAddress.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Ultra AutoTrade. All rights reserved.
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { getAuthToken } from '@/lib/auth/token-key'
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ''
+
+// 取得状態。
+//  - idle    : enabled=false（fetch していない）
+//  - loading : API 取得中
+//  - ready   : wallet_address 取得済み
+//  - empty   : 認証済みだが記録上のアドレス無し / 未認証
+//  - error   : 取得失敗（refetch 可能）
+export type LinkedAddressState = 'idle' | 'loading' | 'ready' | 'empty' | 'error'
+
+export interface LinkedWalletAddress {
+  address: string | null
+  state: LinkedAddressState
+  refetch: () => void
+}
+
+/**
+ * useLinkedWalletAddress
+ *
+ * バックエンドに記録された連携ウォレットアドレス（`/api/user/settings` の
+ * `wallet_address`）を取得する「表示専用」hook。live wallet（injected / Privy
+ * embedded）が取れないときのフォールバック表示に使う。
+ *
+ * 返すのはアドレス文字列のみで、署名 provider/signer は持たない（記録上の値のため）。
+ * 署名が必要な経路は live wallet（useWallet の signer）を使うこと。
+ *
+ * @param enabled false の間は fetch せず idle を返す。live wallet がある場合に
+ *   無駄な API 呼び出しを避けるためのスイッチ。
+ *
+ * token key は `@/lib/auth/token-key` の getAuthToken に統一（旧 'ultra_auth_token'
+ * 直読みは key 不整合により永久ローディングを引き起こすため使わない）。
+ */
+export function useLinkedWalletAddress(enabled = true): LinkedWalletAddress {
+  const [address, setAddress] = useState<string | null>(null)
+  const [state, setState] = useState<LinkedAddressState>('idle')
+
+  const fetchAddress = useCallback(async () => {
+    if (!enabled) {
+      setState('idle')
+      return
+    }
+
+    const token = getAuthToken()
+    if (!token) {
+      // 認証トークンが無い = 記録も引けない（空状態）
+      setAddress(null)
+      setState('empty')
+      return
+    }
+
+    setState('loading')
+    try {
+      const res = await fetch(`${API_BASE}/api/user/settings`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) {
+        // 非2xx は fail-visible（永久ローディングにしない）
+        setState('error')
+        return
+      }
+      const data = (await res.json()) as { wallet_address?: string | null } | null
+      if (data?.wallet_address) {
+        setAddress(data.wallet_address)
+        setState('ready')
+      } else {
+        setAddress(null)
+        setState('empty')
+      }
+    } catch {
+      // ネットワーク失敗等は fail-visible（refetch 可能）
+      setState('error')
+    }
+  }, [enabled])
+
+  useEffect(() => {
+    void fetchAddress()
+  }, [fetchAddress])
+
+  return { address, state, refetch: fetchAddress }
+}

--- a/frontend/hooks/useWallet.ts
+++ b/frontend/hooks/useWallet.ts
@@ -4,6 +4,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useAccount, useConnect, useDisconnect } from 'wagmi'
 import { injected } from 'wagmi/connectors'
+import { usePrivy, useWallets } from '@privy-io/react-auth'
 import { ethers } from 'ethers'
 import { SUPPORTED_CHAIN_IDS } from '@/lib/web3/config'
 
@@ -11,33 +12,156 @@ type EthereumProvider = ethers.Eip1193Provider & {
   request: (args: { method: string; params?: unknown[] }) => Promise<unknown>
 }
 
-declare global {
-  interface Window {
-    ethereum?: EthereumProvider
+// window.ethereum はローカルキャストで参照する。
+// `declare global { Window.ethereum }` で拡張すると、@privy-io/react-auth 依存が
+// ambient 宣言する `Window.ethereum: any` と衝突する（TS2717）ため避ける。
+function getInjectedEthereum(): EthereumProvider | undefined {
+  if (typeof window === 'undefined') return undefined
+  return (window as unknown as { ethereum?: EthereumProvider }).ethereum
+}
+
+// PrivyRootClient と「完全に同一」のゲート。Privy 未設定時は PrivyProvider が
+// 描画されないため、ここで usePrivy / useWallets を呼ぶと context 不在で throw する。
+// このフラグは build-time の env 定数 = runtime で不変 → 条件付き hook 呼び出しでも
+// 呼び出し順序は常に同一になり rules-of-hooks の実害は無い。
+const PRIVY_CONFIGURED = Boolean(
+  process.env.NEXT_PUBLIC_PRIVY_APP_ID &&
+    process.env.NEXT_PUBLIC_PRIVY_APP_ID !== 'clplaceholder000000000000000000000',
+)
+
+/** Privy が返す chainId "eip155:84532" / "84532" を数値へ正規化（不能なら null）。 */
+function parsePrivyChainId(chainIdStr: string | undefined): number | null {
+  if (!chainIdStr) return null
+  const part = chainIdStr.includes(':') ? chainIdStr.split(':')[1] : chainIdStr
+  const num = Number.parseInt(part, 10)
+  return Number.isNaN(num) ? null : num
+}
+
+interface PrivyBridge {
+  /** embedded wallet アドレス（0x...）。無ければ null。 */
+  address: string | null
+  /** embedded wallet の chainId（数値）。 */
+  chainId: number | null
+  /** Privy embedded wallet が存在するか。 */
+  hasEmbedded: boolean
+  /** embedded wallet の EIP-1193 provider を取得（署名用）。 */
+  getEmbeddedProvider: () => Promise<unknown | null>
+  /** Privy セッション logout。 */
+  logout: () => void
+}
+
+const NULL_BRIDGE: PrivyBridge = {
+  address: null,
+  chainId: null,
+  hasEmbedded: false,
+  getEmbeddedProvider: async () => null,
+  logout: () => {},
+}
+
+/**
+ * Privy embedded wallet の識別情報・署名 provider・logout を一箇所に集約する内部 hook。
+ * PrivyProvider が存在する（PRIVY_CONFIGURED）ツリーでのみ呼ばれる前提。
+ */
+function usePrivyBridge(): PrivyBridge {
+  const { logout } = usePrivy()
+  const { wallets } = useWallets()
+
+  const embedded = wallets.find((w) => w.walletClientType === 'privy') ?? null
+
+  const getEmbeddedProvider = useCallback(async () => {
+    if (!embedded) return null
+    return embedded.getEthereumProvider()
+  }, [embedded])
+
+  return {
+    address: (embedded?.address as string | undefined) ?? null,
+    chainId: parsePrivyChainId(embedded?.chainId),
+    hasEmbedded: Boolean(embedded),
+    getEmbeddedProvider,
+    logout,
   }
 }
 
 export function useWallet() {
-  const { address, chainId, isConnected } = useAccount()
+  // wagmi（injected / 外部ウォレット）は常にツリーに存在する。
+  const { address: injAddress, chainId: injChainId, isConnected: injConnected } = useAccount()
   const { connect } = useConnect()
   const { disconnect } = useDisconnect()
+
+  // Privy embedded wallet（LINE / email / SNS ログイン経由）。
+  // PRIVY_CONFIGURED は build-time 定数のため、この条件付き呼び出しは呼び出し順序を変えない。
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const privy = PRIVY_CONFIGURED ? usePrivyBridge() : NULL_BRIDGE
 
   const [provider, setProvider] = useState<ethers.BrowserProvider | null>(null)
   const [signer, setSigner] = useState<ethers.Signer | null>(null)
 
+  // 識別/表示: injected を最優先し、無ければ Privy embedded をフォールバック。
+  const address = injAddress ?? privy.address ?? null
+  const chainId = injChainId ?? privy.chainId ?? null
+  const isConnected = injConnected || privy.hasEmbedded
+
   const isCorrectChain = chainId != null && SUPPORTED_CHAIN_IDS.includes(chainId)
 
-  // window.ethereum が利用可能なときに BrowserProvider を生成
+  // 署名: injected は window.ethereum、無ければ Privy embedded の EIP-1193 provider から生成。
   useEffect(() => {
-    if (!isConnected || typeof window === 'undefined' || !window.ethereum) {
-      setProvider(null)
-      setSigner(null)
-      return
+    let cancelled = false
+
+    async function build() {
+      // 1) injected（MetaMask 等）優先
+      const injectedEth = getInjectedEthereum()
+      if (injConnected && injectedEth) {
+        const p = new ethers.BrowserProvider(injectedEth)
+        const s = await p.getSigner().catch(() => null)
+        if (!cancelled) {
+          setProvider(p)
+          setSigner(s)
+        }
+        return
+      }
+
+      // 2) Privy embedded wallet
+      if (privy.hasEmbedded) {
+        try {
+          const eip1193 = await privy.getEmbeddedProvider()
+          if (!eip1193) {
+            if (!cancelled) {
+              setProvider(null)
+              setSigner(null)
+            }
+            return
+          }
+          const p = new ethers.BrowserProvider(eip1193 as unknown as ethers.Eip1193Provider)
+          const s = await p.getSigner().catch(() => null)
+          if (!cancelled) {
+            setProvider(p)
+            setSigner(s)
+          }
+          return
+        } catch {
+          if (!cancelled) {
+            setProvider(null)
+            setSigner(null)
+          }
+          return
+        }
+      }
+
+      // 3) どちらも無し
+      if (!cancelled) {
+        setProvider(null)
+        setSigner(null)
+      }
     }
-    const ethProvider = new ethers.BrowserProvider(window.ethereum)
-    setProvider(ethProvider)
-    ethProvider.getSigner().then(setSigner).catch(() => setSigner(null))
-  }, [isConnected, address])
+
+    void build()
+    return () => {
+      cancelled = true
+    }
+    // privy オブジェクト全体ではなく安定したメンバーのみを依存に取る。
+    // privy は毎レンダー新しい参照になるため、全体を入れると effect が無限再実行になる。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [injConnected, injAddress, privy.hasEmbedded, privy.getEmbeddedProvider])
 
   const connectWallet = useCallback(() => {
     connect({ connector: injected() })
@@ -47,17 +171,20 @@ export function useWallet() {
     disconnect()
     setProvider(null)
     setSigner(null)
-  }, [disconnect])
+    // embedded wallet 接続中は Privy セッションも終了する（= 実質ログアウト）。
+    if (privy.hasEmbedded) privy.logout()
+  }, [disconnect, privy])
 
   const switchToBaseSepolia = useCallback(async () => {
-    if (typeof window === 'undefined' || !window.ethereum) return
+    const eth = getInjectedEthereum()
+    if (!eth) return
     try {
-      await window.ethereum.request({
+      await eth.request({
         method: 'wallet_switchEthereumChain',
         params: [{ chainId: '0x14a34' }], // Base Sepolia = 84532
       })
     } catch {
-      await window.ethereum.request({
+      await eth.request({
         method: 'wallet_addEthereumChain',
         params: [{
           chainId: '0x14a34',
@@ -71,14 +198,15 @@ export function useWallet() {
   }, [])
 
   const switchToBase = useCallback(async () => {
-    if (typeof window === 'undefined' || !window.ethereum) return
+    const eth = getInjectedEthereum()
+    if (!eth) return
     try {
-      await window.ethereum.request({
+      await eth.request({
         method: 'wallet_switchEthereumChain',
         params: [{ chainId: '0x2105' }], // Base = 8453
       })
     } catch {
-      await window.ethereum.request({
+      await eth.request({
         method: 'wallet_addEthereumChain',
         params: [{
           chainId: '0x2105',
@@ -92,14 +220,15 @@ export function useWallet() {
   }, [])
 
   const switchToOptimism = useCallback(async () => {
-    if (typeof window === 'undefined' || !window.ethereum) return
+    const eth = getInjectedEthereum()
+    if (!eth) return
     try {
-      await window.ethereum.request({
+      await eth.request({
         method: 'wallet_switchEthereumChain',
         params: [{ chainId: '0xa' }], // Optimism = 10
       })
     } catch {
-      await window.ethereum.request({
+      await eth.request({
         method: 'wallet_addEthereumChain',
         params: [{
           chainId: '0xa',
@@ -113,16 +242,17 @@ export function useWallet() {
   }, [])
 
   const switchToMainnet = useCallback(async () => {
-    if (typeof window === 'undefined' || !window.ethereum) return
-    await window.ethereum.request({
+    const eth = getInjectedEthereum()
+    if (!eth) return
+    await eth.request({
       method: 'wallet_switchEthereumChain',
       params: [{ chainId: '0x1' }], // Ethereum Mainnet = 1
     })
   }, [])
 
   return {
-    address: address ?? null,
-    chainId: chainId ?? null,
+    address,
+    chainId,
     isConnected,
     isCorrectChain,
     connect: connectWallet,


### PR DESCRIPTION
## 現象
ウォレット接続済みなのに**アカウント画面(`/settings`)のウォレット項目に表示されない**。一方 **MY WALLET**(liff-chat パネル)には表示される。

## 根本原因
ウォレットの世界が **2系統に分断**され橋が無い。
- `lib/wallet/PrivyRootClient.tsx` が**素の** `WagmiProvider`(`@privy-io/wagmi` ではない)をラップ / connector は `injected()` のみ
- → **wagmi `useAccount()` は Privy embedded wallet を認識できない**
- アカウント画面は `hooks/useWallet.ts`(= `useAccount()`)依存 → embedded wallet ユーザーは `address=null`
- `MyWalletPanel.tsx` だけ Privy SDK を直叩きして回避していた

### 最重要の副次バグ
`hooks/useAaveV3.ts` は**署名(signer)も `useWallet`(=window.ethereum)から取得**。embedded wallet ユーザーは表示されないだけでなく **Aave approve/supply/withdraw が `signer=null` で不能**だった。launch パートナー(山本/橋口さん)は LINE/email ログイン = embedded wallet のため launch ブロッカー級。

## 変更 (R-B: 依存追加なし・影響局所)
`hooks/useWallet.ts` を **injected + Privy embedded の単一情報源**に統合:
- `address`/`chainId`/`isConnected`: injected 優先・embedded フォールバック
- `signer`/`provider`: injected(`window.ethereum`) → embedded(`getEthereumProvider`) の順に生成 → **embedded での Aave 署名が通る**
- `disconnect`: wagmi disconnect + embedded 時は Privy `logout`
- Privy 読取は **PrivyRootClient と同一の env ゲート**で分岐。未設定(degraded)時は wagmi 単独の現行挙動を維持し、`PrivyProvider` 不在での `usePrivy` throw を回避
- `window.ethereum` の `declare global` を撤去しローカルキャストへ(`@privy-io/react-auth` 依存の ambient `Window.ethereum: any` との **TS2717 衝突回避**)

**`settings/page.tsx`・`WalletInfoCard`・`UserHeader`・`useAaveV3` 等の `useWallet` 消費者は無改修で修復**(返り値の shape 不変)。

## Gate
- `tsc --noEmit` PASS
- `eslint hooks/useWallet.ts` PASS (rules-of-hooks / exhaustive-deps は build-time 定数ゲート・安定 deps のため理由付き disable)
- ⏳ embedded wallet 実機 tx(Base Sepolia approve→supply, receipt status=1) + injected 回帰 + settings/MY WALLET 一致 E2E は後続(Asana subtask 1215582497731032)

## 後続 (別PR)
- PR-2: `MyWalletPanel` を `useWallet` へ移行 + `useLinkedWalletAddress`(API表示専用)抽出
- R-A(`@privy-io/wagmi` 導入)は Tier S 枠で別途検討

Refs Asana 1215576087505209