### PR TITLE
feat(liff): v3ヘッダーUATロゴに光沢アニメ(3秒間隔ループ)を追加

### DIFF
--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -157,7 +157,13 @@ export default function LiffChatPage() {
         >
           <Menu className="w-6 h-6" />
         </button>
-        <span className="text-[#4ade9a] font-bold text-xl tracking-wider">UAT</span>
+        <span
+          className="font-bold text-xl tracking-wider bg-clip-text text-transparent
+                     bg-[length:300%_100%] animate-logo-shine motion-reduce:animate-none
+                     bg-[linear-gradient(100deg,#4ade9a_0%,#4ade9a_45%,#ffffff_50%,#4ade9a_55%,#4ade9a_100%)]"
+        >
+          UAT
+        </span>
         <button
           onClick={() => setActivePanel("account")}
           className="text-white p-1 hover:bg-white/10 rounded-lg transition-colors"

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -69,11 +69,20 @@ module.exports = {
           "90%": { opacity: "1" },
           "100%": { transform: "translateY(800px)", opacity: "0" },
         },
+        // UAT ロゴの光沢: 0→33%(=1.5s)で光が左→右に走り、残り(=3s)は待機。
+        // 開始位置と終了位置はどちらも光沢バンドが文字外＝単色なので loop 折返しの段差は出ない。
+        "logo-shine": {
+          "0%": { backgroundPosition: "0% 0" },
+          "33%": { backgroundPosition: "100% 0" },
+          "100%": { backgroundPosition: "100% 0" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
         "scan-line": "scan-line 2s ease-in-out forwards",
+        // sweep 1.5s + wait 3s = 4.5s 周期で無限ループ
+        "logo-shine": "logo-shine 4.5s ease-in-out infinite",
       },
     },
   },


### PR DESCRIPTION
## 概要
v3 デフォルト画面(`/liff-chat`)ヘッダー中央の「UAT」ロゴに、光沢(shine)が走るアニメーションを実装。

ユーザー要望: 「光が走った3秒後にまた光る、それを繰り返す」

## 動作仕様
- 白い光沢が緑ロゴ(`#4ade9a`)上を左→右へ **約1.5秒** で走る
- その後 **3秒** 待機 → 再び走る → **無限ループ**(4.5秒周期)
- 待機中はブランド緑の単色。光沢バンドは開始/終了とも文字外でループ折返しの段差なし
- `prefers-reduced-motion` 時はアニメ停止(`motion-reduce:animate-none`)
- 既存の BUY/SELL 時 pulse/ping は無改変

## 変更ファイル
- `frontend/tailwind.config.js` — `logo-shine` keyframe + animation 追加(sweep 1.5s + wait 3s = 4.5s infinite)
- `frontend/app/(liff)/liff-chat/page.tsx` — UAT ロゴを `bg-clip-text` グラデーション + `animate-logo-shine` に変更

## 検証
- tailwind.config.js JS 妥当性 OK
- Tailwind CLI で `@keyframes logo-shine` / `.animate-logo-shine` / `bg-clip-text` / `background-size:300% 100%` / `linear-gradient(100deg…)` の生成を確認
- **未検証**: 実機ブラウザ/LIFF での見た目の最終確認(デプロイ後に実施)

## デプロイ
- NEXT_PUBLIC 変更なし → `deploy_production.sh --frontend-only` で反映可

## Asana
https://app.asana.com/0/1213741124336104/1215582501600908

🤖 Generated with [Claude Code](https://claude.com/claude-code)