### PR TITLE
feat(ai): 4軸 weighted 合議の決定論関数群 (docs/52 Phase 1 / EPIC-1 1-1〜1-4, 1-9)

### DIFF
--- a/backend/app/ai/agents.py
+++ b/backend/app/ai/agents.py
@@ -46,6 +46,8 @@ def validate_agent_weights(weights: dict[str, Decimal]) -> None:
 
     Requirements (fail-closed — raise ValueError on violation):
     - keys must be exactly {risk, indicator, macro, pattern}
+    - every weight must be within [0, 1] (a negative weight would flip the
+      agent's direction and break the score ∈ [-1, +1] invariant)
     - sum of weights must be within 1.0 ± 0.01 (Decimal arithmetic)
     """
     keys = set(weights.keys())
@@ -54,6 +56,9 @@ def validate_agent_weights(weights: dict[str, Decimal]) -> None:
             f"agent weights keys must be exactly {sorted(_CONSENSUS_AGENT_KEYS)}, "
             f"got {sorted(keys)}"
         )
+    for key, weight in weights.items():
+        if weight < Decimal("0") or weight > Decimal("1"):
+            raise ValueError(f"agent weight {key!r} must be in range [0, 1], got {weight}")
     total = sum(weights.values(), Decimal("0"))
     if abs(total - Decimal("1.0")) > _WEIGHT_SUM_TOLERANCE:
         raise ValueError(f"agent weights must sum to 1.0 ± 0.01, got {total}")

--- a/backend/app/ai/agents.py
+++ b/backend/app/ai/agents.py
@@ -19,15 +19,44 @@ No side effects, no state, easily testable.
 """
 
 import logging
+from decimal import ROUND_HALF_UP, Decimal
 from enum import Enum
-from typing import Optional
+from typing import ClassVar, Optional
 
 from pydantic import BaseModel, Field
 
 from app.ai.judgment_log import CognitiveState
+from app.ai.schemas import AgentContribution, DeterministicVerdict, TradeAction
 from app.data_feeds.context import MarketContext
 
 logger = logging.getLogger(__name__)
+
+
+# ============================================================
+# 4-axis weighted consensus helpers (docs/52 Phase 1)
+# ============================================================
+_CONSENSUS_AGENT_KEYS: frozenset[str] = frozenset({"risk", "indicator", "macro", "pattern"})
+
+#: Allowed deviation of the weight sum from 1.0 (docs/52 §4.2: 1.0 ± 0.01).
+_WEIGHT_SUM_TOLERANCE: Decimal = Decimal("0.01")
+
+
+def validate_agent_weights(weights: dict[str, Decimal]) -> None:
+    """Validate a 4-axis consensus weight mapping (docs/52 §4.2).
+
+    Requirements (fail-closed — raise ValueError on violation):
+    - keys must be exactly {risk, indicator, macro, pattern}
+    - sum of weights must be within 1.0 ± 0.01 (Decimal arithmetic)
+    """
+    keys = set(weights.keys())
+    if keys != _CONSENSUS_AGENT_KEYS:
+        raise ValueError(
+            f"agent weights keys must be exactly {sorted(_CONSENSUS_AGENT_KEYS)}, "
+            f"got {sorted(keys)}"
+        )
+    total = sum(weights.values(), Decimal("0"))
+    if abs(total - Decimal("1.0")) > _WEIGHT_SUM_TOLERANCE:
+        raise ValueError(f"agent weights must sum to 1.0 ± 0.01, got {total}")
 
 
 # ============================================================
@@ -62,6 +91,14 @@ class MultiAgentContext(BaseModel):
     risk_signal: Optional[AgentSignal] = None
     macro_signal: Optional[AgentSignal] = None
     cognitive_state: Optional[CognitiveState] = None
+
+    #: Default 4-axis consensus weights (docs/52 §4.2 — aligned with v4/v5 prompts).
+    DEFAULT_WEIGHTS: ClassVar[dict[str, Decimal]] = {
+        "risk": Decimal("0.40"),
+        "indicator": Decimal("0.25"),
+        "macro": Decimal("0.20"),
+        "pattern": Decimal("0.15"),
+    }
 
     def to_decision_prompt(self) -> str:
         """Format all agent signals for the Decision Agent LLM prompt."""
@@ -222,6 +259,180 @@ class MultiAgentContext(BaseModel):
             and mac.bias == Bias.BULLISH
             and mac.confidence >= self._DIRECTIONAL_THRESHOLD
         )
+
+    # ------------------------------------------------------------------
+    # 4-axis weighted consensus (docs/52 Phase 1 — NOT wired into
+    # service.py yet; shadow/A-B wiring happens in later PRs)
+    # ------------------------------------------------------------------
+
+    def _direction_and_confidence(self, agent_key: str) -> tuple[int, int]:
+        """Return (direction, confidence) for one consensus axis.
+
+        Direction mapping (docs/52 §4.1): BULLISH=+1 / NEUTRAL=0 / BEARISH=-1.
+        A missing signal contributes (0, 0) — its weight is consumed but not
+        re-normalized, so missing axes pull the score toward HOLD (fail-safe).
+        """
+        signal: Optional[AgentSignal] = {
+            "risk": self.risk_signal,
+            "indicator": self.indicator_signal,
+            "macro": self.macro_signal,
+            "pattern": self.pattern_signal,
+        }[agent_key]
+        if signal is None:
+            return 0, 0
+        direction = {Bias.BULLISH: 1, Bias.NEUTRAL: 0, Bias.BEARISH: -1}[signal.bias]
+        return direction, signal.confidence
+
+    def weighted_directional_score(
+        self,
+        weights: Optional[dict[str, Decimal]] = None,
+    ) -> Decimal:
+        """Weighted directional score in [-1, +1] (docs/52 §4.3).
+
+        score = Σ_i  w_i × direction_i × (confidence_i / 100)
+
+        All arithmetic is Decimal (CLAUDE.md §Financial calculations).
+        """
+        resolved = self.DEFAULT_WEIGHTS if weights is None else weights
+        validate_agent_weights(resolved)
+
+        score = Decimal("0")
+        for key in ("risk", "indicator", "macro", "pattern"):
+            direction, confidence = self._direction_and_confidence(key)
+            score += resolved[key] * direction * (Decimal(confidence) / Decimal(100))
+        return score
+
+    def weighted_confidence(
+        self,
+        weights: Optional[dict[str, Decimal]] = None,
+    ) -> int:
+        """Weighted confidence in [0, 100] (docs/52 §4.3).
+
+        weighted_conf = round_half_up( Σ_i  w_i × confidence_i )
+
+        ROUND_HALF_UP is explicit — Python's built-in round() uses banker's
+        rounding (round-half-even), which would turn 69.5 into 70 but 70.5
+        into 70 and break the design's arithmetic examples.
+        """
+        resolved = self.DEFAULT_WEIGHTS if weights is None else weights
+        validate_agent_weights(resolved)
+
+        total = Decimal("0")
+        for key in ("risk", "indicator", "macro", "pattern"):
+            _, confidence = self._direction_and_confidence(key)
+            total += resolved[key] * Decimal(confidence)
+        return int(total.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+    def evaluate_4axis_consensus(
+        self,
+        *,
+        weights: Optional[dict[str, Decimal]] = None,
+        score_threshold: Decimal = Decimal("0.40"),
+        conf_threshold: int = 65,
+    ) -> DeterministicVerdict:
+        """4-axis weighted deterministic verdict (docs/52 §4.4).
+
+        - score >= +score_threshold and conf >= conf_threshold → BUY
+        - score <= -score_threshold and conf >= conf_threshold → SELL
+        - otherwise → HOLD
+        - single-agent runaway guard: a BUY/SELL verdict with fewer than 2
+          agents agreeing with the score direction (conf >= 50) is demoted
+          to HOLD (docs/52 §4.4, SELL-spam #365 recurrence prevention).
+
+        agreeing_count is always computed (even for HOLD verdicts) so shadow
+        logs stay comparable across actions.
+        """
+        resolved = self.DEFAULT_WEIGHTS if weights is None else weights
+        validate_agent_weights(resolved)
+
+        score = self.weighted_directional_score(resolved)
+        conf = self.weighted_confidence(resolved)
+
+        contributions: dict[str, AgentContribution] = {}
+        agreeing_count = 0
+        for key in ("risk", "indicator", "macro", "pattern"):
+            direction, confidence = self._direction_and_confidence(key)
+            contributions[key] = AgentContribution(
+                direction=direction,
+                confidence=confidence,
+                weight=resolved[key],
+                contribution=resolved[key] * direction * (Decimal(confidence) / Decimal(100)),
+            )
+            # sign(direction × score) > 0 — the agent points the same way
+            # as the aggregate score and is individually confident enough.
+            if direction * score > 0 and confidence >= 50:
+                agreeing_count += 1
+
+        if score >= score_threshold and conf >= conf_threshold:
+            action = TradeAction.BUY
+        elif score <= -score_threshold and conf >= conf_threshold:
+            action = TradeAction.SELL
+        else:
+            action = TradeAction.HOLD
+
+        demoted = False
+        if action in (TradeAction.BUY, TradeAction.SELL) and agreeing_count < 2:
+            action = TradeAction.HOLD
+            demoted = True
+
+        reasoning = (
+            f"4-axis consensus: score={score} (threshold=±{score_threshold}), "
+            f"weighted_confidence={conf} (threshold={conf_threshold}), "
+            f"agreeing_count={agreeing_count} → {action.value}"
+        )
+        if demoted:
+            reasoning += ". Demoted to HOLD: single-agent runaway guard (agreeing_count < 2)"
+
+        return DeterministicVerdict(
+            action=action,
+            score=score,
+            weighted_confidence=conf,
+            agreeing_count=agreeing_count,
+            per_agent_contribution=contributions,
+            reasoning=reasoning,
+        )
+
+
+def resolve_llm_and_deterministic(
+    llm_action: TradeAction,
+    llm_confidence: int,
+    det: DeterministicVerdict,
+) -> tuple[TradeAction, int, bool]:
+    """Reconcile the LLM action with the deterministic verdict (docs/52 §4.5).
+
+    Pure module-level function — NOT wired into service.py yet (Phase 1).
+
+    Reconciliation table:
+    - LLM=HOLD → HOLD (existing behaviour preserved; no veto)
+    - LLM matches deterministic (BUY/BUY or SELL/SELL) → adopt (no veto)
+    - LLM=BUY|SELL, deterministic=HOLD → HOLD (deterministic veto)
+    - LLM=BUY vs deterministic=SELL (or inverse) → HOLD + warning (conflict)
+
+    final_confidence = min(llm_confidence, det.weighted_confidence); on veto
+    or conflict it is additionally capped at 50.
+
+    Returns:
+        (final_action, final_confidence, veto_applied)
+    """
+    det_conf = det.weighted_confidence
+
+    if llm_action == TradeAction.HOLD:
+        return TradeAction.HOLD, min(llm_confidence, det_conf), False
+
+    if llm_action == det.action:
+        return llm_action, min(llm_confidence, det_conf), False
+
+    if det.action == TradeAction.HOLD:
+        # Deterministic veto: LLM wants to trade but the 4-axis verdict is HOLD.
+        return TradeAction.HOLD, min(llm_confidence, det_conf, 50), True
+
+    # Directional conflict (BUY vs SELL) — force HOLD on the safe side.
+    logger.warning(
+        "4-axis consensus conflict: llm_action=%s vs deterministic=%s — forcing HOLD",
+        llm_action.value,
+        det.action.value,
+    )
+    return TradeAction.HOLD, min(llm_confidence, det_conf, 50), True
 
 
 # ============================================================

--- a/backend/app/ai/schemas.py
+++ b/backend/app/ai/schemas.py
@@ -9,6 +9,7 @@
 """
 
 from datetime import datetime
+from decimal import Decimal
 from enum import Enum
 from typing import List, Optional
 
@@ -236,3 +237,61 @@ class SentimentHistoryResponse(BaseModel):
     current_label: SentimentLabel = Field(..., description="現在のセンチメントラベル")
     is_mock: bool = Field(False, description="モックデータを返しているか")
     hours: int = Field(24, description="取得期間（時間）")
+
+
+# ---------------------------------------------------------------------------
+# 4軸 weighted 合議スキーマ（docs/52 Phase 1 追加分）
+# ---------------------------------------------------------------------------
+
+
+class AgentContribution(BaseModel):
+    """4軸 weighted 合議における 1 agent の寄与内訳。
+
+    docs/52_decision_layer_4axis_consensus_design.md §4.6 の
+    `per_agent_contribution` 1 エントリに対応する。
+    """
+
+    direction: int = Field(
+        ...,
+        ge=-1,
+        le=1,
+        description="方向値（BULLISH=+1 / NEUTRAL=0 / BEARISH=-1）。signal 欠落時は 0。",
+    )
+    confidence: int = Field(
+        ...,
+        ge=0,
+        le=100,
+        description="agent の信頼度（0〜100）。signal 欠落時は 0。",
+    )
+    weight: Decimal = Field(..., description="この agent に割り当てられた重み（合計 1.0）。")
+    contribution: Decimal = Field(
+        ...,
+        description="weighted directional score への寄与 = weight × direction × (confidence/100)。",
+    )
+
+
+class DeterministicVerdict(BaseModel):
+    """4軸 weighted 合議による決定論レイヤーの判定結果。
+
+    docs/52_decision_layer_4axis_consensus_design.md §4.4 / §4.7 に対応する。
+    """
+
+    action: TradeAction = Field(..., description="決定論レイヤーの判定（BUY / SELL / HOLD）。")
+    score: Decimal = Field(..., description="weighted directional score（-1.0〜+1.0）。")
+    weighted_confidence: int = Field(
+        ...,
+        ge=0,
+        le=100,
+        description="重み付き信頼度（0〜100、ROUND_HALF_UP で整数化）。",
+    )
+    agreeing_count: int = Field(
+        ...,
+        ge=0,
+        le=4,
+        description="score と同方向 かつ confidence>=50 の agent 数（単一暴走抑止用）。",
+    )
+    per_agent_contribution: dict[str, AgentContribution] = Field(
+        ...,
+        description="agent 名（risk/indicator/macro/pattern）→ 寄与内訳。4 軸全て格納。",
+    )
+    reasoning: str = Field(..., description="人間可読の判定サマリ（score/conf/閾値/降格有無）。")

--- a/backend/tests/test_consensus_4axis.py
+++ b/backend/tests/test_consensus_4axis.py
@@ -94,7 +94,9 @@ class TestWeightedDirectionalScore:
     def test_weighted_score_risk_dominant(self) -> None:
         """Risk BEARISH 80 alone: score = -0.32, agreeing_count = 1 → HOLD.
 
-        Single-agent runaway suppression (docs/52 §4.4 / R2).
+        R2(c): Risk 単独 BEARISH 80 は |score|=0.32 < threshold 0.40 で HOLD
+        (閾値分岐での HOLD 到達。§4.4 降格ガード自体の検証は
+        test_single_agent_runaway_demotion を参照)。
         """
         ctx = _make_ctx(
             indicator=(Bias.NEUTRAL, 50),
@@ -179,6 +181,26 @@ class TestEvaluate4AxisConsensus:
         verdict = ctx.evaluate_4axis_consensus()
         assert verdict.action == TradeAction.HOLD
         assert verdict.score == Decimal("-0.190")
+
+    def test_single_agent_runaway_demotion(self) -> None:
+        """§4.4 降格ガード: 閾値を超えても agreeing_count < 2 なら HOLD に降格。
+
+        risk=BULLISH 100 + 他 3 軸 NEUTRAL 90:
+        score = 0.40×1.00 = 0.40 (>= +0.40)、conf = 40+22.5+18+13.5 = 94 (>= 65)
+        → 閾値分岐は BUY だが agreeing_count = 1 → HOLD 降格 (#365 再発防止の核心)。
+        """
+        ctx = _make_ctx(
+            indicator=(Bias.NEUTRAL, 90),
+            pattern=(Bias.NEUTRAL, 90),
+            risk=(Bias.BULLISH, 100),
+            macro=(Bias.NEUTRAL, 90),
+        )
+        verdict = ctx.evaluate_4axis_consensus()
+        assert verdict.score == Decimal("0.40")
+        assert verdict.weighted_confidence == 94
+        assert verdict.agreeing_count == 1
+        assert verdict.action == TradeAction.HOLD
+        assert "Demoted" in verdict.reasoning
 
     def test_missing_signal_counts_as_zero(self) -> None:
         """A missing axis contributes (direction=0, conf=0) without re-normalizing."""
@@ -287,6 +309,20 @@ class TestWeightValidation:
             ctx.weighted_directional_score(bad_weights)
         with pytest.raises(ValueError, match="sum"):
             ctx.evaluate_4axis_consensus(weights=bad_weights)
+
+    def test_weight_validation_rejects_negative_weight(self) -> None:
+        """負の重みは合計が 1.0 でも拒否 (direction 反転 / score 不変条件破壊防止)。"""
+        negative_weights = {
+            "risk": Decimal("1.5"),
+            "indicator": Decimal("-0.5"),
+            "macro": Decimal("0"),
+            "pattern": Decimal("0"),
+        }
+        with pytest.raises(ValueError, match="range"):
+            validate_agent_weights(negative_weights)
+        ctx = _make_ctx(risk=(Bias.BULLISH, 80))
+        with pytest.raises(ValueError, match="range"):
+            ctx.weighted_directional_score(negative_weights)
 
     def test_weight_validation_rejects_wrong_keys(self) -> None:
         """Key set must be exactly {risk, indicator, macro, pattern}."""

--- a/backend/tests/test_consensus_4axis.py
+++ b/backend/tests/test_consensus_4axis.py
@@ -1,0 +1,299 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""Tests for the 4-axis weighted consensus functions (docs/52 §7.1).
+
+Covers:
+- MultiAgentContext.weighted_directional_score()
+- MultiAgentContext.weighted_confidence()
+- MultiAgentContext.evaluate_4axis_consensus()
+- resolve_llm_and_deterministic()
+- validate_agent_weights()
+
+Expected values are cross-checked against
+docs/52_decision_layer_4axis_consensus_design.md Appendix A.1-A.3.
+"""
+
+import logging
+from decimal import Decimal
+from typing import Optional
+
+import pytest
+
+from app.ai.agents import (
+    AgentSignal,
+    Bias,
+    MultiAgentContext,
+    resolve_llm_and_deterministic,
+    validate_agent_weights,
+)
+from app.ai.schemas import DeterministicVerdict, TradeAction
+
+
+def _signal(name: str, bias: Bias, confidence: int) -> AgentSignal:
+    return AgentSignal(
+        agent_name=name,
+        bias=bias,
+        confidence=confidence,
+        reasoning="test signal",
+    )
+
+
+def _make_ctx(
+    indicator: Optional[tuple[Bias, int]] = None,
+    pattern: Optional[tuple[Bias, int]] = None,
+    risk: Optional[tuple[Bias, int]] = None,
+    macro: Optional[tuple[Bias, int]] = None,
+) -> MultiAgentContext:
+    """Build a MultiAgentContext from (bias, confidence) tuples per axis."""
+    return MultiAgentContext(
+        indicator_signal=_signal("Indicator Agent", *indicator) if indicator else None,
+        pattern_signal=_signal("Pattern Agent", *pattern) if pattern else None,
+        risk_signal=_signal("Risk Agent", *risk) if risk else None,
+        macro_signal=_signal("Macro Agent", *macro) if macro else None,
+    )
+
+
+class TestWeightedDirectionalScore:
+    def test_weighted_score_all_bullish_max(self) -> None:
+        """4 axes BULLISH conf=100 → score = +1.0, conf = 100."""
+        ctx = _make_ctx(
+            indicator=(Bias.BULLISH, 100),
+            pattern=(Bias.BULLISH, 100),
+            risk=(Bias.BULLISH, 100),
+            macro=(Bias.BULLISH, 100),
+        )
+        assert ctx.weighted_directional_score() == Decimal("1.0")
+        assert ctx.weighted_confidence() == 100
+
+    def test_weighted_score_all_bearish_max(self) -> None:
+        """4 axes BEARISH conf=100 → score = -1.0, conf = 100."""
+        ctx = _make_ctx(
+            indicator=(Bias.BEARISH, 100),
+            pattern=(Bias.BEARISH, 100),
+            risk=(Bias.BEARISH, 100),
+            macro=(Bias.BEARISH, 100),
+        )
+        assert ctx.weighted_directional_score() == Decimal("-1.0")
+        assert ctx.weighted_confidence() == 100
+
+    def test_weighted_score_cancellation(self) -> None:
+        """Indicator BULLISH 90 vs Macro BEARISH 90 mostly cancel out.
+
+        score = 0.25×0.90 − 0.20×0.90 = 0.225 − 0.180 = +0.045 → HOLD.
+        """
+        ctx = _make_ctx(
+            indicator=(Bias.BULLISH, 90),
+            pattern=(Bias.NEUTRAL, 50),
+            risk=(Bias.NEUTRAL, 50),
+            macro=(Bias.BEARISH, 90),
+        )
+        assert ctx.weighted_directional_score() == Decimal("0.045")
+        verdict = ctx.evaluate_4axis_consensus()
+        assert verdict.action == TradeAction.HOLD
+
+    def test_weighted_score_risk_dominant(self) -> None:
+        """Risk BEARISH 80 alone: score = -0.32, agreeing_count = 1 → HOLD.
+
+        Single-agent runaway suppression (docs/52 §4.4 / R2).
+        """
+        ctx = _make_ctx(
+            indicator=(Bias.NEUTRAL, 50),
+            pattern=(Bias.NEUTRAL, 40),
+            risk=(Bias.BEARISH, 80),
+            macro=(Bias.NEUTRAL, 45),
+        )
+        assert ctx.weighted_directional_score() == Decimal("-0.32")
+        verdict = ctx.evaluate_4axis_consensus()
+        assert verdict.agreeing_count == 1
+        assert verdict.action == TradeAction.HOLD
+
+
+class TestWeightedConfidence:
+    def test_weighted_conf_arithmetic(self) -> None:
+        """Appendix A.1: 0.25×75 + 0.15×40 + 0.40×80 + 0.20×65 = 69.75 → 70.
+
+        ROUND_HALF_UP must produce 70 (built-in round() banker's rounding is
+        forbidden by design).
+        """
+        ctx = _make_ctx(
+            indicator=(Bias.BULLISH, 75),
+            pattern=(Bias.NEUTRAL, 40),
+            risk=(Bias.BULLISH, 80),
+            macro=(Bias.BULLISH, 65),
+        )
+        assert ctx.weighted_confidence() == 70
+
+
+class TestEvaluate4AxisConsensus:
+    def test_evaluate_consensus_buy(self) -> None:
+        """Appendix A.1: score=+0.6375, conf=70, agreeing=3 → BUY."""
+        ctx = _make_ctx(
+            indicator=(Bias.BULLISH, 75),
+            pattern=(Bias.NEUTRAL, 40),
+            risk=(Bias.BULLISH, 80),
+            macro=(Bias.BULLISH, 65),
+        )
+        verdict = ctx.evaluate_4axis_consensus()
+        assert verdict.action == TradeAction.BUY
+        assert verdict.score == Decimal("0.6375")
+        assert verdict.weighted_confidence == 70
+        assert verdict.agreeing_count == 3
+        assert set(verdict.per_agent_contribution.keys()) == {
+            "risk",
+            "indicator",
+            "macro",
+            "pattern",
+        }
+        assert verdict.per_agent_contribution["risk"].contribution == Decimal("0.32")
+        assert verdict.per_agent_contribution["pattern"].contribution == Decimal("0")
+
+    def test_evaluate_consensus_sell(self) -> None:
+        """Indicator+Risk BEARISH 80 + Macro BEARISH 70 → SELL.
+
+        score = −0.20 − 0.32 − 0.14 = −0.66, conf = 20+6+32+14 = 72.
+        """
+        ctx = _make_ctx(
+            indicator=(Bias.BEARISH, 80),
+            pattern=(Bias.NEUTRAL, 40),
+            risk=(Bias.BEARISH, 80),
+            macro=(Bias.BEARISH, 70),
+        )
+        verdict = ctx.evaluate_4axis_consensus()
+        assert verdict.action == TradeAction.SELL
+        assert verdict.score == Decimal("-0.66")
+        assert verdict.weighted_confidence == 72
+        assert verdict.agreeing_count == 3
+
+    def test_evaluate_consensus_macro_stuck_no_sell(self) -> None:
+        """Appendix A.2: Macro BEARISH 95 alone must NOT produce SELL.
+
+        SELL-spam (#365) recurrence prevention key test:
+        score = −0.190, |score| < 0.40 → HOLD.
+        """
+        ctx = _make_ctx(
+            indicator=(Bias.NEUTRAL, 50),
+            pattern=(Bias.NEUTRAL, 35),
+            risk=(Bias.NEUTRAL, 45),
+            macro=(Bias.BEARISH, 95),
+        )
+        verdict = ctx.evaluate_4axis_consensus()
+        assert verdict.action == TradeAction.HOLD
+        assert verdict.score == Decimal("-0.190")
+
+    def test_missing_signal_counts_as_zero(self) -> None:
+        """A missing axis contributes (direction=0, conf=0) without re-normalizing."""
+        ctx = _make_ctx(risk=(Bias.BULLISH, 100))
+        assert ctx.weighted_directional_score() == Decimal("0.40")
+        assert ctx.weighted_confidence() == 40
+        verdict = ctx.evaluate_4axis_consensus()
+        assert verdict.action == TradeAction.HOLD
+        assert verdict.per_agent_contribution["indicator"].direction == 0
+        assert verdict.per_agent_contribution["indicator"].confidence == 0
+
+
+class TestResolveLlmAndDeterministic:
+    def _det_hold(self) -> DeterministicVerdict:
+        """Deterministic HOLD verdict (Appendix A.2 macro-stuck context)."""
+        ctx = _make_ctx(
+            indicator=(Bias.NEUTRAL, 50),
+            pattern=(Bias.NEUTRAL, 35),
+            risk=(Bias.NEUTRAL, 45),
+            macro=(Bias.BEARISH, 95),
+        )
+        return ctx.evaluate_4axis_consensus()
+
+    def _det_sell(self) -> DeterministicVerdict:
+        ctx = _make_ctx(
+            indicator=(Bias.BEARISH, 80),
+            pattern=(Bias.NEUTRAL, 40),
+            risk=(Bias.BEARISH, 80),
+            macro=(Bias.BEARISH, 70),
+        )
+        verdict = ctx.evaluate_4axis_consensus()
+        assert verdict.action == TradeAction.SELL  # sanity
+        return verdict
+
+    def test_post_llm_veto_llm_buy_det_hold(self) -> None:
+        """LLM=BUY, det=HOLD → HOLD, veto_applied=True, confidence <= 50."""
+        det = self._det_hold()
+        action, confidence, veto_applied = resolve_llm_and_deterministic(TradeAction.BUY, 80, det)
+        assert action == TradeAction.HOLD
+        assert veto_applied is True
+        assert confidence <= 50
+
+    def test_post_llm_conflict_buy_vs_sell(self, caplog: pytest.LogCaptureFixture) -> None:
+        """LLM=BUY vs det=SELL → HOLD + warning log (docs/52 §4.5)."""
+        det = self._det_sell()
+        with caplog.at_level(logging.WARNING, logger="app.ai.agents"):
+            action, confidence, veto_applied = resolve_llm_and_deterministic(
+                TradeAction.BUY, 80, det
+            )
+        assert action == TradeAction.HOLD
+        assert veto_applied is True
+        assert confidence <= 50
+        assert any("conflict" in record.message.lower() for record in caplog.records)
+
+    def test_llm_hold_always_holds_without_veto(self) -> None:
+        """LLM=HOLD → HOLD regardless of det (existing behaviour, no veto)."""
+        det = self._det_sell()
+        action, confidence, veto_applied = resolve_llm_and_deterministic(TradeAction.HOLD, 90, det)
+        assert action == TradeAction.HOLD
+        assert veto_applied is False
+        assert confidence == min(90, det.weighted_confidence)
+
+    def test_llm_matches_det_adopts_action(self) -> None:
+        """LLM=SELL, det=SELL → SELL, confidence = min(llm, det), no veto."""
+        det = self._det_sell()
+        action, confidence, veto_applied = resolve_llm_and_deterministic(TradeAction.SELL, 90, det)
+        assert action == TradeAction.SELL
+        assert veto_applied is False
+        assert confidence == min(90, det.weighted_confidence)
+
+
+class TestWeightValidation:
+    def test_weight_env_override(self) -> None:
+        """Custom weights argument is reflected in the calculation."""
+        ctx = _make_ctx(
+            indicator=(Bias.NEUTRAL, 50),
+            pattern=(Bias.NEUTRAL, 40),
+            risk=(Bias.BEARISH, 80),
+            macro=(Bias.NEUTRAL, 45),
+        )
+        custom = {
+            "risk": Decimal("0.25"),
+            "indicator": Decimal("0.25"),
+            "macro": Decimal("0.25"),
+            "pattern": Decimal("0.25"),
+        }
+        # Default weights: risk=0.40 → score = -0.32
+        assert ctx.weighted_directional_score() == Decimal("-0.32")
+        # Custom weights: risk=0.25 → score = -0.20
+        assert ctx.weighted_directional_score(custom) == Decimal("-0.20")
+        verdict = ctx.evaluate_4axis_consensus(weights=custom)
+        assert verdict.per_agent_contribution["risk"].weight == Decimal("0.25")
+
+    def test_weight_validation_fails(self) -> None:
+        """Weights summing to 1.5 must raise ValueError (fail-closed)."""
+        bad_weights = {
+            "risk": Decimal("0.50"),
+            "indicator": Decimal("0.40"),
+            "macro": Decimal("0.30"),
+            "pattern": Decimal("0.30"),
+        }
+        with pytest.raises(ValueError, match="sum"):
+            validate_agent_weights(bad_weights)
+        ctx = _make_ctx(risk=(Bias.BULLISH, 80))
+        with pytest.raises(ValueError, match="sum"):
+            ctx.weighted_directional_score(bad_weights)
+        with pytest.raises(ValueError, match="sum"):
+            ctx.evaluate_4axis_consensus(weights=bad_weights)
+
+    def test_weight_validation_rejects_wrong_keys(self) -> None:
+        """Key set must be exactly {risk, indicator, macro, pattern}."""
+        with pytest.raises(ValueError, match="keys"):
+            validate_agent_weights(
+                {
+                    "risk": Decimal("0.50"),
+                    "indicator": Decimal("0.50"),
+                }
+            )


### PR DESCRIPTION
## 概要

`docs/52_decision_layer_4axis_consensus_design.md` Phase 1 (Shadow) の計算関数群を追加。
**既存判定ロジックへの配線・挙動変更は一切なし** (既存関数 diff ゼロ、削除行は typing import 1 行のみ)。

対応タスク: `docs/launch/v4_implementation_tasks.md` EPIC-1 Phase 1 の 1-1 / 1-2 / 1-3 / 1-4 / 1-9

## 変更内容

- `app/ai/schemas.py`: `AgentContribution` / `DeterministicVerdict` pydantic モデル追加
- `app/ai/agents.py`: `validate_agent_weights` (キー集合 + 合計 1.0±0.01 + per-key [0,1] fail-closed) / `MultiAgentContext.DEFAULT_WEIGHTS` (risk 0.40 / indicator 0.25 / macro 0.20 / pattern 0.15) / `weighted_directional_score` / `weighted_confidence` (ROUND_HALF_UP) / `evaluate_4axis_consensus` (agreeing_count<2 → HOLD 降格) / `resolve_llm_and_deterministic` (§4.5 整合表の純関数)
- `tests/test_consensus_4axis.py`: 設計書 §7.1 必須 12 + 補強 6 = 18 テスト (Appendix A.1-A.3 期待値ハードコード検証)

## 意図的未配線について (Gate 5 注記)

新規関数群は **Shadow Phase 1 設計により意図的に未配線**。`service.py` への Shadow 配線は 1-7、Guard 2 置換は 1-14/1-15 (Tier S) の別タスク。env (`AGENT_WEIGHTS_JSON` 等) 配線は 1-5 後続 PR — 本 PR のテストは weights 引数注入で §7.1 要件を充足。

## パイプライン実績 (Planner→Generator→Evaluator→Tester)

- Planner: 実コード grep 12 回で計画策定 (Tier B / RISK LOW)
- Generator: bb6883a5 → Evaluator minor 差し戻し 1 往復 → 3d85c076 (負重み拒否 + 降格ガードテスト)
- Evaluator: **approved** (セキュリティ違反 0 / 既存関数 diff ゼロ検証 / 期待値手検算一致)
- Tester: **PASS** — ruff/format/S-rules/mypy clean、pytest フル 3411 passed / coverage 84.66%、rebase (52be1b78) 後も対象 55 passed

## Security Rules 遵守

- 金融計算は全て Decimal (float リテラルなし、組込 round 不使用)
- 不正重みは ValueError fail-closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)