### PR TITLE
fix(liff): PWA モード (v3) でトークンなし → /liff-login (Privy) に誘導

### DIFF
--- a/frontend/app/(liff)/layout.tsx
+++ b/frontend/app/(liff)/layout.tsx
@@ -85,6 +85,18 @@ export default function LiffLayout({ children }: { children: React.ReactNode }) 
     )
   }
 
+  // ブラウザ PWA モード (liffConfigured=false / v3) でトークンなし かつ要認証パス
+  // → /liff-login (BrowserLoginPrompt / Privy) へ誘導する。
+  const needsAuth = TERMS_GATE_PATHS.some((p) => (pathname ?? '').startsWith(p))
+  if (!liffConfigured && !token && needsAuth && !isExempt) {
+    router.replace('/liff-login')
+    return (
+      <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center">
+        <p className="text-zinc-400">読み込み中...</p>
+      </div>
+    )
+  }
+
   // ── 重要事項同意ガード (render) ──
   // 同意未確定 (loading / not-accepted) の間は children を描画せず、上の useEffect が
   // /liff-confirm へ遷移するまで読み込み表示でブロックする (未同意ホームの一瞬の表示も防ぐ)。


### PR DESCRIPTION
## Summary

ブラウザ PWA モード (`liffConfigured=false` / v3 本番形態) で JWT なしに `/liff-chat` にアクセスした新規ユーザーが、認証ガードをスルーして空のダッシュボードを見ていた問題を修正。

`(liff)/layout.tsx` に PWA モード用の auth gate を追加:
- `liffConfigured=false` かつ token なし かつ `TERMS_GATE_PATHS`（`/liff-chat`）へのアクセス → `/liff-login` へリダイレクト

## 修正後のオンボーディングフロー

```
新規ユーザーが /liff-chat を開く
  → トークンなし → /liff-login へリダイレクト
  → BrowserLoginPrompt (Privy メール / ウォレット)
  → Privy 認証完了 → JWT 取得
  → /liff-confirm (重要事項同意)
  → 同意完了 → /liff-chat (グローロゴ UAT ダッシュボード)
```

## Test plan
- [ ] シークレットウィンドウで `https://staging.ultra-auto-trade.com/liff-chat` → `/liff-login` にリダイレクトされる
- [ ] BrowserLoginPrompt (Privy) が表示される
- [ ] Privy でログイン → `/liff-confirm` → 同意 → `/liff-chat` に遷移
- [ ] tsc --noEmit: pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)