### PR TITLE
feat(i18n): (admin)/layout.tsx に NextIntlClientProvider を追加

### DIFF
--- a/frontend/app/(admin)/layout.tsx
+++ b/frontend/app/(admin)/layout.tsx
@@ -1,16 +1,22 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
+import { getLocale, getMessages } from 'next-intl/server'
+import { NextIntlClientProvider } from 'next-intl'
 import { AdminProviders } from '@/components/providers/AdminProviders'
 import TermsGuard from '@/components/terms/TermsGuard'
 
-export default function AdminLayout({
+export default async function AdminLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
+  const locale = await getLocale()
+  const messages = await getMessages()
   return (
-    <AdminProviders>
-      <TermsGuard>{children}</TermsGuard>
-    </AdminProviders>
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      <AdminProviders>
+        <TermsGuard>{children}</TermsGuard>
+      </AdminProviders>
+    </NextIntlClientProvider>
   )
 }


### PR DESCRIPTION
## Summary

- `(admin)/layout.tsx` を async 化し `NextIntlClientProvider` で子ツリーをラップ
- `(user)/layout.tsx` / `(partner)/layout.tsx` と同一パターンを踏襲
- admin 配下の全クライアントコンポーネントで `useTranslations()` が解決できる前提条件

## Changes

- `frontend/app/(admin)/layout.tsx`: `async` 化 + `getLocale`/`getMessages` + `NextIntlClientProvider` ラップ追加（既存 `AdminProviders`/`TermsGuard` 構造は変更なし）

## DoD

- [x] tsc --noEmit: エラー 0 件
- [x] 変更ファイル: `(admin)/layout.tsx` 1 ファイルのみ（スコープ明確）
- [x] Evaluator: APPROVED

## Test plan

- [ ] staging で admin 配下ページ (`/protocols` 等) を開き、`useTranslations()` を使う子コンポーネントが正常描画されること
- [ ] `NextIntlClientProvider` ラップ前後で既存 admin UI（TermsGuard / AdminProviders）に視覚的リグレッションがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)