### PR TITLE
feat(ai): ai_decision_features.deterministic_breakdown JSONB 追加 (EPIC-1 1-6 / PR-1)

### DIFF
--- a/backend/alembic/versions/db20260612_add_deterministic_breakdown.py
+++ b/backend/alembic/versions/db20260612_add_deterministic_breakdown.py
@@ -1,0 +1,46 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""add_deterministic_breakdown_to_ai_decision_features
+
+ai_decision_features テーブルに deterministic_breakdown (JSONB, nullable) を追加する
+(EPIC-1 1-6 / 4軸 Shadow consensus 用)。
+
+設計書 docs/52 の judgment_logs テーブルは実在しない (実体は JSONL ロガー) ため、
+承認済み読み替えで実 DB sink の ai_decision_features に追加する。4軸 Shadow consensus の
+決定論的内訳 (各軸スコア/重み) を格納する。NULL 許容 (fail-open)。Shadow 書込配線は後続 PR-3 (1-7)。
+
+CHECK 制約は付けない (models.py が真実源ルール / JSONB に enum CHECK 不要)。
+
+Revision ID: db20260612
+Revises: m3h20260609
+Create Date: 2026-06-12 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "db20260612"
+down_revision: Union[str, Sequence[str], None] = "m3h20260609"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """ai_decision_features.deterministic_breakdown を追加する。"""
+    op.add_column(
+        "ai_decision_features",
+        sa.Column(
+            "deterministic_breakdown",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """ai_decision_features.deterministic_breakdown を削除する。"""
+    op.drop_column("ai_decision_features", "deterministic_breakdown")

--- a/backend/app/ai/models.py
+++ b/backend/app/ai/models.py
@@ -72,6 +72,9 @@ class AiDecisionFeature(Base):
     embedding: Mapped[Optional[List[float]]] = mapped_column(
         _embedding_column_type(), nullable=True
     )
+    # ALTER TABLE ai_decision_features ADD COLUMN IF NOT EXISTS deterministic_breakdown JSONB;
+    # 4軸 Shadow consensus の決定論的内訳 (各軸スコア/重み)。NULL許容 (後続 PR-3 で書込配線)。
+    deterministic_breakdown: Mapped[Optional[Any]] = mapped_column(JSON, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),


### PR DESCRIPTION
## 概要

4軸コンセンサス Shadow Phase 1 のログ書込先カラムを追加 (**小林さん承認済み計画の PR-1 / 3PR 構成の最初**)。

**設計読み替え (承認済み)**: 設計書 docs/52 の `judgment_logs` テーブルは実在しない (実体は `judgment_log.py` の JSONL ロガー) ため、AI 判定の実 DB sink である **`ai_decision_features`** にカラム追加する。

## 変更内容 (migration 単独 PR — head 分岐リスク最小化の定石)

- `models.py`: `AiDecisionFeature.deterministic_breakdown` (JSON, nullable) を `embedding` の後に追加 + ALTER TABLE コメント
- `alembic/versions/db20260612_add_deterministic_breakdown.py`: down_revision=`m3h20260609` (alembic heads で単一 head を確認済み)。JSONB nullable / **CHECK 制約なし** (models.py 真実源ルール)。downgrade = drop_column

## 検証

- `alembic heads`: 適用後も単一 head (`db20260612`)
- offline SQL (`--sql`, postgresql dialect): `ALTER TABLE ai_decision_features ADD COLUMN deterministic_breakdown JSONB;` 生成確認
- ⚠️ dev VPS に Postgres が無いため live round-trip は未実施 — **デプロイ時に staging で `alembic upgrade head` を先行実行のこと** (rollback は `downgrade -1`、NULL 許容・無参照カラムのため即 revert 安全)
- ruff / mypy clean、pytest 75 passed (model/migration 関連)

## 後続 (Tier S 1日1PR)

- PR-2 (明日): config.py 3 env + startup validation + prompts.py v6 template
- PR-3: ai_judgment_scheduler.py への Shadow 書込配線 (kill-switch: `CONSENSUS_4AXIS_MODE=off`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)