### PR TITLE
feat(lido): 実APR取得 (Lido API) と get_position 本実装 (EPIC-2 2-1/2-2/2-4)

### DIFF
--- a/backend/app/protocols/lido/client.py
+++ b/backend/app/protocols/lido/client.py
@@ -9,6 +9,8 @@ from abc import abstractmethod
 from decimal import Decimal
 from typing import Any
 
+import httpx
+
 from app.protocols.base import (
     BaseProtocolClient,
     ProtocolHealthMetrics,
@@ -90,6 +92,8 @@ _WEI_PER_ETH = Decimal("1000000000000000000")
 class AbstractLidoClient(BaseProtocolClient):
     """Lido クライアントの抽象基底クラス。"""
 
+    _config: LidoConfig
+
     # --- BaseProtocolClient 実装 ---
 
     def get_protocol_name(self) -> str:
@@ -132,14 +136,35 @@ class AbstractLidoClient(BaseProtocolClient):
         )
 
     async def get_position(self) -> ProtocolPosition:
-        """ポジション情報を返す（PoC: デフォルトアドレスの残高）。"""
-        balance = Decimal("0")
-        return ProtocolPosition(
+        """ポジション情報を返す（設定ウォレットの stETH 残高）。
+
+        value_usd は balance と同値の近似（stETH≈ETH 近似、USD 換算は将来課題）。
+        wallet_address 未設定・残高取得失敗時は zero position を返す（fail-open）。
+        """
+        zero_position = ProtocolPosition(
             protocol_name=self.get_protocol_name(),
             asset="stETH",
-            balance=balance,
-            value_usd=balance,
+            balance=Decimal("0"),
+            value_usd=Decimal("0"),
         )
+        wallet_address = self._config.wallet_address
+        if not wallet_address:
+            logger.warning("get_position: wallet_address 未設定のため zero position を返します")
+            return zero_position
+        try:
+            balance = await self.get_steth_balance(wallet_address)
+            return ProtocolPosition(
+                protocol_name=self.get_protocol_name(),
+                asset="stETH",
+                balance=balance,
+                value_usd=balance,
+            )
+        except Exception as exc:
+            logger.warning(
+                "get_position: 残高取得失敗のため zero position を返します (fail-open): %s",
+                exc,
+            )
+            return zero_position
 
     async def get_health_metrics(self) -> ProtocolHealthMetrics:
         """ヘルスメトリクスを返す。"""
@@ -363,16 +388,35 @@ class LidoClient(AbstractLidoClient):
             logger.exception("get_steth_balance 失敗: address=%s", address[:10])
             raise RuntimeError(f"stETH 残高取得失敗: {exc}") from exc
 
-    async def get_staking_apr(self) -> Decimal:
-        """Lido staking APR を推定する（オンチェーンデータから計算）。
+    async def _fetch_apr_data(self) -> dict[str, Any]:
+        """Lido 公式 API から stETH APR（SMA）データを取得する。"""
+        url = f"{self._config.api_base_url}/v1/protocol/steth/apr/sma"
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+            return data
 
-        PoC 実装: testnet では固定値を返す。
-        本番では Lido API または イベントログから計算する。
+    async def get_staking_apr(self) -> Decimal:
+        """Lido 公式 API から実 staking APR（%）を取得する。
+
+        API 失敗・異常値（0 < apr <= 50 を外れる）の場合は参考値 3.5% に
+        フォールバックし、例外は呼び出し元へ送出しない（fail-open 設計）。
         """
-        self._ensure_initialized()
-        # testnet / PoC: 推定値を返す（Lido mainnet APR の参考値 ~3.5%）
-        logger.info("get_staking_apr: testnet のため推定値 3.5%% を返します")
-        return Decimal("3.5")
+        try:
+            data = await self._fetch_apr_data()
+            apr = Decimal(str(data["data"]["smaApr"]))
+            if Decimal("0") < apr <= Decimal("50"):
+                return apr
+            logger.warning(
+                "get_staking_apr: 異常値 %s のためフォールバック値 3.5%% を返します", apr
+            )
+            return Decimal("3.5")
+        except Exception as exc:
+            logger.warning(
+                "get_staking_apr: API 取得失敗のためフォールバック値 3.5%% を返します: %s", exc
+            )
+            return Decimal("3.5")
 
     async def get_steth_eth_ratio(self) -> Decimal:
         """stETH/ETH レートを取得（getTotalPooledEther / getTotalShares）。"""

--- a/backend/app/protocols/lido/config.py
+++ b/backend/app/protocols/lido/config.py
@@ -33,6 +33,10 @@ class LidoConfig:
         )
     )
     chain: str = field(default_factory=lambda: os.getenv("LIDO_CHAIN", "holesky"))
+    # Lido 公式 API ベース URL（staking APR 取得用）
+    api_base_url: str = field(
+        default_factory=lambda: os.getenv("LIDO_API_URL", "https://eth-api.lido.fi")
+    )
     wallet_address: str = field(default_factory=lambda: os.getenv("LIDO_WALLET_ADDRESS", ""))
     wallet_private_key: str = field(
         default_factory=lambda: os.getenv("LIDO_WALLET_PRIVATE_KEY", "")

--- a/backend/tests/protocols/test_lido/test_lido_client.py
+++ b/backend/tests/protocols/test_lido/test_lido_client.py
@@ -1,6 +1,7 @@
-"""DummyLidoClient のユニットテスト。"""
+"""DummyLidoClient / LidoClient のユニットテスト。"""
 
 from decimal import Decimal
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -112,3 +113,116 @@ class TestGetLidoClient:
         config = LidoConfig(sandbox=True)
         client = get_lido_client(config)
         assert isinstance(client, DummyLidoClient)
+
+
+_TEST_WALLET = "0x0000000000000000000000000000000000000001"
+
+
+@pytest.fixture
+def real_client() -> LidoClient:
+    return LidoClient(LidoConfig(sandbox=False))
+
+
+class TestLidoClientApr:
+    """LidoClient.get_staking_apr の Lido API 実装テスト（HTTP は mock）。"""
+
+    @pytest.mark.asyncio
+    async def test_apr_returns_real_value_from_api(self, real_client: LidoClient) -> None:
+        """API 成功時に実値が Decimal で返ること。"""
+        with patch.object(
+            real_client,
+            "_fetch_apr_data",
+            new=AsyncMock(return_value={"data": {"smaApr": 2.9}}),
+        ):
+            apr = await real_client.get_staking_apr()
+        assert apr == Decimal("2.9")
+        assert type(apr) is Decimal
+
+    @pytest.mark.asyncio
+    async def test_apr_api_failure_falls_back_to_35(self, real_client: LidoClient) -> None:
+        """API 失敗時にフォールバック値 3.5 が返ること。"""
+        with patch.object(
+            real_client,
+            "_fetch_apr_data",
+            new=AsyncMock(side_effect=Exception("connection error")),
+        ):
+            apr = await real_client.get_staking_apr()
+        assert apr == Decimal("3.5")
+
+    @pytest.mark.asyncio
+    async def test_apr_abnormal_value_falls_back_to_35(self, real_client: LidoClient) -> None:
+        """異常値（smaApr=999 > 50）はフォールバック値 3.5 が返ること。"""
+        with patch.object(
+            real_client,
+            "_fetch_apr_data",
+            new=AsyncMock(return_value={"data": {"smaApr": 999}}),
+        ):
+            apr = await real_client.get_staking_apr()
+        assert apr == Decimal("3.5")
+
+    @pytest.mark.asyncio
+    async def test_apr_never_raises_on_malformed_response(self, real_client: LidoClient) -> None:
+        """レスポンス構造が壊れていても例外が漏洩しないこと（fail-open）。"""
+        with patch.object(
+            real_client,
+            "_fetch_apr_data",
+            new=AsyncMock(return_value={}),
+        ):
+            apr = await real_client.get_staking_apr()  # KeyError が漏洩しないこと
+        assert apr == Decimal("3.5")
+
+    @pytest.mark.asyncio
+    async def test_apr_fail_open_with_unreachable_url(self) -> None:
+        """到達不能な API URL でもフォールバック値 3.5 が返ること（実証）。"""
+        client = LidoClient(LidoConfig(sandbox=False, api_base_url="http://127.0.0.1:1"))
+        apr = await client.get_staking_apr()
+        assert apr == Decimal("3.5")
+
+
+class TestGetPosition:
+    """AbstractLidoClient.get_position のテスト。"""
+
+    @pytest.mark.asyncio
+    async def test_dummy_client_position_returns_balance(self) -> None:
+        """DummyLidoClient は stub 残高 1.0 を position に反映すること。"""
+        client = DummyLidoClient(LidoConfig(sandbox=True, wallet_address=_TEST_WALLET))
+        position = await client.get_position()
+        assert position.protocol_name == "lido"
+        assert position.asset == "stETH"
+        assert position.balance == Decimal("1.0")
+        assert position.value_usd == Decimal("1.0")
+
+    @pytest.mark.asyncio
+    async def test_lido_client_position_reflects_real_balance(self) -> None:
+        """LidoClient は get_steth_balance の実値を position に反映すること。"""
+        client = LidoClient(LidoConfig(sandbox=False, wallet_address=_TEST_WALLET))
+        with patch.object(
+            client,
+            "get_steth_balance",
+            new=AsyncMock(return_value=Decimal("2.5")),
+        ):
+            position = await client.get_position()
+        assert position.balance == Decimal("2.5")
+        assert position.value_usd == Decimal("2.5")
+        assert type(position.balance) is Decimal
+
+    @pytest.mark.asyncio
+    async def test_empty_wallet_address_returns_zero_position(self) -> None:
+        """wallet_address 未設定の場合 zero position を返すこと。"""
+        client = DummyLidoClient(LidoConfig(sandbox=True, wallet_address=""))
+        position = await client.get_position()
+        assert position.balance == Decimal("0")
+        assert position.value_usd == Decimal("0")
+
+    @pytest.mark.asyncio
+    async def test_balance_failure_returns_zero_position(self) -> None:
+        """get_steth_balance 例外時に fail-open で zero position を返すこと。"""
+        client = LidoClient(LidoConfig(sandbox=False, wallet_address=_TEST_WALLET))
+        with patch.object(
+            client,
+            "get_steth_balance",
+            new=AsyncMock(side_effect=RuntimeError("stETH 残高取得失敗")),
+        ):
+            position = await client.get_position()
+        assert position.balance == Decimal("0")
+        assert position.value_usd == Decimal("0")


### PR DESCRIPTION
## 概要

Lido クライアントの PoC スタブ 2 箇所を本実装に置換。
対応タスク: v4 実装タスク EPIC-2 の 2-1 / 2-2 / 2-4

## 変更内容

- `get_staking_apr()`: 固定 3.5% → Lido 公式 API (`{LIDO_API_URL}/v1/protocol/steth/apr/sma`, 7日 SMA) から実 APR 取得。`Decimal(str(...))` 変換 + sanity check (0 < apr <= 50)。**API 失敗・異常値時は logger.warning + `Decimal("3.5")` フォールバック (fail-open、再送出なし)** — blackhole URL での実証テスト済み
- `get_position()`: balance=0 固定 → `get_steth_balance()` (既存本実装) 再利用で実 stETH 残高取得。wallet 未設定 / 例外時は zero position (fail-open)。value_usd は stETH≈ETH 近似 (USD 換算は将来課題、docstring 明記)
- `config.py`: `api_base_url` フィールド追加のみ (env `LIDO_API_URL`、既存デフォルト不変)
- テスト +116 行: APR mock 成功/例外/異常値/非漏洩、position の Dummy/実値/空wallet/例外 — 実 HTTP 不使用 (mock seam `_fetch_apr_data`)

## スコープ注記

- 2-3 (mainnet アドレス設定) は**意図的に除外** — デフォルト変更が staging/production をサイレントに mainnet 切替するリスクがあるため別タスク (env 設計 + HUMAN-REVIEW 付き) に分離
- `get_staking_apr` の戻り値は `aave_integration.py:63` の利回り比較に流入する (固定値→実値化で Optimizer 判断材料が変化)。CI の Codex Auto Review を Gate 6 として適用
- requirements.txt 変更なし (httpx 既存依存)。Tier S / forbidden ファイル diff ゼロ
- DummyLidoClient のスタブ値 (3.5% / balance 1.0) は不変 — staging Shadow Mode への影響なし

## パイプライン実績

- Planner: 実コード grep 29 回 (Lido API レスポンス形・既存 httpx パターン・chaos test lane1 の LIDO_API_URL 整合を確認)
- Generator: cdb0059a
- Evaluator (独立検証): **approved** — ruff/mypy clean、対象 87 passed、フル 3402 passed / cov 84.63%、fail-open 実機実証 (LIDO_API_URL=http://127.0.0.1:1 → Decimal("3.5"))、Decimal(float) 混入なし、秘密情報ログなし
- rebase (fc2e6c3a) 後 87 passed 再確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)