### PR TITLE
feat(i18n): wave12 admin dashboard + automation + dashboard/reports i18n

### DIFF
--- a/frontend/app/(admin)/dashboard/automation/page.tsx
+++ b/frontend/app/(admin)/dashboard/automation/page.tsx
@@ -3,6 +3,7 @@
 // Unauthorized copying or distribution is strictly prohibited.
 
 import React from "react";
+import { useTranslations } from "next-intl";
 import AuthGuard from "@/components/AuthGuard";
 import KpiCards from "@/components/dashboard/KpiCards";
 import StatusPanel from "@/components/dashboard/StatusPanel";
@@ -12,6 +13,7 @@ import { useAuth } from "@/lib/auth";
 import type { AutomationStatus, DashboardSnapshot } from "@/lib/types";
 
 export default function AutomationPage() {
+  const t = useTranslations("AdminDashboardAutomation");
   const { token } = useAuth();
   const [lookbackHours, setLookbackHours] = React.useState<number>(6);
   const [status, setStatus] = React.useState<AutomationStatus | null>(null);
@@ -41,25 +43,25 @@ export default function AutomationPage() {
   return (
     <AuthGuard adminOnly>
       <>
-      <title>自動売買 - Ultra AutoTrade</title>
+      <title>{t("browserTitle")}</title>
 
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 12, flexWrap: "wrap" }}>
         <div>
-          <h1 style={{ marginBottom: 6 }}>自動売買ステータス</h1>
+          <h1 style={{ marginBottom: 6 }}>{t("pageTitle")}</h1>
           <p style={{ marginTop: 0, color: "#555" }}>
-            運用読み取り専用ビュー。<code>docs/19_operations_runbook.md</code> §2.4 に準拠。
+            {t("pageSubtitle")}
           </p>
         </div>
 
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          <label style={{ fontSize: 12, color: "#666" }}>参照時間</label>
+          <label style={{ fontSize: 12, color: "#666" }}>{t("lookbackLabel")}</label>
           <select
             value={lookbackHours}
             onChange={(e) => setLookbackHours(Number(e.target.value))}
             style={{ padding: "6px 10px", borderRadius: 10, border: "1px solid #ddd" }}
           >
             {[1, 6, 12, 24].map((v) => (
-              <option key={v} value={v}>{v}時間</option>
+              <option key={v} value={v}>{t("lookbackOption", { hours: v })}</option>
             ))}
           </select>
           <button
@@ -67,14 +69,14 @@ export default function AutomationPage() {
             disabled={loading}
             style={{ padding: "6px 10px", borderRadius: 10, border: "1px solid #ddd", background: "#fff", cursor: "pointer" }}
           >
-            {loading ? "読み込み中..." : "更新"}
+            {loading ? t("loading") : t("refreshButton")}
           </button>
         </div>
       </div>
 
       {error ? (
         <div style={{ marginTop: 12, padding: 12, border: "1px solid #f1c0c0", background: "#fff5f5", borderRadius: 12 }}>
-          <strong>読み込み失敗</strong>
+          <strong>{t("fetchFailed")}</strong>
           <div style={{ marginTop: 6, fontFamily: "ui-monospace, Menlo, monospace", fontSize: 12 }}>{error}</div>
         </div>
       ) : null}
@@ -85,11 +87,11 @@ export default function AutomationPage() {
       {snapshot ? <SnapshotCharts snapshot={snapshot} /> : null}
 
       <section style={{ marginTop: 16, border: "1px dashed #ddd", borderRadius: 12, padding: 14 }}>
-        <h2 style={{ margin: 0, fontSize: 14 }}>運用アクション（Runbook）</h2>
+        <h2 style={{ margin: 0, fontSize: 14 }}>{t("runbookHeading")}</h2>
         <ul style={{ marginTop: 10, marginBottom: 0, color: "#555" }}>
-          <li><code>is_trading_paused = true</code> の場合、Runbook「緊急停止状態」の確認手順に従う。</li>
-          <li><code>last_health_factor</code> が低い場合、Runbook「Aave HF 低下」の確認手順に従う。</li>
-          <li>エラーが継続する場合、バックエンドログと依存関係の状態を確認。</li>
+          <li>{t("runbookItem1")}</li>
+          <li>{t("runbookItem2")}</li>
+          <li>{t("runbookItem3")}</li>
         </ul>
       </section>
       </>

--- a/frontend/app/(admin)/dashboard/page.tsx
+++ b/frontend/app/(admin)/dashboard/page.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import AuthGuard from "@/components/AuthGuard";
 import { useAuth } from "@/lib/auth";
 import { fetchExchangeStatus } from "@/lib/api/exchange";
 
 export default function DashboardPage() {
+  const t = useTranslations("AdminDashboard");
   const { token } = useAuth();
-  const [status, setStatus] = useState<string>("読み込み中...");
+  const [status, setStatus] = useState<string>(t("loading"));
   const [hf, setHf] = useState<string>("—");
   const [trades, setTrades] = useState<string>("—");
 
@@ -18,32 +20,32 @@ export default function DashboardPage() {
       headers: { Authorization: `Bearer ${token}` },
     })
       .then((r) => r.json())
-      .then((d) => setStatus(d.is_trading_paused ? "停止中" : "稼働中"))
-      .catch(() => setStatus("取得失敗"));
+      .then((d) => setStatus(d.is_trading_paused ? t("statusStopped") : t("statusRunning")))
+      .catch(() => setStatus(t("fetchFailed")));
 
     fetch("/api/aave/status", {
       headers: { Authorization: `Bearer ${token}` },
     })
       .then((r) => r.json())
       .then((d) => setHf(d.health_factor ?? "—"))
-      .catch(() => setHf("取得失敗"));
+      .catch(() => setHf(t("fetchFailed")));
 
     fetchExchangeStatus(token)
-      .then((d) => setTrades(`${d.daily_trades_used ?? 0}件`))
-      .catch(() => setTrades("取得失敗"));
-  }, [token]);
+      .then((d) => setTrades(t("tradeCount", { count: d.daily_trades_used ?? 0 })))
+      .catch(() => setTrades(t("fetchFailed")));
+  }, [token, t]);
 
   return (
     <AuthGuard adminOnly>
       <div style={{ padding: "2rem" }}>
         <h1 style={{ fontSize: "1.5rem", fontWeight: "bold", marginBottom: "1.5rem" }}>
-          運用ダッシュボード
+          {t("pageTitle")}
         </h1>
         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))", gap: "1rem" }}>
-          <Card label="システムステータス" value={status} />
-          <Card label="Health Factor" value={hf} />
-          <Card label="本日の取引" value={trades} />
-          <Card label="総AUM" value="$15,000" />
+          <Card label={t("cardSystemStatus")} value={status} />
+          <Card label={t("cardHealthFactor")} value={hf} />
+          <Card label={t("cardDailyTrades")} value={trades} />
+          <Card label={t("cardTotalAum")} value="$15,000" />
         </div>
       </div>
     </AuthGuard>

--- a/frontend/app/(admin)/dashboard/reports/page.tsx
+++ b/frontend/app/(admin)/dashboard/reports/page.tsx
@@ -3,6 +3,7 @@
 // Unauthorized copying or distribution is strictly prohibited.
 
 import React from "react";
+import { useTranslations } from "next-intl";
 import AuthGuard from "@/components/AuthGuard";
 import ReportSummaryPanel from "@/components/dashboard/ReportSummaryPanel";
 import { fetchLatestReport } from "@/lib/api/automation";
@@ -10,6 +11,7 @@ import { useAuth } from "@/lib/auth";
 import type { AutomationReportSummary } from "@/lib/types";
 
 export default function ReportsPage() {
+  const t = useTranslations("AdminDashboardReports");
   const { token } = useAuth();
   const [report, setReport] = React.useState<AutomationReportSummary | null>(null);
   const [error, setError] = React.useState<string | null>(null);
@@ -33,13 +35,13 @@ export default function ReportsPage() {
   return (
     <AuthGuard adminOnly>
       <>
-      <title>レポート - Ultra AutoTrade</title>
+      <title>{t("browserTitle")}</title>
 
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 12, flexWrap: "wrap" }}>
         <div>
-          <h1 style={{ marginBottom: 6 }}>最新レポート</h1>
+          <h1 style={{ marginBottom: 6 }}>{t("pageTitle")}</h1>
           <p style={{ marginTop: 0, color: "#555" }}>
-            Runbook のレポート確認に沿ったサマリービュー。
+            {t("pageSubtitle")}
           </p>
         </div>
 
@@ -48,13 +50,13 @@ export default function ReportsPage() {
           disabled={loading}
           style={{ padding: "6px 10px", borderRadius: 10, border: "1px solid #ddd", background: "#fff", cursor: "pointer" }}
         >
-          {loading ? "読み込み中..." : "更新"}
+          {loading ? t("loading") : t("refreshButton")}
         </button>
       </div>
 
       {error ? (
         <div style={{ marginTop: 12, padding: 12, border: "1px solid #f1c0c0", background: "#fff5f5", borderRadius: 12 }}>
-          <strong>読み込み失敗</strong>
+          <strong>{t("fetchFailed")}</strong>
           <div style={{ marginTop: 6, fontFamily: "ui-monospace, Menlo, monospace", fontSize: 12 }}>{error}</div>
         </div>
       ) : null}
@@ -62,10 +64,10 @@ export default function ReportsPage() {
       {report ? <ReportSummaryPanel report={report} /> : null}
 
       <section style={{ marginTop: 16, border: "1px dashed #ddd", borderRadius: 12, padding: 14 }}>
-        <h2 style={{ margin: 0, fontSize: 14 }}>運用アクション（Runbook）</h2>
+        <h2 style={{ margin: 0, fontSize: 14 }}>{t("runbookHeading")}</h2>
         <ul style={{ marginTop: 10, marginBottom: 0, color: "#555" }}>
-          <li><code>highlights</code> を確認し、未解決の警告がないことを確認。</li>
-          <li>レポート生成が失敗した場合、ReportingService のログと依存関係を確認。</li>
+          <li>{t("runbookItem1")}</li>
+          <li>{t("runbookItem2")}</li>
         </ul>
       </section>
       </>

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2790,5 +2790,42 @@
   },
   "DemoBanner": {
     "notice": "⚠️ DEMO environment — All displayed data is sample data. This is not the production environment."
+  },
+  "AdminDashboard": {
+    "pageTitle": "Operations Dashboard",
+    "loading": "Loading...",
+    "statusStopped": "Stopped",
+    "statusRunning": "Running",
+    "fetchFailed": "Failed to fetch",
+    "tradeCount": "{count} trades",
+    "cardSystemStatus": "System Status",
+    "cardHealthFactor": "Health Factor",
+    "cardDailyTrades": "Today's Trades",
+    "cardTotalAum": "Total AUM"
+  },
+  "AdminDashboardAutomation": {
+    "browserTitle": "Automation - Ultra AutoTrade",
+    "pageTitle": "Automation Status",
+    "pageSubtitle": "Read-only operations view. See docs/19_operations_runbook.md §2.4.",
+    "lookbackLabel": "Time Range",
+    "lookbackOption": "{hours}h",
+    "loading": "Loading...",
+    "refreshButton": "Refresh",
+    "fetchFailed": "Load failed",
+    "runbookHeading": "Operations Actions (Runbook)",
+    "runbookItem1": "If is_trading_paused = true, follow the Runbook 'Emergency Stop' procedure.",
+    "runbookItem2": "If last_health_factor is low, follow the Runbook 'Aave HF Drop' procedure.",
+    "runbookItem3": "If errors persist, check backend logs and dependency status."
+  },
+  "AdminDashboardReports": {
+    "browserTitle": "Reports - Ultra AutoTrade",
+    "pageTitle": "Latest Report",
+    "pageSubtitle": "Summary view aligned with Runbook report review.",
+    "loading": "Loading...",
+    "refreshButton": "Refresh",
+    "fetchFailed": "Load failed",
+    "runbookHeading": "Operations Actions (Runbook)",
+    "runbookItem1": "Review highlights and confirm there are no unresolved warnings.",
+    "runbookItem2": "If report generation fails, check ReportingService logs and dependencies."
   }
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -2790,5 +2790,42 @@
   },
   "DemoBanner": {
     "notice": "⚠️ DEMO 環境 — 表示データはすべてサンプルです。本番環境ではありません。"
+  },
+  "AdminDashboard": {
+    "pageTitle": "運用ダッシュボード",
+    "loading": "読み込み中...",
+    "statusStopped": "停止中",
+    "statusRunning": "稼働中",
+    "fetchFailed": "取得失敗",
+    "tradeCount": "{count}件",
+    "cardSystemStatus": "システムステータス",
+    "cardHealthFactor": "Health Factor",
+    "cardDailyTrades": "本日の取引",
+    "cardTotalAum": "総AUM"
+  },
+  "AdminDashboardAutomation": {
+    "browserTitle": "自動売買 - Ultra AutoTrade",
+    "pageTitle": "自動売買ステータス",
+    "pageSubtitle": "運用読み取り専用ビュー。docs/19_operations_runbook.md §2.4 に準拠。",
+    "lookbackLabel": "参照時間",
+    "lookbackOption": "{hours}時間",
+    "loading": "読み込み中...",
+    "refreshButton": "更新",
+    "fetchFailed": "読み込み失敗",
+    "runbookHeading": "運用アクション（Runbook）",
+    "runbookItem1": "is_trading_paused = true の場合、Runbook「緊急停止状態」の確認手順に従う。",
+    "runbookItem2": "last_health_factor が低い場合、Runbook「Aave HF 低下」の確認手順に従う。",
+    "runbookItem3": "エラーが継続する場合、バックエンドログと依存関係の状態を確認。"
+  },
+  "AdminDashboardReports": {
+    "browserTitle": "レポート - Ultra AutoTrade",
+    "pageTitle": "最新レポート",
+    "pageSubtitle": "Runbook のレポート確認に沿ったサマリービュー。",
+    "loading": "読み込み中...",
+    "refreshButton": "更新",
+    "fetchFailed": "読み込み失敗",
+    "runbookHeading": "運用アクション（Runbook）",
+    "runbookItem1": "highlights を確認し、未解決の警告がないことを確認。",
+    "runbookItem2": "レポート生成が失敗した場合、ReportingService のログと依存関係を確認。"
   }
 }


### PR DESCRIPTION
## Summary

5ファイルのi18n化タスク。調査の結果、`app/(admin)/reports/page.tsx` と `app/(admin)/events/page.tsx` は前のウェーブで既に完了していたため、残り3ファイルを実装。

## Files Changed

| ファイル | 状態 | Namespace | キー数 |
|---|---|---|---|
| `app/(admin)/dashboard/page.tsx` | 実装 | AdminDashboard | 10 |
| `app/(admin)/dashboard/automation/page.tsx` | 実装 | AdminDashboardAutomation | 12 |
| `app/(admin)/dashboard/reports/page.tsx` | 実装 | AdminDashboardReports | 9 |
| `app/(admin)/reports/page.tsx` | 実装済み (変更なし) | AdminReports | — |
| `app/(admin)/events/page.tsx` | 実装済み (変更なし) | AdminEvents | — |
| `frontend/messages/ja.json` | 3 Namespace 追加 | — | +31 keys |
| `frontend/messages/en.json` | 3 Namespace 追加 | — | +31 keys |

## Gate results

- Gate 1 (ruff): n/a (frontend only)
- Gate 2 (mypy): n/a (frontend only)
- Gate 3a (tsc --noEmit): PASS (TS2688 @types/node のみ、既存ノイズ)
- Gate 4 (E2E): n/a
- ja/en キー数一致: PASS (AdminDashboard 10, AdminDashboardAutomation 12, AdminDashboardReports 9)
- コメント外の日本語ゼロ: PASS

🤖 Generated with Claude Code