### PR TITLE
fix(ai): /api/ai/decisions リストを viewer ロールに開放 — liff-history 403 解消

### DIFF
--- a/backend/app/ai/decisions_router.py
+++ b/backend/app/ai/decisions_router.py
@@ -42,7 +42,7 @@ def list_decisions(
     agreed: Optional[bool] = None,
     date_from: Optional[datetime] = None,
     date_to: Optional[datetime] = None,
-    current_user: User = Depends(require_editor),
+    current_user: User = Depends(require_viewer),
     db: Session = Depends(get_db),
 ) -> AIDecisionListResponse:
     """判定履歴リストを返す（ページネーション・フィルタ付き）。"""

--- a/backend/tests/test_ai_decisions_api.py
+++ b/backend/tests/test_ai_decisions_api.py
@@ -206,6 +206,30 @@ class TestAIDecisionsAPI:
         data = r.json()
         assert all(item["confidence"] >= 80 for item in data["items"])
 
+    def test_list_decisions_viewer_allowed(self, client: TestClient) -> None:
+        """viewer ロールで GET /api/ai/decisions が 200 を返すことを確認 (liff-history 403 解消)。"""
+        admin_token = get_admin_token(client)
+        client.post(
+            "/users",
+            json={
+                "email": "viewer2@test.com",
+                "username": "viewer2",
+                "password": "viewerpassword456",
+                "role": "viewer",
+            },
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        r = client.post(
+            "/auth/login", json={"email": "viewer2@test.com", "password": "viewerpassword456"}
+        )
+        viewer_token = r.json()["access_token"]
+        r = client.get(
+            "/api/ai/decisions",
+            headers={"Authorization": f"Bearer {viewer_token}"},
+        )
+        assert r.status_code == 200
+        assert "items" in r.json()
+
     def test_filter_by_agreed(self, client: TestClient) -> None:
         token = get_admin_token(client)
         client.post(


### PR DESCRIPTION
## 現象
/liff-history（取引履歴）を viewer ロールで開くと 403 Forbidden が返り、データが表示されない（staging UI テストで確認 2026-06-12）。

## 真因
`backend/app/ai/decisions_router.py` の `list_decisions`（GET /api/ai/decisions）が `Depends(require_editor)` で保護されており、LIFF/tester ユーザー（viewer ロール）が弾かれていた。

## 修正
- `list_decisions` の依存を `require_editor` → `require_viewer` に変更（1行）
- viewer ロールで 200 を確認する pytest を追加

## セキュリティ確認
- AIDecisionResponse / AIDecisionListResponse に wallet_address / tx_hash は不含（法務要件: API に wallet 情報非開示）
- 個別取得（GET /api/ai/decisions/latest）は既に require_viewer であり、同一 schema のためリスト開放による新規情報露出なし
- 同ファイルの POST 系（require_editor）/ DELETE 系（require_admin）は変更なし

## テスト
```
pytest tests/test_ai_decisions_api.py -q
→ 13 passed（新規 test_list_decisions_viewer_allowed 含む）
ruff check / ruff format --check → All checks passed
```

## Asana
https://app.asana.com/1/817733952351708/project/1213741124336104/task/1215645442981027

## DoD 残項目（deploy 後）
- staging で viewer ロールの /liff-history が 200 + データ表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)