### PR TITLE
fix(wallet): 生 useAccount 消費者を useWallet へ移行 (#606 を main へ再適用 / PR-3 stacked 取り残し復旧)

### DIFF
--- a/frontend/app/user/deposit/DepositContent.tsx
+++ b/frontend/app/user/deposit/DepositContent.tsx
@@ -3,10 +3,12 @@
 // Unauthorized copying or distribution is strictly prohibited.
 
 import { useState, useCallback } from 'react'
-import { useAccount, useReadContract } from 'wagmi'
+import { useReadContract } from 'wagmi'
 import { useFundWallet } from '@privy-io/react-auth'
 import { base, baseSepolia } from 'wagmi/chains'
 import { formatUnits } from 'viem'
+import { useWallet } from '@/hooks/useWallet'
+import { getChainDisplayName } from '@/lib/web3/config'
 import {
   AlertTriangle,
   CheckCircle2,
@@ -35,17 +37,20 @@ function getChainForPrivy(chainId: number | undefined) {
 }
 
 export function DepositContent() {
-  const { address, isConnected, chain } = useAccount()
+  // injected / Privy embedded を統合した単一情報源（useWallet）から取得。
+  const { address, isConnected, chainId } = useWallet()
   const [isFunding, setIsFunding] = useState(false)
   const [fundError, setFundError] = useState<string | null>(null)
 
-  const usdcAddress = chain?.id != null ? USDC_BY_CHAIN[chain.id] : undefined
+  const chainName = getChainDisplayName(chainId)
+  const usdcAddress = chainId != null ? USDC_BY_CHAIN[chainId] : undefined
 
   const { data: usdcBalanceRaw, refetch: refetchBalance, isLoading: balanceLoading } = useReadContract({
     address: usdcAddress,
     abi: ERC20_ABI,
     functionName: 'balanceOf',
-    args: address ? [address] : undefined,
+    args: address ? [address as `0x${string}`] : undefined,
+    chainId: chainId ?? undefined,
     query: { enabled: !!address && !!usdcAddress },
   })
 
@@ -70,7 +75,7 @@ export function DepositContent() {
       await fundWallet({
         address,
         options: {
-          chain: getChainForPrivy(chain?.id),
+          chain: getChainForPrivy(chainId ?? undefined),
           amount: DEFAULT_ONRAMP_AMOUNT,
           asset: 'USDC',
         },
@@ -83,7 +88,7 @@ export function DepositContent() {
       setIsFunding(false)
       void refetchBalance()
     }
-  }, [address, chain, fundWallet, refetchBalance])
+  }, [address, chainId, fundWallet, refetchBalance])
 
   if (!isConnected || !address) {
     return (
@@ -114,7 +119,7 @@ export function DepositContent() {
           <div className="flex items-center justify-between text-sm">
             <span className="text-muted-foreground">ネットワーク</span>
             <Badge variant="outline" className="text-xs">
-              {chain?.name ?? '不明'}
+              {chainName ?? '不明'}
             </Badge>
           </div>
           <div className="flex items-center justify-between text-sm">
@@ -185,7 +190,7 @@ export function DepositContent() {
           <div className="rounded-lg bg-muted/50 px-3 py-2 text-xs text-muted-foreground space-y-1">
             <p>・入金先: あなた自身のウォレット（ノンカストディアル）</p>
             <p>・推奨金額: ${DEPOSIT_GATE_USD} USDC 以上</p>
-            <p>・着金チェーン: {chain?.name ?? 'Base'}（別ネットワークの USDC も自動変換）</p>
+            <p>・着金チェーン: {chainName ?? 'Base'}（別ネットワークの USDC も自動変換）</p>
           </div>
           <Button
             className="w-full"

--- a/frontend/app/user/wallet/WalletContent.tsx
+++ b/frontend/app/user/wallet/WalletContent.tsx
@@ -3,20 +3,23 @@
 // Unauthorized copying or distribution is strictly prohibited.
 
 import Link from 'next/link'
-import { useAccount, useBalance, useDisconnect } from 'wagmi'
+import { useBalance } from 'wagmi'
 import { formatUnits } from 'viem'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { AlertTriangle, CheckCircle2 } from 'lucide-react'
+import { useWallet } from '@/hooks/useWallet'
+import { getChainDisplayName } from '@/lib/web3/config'
 
 export function WalletContent() {
-  const { address, isConnected, chain } = useAccount()
-  const { data: balance } = useBalance({ address })
-  const { disconnect } = useDisconnect()
-  const defaultChainId = parseInt(process.env.NEXT_PUBLIC_DEFAULT_CHAIN_ID || '8453', 10)
-  const ALLOWED_CHAIN_IDS = [defaultChainId]
-  const isCorrectChain = chain?.id != null && ALLOWED_CHAIN_IDS.includes(chain.id)
+  // injected / Privy embedded を統合した単一情報源（useWallet）から取得。
+  const { address, isConnected, chainId, isCorrectChain, disconnect } = useWallet()
+  const { data: balance } = useBalance({
+    address: address ? (address as `0x${string}`) : undefined,
+    chainId: chainId ?? undefined,
+  })
+  const chainName = getChainDisplayName(chainId)
 
   if (!isConnected) {
     return (
@@ -52,7 +55,7 @@ export function WalletContent() {
             label="アドレス"
             value={address ? `${address.slice(0, 6)}...${address.slice(-4)}` : '—'}
           />
-          <InfoRow label="チェーン" value={chain?.name ?? '—'} />
+          <InfoRow label="チェーン" value={chainName ?? '—'} />
           <InfoRow
             label="残高"
             value={
@@ -69,7 +72,7 @@ export function WalletContent() {
           <AlertTriangle className="h-4 w-4" />
           <AlertTitle>ネットワークが違います</AlertTitle>
           <AlertDescription>
-            Base メインネットに切り替えてください。現在: {chain?.name ?? '不明'}
+            Base メインネットに切り替えてください。現在: {chainName ?? '不明'}
           </AlertDescription>
         </Alert>
       )}

--- a/frontend/components/user/UserHeader.tsx
+++ b/frontend/components/user/UserHeader.tsx
@@ -6,7 +6,8 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import { HelpCircle, ShieldAlert, ShieldOff } from 'lucide-react'
-import { useAccount } from 'wagmi'
+import { useWallet } from '@/hooks/useWallet'
+import { getChainDisplayName } from '@/lib/web3/config'
 import { useAuth } from '@/lib/auth'
 import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
@@ -46,7 +47,8 @@ export function UserHeader() {
   const pathname = usePathname()
   const router = useRouter()
   const { user, logout, token, isAdmin, isPartner } = useAuth()
-  const { address, chain } = useAccount()
+  // injected / Privy embedded を統合した単一情報源（useWallet）から取得。
+  const { address, chainId } = useWallet()
   const { isStopped, refreshStatus } = useAutomationStatus()
   const [showEmergencyConfirm, setShowEmergencyConfirm] = useState(false)
   const [showResumeConfirm, setShowResumeConfirm] = useState(false)
@@ -127,12 +129,12 @@ export function UserHeader() {
                   variant="outline"
                   className={cn(
                     'text-xs hidden sm:flex',
-                    chain?.id === 84532
+                    chainId === 84532
                       ? 'border-yellow-500/50 text-yellow-400'
                       : 'border-red-500/50 text-red-400'
                   )}
                 >
-                  {chain?.name ?? 'Unknown'}
+                  {getChainDisplayName(chainId) ?? 'Unknown'}
                 </Badge>
               </>
             )}

--- a/frontend/lib/web3/config.ts
+++ b/frontend/lib/web3/config.ts
@@ -117,3 +117,17 @@ export function getChainKey(chainId: number): SupportedChainKey | null {
   if (chainId === 1) return 'mainnet'
   return null
 }
+
+// chainId(数値) → 表示名。wagmi の Chain.name に依存していた箇所を useWallet(chainId 数値)
+// 経由に移行するための共通ヘルパー。未知チェーンは `Chain <id>` を返す。
+export function getChainDisplayName(chainId: number | null | undefined): string | undefined {
+  if (chainId == null) return undefined
+  const names: Record<number, string> = {
+    1: 'Ethereum',
+    8453: 'Base',
+    84532: 'Base Sepolia',
+    42161: 'Arbitrum One',
+    10: 'Optimism',
+  }
+  return names[chainId] ?? `Chain ${chainId}`
+}


### PR DESCRIPTION
## 背景: #606 が stacked 取り残しで main 未反映

今日の wallet 移行は 3 段 stacked PR で実施された:
- #602 (base=main) ← #605 (base=#602ブランチ) ← **#606 (base=#605ブランチ)**

#606「生 useAccount 消費者を useWallet へ移行 (PR-3)」(実コミット `4377fcc`) は GitHub 上 **merged** 表示だが、ベースブランチ (#605) が #602 の main マージ後に取り残されたため、**main HEAD に届いていなかった**。

結果、main では以下が **まだ生 `useAccount` のまま**残存していた:
- `frontend/app/user/deposit/DepositContent.tsx`
- `frontend/app/user/wallet/WalletContent.tsx`
- `frontend/components/user/UserHeader.tsx`

このまま staging/production にフロントをデプロイすると、wallet 移行が **PR-3 だけ欠けた中途半端な状態**で配信され、embedded/Privy ウォレットで残高・チェーン表示が壊れるリスクがあった。

## このPRの内容

`4377fcc` を最新 `origin/main` (0c66fc4) へ cherry-pick して再適用 (4 ファイル, 45+/21-)。

### コンフリクト解消 (`DepositContent.tsx` 1 箇所)

`origin/main` には #600「Privy SDK 3.29.2 + Deposit address 入金フロー」が先に入っており、同一行が衝突:

```
HEAD (#600):  ・着金チェーン: {chain?.name ?? 'Base'}（別ネットワークの USDC も自動変換）
#606 (PR-3):  ・対応チェーン: {chainName ?? 'Base'}
```

- #606 は `useAccount` の `chain` を `useWallet` の `chainName` (`getChainDisplayName(chainId)`) に移行。**移行後は `chain` 変数自体が消える**ため、`chain?.name` を残すと未定義参照で壊れる。
- #600 の追加文言「（別ネットワークの USDC も自動変換）」は日本ユーザー向け説明として維持すべき。
- **両者を統合**: 新変数 `chainName` を採用しつつ #600 文言を維持:

```tsx
<p>・着金チェーン: {chainName ?? 'Base'}（別ネットワークの USDC も自動変換）</p>
```

## 検証

- `tsc --noEmit` (frontend): **EXIT=0** (型エラーなし)
- 残存コンフリクトマーカー: なし
- 古い `chain` 変数の参照漏れ: なし (L25 はコメント / L78 は Privy へ渡すオブジェクトキー)

マージ後、staging へは `deploy_staging.sh --frontend-only` でフロント反映。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
