### PR TITLE
feat(user): アカウント削除申請エンドポイント新設 — 404 偽装成功を解消

### DIFF
--- a/backend/alembic/versions/w3x4y5z6a7b8_add_account_deletion_requests.py
+++ b/backend/alembic/versions/w3x4y5z6a7b8_add_account_deletion_requests.py
@@ -1,0 +1,48 @@
+"""add account_deletion_requests table
+
+アカウント削除申請テーブルを新設。APPI / 個人情報保護法対応。
+Asana: PR #713 feat/liff-account-delete-request
+
+Revision ID: w3x4y5z6a7b8
+Revises: v2w3x4y5z6a7
+Create Date: 2026-06-14 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "w3x4y5z6a7b8"
+down_revision: Union[str, Sequence[str], None] = "v2w3x4y5z6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "account_deletion_requests",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="pending"),
+        sa.Column(
+            "requested_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column("processed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_account_deletion_requests_user_id",
+        "account_deletion_requests",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_account_deletion_requests_user_id", table_name="account_deletion_requests")
+    op.drop_table("account_deletion_requests")

--- a/backend/app/users/models.py
+++ b/backend/app/users/models.py
@@ -94,3 +94,54 @@ class UserSettings(Base):
 
     def __repr__(self) -> str:
         return f"<UserSettings(user_id={self.user_id}, risk_mode={self.risk_mode})>"
+
+
+# アカウント削除申請の status 値（models.py を唯一の真実源とする / CHECK は migration 内で独自定義しない）
+ACCOUNT_DELETION_STATUS_PENDING = "pending"
+ACCOUNT_DELETION_STATUS_PROCESSED = "processed"
+ACCOUNT_DELETION_STATUS_CANCELLED = "cancelled"
+
+
+class AccountDeletionRequest(Base):
+    """アカウント削除申請テーブル。
+
+    ユーザーからの削除申請を耐久的に記録する（APPI / 個人情報保護法対応）。
+    本モジュールは main.py から import され、Base.metadata.create_all() 時に
+    テーブルが自動作成される。status は application-layer で制御する
+    （'pending' / 'processed' / 'cancelled'）。CHECK 制約を migration 内で
+    独自定義しない（models.py が唯一の真実源）。
+
+    手動 CREATE TABLE SQL (新規環境・DB 再構築時):
+        CREATE TABLE IF NOT EXISTS account_deletion_requests (
+            id           SERIAL PRIMARY KEY,
+            user_id      INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            status       VARCHAR(20) NOT NULL DEFAULT 'pending',
+            requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            processed_at TIMESTAMPTZ
+        );
+        CREATE INDEX IF NOT EXISTS ix_account_deletion_requests_user_id
+            ON account_deletion_requests (user_id);
+    """
+
+    __tablename__ = "account_deletion_requests"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default=ACCOUNT_DELETION_STATUS_PENDING
+    )
+    requested_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+    processed_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
+
+    def __repr__(self) -> str:
+        return f"<AccountDeletionRequest(user_id={self.user_id}, status={self.status})>"

--- a/backend/app/users/settings_router.py
+++ b/backend/app/users/settings_router.py
@@ -16,6 +16,7 @@ from app.database import get_db
 from app.partner import allocation_service
 from app.partner.allocation_schemas import MyAllocationResponse
 
+from .models import ACCOUNT_DELETION_STATUS_PENDING, AccountDeletionRequest
 from .settings_schemas import UserSettingsResponse, UserSettingsUpdate
 
 logger = logging.getLogger(__name__)
@@ -215,3 +216,45 @@ def resume_user(
     db.add(current_user)
     db.commit()
     return {"message": "resumed", "is_active": True}
+
+
+@router.post("/delete-request", summary="アカウント削除申請")
+def request_account_deletion(
+    current_user: User = Depends(require_active_user),
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    """アカウント削除を申請する（APPI / 個人情報保護法対応 / 冪等）。
+
+    削除申請を account_deletion_requests に記録する。既に pending の申請が
+    あればそれを返す（二重申請を防ぐ）。実際の削除データ処理はバックオフィスで
+    行うため、本エンドポイントは「申請の受付」までを担う。
+    """
+    existing = (
+        db.query(AccountDeletionRequest)
+        .filter(
+            AccountDeletionRequest.user_id == current_user.id,
+            AccountDeletionRequest.status == ACCOUNT_DELETION_STATUS_PENDING,
+        )
+        .first()
+    )
+    if existing is not None:
+        return {
+            "status": existing.status,
+            "requested_at": existing.requested_at.isoformat(),
+            "already_requested": True,
+        }
+
+    req = AccountDeletionRequest(user_id=current_user.id, status=ACCOUNT_DELETION_STATUS_PENDING)
+    db.add(req)
+    db.commit()
+    db.refresh(req)
+    logger.info(
+        "User %s requested account deletion (req_id=%s)",
+        current_user.email,
+        req.id,
+    )
+    return {
+        "status": req.status,
+        "requested_at": req.requested_at.isoformat(),
+        "already_requested": False,
+    }

--- a/backend/tests/test_account_deletion_request.py
+++ b/backend/tests/test_account_deletion_request.py
@@ -1,0 +1,114 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_account_deletion_request.py
+"""アカウント削除申請 API (POST /api/user/delete-request) のテスト。"""
+
+import os
+import tempfile
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-deletion")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "deletion_admin@example.com")
+
+from app.database import Base, get_db  # noqa: E402
+from app.main import create_app  # noqa: E402
+from app.users.models import (  # noqa: E402
+    ACCOUNT_DELETION_STATUS_PENDING,
+    AccountDeletionRequest,
+)
+
+
+@pytest.fixture()
+def test_db():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db() -> Generator:
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    yield override_get_db, SessionLocal
+    Base.metadata.drop_all(bind=engine)
+    os.unlink(path)
+
+
+@pytest.fixture()
+def client(test_db) -> TestClient:
+    override_get_db, _ = test_db
+    app = create_app()
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app)
+
+
+def register_and_login(
+    client: TestClient,
+    email: str | None = None,
+    username: str = "deluser",
+    password: str = "userpassword123",
+) -> str:
+    # /auth/register は request.email == INITIAL_ADMIN_EMAIL を要求するため、
+    # 実際の env 値を使う（他テストモジュールが先に値を設定していても合わせる）。
+    if email is None:
+        email = os.environ.get("INITIAL_ADMIN_EMAIL", "deletion_admin@example.com")
+    client.post(
+        "/auth/register",
+        json={"email": email, "username": username, "password": password},
+    )
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    return r.json()["access_token"]
+
+
+class TestAccountDeletionRequest:
+    def test_requires_auth(self, client: TestClient) -> None:
+        """未認証では 401。"""
+        r = client.post("/api/user/delete-request")
+        assert r.status_code == 401
+
+    def test_creates_pending_request(self, client: TestClient) -> None:
+        """認証済みで申請すると 200 + status=pending + already_requested=False。"""
+        token = register_and_login(client)
+        r = client.post(
+            "/api/user/delete-request",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == ACCOUNT_DELETION_STATUS_PENDING
+        assert body["already_requested"] is False
+        assert "requested_at" in body
+
+    def test_idempotent_second_call(self, client: TestClient) -> None:
+        """二回目の申請は already_requested=True を返し、行は重複しない。"""
+        token = register_and_login(client)
+        headers = {"Authorization": f"Bearer {token}"}
+        first = client.post("/api/user/delete-request", headers=headers)
+        second = client.post("/api/user/delete-request", headers=headers)
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert second.json()["already_requested"] is True
+
+    def test_request_persisted(self, client: TestClient, test_db) -> None:
+        """申請が account_deletion_requests に1行だけ永続化される。"""
+        token = register_and_login(client)
+        headers = {"Authorization": f"Bearer {token}"}
+        client.post("/api/user/delete-request", headers=headers)
+        client.post("/api/user/delete-request", headers=headers)
+
+        _, SessionLocal = test_db
+        db = SessionLocal()
+        try:
+            rows = db.query(AccountDeletionRequest).all()
+            assert len(rows) == 1
+            assert rows[0].status == ACCOUNT_DELETION_STATUS_PENDING
+        finally:
+            db.close()

--- a/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
@@ -387,11 +387,9 @@ export function AccountPanel() {
   }
 
   // アカウント削除申請
-  // TODO: backend に削除申請エンドポイントが未実装（grep で
-  //       /api/user/delete-request は存在せず）。現状は申請 stub として POST し、
-  //       404/405 は「サポートへ誘導」へ graceful fallback する。
-  //       backend 実装後（例 POST /api/user/delete-request、残高チェックは
-  //       サーバ側で行い 409 等を返す）に正式フローへ差し替える。
+  // backend: POST /api/user/delete-request（require_active_user / 冪等）。
+  // 申請は account_deletion_requests に記録される。成功時のみ受付完了を表示し、
+  // 失敗（404 含む）は誤魔化さず実エラーを表示する（押せるのに黙って失敗を防ぐ）。
   const handleDeleteRequest = async () => {
     const token = getAuthToken() ?? ""
     setDeleteSubmitting(true)
@@ -404,20 +402,19 @@ export function AccountPanel() {
         },
       })
       if (res.ok) {
+        // 新規申請・既存 pending（already_requested）いずれも受付済みとして扱う
         showToast(t("toastDeleteRequested"))
         setDeleteSheet(false)
       } else if (res.status === 409) {
-        // 残高ありなどサーバ側拒否（将来仕様）
+        // 残高ありなどサーバ側拒否（将来仕様）— シートは開いたまま理由を見せる
         showToast(t("toastDeleteBalanceError"))
-      } else if (res.status === 404 || res.status === 405) {
-        showToast(t("toastDeleteContactSupport"))
-        setDeleteSheet(false)
       } else {
+        // 404/5xx 等は実エラーとして扱う（成功偽装で dismiss しない）
         showToast(t("toastDeleteError"))
       }
     } catch {
-      showToast(t("toastDeleteContactSupport"))
-      setDeleteSheet(false)
+      // ネットワークエラー — 実エラー表示
+      showToast(t("toastDeleteError"))
     } finally {
       setDeleteSubmitting(false)
     }


### PR DESCRIPTION
## 概要
明日の liff-chat 一般公開に向けた P0 実装（APPI / 個人情報保護法）。

## 問題
liff-chat の「アカウント削除」ボタンが `POST /api/user/delete-request` を叩くが backend に該当ルートが存在せず 404。フロント（`AccountPanel.tsx`）は 404/405 を「サポートへ誘導」で握りつぶし、**成功トーストを偽装表示**していた（押せるのに黙って失敗）。消費者向け一般公開では退会導線が黙って失敗するのはコンプライアンス事故。

## 変更
### backend
- `account_deletion_requests` テーブル新設（`AccountDeletionRequest` model）。`Base.metadata.create_all` で自動作成、手動 `CREATE TABLE` SQL を docstring に記載
- `POST /api/user/delete-request`（**RBAC: `require_active_user`** = 認証済み consumer 可、`settings_router.py`）。**冪等**: 既存 pending があれば `already_requested=true` を返し二重申請を防ぐ
- `status` は application-layer 制御（CHECK を migration 内で独自定義しない / models.py が唯一の真実源 — Asana 1215272519685583 教訓）
- pytest 4 ケース（401 / 新規申請 / 冪等 / 永続化）全 pass

### frontend
- 404/405 を dismiss する偽装成功分岐を撤去。実エラーは `toastDeleteError` で正直に表示。誤解を招く TODO コメント削除

## Gate
- ✅ `npx tsc --noEmit` exit 0
- ✅ `ruff check` / `ruff format --check` pass（3 files）
- ✅ `mypy app/users/...` Success（app/ ゲート対象）
- ✅ `pytest tests/test_account_deletion_request.py` 4 passed

## 補足
- 本 PR は「申請の受付・記録」まで。実データ削除はバックオフィス処理（別タスク）
- `toastDeleteContactSupport` キーは未使用化（残置・無害）

Closes 1215701364408741

🤖 Generated with [Claude Code](https://claude.com/claude-code)