### PR TITLE
feat(optimizer): SignalAdapter live 配線 + Aave 実 APY 化 (#625 M2/M3 フォローアップ / EPIC-5 前提)

### DIFF
--- a/backend/app/ai/optimizer/comparator.py
+++ b/backend/app/ai/optimizer/comparator.py
@@ -10,7 +10,7 @@ from decimal import Decimal
 from typing import Optional
 
 from .net_benefit import ExpectedNetBenefitCalculator
-from .schemas import NetBenefitResult, StrategyComparison
+from .schemas import NetBenefitResult, StrategyCandidate, StrategyComparison
 from .strategy_scorer import StrategyScorer
 
 logger = logging.getLogger(__name__)
@@ -60,6 +60,7 @@ class StrategyComparator:
         return StrategyScorer(
             pendle_adapter=getattr(self._scorer, "_pendle_adapter", None),
             lido_adapter=getattr(self._scorer, "_lido_adapter", None),
+            aave_adapter=getattr(self._scorer, "_aave_adapter", None),
             risk_mode=risk_mode,
         )
 
@@ -84,6 +85,33 @@ class StrategyComparator:
         """
         scorer = self._scorer_for_risk_mode(risk_mode)
         candidates = scorer.get_all_candidates()
+        return self._build_comparison(candidates, investment_usd, holding_days)
+
+    async def compare_async(
+        self,
+        investment_usd: Decimal,
+        risk_mode: str = "conservative",
+        holding_days: int = 30,
+    ) -> StrategyComparison:
+        """全プロトコルを比較して推奨を生成する（adapter live 経路 / 非同期版）。
+
+        compare() の sync シグネチャを維持したまま、注入済み adapter から実 APY を
+        取得する get_all_candidates_async() を使う非同期版（#625 M2/M3 フォローアップ）。
+
+        adapter が未注入なら従来どおりダミー定数で動作する（fail-open / 後方互換）。
+        ランキング以降のロジックは compare() と完全共通（_build_comparison）。
+        """
+        scorer = self._scorer_for_risk_mode(risk_mode)
+        candidates = await scorer.get_all_candidates_async()
+        return self._build_comparison(candidates, investment_usd, holding_days)
+
+    def _build_comparison(
+        self,
+        candidates: list[StrategyCandidate],
+        investment_usd: Decimal,
+        holding_days: int,
+    ) -> StrategyComparison:
+        """候補リストからランク付け・推奨・タイムスタンプを構築する（sync/async 共通）。"""
         ranked_results = self._calculator.rank_strategies(candidates, investment_usd, holding_days)
 
         # 何もしない場合の機会コスト = 0（現金は利回りなし）

--- a/backend/app/ai/optimizer/router.py
+++ b/backend/app/ai/optimizer/router.py
@@ -5,15 +5,14 @@
 OptimizerRequest を受け取り、戦略比較 + ポートフォリオ配分推奨を返す。
 main.py への登録は Tier S として別 PR で実施する。
 
-risk_mode は comparator.compare(risk_mode=...) 経由で StrategyScorer に伝播し、
+risk_mode は comparator.compare_async(risk_mode=...) 経由で StrategyScorer に伝播し、
 ランキング（risk_penalty 重み）へ反映される（レビュー M1 対応済）。
 
-TODO(next-PR): SignalAdapter（Pendle/Lido 実 client）を comparator/router で
-注入し get_all_candidates_async 経路へ live 化する。本 PR では adapter は
-score_*_async / get_all_candidates_async 経由でのみ利用され、router の sync
-compare() 経路（get_all_candidates）からは未配線。async 化 + Aave 側の実 APY 化
-（M3: 現状 Aave のみダミー APY のため Lido/Pendle と非対称）はリスクが大きいため
-別 PR とする。Asana GID 1215620587799245 のフォローアップで実施。
+live 配線（#625 M2/M3 フォローアップ / Asana GID 1215620587799245）:
+SignalAdapter（Pendle/Lido/Aave 実 client）を router で生成し StrategyScorer へ注入、
+comparator.compare_async() → get_all_candidates_async() 経路で実 APY を live 化する。
+client / config 生成失敗時は adapter を None にして fail-open（ダミー定数を継続）。
+adapter は read-only な APY/価格取得のみ呼び、秘密鍵を要するメソッドは呼ばない。
 """
 
 from __future__ import annotations
@@ -25,10 +24,53 @@ from fastapi import APIRouter, HTTPException
 from .allocator import PortfolioAllocator
 from .comparator import StrategyComparator
 from .schemas import OptimizerRequest, OptimizerResponse
+from .signal_adapter import AaveSignalAdapter, LidoSignalAdapter, PendleSignalAdapter
+from .strategy_scorer import StrategyScorer
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/ai/optimizer", tags=["ai-optimizer"])
+
+
+def _build_live_scorer(risk_mode: str) -> StrategyScorer:
+    """実 client から SignalAdapter を生成して注入した StrategyScorer を返す。
+
+    各 adapter は独立して fail-open: config / client 生成に失敗した protocol は
+    adapter=None（= ダミー定数継続）とし、他 protocol の live 化は維持する。
+    risk_mode は comparator が必要に応じて再生成するため初期値として渡す。
+    """
+    pendle_adapter: PendleSignalAdapter | None = None
+    lido_adapter: LidoSignalAdapter | None = None
+    aave_adapter: AaveSignalAdapter | None = None
+
+    try:
+        from app.protocols.pendle.client import get_pendle_client  # noqa: PLC0415
+        from app.protocols.pendle.config import get_pendle_config  # noqa: PLC0415
+
+        pendle_adapter = PendleSignalAdapter(client=get_pendle_client(get_pendle_config()))
+    except Exception as exc:
+        logger.warning("Pendle adapter 生成失敗、ダミー定数継続 (fail-open): %s", exc)
+
+    try:
+        from app.protocols.lido.client import get_lido_client  # noqa: PLC0415
+        from app.protocols.lido.config import get_lido_config  # noqa: PLC0415
+
+        lido_adapter = LidoSignalAdapter(client=get_lido_client(get_lido_config()))
+    except Exception as exc:
+        logger.warning("Lido adapter 生成失敗、ダミー定数継続 (fail-open): %s", exc)
+
+    try:
+        # Aave は read-only な market data fetcher（秘密鍵不要）を adapter 内で遅延 import。
+        aave_adapter = AaveSignalAdapter()
+    except Exception as exc:
+        logger.warning("Aave adapter 生成失敗、ダミー定数継続 (fail-open): %s", exc)
+
+    return StrategyScorer(
+        pendle_adapter=pendle_adapter,
+        lido_adapter=lido_adapter,
+        aave_adapter=aave_adapter,
+        risk_mode=risk_mode,
+    )
 
 
 @router.post("/recommend", response_model=OptimizerResponse)
@@ -39,8 +81,9 @@ async def recommend_strategy(request: OptimizerRequest) -> OptimizerResponse:
     各プロトコルの期待ネット利益を比較して最適配分を推奨する。
     """
     try:
-        comparator = StrategyComparator()
-        comparison = comparator.compare(
+        scorer = _build_live_scorer(request.risk_mode)
+        comparator = StrategyComparator(scorer=scorer)
+        comparison = await comparator.compare_async(
             investment_usd=request.investment_usd,
             risk_mode=request.risk_mode,
             holding_days=request.holding_days,

--- a/backend/app/ai/optimizer/signal_adapter.py
+++ b/backend/app/ai/optimizer/signal_adapter.py
@@ -14,11 +14,13 @@ StrategyScorer が使える形に変換する。
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from decimal import Decimal
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 if TYPE_CHECKING:
+    from app.automation.aave_data_fetcher import AaveMarketData
     from app.protocols.lido.client import AbstractLidoClient
     from app.protocols.pendle.client import AbstractPendleClient
 
@@ -32,6 +34,7 @@ _FALLBACK_PEG_DEVIATION: Decimal = Decimal("0")
 _FALLBACK_PENDLE_PT_APY: Decimal = Decimal("5.2")
 _FALLBACK_PENDLE_YT_APY: Decimal = Decimal("8.0")
 _FALLBACK_PENDLE_MATURITY_DAYS: int = 30
+_FALLBACK_AAVE_USDC_APY: Decimal = Decimal("4.5")
 
 
 class LidoSignalAdapter:
@@ -179,3 +182,60 @@ class PendleSignalAdapter:
         except Exception as exc:
             logger.warning("PendleSignalAdapter.get_maturity_days 失敗、フォールバック: %s", exc)
             return _FALLBACK_PENDLE_MATURITY_DAYS
+
+
+class AaveSignalAdapter:
+    """Aave の read-only マーケットデータ（supply APY）を取得するアダプター。
+
+    M3 対応: Lido/Pendle と対称に Aave も実 APY を取得できるようにする。
+    データ源は `app.automation.aave_data_fetcher.fetch_aave_market_data_safe`
+    （Pool.getReserveData() を直接読む read-only 経路、秘密鍵不要）。
+
+    本体の fetch 関数自体が fail-open（失敗フィールドは None）で実装されているため、
+    本アダプターは supply_apy が None / 取得失敗時にフォールバック定数を返す。
+    既定の fetcher は同期（ブロッキング RPC）のため、async 経路を塞がないよう
+    asyncio.to_thread で別スレッド実行する。
+    """
+
+    def __init__(
+        self,
+        fetcher: Optional[Callable[[str], "AaveMarketData"]] = None,
+        asset_symbol: str = "USDC",
+    ) -> None:
+        """AaveSignalAdapter を初期化する。
+
+        Args:
+            fetcher: AaveMarketData を返す同期 callable。None の場合は
+                aave_data_fetcher.fetch_aave_market_data_safe を遅延 import で使う。
+                テストでは mock callable を注入できる。
+            asset_symbol: 取得対象の資産シンボル（既定 USDC）。
+        """
+        self._fetcher = fetcher
+        self._asset_symbol = asset_symbol
+
+    def _resolve_fetcher(self) -> Callable[[str], "AaveMarketData"]:
+        if self._fetcher is not None:
+            return self._fetcher
+        from app.automation.aave_data_fetcher import (  # noqa: PLC0415
+            fetch_aave_market_data_safe,
+        )
+
+        return fetch_aave_market_data_safe
+
+    async def get_supply_apy(self) -> Decimal:
+        """Aave supply APY（%, 0-100 表記）を返す。失敗時はフォールバック値。"""
+        try:
+            fetcher = self._resolve_fetcher()
+            data = await asyncio.to_thread(fetcher, self._asset_symbol)
+            supply_apy = data.get("supply_apy")
+            if supply_apy is None:
+                logger.debug(
+                    "AaveSignalAdapter.get_supply_apy: supply_apy=None, フォールバック=%s",
+                    _FALLBACK_AAVE_USDC_APY,
+                )
+                return _FALLBACK_AAVE_USDC_APY
+            logger.debug("AaveSignalAdapter.get_supply_apy: apy=%s", supply_apy)
+            return supply_apy
+        except Exception as exc:
+            logger.warning("AaveSignalAdapter.get_supply_apy 失敗、フォールバック: %s", exc)
+            return _FALLBACK_AAVE_USDC_APY

--- a/backend/app/ai/optimizer/strategy_scorer.py
+++ b/backend/app/ai/optimizer/strategy_scorer.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 from typing import Optional
 
 from .schemas import Protocol, StrategyCandidate
-from .signal_adapter import LidoSignalAdapter, PendleSignalAdapter
+from .signal_adapter import AaveSignalAdapter, LidoSignalAdapter, PendleSignalAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +67,7 @@ class StrategyScorer:
         self,
         pendle_adapter: Optional[PendleSignalAdapter] = None,
         lido_adapter: Optional[LidoSignalAdapter] = None,
+        aave_adapter: Optional[AaveSignalAdapter] = None,
         risk_mode: str = "balanced",
     ) -> None:
         """StrategyScorer を初期化する。
@@ -74,11 +75,13 @@ class StrategyScorer:
         Args:
             pendle_adapter: Pendle シグナルアダプター。None の場合はダミー定数を使用。
             lido_adapter: Lido シグナルアダプター。None の場合はダミー定数を使用。
+            aave_adapter: Aave シグナルアダプター。None の場合はダミー定数を使用。
             risk_mode: リスクモード（conservative/balanced/aggressive）。
                        ランキングに使用するリスクペナルティ係数を変える。
         """
         self._pendle_adapter = pendle_adapter
         self._lido_adapter = lido_adapter
+        self._aave_adapter = aave_adapter
         self._risk_mode = risk_mode
         self._risk_weight = _RISK_WEIGHT.get(risk_mode, _DEFAULT_RISK_WEIGHT)
         if risk_mode not in _RISK_WEIGHT:
@@ -237,6 +240,35 @@ class StrategyScorer:
     # 非同期スコアメソッド（adapter から実データ取得）
     # ---------------------------------------------------------------------- #
 
+    async def score_aave_async(self, asset: str = "USDC") -> StrategyCandidate:
+        """Aave V3 supply の StrategyCandidate を生成する（adapter 優先 / M3）。
+
+        adapter が注入されている場合は実 supply APY を使用する。
+        未注入時はダミー定数 AAVE_USDC_APY（4.5）を継続使用（後方互換 / fail-open）。
+        """
+        if self._aave_adapter is not None:
+            apy = await self._aave_adapter.get_supply_apy()
+        else:
+            apy = self.AAVE_USDC_APY
+
+        risk_penalty = self._apply_risk_weight(self.RISK_AAVE_USDC)
+        logger.debug(
+            "score_aave_async: asset=%s, apy=%s, risk_penalty=%s (mode=%s)",
+            asset,
+            apy,
+            risk_penalty,
+            self._risk_mode,
+        )
+        return StrategyCandidate(
+            protocol=Protocol.AAVE,
+            asset=asset,
+            expected_apy=apy,
+            gas_cost_usd=self.GAS_AAVE,
+            bridge_cost_usd=Decimal("0"),
+            risk_penalty=risk_penalty,
+            liquidity_available=self.LIQUIDITY_AAVE,
+        )
+
     async def score_lido_async(self) -> StrategyCandidate:
         """Lido stETH ステーキングの StrategyCandidate を生成する（adapter 優先）。
 
@@ -358,16 +390,15 @@ class StrategyScorer:
     async def get_all_candidates_async(self) -> list[StrategyCandidate]:
         """全5プロトコルの候補を取得する（adapter から実データ取得・非同期版）。
 
-        adapter が注入されていれば Lido/Pendle は実データ優先。なければダミー定数。
+        adapter が注入されていれば Aave/Lido/Pendle すべて実データ優先。なければダミー定数。
 
-        注意（M3 非対称・暫定）: Aave は本メソッドでも score_aave()（同期・ダミー APY
-        AAVE_USDC_APY=4.5）を継続使用する。Aave 実 APY 取得 adapter は未実装のため、
-        adapter 注入時は Aave だけダミー / Lido・Pendle だけ実 APY という非対称が生じる。
-        Aave 側の実 APY 化は next-PR（router docstring TODO 参照）で対応する。
-        本メソッド自体も現状 router の sync compare() からは未配線。
+        M3 解消（#625 フォローアップ）: 従来は Aave のみ同期 score_aave()（ダミー APY）を
+        使い Lido/Pendle と非対称だったが、aave_adapter 注入時は score_aave_async() 経由で
+        実 supply APY を使用するようになり対称化した。aave_adapter 未注入時は従来どおり
+        ダミー定数 AAVE_USDC_APY を継続（fail-open / 後方互換）。
         """
         candidates = [
-            self.score_aave(),
+            await self.score_aave_async(),
             await self.score_lido_async(),
             await self.score_lido_aave_async(),
             await self.score_pendle_pt_async(),

--- a/backend/tests/ai/test_optimizer/test_comparator.py
+++ b/backend/tests/ai/test_optimizer/test_comparator.py
@@ -72,6 +72,63 @@ class TestCompare:
             assert isinstance(candidate.risk_adjusted_yield, Decimal)
 
 
+class TestCompareAsync:
+    """compare_async メソッドのテスト（#625 M2/M3 live 配線）。"""
+
+    @pytest.mark.asyncio
+    async def test_compare_async_returns_all_candidates(
+        self, comparator: StrategyComparator
+    ) -> None:
+        """compare_async が全5候補を含む StrategyComparison を返すこと（adapter なし）。"""
+        result = await comparator.compare_async(Decimal("10000"))
+        assert len(result.candidates) == 5
+        assert result.recommended.rank == 1
+
+    @pytest.mark.asyncio
+    async def test_compare_async_matches_sync_without_adapters(
+        self, comparator: StrategyComparator
+    ) -> None:
+        """adapter 未注入なら compare() と compare_async() の数値が一致すること（後方互換）。"""
+        sync_result = comparator.compare(Decimal("10000"), risk_mode="balanced")
+        async_result = await comparator.compare_async(Decimal("10000"), risk_mode="balanced")
+        sync_map = {c.protocol.value: c.expected_net_benefit for c in sync_result.candidates}
+        async_map = {c.protocol.value: c.expected_net_benefit for c in async_result.candidates}
+        assert sync_map == async_map
+
+    @pytest.mark.asyncio
+    async def test_compare_async_reflects_injected_aave_apy(self) -> None:
+        """aave_adapter 注入時、compare_async の Aave 候補が実 APY を反映すること（M3）。"""
+        from app.ai.optimizer.signal_adapter import AaveSignalAdapter
+
+        def fake_fetcher(asset_symbol: str) -> dict[str, object]:
+            return {
+                "utilization_rate": None,
+                "supply_apy": Decimal("12.0"),
+                "borrow_apy": None,
+                "health_factor": None,
+            }
+
+        scorer = StrategyScorer(aave_adapter=AaveSignalAdapter(fetcher=fake_fetcher))
+        comparator = StrategyComparator(scorer=scorer)
+        # 実 APY を反映した async 経路
+        async_result = await comparator.compare_async(Decimal("10000"), risk_mode="balanced")
+        async_aave = next(c for c in async_result.candidates if c.protocol.value == "aave")
+        # ダミー APY (4.5) を使う sync 経路と比較し、実 APY (12.0) の方が利益が大きいこと
+        sync_result = comparator.compare(Decimal("10000"), risk_mode="balanced")
+        sync_aave = next(c for c in sync_result.candidates if c.protocol.value == "aave")
+        assert async_aave.expected_net_benefit > sync_aave.expected_net_benefit
+
+    @pytest.mark.asyncio
+    async def test_compare_async_risk_mode_propagates(self) -> None:
+        """compare_async でも risk_mode がランキングへ伝播すること（M1 + async）。"""
+        comparator = StrategyComparator()
+        conservative = await comparator.compare_async(Decimal("10000"), risk_mode="conservative")
+        aggressive = await comparator.compare_async(Decimal("10000"), risk_mode="aggressive")
+        c_yt = next(c for c in conservative.candidates if c.protocol.value == "pendle_yt")
+        a_yt = next(c for c in aggressive.candidates if c.protocol.value == "pendle_yt")
+        assert c_yt.expected_net_benefit < a_yt.expected_net_benefit
+
+
 class TestGenerateReport:
     """generate_report メソッドのテスト。"""
 

--- a/backend/tests/ai/test_optimizer/test_optimizer_router.py
+++ b/backend/tests/ai/test_optimizer/test_optimizer_router.py
@@ -104,7 +104,7 @@ class TestRecommendEndpoint:
             patch("app.ai.optimizer.router.PortfolioAllocator") as mock_allocator_cls,
         ):
             mock_comparator = MagicMock()
-            mock_comparator.compare.return_value = comparison
+            mock_comparator.compare_async = AsyncMock(return_value=comparison)
             mock_comparator.generate_report.return_value = report
             mock_comparator_cls.return_value = mock_comparator
 
@@ -134,7 +134,7 @@ class TestRecommendEndpoint:
             patch("app.ai.optimizer.router.PortfolioAllocator") as mock_allocator_cls,
         ):
             mock_comparator = MagicMock()
-            mock_comparator.compare.return_value = comparison
+            mock_comparator.compare_async = AsyncMock(return_value=comparison)
             mock_comparator.generate_report.return_value = report
             mock_comparator_cls.return_value = mock_comparator
 
@@ -160,7 +160,7 @@ class TestRecommendEndpoint:
         """ValueError 発生時に 422 を返すこと。"""
         with patch("app.ai.optimizer.router.StrategyComparator") as mock_comparator_cls:
             mock_comparator = MagicMock()
-            mock_comparator.compare.side_effect = ValueError("無効な投資額")
+            mock_comparator.compare_async = AsyncMock(side_effect=ValueError("無効な投資額"))
             mock_comparator_cls.return_value = mock_comparator
 
             response = _client.post(
@@ -178,7 +178,7 @@ class TestRecommendEndpoint:
         """予期しない例外発生時に 503 を返すこと。"""
         with patch("app.ai.optimizer.router.StrategyComparator") as mock_comparator_cls:
             mock_comparator = MagicMock()
-            mock_comparator.compare.side_effect = RuntimeError("内部エラー")
+            mock_comparator.compare_async = AsyncMock(side_effect=RuntimeError("内部エラー"))
             mock_comparator_cls.return_value = mock_comparator
 
             response = _client.post(
@@ -202,7 +202,7 @@ class TestRecommendEndpoint:
             patch("app.ai.optimizer.router.PortfolioAllocator") as mock_allocator_cls,
         ):
             mock_comparator = MagicMock()
-            mock_comparator.compare.return_value = comparison
+            mock_comparator.compare_async = AsyncMock(return_value=comparison)
             mock_comparator.generate_report.return_value = "balanced report"
             mock_comparator_cls.return_value = mock_comparator
 
@@ -220,12 +220,64 @@ class TestRecommendEndpoint:
             )
 
         assert response.status_code == 200
-        # compare に balanced モードが渡されること
-        mock_comparator.compare.assert_called_once_with(
+        # compare_async に balanced モードが渡されること
+        mock_comparator.compare_async.assert_awaited_once_with(
             investment_usd=Decimal("5000"),
             risk_mode="balanced",
             holding_days=90,
         )
+
+
+class TestBuildLiveScorer:
+    """_build_live_scorer の adapter 注入・fail-open 検証（#625 M2/M3）。"""
+
+    def test_injects_all_adapters(self) -> None:
+        """正常時は Pendle/Lido/Aave の全 adapter が注入されること。"""
+        from app.ai.optimizer.router import _build_live_scorer
+
+        scorer = _build_live_scorer("balanced")
+        assert scorer._pendle_adapter is not None
+        assert scorer._lido_adapter is not None
+        assert scorer._aave_adapter is not None
+        assert scorer._risk_mode == "balanced"
+
+    def test_fail_open_when_pendle_factory_raises(self) -> None:
+        """Pendle client 生成失敗時も他 adapter は注入され例外を投げないこと（fail-open）。"""
+        from app.ai.optimizer.router import _build_live_scorer
+
+        with patch(
+            "app.protocols.pendle.client.get_pendle_client",
+            side_effect=RuntimeError("pendle down"),
+        ):
+            scorer = _build_live_scorer("conservative")
+        # Pendle のみ None、Lido/Aave は生成される
+        assert scorer._pendle_adapter is None
+        assert scorer._lido_adapter is not None
+        assert scorer._aave_adapter is not None
+
+    def test_recommend_live_path_with_adapter_failures_returns_200(self) -> None:
+        """全 client 生成失敗でも live 経路がフォールバックで 200 を返すこと（fail-open）。"""
+        with (
+            patch(
+                "app.protocols.pendle.client.get_pendle_client",
+                side_effect=RuntimeError("pendle down"),
+            ),
+            patch(
+                "app.protocols.lido.client.get_lido_client",
+                side_effect=RuntimeError("lido down"),
+            ),
+        ):
+            response = _client.post(
+                "/api/ai/optimizer/recommend",
+                json={
+                    "investment_usd": "1000",
+                    "risk_mode": "balanced",
+                    "holding_days": 30,
+                },
+            )
+        assert response.status_code == 200, response.text
+        candidates = response.json()["comparison"]["candidates"]
+        assert len(candidates) == 5
 
 
 class TestRecommendRiskModeLive:

--- a/backend/tests/ai/test_optimizer/test_signal_adapter.py
+++ b/backend/tests/ai/test_optimizer/test_signal_adapter.py
@@ -17,11 +17,13 @@ import pytest
 
 from app.ai.optimizer.schemas import Protocol
 from app.ai.optimizer.signal_adapter import (
+    _FALLBACK_AAVE_USDC_APY,
     _FALLBACK_LIDO_APY,
     _FALLBACK_PEG_DEVIATION,
     _FALLBACK_PENDLE_MATURITY_DAYS,
     _FALLBACK_PENDLE_PT_APY,
     _FALLBACK_PENDLE_YT_APY,
+    AaveSignalAdapter,
     LidoSignalAdapter,
     PendleSignalAdapter,
 )
@@ -462,3 +464,94 @@ class TestRiskModeWeight:
         """_RISK_WEIGHT の各値が Decimal 型であること。"""
         for mode, weight in _RISK_WEIGHT.items():
             assert isinstance(weight, Decimal), f"risk_mode={mode}: weight is not Decimal"
+
+
+# --------------------------------------------------------------------------- #
+# AaveSignalAdapter / score_aave_async テスト（M3 解消 / #625 フォローアップ）
+# --------------------------------------------------------------------------- #
+class TestAaveSignalAdapter:
+    """AaveSignalAdapter の実 APY 取得・フォールバック・例外時の検証。"""
+
+    @pytest.mark.asyncio
+    async def test_returns_real_supply_apy(self) -> None:
+        """fetcher が supply_apy を返す場合はその値を返すこと。"""
+
+        def fake_fetcher(asset_symbol: str) -> dict[str, object]:
+            return {
+                "utilization_rate": Decimal("50"),
+                "supply_apy": Decimal("6.3"),
+                "borrow_apy": Decimal("8.0"),
+                "health_factor": None,
+            }
+
+        adapter = AaveSignalAdapter(fetcher=fake_fetcher)
+        apy = await adapter.get_supply_apy()
+        assert apy == Decimal("6.3")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_supply_apy_none(self) -> None:
+        """fetcher が supply_apy=None を返す場合はフォールバック定数を返すこと。"""
+
+        def fake_fetcher(asset_symbol: str) -> dict[str, object]:
+            return {
+                "utilization_rate": None,
+                "supply_apy": None,
+                "borrow_apy": None,
+                "health_factor": None,
+            }
+
+        adapter = AaveSignalAdapter(fetcher=fake_fetcher)
+        apy = await adapter.get_supply_apy()
+        assert apy == _FALLBACK_AAVE_USDC_APY
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_fetcher_raises(self) -> None:
+        """fetcher が例外を投げても握りつぶしフォールバック定数を返すこと（fail-open）。"""
+
+        def boom(asset_symbol: str) -> dict[str, object]:
+            raise RuntimeError("rpc down")
+
+        adapter = AaveSignalAdapter(fetcher=boom)
+        apy = await adapter.get_supply_apy()
+        assert apy == _FALLBACK_AAVE_USDC_APY
+
+    @pytest.mark.asyncio
+    async def test_score_aave_async_uses_adapter(self) -> None:
+        """score_aave_async が adapter 注入時に実 APY を反映すること。"""
+
+        def fake_fetcher(asset_symbol: str) -> dict[str, object]:
+            return {
+                "utilization_rate": None,
+                "supply_apy": Decimal("7.1"),
+                "borrow_apy": None,
+                "health_factor": None,
+            }
+
+        scorer = StrategyScorer(aave_adapter=AaveSignalAdapter(fetcher=fake_fetcher))
+        aave = await scorer.score_aave_async()
+        assert aave.protocol == Protocol.AAVE
+        assert aave.expected_apy == Decimal("7.1")
+
+    @pytest.mark.asyncio
+    async def test_score_aave_async_without_adapter_uses_dummy(self) -> None:
+        """aave_adapter 未注入なら従来のダミー定数を継続使用すること（後方互換）。"""
+        scorer = StrategyScorer()
+        aave = await scorer.score_aave_async()
+        assert aave.expected_apy == StrategyScorer.AAVE_USDC_APY
+
+    @pytest.mark.asyncio
+    async def test_m3_symmetry_aave_real_apy_in_ranking(self) -> None:
+        """M3: aave_adapter 注入時 get_all_candidates_async の Aave が実 APY を反映すること。"""
+
+        def fake_fetcher(asset_symbol: str) -> dict[str, object]:
+            return {
+                "utilization_rate": None,
+                "supply_apy": Decimal("9.9"),
+                "borrow_apy": None,
+                "health_factor": None,
+            }
+
+        scorer = StrategyScorer(aave_adapter=AaveSignalAdapter(fetcher=fake_fetcher))
+        candidates = await scorer.get_all_candidates_async()
+        aave = next(c for c in candidates if c.protocol == Protocol.AAVE)
+        assert aave.expected_apy == Decimal("9.9")

--- a/backend/tests/test_ai_optimizer_router.py
+++ b/backend/tests/test_ai_optimizer_router.py
@@ -84,7 +84,7 @@ class TestOptimizerRouter:
     ) -> None:
         """conservative モードで 200 が返ること。"""
         mock_comparator = MagicMock()
-        mock_comparator.compare.return_value = _make_comparison()
+        mock_comparator.compare_async = AsyncMock(return_value=_make_comparison())
         mock_comparator.generate_report.return_value = "レポート本文"
         mock_comparator_cls.return_value = mock_comparator
 
@@ -116,7 +116,7 @@ class TestOptimizerRouter:
     ) -> None:
         """aggressive モードでも 200 が返ること。"""
         mock_comparator = MagicMock()
-        mock_comparator.compare.return_value = _make_comparison()
+        mock_comparator.compare_async = AsyncMock(return_value=_make_comparison())
         mock_comparator.generate_report.return_value = "aggressive report"
         mock_comparator_cls.return_value = mock_comparator
 
@@ -144,7 +144,7 @@ class TestOptimizerRouter:
     ) -> None:
         """compare / allocate に正しい引数が渡ること。"""
         mock_comparator = MagicMock()
-        mock_comparator.compare.return_value = _make_comparison()
+        mock_comparator.compare_async = AsyncMock(return_value=_make_comparison())
         mock_comparator.generate_report.return_value = ""
         mock_comparator_cls.return_value = mock_comparator
 
@@ -161,7 +161,7 @@ class TestOptimizerRouter:
             },
         )
 
-        mock_comparator.compare.assert_called_once_with(
+        mock_comparator.compare_async.assert_awaited_once_with(
             investment_usd=Decimal("5000"),
             risk_mode="balanced",
             holding_days=60,
@@ -179,7 +179,7 @@ class TestOptimizerRouter:
     ) -> None:
         """内部例外が 503 になること。"""
         mock_comparator = MagicMock()
-        mock_comparator.compare.side_effect = RuntimeError("DB接続失敗")
+        mock_comparator.compare_async = AsyncMock(side_effect=RuntimeError("DB接続失敗"))
         mock_comparator_cls.return_value = mock_comparator
 
         resp = client.post(
@@ -200,7 +200,7 @@ class TestOptimizerRouter:
     ) -> None:
         """ValueError が 422 になること。"""
         mock_comparator = MagicMock()
-        mock_comparator.compare.side_effect = ValueError("不正なリスクモード")
+        mock_comparator.compare_async = AsyncMock(side_effect=ValueError("不正なリスクモード"))
         mock_comparator_cls.return_value = mock_comparator
 
         resp = client.post(


### PR DESCRIPTION
## 概要

PR #625 で「次 PR」に明示先送りした 2 件を解消し、`/api/ai/optimizer/recommend` が**実プロトコルデータで動く**ようにする (EPIC-5 実パラメータ統合の前提)。

- **M2 解消**: `router._build_live_scorer()` が Pendle/Lido/Aave の実 client から SignalAdapter を生成・注入。**protocol 単位の独立 fail-open** (1 protocol の client 生成失敗は当該 adapter のみダミー定数継続、全滅でも 200 + 5 候補)
- **M3 解消**: `AaveSignalAdapter` 新設 + `score_aave_async()` — 実 APY 源は `fetch_aave_market_data_safe` (Pool.getReserveData 直読・read-only・秘密鍵不要)。Lido/Pendle と対称化し、ダミー APY 非対称による ranking 歪みを解消
- `TODO(next-PR)` マーカー 2 箇所すべて解消 (grep 0 件確認済み)

## async 設計

`compare()` の sync シグネチャを温存し **`compare_async()` を追加** (既存 sync テスト回帰ゼロ)。ランキング後処理は `_build_comparison()` に抽出し sync/async 完全共通化。Aave の同期 RPC は `asyncio.to_thread` で包みイベントループを塞がない。

## CLAUDE.md 開発ルール準拠

- adapter は read-only メソッドのみ (`get_staking_apr` / `get_steth_eth_ratio` / `get_market_info` — 実在を grep 確認、鉄則 9)
- client=None/例外 → ダミー定数 fail-open / SignalAggregator は作らない / Decimal 厳守
- Tier S diff なし (main.py 不変、`git diff --name-only` で確認)

## 検証

- ruff / format / mypy (262 files) clean
- optimizer 対象 181 passed (+7 新規: AaveSignalAdapter / compare_async / fail-open)
- **フルスイート 3703 passed / coverage 85.09%**
- rebase 後 push 前に Tier S 混入なしを再監査

🤖 Generated with [Claude Code](https://claude.com/claude-code)