### PR TITLE
fix(chaos): _wait_for_recovery のログ/進捗を stderr へ (戻り値汚染で全 timeout 誤判定を修正)

### DIFF
--- a/scripts/chaos_test_staging.sh
+++ b/scripts/chaos_test_staging.sh
@@ -119,7 +119,12 @@ _wait_for_recovery() {
   local elapsed=0
   local interval=5
 
-  log_info "復旧待機中... (最大 ${MAX_RECOVERY_SEC}秒)"
+  # 重要: 本関数の戻り値は `recovery_sec=$(_wait_for_recovery ...)` で
+  # コマンド置換キャプチャされる。ログ・進捗は必ず stderr (>&2) に出し、
+  # stdout には最終的な数値 (復旧秒 or -1) のみを出すこと。stdout に混ぜると
+  # 戻り値が汚染され `[[ "$recovery_sec" -ge 0 ]]` が算術エラーで誤判定する
+  # (2026-06-11 実機: 即復帰したのに全 timeout 誤報告した真因)。
+  log_info "復旧待機中... (最大 ${MAX_RECOVERY_SEC}秒)" >&2
 
   while [[ $elapsed -lt $MAX_RECOVERY_SEC ]]; do
     sleep "$interval"
@@ -138,16 +143,16 @@ _wait_for_recovery() {
       local health
       health=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$container" 2>/dev/null) || health="none"
       if [[ "$health" == "healthy" || "$health" == "none" ]]; then
-        echo "$elapsed"
+        echo "$elapsed"   # ← stdout: 戻り値 (復旧秒)
         return 0
       fi
     fi
 
-    echo -ne "\r  ${elapsed}秒経過... (container: ${status})"
+    echo -ne "\r  ${elapsed}秒経過... (container: ${status})" >&2
   done
 
-  echo ""
-  echo "-1"  # タイムアウト
+  echo "" >&2
+  echo "-1"   # ← stdout: 戻り値 (タイムアウト)
   return 1
 }
 


### PR DESCRIPTION
## 背景

PR #611（host kill -9 でクラッシュ再現）マージ後、staging で実行したところ:
- **docker events: 全7コンテナが `die`→`start` で即復帰**（restart ポリシー正常）
- **総時間 80秒**（7×300秒=2100秒のはずがない）
- なのに**全コンテナ「復旧失敗: タイムアウト」**で FAIL

= `_wait_for_recovery` は実際には ~10秒で復帰を検知して早期 return しているのに、戻り値の解析に失敗して timeout 扱いになっていた。

## 真因（古典的 bash バグ）

`_wait_for_recovery` の戻り値は `recovery_sec=$(_wait_for_recovery ...)` で**コマンド置換キャプチャ**される。しかし関数内の `log_info` / 進捗 `echo -ne "\r..."` / 空 `echo ""` を **stdout** に出していたため、数値の戻り値にログ文字列が混入。`[[ "$recovery_sec" -ge 0 ]]` が非数値で算術エラー → false → 全 timeout 誤判定。

PR #611 以前は health が永遠に 200 にならず常に 300秒 timeout だったため、このバグは露見しなかった（`-1` の汚染も結果的に timeout 判定と一致）。#611 でコンテナが即復帰するようになり顕在化。

## 変更

`scripts/chaos_test_staging.sh` の `_wait_for_recovery`:
- `log_info` / 進捗 `echo -ne` / 空 `echo ""` → **全て `>&2` (stderr)** へ
- stdout には最終的な数値（復旧秒 or `-1`）のみ
- 再発防止コメント追加

## 検証済み事実（実機 2026-06-11）

docker events が die→start 即復帰を記録 = **インフラ（restart:always）は完全に健全**。本修正で「クラッシュ→即復帰」が正しく PASS 判定される。

## Test plan

- [ ] staging VPS で `sudo RUN_INDEX=1 bash scripts/chaos_test_3day_runner.sh`
- [ ] 各コンテナが「復旧成功: N秒」（N < 300）で PASS
- [ ] 最終 `chaos_rc: 0` / status PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)