### PR TITLE
fix(frontend): terms/privacy ページを Arobix テーマに統一

### DIFF
--- a/frontend/app/privacy-policy/page.tsx
+++ b/frontend/app/privacy-policy/page.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 'use client'
 
+import '../arobix/theme.css'
 import { ArrowLeft } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useSmartBack } from '@/hooks/useSmartBack'
@@ -9,7 +10,7 @@ export default function PrivacyPolicyPage() {
   const goBack = useSmartBack()
 
   return (
-    <div className="min-h-screen bg-zinc-950 text-zinc-100">
+    <div className="arobix-root min-h-screen bg-zinc-950 text-zinc-100">
       <div className="max-w-2xl mx-auto px-4 py-8">
         <Button
           variant="ghost"

--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 'use client'
 
+import '../arobix/theme.css'
 import { ArrowLeft } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useSmartBack } from '@/hooks/useSmartBack'
@@ -9,7 +10,7 @@ export default function TermsPage() {
   const goBack = useSmartBack()
 
   return (
-    <div className="min-h-screen bg-zinc-950 text-zinc-100">
+    <div className="arobix-root min-h-screen bg-zinc-950 text-zinc-100">
       <div className="max-w-2xl mx-auto px-4 py-8">
         <Button
           variant="ghost"


### PR DESCRIPTION
## Summary

- `/terms` と `/privacy-policy` ページに `arobix/theme.css` を import
- ルート div に `arobix-root` クラスを追加
- `bg-zinc-950` 素のダーク背景から theme.css の warm override（`#f7f2ea` 系）へ統一

## 変更ファイル

- `frontend/app/terms/page.tsx`
- `frontend/app/privacy-policy/page.tsx`

## 技術詳細

- `arobix-root` クラスは `.arobix-root .bg-zinc-950 { ... !important }` 等のオーバーライド規則を theme.css が持つため、既存 Tailwind クラスが自動的に Arobix ウォームライトテーマに変換される
- CSS scoping: theme.css の全セレクタは `.arobix-root` 配下にスコープされ、他ルートへの副作用なし
- import パス `../arobix/theme.css` は `app/(liff)/layout.tsx` の前例と同パターン

## Test plan

- [x] Evaluator: APPROVED（Tier S 無変更・CSS スコープ漏れなし・import パス正確）
- [x] Tester: PASS（tsc 変更起因エラー 0 件・両ファイルに import + arobix-root 確認済み）
- [ ] 目視確認: `/terms`・`/privacy-policy` を local dev で開き背景色が `#f7f2ea` 系になることを確認

Closes Asana GID: 1215685195306183

🤖 Generated with [Claude Code](https://claude.ai/claude-code) — auto-pipeline Planner→Generator→Evaluator→Tester