### PR TITLE
feat(risk): check_aave_health 実データ連携 (EPIC-4 4-1) 🛑 HUMAN-REVIEW-REQUIRED

### DIFF
--- a/backend/app/protocols/risk/protocol_monitor.py
+++ b/backend/app/protocols/risk/protocol_monitor.py
@@ -107,16 +107,17 @@ class ProtocolMonitor:
             elif hf < Decimal("1.6"):
                 risk_level = RiskLevel.CRITICAL
                 alerts.append(
-                    f"ヘルスファクターが緊急停止水準（1.6）を下回っています（HF: {float(hf):.2f}）"
+                    f"ヘルスファクターが緊急停止水準（1.6）を下回っています（HF: {hf:.2f}）"
                 )
             elif hf < Decimal("1.8"):
                 risk_level = RiskLevel.HIGH
-                alerts.append(
-                    f"ヘルスファクターが警告水準（1.8）を下回っています（HF: {float(hf):.2f}）"
-                )
+                alerts.append(f"ヘルスファクターが警告水準（1.8）を下回っています（HF: {hf:.2f}）")
 
             is_operational = bool(self._monitoring_service.is_trading_allowed())
-        except Exception as exc:
+        except Exception:
+            # 例外詳細 (AaveClientError 等) は RPC URL (APIキー埋め込み形式) を内包し得る。
+            # alerts は無認証 GET /api/protocols/health で外部露出されるため (Security Rule 8)、
+            # 固定文言のみを返し、詳細はサーバーログ (logger.exception) に限定する。
             logger.exception("Aave ヘルスチェック失敗")
             return ProtocolHealth(
                 protocol="aave",
@@ -125,7 +126,7 @@ class ProtocolMonitor:
                 tvl_change_24h_pct=Decimal("0"),
                 is_operational=False,
                 last_checked=datetime.now(tz=timezone.utc),
-                alerts=[f"Aave ヘルスチェックエラー: {exc}"],
+                alerts=["Aave ヘルスチェックエラー（詳細はログ参照）"],
             )
 
         return ProtocolHealth(

--- a/backend/app/protocols/risk/protocol_monitor.py
+++ b/backend/app/protocols/risk/protocol_monitor.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -17,12 +18,22 @@ logger = logging.getLogger(__name__)
 class ProtocolMonitor:
     """各プロトコルのヘルス状態を監視するクラス。"""
 
-    def __init__(self, lido_client: Any = None, pendle_client: Any = None) -> None:
+    def __init__(
+        self,
+        lido_client: Any = None,
+        pendle_client: Any = None,
+        monitoring_service: Any = None,
+        aave_client: Any = None,
+    ) -> None:
         """初期化。
 
         Args:
             lido_client: Lido クライアント（None の場合はデフォルト設定から生成）
             pendle_client: Pendle クライアント（None の場合はデフォルト設定から生成）
+            monitoring_service: MonitoringService（None の場合は check_aave_health
+                初回呼出時に app.automation.state.get_monitoring_service() で遅延解決）
+            aave_client: Aave クライアント（None の場合は check_aave_health
+                初回呼出時に app.aave.client.get_default_aave_client() で遅延解決）
         """
         if lido_client is None:
             from app.protocols.lido.client import get_lido_client
@@ -37,23 +48,94 @@ class ProtocolMonitor:
 
         self._lido_client = lido_client
         self._pendle_client = pendle_client
+        # Aave 依存は import 時の副作用 (web3 / 環境変数) を避けるため遅延解決する
+        self._monitoring_service = monitoring_service
+        self._aave_client = aave_client
 
     async def check_aave_health(self) -> ProtocolHealth:
         """Aave V3 ヘルスチェック。
 
-        PoC 実装: 健全なダミーステータスを返す。
-        本番では MonitoringService から HF データを取得する。
-        TVL 推定: $10B、is_operational=True、risk=LOW
+        MonitoringService の最新 Health Factor (HF) と Aave クライアントの
+        アカウントデータから判定する。HF が未観測 (None) の場合は
+        AccountData.health_factor をフォールバックとして使用する。
+
+        リスク判定閾値（出典: docs/08_automation_rules.md — 閾値を変更する場合は
+        本 docstring とドキュメント側の二重管理に注意し、同時に更新すること）:
+        - HF が None または inf（ポジションなし）→ LOW
+        - HF < 1.6（緊急停止水準）→ CRITICAL + アラート
+        - HF < 1.8（警告水準）→ HIGH + アラート
+        - それ以外 → LOW
+
+        TVL は AccountData.total_collateral_usd（運用ポジションの担保 USD）を
+        採用する。プロトコル全体 TVL ではなく、自ポジションのエクスポージャー
+        を表す値である点に注意。tvl_change_24h_pct は履歴データを保持しない
+        ため Decimal("0") 固定とする。
+
+        is_operational は MonitoringService.is_trading_allowed()（緊急停止
+        フラグの OR ロジック）を反映する。
+
+        fail-open: 依存サービスの例外時は raise せず CRITICAL /
+        tvl_usd=Decimal("0") / is_operational=False / 日本語アラートで返す
+        （check_lido_health のエラーハンドリングと同型）。
         """
         logger.info("check_aave_health: Aave ヘルスチェック実行")
+        alerts: list[str] = []
+
+        try:
+            if self._monitoring_service is None:
+                from app.automation.state import get_monitoring_service
+
+                self._monitoring_service = get_monitoring_service()
+            if self._aave_client is None:
+                from app.aave.client import get_default_aave_client
+
+                self._aave_client = get_default_aave_client()
+
+            status = self._monitoring_service.get_status()
+            hf = status.last_health_factor
+
+            # get_account_data は同期 (web3 RPC) のため event loop をブロックしない
+            account = await asyncio.to_thread(self._aave_client.get_account_data, "")
+            tvl = account.total_collateral_usd
+
+            if hf is None:
+                hf = account.health_factor
+
+            risk_level = RiskLevel.LOW
+            if hf is None or hf == Decimal("inf"):
+                risk_level = RiskLevel.LOW
+            elif hf < Decimal("1.6"):
+                risk_level = RiskLevel.CRITICAL
+                alerts.append(
+                    f"ヘルスファクターが緊急停止水準（1.6）を下回っています（HF: {float(hf):.2f}）"
+                )
+            elif hf < Decimal("1.8"):
+                risk_level = RiskLevel.HIGH
+                alerts.append(
+                    f"ヘルスファクターが警告水準（1.8）を下回っています（HF: {float(hf):.2f}）"
+                )
+
+            is_operational = bool(self._monitoring_service.is_trading_allowed())
+        except Exception as exc:
+            logger.exception("Aave ヘルスチェック失敗")
+            return ProtocolHealth(
+                protocol="aave",
+                risk_level=RiskLevel.CRITICAL,
+                tvl_usd=Decimal("0"),
+                tvl_change_24h_pct=Decimal("0"),
+                is_operational=False,
+                last_checked=datetime.now(tz=timezone.utc),
+                alerts=[f"Aave ヘルスチェックエラー: {exc}"],
+            )
+
         return ProtocolHealth(
             protocol="aave",
-            risk_level=RiskLevel.LOW,
-            tvl_usd=Decimal("10000000000"),  # $10B 推定
+            risk_level=risk_level,
+            tvl_usd=tvl,
             tvl_change_24h_pct=Decimal("0"),
-            is_operational=True,
+            is_operational=is_operational,
             last_checked=datetime.now(tz=timezone.utc),
-            alerts=[],
+            alerts=alerts,
         )
 
     async def check_lido_health(self) -> ProtocolHealth:

--- a/backend/tests/protocols/test_risk/conftest.py
+++ b/backend/tests/protocols/test_risk/conftest.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
+from app.aave.client import AccountData
 from app.protocols.pendle.schemas import PendleMarketInfo
 from app.protocols.risk.auto_evacuate import AutoEvacuator
 from app.protocols.risk.compound_risk import CompoundRiskAssessor
@@ -45,9 +46,45 @@ def mock_pendle_client() -> AsyncMock:
 
 
 @pytest.fixture
-def protocol_monitor(mock_lido_client: AsyncMock, mock_pendle_client: AsyncMock) -> ProtocolMonitor:
+def mock_monitoring_service() -> MagicMock:
+    """MonitoringService のモック。HF=2.5（健全）、トレード許可状態。"""
+    service = MagicMock()
+    service.get_status.return_value.last_health_factor = Decimal("2.5")
+    service.is_trading_allowed.return_value = True
+    return service
+
+
+@pytest.fixture
+def mock_aave_client() -> Mock:
+    """Aave クライアントのモック。担保 $50,000、HF=2.5。
+
+    get_account_data は同期メソッドのため AsyncMock ではなく Mock を使用する
+    （check_aave_health 側で asyncio.to_thread 経由で呼ばれる）。
+    """
+    client = Mock()
+    client.get_account_data.return_value = AccountData(
+        total_collateral_usd=Decimal("50000"),
+        total_debt_usd=Decimal("10000"),
+        available_borrows_usd=Decimal("20000"),
+        health_factor=Decimal("2.5"),
+    )
+    return client
+
+
+@pytest.fixture
+def protocol_monitor(
+    mock_lido_client: AsyncMock,
+    mock_pendle_client: AsyncMock,
+    mock_monitoring_service: MagicMock,
+    mock_aave_client: Mock,
+) -> ProtocolMonitor:
     """ProtocolMonitor インスタンス（モッククライアント使用）。"""
-    return ProtocolMonitor(lido_client=mock_lido_client, pendle_client=mock_pendle_client)
+    return ProtocolMonitor(
+        lido_client=mock_lido_client,
+        pendle_client=mock_pendle_client,
+        monitoring_service=mock_monitoring_service,
+        aave_client=mock_aave_client,
+    )
 
 
 @pytest.fixture

--- a/backend/tests/protocols/test_risk/test_protocol_monitor.py
+++ b/backend/tests/protocols/test_risk/test_protocol_monitor.py
@@ -4,13 +4,29 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
+from app.aave.client import AccountData
 from app.protocols.pendle.schemas import PendleMarketInfo
 from app.protocols.risk.protocol_monitor import ProtocolMonitor
 from app.protocols.risk.schemas import ProtocolHealth, RiskLevel
+
+
+def _build_aave_monitor(
+    mock_lido_client: AsyncMock,
+    mock_pendle_client: AsyncMock,
+    monitoring_service: MagicMock,
+    aave_client: Mock,
+) -> ProtocolMonitor:
+    """Aave 依存を差し替えた ProtocolMonitor を構築するヘルパー。"""
+    return ProtocolMonitor(
+        lido_client=mock_lido_client,
+        pendle_client=mock_pendle_client,
+        monitoring_service=monitoring_service,
+        aave_client=aave_client,
+    )
 
 
 class TestCheckAaveHealth:
@@ -40,6 +56,163 @@ class TestCheckAaveHealth:
     async def test_aave_health_protocol_name(self, protocol_monitor: ProtocolMonitor) -> None:
         result = await protocol_monitor.check_aave_health()
         assert result.protocol == "aave"
+
+    @pytest.mark.asyncio
+    async def test_aave_health_no_alerts_when_healthy(
+        self, protocol_monitor: ProtocolMonitor
+    ) -> None:
+        """HF=2.5（健全）のときアラートなし。"""
+        result = await protocol_monitor.check_aave_health()
+        assert result.alerts == []
+
+    @pytest.mark.asyncio
+    async def test_aave_health_tvl_equals_total_collateral_usd(
+        self, protocol_monitor: ProtocolMonitor, mock_aave_client: Mock
+    ) -> None:
+        """tvl_usd は AccountData.total_collateral_usd（担保 USD）と一致し Decimal 型。"""
+        result = await protocol_monitor.check_aave_health()
+        expected = mock_aave_client.get_account_data.return_value.total_collateral_usd
+        assert result.tvl_usd == expected
+        assert isinstance(result.tvl_usd, Decimal)
+
+    @pytest.mark.asyncio
+    async def test_aave_health_high_risk_hf_below_warning(
+        self,
+        mock_lido_client: AsyncMock,
+        mock_pendle_client: AsyncMock,
+        mock_monitoring_service: MagicMock,
+        mock_aave_client: Mock,
+    ) -> None:
+        """HF=1.7（警告水準 1.8 未満）のとき HIGH リスク + アラート。"""
+        mock_monitoring_service.get_status.return_value.last_health_factor = Decimal("1.7")
+        monitor = _build_aave_monitor(
+            mock_lido_client, mock_pendle_client, mock_monitoring_service, mock_aave_client
+        )
+        result = await monitor.check_aave_health()
+        assert result.risk_level == RiskLevel.HIGH
+        assert len(result.alerts) == 1
+        assert "警告水準" in result.alerts[0]
+
+    @pytest.mark.asyncio
+    async def test_aave_health_critical_hf_below_hard_stop(
+        self,
+        mock_lido_client: AsyncMock,
+        mock_pendle_client: AsyncMock,
+        mock_monitoring_service: MagicMock,
+        mock_aave_client: Mock,
+    ) -> None:
+        """HF=1.5（緊急停止水準 1.6 未満）のとき CRITICAL リスク + アラート。"""
+        mock_monitoring_service.get_status.return_value.last_health_factor = Decimal("1.5")
+        monitor = _build_aave_monitor(
+            mock_lido_client, mock_pendle_client, mock_monitoring_service, mock_aave_client
+        )
+        result = await monitor.check_aave_health()
+        assert result.risk_level == RiskLevel.CRITICAL
+        assert len(result.alerts) == 1
+        assert "緊急停止水準" in result.alerts[0]
+
+    @pytest.mark.asyncio
+    async def test_aave_health_low_risk_hf_none_and_inf(
+        self,
+        mock_lido_client: AsyncMock,
+        mock_pendle_client: AsyncMock,
+        mock_monitoring_service: MagicMock,
+        mock_aave_client: Mock,
+    ) -> None:
+        """monitoring HF=None + account HF=inf（ポジションなし）のとき LOW リスク。"""
+        mock_monitoring_service.get_status.return_value.last_health_factor = None
+        mock_aave_client.get_account_data.return_value = AccountData(
+            total_collateral_usd=Decimal("0"),
+            total_debt_usd=Decimal("0"),
+            available_borrows_usd=Decimal("0"),
+            health_factor=Decimal("inf"),
+        )
+        monitor = _build_aave_monitor(
+            mock_lido_client, mock_pendle_client, mock_monitoring_service, mock_aave_client
+        )
+        result = await monitor.check_aave_health()
+        assert result.risk_level == RiskLevel.LOW
+        assert result.alerts == []
+
+    @pytest.mark.asyncio
+    async def test_aave_health_hf_fallback_to_account_data(
+        self,
+        mock_lido_client: AsyncMock,
+        mock_pendle_client: AsyncMock,
+        mock_monitoring_service: MagicMock,
+        mock_aave_client: Mock,
+    ) -> None:
+        """monitoring HF=None のとき AccountData.health_factor にフォールバックする。"""
+        mock_monitoring_service.get_status.return_value.last_health_factor = None
+        mock_aave_client.get_account_data.return_value = AccountData(
+            total_collateral_usd=Decimal("50000"),
+            total_debt_usd=Decimal("30000"),
+            available_borrows_usd=Decimal("5000"),
+            health_factor=Decimal("1.5"),
+        )
+        monitor = _build_aave_monitor(
+            mock_lido_client, mock_pendle_client, mock_monitoring_service, mock_aave_client
+        )
+        result = await monitor.check_aave_health()
+        assert result.risk_level == RiskLevel.CRITICAL
+
+    @pytest.mark.asyncio
+    async def test_aave_health_fail_open_on_monitoring_error(
+        self,
+        mock_lido_client: AsyncMock,
+        mock_pendle_client: AsyncMock,
+        mock_monitoring_service: MagicMock,
+        mock_aave_client: Mock,
+    ) -> None:
+        """monitoring 例外時は raise せず CRITICAL / is_operational=False を返す。"""
+        mock_monitoring_service.get_status.side_effect = RuntimeError("monitoring down")
+        monitor = _build_aave_monitor(
+            mock_lido_client, mock_pendle_client, mock_monitoring_service, mock_aave_client
+        )
+        result = await monitor.check_aave_health()
+        assert result.risk_level == RiskLevel.CRITICAL
+        assert result.is_operational is False
+        assert result.tvl_usd == Decimal("0")
+        assert len(result.alerts) == 1
+        assert "Aave ヘルスチェックエラー" in result.alerts[0]
+
+    @pytest.mark.asyncio
+    async def test_aave_health_fail_open_on_aave_client_error(
+        self,
+        mock_lido_client: AsyncMock,
+        mock_pendle_client: AsyncMock,
+        mock_monitoring_service: MagicMock,
+        mock_aave_client: Mock,
+    ) -> None:
+        """Aave クライアント例外時も fail-open（raise しない）。"""
+        mock_aave_client.get_account_data.side_effect = RuntimeError("rpc down")
+        monitor = _build_aave_monitor(
+            mock_lido_client, mock_pendle_client, mock_monitoring_service, mock_aave_client
+        )
+        result = await monitor.check_aave_health()
+        assert result.risk_level == RiskLevel.CRITICAL
+        assert result.is_operational is False
+
+    @pytest.mark.asyncio
+    async def test_aave_health_not_operational_on_emergency_stop(
+        self,
+        mock_lido_client: AsyncMock,
+        mock_pendle_client: AsyncMock,
+        mock_monitoring_service: MagicMock,
+        mock_aave_client: Mock,
+    ) -> None:
+        """緊急停止中（is_trading_allowed=False）のとき is_operational=False。"""
+        mock_monitoring_service.is_trading_allowed.return_value = False
+        monitor = _build_aave_monitor(
+            mock_lido_client, mock_pendle_client, mock_monitoring_service, mock_aave_client
+        )
+        result = await monitor.check_aave_health()
+        assert result.is_operational is False
+
+    def test_protocol_monitor_no_args_backward_compat(self) -> None:
+        """引数なし ProtocolMonitor() が従来通り構築できる（compound_risk.py / router.py 互換）。"""
+        monitor = ProtocolMonitor()
+        assert monitor is not None
 
 
 class TestCheckLidoHealth:

--- a/backend/tests/protocols/test_risk/test_protocol_monitor.py
+++ b/backend/tests/protocols/test_risk/test_protocol_monitor.py
@@ -112,6 +112,41 @@ class TestCheckAaveHealth:
         assert "緊急停止水準" in result.alerts[0]
 
     @pytest.mark.asyncio
+    async def test_aave_health_boundary_hf_exactly_1_6_is_high(
+        self,
+        mock_lido_client: AsyncMock,
+        mock_pendle_client: AsyncMock,
+        mock_monitoring_service: MagicMock,
+        mock_aave_client: Mock,
+    ) -> None:
+        """HF=1.6 ちょうど（< 1.6 ではない）のとき CRITICAL ではなく HIGH。"""
+        mock_monitoring_service.get_status.return_value.last_health_factor = Decimal("1.6")
+        monitor = _build_aave_monitor(
+            mock_lido_client, mock_pendle_client, mock_monitoring_service, mock_aave_client
+        )
+        result = await monitor.check_aave_health()
+        assert result.risk_level == RiskLevel.HIGH
+        assert len(result.alerts) == 1
+        assert "警告水準" in result.alerts[0]
+
+    @pytest.mark.asyncio
+    async def test_aave_health_boundary_hf_exactly_1_8_is_low(
+        self,
+        mock_lido_client: AsyncMock,
+        mock_pendle_client: AsyncMock,
+        mock_monitoring_service: MagicMock,
+        mock_aave_client: Mock,
+    ) -> None:
+        """HF=1.8 ちょうど（< 1.8 ではない）のとき HIGH ではなく LOW + アラートなし。"""
+        mock_monitoring_service.get_status.return_value.last_health_factor = Decimal("1.8")
+        monitor = _build_aave_monitor(
+            mock_lido_client, mock_pendle_client, mock_monitoring_service, mock_aave_client
+        )
+        result = await monitor.check_aave_health()
+        assert result.risk_level == RiskLevel.LOW
+        assert result.alerts == []
+
+    @pytest.mark.asyncio
     async def test_aave_health_low_risk_hf_none_and_inf(
         self,
         mock_lido_client: AsyncMock,
@@ -165,7 +200,9 @@ class TestCheckAaveHealth:
         mock_aave_client: Mock,
     ) -> None:
         """monitoring 例外時は raise せず CRITICAL / is_operational=False を返す。"""
-        mock_monitoring_service.get_status.side_effect = RuntimeError("monitoring down")
+        mock_monitoring_service.get_status.side_effect = RuntimeError(
+            "https://rpc.example/v2/secret-api-key"
+        )
         monitor = _build_aave_monitor(
             mock_lido_client, mock_pendle_client, mock_monitoring_service, mock_aave_client
         )
@@ -173,8 +210,10 @@ class TestCheckAaveHealth:
         assert result.risk_level == RiskLevel.CRITICAL
         assert result.is_operational is False
         assert result.tvl_usd == Decimal("0")
-        assert len(result.alerts) == 1
-        assert "Aave ヘルスチェックエラー" in result.alerts[0]
+        # Security Rule 8: alerts は無認証 API で外部露出されるため固定文言のみ。
+        # 例外詳細 (RPC URL / APIキー等) が漏れていないことを検証する。
+        assert result.alerts == ["Aave ヘルスチェックエラー（詳細はログ参照）"]
+        assert "secret-api-key" not in result.alerts[0]
 
     @pytest.mark.asyncio
     async def test_aave_health_fail_open_on_aave_client_error(


### PR DESCRIPTION
## 🛑 HUMAN-REVIEW-REQUIRED (human-review-gate 判定)

**カテゴリ: DeFi 安全装置** — HF 閾値 (1.6 / 1.8) の比較ロジックが Risk Engine → CompoundRiskAssessor → AutoEvacuator 経路に**初めて実データを供給する**挙動変更のため、draft PR とし人間承認まで merge しません。

- 現時点の実害: なし — AutoEvacuator は dry_run=True 固定 (auto_evacuate.py:244 実実行未実装)、workflow.py:557 は HOLD のみ。誤発火方向は「取引停止」= 安全側 (Evaluator が実配線で確認済み)
- **merge 前に人間確認が必要な事項**: 本番 `.env` で `AAVE_CLIENT_TYPE=web3` が設定されているか。未設定だと `get_default_aave_client()` が DummyAaveClient にフォールバックし、ダミー TVL ($10,000) / HF 2.5 が本番 Risk Engine に流れる。また read-only モード (wallet 未設定) では fail-open により恒常 CRITICAL → 毎サイクル HOLD になる。dev VPS から本番 env は確認不可のため要人間確認

## 概要

`check_aave_health()` のダミー実装 (TVL $10B 固定 / 常に LOW) を実データ連携に置換。
対応タスク: `docs/launch/v4_implementation_tasks.md` EPIC-4 4-1

## 変更内容

- `app/protocols/risk/protocol_monitor.py`: MonitoringService.get_status() の実 HF (read-only) + `AaveClient.get_account_data().total_collateral_usd` の実 TVL。HF=None → account.health_factor フォールバック。hf<1.6 CRITICAL / <1.8 HIGH / else LOW (Decimal リテラル、docs/08 と整合、境界 1.6 ちょうど=HIGH は monitoring_service の `<` 判定と一致)。fail-open (例外 raise なし、alerts は固定文言のみ — Security Rule 8 対応で例外メッセージ非露出)。遅延 import は try 内 (初期化エラーも fail-open)
- **TVL 意味論**: プロトコル全体 TVL ではなく**運用ポジション担保 USD** (total_collateral_usd) を採用 — compound_risk の total_exposure_usd が $10B 固定 → 実ポジション額にスケール変化 (エクスポージャーとして正)
- Tier S ファイル (monitoring_service.py / state.py / scheduled_tasks.py / workflow.py / main.py) **diff ゼロ**。引数なし `ProtocolMonitor()` 後方互換維持 (呼出元 4 箇所 + 専用テスト)
- テスト: 12 ケース追加 (境界値 1.6/1.8、fail-open 2 種 — 擬似 API キー入り URL の非漏洩 assert 含む、緊急停止、後方互換)

## パイプライン実績 (Planner→Generator→Evaluator→Tester)

- Planner: 実コード grep 22 回 (「MonitoringService に TVL なし」発見 → 代替設計)
- Generator: 602d1c55 → Evaluator minor 差し戻し 1 往復 → a5868ce2 (alerts 固定文言化 + 境界値テスト)
- Evaluator: minor → 解消確認 (セキュリティ違反 0)
- Tester: **PASS** — ruff/format/S-rules/mypy clean、pytest フル 3405 passed / coverage 84.62%、rebase (52be1b78) 後も対象 127 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)