### PR TITLE
feat(liff): liff-chatヘッダーにカラータイマーSVGロゴを追加

### DIFF
--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -157,13 +157,31 @@ export default function LiffChatPage() {
         >
           <Menu className="w-6 h-6" />
         </button>
-        <span
-          className="font-bold text-xl tracking-wider bg-clip-text text-transparent
-                     bg-[length:300%_100%] animate-logo-shine motion-reduce:animate-none
-                     bg-[linear-gradient(100deg,#4ade9a_0%,#4ade9a_45%,#ffffff_50%,#4ade9a_55%,#4ade9a_100%)]"
+        <svg
+          width="36"
+          height="36"
+          viewBox="0 0 100 100"
+          aria-label="UAT"
+          className="flex-shrink-0"
         >
-          UAT
-        </span>
+          {/* ベゼル: フラットグレー */}
+          <circle cx="50" cy="50" r="49" fill="#CCCCCC" />
+          {/* 内面: 赤 — カラータイマー点滅 */}
+          <circle
+            cx="50"
+            cy="50"
+            r="41.5"
+            fill="#E8341A"
+            className="animate-color-timer motion-reduce:animate-none"
+          />
+          {/* U リング: 白 */}
+          <g transform="translate(1.75,1.75) scale(0.965)">
+            <path
+              d="M 82.9 22.4 A 43 43 0 1 1 17.1 22.4 L 28.6 32.0 A 28 28 0 1 0 71.4 32.0 Z"
+              fill="white"
+            />
+          </g>
+        </svg>
         <button
           onClick={() => setActivePanel("account")}
           className="text-white p-1 hover:bg-white/10 rounded-lg transition-colors"

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -76,6 +76,19 @@ module.exports = {
           "33%": { backgroundPosition: "100% 0" },
           "100%": { backgroundPosition: "100% 0" },
         },
+        // ウルトラマン カラータイマー: 5s サイクル、4回点滅
+        "color-timer": {
+          "0%":   { opacity: "1" },
+          "9%":   { opacity: "0.15" },
+          "18%":  { opacity: "1" },
+          "27%":  { opacity: "0.15" },
+          "36%":  { opacity: "1" },
+          "45%":  { opacity: "0.15" },
+          "54%":  { opacity: "1" },
+          "63%":  { opacity: "0.15" },
+          "72%":  { opacity: "1" },
+          "100%": { opacity: "1" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
@@ -83,6 +96,7 @@ module.exports = {
         "scan-line": "scan-line 2s ease-in-out forwards",
         // sweep 1.5s + wait 3s = 4.5s 周期で無限ループ
         "logo-shine": "logo-shine 4.5s ease-in-out infinite",
+        "color-timer": "color-timer 5s linear infinite",
       },
     },
   },


### PR DESCRIPTION
## 変更概要

`/liff-chat` ヘッダーの「UAT」テキストアニメーションを、ウルトラマン カラータイマー風の SVG ロゴに差し替え。

## 変更内容

### `frontend/app/(liff)/liff-chat/page.tsx`
- `<span>` + `animate-logo-shine` テキストロゴ → `<svg>` ロゴに差し替え
- SVG 構成:
  - ベゼル: フラットグレー (`#CCCCCC`) の外周 circle
  - 内面: 赤 (`#E8341A`) の circle + `animate-color-timer` で点滅
  - U リング: 白の path（ウルトラマン風）
- `motion-reduce:animate-none` でアクセシビリティ対応

### `frontend/tailwind.config.js`
- `color-timer` keyframes 追加（5秒サイクル、4回点滅）
- `color-timer` animation 定義追加
- 既存の `logo-shine` は削除せず保持（他コンポーネントが使用している可能性あり）

## Gate 結果

| Gate | 結果 |
|------|------|
| tsc --noEmit (変更ファイル) | ✅ エラーなし |
| npm run build | ⚠️ dev VPS メモリ不足で Bus error（既知の環境制約） |
| E2E | n/a |

> **注**: `npm run build` の Bus error は dev VPS のメモリ制約による既知問題（OOM killer）。変更ファイルに新規型エラーはなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)