### PR TITLE
feat(frontend): Arobix-style UI theme preview (中央トークン + 3画面)

### DIFF
--- a/frontend/app/arobix/_components/ArobixBottomNav.tsx
+++ b/frontend/app/arobix/_components/ArobixBottomNav.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { Home, CreditCard, Send, PieChart, User } from 'lucide-react'
+
+const ITEMS = [
+  { href: '/arobix/dashboard', label: 'Home', icon: Home },
+  { href: '/arobix/dashboard#cards', label: 'Cards', icon: CreditCard },
+  { href: '/arobix/send', label: 'Send', icon: Send },
+  { href: '/arobix/dashboard#stats', label: 'Stats', icon: PieChart },
+  { href: '/arobix/dashboard#me', label: 'Me', icon: User },
+]
+
+export function ArobixBottomNav() {
+  const pathname = usePathname()
+  return (
+    <nav
+      className="ax-shadow-card"
+      style={{
+        position: 'fixed',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        bottom: 14,
+        width: 'min(380px, calc(100% - 32px))',
+        background: 'var(--nav-bg)',
+        borderRadius: 'var(--radius-pill)',
+        padding: '10px 14px',
+        zIndex: 50,
+      }}
+    >
+      <div className="flex items-center justify-between">
+        {ITEMS.map(({ href, label, icon: Icon }) => {
+          const base = href.split('#')[0]
+          const active = pathname === base
+          return (
+            <Link
+              key={label}
+              href={href}
+              aria-label={label}
+              className="flex flex-1 flex-col items-center gap-1 py-1"
+              style={{ color: active ? 'var(--nav-active)' : 'var(--nav-fg)' }}
+            >
+              <Icon className="h-5 w-5" strokeWidth={active ? 2.4 : 1.9} />
+              <span style={{ fontSize: 10, fontWeight: active ? 700 : 500 }}>{label}</span>
+            </Link>
+          )
+        })}
+      </div>
+    </nav>
+  )
+}

--- a/frontend/app/arobix/dashboard/page.tsx
+++ b/frontend/app/arobix/dashboard/page.tsx
@@ -1,0 +1,218 @@
+'use client'
+
+import Link from 'next/link'
+import {
+  Plus,
+  ArrowLeftRight,
+  ReceiptText,
+  Grid2x2,
+  Bell,
+  TrendingUp,
+  ArrowUpRight,
+  ArrowDownLeft,
+  ShoppingBag,
+} from 'lucide-react'
+import { ArobixBottomNav } from '../_components/ArobixBottomNav'
+
+const QUICK_ACTIONS = [
+  { label: 'Top Up', icon: Plus },
+  { label: 'Transfer', icon: ArrowLeftRight, href: '/arobix/send' },
+  { label: 'Bills', icon: ReceiptText },
+  { label: 'Others', icon: Grid2x2 },
+]
+
+const TRANSACTIONS = [
+  { name: 'Apple Store', sub: 'Shopping · Today', amount: '-$129.00', icon: ShoppingBag, up: false },
+  { name: 'Salary', sub: 'Income · Yesterday', amount: '+$3,200.00', icon: ArrowDownLeft, up: true },
+  { name: 'Emma Wilson', sub: 'Transfer · Mon', amount: '-$48.50', icon: ArrowUpRight, up: false },
+]
+
+export default function ArobixDashboardPage() {
+  return (
+    <div style={{ paddingBottom: 110 }}>
+      {/* グラデーションヘッダー */}
+      <header
+        className="ax-gradient-header"
+        style={{
+          padding: '24px 22px 64px',
+          borderBottomLeftRadius: 34,
+          borderBottomRightRadius: 34,
+        }}
+      >
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <span
+              className="ax-card-surface ax-r-pill flex items-center justify-center"
+              style={{ width: 42, height: 42, fontWeight: 700 }}
+            >
+              <span className="ax-accent-purple">A</span>
+            </span>
+            <div>
+              <p className="ax-text-on-grad" style={{ fontSize: 12, opacity: 0.75 }}>Good morning</p>
+              <p className="ax-text-on-grad" style={{ fontSize: 15, fontWeight: 700 }}>Alex Morgan</p>
+            </div>
+          </div>
+          <span
+            className="ax-card-surface ax-r-pill flex items-center justify-center"
+            style={{ width: 40, height: 40 }}
+          >
+            <Bell className="h-5 w-5 ax-text-primary" />
+          </span>
+        </div>
+
+        {/* 残高 */}
+        <div style={{ marginTop: 26 }}>
+          <p className="ax-text-on-grad" style={{ fontSize: 13, opacity: 0.78 }}>Total balance</p>
+          <div className="flex items-end gap-3" style={{ marginTop: 4 }}>
+            <h1 className="ax-text-on-grad" style={{ fontSize: 40, fontWeight: 800, letterSpacing: '-0.03em' }}>
+              $12,480.50
+            </h1>
+            <span
+              className="ax-card-surface ax-r-pill flex items-center gap-1"
+              style={{ padding: '4px 9px', marginBottom: 8 }}
+            >
+              <TrendingUp className="h-3.5 w-3.5 ax-accent-purple" />
+              <span className="ax-accent-purple" style={{ fontSize: 12, fontWeight: 700 }}>+2.4% 24h</span>
+            </span>
+          </div>
+        </div>
+      </header>
+
+      {/* クイックアクション（ヘッダーに重ねる） */}
+      <section style={{ padding: '0 18px', marginTop: -36 }}>
+        <div className="ax-card-surface ax-r-card ax-shadow-card" style={{ padding: '18px 12px' }}>
+          <div className="flex items-center justify-between">
+            {QUICK_ACTIONS.map(({ label, icon: Icon, href }) => {
+              const inner = (
+                <div className="flex flex-col items-center gap-2" style={{ flex: 1 }}>
+                  <span
+                    className="ax-card-warm ax-r-btn flex items-center justify-center"
+                    style={{ width: 50, height: 50 }}
+                  >
+                    <Icon className="h-5 w-5 ax-text-primary" />
+                  </span>
+                  <span className="ax-text-primary" style={{ fontSize: 12, fontWeight: 600 }}>{label}</span>
+                </div>
+              )
+              return href ? (
+                <Link key={label} href={href} style={{ flex: 1 }}>{inner}</Link>
+              ) : (
+                <div key={label} style={{ flex: 1 }}>{inner}</div>
+              )
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* My Cards */}
+      <section id="cards" style={{ padding: '26px 18px 0' }}>
+        <SectionHeader title="My Cards" action="See all" />
+        <div className="flex gap-14" style={{ gap: 14, overflowX: 'auto', paddingBottom: 4 }}>
+          <WarmCard
+            tone="warm"
+            brand="Premium"
+            number="4821"
+            balance="$8,240.00"
+            name="ALEX MORGAN"
+          />
+          <WarmCard
+            tone="pink"
+            brand="Savings"
+            number="0934"
+            balance="$4,240.50"
+            name="ALEX MORGAN"
+          />
+        </div>
+      </section>
+
+      {/* Recent Transactions */}
+      <section id="stats" style={{ padding: '26px 18px 0' }}>
+        <SectionHeader title="Recent Transaction" action="See all" />
+        <div className="ax-card-surface ax-r-card ax-shadow-soft" style={{ padding: 8 }}>
+          {TRANSACTIONS.map((tx, i) => (
+            <div
+              key={tx.name}
+              className="flex items-center gap-3"
+              style={{
+                padding: '12px 10px',
+                borderTop: i === 0 ? 'none' : '1px solid rgba(27,26,35,0.06)',
+              }}
+            >
+              <span
+                className={tx.up ? 'ax-card-warm-soft' : 'ax-card-pink'}
+                style={{ width: 44, height: 44, borderRadius: 14, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+              >
+                <tx.icon className={tx.up ? 'h-5 w-5 ax-accent-yellow' : 'h-5 w-5 ax-accent-pink'} />
+              </span>
+              <div style={{ flex: 1 }}>
+                <p className="ax-text-primary" style={{ fontSize: 14, fontWeight: 700 }}>{tx.name}</p>
+                <p className="ax-text-secondary" style={{ fontSize: 12 }}>{tx.sub}</p>
+              </div>
+              <span
+                className="ax-text-primary"
+                style={{ fontSize: 14, fontWeight: 700, color: tx.up ? 'var(--accent-purple)' : 'var(--text-primary)' }}
+              >
+                {tx.amount}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <ArobixBottomNav />
+    </div>
+  )
+}
+
+function SectionHeader({ title, action }: { title: string; action: string }) {
+  return (
+    <div className="flex items-center justify-between" style={{ marginBottom: 14 }}>
+      <h2 className="ax-text-primary" style={{ fontSize: 18, fontWeight: 800, letterSpacing: '-0.02em' }}>{title}</h2>
+      <span className="ax-text-secondary" style={{ fontSize: 13, fontWeight: 600 }}>{action}</span>
+    </div>
+  )
+}
+
+function WarmCard({
+  tone,
+  brand,
+  number,
+  balance,
+  name,
+}: {
+  tone: 'warm' | 'pink'
+  brand: string
+  number: string
+  balance: string
+  name: string
+}) {
+  return (
+    <div
+      className={`${tone === 'warm' ? 'ax-card-warm' : 'ax-card-pink'} ax-r-card ax-shadow-card`}
+      style={{ minWidth: 248, padding: 20 }}
+    >
+      <div className="flex items-center justify-between">
+        <span className="ax-text-primary" style={{ fontSize: 14, fontWeight: 700 }}>{brand}</span>
+        <span
+          className="ax-r-pill"
+          style={{
+            width: 30,
+            height: 20,
+            background: tone === 'warm' ? 'var(--accent-yellow)' : 'var(--accent-pink)',
+            opacity: 0.85,
+          }}
+        />
+      </div>
+      <p className="ax-text-secondary" style={{ marginTop: 22, fontSize: 13, letterSpacing: '0.18em' }}>
+        ••••  ••••  ••••  {number}
+      </p>
+      <div className="flex items-end justify-between" style={{ marginTop: 14 }}>
+        <div>
+          <p className="ax-text-secondary" style={{ fontSize: 11 }}>{name}</p>
+          <p className="ax-text-primary" style={{ fontSize: 20, fontWeight: 800 }}>{balance}</p>
+        </div>
+        <span className="ax-text-secondary" style={{ fontSize: 12, fontWeight: 700, fontStyle: 'italic' }}>VISA</span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/app/arobix/layout.tsx
+++ b/frontend/app/arobix/layout.tsx
@@ -1,0 +1,11 @@
+// Arobix UI theme — self-contained preview layout.
+// 既存の本番画面には一切影響しない独立ルート。テーマトークンは ./theme.css に集約。
+import './theme.css'
+
+export default function ArobixLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="arobix-root ax-bg-app" style={{ minHeight: '100dvh' }}>
+      <div className="ax-phone">{children}</div>
+    </div>
+  )
+}

--- a/frontend/app/arobix/onboarding/page.tsx
+++ b/frontend/app/arobix/onboarding/page.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import Link from 'next/link'
+import { ArrowRight, Sparkles, ShieldCheck, Wallet } from 'lucide-react'
+
+export default function ArobixOnboardingPage() {
+  return (
+    <div
+      className="ax-gradient"
+      style={{
+        minHeight: '100dvh',
+        display: 'flex',
+        flexDirection: 'column',
+        padding: '28px 24px 32px',
+      }}
+    >
+      {/* ブランド */}
+      <div className="flex items-center gap-2">
+        <span
+          className="ax-card-surface ax-r-pill flex items-center justify-center"
+          style={{ width: 36, height: 36 }}
+        >
+          <Sparkles className="h-4 w-4 ax-accent-purple" />
+        </span>
+        <span className="ax-text-on-grad" style={{ fontWeight: 700, fontSize: 18, letterSpacing: '-0.02em' }}>
+          Arobix
+        </span>
+      </div>
+
+      {/* イラストエリア（右側に浮かぶカード群） */}
+      <div style={{ flex: 1, position: 'relative', marginTop: 8 }}>
+        <div
+          className="ax-card-warm ax-r-card ax-shadow-card"
+          style={{ position: 'absolute', right: 0, top: 36, width: 188, height: 116, transform: 'rotate(6deg)', padding: 16 }}
+        >
+          <p className="ax-text-secondary" style={{ fontSize: 11 }}>Total balance</p>
+          <p className="ax-text-primary" style={{ fontSize: 22, fontWeight: 800 }}>$12,480.50</p>
+          <div className="ax-card-pink ax-r-pill" style={{ display: 'inline-block', marginTop: 8, padding: '3px 10px' }}>
+            <span className="ax-accent-pink" style={{ fontSize: 11, fontWeight: 700 }}>+2.4% today</span>
+          </div>
+        </div>
+        <div
+          className="ax-card-pink ax-r-card ax-shadow-soft"
+          style={{ position: 'absolute', left: 4, top: 150, width: 150, height: 92, transform: 'rotate(-7deg)', padding: 14 }}
+        >
+          <Wallet className="h-5 w-5 ax-accent-pink" />
+          <p className="ax-text-primary" style={{ fontSize: 13, fontWeight: 700, marginTop: 10 }}>Smart Wallet</p>
+          <p className="ax-text-secondary" style={{ fontSize: 11 }}>•••• 4821</p>
+        </div>
+        <div
+          className="ax-card-surface ax-r-card ax-shadow-soft"
+          style={{ position: 'absolute', right: 26, top: 188, width: 132, padding: 12, display: 'flex', alignItems: 'center', gap: 10 }}
+        >
+          <span className="ax-card-warm-soft ax-r-pill flex items-center justify-center" style={{ width: 30, height: 30 }}>
+            <ShieldCheck className="h-4 w-4 ax-accent-yellow" />
+          </span>
+          <span className="ax-text-primary" style={{ fontSize: 11, fontWeight: 600 }}>Insured & secure</span>
+        </div>
+      </div>
+
+      {/* コピー（左寄せ） */}
+      <div style={{ marginTop: 8 }}>
+        <h1
+          className="ax-text-on-grad"
+          style={{ fontSize: 34, lineHeight: 1.12, fontWeight: 800, letterSpacing: '-0.03em', maxWidth: 300 }}
+        >
+          Money that feels effortless.
+        </h1>
+        <p className="ax-text-on-grad" style={{ marginTop: 12, fontSize: 15, opacity: 0.78, maxWidth: 280 }}>
+          Save, send and grow your balance — all in one warm, simple place.
+        </p>
+      </div>
+
+      {/* Get Started（ダークボタン） */}
+      <Link
+        href="/arobix/dashboard"
+        className="ax-btn-primary"
+        style={{
+          marginTop: 24,
+          height: 58,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 10,
+          fontSize: 16,
+          fontWeight: 700,
+        }}
+      >
+        Get Started
+        <ArrowRight className="h-5 w-5" />
+      </Link>
+      <p className="ax-text-on-grad" style={{ textAlign: 'center', marginTop: 14, fontSize: 13, opacity: 0.7 }}>
+        Already have an account? <span style={{ fontWeight: 700 }}>Sign in</span>
+      </p>
+    </div>
+  )
+}

--- a/frontend/app/arobix/page.tsx
+++ b/frontend/app/arobix/page.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import Link from 'next/link'
+import { ArrowRight } from 'lucide-react'
+
+const SCREENS = [
+  { href: '/arobix/onboarding', title: 'Onboarding', desc: 'Welcome / Get Started' },
+  { href: '/arobix/dashboard', title: 'Dashboard', desc: 'Balance · Quick actions · Cards' },
+  { href: '/arobix/send', title: 'Send Money', desc: 'Tabs · Cards · Contacts' },
+]
+
+export default function ArobixIndexPage() {
+  return (
+    <div style={{ padding: '32px 22px' }}>
+      <p className="ax-accent-purple" style={{ fontSize: 13, fontWeight: 700 }}>UAT × Arobix</p>
+      <h1 className="ax-text-primary" style={{ fontSize: 28, fontWeight: 800, letterSpacing: '-0.03em', marginTop: 4 }}>
+        Theme preview
+      </h1>
+      <p className="ax-text-secondary" style={{ marginTop: 8, fontSize: 14 }}>
+        柔らかく上品なプレミアムフィンテックテイスト。3 画面をご確認ください。
+      </p>
+
+      <div style={{ marginTop: 26, display: 'flex', flexDirection: 'column', gap: 14 }}>
+        {SCREENS.map((s) => (
+          <Link
+            key={s.href}
+            href={s.href}
+            className="ax-card-warm ax-r-card ax-shadow-soft flex items-center justify-between"
+            style={{ padding: 20 }}
+          >
+            <div>
+              <p className="ax-text-primary" style={{ fontSize: 17, fontWeight: 800 }}>{s.title}</p>
+              <p className="ax-text-secondary" style={{ fontSize: 13, marginTop: 2 }}>{s.desc}</p>
+            </div>
+            <span
+              className="ax-btn-primary flex items-center justify-center"
+              style={{ width: 42, height: 42, borderRadius: 14 }}
+            >
+              <ArrowRight className="h-5 w-5" />
+            </span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/app/arobix/send/page.tsx
+++ b/frontend/app/arobix/send/page.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { ChevronLeft, Search, Plus } from 'lucide-react'
+import { ArobixBottomNav } from '../_components/ArobixBottomNav'
+
+const TABS = ['Cards', 'Accounts', 'Statement'] as const
+
+const CONTACTS = [
+  { name: 'Emma Wilson', handle: '@emma', tone: 'warm', initial: 'E' },
+  { name: 'James Carter', handle: '@jcarter', tone: 'pink', initial: 'J' },
+  { name: 'Sophia Lee', handle: '@sophia', tone: 'warm', initial: 'S' },
+  { name: 'Noah Davis', handle: '@noahd', tone: 'pink', initial: 'N' },
+  { name: 'Olivia Brown', handle: '@olivia', tone: 'warm', initial: 'O' },
+]
+
+export default function ArobixSendPage() {
+  const [tab, setTab] = useState<(typeof TABS)[number]>('Cards')
+
+  return (
+    <div style={{ paddingBottom: 110 }}>
+      {/* グラデーションヘッダー + タブ */}
+      <header
+        className="ax-gradient-header"
+        style={{ padding: '22px 20px 26px', borderBottomLeftRadius: 30, borderBottomRightRadius: 30 }}
+      >
+        <div className="flex items-center justify-between">
+          <Link
+            href="/arobix/dashboard"
+            className="ax-card-surface ax-r-pill flex items-center justify-center"
+            style={{ width: 40, height: 40 }}
+          >
+            <ChevronLeft className="h-5 w-5 ax-text-primary" />
+          </Link>
+          <span className="ax-text-on-grad" style={{ fontSize: 17, fontWeight: 700 }}>Send Money</span>
+          <span style={{ width: 40 }} />
+        </div>
+
+        {/* タブ */}
+        <div
+          className="ax-r-pill flex"
+          style={{ marginTop: 20, padding: 4, background: 'rgba(255,255,255,0.32)' }}
+        >
+          {TABS.map((t) => {
+            const active = t === tab
+            return (
+              <button
+                key={t}
+                onClick={() => setTab(t)}
+                className="ax-r-pill"
+                style={{
+                  flex: 1,
+                  padding: '9px 0',
+                  fontSize: 13,
+                  fontWeight: 700,
+                  border: 'none',
+                  cursor: 'pointer',
+                  background: active ? 'var(--card-surface)' : 'transparent',
+                  color: active ? 'var(--text-primary)' : 'var(--text-on-grad)',
+                  boxShadow: active ? 'var(--shadow-soft)' : 'none',
+                }}
+              >
+                {t}
+              </button>
+            )
+          })}
+        </div>
+      </header>
+
+      {/* カード選択（ベージュ + ピンク） */}
+      <section style={{ padding: '20px 18px 0' }}>
+        <p className="ax-text-secondary" style={{ fontSize: 13, fontWeight: 600, marginBottom: 12 }}>
+          Pay from
+        </p>
+        <div className="flex" style={{ gap: 14, overflowX: 'auto', paddingBottom: 4 }}>
+          <PayCard tone="warm" brand="Premium" number="4821" balance="$8,240.00" selected />
+          <PayCard tone="pink" brand="Savings" number="0934" balance="$4,240.50" />
+          <AddCard />
+        </div>
+      </section>
+
+      {/* Send to */}
+      <section style={{ padding: '24px 18px 0' }}>
+        <p className="ax-text-primary" style={{ fontSize: 18, fontWeight: 800, marginBottom: 12 }}>Send to</p>
+
+        {/* 検索バー */}
+        <div
+          className="ax-card-surface ax-r-btn ax-shadow-soft flex items-center gap-3"
+          style={{ padding: '13px 16px' }}
+        >
+          <Search className="h-5 w-5 ax-text-secondary" />
+          <input
+            placeholder="Search name or @handle"
+            className="ax-text-primary"
+            style={{ flex: 1, border: 'none', outline: 'none', background: 'transparent', fontSize: 14 }}
+          />
+        </div>
+
+        {/* 連絡先リスト */}
+        <div style={{ marginTop: 18 }}>
+          {CONTACTS.map((c) => (
+            <div key={c.name} className="flex items-center gap-3" style={{ padding: '11px 4px' }}>
+              <span
+                className={c.tone === 'warm' ? 'ax-card-warm' : 'ax-card-pink'}
+                style={{
+                  width: 46,
+                  height: 46,
+                  borderRadius: 16,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontWeight: 800,
+                }}
+              >
+                <span className={c.tone === 'warm' ? 'ax-accent-yellow' : 'ax-accent-pink'}>{c.initial}</span>
+              </span>
+              <div style={{ flex: 1 }}>
+                <p className="ax-text-primary" style={{ fontSize: 15, fontWeight: 700 }}>{c.name}</p>
+                <p className="ax-text-secondary" style={{ fontSize: 12 }}>{c.handle}</p>
+              </div>
+              <button
+                className="ax-btn-soft"
+                style={{ padding: '8px 16px', fontSize: 13, fontWeight: 700, border: 'none', cursor: 'pointer' }}
+              >
+                Send
+              </button>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <ArobixBottomNav />
+    </div>
+  )
+}
+
+function PayCard({
+  tone,
+  brand,
+  number,
+  balance,
+  selected,
+}: {
+  tone: 'warm' | 'pink'
+  brand: string
+  number: string
+  balance: string
+  selected?: boolean
+}) {
+  return (
+    <div
+      className={`${tone === 'warm' ? 'ax-card-warm' : 'ax-card-pink'} ax-r-card ax-shadow-card`}
+      style={{
+        minWidth: 200,
+        padding: 18,
+        outline: selected ? '2.5px solid var(--accent-purple)' : 'none',
+        outlineOffset: 2,
+      }}
+    >
+      <div className="flex items-center justify-between">
+        <span className="ax-text-primary" style={{ fontSize: 13, fontWeight: 700 }}>{brand}</span>
+        <span
+          className="ax-r-pill"
+          style={{ width: 26, height: 18, background: tone === 'warm' ? 'var(--accent-yellow)' : 'var(--accent-pink)', opacity: 0.85 }}
+        />
+      </div>
+      <p className="ax-text-secondary" style={{ marginTop: 18, fontSize: 12, letterSpacing: '0.16em' }}>
+        ••••  {number}
+      </p>
+      <p className="ax-text-primary" style={{ marginTop: 8, fontSize: 18, fontWeight: 800 }}>{balance}</p>
+    </div>
+  )
+}
+
+function AddCard() {
+  return (
+    <button
+      className="ax-r-card flex flex-col items-center justify-center gap-2"
+      style={{
+        minWidth: 110,
+        border: '2px dashed rgba(27,26,35,0.18)',
+        background: 'transparent',
+        cursor: 'pointer',
+        color: 'var(--text-secondary)',
+      }}
+    >
+      <Plus className="h-6 w-6" />
+      <span style={{ fontSize: 12, fontWeight: 600 }}>Add card</span>
+    </button>
+  )
+}

--- a/frontend/app/arobix/theme.css
+++ b/frontend/app/arobix/theme.css
@@ -1,0 +1,134 @@
+/*
+ * Arobix — central design tokens
+ * ------------------------------------------------------------
+ * 「柔らかく上品で親しみやすいプレミアムフィンテック」テイストの
+ * カラー / グラデーション / 角丸 / 影 を 1 箇所に集約。
+ * すべての arobix 配下コンポーネントはこのトークンを参照する。
+ * 本番画面へ移植する場合は、この :root ブロックを styles/globals.css へ
+ * 取り込むだけで同じパレットを再利用できる。
+ */
+
+.arobix-root {
+  /* ---- グラデーション（紫 → ピンク → 暖色イエロー）---- */
+  --gradient-from: #b9a4f2; /* lavender / 紫寄り */
+  --gradient-via: #ecaccd;  /* soft pink            */
+  --gradient-to: #fbd9a0;   /* warm amber / 暖色黄  */
+  --gradient-main: linear-gradient(
+    135deg,
+    var(--gradient-from) 0%,
+    var(--gradient-via) 52%,
+    var(--gradient-to) 100%
+  );
+  /* ダッシュボードヘッダー用に少しだけ角度違いの柔らかい版 */
+  --gradient-header: linear-gradient(
+    160deg,
+    var(--gradient-from) 0%,
+    var(--gradient-via) 58%,
+    var(--gradient-to) 105%
+  );
+
+  /* ---- カード ---- */
+  --card-warm: #f5ecdd;      /* メイン: 暖かいクリーム〜ベージュ */
+  --card-warm-soft: #fbf4e9; /* さらに淡い暖色             */
+  --card-pink: #f9dce1;      /* サブ: 柔らかいピンク         */
+  --card-pink-deep: #f4c6d0; /* ピンクのアクセント濃いめ      */
+  --card-surface: #ffffff;   /* 白カード（リスト等）          */
+
+  /* ---- アクセント ---- */
+  --accent-purple: #6e56cf;
+  --accent-pink: #e8739e;
+  --accent-yellow: #f4b740;
+
+  /* ---- テキスト ---- */
+  --text-primary: #1c1a27;   /* 濃いスレート〜黒に近い */
+  --text-secondary: #736f7e; /* サブテキスト          */
+  --text-on-dark: #fbf7f0;   /* ダーク面の白文字       */
+  --text-on-grad: #2a2440;   /* グラデ上の濃色文字     */
+
+  /* ---- ボタン（ダーク・高級感）---- */
+  --button-primary-bg: #1b1a23;
+  --button-primary-fg: #fbf7f0;
+  --button-soft-bg: rgba(27, 26, 35, 0.06);
+
+  /* ---- ボトムナビ（ダーク + 白アイコン）---- */
+  --nav-bg: #1b1a23;
+  --nav-fg: rgba(255, 255, 255, 0.55);
+  --nav-active: #fbd9a0;
+
+  /* ---- 背景 ---- */
+  --bg-app: #f7f2ea; /* 全体: 温かいオフホワイト */
+
+  /* ---- 角丸 ---- */
+  --radius-card: 28px;
+  --radius-card-sm: 20px;
+  --radius-btn: 18px;
+  --radius-pill: 999px;
+
+  /* ---- 影（軽く浮き上がる）---- */
+  --shadow-card: 0 14px 34px -16px rgba(60, 40, 90, 0.28);
+  --shadow-soft: 0 8px 20px -12px rgba(60, 40, 90, 0.22);
+  --shadow-btn: 0 12px 24px -10px rgba(27, 26, 35, 0.45);
+}
+
+/* ============================================================
+ * ユーティリティクラス（Tailwind JIT に依存せず確実に描画）
+ * ============================================================ */
+
+/* 背景 */
+.ax-bg-app { background: var(--bg-app); }
+.ax-gradient { background: var(--gradient-main); }
+.ax-gradient-header { background: var(--gradient-header); }
+
+/* カード面 */
+.ax-card-warm { background: var(--card-warm); }
+.ax-card-warm-soft { background: var(--card-warm-soft); }
+.ax-card-pink { background: var(--card-pink); }
+.ax-card-pink-deep { background: var(--card-pink-deep); }
+.ax-card-surface { background: var(--card-surface); }
+
+/* テキスト */
+.ax-text-primary { color: var(--text-primary); }
+.ax-text-secondary { color: var(--text-secondary); }
+.ax-text-on-dark { color: var(--text-on-dark); }
+.ax-text-on-grad { color: var(--text-on-grad); }
+.ax-accent-purple { color: var(--accent-purple); }
+.ax-accent-pink { color: var(--accent-pink); }
+.ax-accent-yellow { color: var(--accent-yellow); }
+
+/* 角丸 */
+.ax-r-card { border-radius: var(--radius-card); }
+.ax-r-card-sm { border-radius: var(--radius-card-sm); }
+.ax-r-btn { border-radius: var(--radius-btn); }
+.ax-r-pill { border-radius: var(--radius-pill); }
+
+/* 影 */
+.ax-shadow-card { box-shadow: var(--shadow-card); }
+.ax-shadow-soft { box-shadow: var(--shadow-soft); }
+
+/* ボタン */
+.ax-btn-primary {
+  background: var(--button-primary-bg);
+  color: var(--button-primary-fg);
+  border-radius: var(--radius-btn);
+  box-shadow: var(--shadow-btn);
+  transition: transform 0.12s ease, opacity 0.12s ease;
+}
+.ax-btn-primary:active { transform: scale(0.98); opacity: 0.92; }
+
+.ax-btn-soft {
+  background: var(--button-soft-bg);
+  color: var(--text-primary);
+  border-radius: var(--radius-btn);
+  transition: background 0.12s ease;
+}
+.ax-btn-soft:active { background: rgba(27, 26, 35, 0.12); }
+
+/* 端末フレーム（プレビュー用・大画面で中央寄せ） */
+.ax-phone {
+  width: 100%;
+  max-width: 420px;
+  margin-inline: auto;
+  min-height: 100dvh;
+  position: relative;
+  background: var(--bg-app);
+}


### PR DESCRIPTION
## 概要
柔らかく上品なプレミアムフィンテックテイスト（参考: **Arobix**）を、UATに導入。**既存の本番画面・共有コンポーネントを一切変更せず**、独立ルート `app/arobix/` として実装しました。

## 背景 / 設計判断
- UAT本体はダークテーマのAI自動トレードアプリで、依頼にあった汎用ウォレット系コンテンツ（Top Up / Bills / 連絡先送金 / My Cards）は**非存在**。
- 本番ローンチ直前のため、共有コンポーネント（BottomNav / UserHeader 等）の直接recolorは launch-gated な全画面に波及するリスクがある。
- → **既存画面をゼロリスクで保ちつつデザインを忠実再現**するため、新規ルートとして実装。カラートークンはいつでも本番画面へ移植可能。

## 変更点（すべて新規ファイル）
- `app/arobix/theme.css` — カラートークン中央定義（`--gradient-*`, `--card-warm`, `--card-pink`, `--accent-*`, `--text-*`, `--button-primary-bg` 等）+ `.ax-*` ユーティリティ
- `app/arobix/onboarding/page.tsx` — 紫→ピンク→暖色グラデ背景 + ダーク Get Started
- `app/arobix/dashboard/page.tsx` — グラデヘッダー / 大残高+24h / 4クイックアクション / My Cards / Recent Transaction
- `app/arobix/send/page.tsx` — Cards·Accounts·Statement タブ / ベージュ+ピンクのカード選択 / 検索+連絡先リスト
- `app/arobix/_components/ArobixBottomNav.tsx` — ダーク浮遊ピル型ナビ（白アイコン）
- `app/arobix/layout.tsx`, `app/arobix/page.tsx` — テーマ適用レイアウト + 3画面への入口

## 確認方法
`cd frontend && npm run dev` → ブラウザで **`/arobix`**

## 検証
- `tsc --noEmit`（プロジェクト全体）→ エラー0 / 終了コード0
- `next lint --dir app/arobix` → 警告・エラー0
- `git status` → 変更は新規 `app/arobix/` のみ（既存コード無変更）

## 次アクション候補
- 実画面 `app/(user)/onboarding` ・ `app/user/dashboard` へのパレット適用（要判断）
- 見出しフォント（Sora等）/ カード微グレイン / タップマイクロインタラクション / prefers-color-scheme 両対応

Refs Asana: https://app.asana.com/0/1213741124336104/1215580512043666

🤖 Generated with [Claude Code](https://claude.com/claude-code)