### PR TITLE
feat(lido): V2 withdrawal queue 実装 (request/claim/status)

### DIFF
--- a/backend/app/protocols/lido/client.py
+++ b/backend/app/protocols/lido/client.py
@@ -17,7 +17,12 @@ from app.protocols.base import (
 )
 
 from .config import LidoConfig
-from .schemas import TxResult
+from .schemas import (
+    ClaimWithdrawalResult,
+    TxResult,
+    WithdrawalRequestResult,
+    WithdrawalStatus,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +75,7 @@ _STETH_ABI: list[dict[str, Any]] = [
     },
 ]
 
-# Lido WithdrawalQueueERC721 ABI（最小限: requestWithdrawals）
+# Lido WithdrawalQueueERC721 ABI（requestWithdrawals / claimWithdrawals / getWithdrawalStatus）
 _WITHDRAWAL_QUEUE_ABI: list[dict[str, Any]] = [
     {
         "name": "requestWithdrawals",
@@ -81,6 +86,54 @@ _WITHDRAWAL_QUEUE_ABI: list[dict[str, Any]] = [
             {"name": "_owner", "type": "address"},
         ],
         "outputs": [{"name": "requestIds", "type": "uint256[]"}],
+    },
+    {
+        "name": "claimWithdrawals",
+        "type": "function",
+        "stateMutability": "nonpayable",
+        "inputs": [
+            {"name": "_requestIds", "type": "uint256[]"},
+            {"name": "_hints", "type": "uint256[]"},
+        ],
+        "outputs": [],
+    },
+    {
+        "name": "getWithdrawalStatus",
+        "type": "function",
+        "stateMutability": "view",
+        "inputs": [{"name": "_requestIds", "type": "uint256[]"}],
+        "outputs": [
+            {
+                "name": "statuses",
+                "type": "tuple[]",
+                "components": [
+                    {"name": "amountOfStETH", "type": "uint256"},
+                    {"name": "amountOfShares", "type": "uint256"},
+                    {"name": "owner", "type": "address"},
+                    {"name": "timestamp", "type": "uint256"},
+                    {"name": "isFinalized", "type": "bool"},
+                    {"name": "isClaimed", "type": "bool"},
+                ],
+            }
+        ],
+    },
+    {
+        "name": "findCheckpointHints",
+        "type": "function",
+        "stateMutability": "view",
+        "inputs": [
+            {"name": "_requestIds", "type": "uint256[]"},
+            {"name": "_firstIndex", "type": "uint256"},
+            {"name": "_lastIndex", "type": "uint256"},
+        ],
+        "outputs": [{"name": "hintIds", "type": "uint256[]"}],
+    },
+    {
+        "name": "getLastCheckpointIndex",
+        "type": "function",
+        "stateMutability": "view",
+        "inputs": [],
+        "outputs": [{"name": "", "type": "uint256"}],
     },
 ]
 
@@ -123,12 +176,21 @@ class AbstractLidoClient(BaseProtocolClient):
         )
 
     async def withdraw(self, amount: Decimal, asset: str) -> TransactionResult:
-        """stETH の引き出し（Lido では withdraw は未サポート / PoC スタブ）。"""
+        """stETH 引き出しリクエスト送信（WithdrawalQueue への委譲）。"""
+        if asset not in ("ETH", "stETH"):
+            return TransactionResult(
+                success=False,
+                tx_hash=None,
+                amount=amount,
+                error=f"Lido withdraw は ETH/stETH のみサポートしています。指定: {asset}",
+            )
+        amount_wei = int(amount * _WEI_PER_ETH)
+        result = await self.request_withdrawals([amount_wei])
         return TransactionResult(
-            success=False,
-            tx_hash=None,
+            success=result.success,
+            tx_hash=result.tx_hash,
             amount=amount,
-            error="Lido の引き出しは現在サポートされていません（PoC）",
+            error=result.error,
         )
 
     async def get_position(self) -> ProtocolPosition:
@@ -183,6 +245,44 @@ class AbstractLidoClient(BaseProtocolClient):
     @abstractmethod
     async def get_steth_eth_ratio(self) -> Decimal:
         """stETH/ETH レート（1.0=完全ペグ）。"""
+        ...
+
+    @abstractmethod
+    async def request_withdrawals(self, amounts_wei: list[int]) -> WithdrawalRequestResult:
+        """stETH 引き出しリクエストを WithdrawalQueue に送信する。
+
+        Args:
+            amounts_wei: 引き出すstETH量のリスト（Wei単位）。
+                         事前に stETH.approve(withdrawalQueueAddress, sum(amounts_wei)) が必要。
+
+        Returns:
+            WithdrawalRequestResult: リクエスト結果（request_ids を含む）。
+        """
+        ...
+
+    @abstractmethod
+    async def claim_withdrawal(self, request_ids: list[int]) -> ClaimWithdrawalResult:
+        """finalized した withdrawal request をクレームし ETH を受け取る。
+
+        Args:
+            request_ids: クレームする withdrawal request ID のリスト。
+                         対象 request が isFinalized=True になっていること。
+
+        Returns:
+            ClaimWithdrawalResult: クレーム結果。
+        """
+        ...
+
+    @abstractmethod
+    async def get_withdrawal_status(self, request_ids: list[int]) -> list[WithdrawalStatus]:
+        """withdrawal request の現在のステータスを取得する。
+
+        Args:
+            request_ids: 確認する request ID のリスト。
+
+        Returns:
+            list[WithdrawalStatus]: 各リクエストのステータス一覧。
+        """
         ...
 
 
@@ -260,42 +360,44 @@ class LidoClient(AbstractLidoClient):
             logger.exception("stake_eth 失敗: amount_wei=%d", amount_wei)
             return TxResult(success=False, error=str(exc))
 
-    async def withdraw(self, amount: Decimal, asset: str) -> TransactionResult:
-        """stETH → ETH 引き出しリクエスト（Lido WithdrawalQueue）。
+    async def request_withdrawals(self, amounts_wei: list[int]) -> WithdrawalRequestResult:
+        """stETH 引き出しリクエストを WithdrawalQueue に送信する。
 
         引き出しフロー:
-        1. stETH.approve(withdrawalQueueAddress, amount_wei)
-        2. WithdrawalQueueERC721.requestWithdrawals([amount_wei], owner)
-        クレーム（claim）は待機期間後に別途実行が必要。
+        1. stETH.approve(withdrawalQueueAddress, total_amount_wei)
+        2. WithdrawalQueueERC721.requestWithdrawals(amounts_wei, owner)
+
+        Args:
+            amounts_wei: 引き出すstETH量のリスト（Wei単位）。
+
+        Returns:
+            WithdrawalRequestResult: リクエスト結果（request_ids を含む）。
         """
-        if asset not in ("ETH", "stETH"):
-            return TransactionResult(
-                success=False,
-                tx_hash=None,
-                amount=amount,
-                error=f"Lido withdraw は ETH/stETH のみサポートしています。指定: {asset}",
-            )
         self._ensure_initialized()
         try:
             from web3 import Web3  # noqa: PLC0415
 
             if not self._config.wallet_private_key:
-                return TransactionResult(
+                return WithdrawalRequestResult(
                     success=False,
-                    tx_hash=None,
-                    amount=amount,
                     error="LIDO_WALLET_PRIVATE_KEY が未設定",
                 )
 
+            if not amounts_wei:
+                return WithdrawalRequestResult(
+                    success=False,
+                    error="amounts_wei は空にできません",
+                )
+
             account = self._w3.eth.account.from_key(self._config.wallet_private_key)
-            amount_wei = int(amount * _WEI_PER_ETH)
+            total_amount_wei = sum(amounts_wei)
             queue_address = Web3.to_checksum_address(self._config.withdrawal_queue_address)
             gas_price = self._w3.eth.gas_price
 
-            # Step 1: stETH.approve(withdrawalQueueAddress, amount_wei)
+            # Step 1: stETH.approve(withdrawalQueueAddress, total_amount_wei)
             nonce = self._w3.eth.get_transaction_count(account.address)
             approve_tx = self._contract.functions.approve(
-                queue_address, amount_wei
+                queue_address, total_amount_wei
             ).build_transaction(
                 {
                     "from": account.address,
@@ -307,20 +409,21 @@ class LidoClient(AbstractLidoClient):
             signed_approve = self._w3.eth.account.sign_transaction(
                 approve_tx, self._config.wallet_private_key
             )
-            self._w3.eth.send_raw_transaction(signed_approve.raw_transaction)
-            logger.info("stETH approve 送信完了: amount_wei=%d", amount_wei)
+            approve_tx_hash = self._w3.eth.send_raw_transaction(signed_approve.raw_transaction)
+            self._w3.eth.wait_for_transaction_receipt(approve_tx_hash, timeout=120)
+            logger.info("stETH approve 送信完了: total_amount_wei=%d", total_amount_wei)
 
-            # Step 2: WithdrawalQueue.requestWithdrawals([amount_wei], owner)
+            # Step 2: WithdrawalQueue.requestWithdrawals(amounts_wei, owner)
             queue_contract = self._w3.eth.contract(address=queue_address, abi=_WITHDRAWAL_QUEUE_ABI)
             nonce2 = nonce + 1
             withdraw_tx = queue_contract.functions.requestWithdrawals(
-                [amount_wei], account.address
+                amounts_wei, account.address
             ).build_transaction(
                 {
                     "from": account.address,
                     "nonce": nonce2,
                     "gasPrice": gas_price,
-                    "gas": 200_000,
+                    "gas": 200_000 + 50_000 * len(amounts_wei),
                 }
             )
             signed_withdraw = self._w3.eth.account.sign_transaction(
@@ -330,24 +433,135 @@ class LidoClient(AbstractLidoClient):
             receipt = self._w3.eth.wait_for_transaction_receipt(tx_hash, timeout=120)
 
             if receipt["status"] == 1:
+                # decode requestIds from logs (WithdrawalRequested events)
+                # PoC: request ID は解析せずログのみ記録
                 logger.info(
-                    "引き出しリクエスト成功: amount_wei=%d, tx=%s", amount_wei, tx_hash.hex()
+                    "引き出しリクエスト成功: amounts=%s, tx=%s",
+                    amounts_wei,
+                    tx_hash.hex(),
                 )
-                return TransactionResult(
-                    success=True,
+                return WithdrawalRequestResult(
                     tx_hash=tx_hash.hex(),
-                    amount=amount,
-                    error=None,
+                    success=True,
+                    request_ids=[],  # event decodeは別途実装
                 )
-            return TransactionResult(
-                success=False,
+            return WithdrawalRequestResult(
                 tx_hash=tx_hash.hex(),
-                amount=amount,
+                success=False,
                 error="引き出しリクエスト失敗（status=0）",
             )
         except Exception as exc:
-            logger.exception("withdraw 失敗: amount=%s", amount)
-            return TransactionResult(success=False, tx_hash=None, amount=amount, error=str(exc))
+            logger.exception("request_withdrawals 失敗: amounts_wei=%s", amounts_wei)
+            return WithdrawalRequestResult(success=False, error=str(exc))
+
+    async def claim_withdrawal(self, request_ids: list[int]) -> ClaimWithdrawalResult:
+        """finalized した withdrawal request をクレームし ETH を受け取る。
+
+        Args:
+            request_ids: クレームする withdrawal request ID のリスト。
+
+        Returns:
+            ClaimWithdrawalResult: クレーム結果。
+        """
+        self._ensure_initialized()
+        try:
+            from web3 import Web3  # noqa: PLC0415
+
+            if not self._config.wallet_private_key:
+                return ClaimWithdrawalResult(
+                    success=False,
+                    error="LIDO_WALLET_PRIVATE_KEY が未設定",
+                )
+
+            if not request_ids:
+                return ClaimWithdrawalResult(
+                    success=False,
+                    error="request_ids は空にできません",
+                )
+
+            account = self._w3.eth.account.from_key(self._config.wallet_private_key)
+            queue_address = Web3.to_checksum_address(self._config.withdrawal_queue_address)
+            queue_contract = self._w3.eth.contract(address=queue_address, abi=_WITHDRAWAL_QUEUE_ABI)
+            gas_price = self._w3.eth.gas_price
+
+            # checkpointHints を取得（claimWithdrawals に必要）
+            last_checkpoint_index: int = queue_contract.functions.getLastCheckpointIndex().call()
+            hints: list[int] = queue_contract.functions.findCheckpointHints(
+                request_ids, 1, last_checkpoint_index
+            ).call()
+
+            nonce = self._w3.eth.get_transaction_count(account.address)
+            claim_tx = queue_contract.functions.claimWithdrawals(
+                request_ids, hints
+            ).build_transaction(
+                {
+                    "from": account.address,
+                    "nonce": nonce,
+                    "gasPrice": gas_price,
+                    "gas": 150_000 + 50_000 * len(request_ids),
+                }
+            )
+            signed_claim = self._w3.eth.account.sign_transaction(
+                claim_tx, self._config.wallet_private_key
+            )
+            tx_hash = self._w3.eth.send_raw_transaction(signed_claim.raw_transaction)
+            receipt = self._w3.eth.wait_for_transaction_receipt(tx_hash, timeout=120)
+
+            if receipt["status"] == 1:
+                logger.info(
+                    "withdrawal claim 成功: request_ids=%s, tx=%s", request_ids, tx_hash.hex()
+                )
+                return ClaimWithdrawalResult(
+                    tx_hash=tx_hash.hex(),
+                    success=True,
+                    claimed_request_ids=request_ids,
+                )
+            return ClaimWithdrawalResult(
+                tx_hash=tx_hash.hex(),
+                success=False,
+                error="claim 失敗（status=0）",
+            )
+        except Exception as exc:
+            logger.exception("claim_withdrawal 失敗: request_ids=%s", request_ids)
+            return ClaimWithdrawalResult(success=False, error=str(exc))
+
+    async def get_withdrawal_status(self, request_ids: list[int]) -> list[WithdrawalStatus]:
+        """withdrawal request の現在のステータスを取得する。
+
+        Args:
+            request_ids: 確認する request ID のリスト。
+
+        Returns:
+            list[WithdrawalStatus]: 各リクエストのステータス一覧。
+        """
+        self._ensure_initialized()
+        try:
+            from web3 import Web3  # noqa: PLC0415
+
+            queue_address = Web3.to_checksum_address(self._config.withdrawal_queue_address)
+            queue_contract = self._w3.eth.contract(address=queue_address, abi=_WITHDRAWAL_QUEUE_ABI)
+
+            raw_statuses: list[Any] = queue_contract.functions.getWithdrawalStatus(
+                request_ids
+            ).call()
+
+            result: list[WithdrawalStatus] = []
+            for req_id, raw in zip(request_ids, raw_statuses, strict=True):
+                result.append(
+                    WithdrawalStatus(
+                        request_id=req_id,
+                        amount_of_steth=Decimal(raw[0]) / _WEI_PER_ETH,
+                        amount_of_shares=Decimal(raw[1]) / _WEI_PER_ETH,
+                        owner=raw[2],
+                        timestamp=int(raw[3]),
+                        is_finalized=bool(raw[4]),
+                        is_claimed=bool(raw[5]),
+                    )
+                )
+            return result
+        except Exception as exc:
+            logger.exception("get_withdrawal_status 失敗: request_ids=%s", request_ids)
+            raise RuntimeError(f"withdrawal ステータス取得失敗: {exc}") from exc
 
     async def get_steth_balance(self, address: str) -> Decimal:
         """stETH 残高取得（ETH単位）。"""
@@ -404,16 +618,6 @@ class DummyLidoClient(AbstractLidoClient):
             received_steth_wei=amount_wei,  # 1:1 ratio
         )
 
-    async def withdraw(self, amount: Decimal, asset: str) -> TransactionResult:
-        """stETH 引き出しリクエストのシミュレーション。"""
-        logger.info("DummyLidoClient.withdraw: amount=%s %s（シミュレーション）", amount, asset)
-        return TransactionResult(
-            success=True,
-            tx_hash="0x" + "cd" * 32,
-            amount=amount,
-            error=None,
-        )
-
     async def get_steth_balance(self, address: str) -> Decimal:
         """常に 1.0 stETH を返すスタブ。"""
         return Decimal("1.0")
@@ -425,6 +629,61 @@ class DummyLidoClient(AbstractLidoClient):
     async def get_steth_eth_ratio(self) -> Decimal:
         """完全ペグ（1.0）を返すスタブ。"""
         return Decimal("1.0")
+
+    async def request_withdrawals(self, amounts_wei: list[int]) -> WithdrawalRequestResult:
+        """引き出しリクエストのシミュレーション。"""
+        logger.info(
+            "DummyLidoClient.request_withdrawals: amounts_wei=%s（シミュレーション）", amounts_wei
+        )
+        if not amounts_wei:
+            return WithdrawalRequestResult(
+                success=False,
+                error="amounts_wei は空にできません",
+            )
+        # ダミー request_ids（インデックス+1 を使用）
+        dummy_ids = list(range(1000, 1000 + len(amounts_wei)))
+        return WithdrawalRequestResult(
+            tx_hash="0x" + "cd" * 32,
+            success=True,
+            request_ids=dummy_ids,
+        )
+
+    async def claim_withdrawal(self, request_ids: list[int]) -> ClaimWithdrawalResult:
+        """withdrawal claim のシミュレーション。"""
+        logger.info(
+            "DummyLidoClient.claim_withdrawal: request_ids=%s（シミュレーション）", request_ids
+        )
+        if not request_ids:
+            return ClaimWithdrawalResult(
+                success=False,
+                error="request_ids は空にできません",
+            )
+        return ClaimWithdrawalResult(
+            tx_hash="0x" + "ef" * 32,
+            success=True,
+            claimed_request_ids=request_ids,
+        )
+
+    async def get_withdrawal_status(self, request_ids: list[int]) -> list[WithdrawalStatus]:
+        """withdrawal ステータスのシミュレーション（全件 finalized 済みを返す）。"""
+        logger.info(
+            "DummyLidoClient.get_withdrawal_status: request_ids=%s（シミュレーション）",
+            request_ids,
+        )
+        import time  # noqa: PLC0415
+
+        return [
+            WithdrawalStatus(
+                request_id=req_id,
+                amount_of_steth=Decimal("1.0"),
+                amount_of_shares=Decimal("1.0"),
+                owner="0x0000000000000000000000000000000000000001",
+                timestamp=int(time.time()) - 86400,  # 1日前
+                is_finalized=True,
+                is_claimed=False,
+            )
+            for req_id in request_ids
+        ]
 
 
 def get_lido_client(config: LidoConfig) -> AbstractLidoClient:

--- a/backend/app/protocols/lido/schemas.py
+++ b/backend/app/protocols/lido/schemas.py
@@ -85,6 +85,36 @@ class LidoWithdrawResponse(BaseModel):
     )
 
 
+class WithdrawalRequestResult(BaseModel):
+    """withdrawal queue へのリクエスト送信結果。"""
+
+    tx_hash: Optional[str] = None
+    success: bool
+    request_ids: list[int] = Field(default_factory=list, description="払い出しリクエストNFT ID一覧")
+    error: Optional[str] = None
+
+
+class WithdrawalStatus(BaseModel):
+    """withdrawal request の状態。"""
+
+    request_id: int
+    amount_of_steth: Decimal = Field(..., description="引き出し対象 stETH 量（ETH単位）")
+    amount_of_shares: Decimal = Field(..., description="対応するシェア量（ETH単位）")
+    owner: str = Field(..., description="オーナーアドレス")
+    timestamp: int = Field(..., description="リクエスト作成タイムスタンプ (Unix秒)")
+    is_finalized: bool = Field(..., description="最終確定済みか")
+    is_claimed: bool = Field(..., description="クレーム済みか")
+
+
+class ClaimWithdrawalResult(BaseModel):
+    """withdrawal claim 実行結果。"""
+
+    tx_hash: Optional[str] = None
+    success: bool
+    claimed_request_ids: list[int] = Field(default_factory=list)
+    error: Optional[str] = None
+
+
 class CompoundYieldEstimate(BaseModel):
     """複合利回り推定値。"""
 

--- a/backend/tests/protocols/test_lido/test_lido_client.py
+++ b/backend/tests/protocols/test_lido/test_lido_client.py
@@ -1,11 +1,17 @@
 """DummyLidoClient のユニットテスト。"""
 
 from decimal import Decimal
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from app.protocols.lido.client import DummyLidoClient, LidoClient, get_lido_client
 from app.protocols.lido.config import LidoConfig
+from app.protocols.lido.schemas import (
+    ClaimWithdrawalResult,
+    WithdrawalRequestResult,
+    WithdrawalStatus,
+)
 
 
 @pytest.fixture
@@ -80,6 +86,124 @@ class TestDummyLidoClient:
         result = await dummy_client.withdraw(Decimal("0.1"), "ETH")
         assert result.success is True
 
+    # --- request_withdrawals ---
+
+    @pytest.mark.asyncio
+    async def test_request_withdrawals_returns_success(self, dummy_client: DummyLidoClient) -> None:
+        """request_withdrawals が成功を返すこと。"""
+        amounts_wei = [500_000_000_000_000_000]  # 0.5 ETH
+        result = await dummy_client.request_withdrawals(amounts_wei)
+        assert isinstance(result, WithdrawalRequestResult)
+        assert result.success is True
+        assert result.tx_hash is not None
+        assert result.tx_hash.startswith("0x")
+        assert result.error is None
+
+    @pytest.mark.asyncio
+    async def test_request_withdrawals_returns_request_ids(
+        self, dummy_client: DummyLidoClient
+    ) -> None:
+        """request_withdrawals が request_ids を返すこと。"""
+        amounts_wei = [100_000_000_000_000_000, 200_000_000_000_000_000]
+        result = await dummy_client.request_withdrawals(amounts_wei)
+        assert result.success is True
+        assert len(result.request_ids) == len(amounts_wei)
+
+    @pytest.mark.asyncio
+    async def test_request_withdrawals_empty_amounts_fails(
+        self, dummy_client: DummyLidoClient
+    ) -> None:
+        """amounts_wei が空のとき失敗を返すこと。"""
+        result = await dummy_client.request_withdrawals([])
+        assert result.success is False
+        assert result.error is not None
+
+    # --- claim_withdrawal ---
+
+    @pytest.mark.asyncio
+    async def test_claim_withdrawal_returns_success(self, dummy_client: DummyLidoClient) -> None:
+        """claim_withdrawal が成功を返すこと。"""
+        result = await dummy_client.claim_withdrawal([1001, 1002])
+        assert isinstance(result, ClaimWithdrawalResult)
+        assert result.success is True
+        assert result.tx_hash is not None
+        assert result.tx_hash.startswith("0x")
+        assert result.error is None
+
+    @pytest.mark.asyncio
+    async def test_claim_withdrawal_preserves_request_ids(
+        self, dummy_client: DummyLidoClient
+    ) -> None:
+        """claim_withdrawal が claimed_request_ids を返すこと。"""
+        request_ids = [1001, 1002, 1003]
+        result = await dummy_client.claim_withdrawal(request_ids)
+        assert result.claimed_request_ids == request_ids
+
+    @pytest.mark.asyncio
+    async def test_claim_withdrawal_empty_ids_fails(self, dummy_client: DummyLidoClient) -> None:
+        """request_ids が空のとき失敗を返すこと。"""
+        result = await dummy_client.claim_withdrawal([])
+        assert result.success is False
+        assert result.error is not None
+
+    # --- get_withdrawal_status ---
+
+    @pytest.mark.asyncio
+    async def test_get_withdrawal_status_returns_list(self, dummy_client: DummyLidoClient) -> None:
+        """get_withdrawal_status がリストを返すこと。"""
+        statuses = await dummy_client.get_withdrawal_status([1001, 1002])
+        assert isinstance(statuses, list)
+        assert len(statuses) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_withdrawal_status_correct_fields(
+        self, dummy_client: DummyLidoClient
+    ) -> None:
+        """get_withdrawal_status の各フィールドが正しい型であること。"""
+        statuses = await dummy_client.get_withdrawal_status([1001])
+        status = statuses[0]
+        assert isinstance(status, WithdrawalStatus)
+        assert status.request_id == 1001
+        assert isinstance(status.amount_of_steth, Decimal)
+        assert isinstance(status.amount_of_shares, Decimal)
+        assert isinstance(status.is_finalized, bool)
+        assert isinstance(status.is_claimed, bool)
+        assert isinstance(status.timestamp, int)
+
+    @pytest.mark.asyncio
+    async def test_get_withdrawal_status_no_float(self, dummy_client: DummyLidoClient) -> None:
+        """withdrawal status の金額フィールドが Decimal であること（float 禁止）。"""
+        statuses = await dummy_client.get_withdrawal_status([1001])
+        status = statuses[0]
+        assert type(status.amount_of_steth) is Decimal
+        assert type(status.amount_of_shares) is Decimal
+
+    @pytest.mark.asyncio
+    async def test_get_withdrawal_status_dummy_is_finalized(
+        self, dummy_client: DummyLidoClient
+    ) -> None:
+        """DummyLidoClient の withdrawal status は is_finalized=True を返すこと。"""
+        statuses = await dummy_client.get_withdrawal_status([1001])
+        assert statuses[0].is_finalized is True
+
+    # --- withdraw (AbstractLidoClient 経由) ---
+
+    @pytest.mark.asyncio
+    async def test_withdraw_delegates_to_request_withdrawals(
+        self, dummy_client: DummyLidoClient
+    ) -> None:
+        """AbstractLidoClient.withdraw() が request_withdrawals() に委譲すること。"""
+        result = await dummy_client.withdraw(Decimal("1.0"), "stETH")
+        assert result.success is True
+        assert result.tx_hash is not None
+
+    @pytest.mark.asyncio
+    async def test_withdraw_invalid_asset_fails(self, dummy_client: DummyLidoClient) -> None:
+        """無効なアセットで withdraw は失敗を返すこと。"""
+        result = await dummy_client.withdraw(Decimal("1.0"), "USDC")
+        assert result.success is False
+        assert result.error is not None
+
 
 class TestGetLidoClient:
     def test_sandbox_returns_dummy_client(self) -> None:
@@ -112,3 +236,592 @@ class TestGetLidoClient:
         config = LidoConfig(sandbox=True)
         client = get_lido_client(config)
         assert isinstance(client, DummyLidoClient)
+
+
+class TestLidoClientStakeEth:
+    """LidoClient.stake_eth のモックテスト（チェーン接続なし）。"""
+
+    @pytest.mark.asyncio
+    async def test_stake_eth_no_private_key_fails(self) -> None:
+        """秘密鍵未設定で stake_eth は失敗を返すこと。"""
+        config = LidoConfig(sandbox=False, wallet_private_key="")
+        client = LidoClient(config)
+        client._initialized = True
+        client._w3 = None
+        client._contract = None
+
+        result = await client.stake_eth(100_000_000_000_000_000)
+        assert result.success is False
+        assert "LIDO_WALLET_PRIVATE_KEY" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_stake_eth_success_with_mock(self) -> None:
+        """web3 モックで stake_eth 成功パスをテスト。"""
+
+        config = LidoConfig(sandbox=False, wallet_private_key="0x" + "aa" * 32)
+        client = LidoClient(config)
+
+        mock_account = MagicMock()
+        mock_account.address = "0x0000000000000000000000000000000000000001"
+
+        mock_receipt = {"status": 1}
+        fake_tx_hash_obj = MagicMock()
+        fake_tx_hash_obj.hex.return_value = "0x" + "ab" * 32
+
+        mock_contract_fn = MagicMock()
+        mock_contract_fn.build_transaction.return_value = {}
+
+        mock_steth_contract = MagicMock()
+        mock_steth_contract.functions.submit.return_value = mock_contract_fn
+
+        mock_w3 = MagicMock()
+        mock_w3.eth.account.from_key.return_value = mock_account
+        mock_w3.eth.get_transaction_count.return_value = 0
+        mock_w3.eth.gas_price = 20_000_000_000
+        mock_w3.eth.account.sign_transaction.return_value.raw_transaction = b"\x00"
+        mock_w3.eth.send_raw_transaction.return_value = fake_tx_hash_obj
+        mock_w3.eth.wait_for_transaction_receipt.return_value = mock_receipt
+
+        client._w3 = mock_w3
+        client._contract = mock_steth_contract
+        client._initialized = True
+
+        with patch(
+            "web3.Web3.to_checksum_address",
+            return_value="0x0000000000000000000000000000000000000000",
+        ):
+            result = await client.stake_eth(100_000_000_000_000_000)
+
+        assert result.success is True
+        assert result.tx_hash is not None
+
+    @pytest.mark.asyncio
+    async def test_stake_eth_tx_status_zero_fails(self) -> None:
+        """tx status=0 のとき stake_eth は失敗を返すこと。"""
+
+        config = LidoConfig(sandbox=False, wallet_private_key="0x" + "aa" * 32)
+        client = LidoClient(config)
+
+        mock_account = MagicMock()
+        mock_account.address = "0x0000000000000000000000000000000000000001"
+
+        mock_receipt = {"status": 0}
+        fake_tx_hash_obj = MagicMock()
+        fake_tx_hash_obj.hex.return_value = "0x" + "ab" * 32
+
+        mock_contract_fn = MagicMock()
+        mock_contract_fn.build_transaction.return_value = {}
+
+        mock_steth_contract = MagicMock()
+        mock_steth_contract.functions.submit.return_value = mock_contract_fn
+
+        mock_w3 = MagicMock()
+        mock_w3.eth.account.from_key.return_value = mock_account
+        mock_w3.eth.get_transaction_count.return_value = 0
+        mock_w3.eth.gas_price = 20_000_000_000
+        mock_w3.eth.account.sign_transaction.return_value.raw_transaction = b"\x00"
+        mock_w3.eth.send_raw_transaction.return_value = fake_tx_hash_obj
+        mock_w3.eth.wait_for_transaction_receipt.return_value = mock_receipt
+
+        client._w3 = mock_w3
+        client._contract = mock_steth_contract
+        client._initialized = True
+
+        with patch(
+            "web3.Web3.to_checksum_address",
+            return_value="0x0000000000000000000000000000000000000000",
+        ):
+            result = await client.stake_eth(100_000_000_000_000_000)
+
+        assert result.success is False
+        assert result.error is not None
+
+
+class TestLidoClientRequestWithdrawals:
+    """LidoClient.request_withdrawals のモックテスト（チェーン接続なし）。"""
+
+    @pytest.fixture
+    def real_config(self) -> LidoConfig:
+        return LidoConfig(
+            sandbox=False,
+            wallet_private_key="0x" + "aa" * 32,
+        )
+
+    @pytest.mark.asyncio
+    async def test_request_withdrawals_no_private_key_fails(self) -> None:
+        """秘密鍵未設定で request_withdrawals は失敗を返すこと。"""
+        config = LidoConfig(sandbox=False, wallet_private_key="")
+        client = LidoClient(config)
+        client._initialized = True  # _ensure_initialized をスキップ
+        client._w3 = None
+        client._contract = None
+
+        result = await client.request_withdrawals([100_000_000_000_000_000])
+        assert result.success is False
+        assert "LIDO_WALLET_PRIVATE_KEY" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_request_withdrawals_empty_amounts_fails(self) -> None:
+        """amounts_wei が空で request_withdrawals は失敗を返すこと。"""
+        config = LidoConfig(sandbox=False, wallet_private_key="0x" + "aa" * 32)
+        client = LidoClient(config)
+        client._initialized = True
+        client._w3 = None
+        client._contract = None
+
+        result = await client.request_withdrawals([])
+        assert result.success is False
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_request_withdrawals_web3_exception_returns_failure(self) -> None:
+        """web3 呼び出しで例外が出たとき失敗を返すこと。"""
+
+        config = LidoConfig(sandbox=False, wallet_private_key="0x" + "aa" * 32)
+        client = LidoClient(config)
+
+        mock_w3 = MagicMock()
+        mock_w3.eth.account.from_key.side_effect = ValueError("invalid key")
+        client._w3 = mock_w3
+        client._contract = MagicMock()
+        client._initialized = True
+
+        # Web3 は遅延 import されるため、_w3 への side_effect で例外を発生させる
+        result = await client.request_withdrawals([100_000_000_000_000_000])
+
+        assert result.success is False
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_request_withdrawals_success_with_mock(self) -> None:
+        """web3 モックで request_withdrawals 成功パスをテスト。"""
+
+        config = LidoConfig(sandbox=False, wallet_private_key="0x" + "aa" * 32)
+        client = LidoClient(config)
+
+        mock_account = MagicMock()
+        mock_account.address = "0x0000000000000000000000000000000000000001"
+
+        approve_receipt = {"status": 1}
+        withdraw_receipt = {"status": 1}
+        fake_tx_hash_obj = MagicMock()
+        fake_tx_hash_obj.hex.return_value = "0x" + "cd" * 32
+
+        mock_approve_fn = MagicMock()
+        mock_approve_fn.build_transaction.return_value = {}
+
+        mock_withdraw_fn = MagicMock()
+        mock_withdraw_fn.build_transaction.return_value = {}
+
+        mock_steth_contract = MagicMock()
+        mock_steth_contract.functions.approve.return_value = mock_approve_fn
+
+        mock_queue_contract = MagicMock()
+        mock_queue_contract.functions.requestWithdrawals.return_value = mock_withdraw_fn
+
+        mock_w3 = MagicMock()
+        mock_w3.eth.account.from_key.return_value = mock_account
+        mock_w3.eth.get_transaction_count.return_value = 10
+        mock_w3.eth.gas_price = 20_000_000_000
+        mock_w3.eth.account.sign_transaction.return_value.raw_transaction = b"\x00"
+        mock_w3.eth.send_raw_transaction.return_value = fake_tx_hash_obj
+        mock_w3.eth.wait_for_transaction_receipt.side_effect = [
+            approve_receipt,
+            withdraw_receipt,
+        ]
+        mock_w3.eth.contract.return_value = mock_queue_contract
+
+        client._w3 = mock_w3
+        client._contract = mock_steth_contract
+        client._initialized = True
+
+        with patch(
+            "web3.Web3.to_checksum_address",
+            return_value="0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1",
+        ):
+            result = await client.request_withdrawals([500_000_000_000_000_000])
+
+        assert result.success is True
+        assert result.tx_hash is not None
+
+    @pytest.mark.asyncio
+    async def test_request_withdrawals_tx_status_zero_fails(self) -> None:
+        """tx status=0 のとき request_withdrawals は失敗を返すこと。"""
+
+        config = LidoConfig(sandbox=False, wallet_private_key="0x" + "aa" * 32)
+        client = LidoClient(config)
+
+        mock_account = MagicMock()
+        mock_account.address = "0x0000000000000000000000000000000000000001"
+
+        approve_receipt = {"status": 1}
+        withdraw_receipt = {"status": 0}  # 失敗
+        fake_tx_hash_obj = MagicMock()
+        fake_tx_hash_obj.hex.return_value = "0x" + "cd" * 32
+
+        mock_approve_fn = MagicMock()
+        mock_approve_fn.build_transaction.return_value = {}
+
+        mock_withdraw_fn = MagicMock()
+        mock_withdraw_fn.build_transaction.return_value = {}
+
+        mock_steth_contract = MagicMock()
+        mock_steth_contract.functions.approve.return_value = mock_approve_fn
+
+        mock_queue_contract = MagicMock()
+        mock_queue_contract.functions.requestWithdrawals.return_value = mock_withdraw_fn
+
+        mock_w3 = MagicMock()
+        mock_w3.eth.account.from_key.return_value = mock_account
+        mock_w3.eth.get_transaction_count.return_value = 10
+        mock_w3.eth.gas_price = 20_000_000_000
+        mock_w3.eth.account.sign_transaction.return_value.raw_transaction = b"\x00"
+        mock_w3.eth.send_raw_transaction.return_value = fake_tx_hash_obj
+        mock_w3.eth.wait_for_transaction_receipt.side_effect = [
+            approve_receipt,
+            withdraw_receipt,
+        ]
+        mock_w3.eth.contract.return_value = mock_queue_contract
+
+        client._w3 = mock_w3
+        client._contract = mock_steth_contract
+        client._initialized = True
+
+        with patch(
+            "web3.Web3.to_checksum_address",
+            return_value="0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1",
+        ):
+            result = await client.request_withdrawals([500_000_000_000_000_000])
+
+        assert result.success is False
+        assert result.error is not None
+
+
+class TestLidoClientClaimWithdrawal:
+    """LidoClient.claim_withdrawal のモックテスト（チェーン接続なし）。"""
+
+    @pytest.mark.asyncio
+    async def test_claim_withdrawal_no_private_key_fails(self) -> None:
+        """秘密鍵未設定で claim_withdrawal は失敗を返すこと。"""
+        config = LidoConfig(sandbox=False, wallet_private_key="")
+        client = LidoClient(config)
+        client._initialized = True
+        client._w3 = None
+        client._contract = None
+
+        result = await client.claim_withdrawal([1001])
+        assert result.success is False
+        assert "LIDO_WALLET_PRIVATE_KEY" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_claim_withdrawal_empty_ids_fails(self) -> None:
+        """request_ids が空で claim_withdrawal は失敗を返すこと。"""
+        config = LidoConfig(sandbox=False, wallet_private_key="0x" + "aa" * 32)
+        client = LidoClient(config)
+        client._initialized = True
+        client._w3 = None
+        client._contract = None
+
+        result = await client.claim_withdrawal([])
+        assert result.success is False
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_claim_withdrawal_web3_exception_returns_failure(self) -> None:
+        """web3 呼び出しで例外が出たとき失敗を返すこと。"""
+
+        config = LidoConfig(sandbox=False, wallet_private_key="0x" + "aa" * 32)
+        client = LidoClient(config)
+
+        mock_w3 = MagicMock()
+        mock_w3.eth.account.from_key.side_effect = ValueError("invalid key")
+        client._w3 = mock_w3
+        client._contract = MagicMock()
+        client._initialized = True
+
+        # Web3 は遅延 import されるため、_w3 への side_effect で例外を発生させる
+        result = await client.claim_withdrawal([1001])
+
+        assert result.success is False
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_claim_withdrawal_success_with_mock(self) -> None:
+        """web3 モックで claim_withdrawal 成功パスをテスト。"""
+
+        config = LidoConfig(sandbox=False, wallet_private_key="0x" + "aa" * 32)
+        client = LidoClient(config)
+
+        mock_account = MagicMock()
+        mock_account.address = "0x0000000000000000000000000000000000000001"
+
+        claim_receipt = {"status": 1}
+        fake_tx_hash_obj = MagicMock()
+        fake_tx_hash_obj.hex.return_value = "0x" + "ef" * 32
+
+        mock_claim_fn = MagicMock()
+        mock_claim_fn.build_transaction.return_value = {}
+
+        mock_queue_contract = MagicMock()
+        mock_queue_contract.functions.getLastCheckpointIndex.return_value.call.return_value = 100
+        mock_queue_contract.functions.findCheckpointHints.return_value.call.return_value = [50]
+        mock_queue_contract.functions.claimWithdrawals.return_value = mock_claim_fn
+
+        mock_w3 = MagicMock()
+        mock_w3.eth.account.from_key.return_value = mock_account
+        mock_w3.eth.get_transaction_count.return_value = 5
+        mock_w3.eth.gas_price = 20_000_000_000
+        mock_w3.eth.account.sign_transaction.return_value.raw_transaction = b"\x00"
+        mock_w3.eth.send_raw_transaction.return_value = fake_tx_hash_obj
+        mock_w3.eth.wait_for_transaction_receipt.return_value = claim_receipt
+        mock_w3.eth.contract.return_value = mock_queue_contract
+
+        client._w3 = mock_w3
+        client._contract = MagicMock()
+        client._initialized = True
+
+        with patch(
+            "web3.Web3.to_checksum_address",
+            return_value="0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1",
+        ):
+            result = await client.claim_withdrawal([1001])
+
+        assert result.success is True
+        assert result.tx_hash is not None
+        assert result.claimed_request_ids == [1001]
+
+    @pytest.mark.asyncio
+    async def test_claim_withdrawal_tx_status_zero_fails(self) -> None:
+        """tx status=0 のとき claim_withdrawal は失敗を返すこと。"""
+
+        config = LidoConfig(sandbox=False, wallet_private_key="0x" + "aa" * 32)
+        client = LidoClient(config)
+
+        mock_account = MagicMock()
+        mock_account.address = "0x0000000000000000000000000000000000000001"
+
+        claim_receipt = {"status": 0}  # 失敗
+        fake_tx_hash_obj = MagicMock()
+        fake_tx_hash_obj.hex.return_value = "0x" + "ef" * 32
+
+        mock_claim_fn = MagicMock()
+        mock_claim_fn.build_transaction.return_value = {}
+
+        mock_queue_contract = MagicMock()
+        mock_queue_contract.functions.getLastCheckpointIndex.return_value.call.return_value = 100
+        mock_queue_contract.functions.findCheckpointHints.return_value.call.return_value = [50]
+        mock_queue_contract.functions.claimWithdrawals.return_value = mock_claim_fn
+
+        mock_w3 = MagicMock()
+        mock_w3.eth.account.from_key.return_value = mock_account
+        mock_w3.eth.get_transaction_count.return_value = 5
+        mock_w3.eth.gas_price = 20_000_000_000
+        mock_w3.eth.account.sign_transaction.return_value.raw_transaction = b"\x00"
+        mock_w3.eth.send_raw_transaction.return_value = fake_tx_hash_obj
+        mock_w3.eth.wait_for_transaction_receipt.return_value = claim_receipt
+        mock_w3.eth.contract.return_value = mock_queue_contract
+
+        client._w3 = mock_w3
+        client._contract = MagicMock()
+        client._initialized = True
+
+        with patch(
+            "web3.Web3.to_checksum_address",
+            return_value="0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1",
+        ):
+            result = await client.claim_withdrawal([1001])
+
+        assert result.success is False
+        assert result.error is not None
+
+
+class TestLidoClientGetWithdrawalStatus:
+    """LidoClient.get_withdrawal_status のモックテスト（チェーン接続なし）。"""
+
+    @pytest.mark.asyncio
+    async def test_get_withdrawal_status_parses_response(self) -> None:
+        """get_withdrawal_status がコントラクトレスポンスを正しくパースすること。"""
+        import time  # noqa: PLC0415
+
+        config = LidoConfig(sandbox=False)
+        client = LidoClient(config)
+
+        now = int(time.time())
+        mock_raw_statuses = [
+            (
+                500_000_000_000_000_000,  # amountOfStETH (0.5 ETH in Wei)
+                490_000_000_000_000_000,  # amountOfShares
+                "0x0000000000000000000000000000000000000001",  # owner
+                now - 3600,  # timestamp
+                True,  # isFinalized
+                False,  # isClaimed
+            )
+        ]
+
+        mock_queue_contract = MagicMock()
+        mock_queue_contract.functions.getWithdrawalStatus.return_value.call.return_value = (
+            mock_raw_statuses
+        )
+
+        mock_w3 = MagicMock()
+        mock_w3.eth.contract.return_value = mock_queue_contract
+        client._w3 = mock_w3
+        client._contract = MagicMock()
+        client._initialized = True
+
+        # Web3 は遅延 import。web3.Web3.to_checksum_address を patch する
+        with patch(
+            "web3.Web3.to_checksum_address",
+            return_value="0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1",
+        ):
+            statuses = await client.get_withdrawal_status([1001])
+
+        assert len(statuses) == 1
+        status = statuses[0]
+        assert status.request_id == 1001
+        assert type(status.amount_of_steth) is Decimal
+        assert status.amount_of_steth == Decimal("500000000000000000") / Decimal(
+            "1000000000000000000"
+        )
+        assert status.is_finalized is True
+        assert status.is_claimed is False
+
+    @pytest.mark.asyncio
+    async def test_get_withdrawal_status_raises_on_web3_error(self) -> None:
+        """web3 呼び出しで例外が出たとき RuntimeError を raise すること。"""
+
+        config = LidoConfig(sandbox=False)
+        client = LidoClient(config)
+
+        mock_queue_contract = MagicMock()
+        mock_queue_contract.functions.getWithdrawalStatus.side_effect = RuntimeError("RPC error")
+
+        mock_w3 = MagicMock()
+        mock_w3.eth.contract.return_value = mock_queue_contract
+        client._w3 = mock_w3
+        client._contract = MagicMock()
+        client._initialized = True
+
+        with (
+            patch("web3.Web3.to_checksum_address", return_value="0xAddress"),
+            pytest.raises(RuntimeError, match="withdrawal ステータス取得失敗"),
+        ):
+            await client.get_withdrawal_status([1001])
+
+
+class TestLidoClientReadMethods:
+    """LidoClient の読み取り専用メソッドのモックテスト。"""
+
+    @pytest.mark.asyncio
+    async def test_get_steth_balance_success(self) -> None:
+        """get_steth_balance が Decimal を返すこと。"""
+
+        config = LidoConfig(sandbox=False)
+        client = LidoClient(config)
+
+        mock_steth_contract = MagicMock()
+        mock_steth_contract.functions.balanceOf.return_value.call.return_value = (
+            1_500_000_000_000_000_000  # 1.5 ETH in Wei
+        )
+
+        client._contract = mock_steth_contract
+        client._initialized = True
+        client._w3 = MagicMock()
+
+        with patch("web3.Web3.to_checksum_address", return_value="0xAddress"):
+            balance = await client.get_steth_balance("0x0000000000000000000000000000000000000001")
+
+        assert type(balance) is Decimal
+        assert balance == Decimal("1500000000000000000") / Decimal("1000000000000000000")
+
+    @pytest.mark.asyncio
+    async def test_get_steth_balance_raises_on_error(self) -> None:
+        """web3 エラー時に get_steth_balance は RuntimeError を raise すること。"""
+
+        config = LidoConfig(sandbox=False)
+        client = LidoClient(config)
+
+        mock_steth_contract = MagicMock()
+        mock_steth_contract.functions.balanceOf.side_effect = RuntimeError("RPC error")
+
+        client._contract = mock_steth_contract
+        client._initialized = True
+        client._w3 = MagicMock()
+
+        with (
+            patch("web3.Web3.to_checksum_address", return_value="0xAddress"),
+            pytest.raises(RuntimeError, match="stETH 残高取得失敗"),
+        ):
+            await client.get_steth_balance("0xAddress")
+
+    @pytest.mark.asyncio
+    async def test_get_staking_apr_returns_35(self) -> None:
+        """get_staking_apr が testnet で 3.5 を返すこと。"""
+
+        config = LidoConfig(sandbox=False)
+        client = LidoClient(config)
+        client._initialized = True
+        client._w3 = MagicMock()
+        client._contract = MagicMock()
+
+        apr = await client.get_staking_apr()
+        assert type(apr) is Decimal
+        assert apr == Decimal("3.5")
+
+    @pytest.mark.asyncio
+    async def test_get_steth_eth_ratio_success(self) -> None:
+        """get_steth_eth_ratio が正しい比率を返すこと。"""
+
+        config = LidoConfig(sandbox=False)
+        client = LidoClient(config)
+
+        mock_steth_contract = MagicMock()
+        mock_steth_contract.functions.getTotalPooledEther.return_value.call.return_value = (
+            1_050_000_000_000_000_000
+        )
+        mock_steth_contract.functions.getTotalShares.return_value.call.return_value = (
+            1_000_000_000_000_000_000
+        )
+
+        client._contract = mock_steth_contract
+        client._initialized = True
+        client._w3 = MagicMock()
+
+        ratio = await client.get_steth_eth_ratio()
+        assert type(ratio) is Decimal
+        assert ratio == Decimal("1050000000000000000") / Decimal("1000000000000000000")
+
+    @pytest.mark.asyncio
+    async def test_get_steth_eth_ratio_zero_shares_returns_one(self) -> None:
+        """total_shares が 0 のとき get_steth_eth_ratio は 1 を返すこと。"""
+
+        config = LidoConfig(sandbox=False)
+        client = LidoClient(config)
+
+        mock_steth_contract = MagicMock()
+        mock_steth_contract.functions.getTotalPooledEther.return_value.call.return_value = 0
+        mock_steth_contract.functions.getTotalShares.return_value.call.return_value = 0
+
+        client._contract = mock_steth_contract
+        client._initialized = True
+        client._w3 = MagicMock()
+
+        ratio = await client.get_steth_eth_ratio()
+        assert ratio == Decimal("1")
+
+    @pytest.mark.asyncio
+    async def test_get_steth_eth_ratio_raises_on_error(self) -> None:
+        """web3 エラー時に get_steth_eth_ratio は RuntimeError を raise すること。"""
+
+        config = LidoConfig(sandbox=False)
+        client = LidoClient(config)
+
+        mock_steth_contract = MagicMock()
+        mock_steth_contract.functions.getTotalPooledEther.side_effect = RuntimeError("RPC error")
+
+        client._contract = mock_steth_contract
+        client._initialized = True
+        client._w3 = MagicMock()
+
+        with pytest.raises(RuntimeError, match="stETH/ETH レート取得失敗"):
+            await client.get_steth_eth_ratio()


### PR DESCRIPTION
## 概要
Lido V2 の withdrawal queue（request / claim / status）を実装。既存 PoC スタブをリファクタし、claim 側を新規実装。

~~Closes Asana GID 1215620828227794~~ (⚠️ GID誤記: 該当タスクはAsana未起票だった。事後起票で対応 2026-06-12) (EPIC-2)

## 実装
- `LidoClient.request_withdrawals()` — approve(正確額) + requestWithdrawals の2ステップ
- `LidoClient.claim_withdrawal()` — getLastCheckpointIndex → findCheckpointHints → claimWithdrawals
- `LidoClient.get_withdrawal_status()` — Decimal(wei)/1e18 変換
- schemas 3種追加（WithdrawalRequestResult / WithdrawalStatus / ClaimWithdrawalResult）

## DoD / Gate
- ruff / ruff format / mypy: clean
- pytest: 91 passed, coverage **91%**（client.py 86% / schemas 100% / service 96%）
- Decimal型のみ・秘密鍵は環境変数経由・approve は正確額（無限approveなし）

## フォローアップ
- `request_ids` は実チェーンの WithdrawalRequested イベントログ解析が必要（unit testスコープ外、現状空リスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)