### PR TITLE
fix(wallet): 生 useAccount 消費者を useWallet へ移行 (PR-3, embedded を全画面へ)

### DIFF
--- a/frontend/app/user/deposit/DepositContent.tsx
+++ b/frontend/app/user/deposit/DepositContent.tsx
@@ -3,10 +3,12 @@
 // Unauthorized copying or distribution is strictly prohibited.
 
 import { useState, useCallback } from 'react'
-import { useAccount, useReadContract } from 'wagmi'
+import { useReadContract } from 'wagmi'
 import { useFundWallet } from '@privy-io/react-auth'
 import { base, baseSepolia } from 'wagmi/chains'
 import { formatUnits } from 'viem'
+import { useWallet } from '@/hooks/useWallet'
+import { getChainDisplayName } from '@/lib/web3/config'
 import {
   AlertTriangle,
   CheckCircle2,
@@ -35,17 +37,20 @@ function getChainForPrivy(chainId: number | undefined) {
 }
 
 export function DepositContent() {
-  const { address, isConnected, chain } = useAccount()
+  // injected / Privy embedded を統合した単一情報源（useWallet）から取得。
+  const { address, isConnected, chainId } = useWallet()
   const [isFunding, setIsFunding] = useState(false)
   const [fundError, setFundError] = useState<string | null>(null)
 
-  const usdcAddress = chain?.id != null ? USDC_BY_CHAIN[chain.id] : undefined
+  const chainName = getChainDisplayName(chainId)
+  const usdcAddress = chainId != null ? USDC_BY_CHAIN[chainId] : undefined
 
   const { data: usdcBalanceRaw, refetch: refetchBalance, isLoading: balanceLoading } = useReadContract({
     address: usdcAddress,
     abi: ERC20_ABI,
     functionName: 'balanceOf',
-    args: address ? [address] : undefined,
+    args: address ? [address as `0x${string}`] : undefined,
+    chainId: chainId ?? undefined,
     query: { enabled: !!address && !!usdcAddress },
   })
 
@@ -70,7 +75,7 @@ export function DepositContent() {
       await fundWallet({
         address,
         options: {
-          chain: getChainForPrivy(chain?.id),
+          chain: getChainForPrivy(chainId ?? undefined),
           amount: DEFAULT_ONRAMP_AMOUNT,
           asset: 'USDC',
         },
@@ -83,7 +88,7 @@ export function DepositContent() {
       setIsFunding(false)
       void refetchBalance()
     }
-  }, [address, chain, fundWallet, refetchBalance])
+  }, [address, chainId, fundWallet, refetchBalance])
 
   if (!isConnected || !address) {
     return (
@@ -114,7 +119,7 @@ export function DepositContent() {
           <div className="flex items-center justify-between text-sm">
             <span className="text-muted-foreground">ネットワーク</span>
             <Badge variant="outline" className="text-xs">
-              {chain?.name ?? '不明'}
+              {chainName ?? '不明'}
             </Badge>
           </div>
           <div className="flex items-center justify-between text-sm">
@@ -185,7 +190,7 @@ export function DepositContent() {
           <div className="rounded-lg bg-muted/50 px-3 py-2 text-xs text-muted-foreground space-y-1">
             <p>・入金先: あなた自身のウォレット（ノンカストディアル）</p>
             <p>・推奨金額: ${DEPOSIT_GATE_USD} USDC 以上</p>
-            <p>・対応チェーン: {chain?.name ?? 'Base'}</p>
+            <p>・対応チェーン: {chainName ?? 'Base'}</p>
           </div>
           <Button
             className="w-full"

--- a/frontend/app/user/wallet/WalletContent.tsx
+++ b/frontend/app/user/wallet/WalletContent.tsx
@@ -3,20 +3,23 @@
 // Unauthorized copying or distribution is strictly prohibited.
 
 import Link from 'next/link'
-import { useAccount, useBalance, useDisconnect } from 'wagmi'
+import { useBalance } from 'wagmi'
 import { formatUnits } from 'viem'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { AlertTriangle, CheckCircle2 } from 'lucide-react'
+import { useWallet } from '@/hooks/useWallet'
+import { getChainDisplayName } from '@/lib/web3/config'
 
 export function WalletContent() {
-  const { address, isConnected, chain } = useAccount()
-  const { data: balance } = useBalance({ address })
-  const { disconnect } = useDisconnect()
-  const defaultChainId = parseInt(process.env.NEXT_PUBLIC_DEFAULT_CHAIN_ID || '8453', 10)
-  const ALLOWED_CHAIN_IDS = [defaultChainId]
-  const isCorrectChain = chain?.id != null && ALLOWED_CHAIN_IDS.includes(chain.id)
+  // injected / Privy embedded を統合した単一情報源（useWallet）から取得。
+  const { address, isConnected, chainId, isCorrectChain, disconnect } = useWallet()
+  const { data: balance } = useBalance({
+    address: address ? (address as `0x${string}`) : undefined,
+    chainId: chainId ?? undefined,
+  })
+  const chainName = getChainDisplayName(chainId)
 
   if (!isConnected) {
     return (
@@ -52,7 +55,7 @@ export function WalletContent() {
             label="アドレス"
             value={address ? `${address.slice(0, 6)}...${address.slice(-4)}` : '—'}
           />
-          <InfoRow label="チェーン" value={chain?.name ?? '—'} />
+          <InfoRow label="チェーン" value={chainName ?? '—'} />
           <InfoRow
             label="残高"
             value={
@@ -69,7 +72,7 @@ export function WalletContent() {
           <AlertTriangle className="h-4 w-4" />
           <AlertTitle>ネットワークが違います</AlertTitle>
           <AlertDescription>
-            Base メインネットに切り替えてください。現在: {chain?.name ?? '不明'}
+            Base メインネットに切り替えてください。現在: {chainName ?? '不明'}
           </AlertDescription>
         </Alert>
       )}

--- a/frontend/components/user/UserHeader.tsx
+++ b/frontend/components/user/UserHeader.tsx
@@ -6,7 +6,8 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import { HelpCircle, ShieldAlert, ShieldOff } from 'lucide-react'
-import { useAccount } from 'wagmi'
+import { useWallet } from '@/hooks/useWallet'
+import { getChainDisplayName } from '@/lib/web3/config'
 import { useAuth } from '@/lib/auth'
 import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
@@ -46,7 +47,8 @@ export function UserHeader() {
   const pathname = usePathname()
   const router = useRouter()
   const { user, logout, token, isAdmin, isPartner } = useAuth()
-  const { address, chain } = useAccount()
+  // injected / Privy embedded を統合した単一情報源（useWallet）から取得。
+  const { address, chainId } = useWallet()
   const { isStopped, refreshStatus } = useAutomationStatus()
   const [showEmergencyConfirm, setShowEmergencyConfirm] = useState(false)
   const [showResumeConfirm, setShowResumeConfirm] = useState(false)
@@ -127,12 +129,12 @@ export function UserHeader() {
                   variant="outline"
                   className={cn(
                     'text-xs hidden sm:flex',
-                    chain?.id === 84532
+                    chainId === 84532
                       ? 'border-yellow-500/50 text-yellow-400'
                       : 'border-red-500/50 text-red-400'
                   )}
                 >
-                  {chain?.name ?? 'Unknown'}
+                  {getChainDisplayName(chainId) ?? 'Unknown'}
                 </Badge>
               </>
             )}

--- a/frontend/lib/web3/config.ts
+++ b/frontend/lib/web3/config.ts
@@ -117,3 +117,17 @@ export function getChainKey(chainId: number): SupportedChainKey | null {
   if (chainId === 1) return 'mainnet'
   return null
 }
+
+// chainId(数値) → 表示名。wagmi の Chain.name に依存していた箇所を useWallet(chainId 数値)
+// 経由に移行するための共通ヘルパー。未知チェーンは `Chain <id>` を返す。
+export function getChainDisplayName(chainId: number | null | undefined): string | undefined {
+  if (chainId == null) return undefined
+  const names: Record<number, string> = {
+    1: 'Ethereum',
+    8453: 'Base',
+    84532: 'Base Sepolia',
+    42161: 'Arbitrum One',
+    10: 'Optimism',
+  }
+  return names[chainId] ?? `Chain ${chainId}`
+}


### PR DESCRIPTION
## 概要 (PR-3 / #605 の上に stack)
PR-1/PR-2 で `useWallet` を単一情報源化したが、wagmi `useAccount()` を**直接**使う3画面が残り、embedded wallet ユーザーに「未接続」表示されていた。これらを `useWallet` へ移行し、injected/embedded 両対応をユーザー画面全体へ拡張する。

> base は `fix/mywallet-usewallet-migration-20260610`(PR #605)。merge 順は #602 → #605 → 本PR。各 merge 後に base を順次 retarget。

## 対象 / 変更
- `app/user/wallet/WalletContent.tsx`（残高・接続状態・切断）
- `app/user/deposit/DepositContent.tsx`（USDC残高・オンランプ）
- `components/user/UserHeader.tsx`（admin/partner アドレスバッジ）

- `useAccount()` → `useWallet()`。`address`/`isConnected`/`chainId`/`isCorrectChain`/`disconnect` を共有
- wagmi `Chain.name` 依存を解消するため `lib/web3/config.ts` に **`getChainDisplayName(chainId)`** 共通ヘルパーを追加(additive export)。`chain?.name` を置換
- `useBalance`/`useReadContract` は `address`/`chainId` を明示渡しで read 継続(public client 経由)
- `WalletContent` の切断は `useWallet` 版(embedded 時に Privy logout も実行)に統一

## 効果
生 `useAccount()` 消費者は `useWallet.ts` のみ(正)に収束。embedded wallet ユーザーが残高/入金/ヘッダ画面でも正しく認識される。

## R-A 判断
`@privy-io/wagmi` 導入(R-A)は **viem 2.52.0 厳密ピンへの bump + Tier S** を伴い、また当アプリは embedded の write を Privy `getEthereumProvider` で直接行い wagmi connector に依存しないため旨味が薄い。→ **launch 後の任意クリーンアップに延期**(R-B 拡張で同等のユーザー価値を確保)。

## Gate
- `tsc --noEmit` PASS
- `eslint`(変更4ファイル) PASS
- ⏳ 実機 E2E は後続(Asana subtask 1215582497731032)

Refs Asana 1215576087505209