### PR TITLE
feat(ai): 4軸コンセンサス Shadow 書込配線 (EPIC-1 1-7 / PR-3)

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -255,6 +255,51 @@ def _generate_embedding(text: str) -> Optional[list[float]]:
         return None
 
 
+def _write_shadow_consensus(
+    db: Session,
+    feature: AiDecisionFeature,
+    market_ctx: Any,
+) -> None:
+    """4 軸コンセンサスの決定論判定を Shadow 記録する (EPIC-1 1-7 / fail-open)。
+
+    consensus_4axis_mode が "off" の場合は何もしない。それ以外 (shadow/a_b/on)
+    のとき feature.deterministic_breakdown に DeterministicVerdict を格納する。
+    Shadow = 記録のみで、既存の判定・保存ロジックには一切影響させない。
+
+    market_ctx が MarketContext でない場合 (degraded dict) は skip する。
+    本関数の例外は WARNING ログに留め、呼び出し元の判定保存処理を阻害しない。
+    """
+    from app.ai.agents import run_all_agents  # noqa: PLC0415
+    from app.ai.config import get_ai_settings  # noqa: PLC0415
+
+    try:
+        settings = get_ai_settings()
+        if settings.consensus_4axis_mode == "off":
+            return
+        if not isinstance(market_ctx, MarketContext):
+            return
+
+        agent_ctx = run_all_agents(market_ctx)
+        verdict = agent_ctx.evaluate_4axis_consensus(
+            score_threshold=settings.consensus_score_threshold,
+            conf_threshold=settings.consensus_conf_threshold,
+        )
+        feature.deterministic_breakdown = verdict.model_dump(mode="json")
+        db.flush()
+        logger.info(
+            "shadow consensus recorded: feature_id=%s mode=%s action=%s",
+            feature.id,
+            settings.consensus_4axis_mode,
+            verdict.action.value,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "_write_shadow_consensus failed (fail-open, decision_id=%s): %s",
+            getattr(feature, "ai_decision_id", None),
+            exc,
+        )
+
+
 def save_ai_decision_features(
     db: Session,
     decision: AIDecision,
@@ -297,6 +342,8 @@ def save_ai_decision_features(
             result.final_action.value,
             result.final_confidence,
         )
+        # EPIC-1 1-7: 4 軸コンセンサス Shadow 書込配線 (記録のみ / fail-open)
+        _write_shadow_consensus(db, feature, market_ctx)
     except Exception as exc:  # noqa: BLE001
         logger.warning(
             "save_ai_decision_features failed (fail-open, decision_id=%d): %s",

--- a/backend/tests/test_consensus_shadow_wiring.py
+++ b/backend/tests/test_consensus_shadow_wiring.py
@@ -1,0 +1,268 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_consensus_shadow_wiring.py
+"""4 軸コンセンサス Shadow 書込配線のテスト (EPIC-1 1-7 / PR-3)。
+
+対象: ai_judgment_scheduler._write_shadow_consensus / save_ai_decision_features。
+
+検証観点:
+- shadow 有効 (mode="shadow") で deterministic_breakdown がセットされる
+- mode="off" で None のまま (Shadow skip)
+- evaluate_4axis_consensus が例外を投げても判定保存が継続する (fail-open)
+- market_ctx が dict (degraded) のとき skip される
+- Shadow = 記録のみで既存の保存項目は不変
+"""
+
+import os
+import tempfile
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-consensus-shadow-wiring")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "admin@example.com")
+
+from app.ai.agents import AgentSignal, Bias, MultiAgentContext  # noqa: E402
+from app.ai.models import AIDecision, AiDecisionFeature  # noqa: E402
+from app.ai.schemas import (  # noqa: E402
+    CrossValidationResult,
+    LLMDecision,
+    LLMProvider,
+    TradeAction,
+)
+from app.automation.aave_data_fetcher import AaveMarketData  # noqa: E402
+from app.automation.ai_judgment_scheduler import (  # noqa: E402
+    _write_shadow_consensus,
+    save_ai_decision_features,
+)
+from app.data_feeds.context import MarketContext  # noqa: E402
+from app.database import Base  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_session():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    Session = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    session = Session()
+    try:
+        yield session
+    finally:
+        session.close()
+    Base.metadata.drop_all(bind=engine)
+    os.unlink(path)
+
+
+def _make_decision(session) -> AIDecision:
+    d = AIDecision(
+        query="test",
+        action="HOLD",
+        confidence=60,
+        primary_provider="claude",
+        primary_action="HOLD",
+        primary_confidence=60,
+        agreed=True,
+    )
+    session.add(d)
+    session.flush()
+    return d
+
+
+def _make_feature(session, decision: AIDecision) -> AiDecisionFeature:
+    feature = AiDecisionFeature(
+        ai_decision_id=decision.id,
+        agent_signals=None,
+        raw_features={"utilization_rate": "45.5"},
+        judge_action="HOLD",
+        confidence=60,
+        cross_verify=True,
+        embedding=None,
+    )
+    session.add(feature)
+    session.flush()
+    return feature
+
+
+def _make_result() -> CrossValidationResult:
+    primary = LLMDecision(
+        provider=LLMProvider.CLAUDE,
+        action=TradeAction.HOLD,
+        confidence=80,
+        reason="テスト判定",
+    )
+    return CrossValidationResult(
+        primary=primary,
+        secondary=None,
+        agreed=True,
+        final_action=TradeAction.HOLD,
+        final_confidence=80,
+        final_reason="テスト判定理由",
+    )
+
+
+def _make_aave_data() -> AaveMarketData:
+    return {
+        "utilization_rate": Decimal("45.5"),
+        "supply_apy": Decimal("3.2"),
+        "borrow_apy": Decimal("5.1"),
+        "health_factor": Decimal("2.1"),
+    }
+
+
+def _make_agent_ctx() -> MultiAgentContext:
+    """全軸 BULLISH conf=100 の MultiAgentContext (score=+1.0 → BUY を期待)。"""
+
+    def _sig(name: str) -> AgentSignal:
+        return AgentSignal(
+            agent_name=name,
+            bias=Bias.BULLISH,
+            confidence=100,
+            reasoning="test",
+        )
+
+    return MultiAgentContext(
+        indicator_signal=_sig("Indicator Agent"),
+        pattern_signal=_sig("Pattern Agent"),
+        risk_signal=_sig("Risk Agent"),
+        macro_signal=_sig("Macro Agent"),
+    )
+
+
+def _settings(mode: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        consensus_4axis_mode=mode,
+        consensus_score_threshold=Decimal("0.40"),
+        consensus_conf_threshold=65,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _write_shadow_consensus 直接テスト
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_mode_sets_deterministic_breakdown(db_session):
+    """mode="shadow" で deterministic_breakdown が verdict の dict でセットされる。"""
+    decision = _make_decision(db_session)
+    feature = _make_feature(db_session, decision)
+
+    with (
+        patch("app.ai.config.get_ai_settings", return_value=_settings("shadow")),
+        patch("app.ai.agents.run_all_agents", return_value=_make_agent_ctx()),
+    ):
+        _write_shadow_consensus(db_session, feature, MarketContext())
+
+    row = db_session.query(AiDecisionFeature).filter_by(ai_decision_id=decision.id).one()
+    assert row.deterministic_breakdown is not None
+    # 全軸 BULLISH conf=100 → action=BUY, agreeing_count=4
+    assert row.deterministic_breakdown["action"] == "BUY"
+    assert row.deterministic_breakdown["agreeing_count"] == 4
+    assert "per_agent_contribution" in row.deterministic_breakdown
+
+
+def test_off_mode_leaves_breakdown_none(db_session):
+    """mode="off" のとき deterministic_breakdown は None のまま (Shadow skip)。"""
+    decision = _make_decision(db_session)
+    feature = _make_feature(db_session, decision)
+
+    with (
+        patch("app.ai.config.get_ai_settings", return_value=_settings("off")),
+        patch("app.ai.agents.run_all_agents") as mock_run,
+    ):
+        _write_shadow_consensus(db_session, feature, MarketContext())
+        # off では run_all_agents すら呼ばれない
+        mock_run.assert_not_called()
+
+    row = db_session.query(AiDecisionFeature).filter_by(ai_decision_id=decision.id).one()
+    assert row.deterministic_breakdown is None
+
+
+def test_degraded_dict_market_ctx_is_skipped(db_session):
+    """market_ctx が dict (degraded) のとき Shadow は skip され breakdown は None。"""
+    decision = _make_decision(db_session)
+    feature = _make_feature(db_session, decision)
+    degraded = {"degraded": True, "reason": "feed down"}
+
+    with (
+        patch("app.ai.config.get_ai_settings", return_value=_settings("shadow")),
+        patch("app.ai.agents.run_all_agents") as mock_run,
+    ):
+        _write_shadow_consensus(db_session, feature, degraded)
+        mock_run.assert_not_called()
+
+    row = db_session.query(AiDecisionFeature).filter_by(ai_decision_id=decision.id).one()
+    assert row.deterministic_breakdown is None
+
+
+def test_evaluate_exception_is_fail_open(db_session):
+    """evaluate_4axis_consensus が例外を投げても _write_shadow_consensus は例外を伝播しない。"""
+    decision = _make_decision(db_session)
+    feature = _make_feature(db_session, decision)
+
+    with (
+        patch("app.ai.config.get_ai_settings", return_value=_settings("shadow")),
+        patch(
+            "app.ai.agents.run_all_agents",
+            side_effect=RuntimeError("agents boom"),
+        ),
+    ):
+        # 例外を握り潰す (fail-open) — raise しないこと
+        _write_shadow_consensus(db_session, feature, MarketContext())
+
+    row = db_session.query(AiDecisionFeature).filter_by(ai_decision_id=decision.id).one()
+    assert row.deterministic_breakdown is None
+
+
+# ---------------------------------------------------------------------------
+# save_ai_decision_features 経由の統合テスト (Shadow = 記録のみ)
+# ---------------------------------------------------------------------------
+
+
+def test_save_features_continues_when_shadow_raises(db_session):
+    """Shadow 算出が例外を投げても save_ai_decision_features は feature を保存し続ける (fail-open)。"""
+    decision = _make_decision(db_session)
+    result = _make_result()
+
+    with (
+        patch("app.ai.config.get_ai_settings", return_value=_settings("shadow")),
+        patch(
+            "app.ai.agents.run_all_agents",
+            side_effect=RuntimeError("agents boom"),
+        ),
+    ):
+        save_ai_decision_features(db_session, decision, result, _make_aave_data(), MarketContext())
+
+    # feature 自体は保存され、Shadow 失敗で deterministic_breakdown は None
+    row = db_session.query(AiDecisionFeature).filter_by(ai_decision_id=decision.id).one()
+    assert row.judge_action == "HOLD"
+    assert row.confidence == 80
+    assert row.deterministic_breakdown is None
+
+
+def test_save_features_records_breakdown_when_shadow_on(db_session):
+    """save_ai_decision_features 経由でも shadow 有効なら deterministic_breakdown が記録される。"""
+    decision = _make_decision(db_session)
+    result = _make_result()
+
+    with (
+        patch("app.ai.config.get_ai_settings", return_value=_settings("shadow")),
+        patch("app.ai.agents.run_all_agents", return_value=_make_agent_ctx()),
+    ):
+        save_ai_decision_features(db_session, decision, result, _make_aave_data(), MarketContext())
+
+    row = db_session.query(AiDecisionFeature).filter_by(ai_decision_id=decision.id).one()
+    # 既存の保存項目は不変
+    assert row.judge_action == "HOLD"
+    assert row.cross_verify is True
+    # Shadow 記録が追加される
+    assert row.deterministic_breakdown is not None
+    assert row.deterministic_breakdown["action"] == "BUY"


### PR DESCRIPTION
## 概要

**小林さん承認済み 3PR 構成の最終 PR-3** (PR-1 #629 / PR-2 #630 マージ済み)。4軸コンセンサスの決定論判定を `ai_decision_features.deterministic_breakdown` に **Shadow 記録** する配線を追加。

**既存判定・既存保存項目への影響ゼロ** — `git diff --numstat` で `ai_judgment_scheduler.py` は **+47 / -0 (完全追記)** を検証済み。

## 変更内容

- `_write_shadow_consensus()` 新設: `consensus_4axis_mode=="off"` で即 return / `isinstance(market_ctx, MarketContext)` ガード (degraded dict は skip) / `run_all_agents` → `evaluate_4axis_consensus(承認済み env 閾値)` → `model_dump(mode="json")` で記録
- **二重 fail-open**: 関数全体の try/except (logger.warning のみ) + 呼出元 `save_ai_decision_features` の既存例外ポリシー — Shadow 系の例外が判定保存を阻害することは構造的に不可能
- 配線先は承認済み読み替えの `ai_judgment_scheduler.py` (設計書記載の service.py は DB に触れないため)
- forbidden 遵守: scheduled_tasks.py / monitoring_service.py / workflow.py / service.py / main.py は **1 行も変更なし**

## kill-switch

`CONSENSUS_4AXIS_MODE=off` (env + 再起動のみ、コード revert 不要)。

## テスト (新規 6 件 + 回帰)

shadow 有効で記録 (実値検証: 全軸 BULLISH → BUY/agreeing=4) / off で None + run_all_agents 未呼出 / degraded skip / 例外 fail-open ×2 (単体 + save 経由) / 既存保存項目不変

- ruff (S 含む) / mypy (262 files) clean
- **フルスイート 3690 passed / coverage 85.01%**
- rebase (#630 マージ後) 後も対象 174 passed

## これで EPIC-1 Phase 1 (Shadow) のコード側が完結

マージ + デプロイ後、staging で 7 日 soak (旧/新判定一致率 ≥90% で Phase 2 gate clear — docs/52 §6)。staging 反映時は `alembic upgrade head` 先行実行 (#629 のカラム) を忘れずに。

🤖 Generated with [Claude Code](https://claude.com/claude-code)