### PR TITLE
feat(liff-chat): 緊急停止ボタン + safe-area-inset 対応

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/ChatPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/ChatPanel.tsx
@@ -280,7 +280,7 @@ export function ChatPanel({ onClose }: Props) {
         </div>
 
         {/* サジェストボタン（固定底部）*/}
-        <div className="flex-shrink-0 px-4 pb-6 pt-3 border-t border-zinc-800">
+        <div className="flex-shrink-0 px-4 pt-3 border-t border-zinc-800 ax-safe-bottom">
           <p className="text-zinc-600 text-xs mb-2">{t("suggestLabel")}</p>
           <div className="grid grid-cols-2 gap-2">
             {SUGGEST_CONFIG.map((cfg) => {

--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -77,6 +77,12 @@ export default function LiffChatPage() {
   const [unreadCount] = useState(0)
   const [reasonOpen, setReasonOpen] = useState(false)
 
+  // ── 緊急停止 state
+  const [paused, setPaused] = useState(false)
+  const [stopConfirmOpen, setStopConfirmOpen] = useState(false)
+  const [stopLoading, setStopLoading] = useState(false)
+  const [toast, setToast] = useState<string | null>(null)
+
   // ── データ取得
   useEffect(() => {
     const token =
@@ -89,15 +95,17 @@ export default function LiffChatPage() {
     const headers = { Authorization: `Bearer ${token}` }
 
     // 資産サマリー（/api/user/settings から balance を読む）
+    // 併せて is_active=false（運用停止中）を読んで緊急停止バーの初期状態に反映する。
     fetch(`${API_BASE}/api/user/settings`, { headers })
       .then((r) => (r.ok ? r.json() : null))
-      .then((d: Record<string, string> | null) => {
+      .then((d: (Record<string, string> & { is_active?: boolean }) | null) => {
         if (d) {
           const current = parseFloat(d.balance ?? "0")
           const initial = parseFloat(d.initial_balance ?? d.balance ?? "0")
           const pnlUsd = current - initial
           const pnlPct = initial > 0 ? (pnlUsd / initial) * 100 : 0
           setAssetData({ current_usd: current, initial_usd: initial, pnl_usd: pnlUsd, pnl_pct: pnlPct })
+          if (d.is_active === false) setPaused(true)
         }
       })
       .catch(() => {})
@@ -126,6 +134,33 @@ export default function LiffChatPage() {
   }
   function handleReject() {
     setAiJudgment(null)
+  }
+
+  // ── 緊急停止: POST /api/user/pause（require_active_user / consumer 可）
+  // backend の OR ロジック安全装置は変更せず、ユーザーの is_active フラグを落とすだけ。
+  async function handleEmergencyStop() {
+    const token =
+      typeof window !== "undefined"
+        ? (localStorage.getItem("auth_token") ?? "")
+        : ""
+    const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ""
+    if (!token) return
+    setStopLoading(true)
+    try {
+      const res = await fetch(`${API_BASE}/api/user/pause`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      setPaused(true)
+      setStopConfirmOpen(false)
+      setToast(t("home.stopSuccess"))
+    } catch {
+      setToast(t("home.stopFailed"))
+    } finally {
+      setStopLoading(false)
+      setTimeout(() => setToast(null), 2800)
+    }
   }
 
   // ── AI カード色設定
@@ -347,10 +382,79 @@ export default function LiffChatPage() {
         </div>
       </main>
 
+      {/* ── 緊急停止バー（下部固定 / safe-area 対応） */}
+      <div
+        className="fixed bottom-0 left-0 right-0 z-30 w-[375px] mx-auto px-4 pt-2 ax-safe-bottom
+                   bg-gradient-to-t from-zinc-950 via-zinc-950/95 to-transparent"
+      >
+        {paused ? (
+          <div
+            role="status"
+            className="w-full py-3 rounded-xl border border-red-500/60 bg-red-500/10
+                       text-red-300 text-sm font-semibold flex items-center justify-center gap-2"
+          >
+            <span className="w-2 h-2 rounded-full bg-red-500" />
+            {t("home.stoppedStatus")}
+          </div>
+        ) : (
+          <button
+            onClick={() => setStopConfirmOpen(true)}
+            className="w-full py-3 rounded-xl bg-red-600 active:bg-red-700 text-white font-bold
+                       shadow-lg transition-colors"
+            aria-label={t("home.emergencyStopAriaLabel")}
+          >
+            {t("home.emergencyStop")}
+          </button>
+        )}
+      </div>
+
+      {/* 緊急停止 確認ダイアログ */}
+      {stopConfirmOpen && (
+        <div className="fixed inset-0 z-50 flex items-end justify-center">
+          <div
+            className="absolute inset-0 bg-black/60"
+            onClick={() => !stopLoading && setStopConfirmOpen(false)}
+          />
+          <div className="relative w-[375px] mx-auto bg-zinc-900 rounded-t-2xl p-5 ax-safe-bottom">
+            <h3 className="text-white font-bold text-lg mb-1">{t("home.stopConfirmTitle")}</h3>
+            <p className="text-zinc-400 text-sm mb-4 leading-relaxed">
+              {t("home.stopConfirmDesc")}
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setStopConfirmOpen(false)}
+                disabled={stopLoading}
+                className="flex-1 py-3 rounded-xl border border-zinc-600 text-zinc-300 font-semibold disabled:opacity-40"
+              >
+                {t("home.stopCancel")}
+              </button>
+              <button
+                onClick={handleEmergencyStop}
+                disabled={stopLoading}
+                className="flex-1 py-3 rounded-xl bg-red-600 active:bg-red-700 text-white font-bold disabled:opacity-50"
+              >
+                {stopLoading ? t("home.stopping") : t("home.stopConfirm")}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* トースト */}
+      {toast && (
+        <div
+          role="status"
+          className="fixed top-4 left-1/2 -translate-x-1/2 z-[60] px-4 py-2 rounded-xl bg-zinc-800
+                     border border-zinc-700 text-white text-sm shadow-lg whitespace-nowrap"
+        >
+          {toast}
+        </div>
+      )}
+
       {/* ── FAB（右下固定） */}
       <button
         onClick={() => setChatOpen(true)}
-        className="fixed bottom-6 right-6 z-30 w-14 h-14 rounded-full shadow-lg
+        className="fixed bottom-24 right-6 z-40 w-14 h-14 rounded-full shadow-lg
                    flex items-center justify-center active:scale-95 transition-transform
                    bg-gradient-to-br from-[#b9a4f2] via-[#ecaccd] to-[#fbd9a0]"
         aria-label={t("home.openChatAriaLabel")}

--- a/frontend/app/arobix/theme.css
+++ b/frontend/app/arobix/theme.css
@@ -175,3 +175,15 @@
 .arobix-root .border-zinc-800 { border-color: #e5ddd0 !important; }
 .arobix-root .border-zinc-700 { border-color: #d8cfc4 !important; }
 .arobix-root .border-zinc-600 { border-color: #cfc5b8 !important; }
+
+/* ================================================================
+ * Safe area (Android edge-to-edge / iOS home indicator)
+ * 2026-03-09 以降の Android LINE は edge-to-edge 表示になり、下部固定 CTA が
+ * システムナビバーに埋没する。下部固定要素に .ax-safe-bottom を当てて
+ * env(safe-area-inset-bottom) ぶんの余白を確保する。個別ハックの乱発を避け、
+ * 下部 inset はこの 1 クラスに集約する（theme.css は (liff)/layout.tsx で
+ * 読み込まれ全 liff 画面に適用される）。
+ * ================================================================ */
+.ax-safe-bottom {
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 0.75rem);
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -617,7 +617,17 @@
       "operatingCoins": "Active Holdings",
       "noCoins": "No active holdings",
       "openChatAriaLabel": "Open chat",
-      "assetChartLoading": "Loading chart..."
+      "assetChartLoading": "Loading chart...",
+      "emergencyStop": "Emergency Stop",
+      "emergencyStopAriaLabel": "Emergency stop autonomous trading",
+      "stoppedStatus": "Autonomous trading is stopped",
+      "stopConfirmTitle": "Stop autonomous trading?",
+      "stopConfirmDesc": "Stopping halts the AI's automatic decisions and execution. To resume, please contact support.",
+      "stopCancel": "Cancel",
+      "stopConfirm": "Stop",
+      "stopping": "Stopping...",
+      "stopSuccess": "Autonomous trading stopped",
+      "stopFailed": "Failed to stop. Please try again later."
     },
     "panels": {
       "assetHistory": "Asset History",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -617,7 +617,17 @@
       "operatingCoins": "運用中コイン",
       "noCoins": "運用中のコインがありません",
       "openChatAriaLabel": "チャットを開く",
-      "assetChartLoading": "グラフを読み込み中..."
+      "assetChartLoading": "グラフを読み込み中...",
+      "emergencyStop": "緊急停止",
+      "emergencyStopAriaLabel": "自律売買を緊急停止する",
+      "stoppedStatus": "自律売買は停止中です",
+      "stopConfirmTitle": "自律売買を停止しますか？",
+      "stopConfirmDesc": "停止すると、AIによる自動の判断・実行が止まります。再開はサポートにご連絡ください。",
+      "stopCancel": "キャンセル",
+      "stopConfirm": "停止する",
+      "stopping": "停止中...",
+      "stopSuccess": "自律売買を停止しました",
+      "stopFailed": "停止に失敗しました。時間をおいて再度お試しください"
     },
     "panels": {
       "assetHistory": "資産推移",


### PR DESCRIPTION
## 概要
明日の liff-chat 一般公開に向けた P0 実装2件。

## 変更
### 1. 緊急停止ボタン (Closes 1215677814077596)
- liff-chat ホーム下部に固定の緊急停止バーを追加
- **接続先**: `POST /api/user/pause` (`backend/app/users/settings_router.py:196`)
- **RBAC**: `Depends(require_active_user)` (`backend/app/auth/dependencies.py:104`) — ロールゲートなし、認証済み consumer/viewer が呼べる
- `require_partner` の `/api/automation/emergency-stop`（システム全体キルスイッチ）は consumer には過剰なため不採用
- backend の OR ロジック安全装置は不変更（`is_active` フラグを落とすのみ）
- 確認ダイアログ + 成功/失敗トースト + 「停止中」表示。初期状態は `/api/user/settings` の `is_active` で復元
- 注記: `/resume` も `require_active_user` のため、停止後の self-resume は API 上不可（backend 仕様、別スコープ）。UI は楽観的に停止中表示

### 2. safe-area-inset (Closes 1215685233707264)
- 2026-03-09 Android edge-to-edge で下部固定ボタンがナビバーに埋没する問題への対応
- `theme.css` に `.ax-safe-bottom` を1箇所集約（`env(safe-area-inset-bottom)`）
- 緊急停止バー・確認ダイアログ・ChatPanel 下部入力に適用
- FAB は `z-40`/`bottom-24` へ退避し停止バーと非干渉化

## Gate
- ✅ `npx tsc --noEmit` exit 0
- ✅ ja/en JSON 妥当性 OK、全文言 i18n 化（ハードコードなし）
- ⏳ Android LINE 実機での safe-area 重なり確認は要実機（CF Access 環境）

🤖 Generated with [Claude Code](https://claude.com/claude-code)