### PR TITLE
feat(i18n): app/user/ 非金融4ページ i18n 化 (grid/terms-accept/copy-trading/root)

### DIFF
--- a/frontend/app/user/copy-trading/page.tsx
+++ b/frontend/app/user/copy-trading/page.tsx
@@ -6,6 +6,7 @@ export const dynamic = 'force-dynamic'
 
 import { useState, useEffect, useCallback } from 'react'
 import { TrendingUp, RefreshCw } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 import { useAuth } from '@/lib/auth'
 import { UserProviders } from '@/components/user/UserProviders'
 import AuthGuard from '@/components/AuthGuard'
@@ -22,6 +23,8 @@ import {
 
 function CopyTradingPage() {
   const { token } = useAuth()
+  const t = useTranslations('CopyTrading')
+  const tCommon = useTranslations('Common')
 
   const [strategies, setStrategies] = useState<StrategyWithPerformance[]>([])
   const [subscriptions, setSubscriptions] = useState<CopySubscription[]>([])
@@ -41,11 +44,11 @@ function CopyTradingPage() {
       setStrategies(strats)
       setSubscriptions(subs)
     } catch {
-      setError('エラーが発生しました')
+      setError(tCommon('error'))
     } finally {
       setIsLoading(false)
     }
-  }, [token])
+  }, [token, tCommon])
 
   useEffect(() => {
     fetchData()
@@ -62,10 +65,10 @@ function CopyTradingPage() {
         token
       )
       setSubscriptions(prev => [...prev, sub])
-      setSuccessMsg('フォローしました')
+      setSuccessMsg(t('subscribeSuccess'))
       setTimeout(() => setSuccessMsg(null), 3000)
     } catch {
-      setError('エラーが発生しました')
+      setError(tCommon('error'))
     }
   }
 
@@ -74,10 +77,10 @@ function CopyTradingPage() {
     try {
       await unsubscribeStrategy(strategyId, token)
       setSubscriptions(prev => prev.filter(s => s.strategy_id !== strategyId))
-      setSuccessMsg('フォロー解除しました')
+      setSuccessMsg(t('unsubscribeSuccess'))
       setTimeout(() => setSuccessMsg(null), 3000)
     } catch {
-      setError('エラーが発生しました')
+      setError(tCommon('error'))
     }
   }
 
@@ -85,7 +88,7 @@ function CopyTradingPage() {
     return (
       <div className="flex flex-col items-center justify-center min-h-screen text-muted-foreground">
         <RefreshCw className="mb-3 h-8 w-8 animate-spin" />
-        <p className="text-sm">読み込み中...</p>
+        <p className="text-sm">{tCommon('loading')}</p>
       </div>
     )
   }
@@ -95,9 +98,9 @@ function CopyTradingPage() {
       <div className="sticky top-0 z-10 border-b bg-background/80 backdrop-blur">
         <div className="flex items-center gap-2 px-4 py-3">
           <TrendingUp className="h-5 w-5" />
-          <h1 className="text-lg font-semibold">コピートレード</h1>
+          <h1 className="text-lg font-semibold">{t('title')}</h1>
         </div>
-        <p className="px-4 pb-3 text-xs text-muted-foreground">プロのストラテジストをフォローして自動コピー</p>
+        <p className="px-4 pb-3 text-xs text-muted-foreground">{t('subtitle')}</p>
       </div>
 
       <div className="space-y-4 px-4 py-4 pb-8">
@@ -105,7 +108,7 @@ function CopyTradingPage() {
           <div className="absolute inset-0 bg-white dark:bg-gray-900/80 backdrop-blur-sm z-10 flex flex-col items-center justify-center rounded-lg">
             <div className="text-center">
               <p className="text-2xl font-bold text-gray-700 mb-2">Coming Soon</p>
-              <p className="text-gray-500">Phase 2で対応予定</p>
+              <p className="text-gray-500">{t('comingSoon')}</p>
             </div>
           </div>
           <div className="pointer-events-none select-none">
@@ -122,10 +125,10 @@ function CopyTradingPage() {
 
             <section>
               <h2 className="mb-3 text-sm font-semibold text-muted-foreground uppercase tracking-wide">
-                公開戦略
+                {t('strategies')}
               </h2>
               {strategies.length === 0 ? (
-                <p className="text-sm text-muted-foreground">公開戦略がありません</p>
+                <p className="text-sm text-muted-foreground">{t('noStrategies')}</p>
               ) : (
                 <div className="space-y-3">
                   {strategies.map(strategy => (

--- a/frontend/app/user/grid/page.tsx
+++ b/frontend/app/user/grid/page.tsx
@@ -3,6 +3,7 @@
 // Unauthorized copying or distribution is strictly prohibited.
 
 import { useState, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import AuthGuard from "@/components/AuthGuard";
 import { useAuth } from "@/lib/auth";
 import { executeGridBot, fetchGridStatus } from "@/lib/api/exchange";
@@ -11,6 +12,7 @@ import type { GridStatusResponse, GridConfigRequest } from "@/lib/api/exchange";
 const SYMBOLS = ["BTC/USDT", "ETH/USDT"] as const;
 
 function GridVisualization({ gridStatus }: { gridStatus: GridStatusResponse }) {
+  const t = useTranslations("Grid");
   const upper = parseFloat(gridStatus.upper_price);
   const lower = parseFloat(gridStatus.lower_price);
   const current = gridStatus.current_price ? parseFloat(gridStatus.current_price) : null;
@@ -19,7 +21,7 @@ function GridVisualization({ gridStatus }: { gridStatus: GridStatusResponse }) {
   if (range <= 0 || gridStatus.levels.length === 0) {
     return (
       <div style={{ color: "#9ca3af", fontSize: 13, padding: "16px 0" }}>
-        グリッドレベルがありません
+        {t("noGridLevels")}
       </div>
     );
   }
@@ -33,8 +35,8 @@ function GridVisualization({ gridStatus }: { gridStatus: GridStatusResponse }) {
     <div style={{ position: "relative", width: "100%", maxWidth: 480 }}>
       {/* Price axis labels */}
       <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4, fontSize: 11, color: "#666" }}>
-        <span>上限: ${(upper || 0).toLocaleString()}</span>
-        <span>下限: ${(lower || 0).toLocaleString()}</span>
+        <span>{t("upperLabel")}: ${(upper || 0).toLocaleString()}</span>
+        <span>{t("lowerLabel")}: ${(lower || 0).toLocaleString()}</span>
       </div>
 
       {/* Grid levels container */}
@@ -86,10 +88,10 @@ function GridVisualization({ gridStatus }: { gridStatus: GridStatusResponse }) {
                 {isBuy ? "BUY" : "SELL"}
               </span>
               {level.filled && (
-                <span style={{ fontSize: 11, color: "#374151", fontWeight: 600 }}>✓ 約定</span>
+                <span style={{ fontSize: 11, color: "#374151", fontWeight: 600 }}>✓ {t("filled")}</span>
               )}
               {isCurrent && (
-                <span style={{ fontSize: 11, color: "#d97706", fontWeight: 700 }}>← 現在値</span>
+                <span style={{ fontSize: 11, color: "#d97706", fontWeight: 700 }}>{t("currentPriceIndicator")}</span>
               )}
             </div>
           );
@@ -99,7 +101,7 @@ function GridVisualization({ gridStatus }: { gridStatus: GridStatusResponse }) {
       {/* Current price overlay label */}
       {current != null && (
         <div style={{ marginTop: 8, fontSize: 13, color: "#d97706", fontWeight: 600 }}>
-          現在価格: ${current.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+          {t("currentPriceLabel")}: ${current.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
         </div>
       )}
     </div>
@@ -108,6 +110,7 @@ function GridVisualization({ gridStatus }: { gridStatus: GridStatusResponse }) {
 
 function GridContent() {
   const { token } = useAuth();
+  const t = useTranslations("Grid");
 
   const [upperPrice, setUpperPrice] = useState("");
   const [lowerPrice, setLowerPrice] = useState("");
@@ -124,13 +127,13 @@ function GridContent() {
   const handleExecute = useCallback(async () => {
     if (!token) return;
     if (!upperPrice || !lowerPrice || !amountPerGrid) {
-      setError("上限価格・下限価格・各グリッド金額を入力してください");
+      setError(t("errInputRequired"));
       return;
     }
     const upper = parseFloat(upperPrice);
     const lower = parseFloat(lowerPrice);
     if (isNaN(upper) || isNaN(lower) || upper <= lower) {
-      setError("上限価格は下限価格より大きい値を入力してください");
+      setError(t("errUpperLower"));
       return;
     }
     setIsExecuting(true);
@@ -149,11 +152,11 @@ function GridContent() {
       setGridStatus(result);
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
-      setError(`Bot起動エラー: ${msg}`);
+      setError(t("botStartError", { msg }));
     } finally {
       setIsExecuting(false);
     }
-  }, [token, upperPrice, lowerPrice, gridCount, symbol, amountPerGrid, dryRun]);
+  }, [token, upperPrice, lowerPrice, gridCount, symbol, amountPerGrid, dryRun, t]);
 
   const handleFetchStatus = useCallback(async () => {
     if (!token) return;
@@ -164,21 +167,21 @@ function GridContent() {
       setGridStatus(result);
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
-      setError(`ステータス取得エラー: ${msg}`);
+      setError(t("statusFetchError", { msg }));
     } finally {
       setIsFetchingStatus(false);
     }
-  }, [token]);
+  }, [token, t]);
 
   const pnl = gridStatus ? parseFloat(gridStatus.pnl_usd) : null;
 
   return (
     <>
-      {/* ヘッダー */}
+      {/* header */}
       <div style={{ marginBottom: 8 }}>
         <h1 style={{ margin: 0 }}>Grid Trading Bot</h1>
         <p style={{ fontSize: 13, color: "#666", marginTop: 4 }}>
-          グリッド間隔で自動売買を行うボット設定
+          {t("subtitle")}
         </p>
       </div>
 
@@ -188,41 +191,41 @@ function GridContent() {
         </div>
       )}
 
-      {/* 設定フォーム */}
+      {/* settings form */}
       <section style={{ marginTop: 16 }}>
-        <h2 style={{ fontSize: 16, marginBottom: 12 }}>グリッド設定</h2>
+        <h2 style={{ fontSize: 16, marginBottom: 12 }}>{t("gridSettings")}</h2>
         <div style={{ ...cardStyle, maxWidth: 520 }}>
           <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
 
-            {/* 上限価格 */}
+            {/* upper price */}
             <div>
-              <label style={labelStyle}>上限価格 (USD)</label>
+              <label style={labelStyle}>{t("upperPriceLabel")}</label>
               <input
                 type="number"
                 value={upperPrice}
                 onChange={(e) => setUpperPrice(e.target.value)}
-                placeholder="例: 50000"
+                placeholder={t("upperPricePlaceholder")}
                 style={inputStyle}
                 disabled
               />
             </div>
 
-            {/* 下限価格 */}
+            {/* lower price */}
             <div>
-              <label style={labelStyle}>下限価格 (USD)</label>
+              <label style={labelStyle}>{t("lowerPriceLabel")}</label>
               <input
                 type="number"
                 value={lowerPrice}
                 onChange={(e) => setLowerPrice(e.target.value)}
-                placeholder="例: 40000"
+                placeholder={t("lowerPricePlaceholder")}
                 style={inputStyle}
                 disabled
               />
             </div>
 
-            {/* グリッド数 */}
+            {/* grid count */}
             <div>
-              <label style={labelStyle}>グリッド数（2〜100）</label>
+              <label style={labelStyle}>{t("gridCountLabel")}</label>
               <input
                 type="number"
                 value={gridCount}
@@ -234,9 +237,9 @@ function GridContent() {
               />
             </div>
 
-            {/* シンボル */}
+            {/* symbol */}
             <div>
-              <label style={labelStyle}>取引ペア</label>
+              <label style={labelStyle}>{t("symbolLabel")}</label>
               <select
                 value={symbol}
                 onChange={(e) => setSymbol(e.target.value)}
@@ -249,21 +252,21 @@ function GridContent() {
               </select>
             </div>
 
-            {/* 各グリッド金額 */}
+            {/* amount per grid */}
             <div style={{ gridColumn: "1 / -1" }}>
-              <label style={labelStyle}>各グリッド金額 (USD)</label>
+              <label style={labelStyle}>{t("amountPerGridLabel")}</label>
               <input
                 type="number"
                 value={amountPerGrid}
                 onChange={(e) => setAmountPerGrid(e.target.value)}
-                placeholder="例: 100"
+                placeholder={t("amountPerGridPlaceholder")}
                 style={inputStyle}
                 disabled
               />
             </div>
           </div>
 
-          {/* Dry Run トグル */}
+          {/* dry run toggle */}
           <div style={{ marginTop: 16, display: "flex", alignItems: "center", gap: 10 }}>
             <input
               id="dry-run-toggle"
@@ -274,7 +277,7 @@ function GridContent() {
               disabled
             />
             <label htmlFor="dry-run-toggle" style={{ fontSize: 14, color: "#374151", cursor: "pointer" }}>
-              ドライランモード（実際の注文は発行しない）
+              {t("dryRunLabel")}
             </label>
           </div>
 
@@ -288,13 +291,13 @@ function GridContent() {
               fontSize: 13,
               color: "#92400e",
             }}>
-              ドライランモードが有効です。実際の注文は発行されません。
+              {t("dryRunActive")}
             </div>
           )}
         </div>
       </section>
 
-      {/* アクションボタン */}
+      {/* action buttons */}
       <section style={{ marginTop: 24 }}>
         <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
           <button
@@ -311,7 +314,7 @@ function GridContent() {
               cursor: "not-allowed",
             }}
           >
-            {isExecuting ? "起動中..." : "Bot起動"}
+            {isExecuting ? t("starting") : t("startBot")}
           </button>
           <button
             onClick={handleFetchStatus}
@@ -327,21 +330,21 @@ function GridContent() {
               cursor: "not-allowed",
             }}
           >
-            {isFetchingStatus ? "取得中..." : "ステータス取得"}
+            {isFetchingStatus ? t("fetching") : t("fetchStatus")}
           </button>
         </div>
       </section>
 
-      {/* ステータス表示 */}
+      {/* status display */}
       {gridStatus && (
         <>
           <section style={{ marginTop: 32 }}>
-            <h2 style={{ fontSize: 16, marginBottom: 12 }}>Bot ステータス</h2>
+            <h2 style={{ fontSize: 16, marginBottom: 12 }}>{t("botStatus")}</h2>
             <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
 
-              {/* 稼働状態カード */}
+              {/* operation status card */}
               <div style={cardStyle}>
-                <div style={{ fontSize: 13, color: "#666", marginBottom: 8 }}>稼働状態</div>
+                <div style={{ fontSize: 13, color: "#666", marginBottom: 8 }}>{t("operationStatus")}</div>
                 <span style={{
                   display: "inline-block",
                   padding: "4px 14px",
@@ -351,28 +354,28 @@ function GridContent() {
                   background: gridStatus.enabled ? "#dcfce7" : "#f3f4f6",
                   color: gridStatus.enabled ? "#16a34a" : "#374151",
                 }}>
-                  {gridStatus.enabled ? "稼働中" : "停止中"}
+                  {gridStatus.enabled ? t("running") : t("stopped")}
                 </span>
                 <div style={{ marginTop: 8, fontSize: 13, color: "#666" }}>
                   {gridStatus.symbol}
                 </div>
               </div>
 
-              {/* 注文統計カード */}
+              {/* order stats card */}
               <div style={cardStyle}>
-                <div style={{ fontSize: 13, color: "#666", marginBottom: 8 }}>注文統計</div>
+                <div style={{ fontSize: 13, color: "#666", marginBottom: 8 }}>{t("orderStats")}</div>
                 <div style={{ fontSize: 28, fontWeight: 700, color: "#111" }}>
                   {gridStatus.filled_orders}
                   <span style={{ fontSize: 16, color: "#666", fontWeight: 400 }}>
                     {" "}/ {gridStatus.total_orders}
                   </span>
                 </div>
-                <div style={{ fontSize: 12, color: "#666", marginTop: 4 }}>約定済み / 総注文数</div>
+                <div style={{ fontSize: 12, color: "#666", marginTop: 4 }}>{t("filledOrders")}</div>
               </div>
 
-              {/* PnL カード */}
+              {/* PnL card */}
               <div style={cardStyle}>
-                <div style={{ fontSize: 13, color: "#666", marginBottom: 8 }}>損益 (USD)</div>
+                <div style={{ fontSize: 13, color: "#666", marginBottom: 8 }}>{t("pnl")}</div>
                 <div style={{
                   fontSize: 32,
                   fontWeight: 700,
@@ -384,9 +387,9 @@ function GridContent() {
             </div>
           </section>
 
-          {/* グリッドビジュアライゼーション */}
+          {/* grid visualization */}
           <section style={{ marginTop: 32 }}>
-            <h2 style={{ fontSize: 16, marginBottom: 12 }}>グリッドビジュアライゼーション</h2>
+            <h2 style={{ fontSize: 16, marginBottom: 12 }}>{t("gridVisualization")}</h2>
             <GridVisualization gridStatus={gridStatus} />
           </section>
         </>
@@ -396,6 +399,7 @@ function GridContent() {
 }
 
 export default function GridPage() {
+  const t = useTranslations("Grid");
   return (
     <AuthGuard>
       <>
@@ -405,7 +409,7 @@ export default function GridPage() {
           <div className="absolute inset-0 bg-white dark:bg-gray-900/80 backdrop-blur-sm z-10 flex flex-col items-center justify-center rounded-lg">
             <div className="text-center">
               <p className="text-2xl font-bold text-gray-700 mb-2">Coming Soon</p>
-              <p className="text-gray-500">Phase 2で対応予定</p>
+              <p className="text-gray-500">{t("comingSoon")}</p>
             </div>
           </div>
           <div className="pointer-events-none select-none">

--- a/frontend/app/user/page.tsx
+++ b/frontend/app/user/page.tsx
@@ -2,6 +2,7 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
 
+import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -9,35 +10,24 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { AlertTriangle, Wallet, Brain, CheckCircle } from 'lucide-react'
 import Link from 'next/link'
 
-const steps = [
-  {
-    number: 1,
-    icon: Wallet,
-    title: 'ウォレットを接続',
-    description: 'MetaMask / WalletConnect 対応ウォレットをBase メインネットに接続',
-  },
-  {
-    number: 2,
-    icon: Brain,
-    title: 'AIが市場を分析',
-    description: 'Claude Opus が最適なタイミングを提案。GPT-4o でクロス検証。',
-  },
-  {
-    number: 3,
-    icon: CheckCircle,
-    title: 'あなたが承認・署名',
-    description: '提案を確認し、ウォレットで署名。あなたが最終判断者です。',
-  },
-]
+const STEP_ICONS = [Wallet, Brain, CheckCircle] as const
 
 export default function LandingPage() {
+  const t = useTranslations('UserHome')
+
+  const steps = [
+    { number: 1, icon: STEP_ICONS[0], title: t('step1.title'), description: t('step1.description') },
+    { number: 2, icon: STEP_ICONS[1], title: t('step2.title'), description: t('step2.description') },
+    { number: 3, icon: STEP_ICONS[2], title: t('step3.title'), description: t('step3.description') },
+  ]
+
   return (
     <main className="min-h-[calc(100vh-4rem)] px-4 py-8">
       <div className="max-w-md mx-auto space-y-8">
         {/* Hero */}
         <div className="text-center space-y-6 pt-8">
           <h1 className="text-2xl font-bold tracking-tight leading-snug">
-            AIが最適なタイミングで、<br />あなたの資産を運用します
+            {t('heroLine1')}<br />{t('heroLine2')}
           </h1>
           <Button size="lg" className="w-full text-base font-semibold" asChild>
             <Link href="/user/wallet">
@@ -46,7 +36,7 @@ export default function LandingPage() {
             </Link>
           </Button>
           <p className="text-xs text-muted-foreground">
-            Non-custodial — あなたのウォレット、あなたの資産
+            {t('nonCustodial')}
           </p>
         </div>
 
@@ -60,7 +50,7 @@ export default function LandingPage() {
               Aave V3
             </Badge>
             <Badge variant="outline" className="text-indigo-400 border-indigo-400/50">
-              Base メインネット
+              Base Mainnet
             </Badge>
           </div>
         </div>
@@ -91,7 +81,7 @@ export default function LandingPage() {
         <Alert className="border-amber-500/50 bg-amber-500/10 text-amber-400">
           <AlertTriangle className="h-4 w-4 text-amber-400" />
           <AlertDescription className="text-xs leading-relaxed text-amber-400/90">
-            これは投資助言ではありません。暗号資産取引には元本損失のリスクがあります。ご自身の判断と責任において利用してください。
+            {t('riskDisclaimer')}
           </AlertDescription>
         </Alert>
 
@@ -99,7 +89,7 @@ export default function LandingPage() {
         <div className="text-center pb-4">
           <Button variant="ghost" size="sm" asChild>
             <Link href="/user/dashboard" className="text-xs text-muted-foreground">
-              すでに接続済みの方はダッシュボードへ →
+              {t('dashboardCta')}
             </Link>
           </Button>
         </div>

--- a/frontend/app/user/terms-accept/page.tsx
+++ b/frontend/app/user/terms-accept/page.tsx
@@ -12,6 +12,7 @@
 
 import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
+import { useTranslations } from "next-intl"
 import { CheckCircle, ChevronDown, ExternalLink } from "lucide-react"
 import { getAuthToken } from "@/lib/auth/token-key"
 import { acceptTerms, getTermsStatus } from "@/lib/api/auth"
@@ -19,35 +20,23 @@ import { acceptTerms, getTermsStatus } from "@/lib/api/auth"
 /** ブラウザ経路で記録する同意バージョン（backend _ACCEPTED_TERMS_VERSIONS と一致） */
 const BROWSER_TERMS_VERSION = "2.0"
 
-const ITEMS = [
-  {
-    id: "self_custody",
-    title: "資産はユーザー自身が管理します",
-    detail:
-      "本サービスはノンカストディアル型です。秘密鍵はユーザーが管理し、弊社はウォレットにアクセスできません。",
-  },
-  {
-    id: "defi_risk",
-    title: "DeFi運用にはリスクがあります",
-    detail:
-      "スマートコントラクトのリスク、価格変動リスク、流動性リスクが存在します。投資は自己責任でお願いします。",
-  },
-  {
-    id: "user_responsibility",
-    title: "アカウント管理は利用者自身の責任です",
-    detail:
-      "ログイン情報の管理、不正アクセスへの対応はユーザーご自身の責任となります。弊社はアカウント損失に対して責任を負いません。",
-  },
-]
+const ITEM_IDS = ["self_custody", "defi_risk", "user_responsibility"] as const
+type ItemId = typeof ITEM_IDS[number]
+const ITEM_KEY_MAP: Record<ItemId, "item1" | "item2" | "item3"> = {
+  self_custody: "item1",
+  defi_risk: "item2",
+  user_responsibility: "item3",
+}
 
 export default function BrowserTermsAcceptPage() {
   const router = useRouter()
+  const t = useTranslations("TermsAccept")
   const [checked, setChecked] = useState<Record<string, boolean>>({})
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
   const [submitting, setSubmitting] = useState(false)
   const [loading, setLoading] = useState(true)
 
-  const allChecked = ITEMS.every((item) => checked[item.id])
+  const allChecked = ITEM_IDS.every((id) => checked[id])
   const checkedCount = Object.values(checked).filter(Boolean).length
 
   // 既同意チェック: 既に同意済みなら /user/dashboard へ即リダイレクト（冪等）
@@ -97,11 +86,11 @@ export default function BrowserTermsAcceptPage() {
 
   return (
     <div className="max-w-[480px] mx-auto min-h-screen bg-zinc-950 text-zinc-100 flex flex-col overflow-hidden">
-      {/* ヘッダー */}
+      {/* header */}
       <div className="bg-[#1a3d2e] px-4 py-5 flex-shrink-0">
-        <h1 className="text-white font-bold text-lg">重要事項の確認</h1>
-        <p className="text-zinc-300 text-sm mt-1">運用開始前に以下をご確認ください</p>
-        {/* ステップドット */}
+        <h1 className="text-white font-bold text-lg">{t("title")}</h1>
+        <p className="text-zinc-300 text-sm mt-1">{t("subtitle")}</p>
+        {/* step dots */}
         <div className="flex gap-1.5 mt-3">
           {[0, 1, 2].map((i) => (
             <div
@@ -114,10 +103,10 @@ export default function BrowserTermsAcceptPage() {
         </div>
       </div>
 
-      {/* プログレスバー */}
+      {/* progress bar */}
       <div className="px-4 py-3 border-b border-zinc-800 flex-shrink-0">
         <div className="flex items-center justify-between text-sm mb-1.5">
-          <span className="text-zinc-400">確認状況</span>
+          <span className="text-zinc-400">{t("progressLabel")}</span>
           <span className="text-[#4ade9a] font-semibold">{checkedCount} / 3</span>
         </div>
         <div className="h-1.5 bg-zinc-800 rounded-full overflow-hidden">
@@ -128,14 +117,15 @@ export default function BrowserTermsAcceptPage() {
         </div>
       </div>
 
-      {/* アコーディオンリスト */}
+      {/* accordion list */}
       <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
-        {ITEMS.map((item, idx) => {
-          const isChecked = checked[item.id]
-          const isExpanded = expanded[item.id]
+        {ITEM_IDS.map((id, idx) => {
+          const msgKey = ITEM_KEY_MAP[id]
+          const isChecked = checked[id]
+          const isExpanded = expanded[id]
           return (
             <div
-              key={item.id}
+              key={id}
               className={`rounded-xl border transition-all duration-200 ${
                 isChecked
                   ? "border-[#1D9E75] bg-[#1D9E75]/5"
@@ -148,12 +138,12 @@ export default function BrowserTermsAcceptPage() {
                 tabIndex={0}
                 className="flex items-center w-full px-4 py-4 text-left cursor-pointer"
                 onClick={() =>
-                  setExpanded((prev) => ({ ...prev, [item.id]: !prev[item.id] }))
+                  setExpanded((prev) => ({ ...prev, [id]: !prev[id] }))
                 }
                 onKeyDown={(e) => {
                   if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault()
-                    setExpanded((prev) => ({ ...prev, [item.id]: !prev[item.id] }))
+                    setExpanded((prev) => ({ ...prev, [id]: !prev[id] }))
                   }
                 }}
               >
@@ -161,9 +151,9 @@ export default function BrowserTermsAcceptPage() {
                   className="mr-3 flex-shrink-0"
                   onClick={(e) => {
                     e.stopPropagation()
-                    setChecked((prev) => ({ ...prev, [item.id]: !prev[item.id] }))
-                    if (!expanded[item.id]) {
-                      setExpanded((prev) => ({ ...prev, [item.id]: true }))
+                    setChecked((prev) => ({ ...prev, [id]: !prev[id] }))
+                    if (!expanded[id]) {
+                      setExpanded((prev) => ({ ...prev, [id]: true }))
                     }
                   }}
                 >
@@ -180,7 +170,7 @@ export default function BrowserTermsAcceptPage() {
                     isChecked ? "text-[#4ade9a]" : "text-white"
                   }`}
                 >
-                  {item.title}
+                  {t(`${msgKey}.title`)}
                 </span>
                 <ChevronDown
                   className={`w-4 h-4 text-zinc-500 transition-transform ${
@@ -190,15 +180,15 @@ export default function BrowserTermsAcceptPage() {
               </div>
               {isExpanded && (
                 <div className="px-4 pb-4">
-                  <p className="text-zinc-400 text-sm leading-relaxed">{item.detail}</p>
+                  <p className="text-zinc-400 text-sm leading-relaxed">{t(`${msgKey}.detail`)}</p>
                   {!isChecked && (
                     <button
                       onClick={() =>
-                        setChecked((prev) => ({ ...prev, [item.id]: true }))
+                        setChecked((prev) => ({ ...prev, [id]: true }))
                       }
                       className="mt-3 w-full py-2.5 rounded-lg bg-[#1D9E75]/20 text-[#4ade9a] text-sm font-medium border border-[#1D9E75]/30 hover:bg-[#1D9E75]/30 transition-colors"
                     >
-                      確認しました
+                      {t("confirmItem")}
                     </button>
                   )}
                 </div>
@@ -208,7 +198,7 @@ export default function BrowserTermsAcceptPage() {
         })}
       </div>
 
-      {/* 下部: リンク + ボタン */}
+      {/* footer: links + button */}
       <div className="px-4 pb-8 pt-4 border-t border-zinc-800 flex-shrink-0 space-y-3">
         <div className="flex gap-4 justify-center text-xs text-zinc-500">
           <a
@@ -217,7 +207,7 @@ export default function BrowserTermsAcceptPage() {
             rel="noopener noreferrer"
             className="flex items-center gap-1 hover:text-zinc-300"
           >
-            利用規約 <ExternalLink className="w-3 h-3" />
+            {t("termsLink")} <ExternalLink className="w-3 h-3" />
           </a>
           <a
             href="/privacy-policy"
@@ -225,7 +215,7 @@ export default function BrowserTermsAcceptPage() {
             rel="noopener noreferrer"
             className="flex items-center gap-1 hover:text-zinc-300"
           >
-            プライバシーポリシー <ExternalLink className="w-3 h-3" />
+            {t("privacyLink")} <ExternalLink className="w-3 h-3" />
           </a>
         </div>
         <button
@@ -240,10 +230,10 @@ export default function BrowserTermsAcceptPage() {
           {submitting ? (
             <span className="flex items-center justify-center gap-2">
               <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-              保存中...
+              {t("saving")}
             </span>
           ) : (
-            "運用を開始する"
+            t("startButton")
           )}
         </button>
       </div>

--- a/frontend/components/user/CopyTradingCard.tsx
+++ b/frontend/components/user/CopyTradingCard.tsx
@@ -2,9 +2,9 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
 
-import { TrendingUp, Users, ShieldCheck } from 'lucide-react'
+import { Users } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import type { StrategyWithPerformance } from '@/lib/api/copy_trading'
 
@@ -22,13 +22,15 @@ const RISK_COLORS = {
 } as const
 
 export function CopyTradingCard({ strategy, isSubscribed, onSubscribe, onUnsubscribe }: Props) {
+  const t = useTranslations('CopyTrading')
+  const tCommon = useTranslations('Common')
   const p = strategy.performance
 
-  const riskLabel = {
-    low: '低',
-    medium: '中',
-    high: '高',
-  }[strategy.risk_level]
+  const riskLabelKey = {
+    low: 'riskLow',
+    medium: 'riskMedium',
+    high: 'riskHigh',
+  }[strategy.risk_level] as 'riskLow' | 'riskMedium' | 'riskHigh'
 
   return (
     <Card className="w-full">
@@ -43,7 +45,7 @@ export function CopyTradingCard({ strategy, isSubscribed, onSubscribe, onUnsubsc
           <span
             className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${RISK_COLORS[strategy.risk_level]}`}
           >
-            {riskLabel}
+            {t(riskLabelKey)}
           </span>
         </div>
       </CardHeader>
@@ -51,21 +53,21 @@ export function CopyTradingCard({ strategy, isSubscribed, onSubscribe, onUnsubsc
         {p && (
           <div className="grid grid-cols-2 gap-2 text-sm">
             <div className="flex flex-col">
-              <span className="text-xs text-muted-foreground">勝率</span>
+              <span className="text-xs text-muted-foreground">{t('winRate')}</span>
               <span className="font-semibold">{(p.win_rate * 100).toFixed(1)}%</span>
             </div>
             <div className="flex flex-col">
-              <span className="text-xs text-muted-foreground">シャープレシオ</span>
+              <span className="text-xs text-muted-foreground">{t('sharpeRatio')}</span>
               <span className="font-semibold">{p.sharpe_ratio.toFixed(2)}</span>
             </div>
             <div className="flex flex-col">
-              <span className="text-xs text-muted-foreground">累積損益</span>
+              <span className="text-xs text-muted-foreground">{t('totalPnl')}</span>
               <span className={`font-semibold ${parseFloat(p.total_pnl) >= 0 ? 'text-green-600' : 'text-red-600'}`}>
                 {parseFloat(p.total_pnl) >= 0 ? '+' : ''}{parseFloat(p.total_pnl).toFixed(2)} USDT
               </span>
             </div>
             <div className="flex flex-col">
-              <span className="text-xs text-muted-foreground">取引回数</span>
+              <span className="text-xs text-muted-foreground">{t('trades')}</span>
               <span className="font-semibold">{p.total_trades}</span>
             </div>
           </div>
@@ -73,7 +75,7 @@ export function CopyTradingCard({ strategy, isSubscribed, onSubscribe, onUnsubsc
         <div className="flex items-center justify-between pt-1">
           <div className="flex items-center gap-1 text-xs text-muted-foreground">
             <Users className="h-3 w-3" />
-            <span>ストラテジスト: {strategy.strategist_id.slice(0, 8)}...</span>
+            <span>{t('strategist')}: {strategy.strategist_id.slice(0, 8)}...</span>
           </div>
           {isSubscribed ? (
             <Button
@@ -82,7 +84,7 @@ export function CopyTradingCard({ strategy, isSubscribed, onSubscribe, onUnsubsc
               onClick={() => onUnsubscribe(strategy.id)}
               className="text-xs"
             >
-              フォロー解除
+              {tCommon('unsubscribe')}
             </Button>
           ) : (
             <Button
@@ -90,7 +92,7 @@ export function CopyTradingCard({ strategy, isSubscribed, onSubscribe, onUnsubsc
               onClick={() => onSubscribe(strategy)}
               className="text-xs"
             >
-              フォローする
+              {tCommon('subscribe')}
             </Button>
           )}
         </div>

--- a/frontend/e2e/user-batch3-i18n.spec.ts
+++ b/frontend/e2e/user-batch3-i18n.spec.ts
@@ -1,0 +1,388 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+//
+// [Gate 4] user-batch3-i18n: user/grid, user/terms-accept, user/copy-trading, user (UserHome) の
+// i18n 実装検証 E2E spec。
+//
+// 対象ページ (app/user/ は通常フォルダなので URL に user/ が含まれる):
+//   /user/grid          - app/user/grid/page.tsx       (Grid 35 キー)
+//   /user/terms-accept  - app/user/terms-accept/page.tsx (TermsAccept 14 キー)
+//   /user/copy-trading  - app/user/copy-trading/page.tsx (CopyTrading 20 キー)
+//   /user              - app/user/page.tsx              (UserHome 11 キー)
+//
+// 検証方針:
+//   TC1: 各ページが 5xx を返さない (疎通確認)
+//   TC2: AuthGuard 越え後の日本語見出し表示 (モック認証使用)
+//   TC3: NEXT_LOCALE=en cookie 設定で英語見出しに切替
+//   TC4: 翻訳キーリテラル (例: "Grid.title") が画面に露出していない
+//
+// 認証ゲートの扱い:
+//   AuthGuard のあるページ (grid, copy-trading) は localStorage に JWT 注入 + /auth/me モックで回避。
+//   terms-accept は JWT 不要で表示開始するが、既同意チェック (getTermsStatus) をモック。
+//   UserHome (/user) は認証ガードなし (LandingPage)。
+//
+// baseURL: playwright.config.ts の STAGING_URL 優先、なければ本番 URL。
+// 本番 URL では CF Access 認証 / ネットワーク要因で疎通不能の場合 test.skip で理由明記。
+
+import { test, expect, Page } from '@playwright/test'
+import path from 'path'
+import fs from 'fs'
+
+// ─── 定数 ─────────────────────────────────────────────────────────────────────
+
+const SCREENSHOT_DIR = path.join('e2e', 'screenshots', 'user-batch3-i18n')
+
+const TARGET_PAGES = [
+  { href: '/user/grid',         name: 'Grid'        },
+  { href: '/user/terms-accept', name: 'TermsAccept' },
+  { href: '/user/copy-trading', name: 'CopyTrading' },
+  { href: '/user',              name: 'UserHome'    },
+] as const
+
+// ─── ヘルパー ─────────────────────────────────────────────────────────────────
+
+function ensureScreenshotDir(): void {
+  if (!fs.existsSync(SCREENSHOT_DIR)) {
+    fs.mkdirSync(SCREENSHOT_DIR, { recursive: true })
+  }
+}
+
+/**
+ * user JWT + /auth/me モックで AuthGuard を通過させる最小セットアップ。
+ * page.goto() の前に呼ぶこと。
+ */
+async function setupUserAuth(page: Page): Promise<void> {
+  const mockToken = 'dummy-user-token-for-e2e'
+  const safeExpiresAt = Date.now() + 24 * 60 * 60 * 1000
+
+  await page.addInitScript(
+    (args) => {
+      localStorage.setItem(args.tokenKey, args.t)
+      localStorage.setItem(args.expiresKey, String(args.e))
+    },
+    {
+      tokenKey: 'ultra_auth_token',
+      expiresKey: 'ultra_auth_expires',
+      t: mockToken,
+      e: safeExpiresAt,
+    },
+  )
+
+  await page.route('**/auth/me', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 99,
+          email: 'e2e-user@ultra-autotrade.com',
+          username: 'e2e-user',
+          role: 'user',
+          is_active: true,
+          terms_accepted_at: '2026-01-01T00:00:00+00:00',
+          terms_version: '2.0',
+          risk_mode: 'conservative',
+          tier: 'GENERAL',
+        }),
+      })
+    } else {
+      await route.continue()
+    }
+  })
+
+  // TermsAccept が既同意チェックに使う /user/terms-status をモック (リダイレクトさせない)
+  await page.route('**/user/terms-status', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ needs_acceptance: true }),
+      })
+    } else {
+      await route.continue()
+    }
+  })
+}
+
+/** DOM のテキストノードを列挙して pattern にマッチするものを返す。
+ *  script / style / noscript 内は除外。
+ */
+async function findTextNodes(page: Page, pattern: RegExp): Promise<string[]> {
+  return page.evaluate((patternSource: string) => {
+    const re = new RegExp(patternSource, 'i')
+    const SKIP_TAGS = new Set(['SCRIPT', 'STYLE', 'NOSCRIPT'])
+    const walker = document.createTreeWalker(
+      document.body,
+      NodeFilter.SHOW_TEXT,
+      {
+        acceptNode(node) {
+          const tag = node.parentElement?.tagName ?? ''
+          return SKIP_TAGS.has(tag)
+            ? NodeFilter.FILTER_REJECT
+            : NodeFilter.FILTER_ACCEPT
+        },
+      },
+    )
+    const matches: string[] = []
+    let node: Node | null
+    while ((node = walker.nextNode())) {
+      const text = (node.textContent ?? '').trim()
+      if (text && re.test(text)) {
+        matches.push(text)
+      }
+    }
+    return matches
+  }, pattern.source)
+}
+
+// ─── TC1: 疎通 (5xx でない) ─────────────────────────────────────────────────
+
+test.describe('[user-batch3-i18n] TC1: 疎通確認 (5xx なし)', () => {
+  test.beforeEach(ensureScreenshotDir)
+
+  for (const { href, name } of TARGET_PAGES) {
+    test(`${name} (${href}) が 5xx を返さない`, async ({ page }) => {
+      let serverError = false
+      page.on('response', (res) => {
+        if (res.url().includes(href.replace('/user', '')) && res.status() >= 500) {
+          serverError = true
+        }
+      })
+
+      await setupUserAuth(page)
+
+      let navigationFailed = false
+      try {
+        const response = await page.goto(href, { timeout: 30_000, waitUntil: 'domcontentloaded' })
+        // 本番 CF Access / ネットワーク到達不能時は skip
+        if (!response) {
+          test.skip(true, `${href}: no response (CF Access / network unreachable)`)
+          return
+        }
+        const status = response.status()
+        // 5xx は失敗
+        expect(status, `${href} returned HTTP ${status}`).toBeLessThan(500)
+        // 注: 認証リダイレクト (302/401) はここでは許容し、5xx のみ検出する
+        console.log(`[TC1] ${href} → HTTP ${status}`)
+      } catch (e) {
+        // CF Access / タイムアウトでナビゲーション自体が失敗した場合は skip
+        navigationFailed = true
+        const msg = e instanceof Error ? e.message : String(e)
+        test.skip(true, `${href}: navigation failed (${msg}) — likely CF Access or unreachable`)
+      }
+
+      if (!navigationFailed) {
+        expect(serverError, `${href}: server-side 5xx detected in sub-requests`).toBe(false)
+        await page.screenshot({
+          path: path.join(SCREENSHOT_DIR, `tc1-${name.toLowerCase()}-status.png`),
+          fullPage: false,
+        })
+      }
+    })
+  }
+})
+
+// ─── TC2: 日本語見出し表示 ─────────────────────────────────────────────────────
+
+test.describe('[user-batch3-i18n] TC2: 日本語見出し (locale=ja)', () => {
+  test.beforeEach(ensureScreenshotDir)
+
+  test('Grid (/user/grid) に日本語見出し or Coming Soon overlay が表示される', async ({ page }) => {
+    await setupUserAuth(page)
+    let response
+    try {
+      response = await page.goto('/user/grid', { timeout: 30_000, waitUntil: 'domcontentloaded' })
+    } catch (e) {
+      test.skip(true, `/user/grid: navigation failed — ${e instanceof Error ? e.message : String(e)}`)
+      return
+    }
+    if (!response || response.status() >= 400) {
+      test.skip(true, `/user/grid: HTTP ${response?.status() ?? 'no response'}`)
+      return
+    }
+    await page.waitForTimeout(1_000)
+    const bodyText = await page.evaluate(() => (document.body as HTMLElement).innerText ?? '')
+    // 本番 URL では AuthGuard / CF Access によりリダイレクトされる場合がある → skip
+    const finalUrl = page.url()
+    if (!finalUrl.includes('/user/grid')) {
+      test.skip(true, `/user/grid: redirected to ${finalUrl} (auth gate / CF Access on production URL)`)
+      return
+    }
+    // "Coming Soon" オーバーレイ or 日本語テキスト
+    const hasExpected = bodyText.includes('Coming Soon') || /[぀-ヿ一-鿿]/.test(bodyText)
+    expect(hasExpected, 'Grid: Coming Soon overlay or Japanese text not found').toBeTruthy()
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'tc2-grid-ja.png'),
+      fullPage: false,
+    })
+    console.log(`[TC2] Grid bodyText sample: ${bodyText.slice(0, 80)}`)
+  })
+
+  test('TermsAccept (/user/terms-accept) に日本語見出しが表示される', async ({ page }) => {
+    await setupUserAuth(page)
+    let response
+    try {
+      response = await page.goto('/user/terms-accept', { timeout: 30_000, waitUntil: 'domcontentloaded' })
+    } catch (e) {
+      test.skip(true, `/user/terms-accept: navigation failed — ${e instanceof Error ? e.message : String(e)}`)
+      return
+    }
+    if (!response || response.status() >= 400) {
+      test.skip(true, `/user/terms-accept: HTTP ${response?.status() ?? 'no response'}`)
+      return
+    }
+    await page.waitForTimeout(1_000)
+    const bodyText = await page.evaluate(() => (document.body as HTMLElement).innerText ?? '')
+    // 「利用規約」「同意」等の日本語テキスト or ローディングスピナー (loading=true 状態)
+    const hasJapanese = /[぀-ヿ一-鿿]/.test(bodyText)
+    const hasLoadingOrContent = bodyText.length > 0
+    expect(hasLoadingOrContent, 'TermsAccept: page rendered empty').toBeTruthy()
+    if (hasJapanese) {
+      console.log(`[TC2] TermsAccept: Japanese text found`)
+    } else {
+      console.log(`[TC2] TermsAccept: loading spinner state (no Japanese text yet, bodyText: ${bodyText.slice(0, 50)})`)
+    }
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'tc2-terms-accept-ja.png'),
+      fullPage: false,
+    })
+  })
+
+  test('CopyTrading (/user/copy-trading) に日本語見出し or Coming Soon overlay が表示される', async ({ page }) => {
+    await setupUserAuth(page)
+    let response
+    try {
+      response = await page.goto('/user/copy-trading', { timeout: 30_000, waitUntil: 'domcontentloaded' })
+    } catch (e) {
+      test.skip(true, `/user/copy-trading: navigation failed — ${e instanceof Error ? e.message : String(e)}`)
+      return
+    }
+    if (!response || response.status() >= 400) {
+      test.skip(true, `/user/copy-trading: HTTP ${response?.status() ?? 'no response'}`)
+      return
+    }
+    await page.waitForTimeout(1_500)
+    const bodyText = await page.evaluate(() => (document.body as HTMLElement).innerText ?? '')
+    // 本番 URL では AuthGuard / CF Access によりリダイレクトされる場合がある
+    // その場合 bodyText には "Ultra AutoTrade" のみ含まれ日本語コンテンツが得られない → skip
+    const finalUrl = page.url()
+    if (!finalUrl.includes('/user/copy-trading')) {
+      test.skip(true, `/user/copy-trading: redirected to ${finalUrl} (auth gate / CF Access on production URL)`)
+      return
+    }
+    const hasExpected = bodyText.includes('Coming Soon') || /[぀-ヿ一-鿿]/.test(bodyText)
+    expect(hasExpected, 'CopyTrading: Coming Soon overlay or Japanese text not found').toBeTruthy()
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'tc2-copy-trading-ja.png'),
+      fullPage: false,
+    })
+    console.log(`[TC2] CopyTrading bodyText sample: ${bodyText.slice(0, 80)}`)
+  })
+
+  test('UserHome (/user) に日本語見出しが表示される', async ({ page }) => {
+    await setupUserAuth(page)
+    let response
+    try {
+      response = await page.goto('/user', { timeout: 30_000, waitUntil: 'domcontentloaded' })
+    } catch (e) {
+      test.skip(true, `/user: navigation failed — ${e instanceof Error ? e.message : String(e)}`)
+      return
+    }
+    if (!response || response.status() >= 400) {
+      test.skip(true, `/user: HTTP ${response?.status() ?? 'no response'}`)
+      return
+    }
+    await page.waitForTimeout(1_000)
+    const bodyText = await page.evaluate(() => (document.body as HTMLElement).innerText ?? '')
+    // 本番 URL では AuthGuard / CF Access によりリダイレクトされる場合がある → skip
+    const finalUrl = page.url()
+    if (!finalUrl.includes('/user') || finalUrl.includes('/login') || finalUrl.includes('/auth')) {
+      test.skip(true, `/user: redirected to ${finalUrl} (auth gate / CF Access on production URL)`)
+      return
+    }
+    const hasJapanese = /[぀-ヿ一-鿿]/.test(bodyText)
+    expect(hasJapanese, 'UserHome: Japanese text not found').toBeTruthy()
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'tc2-user-home-ja.png'),
+      fullPage: false,
+    })
+    console.log(`[TC2] UserHome bodyText sample: ${bodyText.slice(0, 80)}`)
+  })
+})
+
+// ─── TC3: 英語 locale 切替 ─────────────────────────────────────────────────────
+
+test.describe('[user-batch3-i18n] TC3: 英語 locale 切替 (NEXT_LOCALE=en)', () => {
+  test.beforeEach(ensureScreenshotDir)
+
+  for (const { href, name } of TARGET_PAGES) {
+    test(`${name} (${href}) NEXT_LOCALE=en cookie で英語テキストが含まれる`, async ({ page, baseURL }) => {
+      await setupUserAuth(page)
+
+      // baseURL から domain を取得して cookie を正しく設定する
+      // localhost / 本番 URL 両対応
+      const resolvedBaseURL = baseURL ?? 'https://app.ultra-auto-trade.com'
+      const cookieDomain = new URL(resolvedBaseURL).hostname
+
+      await page.context().addCookies([
+        { name: 'NEXT_LOCALE', value: 'en', domain: cookieDomain, path: '/' },
+      ])
+
+      let response
+      try {
+        response = await page.goto(href, { timeout: 30_000, waitUntil: 'domcontentloaded' })
+      } catch (e) {
+        test.skip(true, `${href}: navigation failed (en) — ${e instanceof Error ? e.message : String(e)}`)
+        return
+      }
+      if (!response || response.status() >= 400) {
+        test.skip(true, `${href}: HTTP ${response?.status() ?? 'no response'} (en locale)`)
+        return
+      }
+      await page.waitForTimeout(1_000)
+      const bodyText = await page.evaluate(() => (document.body as HTMLElement).innerText ?? '')
+      // 本番 URL でリダイレクトされた場合 (bodyText が layout のみ) は skip
+      // "Ultra AutoTrade\n" のみ、または length < 30 の場合は実コンテンツ未描画
+      const finalUrl = page.url()
+      const strippedBody = bodyText.replace(/Ultra AutoTrade/g, '').replace(/\s+/g, '').trim()
+      if (strippedBody.length < 20) {
+        test.skip(true, `${href} (en): auth redirect or layout-only body on production URL (url: ${finalUrl})`)
+        return
+      }
+      // 英語ロケールではアルファベットのテキストが含まれることを確認
+      const hasEnglish = /[a-zA-Z]{3,}/.test(bodyText)
+      expect(hasEnglish, `${name}: no English text found in en locale (bodyText empty or no latin chars)`).toBeTruthy()
+      console.log(`[TC3] ${name} (en) bodyText sample: ${bodyText.slice(0, 80)}`)
+    })
+  }
+})
+
+// ─── TC4: 翻訳キーリテラル露出なし ───────────────────────────────────────────
+
+test.describe('[user-batch3-i18n] TC4: 翻訳キーリテラルが画面に露出しない', () => {
+  test.beforeEach(ensureScreenshotDir)
+
+  for (const { href, name } of TARGET_PAGES) {
+    test(`${name} (${href}) に翻訳キーリテラルが露出しない`, async ({ page }) => {
+      await setupUserAuth(page)
+      let response
+      try {
+        response = await page.goto(href, { timeout: 30_000, waitUntil: 'domcontentloaded' })
+      } catch (e) {
+        test.skip(true, `${href}: navigation failed — ${e instanceof Error ? e.message : String(e)}`)
+        return
+      }
+      if (!response || response.status() >= 400) {
+        test.skip(true, `${href}: HTTP ${response?.status() ?? 'no response'}`)
+        return
+      }
+      await page.waitForTimeout(1_000)
+      // 翻訳キーリテラルパターン: "Grid.xxx" / "TermsAccept.xxx" 等
+      const keyLiterals = await findTextNodes(page, /\b(Grid|TermsAccept|CopyTrading|UserHome|Common)\.[a-z][a-zA-Z.]+/)
+      if (keyLiterals.length > 0) {
+        console.log(`[WARN] ${name}: key literals exposed: ${keyLiterals.slice(0, 5).join(', ')}`)
+      }
+      expect(keyLiterals.length, `${name}: translation key literal exposed on screen`).toBe(0)
+    })
+  }
+})

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -360,7 +360,86 @@
     "riskLow": "Low",
     "riskMedium": "Medium",
     "riskHigh": "High",
-    "strategist": "Strategist"
+    "strategist": "Strategist",
+    "comingSoon": "Coming in Phase 2"
+  },
+  "Grid": {
+    "subtitle": "Automated trading bot with grid-interval orders",
+    "noGridLevels": "No grid levels",
+    "upperLabel": "Upper",
+    "lowerLabel": "Lower",
+    "gridSettings": "Grid Settings",
+    "upperPriceLabel": "Upper Price (USD)",
+    "lowerPriceLabel": "Lower Price (USD)",
+    "gridCountLabel": "Grid Count (2–100)",
+    "symbolLabel": "Trading Pair",
+    "amountPerGridLabel": "Amount per Grid (USD)",
+    "dryRunLabel": "Dry-run mode (no real orders placed)",
+    "dryRunActive": "Dry-run mode is enabled. No real orders will be placed.",
+    "starting": "Starting...",
+    "startBot": "Start Bot",
+    "fetching": "Fetching...",
+    "fetchStatus": "Fetch Status",
+    "botStatus": "Bot Status",
+    "operationStatus": "Status",
+    "running": "Running",
+    "stopped": "Stopped",
+    "orderStats": "Order Stats",
+    "filledOrders": "Filled / Total Orders",
+    "pnl": "PnL (USD)",
+    "gridVisualization": "Grid Visualization",
+    "errInputRequired": "Please enter upper price, lower price, and amount per grid",
+    "errUpperLower": "Upper price must be greater than lower price",
+    "botStartError": "Bot start error: {msg}",
+    "statusFetchError": "Status fetch error: {msg}",
+    "filled": "Filled",
+    "currentPriceIndicator": "← Current",
+    "currentPriceLabel": "Current Price",
+    "comingSoon": "Coming in Phase 2",
+    "upperPricePlaceholder": "e.g. 50000",
+    "lowerPricePlaceholder": "e.g. 40000",
+    "amountPerGridPlaceholder": "e.g. 100"
+  },
+  "TermsAccept": {
+    "title": "Important Information",
+    "subtitle": "Please review the following before starting",
+    "progressLabel": "Progress",
+    "confirmItem": "I understand",
+    "termsLink": "Terms of Service",
+    "privacyLink": "Privacy Policy",
+    "saving": "Saving...",
+    "startButton": "Start investing",
+    "item1": {
+      "title": "You manage your own assets",
+      "detail": "This service is non-custodial. You hold your private keys; we have no access to your wallet."
+    },
+    "item2": {
+      "title": "DeFi involves risks",
+      "detail": "Smart contract risk, price volatility, and liquidity risk all exist. Please invest at your own responsibility."
+    },
+    "item3": {
+      "title": "You are responsible for your account",
+      "detail": "Managing login credentials and responding to unauthorized access is your responsibility. We are not liable for account losses."
+    }
+  },
+  "UserHome": {
+    "heroLine1": "AI manages your assets",
+    "heroLine2": "at the optimal time",
+    "nonCustodial": "Non-custodial — your wallet, your assets",
+    "step1": {
+      "title": "Connect your wallet",
+      "description": "Connect a MetaMask / WalletConnect wallet to Base Mainnet"
+    },
+    "step2": {
+      "title": "AI analyzes the market",
+      "description": "Claude Opus suggests optimal timing. Cross-verified by GPT-4o."
+    },
+    "step3": {
+      "title": "You approve and sign",
+      "description": "Review the proposal and sign with your wallet. You are the final decision-maker."
+    },
+    "riskDisclaimer": "This is not investment advice. Cryptocurrency trading carries the risk of principal loss. Please use at your own judgment and responsibility.",
+    "dashboardCta": "Already connected? Go to dashboard →"
   },
   "Chat": {
     "headerTitle": "UATa AI",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -360,7 +360,86 @@
     "riskLow": "低",
     "riskMedium": "中",
     "riskHigh": "高",
-    "strategist": "ストラテジスト"
+    "strategist": "ストラテジスト",
+    "comingSoon": "Phase 2で対応予定"
+  },
+  "Grid": {
+    "subtitle": "グリッド間隔で自動売買を行うボット設定",
+    "noGridLevels": "グリッドレベルがありません",
+    "upperLabel": "上限",
+    "lowerLabel": "下限",
+    "gridSettings": "グリッド設定",
+    "upperPriceLabel": "上限価格 (USD)",
+    "lowerPriceLabel": "下限価格 (USD)",
+    "gridCountLabel": "グリッド数（2〜100）",
+    "symbolLabel": "取引ペア",
+    "amountPerGridLabel": "各グリッド金額 (USD)",
+    "dryRunLabel": "ドライランモード（実際の注文は発行しない）",
+    "dryRunActive": "ドライランモードが有効です。実際の注文は発行されません。",
+    "starting": "起動中...",
+    "startBot": "Bot起動",
+    "fetching": "取得中...",
+    "fetchStatus": "ステータス取得",
+    "botStatus": "Bot ステータス",
+    "operationStatus": "稼働状態",
+    "running": "稼働中",
+    "stopped": "停止中",
+    "orderStats": "注文統計",
+    "filledOrders": "約定済み / 総注文数",
+    "pnl": "損益 (USD)",
+    "gridVisualization": "グリッドビジュアライゼーション",
+    "errInputRequired": "上限価格・下限価格・各グリッド金額を入力してください",
+    "errUpperLower": "上限価格は下限価格より大きい値を入力してください",
+    "botStartError": "Bot起動エラー: {msg}",
+    "statusFetchError": "ステータス取得エラー: {msg}",
+    "filled": "約定",
+    "currentPriceIndicator": "← 現在値",
+    "currentPriceLabel": "現在価格",
+    "comingSoon": "Phase 2で対応予定",
+    "upperPricePlaceholder": "例: 50000",
+    "lowerPricePlaceholder": "例: 40000",
+    "amountPerGridPlaceholder": "例: 100"
+  },
+  "TermsAccept": {
+    "title": "重要事項の確認",
+    "subtitle": "運用開始前に以下をご確認ください",
+    "progressLabel": "確認状況",
+    "confirmItem": "確認しました",
+    "termsLink": "利用規約",
+    "privacyLink": "プライバシーポリシー",
+    "saving": "保存中...",
+    "startButton": "運用を開始する",
+    "item1": {
+      "title": "資産はユーザー自身が管理します",
+      "detail": "本サービスはノンカストディアル型です。秘密鍵はユーザーが管理し、弊社はウォレットにアクセスできません。"
+    },
+    "item2": {
+      "title": "DeFi運用にはリスクがあります",
+      "detail": "スマートコントラクトのリスク、価格変動リスク、流動性リスクが存在します。投資は自己責任でお願いします。"
+    },
+    "item3": {
+      "title": "アカウント管理は利用者自身の責任です",
+      "detail": "ログイン情報の管理、不正アクセスへの対応はユーザーご自身の責任となります。弊社はアカウント損失に対して責任を負いません。"
+    }
+  },
+  "UserHome": {
+    "heroLine1": "AIが最適なタイミングで、",
+    "heroLine2": "あなたの資産を運用します",
+    "nonCustodial": "Non-custodial — あなたのウォレット、あなたの資産",
+    "step1": {
+      "title": "ウォレットを接続",
+      "description": "MetaMask / WalletConnect 対応ウォレットをBase メインネットに接続"
+    },
+    "step2": {
+      "title": "AIが市場を分析",
+      "description": "Claude Opus が最適なタイミングを提案。GPT-4o でクロス検証。"
+    },
+    "step3": {
+      "title": "あなたが承認・署名",
+      "description": "提案を確認し、ウォレットで署名。あなたが最終判断者です。"
+    },
+    "riskDisclaimer": "これは投資助言ではありません。暗号資産取引には元本損失のリスクがあります。ご自身の判断と責任において利用してください。",
+    "dashboardCta": "すでに接続済みの方はダッシュボードへ →"
   },
   "Chat": {
     "headerTitle": "UATa AI",


### PR DESCRIPTION
## app/user/ 非金融4ページ + CopyTradingCard i18n 化（live ツリースイープ バッチ3）

### 対象
- `app/user/grid/page.tsx` — `Grid` namespace 35キー（**グリッド Bot 設定/起動画面**）
- `app/user/terms-accept/page.tsx` — `TermsAccept` namespace 14キー（規約同意フロー）
- `app/user/copy-trading/page.tsx` + `components/user/CopyTradingCard.tsx` — `CopyTrading` 20キー + `Common` 再利用
- `app/user/page.tsx` — `UserHome` namespace 11キー

### 🔴 金融近接ロジックの非改変（Evaluator が git diff で実証）
- **grid**: `handleExecute`/`handleFetchStatus` の async フロー・バリデーション（`upper <= lower`/`isNaN`）・`config`（`dry_run`/`enabled` 含む）構築・`executeGridBot(token, config)` 呼び出し・SYMBOLS 定数・早期 return すべて不変。変更は useTranslations 追加 + setError 文字列の t() 化 + useCallback deps のみ。
- **CopyTradingCard**: `strategy.risk_level`（英語 "low"/"medium"/"high"）の比較・`RISK_COLORS` 色引き当て不変。表示のみ riskLabelKey マッピングで t() 化。
- **terms-accept**: 同意チェック・POST・router 遷移不変。ITEMS→ITEM_IDS tuple 化で `checked`/`allChecked` ロジック維持。

### Gate 結果
- tsc --noEmit: 変更5ファイル起因の新規エラー **0**
- ja/en namespace 完全一致: Grid 35 / TermsAccept 14 / CopyTrading 20 / UserHome 11 / Common（全て差分0）。`botStartError {msg}` 補間保持
- `npm run build` は dev VPS OOM → `ignoreBuildErrors` 構成で CI 通過（委譲）
- Gate 4: `frontend/e2e/user-batch3-i18n.spec.ts` 新規。疎通4/4 PASS、認証ゲート skip は設計通り
- Evaluator: APPROVED（CRITICAL 0、MINOR 1件記録のみ）
- ついでに CopyTradingCard の未使用 import（TrendingUp/ShieldCheck/Badge）除去

### スイープ残
- settings(+7 components) = 次バッチ
- trade / deposit / wallet / approve（金融操作近接 = **人間ゲート**、文字列のみ置換でも要人間レビュー）

🤖 Generated with [Claude Code](https://claude.com/claude-code)