### PR TITLE
fix(onboarding): / を /connect (Privy UI) に誘導 + UserGuard から /connect を除外

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -21,7 +21,7 @@ function RedirectGate() {
     if (isAuthenticated) {
       router.replace(getRoleDefaultPath(user?.role))
     } else {
-      router.replace('/login')
+      router.replace('/connect')
     }
   }, [isLoading, isAuthenticated, user, router])
 

--- a/frontend/components/user/UserProviders.tsx
+++ b/frontend/components/user/UserProviders.tsx
@@ -3,7 +3,7 @@
 // Unauthorized copying or distribution is strictly prohibited.
 
 import { createContext, useContext, useState, useEffect, useCallback } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 import { AuthProvider, useAuth } from '@/lib/auth'
 import { SessionExpiryBanner } from '@/components/SessionExpiryBanner'
 import { Toaster } from 'sonner'
@@ -40,20 +40,27 @@ function toSystemStatus(s: AutomationStatus): SystemStatus {
   return 'NORMAL'
 }
 
+/** UserGuard を適用しないパス（Privy オンボーディング経路） */
+const GUARD_EXEMPT_PATHS = ['/connect']
+
 function UserGuard({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, isLoading } = useAuth()
   const router = useRouter()
+  const pathname = usePathname()
+
+  const isExempt = GUARD_EXEMPT_PATHS.includes(pathname ?? '')
 
   useEffect(() => {
+    if (isExempt) return
     if (!isLoading && !isAuthenticated) {
       router.replace('/login')
     }
-  }, [isLoading, isAuthenticated, router])
+  }, [isLoading, isAuthenticated, router, isExempt])
 
   if (isLoading) {
     return <div style={{ padding: 40, textAlign: 'center' }}>読み込み中...</div>
   }
-  if (!isAuthenticated) {
+  if (!isExempt && !isAuthenticated) {
     return null
   }
   return <>{children}</>


### PR DESCRIPTION
## Summary

- `app/page.tsx`: 未認証時のリダイレクト先を `/login` → `/connect` に変更
- `UserProviders.tsx`: `UserGuard` に `GUARD_EXEMPT_PATHS = ['/connect']` を追加（Privy ログイン前にアクセスするページのため除外）

## 修正前後のフロー

**修正前:** `/` → `/login`（旧メール/パスワードUI）  
**修正後:** `/` → `/connect`（Privy UI）→ wallet接続 → 規約チェック → `/user/dashboard`

## 注意
- 管理者・パートナーは `/login` に直接アクセスすれば従来通りメール/パスワードでログイン可能
- `BrowserTermsGate` は `UserGuard` の内側にあるため、`/connect` 経由でログイン後に terms チェックが機能する

Closes Asana GID 1215645261952731

## Test plan
- [ ] staging で `/` にアクセス → `/connect`（Privy UI）が表示される
- [ ] Privy でウォレット接続 → 規約チェックボックスにチェック → 「運用を開始する」→ `/user/dashboard` に遷移
- [ ] 既存ログイン済みユーザーは `/` → 各ロールのダッシュボードに直行
- [ ] tsc --noEmit: pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)