### PR TITLE
feat(frontend): Arobixカラーテーマを liff 全画面に適用

### DIFF
--- a/frontend/app/(liff)/layout.tsx
+++ b/frontend/app/(liff)/layout.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 'use client'
 
+import '../arobix/theme.css'
 import { useEffect } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import { useLiff } from '@/hooks/useLiff'
@@ -48,24 +49,30 @@ export default function LiffLayout({ children }: { children: React.ReactNode }) 
   // 下の通常描画にフォールスルーして children をブラウザで表示する（degrade）。
   if (liffConfigured && error) {
     return (
-      <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center">
-        <p className="text-red-400">LIFF初期化エラー: {error}</p>
+      <div className="arobix-root">
+        <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center">
+          <p className="text-red-400">LIFF初期化エラー: {error}</p>
+        </div>
       </div>
     )
   }
 
   if (!isInitialized) {
     return (
-      <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center">
-        <p className="text-zinc-400">読み込み中...</p>
+      <div className="arobix-root">
+        <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center">
+          <p className="text-zinc-400">読み込み中...</p>
+        </div>
       </div>
     )
   }
 
   if (reauth.state === 'reauthing') {
     return (
-      <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center">
-        <p className="text-zinc-400">セッションを復元しています...</p>
+      <div className="arobix-root">
+        <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center">
+          <p className="text-zinc-400">セッションを復元しています...</p>
+        </div>
       </div>
     )
   }
@@ -79,8 +86,10 @@ export default function LiffLayout({ children }: { children: React.ReactNode }) 
   const isExempt = AUTH_GUARD_EXEMPT.includes(pathname ?? '')
   if (liffConfigured && !isLoggedIn && !token && !isExempt) {
     return (
-      <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center px-4">
-        <p className="text-zinc-400 text-sm">LINEアプリから開いてください</p>
+      <div className="arobix-root">
+        <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center px-4">
+          <p className="text-zinc-400 text-sm">LINEアプリから開いてください</p>
+        </div>
       </div>
     )
   }
@@ -90,16 +99,20 @@ export default function LiffLayout({ children }: { children: React.ReactNode }) 
   // /liff-confirm へ遷移するまで読み込み表示でブロックする (未同意ホームの一瞬の表示も防ぐ)。
   if (needsTermsGate && termsState !== 'accepted') {
     return (
-      <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center">
-        <p className="text-zinc-400">読み込み中...</p>
+      <div className="arobix-root">
+        <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center">
+          <p className="text-zinc-400">読み込み中...</p>
+        </div>
       </div>
     )
   }
 
   return (
-    <PrivyRootClient>
-      <SessionExpiryBanner loginHref="/liff-login" />
-      {children}
-    </PrivyRootClient>
+    <div className="arobix-root">
+      <PrivyRootClient>
+        <SessionExpiryBanner loginHref="/liff-login" />
+        {children}
+      </PrivyRootClient>
+    </div>
   )
 }

--- a/frontend/app/arobix/theme.css
+++ b/frontend/app/arobix/theme.css
@@ -132,3 +132,45 @@
   position: relative;
   background: var(--bg-app);
 }
+
+/* ================================================================
+ * Liff dark → Arobix warm-light overrides
+ * 既存 liff 画面のダーク系 Tailwind クラスを .arobix-root スコープ内で
+ * Arobix ウォームライトパレットにマッピングする。
+ * ================================================================ */
+
+/* App background */
+.arobix-root { background-color: #f7f2ea; }
+
+/* Zinc dark backgrounds → Arobix warm */
+.arobix-root .bg-zinc-950 { background-color: #f7f2ea !important; }
+.arobix-root .bg-zinc-900 { background-color: #f5ecdd !important; }
+.arobix-root .bg-zinc-800 { background-color: #ede4d4 !important; }
+.arobix-root .bg-zinc-700 { background-color: #e0d5c4 !important; }
+
+/* Dark green headers → Arobix gradient */
+.arobix-root .bg-\[\#1a3d2e\] {
+  background: linear-gradient(135deg, #b9a4f2 0%, #ecaccd 52%, #fbd9a0 100%) !important;
+}
+
+/* Light text on dark → dark text on light */
+.arobix-root .text-white { color: #2a2440 !important; }
+.arobix-root .text-zinc-100 { color: #1c1a27 !important; }
+.arobix-root .text-zinc-300 { color: #2a2440 !important; }
+.arobix-root .text-zinc-400 { color: #736f7e !important; }
+.arobix-root .text-zinc-500 { color: #9d98a6 !important; }
+.arobix-root .text-zinc-600 { color: #b0aab9 !important; }
+
+/* Keep white text on intentionally colored buttons/badges */
+.arobix-root .bg-\[\#1D9E75\].text-white,
+.arobix-root .bg-\[\#1D9E75\] .text-white,
+.arobix-root .bg-red-500.text-white,
+.arobix-root .bg-red-500 .text-white { color: white !important; }
+
+/* Keep text-transparent for logo-shine / bg-clip-text */
+.arobix-root .text-transparent { color: transparent !important; }
+
+/* Borders */
+.arobix-root .border-zinc-800 { border-color: #e5ddd0 !important; }
+.arobix-root .border-zinc-700 { border-color: #d8cfc4 !important; }
+.arobix-root .border-zinc-600 { border-color: #cfc5b8 !important; }


### PR DESCRIPTION
## Summary
- PR #603 で `/arobix/` プレビュールートに作成したArobixテーマを、既存 liff 画面（liff-chat / liff-approve / liff-history 等）に適用
- `theme.css` に `.arobix-root` スコープのCSSオーバーライドを追加（dark zinc → Arobix warm-light、dark green header → 紫ピンク暖色グラデ）
- liff `layout.tsx` で `theme.css` をimportし、全 return を `<div className="arobix-root">` でラップ
- page.tsx / panel コンポーネントは**無修正**（CSS上書きのみ）

## 変更内容
| ファイル | 変更 |
|---|---|
| `frontend/app/arobix/theme.css` | dark→light オーバーライドCSS 42行追加 |
| `frontend/app/(liff)/layout.tsx` | theme.css import + arobix-rootラッパー |

## カラーマッピング
| 変更前 | 変更後 |
|---|---|
| `bg-zinc-950` (ほぼ黒) | `#f7f2ea` (暖かいオフホワイト) |
| `bg-zinc-900` (濃グレー) | `#f5ecdd` (クリーム) |
| `bg-[#1a3d2e]` (ダーク緑) | 紫→ピンク→暖色グラデ |
| `text-white` | `#2a2440` (濃ダーク) |
| `text-zinc-400/500` | `#736f7e` / `#9d98a6` |
| BUY/SELL緑・赤 | そのまま維持 |

## Test plan
- [ ] staging デプロイ後、`/liff-chat` を開いてArobixウォームライトテーマになっていることを確認
- [ ] BUYシグナル時: 緑ボタン・赤ボタンのテキストが白のままであることを確認
- [ ] ロゴ光沢アニメ（animate-logo-shine）が正常動作していることを確認
- [ ] ハンバーガーメニュー・SlideUpPanel・各パネルが全てウォームライトで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)