### PR TITLE
refactor(wallet): MyWalletPanel を useWallet へ移行 + useLinkedWalletAddress 抽出 (PR-2, stacked on #602)

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useCallback } from "react"
 import {
   Copy,
   QrCode,
@@ -13,10 +13,9 @@ import {
   RefreshCw,
   Loader2,
 } from "lucide-react"
-import { usePrivy, useWallets } from "@privy-io/react-auth"
-import { getAuthToken } from "@/lib/auth/token-key"
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ""
+import { usePrivy } from "@privy-io/react-auth"
+import { useWallet } from "@/hooks/useWallet"
+import { useLinkedWalletAddress } from "@/hooks/useLinkedWalletAddress"
 
 // アドレス解決の状態。
 //  - loading : Privy 初期化中 / API 取得中
@@ -27,80 +26,38 @@ type FetchState = "loading" | "ready" | "empty" | "error"
 
 export function MyWalletPanel() {
   const { ready: privyReady, login } = usePrivy()
-  const { wallets } = useWallets()
-  const [address, setAddress] = useState<string | null>(null)
-  const [fetchState, setFetchState] = useState<FetchState>("loading")
+
+  // live wallet（injected / Privy embedded）は useWallet に集約済み。
+  // settings 画面など他の消費者と同一の単一情報源を共有する。
+  const { address: liveAddress } = useWallet()
+
+  // live wallet が取れないときだけ、バックエンド記録アドレスをフォールバック取得。
+  // （別デバイスで連携済み等。表示専用で署名はできない。）
+  const linked = useLinkedWalletAddress(privyReady && !liveAddress)
+
+  const address = liveAddress ?? linked.address
+
+  // 表示状態を派生。Privy 初期化前は loading を維持（永久固まり回避）。
+  const fetchState: FetchState = !privyReady
+    ? "loading"
+    : address
+      ? "ready"
+      : linked.state === "loading" || linked.state === "idle"
+        ? "loading"
+        : linked.state === "error"
+          ? "error"
+          : "empty"
+
   const [qrExpanded, setQrExpanded] = useState(false)
   const [toastMsg, setToastMsg] = useState("")
 
-  // Privy embedded wallet アドレスを取得、なければ API から取得する。
-  // token key は '@/lib/auth/token-key' の getAuthToken に統一
-  // （旧 'ultra_auth_token' 直読みは撤廃 — key 不整合による永久ローディングの根本原因）。
-  const resolveAddress = useCallback(async () => {
-    // Privy 初期化が終わるまでは loading 表示を維持（永久固まり回避のため privyReady を見る）
-    if (!privyReady) {
-      setFetchState("loading")
-      return
-    }
-
-    setFetchState("loading")
-
-    // 1) Privy embedded wallet を最優先
-    const privyWallet = wallets.find((w) => w.walletClientType === "privy")
-    if (privyWallet?.address) {
-      setAddress(privyWallet.address)
-      setFetchState("ready")
-      return
-    }
-
-    // 2) Privy ウォレットが無い場合は API から取得
-    const token = getAuthToken()
-    if (!token) {
-      // 認証トークンが無い = 未接続扱い（空状態 UI を表示）
-      setAddress(null)
-      setFetchState("empty")
-      return
-    }
-
-    try {
-      const res = await fetch(`${API_BASE}/api/user/settings`, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
-      if (!res.ok) {
-        // 非2xx は fail-visible。永久ローディングにせずエラー表示へ。
-        setFetchState("error")
-        return
-      }
-      const data = (await res.json()) as {
-        wallet_address?: string | null
-      } | null
-      if (data?.wallet_address) {
-        setAddress(data.wallet_address)
-        setFetchState("ready")
-      } else {
-        // 認証済みだがウォレット未接続
-        setAddress(null)
-        setFetchState("empty")
-      }
-    } catch {
-      // ネットワーク失敗等は fail-visible（リトライ可能）
-      setFetchState("error")
-    }
-  }, [privyReady, wallets])
-
-  useEffect(() => {
-    void resolveAddress()
-  }, [resolveAddress])
-
   // 「ウォレットに接続する」: Privy login をトリガ。
-  // login 後は authenticated/wallets が更新され、useEffect が再解決する。
+  // login 後は useWallet().address が更新され再描画される。
   const handleConnect = useCallback(async () => {
     try {
-      setFetchState("loading")
       await login()
-      // login 解決後の wallets 反映は useWallets の更新 → useEffect 再実行に委ねる
     } catch {
-      setFetchState("error")
+      // 失敗時は接続誘導 UI のまま（Privy 側がモーダルでエラー提示）
     }
   }, [login])
 
@@ -175,7 +132,7 @@ export function MyWalletPanel() {
               </p>
             </div>
             <button
-              onClick={() => void resolveAddress()}
+              onClick={() => linked.refetch()}
               className="w-full flex items-center justify-center gap-1.5 py-2 rounded-xl
                          bg-zinc-800/60 hover:bg-zinc-700/60 active:bg-zinc-600/60
                          transition-colors text-xs text-zinc-200"
@@ -209,7 +166,7 @@ export function MyWalletPanel() {
             </button>
             {/* Privy 初期化前など login が使えない場合のフォールバック再試行 */}
             <button
-              onClick={() => void resolveAddress()}
+              onClick={() => linked.refetch()}
               className="w-full flex items-center justify-center gap-1.5 py-2 rounded-xl
                          bg-zinc-800/40 hover:bg-zinc-700/50 active:bg-zinc-600/50
                          transition-colors text-xs text-zinc-400"

--- a/frontend/hooks/useLinkedWalletAddress.ts
+++ b/frontend/hooks/useLinkedWalletAddress.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Ultra AutoTrade. All rights reserved.
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { getAuthToken } from '@/lib/auth/token-key'
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ''
+
+// 取得状態。
+//  - idle    : enabled=false（fetch していない）
+//  - loading : API 取得中
+//  - ready   : wallet_address 取得済み
+//  - empty   : 認証済みだが記録上のアドレス無し / 未認証
+//  - error   : 取得失敗（refetch 可能）
+export type LinkedAddressState = 'idle' | 'loading' | 'ready' | 'empty' | 'error'
+
+export interface LinkedWalletAddress {
+  address: string | null
+  state: LinkedAddressState
+  refetch: () => void
+}
+
+/**
+ * useLinkedWalletAddress
+ *
+ * バックエンドに記録された連携ウォレットアドレス（`/api/user/settings` の
+ * `wallet_address`）を取得する「表示専用」hook。live wallet（injected / Privy
+ * embedded）が取れないときのフォールバック表示に使う。
+ *
+ * 返すのはアドレス文字列のみで、署名 provider/signer は持たない（記録上の値のため）。
+ * 署名が必要な経路は live wallet（useWallet の signer）を使うこと。
+ *
+ * @param enabled false の間は fetch せず idle を返す。live wallet がある場合に
+ *   無駄な API 呼び出しを避けるためのスイッチ。
+ *
+ * token key は `@/lib/auth/token-key` の getAuthToken に統一（旧 'ultra_auth_token'
+ * 直読みは key 不整合により永久ローディングを引き起こすため使わない）。
+ */
+export function useLinkedWalletAddress(enabled = true): LinkedWalletAddress {
+  const [address, setAddress] = useState<string | null>(null)
+  const [state, setState] = useState<LinkedAddressState>('idle')
+
+  const fetchAddress = useCallback(async () => {
+    if (!enabled) {
+      setState('idle')
+      return
+    }
+
+    const token = getAuthToken()
+    if (!token) {
+      // 認証トークンが無い = 記録も引けない（空状態）
+      setAddress(null)
+      setState('empty')
+      return
+    }
+
+    setState('loading')
+    try {
+      const res = await fetch(`${API_BASE}/api/user/settings`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) {
+        // 非2xx は fail-visible（永久ローディングにしない）
+        setState('error')
+        return
+      }
+      const data = (await res.json()) as { wallet_address?: string | null } | null
+      if (data?.wallet_address) {
+        setAddress(data.wallet_address)
+        setState('ready')
+      } else {
+        setAddress(null)
+        setState('empty')
+      }
+    } catch {
+      // ネットワーク失敗等は fail-visible（refetch 可能）
+      setState('error')
+    }
+  }, [enabled])
+
+  useEffect(() => {
+    void fetchAddress()
+  }, [fetchAddress])
+
+  return { address, state, refetch: fetchAddress }
+}


### PR DESCRIPTION
## 概要 (PR-2 / #602 の上に stack)
`MyWalletPanel` を PR-1 で統合した `useWallet`(単一情報源)へ移行し、ウォレット取得経路の二重化を解消する。

> base は `fix/account-wallet-usewallet-merge-20260610`(PR #602)。#602 merge 後に base を main へ retarget するか、#602 と続けて merge してください。

## 変更
- **新規 `hooks/useLinkedWalletAddress.ts`**: バックエンド記録アドレス(`/api/user/settings.wallet_address`)を取得する**表示専用** hook として抽出。`enabled` スイッチで live wallet がある間は fetch しない。署名 provider/signer は持たない(記録上の値のため)。settings 等からも再利用可能。
- **`MyWalletPanel.tsx`**: 自前の `resolveAddress`(Privy 直叩き + API)を撤去。
  - live = `useWallet().address`(injected/embedded 統合済)
  - 無ければ `useLinkedWalletAddress` でフォールバック表示
  - `loading`/`ready`/`empty`/`error` 表示状態は派生に置換、`privyReady` ガード(永久ローディング回避)は維持
  - JSX/スタイル/QR/トーストは不変

## 効果
- MY WALLET と settings 画面が**同一の live wallet 情報源**を共有(経路二重化の根絶)
- embedded wallet ユーザーは PR-1 で settings 表示が直り、本 PR で MY WALLET も同一経路に統一

## Gate
- `tsc --noEmit` PASS
- `eslint`(変更2ファイル) PASS
- ⏳ 実機: MY WALLET 表示 / settings 表示 / 両者一致 E2E は後続(Asana subtask 1215582497731032)

Refs Asana 1215576087505209