### PR TITLE
feat(pendle): RouterV4 YT/PT buy/sell + addLiquidity 実装 (Phase 1)

### DIFF
--- a/backend/app/protocols/pendle/client.py
+++ b/backend/app/protocols/pendle/client.py
@@ -20,7 +20,13 @@ from app.protocols.base import (
 )
 
 from .config import PendleConfig
-from .schemas import PendleMarketInfo
+from .schemas import (
+    PendleMarketInfo,
+    RouterV4AddLiquidityRequest,
+    RouterV4AddLiquidityResult,
+    RouterV4SwapRequest,
+    RouterV4SwapResult,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -376,6 +382,339 @@ class PendleWebClient(AbstractPendleClient):
         """YT リデーム（Phase 2 PoC: オンチェーン操作は未実装）。"""
         logger.warning("PendleWebClient.redeem_yt: Phase 2 PoC のためオンチェーン操作を拒否")
         return {"success": False, "error": "オンチェーン操作は Phase 3 以降に対応予定です"}
+
+
+class PendleRouterV4Client:
+    """Pendle RouterV4 クライアント（YT/PT 売買 + add_liquidity）。
+
+    Pendle Hosted SDK（https://api-v2.pendle.finance/sdk/api/v1）を使って calldata を生成し、
+    web3.py でトランザクションを送信する。
+
+    設計方針:
+    - calldata は SDK が生成するため、こちらでの ABI encode は不要。
+    - 金額は必ず Decimal 型。float 使用禁止。
+    - 秘密鍵は config 経由で環境変数から取得。ログに出力しない。
+    - 外部 HTTP 失敗は例外を握りつぶさず RouterV4SwapResult(success=False) を返す（fail-open）。
+    - slippage デフォルト 0.5%（Decimal("0.005")）。
+    """
+
+    _SDK_BASE = "https://api-v2.pendle.finance/sdk/api/v1"
+    _ROUTER_ADDRESS = "0x888888888889758F76e7103c6CbF23ABbF58F946"
+    _DEFAULT_SLIPPAGE = Decimal("0.005")
+    _REQUEST_TIMEOUT = 15.0
+
+    # チェーン ID マッピング（Pendle SDK が使用するチェーン ID）
+    _CHAIN_ID_MAP: dict[str, int] = {
+        "arbitrum": 42161,
+        "ethereum": 1,
+        "polygon": 137,
+        "sepolia": 421614,  # Arbitrum Sepolia
+    }
+
+    def __init__(self, config: PendleConfig) -> None:
+        self._config = config
+        self._chain_id = self._CHAIN_ID_MAP.get(config.chain, 42161)
+        logger.info(
+            "PendleRouterV4Client initialized (chain=%s, chain_id=%d, router=%s)",
+            config.chain,
+            self._chain_id,
+            self._ROUTER_ADDRESS[:10] + "...",
+        )
+
+    async def _call_sdk(self, endpoint: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Pendle Hosted SDK を呼び出して calldata を取得する。
+
+        Args:
+            endpoint: SDK エンドポイント（例: "swapExactTokenForYt"）
+            params: クエリパラメータ
+
+        Returns:
+            SDK レスポンス dict
+
+        Raises:
+            httpx.HTTPError: HTTP エラー
+            Exception: その他のエラー
+        """
+        url = f"{self._SDK_BASE}/{self._chain_id}/{endpoint}"
+        async with httpx.AsyncClient(timeout=self._REQUEST_TIMEOUT) as client:
+            response = await client.get(url, params=params)
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+            return data
+
+    def _amount_to_wei(self, amount: Decimal, decimals: int = 18) -> int:
+        """Decimal 量を wei 単位の int に変換する。"""
+        factor = Decimal(10) ** decimals
+        return int(amount * factor)
+
+    def _wei_to_decimal(self, wei: int, decimals: int = 18) -> Decimal:
+        """wei 単位の int を Decimal 量に変換する。"""
+        factor = Decimal(10) ** decimals
+        return Decimal(str(wei)) / factor
+
+    async def buy_yt(
+        self,
+        market_address: str,
+        token_in: str,
+        amount_in: Decimal,
+        receiver: str,
+        slippage: Decimal | None = None,
+    ) -> RouterV4SwapResult:
+        """YT を購入する（token_in → YT swap）。
+
+        Args:
+            market_address: 対象マーケットアドレス
+            token_in: 入力トークンアドレス
+            amount_in: 入力量（Decimal）
+            receiver: YT 受取アドレス
+            slippage: スリッページ（デフォルト 0.5% = 0.005）
+
+        Returns:
+            RouterV4SwapResult
+        """
+        effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
+        req = RouterV4SwapRequest(
+            market_address=market_address,
+            token_in=token_in,
+            token_out="YT",
+            amount_in=amount_in,
+            slippage=effective_slippage,
+            receiver=receiver,
+        )
+        return await self._execute_swap(req, "swapExactTokenForYt")
+
+    async def sell_yt(
+        self,
+        market_address: str,
+        token_out: str,
+        yt_amount_in: Decimal,
+        receiver: str,
+        slippage: Decimal | None = None,
+    ) -> RouterV4SwapResult:
+        """YT を売却する（YT → token_out swap）。
+
+        Args:
+            market_address: 対象マーケットアドレス
+            token_out: 出力トークンアドレス
+            yt_amount_in: 売却する YT 量（Decimal）
+            receiver: 受取アドレス
+            slippage: スリッページ（デフォルト 0.5% = 0.005）
+
+        Returns:
+            RouterV4SwapResult
+        """
+        effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
+        req = RouterV4SwapRequest(
+            market_address=market_address,
+            token_in="YT",
+            token_out=token_out,
+            amount_in=yt_amount_in,
+            slippage=effective_slippage,
+            receiver=receiver,
+        )
+        return await self._execute_swap(req, "swapExactYtForToken")
+
+    async def buy_pt(
+        self,
+        market_address: str,
+        token_in: str,
+        amount_in: Decimal,
+        receiver: str,
+        slippage: Decimal | None = None,
+    ) -> RouterV4SwapResult:
+        """PT を購入する（token_in → PT swap）。
+
+        Args:
+            market_address: 対象マーケットアドレス
+            token_in: 入力トークンアドレス
+            amount_in: 入力量（Decimal）
+            receiver: PT 受取アドレス
+            slippage: スリッページ（デフォルト 0.5% = 0.005）
+
+        Returns:
+            RouterV4SwapResult
+        """
+        effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
+        req = RouterV4SwapRequest(
+            market_address=market_address,
+            token_in=token_in,
+            token_out="PT",
+            amount_in=amount_in,
+            slippage=effective_slippage,
+            receiver=receiver,
+        )
+        return await self._execute_swap(req, "swapExactTokenForPt")
+
+    async def sell_pt(
+        self,
+        market_address: str,
+        token_out: str,
+        pt_amount_in: Decimal,
+        receiver: str,
+        slippage: Decimal | None = None,
+    ) -> RouterV4SwapResult:
+        """PT を売却する（PT → token_out swap）。
+
+        Args:
+            market_address: 対象マーケットアドレス
+            token_out: 出力トークンアドレス
+            pt_amount_in: 売却する PT 量（Decimal）
+            receiver: 受取アドレス
+            slippage: スリッページ（デフォルト 0.5% = 0.005）
+
+        Returns:
+            RouterV4SwapResult
+        """
+        effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
+        req = RouterV4SwapRequest(
+            market_address=market_address,
+            token_in="PT",
+            token_out=token_out,
+            amount_in=pt_amount_in,
+            slippage=effective_slippage,
+            receiver=receiver,
+        )
+        return await self._execute_swap(req, "swapExactPtForToken")
+
+    async def _execute_swap(
+        self, req: RouterV4SwapRequest, sdk_endpoint: str
+    ) -> RouterV4SwapResult:
+        """SDK を呼び出して swap calldata を取得し、tx を送信する。
+
+        外部 HTTP 失敗は例外を握りつぶさず RouterV4SwapResult(success=False) を返す。
+
+        Args:
+            req: swap リクエスト
+            sdk_endpoint: SDK エンドポイント名
+
+        Returns:
+            RouterV4SwapResult
+        """
+        try:
+            amount_wei = self._amount_to_wei(req.amount_in)
+            # slippage は SDK に対して小数形式で渡す（0.005 = 0.5%）
+            params: dict[str, Any] = {
+                "chainId": self._chain_id,
+                "market": req.market_address,
+                "tokenIn": req.token_in,
+                "tokenOut": req.token_out,
+                "amountIn": str(amount_wei),
+                "slippage": str(req.slippage),
+                "receiver": req.receiver,
+            }
+
+            logger.info(
+                "PendleRouterV4Client._execute_swap: endpoint=%s, market=%s, amountIn=%s",
+                sdk_endpoint,
+                req.market_address[:10] + "...",
+                req.amount_in,
+            )
+
+            sdk_response = await self._call_sdk(sdk_endpoint, params)
+
+            calldata: str = sdk_response.get("data", {}).get("tx", {}).get("data", "")
+            out_amount_raw = sdk_response.get("data", {}).get("amountOut", "0")
+            amount_out = self._wei_to_decimal(int(str(out_amount_raw)))
+
+            return RouterV4SwapResult(
+                success=True,
+                tx_hash=None,  # tx 送信は Phase 2 以降（現フェーズは calldata 取得のみ）
+                amount_out=amount_out,
+                calldata=calldata,
+            )
+
+        except httpx.HTTPStatusError as exc:
+            logger.warning(
+                "PendleRouterV4Client._execute_swap HTTP エラー: endpoint=%s, status=%d, detail=%s",
+                sdk_endpoint,
+                exc.response.status_code,
+                exc.response.text[:200],
+            )
+            return RouterV4SwapResult(
+                success=False,
+                error=f"SDK HTTP {exc.response.status_code}: {exc.response.text[:100]}",
+            )
+        except Exception as exc:
+            logger.warning(
+                "PendleRouterV4Client._execute_swap 失敗: endpoint=%s, error=%s",
+                sdk_endpoint,
+                exc,
+            )
+            return RouterV4SwapResult(success=False, error=str(exc))
+
+    async def add_liquidity(
+        self,
+        market_address: str,
+        token_in: str,
+        amount_in: Decimal,
+        receiver: str,
+        slippage: Decimal | None = None,
+    ) -> RouterV4AddLiquidityResult:
+        """マーケットに流動性を追加する（token_in → LP）。
+
+        Args:
+            market_address: 対象マーケットアドレス
+            token_in: 入力トークンアドレス
+            amount_in: 入力量（Decimal）
+            receiver: LP 受取アドレス
+            slippage: スリッページ（デフォルト 0.5% = 0.005）
+
+        Returns:
+            RouterV4AddLiquidityResult
+        """
+        effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
+        req = RouterV4AddLiquidityRequest(
+            market_address=market_address,
+            token_in=token_in,
+            amount_in=amount_in,
+            slippage=effective_slippage,
+            receiver=receiver,
+        )
+
+        try:
+            amount_wei = self._amount_to_wei(req.amount_in)
+            params: dict[str, Any] = {
+                "chainId": self._chain_id,
+                "market": req.market_address,
+                "tokenIn": req.token_in,
+                "amountIn": str(amount_wei),
+                "slippage": str(req.slippage),
+                "receiver": req.receiver,
+            }
+
+            logger.info(
+                "PendleRouterV4Client.add_liquidity: market=%s, tokenIn=%s, amountIn=%s",
+                req.market_address[:10] + "...",
+                req.token_in[:10] + "..." if len(req.token_in) > 10 else req.token_in,
+                req.amount_in,
+            )
+
+            sdk_response = await self._call_sdk("addLiquiditySingleToken", params)
+
+            calldata = sdk_response.get("data", {}).get("tx", {}).get("data", "")
+            lp_amount_raw = sdk_response.get("data", {}).get("amountLpOut", "0")
+            lp_amount = self._wei_to_decimal(int(str(lp_amount_raw)))
+
+            return RouterV4AddLiquidityResult(
+                success=True,
+                tx_hash=None,  # tx 送信は Phase 2 以降
+                lp_amount=lp_amount,
+                calldata=calldata,
+            )
+
+        except httpx.HTTPStatusError as exc:
+            logger.warning(
+                "PendleRouterV4Client.add_liquidity HTTP エラー: status=%d, detail=%s",
+                exc.response.status_code,
+                exc.response.text[:200],
+            )
+            return RouterV4AddLiquidityResult(
+                success=False,
+                error=f"SDK HTTP {exc.response.status_code}: {exc.response.text[:100]}",
+            )
+        except Exception as exc:
+            logger.warning("PendleRouterV4Client.add_liquidity 失敗: error=%s", exc)
+            return RouterV4AddLiquidityResult(success=False, error=str(exc))
 
 
 def get_pendle_client(config: PendleConfig) -> AbstractPendleClient:

--- a/backend/app/protocols/pendle/client.py
+++ b/backend/app/protocols/pendle/client.py
@@ -24,6 +24,7 @@ from .schemas import (
     PendleMarketInfo,
     RouterV4AddLiquidityRequest,
     RouterV4AddLiquidityResult,
+    RouterV4Approval,
     RouterV4SwapRequest,
     RouterV4SwapResult,
 )
@@ -452,6 +453,79 @@ class PendleRouterV4Client:
         factor = Decimal(10) ** decimals
         return Decimal(str(wei)) / factor
 
+    def _check_guards(
+        self,
+        amount_in: Decimal,
+        portfolio_value_usd: Decimal | None = None,
+    ) -> RouterV4SwapResult | None:
+        """二段ガード + 10%上限チェック。
+
+        問題があれば RouterV4SwapResult(success=False) を返す。問題なければ None を返す。
+        """
+        # Q1 一段目: オンチェーン書き込み無効ガード
+        if not self._config.enable_onchain_write:
+            return RouterV4SwapResult(
+                success=False,
+                error="on-chain write disabled (PENDLE_ENABLE_ONCHAIN_WRITE=false)",
+            )
+        # Q2: 単一トレード上限（10%）チェック
+        if portfolio_value_usd is not None:
+            limit = portfolio_value_usd * self._config.max_single_trade_pct
+            if amount_in > limit:
+                return RouterV4SwapResult(
+                    success=False,
+                    error=(
+                        f"exceeds max single trade ({self._config.max_single_trade_pct * 100:.0f}%): "
+                        f"amount_in={amount_in}, limit={limit}"
+                    ),
+                )
+        else:
+            logger.warning(
+                "PendleRouterV4Client: portfolio_value_usd が未指定のため 10%上限チェックをスキップ"
+            )
+        return None
+
+    def _check_guards_liq(
+        self,
+        amount_in: Decimal,
+        portfolio_value_usd: Decimal | None = None,
+    ) -> RouterV4AddLiquidityResult | None:
+        """二段ガード + 10%上限チェック（add_liquidity 用）。
+
+        問題があれば RouterV4AddLiquidityResult(success=False) を返す。問題なければ None を返す。
+        """
+        if not self._config.enable_onchain_write:
+            return RouterV4AddLiquidityResult(
+                success=False,
+                error="on-chain write disabled (PENDLE_ENABLE_ONCHAIN_WRITE=false)",
+            )
+        if portfolio_value_usd is not None:
+            limit = portfolio_value_usd * self._config.max_single_trade_pct
+            if amount_in > limit:
+                return RouterV4AddLiquidityResult(
+                    success=False,
+                    error=(
+                        f"exceeds max single trade ({self._config.max_single_trade_pct * 100:.0f}%): "
+                        f"amount_in={amount_in}, limit={limit}"
+                    ),
+                )
+        else:
+            logger.warning(
+                "PendleRouterV4Client: portfolio_value_usd が未指定のため 10%上限チェックをスキップ"
+            )
+        return None
+
+    def _extract_approvals(self, sdk_response: dict[str, Any]) -> list[RouterV4Approval] | None:
+        """SDK レスポンスから approvals を抽出する。"""
+        raw_approvals = sdk_response.get("data", {}).get("approvals", [])
+        if not raw_approvals:
+            return None
+        result: list[RouterV4Approval] = []
+        for item in raw_approvals:
+            if isinstance(item, dict) and "spender" in item and "token" in item:
+                result.append(RouterV4Approval(spender=item["spender"], token=item["token"]))
+        return result if result else None
+
     async def buy_yt(
         self,
         market_address: str,
@@ -459,6 +533,8 @@ class PendleRouterV4Client:
         amount_in: Decimal,
         receiver: str,
         slippage: Decimal | None = None,
+        dry_run: bool = True,
+        portfolio_value_usd: Decimal | None = None,
     ) -> RouterV4SwapResult:
         """YT を購入する（token_in → YT swap）。
 
@@ -468,10 +544,15 @@ class PendleRouterV4Client:
             amount_in: 入力量（Decimal）
             receiver: YT 受取アドレス
             slippage: スリッページ（デフォルト 0.5% = 0.005）
+            dry_run: True の場合 calldata 生成のみで tx 送信なし（デフォルト True）
+            portfolio_value_usd: ポートフォリオ総額（10%上限チェック用。None でスキップ）
 
         Returns:
             RouterV4SwapResult
         """
+        guard = self._check_guards(amount_in, portfolio_value_usd)
+        if guard is not None:
+            return guard
         effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
         req = RouterV4SwapRequest(
             market_address=market_address,
@@ -481,7 +562,7 @@ class PendleRouterV4Client:
             slippage=effective_slippage,
             receiver=receiver,
         )
-        return await self._execute_swap(req, "swapExactTokenForYt")
+        return await self._execute_swap(req, "swapExactTokenForYt", dry_run=dry_run)
 
     async def sell_yt(
         self,
@@ -490,6 +571,8 @@ class PendleRouterV4Client:
         yt_amount_in: Decimal,
         receiver: str,
         slippage: Decimal | None = None,
+        dry_run: bool = True,
+        portfolio_value_usd: Decimal | None = None,
     ) -> RouterV4SwapResult:
         """YT を売却する（YT → token_out swap）。
 
@@ -499,10 +582,15 @@ class PendleRouterV4Client:
             yt_amount_in: 売却する YT 量（Decimal）
             receiver: 受取アドレス
             slippage: スリッページ（デフォルト 0.5% = 0.005）
+            dry_run: True の場合 calldata 生成のみで tx 送信なし（デフォルト True）
+            portfolio_value_usd: ポートフォリオ総額（10%上限チェック用。None でスキップ）
 
         Returns:
             RouterV4SwapResult
         """
+        guard = self._check_guards(yt_amount_in, portfolio_value_usd)
+        if guard is not None:
+            return guard
         effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
         req = RouterV4SwapRequest(
             market_address=market_address,
@@ -512,7 +600,7 @@ class PendleRouterV4Client:
             slippage=effective_slippage,
             receiver=receiver,
         )
-        return await self._execute_swap(req, "swapExactYtForToken")
+        return await self._execute_swap(req, "swapExactYtForToken", dry_run=dry_run)
 
     async def buy_pt(
         self,
@@ -521,6 +609,8 @@ class PendleRouterV4Client:
         amount_in: Decimal,
         receiver: str,
         slippage: Decimal | None = None,
+        dry_run: bool = True,
+        portfolio_value_usd: Decimal | None = None,
     ) -> RouterV4SwapResult:
         """PT を購入する（token_in → PT swap）。
 
@@ -530,10 +620,15 @@ class PendleRouterV4Client:
             amount_in: 入力量（Decimal）
             receiver: PT 受取アドレス
             slippage: スリッページ（デフォルト 0.5% = 0.005）
+            dry_run: True の場合 calldata 生成のみで tx 送信なし（デフォルト True）
+            portfolio_value_usd: ポートフォリオ総額（10%上限チェック用。None でスキップ）
 
         Returns:
             RouterV4SwapResult
         """
+        guard = self._check_guards(amount_in, portfolio_value_usd)
+        if guard is not None:
+            return guard
         effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
         req = RouterV4SwapRequest(
             market_address=market_address,
@@ -543,7 +638,7 @@ class PendleRouterV4Client:
             slippage=effective_slippage,
             receiver=receiver,
         )
-        return await self._execute_swap(req, "swapExactTokenForPt")
+        return await self._execute_swap(req, "swapExactTokenForPt", dry_run=dry_run)
 
     async def sell_pt(
         self,
@@ -552,6 +647,8 @@ class PendleRouterV4Client:
         pt_amount_in: Decimal,
         receiver: str,
         slippage: Decimal | None = None,
+        dry_run: bool = True,
+        portfolio_value_usd: Decimal | None = None,
     ) -> RouterV4SwapResult:
         """PT を売却する（PT → token_out swap）。
 
@@ -561,10 +658,15 @@ class PendleRouterV4Client:
             pt_amount_in: 売却する PT 量（Decimal）
             receiver: 受取アドレス
             slippage: スリッページ（デフォルト 0.5% = 0.005）
+            dry_run: True の場合 calldata 生成のみで tx 送信なし（デフォルト True）
+            portfolio_value_usd: ポートフォリオ総額（10%上限チェック用。None でスキップ）
 
         Returns:
             RouterV4SwapResult
         """
+        guard = self._check_guards(pt_amount_in, portfolio_value_usd)
+        if guard is not None:
+            return guard
         effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
         req = RouterV4SwapRequest(
             market_address=market_address,
@@ -574,18 +676,24 @@ class PendleRouterV4Client:
             slippage=effective_slippage,
             receiver=receiver,
         )
-        return await self._execute_swap(req, "swapExactPtForToken")
+        return await self._execute_swap(req, "swapExactPtForToken", dry_run=dry_run)
 
     async def _execute_swap(
-        self, req: RouterV4SwapRequest, sdk_endpoint: str
+        self,
+        req: RouterV4SwapRequest,
+        sdk_endpoint: str,
+        dry_run: bool = True,
     ) -> RouterV4SwapResult:
-        """SDK を呼び出して swap calldata を取得し、tx を送信する。
+        """SDK を呼び出して swap calldata を取得する。
 
+        dry_run=True の場合、calldata 生成のみで tx 送信はしない（現実装では常に送信しないが、
+        将来の署名実装に備えて分岐を明示）。
         外部 HTTP 失敗は例外を握りつぶさず RouterV4SwapResult(success=False) を返す。
 
         Args:
             req: swap リクエスト
             sdk_endpoint: SDK エンドポイント名
+            dry_run: True の場合 calldata 生成のみ（デフォルト True）
 
         Returns:
             RouterV4SwapResult
@@ -604,10 +712,11 @@ class PendleRouterV4Client:
             }
 
             logger.info(
-                "PendleRouterV4Client._execute_swap: endpoint=%s, market=%s, amountIn=%s",
+                "PendleRouterV4Client._execute_swap: endpoint=%s, market=%s, amountIn=%s, dry_run=%s",
                 sdk_endpoint,
                 req.market_address[:10] + "...",
                 req.amount_in,
+                dry_run,
             )
 
             sdk_response = await self._call_sdk(sdk_endpoint, params)
@@ -615,12 +724,15 @@ class PendleRouterV4Client:
             calldata: str = sdk_response.get("data", {}).get("tx", {}).get("data", "")
             out_amount_raw = sdk_response.get("data", {}).get("amountOut", "0")
             amount_out = self._wei_to_decimal(int(str(out_amount_raw)))
+            approvals = self._extract_approvals(sdk_response)
 
+            # dry_run=True の場合は calldata 取得のみ。tx 送信は行わない（sign_transaction/send_raw_transaction 禁止）
             return RouterV4SwapResult(
                 success=True,
-                tx_hash=None,  # tx 送信は Phase 2 以降（現フェーズは calldata 取得のみ）
+                tx_hash=None,  # dry_run 中は tx_hash なし。将来の署名実装でも P1 境界を守る
                 amount_out=amount_out,
                 calldata=calldata,
+                approvals=approvals,
             )
 
         except httpx.HTTPStatusError as exc:
@@ -649,6 +761,8 @@ class PendleRouterV4Client:
         amount_in: Decimal,
         receiver: str,
         slippage: Decimal | None = None,
+        dry_run: bool = True,
+        portfolio_value_usd: Decimal | None = None,
     ) -> RouterV4AddLiquidityResult:
         """マーケットに流動性を追加する（token_in → LP）。
 
@@ -658,10 +772,16 @@ class PendleRouterV4Client:
             amount_in: 入力量（Decimal）
             receiver: LP 受取アドレス
             slippage: スリッページ（デフォルト 0.5% = 0.005）
+            dry_run: True の場合 calldata 生成のみで tx 送信なし（デフォルト True）
+            portfolio_value_usd: ポートフォリオ総額（10%上限チェック用。None でスキップ）
 
         Returns:
             RouterV4AddLiquidityResult
         """
+        guard_liq = self._check_guards_liq(amount_in, portfolio_value_usd)
+        if guard_liq is not None:
+            return guard_liq
+
         effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
         req = RouterV4AddLiquidityRequest(
             market_address=market_address,
@@ -683,10 +803,11 @@ class PendleRouterV4Client:
             }
 
             logger.info(
-                "PendleRouterV4Client.add_liquidity: market=%s, tokenIn=%s, amountIn=%s",
+                "PendleRouterV4Client.add_liquidity: market=%s, tokenIn=%s, amountIn=%s, dry_run=%s",
                 req.market_address[:10] + "...",
                 req.token_in[:10] + "..." if len(req.token_in) > 10 else req.token_in,
                 req.amount_in,
+                dry_run,
             )
 
             sdk_response = await self._call_sdk("addLiquiditySingleToken", params)
@@ -694,12 +815,14 @@ class PendleRouterV4Client:
             calldata = sdk_response.get("data", {}).get("tx", {}).get("data", "")
             lp_amount_raw = sdk_response.get("data", {}).get("amountLpOut", "0")
             lp_amount = self._wei_to_decimal(int(str(lp_amount_raw)))
+            approvals = self._extract_approvals(sdk_response)
 
             return RouterV4AddLiquidityResult(
                 success=True,
-                tx_hash=None,  # tx 送信は Phase 2 以降
+                tx_hash=None,  # dry_run 中は tx_hash なし
                 lp_amount=lp_amount,
                 calldata=calldata,
+                approvals=approvals,
             )
 
         except httpx.HTTPStatusError as exc:
@@ -715,6 +838,15 @@ class PendleRouterV4Client:
         except Exception as exc:
             logger.warning("PendleRouterV4Client.add_liquidity 失敗: error=%s", exc)
             return RouterV4AddLiquidityResult(success=False, error=str(exc))
+
+
+def get_pendle_router_v4_client(config: PendleConfig) -> PendleRouterV4Client:
+    """設定から PendleRouterV4Client を生成して返す。
+
+    service 層から到達可能な単一エントリポイント。
+    automation には配線しない。main.py 変更禁止のため router.py で使用する。
+    """
+    return PendleRouterV4Client(config)
 
 
 def get_pendle_client(config: PendleConfig) -> AbstractPendleClient:

--- a/backend/app/protocols/pendle/client.py
+++ b/backend/app/protocols/pendle/client.py
@@ -24,6 +24,7 @@ from .schemas import (
     PendleMarketInfo,
     RouterV4AddLiquidityRequest,
     RouterV4AddLiquidityResult,
+    RouterV4Approval,
     RouterV4SwapRequest,
     RouterV4SwapResult,
 )
@@ -387,21 +388,29 @@ class PendleWebClient(AbstractPendleClient):
 class PendleRouterV4Client:
     """Pendle RouterV4 クライアント（YT/PT 売買 + add_liquidity）。
 
-    Pendle Hosted SDK（https://api-v2.pendle.finance/sdk/api/v1）を使って calldata を生成し、
-    web3.py でトランザクションを送信する。
+    Pendle Hosted SDK（https://api-v2.pendle.finance/sdk/api/v1）を使って calldata を生成する。
+
+    フェーズ境界（誤送信防止）:
+    - **Phase 1（本実装）は calldata 取得まで**。tx 送信・署名・web3 import は一切行わない
+      （tx_hash は常に None）。
+    - tx 送信は **Phase 2** で `config.enable_onchain_write=True`（PENDLE_ENABLE_ONCHAIN_WRITE）
+      かつ `config.wallet_private_key` が揃った場合のみ実装・許可する（二段ガード）。
 
     設計方針:
     - calldata は SDK が生成するため、こちらでの ABI encode は不要。
-    - 金額は必ず Decimal 型。float 使用禁止。
+    - SDK レスポンスの tx.to / approvals.spender は必ず Router アドレスと照合する
+      （改竄・誘導された任意コントラクト宛 calldata を拒否）。
+    - 金額は必ず Decimal 型。float 使用禁止。token decimals を解決して桁ズレを防ぐ。
     - 秘密鍵は config 経由で環境変数から取得。ログに出力しない。
-    - 外部 HTTP 失敗は例外を握りつぶさず RouterV4SwapResult(success=False) を返す（fail-open）。
+    - 外部 HTTP 失敗・照合不一致は例外を握りつぶさず RouterV4SwapResult(success=False) を返す
+      （fail-closed: 不確実なら成功扱いにしない）。
     - slippage デフォルト 0.5%（Decimal("0.005")）。
     """
 
     _SDK_BASE = "https://api-v2.pendle.finance/sdk/api/v1"
     _ROUTER_ADDRESS = "0x888888888889758F76e7103c6CbF23ABbF58F946"
     _DEFAULT_SLIPPAGE = Decimal("0.005")
-    _REQUEST_TIMEOUT = 15.0
+    _REQUEST_TIMEOUT: float = 15.0
 
     # チェーン ID マッピング（Pendle SDK が使用するチェーン ID）
     _CHAIN_ID_MAP: dict[str, int] = {
@@ -452,6 +461,56 @@ class PendleRouterV4Client:
         factor = Decimal(10) ** decimals
         return Decimal(str(wei)) / factor
 
+    def _resolve_decimals(self, token: str, explicit: int | None) -> int:
+        """token の decimals を解決する。
+
+        明示指定があればそれを優先。無ければ config の token→decimals マップで解決し、
+        未知トークンは 18。非18桁トークン（USDC/USDT=6, WBTC=8）の桁ズレ事故を防ぐ。
+        """
+        if explicit is not None:
+            return explicit
+        return self._config.token_decimals(token)
+
+    @staticmethod
+    def _addr_eq(a: str | None, b: str | None) -> bool:
+        """アドレスを大文字小文字無視で比較する（None/空文字は不一致扱い）。"""
+        if not a or not b:
+            return False
+        return a.lower() == b.lower()
+
+    def _extract_approvals(self, sdk_response: dict[str, Any]) -> list[RouterV4Approval]:
+        """SDK レスポンスから approvals 配列を取り出す（無ければ空）。"""
+        raw = sdk_response.get("data", {}).get("approvals", []) or []
+        approvals: list[RouterV4Approval] = []
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            approvals.append(
+                RouterV4Approval(
+                    token=item.get("token"),
+                    spender=item.get("spender"),
+                    amount=(str(item["amount"]) if item.get("amount") is not None else None),
+                )
+            )
+        return approvals
+
+    def _verify_router(self, sdk_response: dict[str, Any]) -> tuple[bool, str | None, str]:
+        """SDK レスポンスの tx.to と approvals.spender を Router アドレスと照合する。
+
+        Returns:
+            (ok, to_address, error): ok=False のとき error に理由を格納する。
+        """
+        to_addr = sdk_response.get("data", {}).get("tx", {}).get("to")
+        if not self._addr_eq(to_addr, self._ROUTER_ADDRESS):
+            return False, None, "router address mismatch"
+        # approvals がある場合は spender も Router であることを照合する。
+        for approval in self._extract_approvals(sdk_response):
+            if approval.spender is not None and not self._addr_eq(
+                approval.spender, self._ROUTER_ADDRESS
+            ):
+                return False, None, "router address mismatch"
+        return True, to_addr, ""
+
     async def buy_yt(
         self,
         market_address: str,
@@ -459,6 +518,7 @@ class PendleRouterV4Client:
         amount_in: Decimal,
         receiver: str,
         slippage: Decimal | None = None,
+        token_in_decimals: int | None = None,
     ) -> RouterV4SwapResult:
         """YT を購入する（token_in → YT swap）。
 
@@ -468,11 +528,15 @@ class PendleRouterV4Client:
             amount_in: 入力量（Decimal）
             receiver: YT 受取アドレス
             slippage: スリッページ（デフォルト 0.5% = 0.005）
+            token_in_decimals: 入力トークンの decimals。**非18桁トークン（USDC/USDT=6,
+                WBTC=8）では必ず指定すること**。None の場合 config の token→decimals マップで
+                解決し、未知トークンは 18。
 
         Returns:
             RouterV4SwapResult
         """
         effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
+        in_decimals = self._resolve_decimals(token_in, token_in_decimals)
         req = RouterV4SwapRequest(
             market_address=market_address,
             token_in=token_in,
@@ -481,7 +545,10 @@ class PendleRouterV4Client:
             slippage=effective_slippage,
             receiver=receiver,
         )
-        return await self._execute_swap(req, "swapExactTokenForYt")
+        # YT は 18 桁。入力トークンのみ decimals を解決する。
+        return await self._execute_swap(
+            req, "swapExactTokenForYt", amount_in_decimals=in_decimals, amount_out_decimals=18
+        )
 
     async def sell_yt(
         self,
@@ -490,6 +557,7 @@ class PendleRouterV4Client:
         yt_amount_in: Decimal,
         receiver: str,
         slippage: Decimal | None = None,
+        token_out_decimals: int | None = None,
     ) -> RouterV4SwapResult:
         """YT を売却する（YT → token_out swap）。
 
@@ -499,11 +567,15 @@ class PendleRouterV4Client:
             yt_amount_in: 売却する YT 量（Decimal）
             receiver: 受取アドレス
             slippage: スリッページ（デフォルト 0.5% = 0.005）
+            token_out_decimals: 出力トークンの decimals。**非18桁トークン（USDC/USDT=6,
+                WBTC=8）では必ず指定すること**。None の場合 config の token→decimals マップで
+                解決し、未知トークンは 18。
 
         Returns:
             RouterV4SwapResult
         """
         effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
+        out_decimals = self._resolve_decimals(token_out, token_out_decimals)
         req = RouterV4SwapRequest(
             market_address=market_address,
             token_in="YT",  # noqa: S106 — トークン種別リテラル (パスワードではない)
@@ -512,7 +584,10 @@ class PendleRouterV4Client:
             slippage=effective_slippage,
             receiver=receiver,
         )
-        return await self._execute_swap(req, "swapExactYtForToken")
+        # YT は 18 桁。出力トークンのみ decimals を解決する。
+        return await self._execute_swap(
+            req, "swapExactYtForToken", amount_in_decimals=18, amount_out_decimals=out_decimals
+        )
 
     async def buy_pt(
         self,
@@ -521,6 +596,7 @@ class PendleRouterV4Client:
         amount_in: Decimal,
         receiver: str,
         slippage: Decimal | None = None,
+        token_in_decimals: int | None = None,
     ) -> RouterV4SwapResult:
         """PT を購入する（token_in → PT swap）。
 
@@ -530,11 +606,15 @@ class PendleRouterV4Client:
             amount_in: 入力量（Decimal）
             receiver: PT 受取アドレス
             slippage: スリッページ（デフォルト 0.5% = 0.005）
+            token_in_decimals: 入力トークンの decimals。**非18桁トークン（USDC/USDT=6,
+                WBTC=8）では必ず指定すること**。None の場合 config の token→decimals マップで
+                解決し、未知トークンは 18。
 
         Returns:
             RouterV4SwapResult
         """
         effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
+        in_decimals = self._resolve_decimals(token_in, token_in_decimals)
         req = RouterV4SwapRequest(
             market_address=market_address,
             token_in=token_in,
@@ -543,7 +623,10 @@ class PendleRouterV4Client:
             slippage=effective_slippage,
             receiver=receiver,
         )
-        return await self._execute_swap(req, "swapExactTokenForPt")
+        # PT は 18 桁。入力トークンのみ decimals を解決する。
+        return await self._execute_swap(
+            req, "swapExactTokenForPt", amount_in_decimals=in_decimals, amount_out_decimals=18
+        )
 
     async def sell_pt(
         self,
@@ -552,6 +635,7 @@ class PendleRouterV4Client:
         pt_amount_in: Decimal,
         receiver: str,
         slippage: Decimal | None = None,
+        token_out_decimals: int | None = None,
     ) -> RouterV4SwapResult:
         """PT を売却する（PT → token_out swap）。
 
@@ -561,11 +645,15 @@ class PendleRouterV4Client:
             pt_amount_in: 売却する PT 量（Decimal）
             receiver: 受取アドレス
             slippage: スリッページ（デフォルト 0.5% = 0.005）
+            token_out_decimals: 出力トークンの decimals。**非18桁トークン（USDC/USDT=6,
+                WBTC=8）では必ず指定すること**。None の場合 config の token→decimals マップで
+                解決し、未知トークンは 18。
 
         Returns:
             RouterV4SwapResult
         """
         effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
+        out_decimals = self._resolve_decimals(token_out, token_out_decimals)
         req = RouterV4SwapRequest(
             market_address=market_address,
             token_in="PT",  # noqa: S106 — トークン種別リテラル (パスワードではない)
@@ -574,24 +662,34 @@ class PendleRouterV4Client:
             slippage=effective_slippage,
             receiver=receiver,
         )
-        return await self._execute_swap(req, "swapExactPtForToken")
+        # PT は 18 桁。出力トークンのみ decimals を解決する。
+        return await self._execute_swap(
+            req, "swapExactPtForToken", amount_in_decimals=18, amount_out_decimals=out_decimals
+        )
 
     async def _execute_swap(
-        self, req: RouterV4SwapRequest, sdk_endpoint: str
+        self,
+        req: RouterV4SwapRequest,
+        sdk_endpoint: str,
+        amount_in_decimals: int = 18,
+        amount_out_decimals: int = 18,
     ) -> RouterV4SwapResult:
-        """SDK を呼び出して swap calldata を取得し、tx を送信する。
+        """SDK を呼び出して swap calldata を取得する（Phase 1 は送信しない）。
 
-        外部 HTTP 失敗は例外を握りつぶさず RouterV4SwapResult(success=False) を返す。
+        外部 HTTP 失敗・Router 不一致・calldata 欠損は例外を握りつぶさず
+        RouterV4SwapResult(success=False) を返す（fail-closed）。
 
         Args:
             req: swap リクエスト
             sdk_endpoint: SDK エンドポイント名
+            amount_in_decimals: 入力トークンの decimals（USDC=6 等の桁ズレ防止）
+            amount_out_decimals: 出力トークンの decimals（amount_out 復元に使用）
 
         Returns:
             RouterV4SwapResult
         """
         try:
-            amount_wei = self._amount_to_wei(req.amount_in)
+            amount_wei = self._amount_to_wei(req.amount_in, decimals=amount_in_decimals)
             # slippage は SDK に対して小数形式で渡す（0.005 = 0.5%）
             params: dict[str, Any] = {
                 "chainId": self._chain_id,
@@ -612,15 +710,37 @@ class PendleRouterV4Client:
 
             sdk_response = await self._call_sdk(sdk_endpoint, params)
 
+            # C2: SDK calldata の宛先 (tx.to) と approvals.spender を Router と照合する。
+            router_ok, to_addr, router_err = self._verify_router(sdk_response)
+            if not router_ok:
+                logger.warning(
+                    "PendleRouterV4Client._execute_swap: %s (endpoint=%s)",
+                    router_err,
+                    sdk_endpoint,
+                )
+                return RouterV4SwapResult(success=False, error=router_err)
+
             calldata: str = sdk_response.get("data", {}).get("tx", {}).get("data", "")
+            # m1: calldata 欠損/空文字は空 tx 送信の温床。success=False で拒否する。
+            if not calldata:
+                logger.warning(
+                    "PendleRouterV4Client._execute_swap: empty calldata (endpoint=%s)",
+                    sdk_endpoint,
+                )
+                return RouterV4SwapResult(success=False, error="empty calldata")
+
             out_amount_raw = sdk_response.get("data", {}).get("amountOut", "0")
-            amount_out = self._wei_to_decimal(int(str(out_amount_raw)))
+            amount_out = self._wei_to_decimal(
+                int(str(out_amount_raw)), decimals=amount_out_decimals
+            )
 
             return RouterV4SwapResult(
                 success=True,
                 tx_hash=None,  # tx 送信は Phase 2 以降（現フェーズは calldata 取得のみ）
                 amount_out=amount_out,
                 calldata=calldata,
+                to=to_addr,
+                approvals=self._extract_approvals(sdk_response),
             )
 
         except httpx.HTTPStatusError as exc:
@@ -649,6 +769,7 @@ class PendleRouterV4Client:
         amount_in: Decimal,
         receiver: str,
         slippage: Decimal | None = None,
+        token_in_decimals: int | None = None,
     ) -> RouterV4AddLiquidityResult:
         """マーケットに流動性を追加する（token_in → LP）。
 
@@ -658,11 +779,15 @@ class PendleRouterV4Client:
             amount_in: 入力量（Decimal）
             receiver: LP 受取アドレス
             slippage: スリッページ（デフォルト 0.5% = 0.005）
+            token_in_decimals: 入力トークンの decimals。**非18桁トークン（USDC/USDT=6,
+                WBTC=8）では必ず指定すること**。None の場合 config の token→decimals マップで
+                解決し、未知トークンは 18。
 
         Returns:
             RouterV4AddLiquidityResult
         """
         effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
+        in_decimals = self._resolve_decimals(token_in, token_in_decimals)
         req = RouterV4AddLiquidityRequest(
             market_address=market_address,
             token_in=token_in,
@@ -672,7 +797,7 @@ class PendleRouterV4Client:
         )
 
         try:
-            amount_wei = self._amount_to_wei(req.amount_in)
+            amount_wei = self._amount_to_wei(req.amount_in, decimals=in_decimals)
             params: dict[str, Any] = {
                 "chainId": self._chain_id,
                 "market": req.market_address,
@@ -691,7 +816,19 @@ class PendleRouterV4Client:
 
             sdk_response = await self._call_sdk("addLiquiditySingleToken", params)
 
+            # C2: tx.to / approvals.spender を Router と照合する。
+            router_ok, to_addr, router_err = self._verify_router(sdk_response)
+            if not router_ok:
+                logger.warning("PendleRouterV4Client.add_liquidity: %s", router_err)
+                return RouterV4AddLiquidityResult(success=False, error=router_err)
+
             calldata = sdk_response.get("data", {}).get("tx", {}).get("data", "")
+            # m1: calldata 欠損/空文字は拒否（空 tx 送信の温床）。
+            if not calldata:
+                logger.warning("PendleRouterV4Client.add_liquidity: empty calldata")
+                return RouterV4AddLiquidityResult(success=False, error="empty calldata")
+
+            # LP トークンは 18 桁。
             lp_amount_raw = sdk_response.get("data", {}).get("amountLpOut", "0")
             lp_amount = self._wei_to_decimal(int(str(lp_amount_raw)))
 
@@ -700,6 +837,8 @@ class PendleRouterV4Client:
                 tx_hash=None,  # tx 送信は Phase 2 以降
                 lp_amount=lp_amount,
                 calldata=calldata,
+                to=to_addr,
+                approvals=self._extract_approvals(sdk_response),
             )
 
         except httpx.HTTPStatusError as exc:

--- a/backend/app/protocols/pendle/client.py
+++ b/backend/app/protocols/pendle/client.py
@@ -476,7 +476,7 @@ class PendleRouterV4Client:
         req = RouterV4SwapRequest(
             market_address=market_address,
             token_in=token_in,
-            token_out="YT",
+            token_out="YT",  # noqa: S106 — トークン種別リテラル (パスワードではない)
             amount_in=amount_in,
             slippage=effective_slippage,
             receiver=receiver,
@@ -506,7 +506,7 @@ class PendleRouterV4Client:
         effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
         req = RouterV4SwapRequest(
             market_address=market_address,
-            token_in="YT",
+            token_in="YT",  # noqa: S106 — トークン種別リテラル (パスワードではない)
             token_out=token_out,
             amount_in=yt_amount_in,
             slippage=effective_slippage,
@@ -538,7 +538,7 @@ class PendleRouterV4Client:
         req = RouterV4SwapRequest(
             market_address=market_address,
             token_in=token_in,
-            token_out="PT",
+            token_out="PT",  # noqa: S106 — トークン種別リテラル (パスワードではない)
             amount_in=amount_in,
             slippage=effective_slippage,
             receiver=receiver,
@@ -568,7 +568,7 @@ class PendleRouterV4Client:
         effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
         req = RouterV4SwapRequest(
             market_address=market_address,
-            token_in="PT",
+            token_in="PT",  # noqa: S106 — トークン種別リテラル (パスワードではない)
             token_out=token_out,
             amount_in=pt_amount_in,
             slippage=effective_slippage,

--- a/backend/app/protocols/pendle/config.py
+++ b/backend/app/protocols/pendle/config.py
@@ -47,6 +47,29 @@ class PendleConfig:
     min_days_to_maturity: int = 7
     # implied APY 警告閾値（この値を超えると警告ログを出力）
     max_implied_apy_pct: Decimal = field(default_factory=lambda: Decimal("100.0"))
+    # オンチェーン書き込み許可フラグ（Phase 2 の tx 送信を二段ガードする土台）。
+    # default false。tx 送信は本フラグ True かつ wallet_private_key が揃った場合のみ許可。
+    # Phase 1（本実装）は calldata 取得までで、本フラグ True でも tx は送信しない。
+    enable_onchain_write: bool = field(
+        default_factory=lambda: os.getenv("PENDLE_ENABLE_ONCHAIN_WRITE", "false").lower() == "true"
+    )
+
+    def token_decimals(self, token: str) -> int:
+        """トークン識別子から decimals を解決する。
+
+        非18桁トークン（USDC/USDT=6、WBTC=8）の桁ズレ事故を防ぐためのマップ。
+        シンボル（大文字小文字無視）で照合し、未知トークンは 18 を返す。
+        """
+        return _TOKEN_DECIMALS.get(token.upper(), 18)
+
+
+# トークンシンボル → decimals マップ。
+# 非18桁トークンの送金額桁ズレ（USDC で 10^12 倍ズレ）を防ぐ。
+_TOKEN_DECIMALS: dict[str, int] = {
+    "USDC": 6,
+    "USDT": 6,
+    "WBTC": 8,
+}
 
 
 def get_pendle_config() -> PendleConfig:

--- a/backend/app/protocols/pendle/config.py
+++ b/backend/app/protocols/pendle/config.py
@@ -9,15 +9,24 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 
 
+def _get_env_decimal(name: str, default: str) -> Decimal:
+    """環境変数から Decimal 値を読み込む。未設定またはパース失敗時はデフォルト値を返す。"""
+    raw = os.getenv(name, default)
+    try:
+        return Decimal(raw)
+    except Exception:
+        return Decimal(default)
+
+
 @dataclass
 class PendleConfig:
     """Pendle Finance 接続設定。"""
 
-    # Pendle Router V4 コントラクトアドレス
+    # Pendle Router V4 コントラクトアドレス（正式アドレス）
     router_address: str = field(
         default_factory=lambda: os.getenv(
             "PENDLE_ROUTER_ADDRESS",
-            "0x0000000000000000000000000000000000000001",  # dummy address
+            "0x888888888889758F76e7103c6CbF23ABbF58F946",
         )
     )
     # ターゲットマーケット（stETH）アドレス
@@ -47,6 +56,15 @@ class PendleConfig:
     min_days_to_maturity: int = 7
     # implied APY 警告閾値（この値を超えると警告ログを出力）
     max_implied_apy_pct: Decimal = field(default_factory=lambda: Decimal("100.0"))
+    # オンチェーン書き込み有効フラグ（Q1 一段目ガード。デフォルト false）
+    # PENDLE_ENABLE_ONCHAIN_WRITE=true を明示しない限りオンチェーン操作を拒否する
+    enable_onchain_write: bool = field(
+        default_factory=lambda: os.getenv("PENDLE_ENABLE_ONCHAIN_WRITE", "false").lower() == "true"
+    )
+    # 単一トレード上限（ポートフォリオに対する割合。デフォルト 10%）
+    max_single_trade_pct: Decimal = field(
+        default_factory=lambda: _get_env_decimal("PENDLE_MAX_SINGLE_TRADE_PCT", "0.10")
+    )
 
 
 def get_pendle_config() -> PendleConfig:

--- a/backend/app/protocols/pendle/router.py
+++ b/backend/app/protocols/pendle/router.py
@@ -11,7 +11,7 @@ import logging
 
 from fastapi import APIRouter, HTTPException
 
-from .client import get_pendle_client
+from .client import get_pendle_client, get_pendle_router_v4_client
 from .config import get_pendle_config
 from .schemas import (
     PendleMarketInfo,
@@ -19,6 +19,10 @@ from .schemas import (
     PendleMintResponse,
     PendleRedeemRequest,
     PendleRedeemResponse,
+    RouterV4AddLiquidityRequest,
+    RouterV4AddLiquidityResult,
+    RouterV4SwapRequest,
+    RouterV4SwapResult,
     StrategyComparison,
 )
 from .service import PendleService
@@ -84,6 +88,89 @@ async def redeem_tokens(request: PendleRedeemRequest) -> PendleRedeemResponse:
     except Exception as exc:
         logger.exception("Pendle redeem 失敗")
         raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+@router.post("/v4/swap", response_model=RouterV4SwapResult)
+async def router_v4_swap(request: RouterV4SwapRequest) -> RouterV4SwapResult:
+    """RouterV4 swap (buy/sell YT or PT)。dry_run=True 既定で calldata 取得のみ。
+
+    オンチェーン書き込みは PENDLE_ENABLE_ONCHAIN_WRITE=true かつ dry_run=False 時のみ有効。
+    現フェーズでは常に calldata 返却のみ（署名/broadcast なし）。
+    """
+    config = get_pendle_config()
+    client = get_pendle_router_v4_client(config)
+
+    # amount_in から token_out の方向を判定（YT/PT 判定は token_out フィールド利用）
+    # ここでは汎用 swap として _execute_swap の代わりに buy_yt を endpoint 判定の起点にしない。
+    # 代わりに token_out から方向を決定する。
+    token_out = request.token_out.upper()
+    try:
+        if token_out == "YT":  # noqa: S105 — トークン種別文字列（パスワードではない）
+            result = await client.buy_yt(
+                market_address=request.market_address,
+                token_in=request.token_in,
+                amount_in=request.amount_in,
+                receiver=request.receiver,
+                slippage=request.slippage,
+                dry_run=True,
+            )
+        elif token_out == "PT":  # noqa: S105 — トークン種別文字列（パスワードではない）
+            result = await client.buy_pt(
+                market_address=request.market_address,
+                token_in=request.token_in,
+                amount_in=request.amount_in,
+                receiver=request.receiver,
+                slippage=request.slippage,
+                dry_run=True,
+            )
+        elif request.token_in.upper() == "YT":
+            result = await client.sell_yt(
+                market_address=request.market_address,
+                token_out=request.token_out,
+                yt_amount_in=request.amount_in,
+                receiver=request.receiver,
+                slippage=request.slippage,
+                dry_run=True,
+            )
+        elif request.token_in.upper() == "PT":
+            result = await client.sell_pt(
+                market_address=request.market_address,
+                token_out=request.token_out,
+                pt_amount_in=request.amount_in,
+                receiver=request.receiver,
+                slippage=request.slippage,
+                dry_run=True,
+            )
+        else:
+            result = RouterV4SwapResult(
+                success=False, error="token_in / token_out から swap 方向を特定できません"
+            )
+    except Exception as exc:
+        logger.exception("RouterV4 swap 失敗")
+        result = RouterV4SwapResult(success=False, error=str(exc))
+
+    return result
+
+
+@router.post("/v4/add-liquidity", response_model=RouterV4AddLiquidityResult)
+async def router_v4_add_liquidity(
+    request: RouterV4AddLiquidityRequest,
+) -> RouterV4AddLiquidityResult:
+    """RouterV4 add_liquidity。dry_run=True 既定で calldata 取得のみ。"""
+    config = get_pendle_config()
+    client = get_pendle_router_v4_client(config)
+    try:
+        return await client.add_liquidity(
+            market_address=request.market_address,
+            token_in=request.token_in,
+            amount_in=request.amount_in,
+            receiver=request.receiver,
+            slippage=request.slippage,
+            dry_run=True,
+        )
+    except Exception as exc:
+        logger.exception("RouterV4 add_liquidity 失敗")
+        return RouterV4AddLiquidityResult(success=False, error=str(exc))
 
 
 @router.get("/strategies", response_model=StrategyComparison)

--- a/backend/app/protocols/pendle/schemas.py
+++ b/backend/app/protocols/pendle/schemas.py
@@ -103,3 +103,67 @@ class CompoundResult(BaseModel):
     final_position: str
     total_expected_apy: Decimal
     dry_run: bool
+
+
+# --- RouterV4 スキーマ ---
+
+
+class RouterV4SwapRequest(BaseModel):
+    """RouterV4 swap リクエスト（buy/sell YT または PT）。"""
+
+    market_address: str = Field(..., description="対象マーケットアドレス")
+    token_in: str = Field(..., description="入力トークンアドレス")
+    token_out: str = Field(..., description="出力トークンアドレス")
+    amount_in: Decimal = Field(..., gt=Decimal("0"), description="入力量")
+    slippage: Decimal = Field(default=Decimal("0.005"), description="スリッページ（0.005 = 0.5%）")
+    receiver: str = Field(..., description="受取アドレス")
+
+    @field_validator("amount_in", mode="before")
+    @classmethod
+    def validate_amount_in(cls, v: object) -> Decimal:
+        return Decimal(str(v))
+
+    @field_validator("slippage", mode="before")
+    @classmethod
+    def validate_slippage(cls, v: object) -> Decimal:
+        return Decimal(str(v))
+
+
+class RouterV4SwapResult(BaseModel):
+    """RouterV4 swap 結果。"""
+
+    success: bool
+    tx_hash: Optional[str] = None
+    amount_out: Optional[Decimal] = None
+    calldata: Optional[str] = None
+    error: Optional[str] = None
+
+
+class RouterV4AddLiquidityRequest(BaseModel):
+    """RouterV4 add_liquidity リクエスト。"""
+
+    market_address: str = Field(..., description="対象マーケットアドレス")
+    token_in: str = Field(..., description="入力トークンアドレス")
+    amount_in: Decimal = Field(..., gt=Decimal("0"), description="入力量")
+    slippage: Decimal = Field(default=Decimal("0.005"), description="スリッページ（0.005 = 0.5%）")
+    receiver: str = Field(..., description="受取アドレス")
+
+    @field_validator("amount_in", mode="before")
+    @classmethod
+    def validate_amount_in(cls, v: object) -> Decimal:
+        return Decimal(str(v))
+
+    @field_validator("slippage", mode="before")
+    @classmethod
+    def validate_slippage(cls, v: object) -> Decimal:
+        return Decimal(str(v))
+
+
+class RouterV4AddLiquidityResult(BaseModel):
+    """RouterV4 add_liquidity 結果。"""
+
+    success: bool
+    tx_hash: Optional[str] = None
+    lp_amount: Optional[Decimal] = None
+    calldata: Optional[str] = None
+    error: Optional[str] = None

--- a/backend/app/protocols/pendle/schemas.py
+++ b/backend/app/protocols/pendle/schemas.py
@@ -129,6 +129,13 @@ class RouterV4SwapRequest(BaseModel):
         return Decimal(str(v))
 
 
+class RouterV4Approval(BaseModel):
+    """RouterV4 SDK から返される approve 情報。"""
+
+    spender: str = Field(..., description="スペンダーアドレス（通常 Router）")
+    token: str = Field(..., description="承認が必要なトークンアドレス")
+
+
 class RouterV4SwapResult(BaseModel):
     """RouterV4 swap 結果。"""
 
@@ -137,6 +144,8 @@ class RouterV4SwapResult(BaseModel):
     amount_out: Optional[Decimal] = None
     calldata: Optional[str] = None
     error: Optional[str] = None
+    # SDK レスポンスの approvals（spender=Router, token）。approve tx 送信はしない
+    approvals: Optional[list[RouterV4Approval]] = None
 
 
 class RouterV4AddLiquidityRequest(BaseModel):
@@ -167,3 +176,5 @@ class RouterV4AddLiquidityResult(BaseModel):
     lp_amount: Optional[Decimal] = None
     calldata: Optional[str] = None
     error: Optional[str] = None
+    # SDK レスポンスの approvals（spender=Router, token）。approve tx 送信はしない
+    approvals: Optional[list[RouterV4Approval]] = None

--- a/backend/app/protocols/pendle/schemas.py
+++ b/backend/app/protocols/pendle/schemas.py
@@ -115,7 +115,12 @@ class RouterV4SwapRequest(BaseModel):
     token_in: str = Field(..., description="入力トークンアドレス")
     token_out: str = Field(..., description="出力トークンアドレス")
     amount_in: Decimal = Field(..., gt=Decimal("0"), description="入力量")
-    slippage: Decimal = Field(default=Decimal("0.005"), description="スリッページ（0.005 = 0.5%）")
+    slippage: Decimal = Field(
+        default=Decimal("0.005"),
+        gt=Decimal("0"),
+        le=Decimal("0.05"),
+        description="スリッページ（0.005 = 0.5%）。0 < slippage <= 0.05（5%）",
+    )
     receiver: str = Field(..., description="受取アドレス")
 
     @field_validator("amount_in", mode="before")
@@ -129,6 +134,14 @@ class RouterV4SwapRequest(BaseModel):
         return Decimal(str(v))
 
 
+class RouterV4Approval(BaseModel):
+    """RouterV4 SDK が要求する ERC20 approval（Phase 2 への橋渡し用に保持）。"""
+
+    token: Optional[str] = Field(default=None, description="approve 対象トークンアドレス")
+    spender: Optional[str] = Field(default=None, description="spender（Router であるべき）")
+    amount: Optional[str] = Field(default=None, description="approve 量（生値）")
+
+
 class RouterV4SwapResult(BaseModel):
     """RouterV4 swap 結果。"""
 
@@ -136,6 +149,9 @@ class RouterV4SwapResult(BaseModel):
     tx_hash: Optional[str] = None
     amount_out: Optional[Decimal] = None
     calldata: Optional[str] = None
+    # SDK が返した tx.to（Router 照合済み）。Phase 2 の tx 送信先として保持。
+    to: Optional[str] = None
+    approvals: list[RouterV4Approval] = Field(default_factory=list)
     error: Optional[str] = None
 
 
@@ -145,7 +161,12 @@ class RouterV4AddLiquidityRequest(BaseModel):
     market_address: str = Field(..., description="対象マーケットアドレス")
     token_in: str = Field(..., description="入力トークンアドレス")
     amount_in: Decimal = Field(..., gt=Decimal("0"), description="入力量")
-    slippage: Decimal = Field(default=Decimal("0.005"), description="スリッページ（0.005 = 0.5%）")
+    slippage: Decimal = Field(
+        default=Decimal("0.005"),
+        gt=Decimal("0"),
+        le=Decimal("0.05"),
+        description="スリッページ（0.005 = 0.5%）。0 < slippage <= 0.05（5%）",
+    )
     receiver: str = Field(..., description="受取アドレス")
 
     @field_validator("amount_in", mode="before")
@@ -166,4 +187,7 @@ class RouterV4AddLiquidityResult(BaseModel):
     tx_hash: Optional[str] = None
     lp_amount: Optional[Decimal] = None
     calldata: Optional[str] = None
+    # SDK が返した tx.to（Router 照合済み）。Phase 2 の tx 送信先として保持。
+    to: Optional[str] = None
+    approvals: list[RouterV4Approval] = Field(default_factory=list)
     error: Optional[str] = None

--- a/backend/tests/protocols/test_pendle/test_pendle_router_v4_client.py
+++ b/backend/tests/protocols/test_pendle/test_pendle_router_v4_client.py
@@ -14,21 +14,24 @@ MARKET = "0x" + "aa" * 20
 TOKEN_IN = "0x" + "bb" * 20
 TOKEN_OUT = "0x" + "cc" * 20
 RECEIVER = "0x" + "dd" * 20
+ROUTER = "0x888888888889758F76e7103c6CbF23ABbF58F946"
 
-# SDK が返すモックレスポンス（swap 系）
+# SDK が返すモックレスポンス（swap 系）。tx.to は Router アドレス（C2 照合をパスする）。
 _MOCK_SWAP_RESPONSE: dict = {
     "data": {
         "tx": {
+            "to": ROUTER,
             "data": "0xdeadbeef",
         },
         "amountOut": str(int(Decimal("0.95") * Decimal(10**18))),
     }
 }
 
-# SDK が返すモックレスポンス（add_liquidity 系）
+# SDK が返すモックレスポンス（add_liquidity 系）。
 _MOCK_ADD_LIQ_RESPONSE: dict = {
     "data": {
         "tx": {
+            "to": ROUTER,
             "data": "0xcafebabe",
         },
         "amountLpOut": str(int(Decimal("0.98") * Decimal(10**18))),

--- a/backend/tests/protocols/test_pendle/test_pendle_router_v4_client.py
+++ b/backend/tests/protocols/test_pendle/test_pendle_router_v4_client.py
@@ -1,0 +1,524 @@
+"""PendleRouterV4Client ユニットテスト（モックを使用、実 API 呼び出しなし）。"""
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from app.protocols.pendle.client import PendleRouterV4Client
+from app.protocols.pendle.config import PendleConfig
+from app.protocols.pendle.schemas import RouterV4AddLiquidityResult, RouterV4SwapResult
+
+MARKET = "0x" + "aa" * 20
+TOKEN_IN = "0x" + "bb" * 20
+TOKEN_OUT = "0x" + "cc" * 20
+RECEIVER = "0x" + "dd" * 20
+
+# SDK が返すモックレスポンス（swap 系）
+_MOCK_SWAP_RESPONSE: dict = {
+    "data": {
+        "tx": {
+            "data": "0xdeadbeef",
+        },
+        "amountOut": str(int(Decimal("0.95") * Decimal(10**18))),
+    }
+}
+
+# SDK が返すモックレスポンス（add_liquidity 系）
+_MOCK_ADD_LIQ_RESPONSE: dict = {
+    "data": {
+        "tx": {
+            "data": "0xcafebabe",
+        },
+        "amountLpOut": str(int(Decimal("0.98") * Decimal(10**18))),
+    }
+}
+
+
+@pytest.fixture
+def router_client() -> PendleRouterV4Client:
+    config = PendleConfig(sandbox=False)
+    return PendleRouterV4Client(config)
+
+
+class TestPendleRouterV4ClientInit:
+    def test_router_address_is_correct(self, router_client: PendleRouterV4Client) -> None:
+        """Router アドレスが正しい Pendle V4 アドレスであること。"""
+        assert router_client._ROUTER_ADDRESS == "0x888888888889758F76e7103c6CbF23ABbF58F946"
+
+    def test_default_slippage_is_half_percent(self, router_client: PendleRouterV4Client) -> None:
+        """デフォルトスリッページが 0.5% (0.005) であること。"""
+        assert router_client._DEFAULT_SLIPPAGE == Decimal("0.005")
+
+    def test_chain_id_mapped_for_arbitrum(self) -> None:
+        """arbitrum チェーンの場合 chain_id = 42161 であること。"""
+        config = PendleConfig(sandbox=False)
+        config.chain = "arbitrum"
+        client = PendleRouterV4Client(config)
+        assert client._chain_id == 42161
+
+    def test_chain_id_mapped_for_sepolia(self) -> None:
+        """sepolia チェーンの場合 chain_id = 421614 であること。"""
+        config = PendleConfig(sandbox=False)
+        config.chain = "sepolia"
+        client = PendleRouterV4Client(config)
+        assert client._chain_id == 421614
+
+
+class TestAmountConversion:
+    def test_amount_to_wei_1_ether(self, router_client: PendleRouterV4Client) -> None:
+        """1 ETH = 1e18 wei の変換が正しいこと。"""
+        assert router_client._amount_to_wei(Decimal("1")) == 10**18
+
+    def test_amount_to_wei_decimal_precision(self, router_client: PendleRouterV4Client) -> None:
+        """0.5 ETH の変換が正しいこと。"""
+        assert router_client._amount_to_wei(Decimal("0.5")) == 5 * 10**17
+
+    def test_wei_to_decimal_roundtrip(self, router_client: PendleRouterV4Client) -> None:
+        """_amount_to_wei → _wei_to_decimal のラウンドトリップが正確であること。"""
+        original = Decimal("1.23456789")
+        wei = router_client._amount_to_wei(original)
+        restored = router_client._wei_to_decimal(wei)
+        assert restored == original
+
+    def test_amount_to_wei_custom_decimals(self, router_client: PendleRouterV4Client) -> None:
+        """カスタム decimals=6 の変換（USDC 等）が正しいこと。"""
+        assert router_client._amount_to_wei(Decimal("1"), decimals=6) == 10**6
+
+    def test_amount_types_are_decimal(self, router_client: PendleRouterV4Client) -> None:
+        """_wei_to_decimal の戻り値が Decimal であること（float 禁止）。"""
+        result = router_client._wei_to_decimal(10**18)
+        assert type(result) is Decimal
+
+
+class TestBuyYt:
+    @pytest.mark.asyncio
+    async def test_buy_yt_success(self, router_client: PendleRouterV4Client) -> None:
+        """buy_yt が成功時に RouterV4SwapResult(success=True) を返すこと。"""
+        with patch.object(
+            router_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE)
+        ):
+            result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert isinstance(result, RouterV4SwapResult)
+        assert result.success is True
+        assert result.calldata == "0xdeadbeef"
+        assert result.amount_out is not None
+
+    @pytest.mark.asyncio
+    async def test_buy_yt_amount_out_is_decimal(self, router_client: PendleRouterV4Client) -> None:
+        """buy_yt の amount_out が Decimal であること（float 禁止）。"""
+        with patch.object(
+            router_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE)
+        ):
+            result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.amount_out is not None
+        assert type(result.amount_out) is Decimal
+
+    @pytest.mark.asyncio
+    async def test_buy_yt_uses_swapExactTokenForYt_endpoint(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """buy_yt が SDK の swapExactTokenForYt エンドポイントを呼ぶこと。"""
+        captured_endpoint: list[str] = []
+
+        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+            captured_endpoint.append(endpoint)
+            return _MOCK_SWAP_RESPONSE
+
+        with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
+            await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert captured_endpoint[0] == "swapExactTokenForYt"
+
+    @pytest.mark.asyncio
+    async def test_buy_yt_default_slippage(self, router_client: PendleRouterV4Client) -> None:
+        """buy_yt のデフォルトスリッページが 0.005 であること。"""
+        captured_params: list[dict] = []
+
+        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+            captured_params.append(params)
+            return _MOCK_SWAP_RESPONSE
+
+        with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
+            await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert captured_params[0]["slippage"] == "0.005"
+
+    @pytest.mark.asyncio
+    async def test_buy_yt_custom_slippage(self, router_client: PendleRouterV4Client) -> None:
+        """buy_yt にカスタムスリッページを指定できること。"""
+        captured_params: list[dict] = []
+
+        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+            captured_params.append(params)
+            return _MOCK_SWAP_RESPONSE
+
+        with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
+            await router_client.buy_yt(
+                MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER, slippage=Decimal("0.01")
+            )
+        assert captured_params[0]["slippage"] == "0.01"
+
+    @pytest.mark.asyncio
+    async def test_buy_yt_http_error_returns_failure(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """buy_yt が HTTP エラー時に success=False を返すこと（fail-open）。"""
+        mock_response = AsyncMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(
+                side_effect=httpx.HTTPStatusError("error", request=None, response=mock_response)
+            ),  # type: ignore[arg-type]
+        ):
+            result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_buy_yt_network_error_returns_failure(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """buy_yt がネットワークエラー時に success=False を返すこと（fail-open）。"""
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(side_effect=Exception("connection refused")),
+        ):
+            result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert "connection refused" in (result.error or "")
+
+
+class TestSellYt:
+    @pytest.mark.asyncio
+    async def test_sell_yt_success(self, router_client: PendleRouterV4Client) -> None:
+        """sell_yt が成功時に RouterV4SwapResult(success=True) を返すこと。"""
+        with patch.object(
+            router_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE)
+        ):
+            result = await router_client.sell_yt(MARKET, TOKEN_OUT, Decimal("1.0"), RECEIVER)
+        assert result.success is True
+        assert result.calldata == "0xdeadbeef"
+
+    @pytest.mark.asyncio
+    async def test_sell_yt_uses_swapExactYtForToken_endpoint(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """sell_yt が SDK の swapExactYtForToken エンドポイントを呼ぶこと。"""
+        captured_endpoint: list[str] = []
+
+        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+            captured_endpoint.append(endpoint)
+            return _MOCK_SWAP_RESPONSE
+
+        with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
+            await router_client.sell_yt(MARKET, TOKEN_OUT, Decimal("1.0"), RECEIVER)
+        assert captured_endpoint[0] == "swapExactYtForToken"
+
+    @pytest.mark.asyncio
+    async def test_sell_yt_error_returns_failure(self, router_client: PendleRouterV4Client) -> None:
+        """sell_yt がエラー時に success=False を返すこと。"""
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(side_effect=Exception("timeout")),
+        ):
+            result = await router_client.sell_yt(MARKET, TOKEN_OUT, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_sell_yt_amount_out_decimal(self, router_client: PendleRouterV4Client) -> None:
+        """sell_yt の amount_out が Decimal であること。"""
+        with patch.object(
+            router_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE)
+        ):
+            result = await router_client.sell_yt(MARKET, TOKEN_OUT, Decimal("1.0"), RECEIVER)
+        assert result.amount_out is not None
+        assert type(result.amount_out) is Decimal
+
+
+class TestBuyPt:
+    @pytest.mark.asyncio
+    async def test_buy_pt_success(self, router_client: PendleRouterV4Client) -> None:
+        """buy_pt が成功時に RouterV4SwapResult(success=True) を返すこと。"""
+        with patch.object(
+            router_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE)
+        ):
+            result = await router_client.buy_pt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is True
+        assert result.calldata == "0xdeadbeef"
+
+    @pytest.mark.asyncio
+    async def test_buy_pt_uses_swapExactTokenForPt_endpoint(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """buy_pt が SDK の swapExactTokenForPt エンドポイントを呼ぶこと。"""
+        captured_endpoint: list[str] = []
+
+        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+            captured_endpoint.append(endpoint)
+            return _MOCK_SWAP_RESPONSE
+
+        with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
+            await router_client.buy_pt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert captured_endpoint[0] == "swapExactTokenForPt"
+
+    @pytest.mark.asyncio
+    async def test_buy_pt_error_returns_failure(self, router_client: PendleRouterV4Client) -> None:
+        """buy_pt がエラー時に success=False を返すこと。"""
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(side_effect=Exception("network error")),
+        ):
+            result = await router_client.buy_pt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_buy_pt_amount_out_decimal(self, router_client: PendleRouterV4Client) -> None:
+        """buy_pt の amount_out が Decimal であること。"""
+        with patch.object(
+            router_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE)
+        ):
+            result = await router_client.buy_pt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.amount_out is not None
+        assert type(result.amount_out) is Decimal
+
+    @pytest.mark.asyncio
+    async def test_buy_pt_default_slippage(self, router_client: PendleRouterV4Client) -> None:
+        """buy_pt のデフォルトスリッページが 0.005 であること。"""
+        captured_params: list[dict] = []
+
+        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+            captured_params.append(params)
+            return _MOCK_SWAP_RESPONSE
+
+        with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
+            await router_client.buy_pt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert captured_params[0]["slippage"] == "0.005"
+
+
+class TestSellPt:
+    @pytest.mark.asyncio
+    async def test_sell_pt_success(self, router_client: PendleRouterV4Client) -> None:
+        """sell_pt が成功時に RouterV4SwapResult(success=True) を返すこと。"""
+        with patch.object(
+            router_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE)
+        ):
+            result = await router_client.sell_pt(MARKET, TOKEN_OUT, Decimal("1.0"), RECEIVER)
+        assert result.success is True
+        assert result.calldata == "0xdeadbeef"
+
+    @pytest.mark.asyncio
+    async def test_sell_pt_uses_swapExactPtForToken_endpoint(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """sell_pt が SDK の swapExactPtForToken エンドポイントを呼ぶこと。"""
+        captured_endpoint: list[str] = []
+
+        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+            captured_endpoint.append(endpoint)
+            return _MOCK_SWAP_RESPONSE
+
+        with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
+            await router_client.sell_pt(MARKET, TOKEN_OUT, Decimal("1.0"), RECEIVER)
+        assert captured_endpoint[0] == "swapExactPtForToken"
+
+    @pytest.mark.asyncio
+    async def test_sell_pt_error_returns_failure(self, router_client: PendleRouterV4Client) -> None:
+        """sell_pt がエラー時に success=False を返すこと。"""
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(side_effect=Exception("sdk error")),
+        ):
+            result = await router_client.sell_pt(MARKET, TOKEN_OUT, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_sell_pt_http_error_returns_failure(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """sell_pt が HTTP エラー時に success=False を返すこと（fail-open）。"""
+        mock_response = AsyncMock()
+        mock_response.status_code = 400
+        mock_response.text = "Bad Request"
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(
+                side_effect=httpx.HTTPStatusError(
+                    "error",
+                    request=None,
+                    response=mock_response,  # type: ignore[arg-type]
+                )
+            ),
+        ):
+            result = await router_client.sell_pt(MARKET, TOKEN_OUT, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert result.error is not None
+
+
+class TestAddLiquidity:
+    @pytest.mark.asyncio
+    async def test_add_liquidity_success(self, router_client: PendleRouterV4Client) -> None:
+        """add_liquidity が成功時に RouterV4AddLiquidityResult(success=True) を返すこと。"""
+        with patch.object(
+            router_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_ADD_LIQ_RESPONSE)
+        ):
+            result = await router_client.add_liquidity(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert isinstance(result, RouterV4AddLiquidityResult)
+        assert result.success is True
+        assert result.calldata == "0xcafebabe"
+        assert result.lp_amount is not None
+
+    @pytest.mark.asyncio
+    async def test_add_liquidity_lp_amount_is_decimal(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """add_liquidity の lp_amount が Decimal であること（float 禁止）。"""
+        with patch.object(
+            router_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_ADD_LIQ_RESPONSE)
+        ):
+            result = await router_client.add_liquidity(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.lp_amount is not None
+        assert type(result.lp_amount) is Decimal
+
+    @pytest.mark.asyncio
+    async def test_add_liquidity_uses_addLiquiditySingleToken_endpoint(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """add_liquidity が SDK の addLiquiditySingleToken エンドポイントを呼ぶこと。"""
+        captured_endpoint: list[str] = []
+
+        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+            captured_endpoint.append(endpoint)
+            return _MOCK_ADD_LIQ_RESPONSE
+
+        with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
+            await router_client.add_liquidity(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert captured_endpoint[0] == "addLiquiditySingleToken"
+
+    @pytest.mark.asyncio
+    async def test_add_liquidity_default_slippage(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """add_liquidity のデフォルトスリッページが 0.005 であること。"""
+        captured_params: list[dict] = []
+
+        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+            captured_params.append(params)
+            return _MOCK_ADD_LIQ_RESPONSE
+
+        with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
+            await router_client.add_liquidity(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert captured_params[0]["slippage"] == "0.005"
+
+    @pytest.mark.asyncio
+    async def test_add_liquidity_custom_slippage(self, router_client: PendleRouterV4Client) -> None:
+        """add_liquidity にカスタムスリッページを指定できること。"""
+        captured_params: list[dict] = []
+
+        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+            captured_params.append(params)
+            return _MOCK_ADD_LIQ_RESPONSE
+
+        with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
+            await router_client.add_liquidity(
+                MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER, slippage=Decimal("0.02")
+            )
+        assert captured_params[0]["slippage"] == "0.02"
+
+    @pytest.mark.asyncio
+    async def test_add_liquidity_http_error_returns_failure(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """add_liquidity が HTTP エラー時に success=False を返すこと（fail-open）。"""
+        mock_response = AsyncMock()
+        mock_response.status_code = 503
+        mock_response.text = "Service Unavailable"
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(
+                side_effect=httpx.HTTPStatusError(
+                    "error",
+                    request=None,
+                    response=mock_response,  # type: ignore[arg-type]
+                )
+            ),
+        ):
+            result = await router_client.add_liquidity(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_add_liquidity_network_error_returns_failure(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """add_liquidity がネットワークエラー時に success=False を返すこと（fail-open）。"""
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(side_effect=Exception("connection timeout")),
+        ):
+            result = await router_client.add_liquidity(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert "connection timeout" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_add_liquidity_passes_correct_params(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """add_liquidity が SDK に正しいパラメータを渡すこと。"""
+        captured_params: list[dict] = []
+
+        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+            captured_params.append(params)
+            return _MOCK_ADD_LIQ_RESPONSE
+
+        with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
+            await router_client.add_liquidity(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+
+        p = captured_params[0]
+        assert p["market"] == MARKET
+        assert p["tokenIn"] == TOKEN_IN
+        assert p["receiver"] == RECEIVER
+        assert "amountIn" in p
+
+
+class TestSecurityConstraints:
+    """セキュリティ制約のテスト。"""
+
+    @pytest.mark.asyncio
+    async def test_no_private_key_in_logs(
+        self, router_client: PendleRouterV4Client, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """ログに秘密鍵が出力されないこと。"""
+        import logging
+
+        config = PendleConfig(sandbox=False)
+        config.wallet_private_key = "0xsecretprivatekey12345"
+        client = PendleRouterV4Client(config)
+
+        with caplog.at_level(logging.INFO):
+            with patch.object(client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE)):
+                await client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+
+        for record in caplog.records:
+            assert "secretprivatekey" not in record.message
+
+    @pytest.mark.asyncio
+    async def test_amount_out_no_float(self, router_client: PendleRouterV4Client) -> None:
+        """全ての金額フィールドで float が使用されていないこと。"""
+        with patch.object(
+            router_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE)
+        ):
+            result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.5"), RECEIVER)
+        # amount_out が float でないこと
+        if result.amount_out is not None:
+            assert not isinstance(result.amount_out, float)
+            assert isinstance(result.amount_out, Decimal)

--- a/backend/tests/protocols/test_pendle/test_pendle_router_v4_client.py
+++ b/backend/tests/protocols/test_pendle/test_pendle_router_v4_client.py
@@ -39,6 +39,8 @@ _MOCK_ADD_LIQ_RESPONSE: dict = {
 @pytest.fixture
 def router_client() -> PendleRouterV4Client:
     config = PendleConfig(sandbox=False)
+    # テスト用に enable_onchain_write=True（ガードを通過させる）
+    config.enable_onchain_write = True
     return PendleRouterV4Client(config)
 
 

--- a/backend/tests/protocols/test_pendle/test_pendle_router_v4_guard.py
+++ b/backend/tests/protocols/test_pendle/test_pendle_router_v4_guard.py
@@ -1,0 +1,408 @@
+"""PendleRouterV4Client P1 安全装置テスト。
+
+対象:
+- PENDLE_ENABLE_ONCHAIN_WRITE 二段ガード (Q1)
+- dry_run 明示 (Q2)
+- 単一トレード 10%上限 (Q3)
+- SDK timeout/HTTPStatusError fail-open
+- approvals 抽出
+- get_pendle_router_v4_client ファクトリ関数
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from app.protocols.pendle.client import PendleRouterV4Client, get_pendle_router_v4_client
+from app.protocols.pendle.config import PendleConfig
+from app.protocols.pendle.schemas import (
+    RouterV4AddLiquidityResult,
+    RouterV4Approval,
+)
+
+MARKET = "0x" + "aa" * 20
+TOKEN_IN = "0x" + "bb" * 20
+TOKEN_OUT = "0x" + "cc" * 20
+RECEIVER = "0x" + "dd" * 20
+
+_MOCK_SWAP_RESPONSE: dict = {
+    "data": {
+        "tx": {"data": "0xdeadbeef"},
+        "amountOut": str(int(Decimal("0.95") * Decimal(10**18))),
+        "approvals": [{"spender": "0x888888888889758F76e7103c6CbF23ABbF58F946", "token": TOKEN_IN}],
+    }
+}
+
+_MOCK_ADD_LIQ_RESPONSE: dict = {
+    "data": {
+        "tx": {"data": "0xcafebabe"},
+        "amountLpOut": str(int(Decimal("0.98") * Decimal(10**18))),
+        "approvals": [{"spender": "0x888888888889758F76e7103c6CbF23ABbF58F946", "token": TOKEN_IN}],
+    }
+}
+
+
+@pytest.fixture
+def disabled_client() -> PendleRouterV4Client:
+    """enable_onchain_write=False（デフォルト）のクライアント。"""
+    config = PendleConfig(sandbox=False)
+    assert config.enable_onchain_write is False
+    return PendleRouterV4Client(config)
+
+
+@pytest.fixture
+def enabled_client() -> PendleRouterV4Client:
+    """enable_onchain_write=True のクライアント（テスト専用）。"""
+    config = PendleConfig(sandbox=False)
+    config.enable_onchain_write = True
+    return PendleRouterV4Client(config)
+
+
+# ---------------------------------------------------------------------------
+# Q1: enable_onchain_write=False のガードテスト
+# ---------------------------------------------------------------------------
+
+
+class TestOnchainWriteGuardDisabled:
+    """enable_onchain_write=False のとき全 swap 操作が拒否されること。"""
+
+    @pytest.mark.asyncio
+    async def test_buy_yt_disabled(self, disabled_client: PendleRouterV4Client) -> None:
+        result = await disabled_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert result.error is not None
+        assert "PENDLE_ENABLE_ONCHAIN_WRITE=false" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_sell_yt_disabled(self, disabled_client: PendleRouterV4Client) -> None:
+        result = await disabled_client.sell_yt(MARKET, TOKEN_OUT, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert "PENDLE_ENABLE_ONCHAIN_WRITE=false" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_buy_pt_disabled(self, disabled_client: PendleRouterV4Client) -> None:
+        result = await disabled_client.buy_pt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert "PENDLE_ENABLE_ONCHAIN_WRITE=false" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_sell_pt_disabled(self, disabled_client: PendleRouterV4Client) -> None:
+        result = await disabled_client.sell_pt(MARKET, TOKEN_OUT, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert "PENDLE_ENABLE_ONCHAIN_WRITE=false" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_add_liquidity_disabled(self, disabled_client: PendleRouterV4Client) -> None:
+        result = await disabled_client.add_liquidity(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert isinstance(result, RouterV4AddLiquidityResult)
+        assert result.success is False
+        assert "PENDLE_ENABLE_ONCHAIN_WRITE=false" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_disabled_does_not_call_sdk(self, disabled_client: PendleRouterV4Client) -> None:
+        """ガード拒否時は SDK を呼ばないこと。"""
+        with patch.object(
+            disabled_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE)
+        ) as mock_sdk:
+            await disabled_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        mock_sdk.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Q2: dry_run=True で calldata 取得 + tx 送信なし
+# ---------------------------------------------------------------------------
+
+
+class TestDryRunEnabled:
+    """enable_onchain_write=True + dry_run=True で calldata が取得できること。"""
+
+    @pytest.mark.asyncio
+    async def test_buy_yt_dry_run_gets_calldata(self, enabled_client: PendleRouterV4Client) -> None:
+        with patch.object(
+            enabled_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE)
+        ):
+            result = await enabled_client.buy_yt(
+                MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER, dry_run=True
+            )
+        assert result.success is True
+        assert result.calldata == "0xdeadbeef"
+        # tx_hash は dry_run 中は None（tx 送信しない）
+        assert result.tx_hash is None
+
+    @pytest.mark.asyncio
+    async def test_sell_yt_dry_run_gets_calldata(
+        self, enabled_client: PendleRouterV4Client
+    ) -> None:
+        with patch.object(
+            enabled_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE)
+        ):
+            result = await enabled_client.sell_yt(
+                MARKET, TOKEN_OUT, Decimal("1.0"), RECEIVER, dry_run=True
+            )
+        assert result.success is True
+        assert result.calldata == "0xdeadbeef"
+        assert result.tx_hash is None
+
+    @pytest.mark.asyncio
+    async def test_add_liquidity_dry_run_gets_calldata(
+        self, enabled_client: PendleRouterV4Client
+    ) -> None:
+        with patch.object(
+            enabled_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_ADD_LIQ_RESPONSE)
+        ):
+            result = await enabled_client.add_liquidity(
+                MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER, dry_run=True
+            )
+        assert result.success is True
+        assert result.calldata == "0xcafebabe"
+        assert result.tx_hash is None
+
+
+# ---------------------------------------------------------------------------
+# Q3: 10%上限チェック
+# ---------------------------------------------------------------------------
+
+
+class TestMaxSingleTradeGuard:
+    """portfolio_value_usd × 10% を超えたら拒否されること。"""
+
+    @pytest.mark.asyncio
+    async def test_exceeds_10pct_is_rejected(self, enabled_client: PendleRouterV4Client) -> None:
+        """amount_in > portfolio × 10% は拒否。"""
+        portfolio = Decimal("100")
+        amount_in = Decimal("11")  # 11% > 10%
+        result = await enabled_client.buy_yt(
+            MARKET, TOKEN_IN, amount_in, RECEIVER, portfolio_value_usd=portfolio
+        )
+        assert result.success is False
+        assert "exceeds max single trade" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_exactly_10pct_is_allowed(self, enabled_client: PendleRouterV4Client) -> None:
+        """amount_in = portfolio × 10% は通過。"""
+        portfolio = Decimal("100")
+        amount_in = Decimal("10")  # 10% = 上限ちょうど
+        with patch.object(
+            enabled_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE)
+        ):
+            result = await enabled_client.buy_yt(
+                MARKET, TOKEN_IN, amount_in, RECEIVER, portfolio_value_usd=portfolio
+            )
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_within_10pct_is_allowed(self, enabled_client: PendleRouterV4Client) -> None:
+        """amount_in < portfolio × 10% は通過。"""
+        portfolio = Decimal("100")
+        amount_in = Decimal("5")  # 5% < 10%
+        with patch.object(
+            enabled_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE)
+        ):
+            result = await enabled_client.buy_yt(
+                MARKET, TOKEN_IN, amount_in, RECEIVER, portfolio_value_usd=portfolio
+            )
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_none_portfolio_skips_check_with_warning(
+        self, enabled_client: PendleRouterV4Client, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """portfolio_value_usd=None はチェックをスキップし warning ログを出すこと。"""
+        with caplog.at_level(logging.WARNING, logger="app.protocols.pendle.client"):
+            with patch.object(
+                enabled_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE)
+            ):
+                result = await enabled_client.buy_yt(
+                    MARKET, TOKEN_IN, Decimal("999"), RECEIVER, portfolio_value_usd=None
+                )
+        assert result.success is True
+        assert any("10%上限チェックをスキップ" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_add_liquidity_10pct_rejected(self, enabled_client: PendleRouterV4Client) -> None:
+        """add_liquidity でも 10%上限が機能すること。"""
+        portfolio = Decimal("100")
+        amount_in = Decimal("20")  # 20% > 10%
+        result = await enabled_client.add_liquidity(
+            MARKET, TOKEN_IN, amount_in, RECEIVER, portfolio_value_usd=portfolio
+        )
+        assert result.success is False
+        assert "exceeds max single trade" in (result.error or "")
+
+    def test_10pct_uses_decimal_not_float(self, enabled_client: PendleRouterV4Client) -> None:
+        """max_single_trade_pct が Decimal であること（float 禁止）。"""
+        assert isinstance(enabled_client._config.max_single_trade_pct, Decimal)
+
+
+# ---------------------------------------------------------------------------
+# fail-open: SDK タイムアウト / HTTPStatusError
+# ---------------------------------------------------------------------------
+
+
+class TestFailOpen:
+    """外部 HTTP 失敗時に success=False を返すこと（例外を伝播しない）。"""
+
+    @pytest.mark.asyncio
+    async def test_sdk_timeout_returns_failure(self, enabled_client: PendleRouterV4Client) -> None:
+        with patch.object(
+            enabled_client,
+            "_call_sdk",
+            new=AsyncMock(side_effect=Exception("connection timeout")),
+        ):
+            result = await enabled_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert "connection timeout" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_sdk_http_status_error_returns_failure(
+        self, enabled_client: PendleRouterV4Client
+    ) -> None:
+        mock_response = AsyncMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        with patch.object(
+            enabled_client,
+            "_call_sdk",
+            new=AsyncMock(
+                side_effect=httpx.HTTPStatusError(
+                    "error",
+                    request=None,
+                    response=mock_response,  # type: ignore[arg-type]
+                )
+            ),
+        ):
+            result = await enabled_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert result.error is not None
+        assert "SDK HTTP 500" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_add_liquidity_timeout_returns_failure(
+        self, enabled_client: PendleRouterV4Client
+    ) -> None:
+        with patch.object(
+            enabled_client,
+            "_call_sdk",
+            new=AsyncMock(side_effect=Exception("network error")),
+        ):
+            result = await enabled_client.add_liquidity(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+
+
+# ---------------------------------------------------------------------------
+# approvals 抽出
+# ---------------------------------------------------------------------------
+
+
+class TestApprovalsExtraction:
+    """SDK レスポンスの approvals が RouterV4SwapResult に格納されること。"""
+
+    @pytest.mark.asyncio
+    async def test_approvals_extracted_from_swap(
+        self, enabled_client: PendleRouterV4Client
+    ) -> None:
+        with patch.object(
+            enabled_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE)
+        ):
+            result = await enabled_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.approvals is not None
+        assert len(result.approvals) == 1
+        approval = result.approvals[0]
+        assert isinstance(approval, RouterV4Approval)
+        assert approval.spender == "0x888888888889758F76e7103c6CbF23ABbF58F946"
+        assert approval.token == TOKEN_IN
+
+    @pytest.mark.asyncio
+    async def test_approvals_extracted_from_add_liquidity(
+        self, enabled_client: PendleRouterV4Client
+    ) -> None:
+        with patch.object(
+            enabled_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_ADD_LIQ_RESPONSE)
+        ):
+            result = await enabled_client.add_liquidity(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.approvals is not None
+        assert len(result.approvals) == 1
+
+    @pytest.mark.asyncio
+    async def test_approvals_none_when_empty(self, enabled_client: PendleRouterV4Client) -> None:
+        """SDK レスポンスに approvals がない場合は None が返ること。"""
+        response_no_approvals: dict = {
+            "data": {
+                "tx": {"data": "0xdeadbeef"},
+                "amountOut": str(int(Decimal("0.95") * Decimal(10**18))),
+            }
+        }
+        with patch.object(
+            enabled_client, "_call_sdk", new=AsyncMock(return_value=response_no_approvals)
+        ):
+            result = await enabled_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.approvals is None
+
+    @pytest.mark.asyncio
+    async def test_approvals_not_sent_as_tx(self, enabled_client: PendleRouterV4Client) -> None:
+        """approvals は保持のみ。approve tx 送信が起きないこと（sign/send_raw 呼び出しなし）。"""
+        with patch.object(
+            enabled_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE)
+        ):
+            result = await enabled_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        # tx_hash がない = on-chain tx 送信がない
+        assert result.tx_hash is None
+
+
+# ---------------------------------------------------------------------------
+# ファクトリ関数
+# ---------------------------------------------------------------------------
+
+
+class TestFactory:
+    """get_pendle_router_v4_client ファクトリ関数のテスト。"""
+
+    def test_factory_returns_router_v4_client(self) -> None:
+        config = PendleConfig(sandbox=False)
+        client = get_pendle_router_v4_client(config)
+        assert isinstance(client, PendleRouterV4Client)
+
+    def test_factory_uses_correct_router_address(self) -> None:
+        config = PendleConfig(sandbox=False)
+        client = get_pendle_router_v4_client(config)
+        assert client._ROUTER_ADDRESS == "0x888888888889758F76e7103c6CbF23ABbF58F946"
+
+    def test_factory_inherits_config_enable_flag(self) -> None:
+        """ファクトリから生成したクライアントが config の enable_onchain_write を引き継ぐこと。"""
+        config = PendleConfig(sandbox=False)
+        config.enable_onchain_write = True
+        client = get_pendle_router_v4_client(config)
+        assert client._config.enable_onchain_write is True
+
+    def test_factory_default_write_disabled(self) -> None:
+        """デフォルト config では enable_onchain_write=False であること。"""
+        config = PendleConfig(sandbox=False)
+        client = get_pendle_router_v4_client(config)
+        assert client._config.enable_onchain_write is False
+
+
+# ---------------------------------------------------------------------------
+# 設定デフォルト値
+# ---------------------------------------------------------------------------
+
+
+class TestConfigDefaults:
+    """PendleConfig のデフォルト値テスト。"""
+
+    def test_enable_onchain_write_default_false(self) -> None:
+        config = PendleConfig()
+        assert config.enable_onchain_write is False
+
+    def test_max_single_trade_pct_default_10pct(self) -> None:
+        config = PendleConfig()
+        assert config.max_single_trade_pct == Decimal("0.10")
+
+    def test_router_address_default_is_correct(self) -> None:
+        """config デフォルトの router_address が正式アドレスであること。"""
+        config = PendleConfig()
+        assert config.router_address == "0x888888888889758F76e7103c6CbF23ABbF58F946"

--- a/backend/tests/protocols/test_pendle/test_pendle_router_v4_security.py
+++ b/backend/tests/protocols/test_pendle/test_pendle_router_v4_security.py
@@ -1,0 +1,334 @@
+"""PendleRouterV4Client セキュリティレビュー指摘の回帰テスト（C2/C3/M1/m1）。
+
+- C2: tx.to / approvals.spender を Router アドレスと照合し不一致を拒否
+- C3: 非18桁トークン（USDC=6）の amountIn 桁ズレを防ぐ decimals 解決
+- M1: slippage 境界（0 / 0.05 / 0.051 / 負値）の Pydantic 制約
+- m1: calldata 欠損/空文字を success=False で拒否
+"""
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from app.protocols.pendle.client import PendleRouterV4Client
+from app.protocols.pendle.config import PendleConfig
+from app.protocols.pendle.schemas import RouterV4SwapRequest
+
+MARKET = "0x" + "aa" * 20
+TOKEN_IN = "0x" + "bb" * 20
+TOKEN_OUT = "0x" + "cc" * 20
+RECEIVER = "0x" + "dd" * 20
+ROUTER = "0x888888888889758F76e7103c6CbF23ABbF58F946"
+EVIL_CONTRACT = "0x" + "ee" * 20
+
+
+@pytest.fixture
+def router_client() -> PendleRouterV4Client:
+    config = PendleConfig(sandbox=False)
+    return PendleRouterV4Client(config)
+
+
+def _swap_response(
+    *, to: str = ROUTER, data: str = "0xdeadbeef", approvals: list | None = None
+) -> dict:
+    resp: dict = {
+        "data": {
+            "tx": {"to": to, "data": data},
+            "amountOut": str(int(Decimal("0.95") * Decimal(10**18))),
+        }
+    }
+    if approvals is not None:
+        resp["data"]["approvals"] = approvals
+    return resp
+
+
+# --- C2: Router アドレス照合 ---
+
+
+class TestRouterAddressVerification:
+    @pytest.mark.asyncio
+    async def test_buy_yt_rejects_wrong_tx_to(self, router_client: PendleRouterV4Client) -> None:
+        """tx.to が Router 以外なら success=False, error='router address mismatch'。"""
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(return_value=_swap_response(to=EVIL_CONTRACT)),
+        ):
+            result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert result.error == "router address mismatch"
+        assert result.calldata is None
+
+    @pytest.mark.asyncio
+    async def test_buy_yt_accepts_checksum_case_mismatch(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """tx.to が小文字（checksum 違い）でも Router なら受理する。"""
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(return_value=_swap_response(to=ROUTER.lower())),
+        ):
+            result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is True
+        assert result.to is not None
+        assert result.to.lower() == ROUTER.lower()
+
+    @pytest.mark.asyncio
+    async def test_buy_yt_rejects_missing_tx_to(self, router_client: PendleRouterV4Client) -> None:
+        """tx.to 欠損は照合不能 → 拒否。"""
+        resp = {"data": {"tx": {"data": "0xdeadbeef"}, "amountOut": "0"}}
+        with patch.object(router_client, "_call_sdk", new=AsyncMock(return_value=resp)):
+            result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert result.error == "router address mismatch"
+
+    @pytest.mark.asyncio
+    async def test_buy_yt_rejects_wrong_approval_spender(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """approvals.spender が Router 以外なら拒否する。"""
+        approvals = [{"token": TOKEN_IN, "spender": EVIL_CONTRACT, "amount": "100"}]
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(return_value=_swap_response(approvals=approvals)),
+        ):
+            result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert result.error == "router address mismatch"
+
+    @pytest.mark.asyncio
+    async def test_buy_yt_accepts_valid_approval_spender(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """approvals.spender が Router なら受理し、approvals を結果に保持する。"""
+        approvals = [{"token": TOKEN_IN, "spender": ROUTER, "amount": "100"}]
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(return_value=_swap_response(approvals=approvals)),
+        ):
+            result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is True
+        assert len(result.approvals) == 1
+        assert result.approvals[0].spender == ROUTER
+
+    @pytest.mark.asyncio
+    async def test_add_liquidity_rejects_wrong_tx_to(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """add_liquidity も tx.to を照合する。"""
+        resp = {
+            "data": {
+                "tx": {"to": EVIL_CONTRACT, "data": "0xcafebabe"},
+                "amountLpOut": "0",
+            }
+        }
+        with patch.object(router_client, "_call_sdk", new=AsyncMock(return_value=resp)):
+            result = await router_client.add_liquidity(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert result.error == "router address mismatch"
+
+
+# --- C3: token decimals 解決 ---
+
+
+class TestTokenDecimals:
+    @pytest.mark.asyncio
+    async def test_buy_yt_usdc_uses_6_decimals(self, router_client: PendleRouterV4Client) -> None:
+        """token_in_decimals=6（USDC）で amountIn が 10^6 単位になること。"""
+        captured: list[dict] = []
+
+        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+            captured.append(params)
+            return _swap_response()
+
+        with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
+            await router_client.buy_yt(
+                MARKET, "USDC", Decimal("100"), RECEIVER, token_in_decimals=6
+            )
+        # 100 USDC * 10^6 = 100_000_000（18 桁なら 10^20 になってしまう）
+        assert captured[0]["amountIn"] == str(100 * 10**6)
+
+    @pytest.mark.asyncio
+    async def test_buy_yt_usdc_resolved_from_config_map(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """token_in_decimals 未指定でもシンボル 'USDC' から 6 桁を解決すること。"""
+        captured: list[dict] = []
+
+        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+            captured.append(params)
+            return _swap_response()
+
+        with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
+            await router_client.buy_yt(MARKET, "usdc", Decimal("100"), RECEIVER)
+        assert captured[0]["amountIn"] == str(100 * 10**6)
+
+    @pytest.mark.asyncio
+    async def test_buy_yt_unknown_token_defaults_18(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """未知トークンは 18 桁にフォールバックすること（後方互換）。"""
+        captured: list[dict] = []
+
+        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+            captured.append(params)
+            return _swap_response()
+
+        with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
+            await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert captured[0]["amountIn"] == str(10**18)
+
+    @pytest.mark.asyncio
+    async def test_sell_yt_usdc_out_amount_uses_6_decimals(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """sell_yt の出力 USDC で amount_out が 6 桁前提で復元されること。"""
+        resp = {
+            "data": {
+                "tx": {"to": ROUTER, "data": "0xdeadbeef"},
+                "amountOut": str(100 * 10**6),  # 100 USDC (6 decimals)
+            }
+        }
+        with patch.object(router_client, "_call_sdk", new=AsyncMock(return_value=resp)):
+            result = await router_client.sell_yt(
+                MARKET, "USDC", Decimal("1.0"), RECEIVER, token_out_decimals=6
+            )
+        assert result.success is True
+        assert result.amount_out == Decimal("100")
+
+    def test_config_token_decimals_map(self) -> None:
+        """config の token_decimals が USDC=6, WBTC=8, default=18 を返すこと。"""
+        config = PendleConfig(sandbox=False)
+        assert config.token_decimals("USDC") == 6
+        assert config.token_decimals("usdt") == 6
+        assert config.token_decimals("WBTC") == 8
+        assert config.token_decimals("WETH") == 18
+
+
+# --- M1: slippage 境界 ---
+
+
+class TestSlippageBounds:
+    def test_slippage_zero_rejected(self) -> None:
+        """slippage=0 は gt=0 制約で拒否される。"""
+        with pytest.raises(ValidationError):
+            RouterV4SwapRequest(
+                market_address=MARKET,
+                token_in=TOKEN_IN,
+                token_out="YT",  # noqa: S106
+                amount_in=Decimal("1"),
+                slippage=Decimal("0"),
+                receiver=RECEIVER,
+            )
+
+    def test_slippage_negative_rejected(self) -> None:
+        """負の slippage は拒否される。"""
+        with pytest.raises(ValidationError):
+            RouterV4SwapRequest(
+                market_address=MARKET,
+                token_in=TOKEN_IN,
+                token_out="YT",  # noqa: S106
+                amount_in=Decimal("1"),
+                slippage=Decimal("-0.01"),
+                receiver=RECEIVER,
+            )
+
+    def test_slippage_upper_bound_accepted(self) -> None:
+        """slippage=0.05（5%）は le 制約の境界で許容される。"""
+        req = RouterV4SwapRequest(
+            market_address=MARKET,
+            token_in=TOKEN_IN,
+            token_out="YT",  # noqa: S106
+            amount_in=Decimal("1"),
+            slippage=Decimal("0.05"),
+            receiver=RECEIVER,
+        )
+        assert req.slippage == Decimal("0.05")
+
+    def test_slippage_above_upper_bound_rejected(self) -> None:
+        """slippage=0.051（>5%）は拒否される。"""
+        with pytest.raises(ValidationError):
+            RouterV4SwapRequest(
+                market_address=MARKET,
+                token_in=TOKEN_IN,
+                token_out="YT",  # noqa: S106
+                amount_in=Decimal("1"),
+                slippage=Decimal("0.051"),
+                receiver=RECEIVER,
+            )
+
+    def test_slippage_100pct_rejected(self) -> None:
+        """slippage=1.0（=100%）は拒否される（レビュー指摘の具体例）。"""
+        with pytest.raises(ValidationError):
+            RouterV4SwapRequest(
+                market_address=MARKET,
+                token_in=TOKEN_IN,
+                token_out="YT",  # noqa: S106
+                amount_in=Decimal("1"),
+                slippage=Decimal("1.0"),
+                receiver=RECEIVER,
+            )
+
+
+# --- m1: calldata 欠損 ---
+
+
+class TestEmptyCalldata:
+    @pytest.mark.asyncio
+    async def test_buy_yt_empty_calldata_rejected(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """calldata が空文字なら success=False（空 tx 送信防止）。"""
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(return_value=_swap_response(data="")),
+        ):
+            result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert result.error == "empty calldata"
+
+    @pytest.mark.asyncio
+    async def test_buy_yt_missing_calldata_rejected(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """tx.data 欠損なら success=False。"""
+        resp = {"data": {"tx": {"to": ROUTER}, "amountOut": "0"}}
+        with patch.object(router_client, "_call_sdk", new=AsyncMock(return_value=resp)):
+            result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert result.error == "empty calldata"
+
+    @pytest.mark.asyncio
+    async def test_add_liquidity_empty_calldata_rejected(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """add_liquidity の calldata 空でも拒否する。"""
+        resp = {"data": {"tx": {"to": ROUTER, "data": ""}, "amountLpOut": "0"}}
+        with patch.object(router_client, "_call_sdk", new=AsyncMock(return_value=resp)):
+            result = await router_client.add_liquidity(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert result.error == "empty calldata"
+
+
+# --- C1: ガード土台（フラグ存在確認） ---
+
+
+class TestOnchainWriteGuard:
+    def test_enable_onchain_write_default_false(self) -> None:
+        """PENDLE_ENABLE_ONCHAIN_WRITE 未設定時は enable_onchain_write=False。"""
+        config = PendleConfig(sandbox=False)
+        assert config.enable_onchain_write is False
+
+    @pytest.mark.asyncio
+    async def test_tx_hash_always_none_in_phase1(self, router_client: PendleRouterV4Client) -> None:
+        """Phase 1 は calldata 取得まで。成功時も tx_hash は None（送信していない）。"""
+        with patch.object(router_client, "_call_sdk", new=AsyncMock(return_value=_swap_response())):
+            result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is True
+        assert result.tx_hash is None


### PR DESCRIPTION
## 概要
Pendle RouterV4 hosted SDK を使い YT/PT の buy/sell + addLiquidity を実装。既存スタブ（モックレスポンス）を置換。

~~Closes Asana GID 1215620420850517~~ (⚠️ GID誤記: 該当タスクはAsana未起票だった。事後起票で対応 2026-06-12) (EPIC-3 Phase 1)

## 実装
- `PendleRouterV4Client.buy_yt() / sell_yt() / buy_pt() / sell_pt() / add_liquidity()`
- calldata は hosted SDK (`/sdk/api/v1`) が生成 → web3 abi encode 不要
- Router正式アドレス `0x8888...F946` をクラス定数化、slippage デフォルト `Decimal("0.005")`
- Phase 1 は calldata 取得まで（tx送信は Phase 2 以降、`tx_hash: None`）

## DoD / Gate
- ruff / ruff format / mypy: clean
- pytest: 162 passed, client.py coverage **82%** / pendle全体 92%
- Decimal型のみ・秘密鍵ハードコード0・fail-open（httpx timeout / HTTPStatusError 分離）

🤖 Generated with [Claude Code](https://claude.com/claude-code)