### PR TITLE
feat(terms): ブラウザ wallet 経路に利用規約ゲート実装 — needs_terms_acceptance 消費 + fail-closed

### DIFF
--- a/frontend/app/(user)/connect/page.tsx
+++ b/frontend/app/(user)/connect/page.tsx
@@ -11,6 +11,8 @@ import { Card, CardContent } from '@/components/ui/card'
 import { useAuth } from '@/lib/auth'
 import { useMinimumBalance } from '@/hooks/useMinimumBalance'
 import { apiPut } from '@/lib/api/client'
+import { acceptTerms } from '@/lib/api/auth'
+import { getAuthToken } from '@/lib/auth/token-key'
 import { OperationModeSelector } from '@/components/OperationModeSelector'
 
 type UserMode = 'managed' | 'active' | 'pro'
@@ -147,6 +149,16 @@ export default function ConnectPage() {
       const ethProvider = new ethers.BrowserProvider(eip1193 as unknown as ethers.Eip1193Provider)
       const signer = await ethProvider.getSigner()
       await loginWithWallet(address, signer)
+      // 利用規約同意を即時記録する（UI チェックボックス同意済みが前提）。
+      // 失敗しても遷移は継続 — BrowserTermsGate が backstop として機能する。
+      try {
+        const tok = getAuthToken()
+        if (tok) {
+          await acceptTerms(tok, "2.0")
+        }
+      } catch (termsErr) {
+        console.error('Failed to record terms acceptance:', termsErr)
+      }
       // Sync user mode to backend (fire-and-forget; auth continues on failure)
       try {
         await apiPut('/api/user/settings', { user_mode: userMode })

--- a/frontend/app/user/layout.tsx
+++ b/frontend/app/user/layout.tsx
@@ -4,6 +4,7 @@ import { NextIntlClientProvider } from 'next-intl'
 import { getLocale, getMessages } from 'next-intl/server'
 import { WagmiRootProvider } from '@/lib/wallet/WagmiRootProvider'
 import { UserProviders } from '@/components/user/UserProviders'
+import { BrowserTermsGate } from '@/components/user/BrowserTermsGate'
 import { UserHeader } from '@/components/user/UserHeader'
 import { BottomNav } from '@/components/shared/BottomNav'
 import { UserErrorBoundary } from './_components/UserErrorBoundary'
@@ -20,14 +21,16 @@ export default async function UserLayout({
     <NextIntlClientProvider locale={locale} messages={messages}>
       <WagmiRootProvider>
         <UserProviders>
-          <UserErrorBoundary>
-            <UserHeader />
-            <div className="min-h-screen pb-16">
-              {children}
-            </div>
-            <BottomNav />
-            <EmergencyStopFloat />
-          </UserErrorBoundary>
+          <BrowserTermsGate>
+            <UserErrorBoundary>
+              <UserHeader />
+              <div className="min-h-screen pb-16">
+                {children}
+              </div>
+              <BottomNav />
+              <EmergencyStopFloat />
+            </UserErrorBoundary>
+          </BrowserTermsGate>
         </UserProviders>
       </WagmiRootProvider>
     </NextIntlClientProvider>

--- a/frontend/app/user/terms-accept/page.tsx
+++ b/frontend/app/user/terms-accept/page.tsx
@@ -1,0 +1,243 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+// frontend/app/user/terms-accept/page.tsx
+//
+// ブラウザ wallet 経路の利用規約同意ページ。
+// BrowserTermsGate が未同意ユーザーをここへリダイレクトする。
+// 同意送信成功後は /user/dashboard へ遷移する（冪等）。
+//
+// UI 構成は (liff)/liff-confirm/page.tsx に準拠。
+
+"use client"
+
+import { useState, useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { CheckCircle, ChevronDown, ExternalLink } from "lucide-react"
+import { getAuthToken } from "@/lib/auth/token-key"
+import { acceptTerms, getTermsStatus } from "@/lib/api/auth"
+
+/** ブラウザ経路で記録する同意バージョン（backend _ACCEPTED_TERMS_VERSIONS と一致） */
+const BROWSER_TERMS_VERSION = "2.0"
+
+const ITEMS = [
+  {
+    id: "self_custody",
+    title: "資産はユーザー自身が管理します",
+    detail:
+      "本サービスはノンカストディアル型です。秘密鍵はユーザーが管理し、弊社はウォレットにアクセスできません。",
+  },
+  {
+    id: "defi_risk",
+    title: "DeFi運用にはリスクがあります",
+    detail:
+      "スマートコントラクトのリスク、価格変動リスク、流動性リスクが存在します。投資は自己責任でお願いします。",
+  },
+  {
+    id: "user_responsibility",
+    title: "アカウント管理は利用者自身の責任です",
+    detail:
+      "ログイン情報の管理、不正アクセスへの対応はユーザーご自身の責任となります。弊社はアカウント損失に対して責任を負いません。",
+  },
+]
+
+export default function BrowserTermsAcceptPage() {
+  const router = useRouter()
+  const [checked, setChecked] = useState<Record<string, boolean>>({})
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({})
+  const [submitting, setSubmitting] = useState(false)
+  const [loading, setLoading] = useState(true)
+
+  const allChecked = ITEMS.every((item) => checked[item.id])
+  const checkedCount = Object.values(checked).filter(Boolean).length
+
+  // 既同意チェック: 既に同意済みなら /user/dashboard へ即リダイレクト（冪等）
+  useEffect(() => {
+    const token = getAuthToken()
+    if (!token) {
+      setLoading(false)
+      return
+    }
+
+    getTermsStatus(token)
+      .then((data) => {
+        if (!data.needs_acceptance) {
+          router.replace("/user/dashboard")
+        } else {
+          setLoading(false)
+        }
+      })
+      .catch(() => setLoading(false))
+  }, [router])
+
+  const handleSubmit = async () => {
+    if (!allChecked || submitting) return
+    setSubmitting(true)
+
+    const token = getAuthToken()
+    if (!token) {
+      setSubmitting(false)
+      return
+    }
+
+    try {
+      await acceptTerms(token, BROWSER_TERMS_VERSION)
+      router.replace("/user/dashboard")
+    } catch {
+      setSubmitting(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-zinc-950 flex items-center justify-center">
+        <div className="w-6 h-6 border-2 border-[#1D9E75] border-t-transparent rounded-full animate-spin" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-[480px] mx-auto min-h-screen bg-zinc-950 text-zinc-100 flex flex-col overflow-hidden">
+      {/* ヘッダー */}
+      <div className="bg-[#1a3d2e] px-4 py-5 flex-shrink-0">
+        <h1 className="text-white font-bold text-lg">重要事項の確認</h1>
+        <p className="text-zinc-300 text-sm mt-1">運用開始前に以下をご確認ください</p>
+        {/* ステップドット */}
+        <div className="flex gap-1.5 mt-3">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className={`h-1.5 rounded-full transition-all duration-300 ${
+                i < checkedCount ? "bg-[#4ade9a] w-6" : "bg-zinc-700 w-4"
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* プログレスバー */}
+      <div className="px-4 py-3 border-b border-zinc-800 flex-shrink-0">
+        <div className="flex items-center justify-between text-sm mb-1.5">
+          <span className="text-zinc-400">確認状況</span>
+          <span className="text-[#4ade9a] font-semibold">{checkedCount} / 3</span>
+        </div>
+        <div className="h-1.5 bg-zinc-800 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-[#1D9E75] rounded-full transition-all duration-500 ease-out"
+            style={{ width: `${(checkedCount / 3) * 100}%` }}
+          />
+        </div>
+      </div>
+
+      {/* アコーディオンリスト */}
+      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
+        {ITEMS.map((item, idx) => {
+          const isChecked = checked[item.id]
+          const isExpanded = expanded[item.id]
+          return (
+            <div
+              key={item.id}
+              className={`rounded-xl border transition-all duration-200 ${
+                isChecked
+                  ? "border-[#1D9E75] bg-[#1D9E75]/5"
+                  : "border-zinc-800 bg-zinc-900"
+              }`}
+            >
+              <button
+                className="flex items-center w-full px-4 py-4 text-left"
+                onClick={() =>
+                  setExpanded((prev) => ({ ...prev, [item.id]: !prev[item.id] }))
+                }
+              >
+                <button
+                  className="mr-3 flex-shrink-0"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setChecked((prev) => ({ ...prev, [item.id]: !prev[item.id] }))
+                    if (!expanded[item.id]) {
+                      setExpanded((prev) => ({ ...prev, [item.id]: true }))
+                    }
+                  }}
+                >
+                  {isChecked ? (
+                    <CheckCircle className="w-6 h-6 text-[#4ade9a]" />
+                  ) : (
+                    <div className="w-6 h-6 rounded-full border-2 border-zinc-600 flex items-center justify-center">
+                      <span className="text-zinc-500 text-xs font-bold">{idx + 1}</span>
+                    </div>
+                  )}
+                </button>
+                <span
+                  className={`flex-1 text-sm font-medium ${
+                    isChecked ? "text-[#4ade9a]" : "text-white"
+                  }`}
+                >
+                  {item.title}
+                </span>
+                <ChevronDown
+                  className={`w-4 h-4 text-zinc-500 transition-transform ${
+                    isExpanded ? "rotate-180" : ""
+                  }`}
+                />
+              </button>
+              {isExpanded && (
+                <div className="px-4 pb-4">
+                  <p className="text-zinc-400 text-sm leading-relaxed">{item.detail}</p>
+                  {!isChecked && (
+                    <button
+                      onClick={() =>
+                        setChecked((prev) => ({ ...prev, [item.id]: true }))
+                      }
+                      className="mt-3 w-full py-2.5 rounded-lg bg-[#1D9E75]/20 text-[#4ade9a] text-sm font-medium border border-[#1D9E75]/30 hover:bg-[#1D9E75]/30 transition-colors"
+                    >
+                      確認しました
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      {/* 下部: リンク + ボタン */}
+      <div className="px-4 pb-8 pt-4 border-t border-zinc-800 flex-shrink-0 space-y-3">
+        <div className="flex gap-4 justify-center text-xs text-zinc-500">
+          <a
+            href="/terms"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 hover:text-zinc-300"
+          >
+            利用規約 <ExternalLink className="w-3 h-3" />
+          </a>
+          <a
+            href="/privacy-policy"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 hover:text-zinc-300"
+          >
+            プライバシーポリシー <ExternalLink className="w-3 h-3" />
+          </a>
+        </div>
+        <button
+          disabled={!allChecked || submitting}
+          onClick={handleSubmit}
+          className={`w-full py-4 rounded-xl font-semibold text-base transition-all duration-200 ${
+            allChecked && !submitting
+              ? "bg-[#1D9E75] text-white hover:bg-[#1D9E75]/90 active:scale-95"
+              : "bg-zinc-800 text-zinc-600 cursor-not-allowed"
+          }`}
+        >
+          {submitting ? (
+            <span className="flex items-center justify-center gap-2">
+              <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+              保存中...
+            </span>
+          ) : (
+            "運用を開始する"
+          )}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/app/user/terms-accept/page.tsx
+++ b/frontend/app/user/terms-accept/page.tsx
@@ -142,11 +142,20 @@ export default function BrowserTermsAcceptPage() {
                   : "border-zinc-800 bg-zinc-900"
               }`}
             >
-              <button
-                className="flex items-center w-full px-4 py-4 text-left"
+              {/* interactive content (button) のネスト禁止 (HTML 仕様) のため外側は div + role="button" */}
+              <div
+                role="button"
+                tabIndex={0}
+                className="flex items-center w-full px-4 py-4 text-left cursor-pointer"
                 onClick={() =>
                   setExpanded((prev) => ({ ...prev, [item.id]: !prev[item.id] }))
                 }
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault()
+                    setExpanded((prev) => ({ ...prev, [item.id]: !prev[item.id] }))
+                  }
+                }}
               >
                 <button
                   className="mr-3 flex-shrink-0"
@@ -178,7 +187,7 @@ export default function BrowserTermsAcceptPage() {
                     isExpanded ? "rotate-180" : ""
                   }`}
                 />
-              </button>
+              </div>
               {isExpanded && (
                 <div className="px-4 pb-4">
                   <p className="text-zinc-400 text-sm leading-relaxed">{item.detail}</p>

--- a/frontend/components/user/BrowserTermsGate.tsx
+++ b/frontend/components/user/BrowserTermsGate.tsx
@@ -1,0 +1,66 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+// frontend/components/user/BrowserTermsGate.tsx
+//
+// ブラウザ wallet 経路の利用規約ゲート。
+//
+// 背景 (Asana 1215645261952731):
+//   /user 配下の全ページを通じて、ブラウザ wallet ログインユーザーに対して
+//   利用規約同意 (version="2.0") を fail-closed パターンで強制する。
+//   (liff)/layout.tsx の useLiffTermsGate 適用と同じ考え方を /user レイアウトに展開する。
+//
+// 動作:
+//   - 除外パス: /user/terms-accept 自身（無限ループ防止）
+//   - token 無しの場合はゲート無効（未ログインは UserGuard → /login に委ねる）
+//   - 判定中は children を描画せずローディング表示
+//   - 未同意 → router.replace('/user/terms-accept')
+//   - liff-v3 または 2.0 で同意済み → children をそのまま描画
+
+"use client"
+
+import { useEffect } from "react"
+import { usePathname, useRouter } from "next/navigation"
+import { useLiffTermsGate } from "@/hooks/useLiffTermsGate"
+import { getAuthToken } from "@/lib/auth/token-key"
+
+/** ゲートを適用しないパス。terms-accept 自身は除外（無限ループ防止）。 */
+const GATE_EXEMPT_PATHS = ["/user/terms-accept"]
+
+/** ブラウザ経路で「同意済み」とみなすバージョン一覧。 */
+const BROWSER_ACCEPTED_VERSIONS: readonly string[] = ["liff-v3", "2.0"]
+
+export function BrowserTermsGate({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const router = useRouter()
+
+  const isExempt = GATE_EXEMPT_PATHS.includes(pathname ?? "")
+  const token = typeof window !== "undefined" ? getAuthToken() : null
+
+  // token 無し（未ログイン）はゲート無効: UserGuard が /login へ誘導するため不要。
+  // 除外パス / token 無しの場合は enabled=false で常に "accepted" を返す。
+  const gateState = useLiffTermsGate(
+    !isExempt && !!token,
+    BROWSER_ACCEPTED_VERSIONS
+  )
+
+  useEffect(() => {
+    if (gateState === "not-accepted") {
+      router.replace("/user/terms-accept")
+    }
+  }, [gateState, router])
+
+  if (gateState === "loading") {
+    return (
+      <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center">
+        <p className="text-zinc-400">読み込み中...</p>
+      </div>
+    )
+  }
+
+  // "not-accepted" の場合は useEffect でリダイレクト中のため children を描画しない。
+  if (gateState === "not-accepted") {
+    return null
+  }
+
+  return <>{children}</>
+}

--- a/frontend/hooks/useLiffTermsGate.ts
+++ b/frontend/hooks/useLiffTermsGate.ts
@@ -25,14 +25,27 @@ import { getAuthToken } from "@/lib/auth/token-key"
 /** liff-confirm / settings_router (LIFF_TERMS_VERSION) と一致させること。 */
 const LIFF_TERMS_VERSION = "liff-v3"
 
+/** ブラウザ wallet 経路の同意バージョン (POST /auth/terms/accept で記録)。 */
+const BROWSER_TERMS_VERSION = "2.0"
+
+/** デフォルト accepted バージョン一覧 (LIFF 経路向け後方互換)。 */
+const DEFAULT_ACCEPTED_VERSIONS: readonly string[] = [LIFF_TERMS_VERSION]
+
 export type LiffTermsGateState = "loading" | "accepted" | "not-accepted"
 
 /**
- * 重要事項同意 (liff-v3) の状態を返す。
- * @param enabled false の間はゲートを無効化し常に "accepted" を返す
- *                (除外ページ / 未認証時に呼び出し側が無効化する)。
+ * 重要事項同意の状態を返す。LIFF / ブラウザ両経路に対応。
+ *
+ * @param enabled          false の間はゲートを無効化し常に "accepted" を返す
+ *                         (除外ページ / 未認証時に呼び出し側が無効化する)。
+ * @param acceptedVersions 「同意済み」とみなすバージョン一覧。
+ *                         デフォルト ['liff-v3'] — 既存 LIFF 呼び出しは引数省略で後方互換。
+ *                         ブラウザ経路では ['liff-v3', '2.0'] を渡す。
  */
-export function useLiffTermsGate(enabled: boolean): LiffTermsGateState {
+export function useLiffTermsGate(
+  enabled: boolean,
+  acceptedVersions: readonly string[] = DEFAULT_ACCEPTED_VERSIONS
+): LiffTermsGateState {
   const [state, setState] = useState<LiffTermsGateState>("loading")
 
   useEffect(() => {
@@ -60,7 +73,9 @@ export function useLiffTermsGate(enabled: boolean): LiffTermsGateState {
       .then((data: { terms_version?: string | null } | null) => {
         if (cancelled) return
         setState(
-          data?.terms_version === LIFF_TERMS_VERSION ? "accepted" : "not-accepted"
+          data?.terms_version != null && acceptedVersions.includes(data.terms_version)
+            ? "accepted"
+            : "not-accepted"
         )
       })
       .catch(() => {
@@ -72,7 +87,9 @@ export function useLiffTermsGate(enabled: boolean): LiffTermsGateState {
     return () => {
       cancelled = true
     }
-  }, [enabled])
+  }, [enabled, acceptedVersions])
 
   return state
 }
+
+export { LIFF_TERMS_VERSION, BROWSER_TERMS_VERSION }

--- a/frontend/lib/api/auth.ts
+++ b/frontend/lib/api/auth.ts
@@ -161,3 +161,39 @@ export interface WalletConnectResponse {
 export async function walletConnect(request: WalletConnectRequest): Promise<WalletConnectResponse> {
   return await postJson<WalletConnectResponse>("/auth/wallet/connect", request);
 }
+
+export interface TermsStatusResponse {
+  accepted: boolean;
+  terms_version: string | null;
+  terms_accepted_at: string | null;
+  current_version: string;
+  needs_acceptance: boolean;
+}
+
+/**
+ * 利用規約の同意状態を取得（GET /auth/terms/status）
+ */
+export async function getTermsStatus(token: string): Promise<TermsStatusResponse> {
+  return await getJson<TermsStatusResponse>("/auth/terms/status", {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+}
+
+/**
+ * 利用規約に同意を記録（POST /auth/terms/accept）
+ * @param token   JWT アクセストークン
+ * @param version 同意バージョン文字列（例: "2.0"）
+ */
+export async function acceptTerms(token: string, version: string): Promise<TermsStatusResponse> {
+  return await postJson<TermsStatusResponse>(
+    "/auth/terms/accept",
+    { version },
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
+}


### PR DESCRIPTION
## 現象（Asana 1215645261952731）
Privy ログイン + ウォレット接続後、利用規約チェック画面に遷移せずダッシュボードに直行する（ブラウザ経路）。backend が返す `needs_terms_acceptance` フラグがフロントで未消費だった。

## 設計（LIFF PR #565 の fail-closed パターンをブラウザ経路に展開）
| コンポーネント | 内容 |
|---|---|
| `hooks/useLiffTermsGate.ts` | `acceptedVersions` 引数で汎用化。デフォルト `['liff-v3']` のため**既存 LIFF 呼び出しは完全後方互換**（`(liff)/layout.tsx` は無変更） |
| `lib/api/auth.ts` | `getTermsStatus` / `acceptTerms` 追加（backend `TermsStatusResponse` schema と一致確認済み） |
| `components/user/BrowserTermsGate.tsx` | `/user` layout に fail-closed ゲート。未同意 → `/user/terms-accept` 強制リダイレクト。判定中 children 非描画。`/user/terms-accept` は除外（ループ防止）。token 無しはゲート無効 |
| `app/user/terms-accept/page.tsx` | 同意ページ新設（liff-confirm UI 踏襲、`POST /auth/terms/accept` version="2.0"、既同意なら冪等リダイレクト） |
| `app/(user)/connect/page.tsx` | `handleStart` でログイン成功後にチェックボックス同意を `acceptTerms("2.0")` で即記録（失敗時はゲートが backstop） |

## backend 変更なし
`_ACCEPTED_TERMS_VERSIONS = {"2.0", "liff-v3"}`（auth/router.py:63-66）が既存のため、どちらのバージョンで同意済みでもゲート通過。既存同意ユーザーの再同意は発生しない。

## 検証
- `npx tsc --noEmit` → exit 0
- `BROWSER_ACCEPTED_VERSIONS` はモジュール定数（useEffect deps 安定、再フェッチループなし）
- token-key 正準モジュール（`getAuthToken`）経由で `loginWithWallet` 保存トークンと整合

## DoD 残（staging deploy 後・人間確認）
- 未同意ユーザー: `/user/dashboard` アクセス → `/user/terms-accept` リダイレクト → 同意 → dashboard
- 同意済みユーザー: dashboard 直行（再同意なし）
- LIFF 経路リグレッションなし（/liff-chat → liff-confirm ゲート）

## Asana
https://app.asana.com/1/817733952351708/project/1213741124336104/task/1215645261952731

🤖 Generated with [Claude Code](https://claude.com/claude-code)