### PR TITLE
feat(pendle): /api/protocols/pendle/positions endpoint 実装 (EPIC-3 配線漏れ解消)

### DIFF
--- a/backend/app/protocols/pendle/router.py
+++ b/backend/app/protocols/pendle/router.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.auth.dependencies import require_admin
 
 from .client import get_pendle_client, get_pendle_router_v4_client
 from .config import get_pendle_config
@@ -17,6 +19,7 @@ from .schemas import (
     PendleMarketInfo,
     PendleMintRequest,
     PendleMintResponse,
+    PendlePositionResponse,
     PendleRedeemRequest,
     PendleRedeemResponse,
     RouterV4AddLiquidityRequest,
@@ -36,6 +39,21 @@ def _get_service() -> PendleService:
     config = get_pendle_config()
     client = get_pendle_client(config)
     return PendleService(client=client, config=config)
+
+
+@router.get(
+    "/positions",
+    response_model=PendlePositionResponse,
+    dependencies=[Depends(require_admin)],
+)
+async def list_positions() -> PendlePositionResponse:
+    """Pendle PT/YT ポジション一覧を返す。admin RBAC 必須。
+
+    sandbox モードではダミー 1 件を返す。
+    非 sandbox モードでは実残量取得手段が無いため空リストを返す。
+    """
+    service = _get_service()
+    return await service.get_positions()
 
 
 @router.get("/markets", response_model=list[PendleMarketInfo])

--- a/backend/app/protocols/pendle/schemas.py
+++ b/backend/app/protocols/pendle/schemas.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Literal, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_serializer, field_validator
 
 
 class PendleMarketInfo(BaseModel):
@@ -207,3 +207,44 @@ class RouterV4AddLiquidityResult(BaseModel):
     to: Optional[str] = None
     approvals: list[RouterV4Approval] = Field(default_factory=list)
     error: Optional[str] = None
+
+
+# --- Positions スキーマ ---
+
+
+class PendlePosition(BaseModel):
+    """Pendle PT/YT ポジション情報。
+
+    Decimal フィールドはフロントエンド契約上すべて文字列で返却する。
+    （frontend/lib/api/pendle.ts PendlePosition インターフェース準拠）
+    """
+
+    id: str
+    market_address: str
+    underlying_asset: str
+    pt_amount: Decimal
+    yt_amount: Decimal
+    pt_price_usd: Decimal
+    yt_price_usd: Decimal
+    implied_apy: Decimal
+    maturity: datetime
+    days_to_maturity: int
+    fetched_at: datetime
+
+    @field_serializer("pt_amount", "yt_amount", "pt_price_usd", "yt_price_usd", "implied_apy")
+    def serialize_decimal(self, v: Decimal) -> str:
+        return str(v)
+
+
+class PendlePositionResponse(BaseModel):
+    """Pendle ポジション一覧レスポンス。
+
+    total_value_usd はフロントエンド契約上文字列で返却する。
+    """
+
+    positions: list[PendlePosition]
+    total_value_usd: Decimal
+
+    @field_serializer("total_value_usd")
+    def serialize_total(self, v: Decimal) -> str:
+        return str(v)

--- a/backend/app/protocols/pendle/service.py
+++ b/backend/app/protocols/pendle/service.py
@@ -5,14 +5,17 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 from decimal import Decimal
 
-from .client import AbstractPendleClient
+from .client import AbstractPendleClient, DummyPendleClient
 from .config import PendleConfig
 from .schemas import (
     PendleMarketInfo,
     PendleMintRequest,
     PendleMintResponse,
+    PendlePosition,
+    PendlePositionResponse,
     PendleRedeemRequest,
     PendleRedeemResponse,
 )
@@ -212,6 +215,64 @@ class PendleService:
     async def get_market_info(self, market_address: str) -> PendleMarketInfo:
         """マーケット情報を取得する。"""
         return await self._client.get_market_info(market_address)
+
+    async def get_positions(self) -> PendlePositionResponse:
+        """PT/YT ポジション一覧を返す。
+
+        sandbox モード（DummyPendleClient）の場合はダミー 1 件を返す。
+        非 sandbox モードでは実残量取得手段が無いため正直な空リストを返す（捏造禁止）。
+        例外は握りつぶして fail-open（500 にしない）。
+        """
+        try:
+            market = self._config.market_address
+            info = await self._client.get_market_info(market)
+
+            is_sandbox = isinstance(self._client, DummyPendleClient)
+
+            if is_sandbox:
+                pt_amount = Decimal("100")
+                yt_amount = Decimal("100")
+                pt_price_usd = info.pt_price
+                yt_price_usd = info.yt_price
+                total_value_usd = pt_amount * pt_price_usd + yt_amount * yt_price_usd
+                position = PendlePosition(
+                    id=f"pendle-{market[:10]}",
+                    market_address=market,
+                    underlying_asset=info.underlying_asset,
+                    pt_amount=pt_amount,
+                    yt_amount=yt_amount,
+                    pt_price_usd=pt_price_usd,
+                    yt_price_usd=yt_price_usd,
+                    implied_apy=info.implied_apy,
+                    maturity=info.maturity,
+                    days_to_maturity=info.days_to_maturity,
+                    fetched_at=datetime.now(tz=timezone.utc),
+                )
+                logger.info(
+                    "get_positions (sandbox): market=%s, total_value_usd=%s",
+                    market[:10],
+                    total_value_usd,
+                )
+                return PendlePositionResponse(
+                    positions=[position],
+                    total_value_usd=total_value_usd,
+                )
+
+            # 非 sandbox: 実残量取得手段が無いため空を返す
+            logger.info(
+                "get_positions (live): on-chain position fetch not implemented, returning empty"
+            )
+            return PendlePositionResponse(
+                positions=[],
+                total_value_usd=Decimal("0"),
+            )
+
+        except Exception:
+            logger.warning("get_positions 失敗、空レスポンスを返す", exc_info=True)
+            return PendlePositionResponse(
+                positions=[],
+                total_value_usd=Decimal("0"),
+            )
 
     async def estimate_fixed_yield(self, amount: Decimal, market_address: str) -> Decimal:
         """固定利回りの年換算推定値を返す（%）。

--- a/backend/tests/test_protocols_pendle_integration.py
+++ b/backend/tests/test_protocols_pendle_integration.py
@@ -15,17 +15,21 @@ DummyPendleClient / DummyLidoClient を用いて Router → Service → Client �
   6. /api/protocols/health/pendle          — ProtocolMonitor 正常パス
   7. 入力バリデーション (422)
   8. staging 環境での DummyClient 禁止ガード (500/503)
+  9. /api/protocols/pendle/positions       — ポジション一覧 (RBAC + Decimal 文字列化)
 
 注意: Phase 4 実機検証 (staging-new) は P0-1 fix (LIDO_SANDBOX=false in staging) 完了後。
 """
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, status
 from fastapi.testclient import TestClient
 
 # テスト対象 router
+from app.auth.dependencies import require_admin
 from app.protocols.pendle.router import router as pendle_router
 from app.protocols.risk.router import router as health_router
 
@@ -37,12 +41,24 @@ DUMMY_MARKET_ADDRESS = "0x" + "ab" * 20
 # ---------------------------------------------------------------------------
 
 
+def _admin_user() -> MagicMock:
+    u = MagicMock()
+    u.id = 1
+    u.role = "admin"
+    u.is_active = True
+    return u
+
+
 @pytest.fixture(scope="module")
 def pendle_app() -> FastAPI:
-    """Pendle 関連エンドポイントのみを持つ最小 FastAPI アプリ (DB 不要)。"""
+    """Pendle 関連エンドポイントのみを持つ最小 FastAPI アプリ (DB 不要)。
+
+    positions エンドポイントが require_admin を依存するため、admin override を注入済み。
+    """
     app = FastAPI()
     app.include_router(pendle_router)
     app.include_router(health_router)
+    app.dependency_overrides[require_admin] = lambda: _admin_user()
     return app
 
 
@@ -273,3 +289,95 @@ class TestEnvGuard:
         staging_client = TestClient(pendle_app, raise_server_exceptions=False)
         resp = staging_client.get("/api/protocols/pendle/markets")
         assert resp.status_code in (500, 503)
+
+
+# ---------------------------------------------------------------------------
+# 9. ポジション一覧 GET /api/protocols/pendle/positions
+# ---------------------------------------------------------------------------
+
+
+class TestPositionsEndpoint:
+    """GET /api/protocols/pendle/positions のテスト。
+
+    RBAC・Decimal 文字列化・フロント契約 (frontend/lib/api/pendle.ts) を検証する。
+    """
+
+    def test_returns_200_with_admin(self, client: TestClient) -> None:
+        """admin override 有り（pendle_app fixture）で 200 を返すこと。"""
+        resp = client.get("/api/protocols/pendle/positions")
+        assert resp.status_code == 200
+
+    def test_response_has_positions_and_total(self, client: TestClient) -> None:
+        """レスポンスに positions と total_value_usd フィールドが存在すること。"""
+        data = client.get("/api/protocols/pendle/positions").json()
+        assert "positions" in data
+        assert "total_value_usd" in data
+
+    def test_sandbox_returns_one_position(self, client: TestClient) -> None:
+        """sandbox モードではダミー 1 件のポジションを返すこと。"""
+        data = client.get("/api/protocols/pendle/positions").json()
+        assert len(data["positions"]) == 1
+
+    def test_decimal_fields_are_strings(self, client: TestClient) -> None:
+        """Decimal フィールド (pt_amount / yt_amount / pt_price_usd / yt_price_usd / implied_apy) が
+        文字列で返却されること。（フロントエンド契約: Number(str).toFixed() で受ける）"""
+        pos = client.get("/api/protocols/pendle/positions").json()["positions"][0]
+        for field in ("pt_amount", "yt_amount", "pt_price_usd", "yt_price_usd", "implied_apy"):
+            assert isinstance(pos[field], str), f"{field} が文字列ではありません"
+            # 数値変換可能であることも確認
+            float(pos[field])
+
+    def test_total_value_usd_is_string(self, client: TestClient) -> None:
+        """total_value_usd が文字列で返却されること。"""
+        data = client.get("/api/protocols/pendle/positions").json()
+        assert isinstance(data["total_value_usd"], str)
+        float(data["total_value_usd"])
+
+    def test_position_has_all_frontend_contract_fields(self, client: TestClient) -> None:
+        """フロント契約 (frontend/lib/api/pendle.ts PendlePosition) のフィールドが全て存在すること。"""
+        pos = client.get("/api/protocols/pendle/positions").json()["positions"][0]
+        required_fields = (
+            "id",
+            "market_address",
+            "underlying_asset",
+            "pt_amount",
+            "yt_amount",
+            "pt_price_usd",
+            "yt_price_usd",
+            "implied_apy",
+            "maturity",
+            "days_to_maturity",
+            "fetched_at",
+        )
+        for field in required_fields:
+            assert field in pos, f"フロント契約フィールド '{field}' が見つかりません"
+
+    def test_days_to_maturity_is_int(self, client: TestClient) -> None:
+        """days_to_maturity が整数で返却されること。"""
+        pos = client.get("/api/protocols/pendle/positions").json()["positions"][0]
+        assert isinstance(pos["days_to_maturity"], int)
+
+    def test_maturity_is_iso8601(self, client: TestClient) -> None:
+        """maturity / fetched_at が ISO8601 文字列であること。"""
+        from datetime import datetime
+
+        pos = client.get("/api/protocols/pendle/positions").json()["positions"][0]
+        # 例外が出なければ OK
+        datetime.fromisoformat(pos["maturity"].replace("Z", "+00:00"))
+        datetime.fromisoformat(pos["fetched_at"].replace("Z", "+00:00"))
+
+    def test_rbac_unauthenticated_returns_401_or_403(self, pendle_app: FastAPI) -> None:
+        """admin override を外すと 401/403 を返すこと。"""
+
+        def _deny() -> None:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required"
+            )
+
+        # 認証拒否用の別アプリを作成（既存 pendle_app の override を汚染しない）
+        deny_app = FastAPI()
+        deny_app.include_router(pendle_router)
+        deny_app.dependency_overrides[require_admin] = _deny
+        deny_client = TestClient(deny_app, raise_server_exceptions=False)
+        resp = deny_client.get("/api/protocols/pendle/positions")
+        assert resp.status_code in (401, 403)


### PR DESCRIPTION
## 概要

PR #624 (Pendle YT/PT ポジション表示、マージ済み) のフロントが呼ぶ backend endpoint が欠落していた配線漏れの解消 (EPIC-3, Asana GID: **1215614752287666**)。admin /protocols ページの「API未実装」黄色警告が解消される。

## 設計判断（Planner 承認済み）
- **RBAC**: `require_admin`（システム資産情報の露出のため。フロントも AuthGuard adminOnly ページ配置）
- **データ**: sandbox (DummyPendleClient) = ダミー 1 件（表示確認用）/ **live (PendleWebClient) = 正直な空リスト**（PT/YT 実残量取得手段が未実装のため捏造しない。`get_pendle_client` の production×sandbox 禁止ガードによりダミーが本番に出る経路なし）
- **fail-open**: service 例外時は空レスポンス（500 にしない）
- **Decimal**: field_serializer で全て文字列化（フロント契約 frontend/lib/api/pendle.ts 準拠）

## 変更（4 ファイル +233 行、main.py 不変更 = Tier S 回避）
- schemas.py: PendlePosition / PendlePositionResponse
- service.py: get_positions()
- router.py: GET /positions ハンドラ
- tests: TestPositionsEndpoint 9 件（RBAC 検証含む — override 差替で依存宣言の実在を検証）

## DoD 証跡
- pytest (pendle integration + suite) → **296 passed**
- ruff / ruff format / mypy (267 files) → clean
- `git diff --stat` に main.py 含まれず。float 新規演算なし

## パイプライン証跡
- Explore → Planner (Opus) → Generator (Sonnet, worktree) → Evaluator (Fable 5, APPROVED) → Tester (独立再実行 PASS)
- マージは人間ゲート

🤖 Generated with [Claude Code](https://claude.com/claude-code)