### PR TITLE
test(pendle): RouterV4 _extract_approvals 実コードパス統合テスト追加 (EPIC-3 3-6)

### DIFF
--- a/backend/tests/protocols/test_pendle/test_pendle_service_real_execution.py
+++ b/backend/tests/protocols/test_pendle/test_pendle_service_real_execution.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from app.protocols.pendle.client import PendleRouterV4Client
 from app.protocols.pendle.config import PendleConfig
 from app.protocols.pendle.schemas import (
     PendleMarketInfo,
@@ -285,3 +286,106 @@ class TestGetMarketInfo:
         result = await svc.estimate_fixed_yield(Decimal("1.0"), _MARKET_ADDR)
 
         assert result == Decimal("0")
+
+
+_ROUTER = "0x888888888889758F76e7103c6CbF23ABbF58F946"
+_MARKET = "0x" + "aa" * 20
+_TOKEN_IN = "0x" + "bb" * 20  # noqa: S106 — トークンアドレス（パスワードではない）
+_RECEIVER = "0x" + "dd" * 20
+
+
+def _sdk_resp(
+    *,
+    to: str = _ROUTER,
+    data: str = "0xdeadbeef",
+    approvals: list | None = None,
+) -> dict:
+    """テスト用 SDK レスポンスを生成する。"""
+    resp: dict = {
+        "data": {
+            "tx": {"to": to, "data": data},
+            "amountOut": str(int(Decimal("0.95") * Decimal(10**18))),
+        }
+    }
+    if approvals is not None:
+        resp["data"]["approvals"] = approvals
+    return resp
+
+
+@pytest.fixture
+def router_client_write_enabled() -> PendleRouterV4Client:
+    """enable_onchain_write=True の RouterV4 クライアント（実コードパス統合テスト用）。
+
+    Q1 ガード（enable_onchain_write=False）は test_pendle_router_v4_guard.py で検証済み。
+    本クラスは Q1 をバイパスし、_extract_approvals / _verify_router の実コードパスをテストする。
+    """
+    config = PendleConfig(sandbox=False)
+    config.enable_onchain_write = True
+    return PendleRouterV4Client(config)
+
+
+class TestRouterV4RealCalldataPath:
+    """PendleRouterV4Client の実コードパス統合テスト。
+
+    test_pendle_router_v4_guard.py / test_pendle_router_v4_security.py との重複を避け、
+    カバレッジ計測で未到達だった _extract_approvals 内の非 dict スキップ分岐を通す。
+    """
+
+    @pytest.mark.asyncio
+    async def test_extract_approvals_skips_non_dict_items(
+        self, router_client_write_enabled: PendleRouterV4Client
+    ) -> None:
+        """_extract_approvals が非 dict 要素（文字列・None）を無視して dict のみを返すこと。
+
+        approvals リストに dict と非 dict が混在する場合、非 dict は continue でスキップされ、
+        有効な dict アイテムのみが RouterV4Approval として返される。
+        """
+        # 非 dict 要素（文字列、None）を混在させた approvals を _call_sdk がモックで返す
+        mixed_approvals = [
+            "invalid_string_item",  # 非 dict — continue 分岐を通す
+            None,  # 非 dict — continue 分岐を通す
+            {"token": _TOKEN_IN, "spender": _ROUTER, "amount": "100"},  # 有効な dict
+        ]
+        sdk_resp = _sdk_resp(approvals=mixed_approvals)
+
+        with patch.object(
+            router_client_write_enabled,
+            "_call_sdk",
+            new=AsyncMock(return_value=sdk_resp),
+        ):
+            result = await router_client_write_enabled.buy_yt(
+                _MARKET,
+                _TOKEN_IN,
+                Decimal("1.0"),
+                _RECEIVER,
+            )
+
+        # 非 dict をスキップして dict のみが approvals に残ること
+        assert result.success is True
+        assert len(result.approvals) == 1
+        assert result.approvals[0].spender == _ROUTER
+        assert result.approvals[0].token == _TOKEN_IN
+
+    @pytest.mark.asyncio
+    async def test_extract_approvals_all_non_dict_returns_empty(
+        self, router_client_write_enabled: PendleRouterV4Client
+    ) -> None:
+        """approvals が全て非 dict のとき空リストが返り、Router 照合が通過すること。"""
+        all_invalid_approvals: list = ["str_item", 42, None]
+        sdk_resp = _sdk_resp(approvals=all_invalid_approvals)
+
+        with patch.object(
+            router_client_write_enabled,
+            "_call_sdk",
+            new=AsyncMock(return_value=sdk_resp),
+        ):
+            result = await router_client_write_enabled.buy_yt(
+                _MARKET,
+                _TOKEN_IN,
+                Decimal("1.0"),
+                _RECEIVER,
+            )
+
+        # 非 dict を全てスキップした結果、approvals は空 → Router 照合は通過し success=True
+        assert result.success is True
+        assert result.approvals == []


### PR DESCRIPTION
## 概要

EPIC-3 サブタスク 3-6「test_pendle_service_real_execution.py モック→実パス化」(Asana GID: **1215614752287666**) の実装。

> 注: コミットメッセージ内の GID 1215614752138567 は誤記（EPIC-0 の GID）。正しくは本 PR description の 1215614752287666 (EPIC-3)。

## Planner 判定（要旨）
- service の non-dry_run テストは既に実コードパスを通している（mock は client 境界のみ = 正しい構造）→ 剥がさない
- RouterV4 実コードのカバレッジ実測で未到達だったのは `_extract_approvals` の非 dict スキップ分岐（client.py:576）のみ
- 既存 test_pendle_router_v4_client.py / guard / security テストと重複するテストは書かない

## 変更内容
- `TestRouterV4RealCalldataPath` クラス追加（テストファイル 1 本のみ、本体コード無変更、Tier B）
  - 非 dict approvals（文字列/None/int）をスキップして dict のみ返すこと
  - 全件非 dict なら空リスト + Router 照合通過

## DoD 証跡
- pytest tests/protocols/test_pendle/ → **258 passed**（256→+2）
- ruff check / ruff format --check → clean
- coverage: client.py 86%→87%、576 行が Missing から除去（実コードパス通過の証跡）
- 署名系シンボル（wallet_private_key / send_transaction / .sign）不在を grep 確認。実ネットワーク呼出なし

## パイプライン証跡
- Planner (Opus) → Generator (Sonnet, worktree 分離) → Evaluator (Fable 5, APPROVED) → Tester (独立再実行 PASS)
- マージは人間ゲート（EPIC-3 Phase 2 実 tx 送信は本 PR のスコープ外・未承認のまま）

🤖 Generated with [Claude Code](https://claude.com/claude-code)