### PR TITLE
feat(i18n): wave14 partner pages i18n (8 files)

### DIFF
--- a/frontend/app/(partner)/partner/dashboard/_components/AllocationChartRecharts.tsx
+++ b/frontend/app/(partner)/partner/dashboard/_components/AllocationChartRecharts.tsx
@@ -4,6 +4,7 @@
 // NOTE: This component must be loaded via dynamic(() => import('./AllocationChartRecharts'), { ssr: false })
 
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts'
+import { useTranslations } from 'next-intl'
 import type { Allocation } from '@/lib/api/allocations'
 
 const COLORS = [
@@ -16,10 +17,12 @@ interface Props {
 }
 
 export default function AllocationChartRecharts({ allocations }: Props) {
+  const t = useTranslations('PartnerAllocationChart')
+
   if (!allocations || allocations.length === 0) {
     return (
       <div className="flex items-center justify-center h-48 text-sm text-muted-foreground">
-        データがありません
+        {t('noData')}
       </div>
     )
   }
@@ -51,7 +54,7 @@ export default function AllocationChartRecharts({ allocations }: Props) {
           <Tooltip
             formatter={(value: number) => [
               `$${new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(value)}`,
-              '割り当て額',
+              t('tooltipLabel'),
             ]}
             contentStyle={{ fontSize: 12 }}
           />

--- a/frontend/app/(partner)/partner/dashboard/_components/AllocationTable.tsx
+++ b/frontend/app/(partner)/partner/dashboard/_components/AllocationTable.tsx
@@ -3,6 +3,7 @@
 // Unauthorized copying or distribution is strictly prohibited.
 
 import { useCallback, useEffect, useState } from 'react'
+import { useTranslations } from 'next-intl'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
@@ -32,15 +33,6 @@ function fmtUsd(v: number): string {
   }).format(v)
 }
 
-// Tier ラベル辞書 (backend TIER_JP_LABELS と整合 — app/auth/models.py)
-// GENERAL は v9 互換 (LOWER と同義、F-13 で削除予定)
-const TIER_LABELS: Record<string, string> = {
-  LOWER: '一般',
-  MIDDLE: 'ミドル',
-  UPPER: 'アッパー',
-  GENERAL: '一般',
-}
-
 function tierBadgeClass(tier: string): string {
   if (tier === 'UPPER') {
     return 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
@@ -51,9 +43,9 @@ function tierBadgeClass(tier: string): string {
   return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
 }
 
-function TierBadge({ tier }: { tier?: string }) {
+function TierBadge({ tier, tierLabels }: { tier?: string; tierLabels: Record<string, string> }) {
   if (!tier) return <span className="text-muted-foreground text-xs">—</span>
-  const label = TIER_LABELS[tier] ?? tier
+  const label = tierLabels[tier] ?? tier
   return (
     <span
       data-testid={`tier-badge-${tier}`}
@@ -65,8 +57,18 @@ function TierBadge({ tier }: { tier?: string }) {
 }
 
 export default function AllocationTable({ performanceMap = {}, tierMap = {} }: Props) {
+  const t = useTranslations('PartnerAllocationTable')
   const [allocations, setAllocations] = useState<Allocation[]>([])
   const [loading, setLoading] = useState(true)
+
+  // Tier ラベル辞書 (backend TIER_JP_LABELS と整合 — app/auth/models.py)
+  // GENERAL は v9 互換 (LOWER と同義、F-13 で削除予定)
+  const tierLabels: Record<string, string> = {
+    LOWER: t('tierLower'),
+    MIDDLE: t('tierMiddle'),
+    UPPER: t('tierUpper'),
+    GENERAL: t('tierLower'),
+  }
 
   const load = useCallback(async () => {
     const token = getStoredToken()
@@ -89,9 +91,9 @@ export default function AllocationTable({ performanceMap = {}, tierMap = {} }: P
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0">
-        <CardTitle className="text-base">資金割り振り一覧</CardTitle>
+        <CardTitle className="text-base">{t('cardTitle')}</CardTitle>
         <span className="inline-block rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
-          閲覧のみ（廃止予定）
+          {t('readOnlyBadge')}
         </span>
       </CardHeader>
       <CardContent className="p-0">
@@ -103,20 +105,20 @@ export default function AllocationTable({ performanceMap = {}, tierMap = {} }: P
           </div>
         ) : allocations.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-8">
-            割り振りデータがありません
+            {t('noData')}
           </p>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b bg-muted/50">
-                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">名前</th>
-                  <th className="text-right px-4 py-3 font-medium text-muted-foreground">元本 (USD)</th>
-                  <th className="text-right px-4 py-3 font-medium text-muted-foreground">現在値 (USD)</th>
-                  <th className="text-right px-4 py-3 font-medium text-muted-foreground">損益 (USD)</th>
-                  <th className="text-right px-4 py-3 font-medium text-muted-foreground">利回り</th>
-                  <th className="text-center px-4 py-3 font-medium text-muted-foreground">ティア</th>
-                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">割当日</th>
+                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t('colName')}</th>
+                  <th className="text-right px-4 py-3 font-medium text-muted-foreground">{t('colPrincipal')}</th>
+                  <th className="text-right px-4 py-3 font-medium text-muted-foreground">{t('colCurrent')}</th>
+                  <th className="text-right px-4 py-3 font-medium text-muted-foreground">{t('colPnl')}</th>
+                  <th className="text-right px-4 py-3 font-medium text-muted-foreground">{t('colReturn')}</th>
+                  <th className="text-center px-4 py-3 font-medium text-muted-foreground">{t('colTier')}</th>
+                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t('colDate')}</th>
                 </tr>
               </thead>
               <tbody>
@@ -144,7 +146,7 @@ export default function AllocationTable({ performanceMap = {}, tierMap = {} }: P
                           : '—'}
                       </td>
                       <td className="px-4 py-3 text-center">
-                        <TierBadge tier={tier} />
+                        <TierBadge tier={tier} tierLabels={tierLabels} />
                       </td>
                       <td className="px-4 py-3 text-muted-foreground">
                         {new Date(item.allocated_at).toLocaleDateString('ja-JP')}

--- a/frontend/app/(partner)/partner/dashboard/_components/MonthlyChartRecharts.tsx
+++ b/frontend/app/(partner)/partner/dashboard/_components/MonthlyChartRecharts.tsx
@@ -13,6 +13,7 @@ import {
   ResponsiveContainer,
   Cell,
 } from 'recharts'
+import { useTranslations } from 'next-intl'
 
 export interface MonthlyData {
   month: string
@@ -27,10 +28,12 @@ interface Props {
 }
 
 export default function MonthlyChartRecharts({ data }: Props) {
+  const t = useTranslations('PartnerMonthlyChart')
+
   if (!data || data.length === 0) {
     return (
       <div className="flex items-center justify-center h-48 text-sm text-muted-foreground">
-        データがありません
+        {t('noData')}
       </div>
     )
   }
@@ -46,11 +49,11 @@ export default function MonthlyChartRecharts({ data }: Props) {
         />
         <ReferenceLine y={0} stroke="#9ca3af" />
         <Tooltip
-          formatter={(v: number) => [`${v.toFixed(2)}%`, '月次利回り']}
+          formatter={(v: number) => [`${v.toFixed(2)}%`, t('tooltipLabel')]}
           labelStyle={{ fontSize: 12 }}
           contentStyle={{ fontSize: 12 }}
         />
-        <Bar dataKey="return_pct" name="月次利回り" radius={[4, 4, 0, 0]}>
+        <Bar dataKey="return_pct" name={t('tooltipLabel')} radius={[4, 4, 0, 0]}>
           {data.map((entry, index) => (
             <Cell
               key={index}

--- a/frontend/app/(partner)/partner/dashboard/_components/PerformanceSummaryKPI.tsx
+++ b/frontend/app/(partner)/partner/dashboard/_components/PerformanceSummaryKPI.tsx
@@ -4,6 +4,7 @@
 
 import { useEffect, useState } from 'react'
 import { DollarSign, TrendingUp, Users, Shield, Wallet, AlertTriangle } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { fetchPerformance, type PerformanceResponse } from '@/lib/api/allocations'
@@ -45,6 +46,7 @@ function fmtTokenAmount(v: string | number | undefined | null, maxFractionDigits
 }
 
 export default function PerformanceSummaryKPI() {
+  const t = useTranslations('PartnerPerformanceKPI')
   const [data, setData] = useState<PerformanceResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const { data: walletBalance, loading: walletLoading } = useWalletBalance()
@@ -92,7 +94,7 @@ export default function PerformanceSummaryKPI() {
       {/* 現在の運用残高 */}
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium text-muted-foreground">現在の運用残高</CardTitle>
+          <CardTitle className="text-sm font-medium text-muted-foreground">{t('currentBalance')}</CardTitle>
           <DollarSign className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
@@ -105,7 +107,7 @@ export default function PerformanceSummaryKPI() {
       {/* 全体損益 */}
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium text-muted-foreground">全体損益</CardTitle>
+          <CardTitle className="text-sm font-medium text-muted-foreground">{t('totalPnl')}</CardTitle>
           <TrendingUp className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
@@ -127,21 +129,21 @@ export default function PerformanceSummaryKPI() {
       {/* テスター数 */}
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium text-muted-foreground">テスター数</CardTitle>
+          <CardTitle className="text-sm font-medium text-muted-foreground">{t('testerCount')}</CardTitle>
           <Users className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold">
             {data != null ? testerCount : '—'}
           </div>
-          <div className="text-xs text-muted-foreground mt-1">人</div>
+          <div className="text-xs text-muted-foreground mt-1">{t('testerUnit')}</div>
         </CardContent>
       </Card>
 
       {/* Health Factor */}
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium text-muted-foreground">Health Factor</CardTitle>
+          <CardTitle className="text-sm font-medium text-muted-foreground">{t('healthFactor')}</CardTitle>
           <Shield className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
@@ -150,7 +152,7 @@ export default function PerformanceSummaryKPI() {
           </div>
           {hf != null && (
             <div className={`text-xs mt-1 ${hfColor(hf)}`}>
-              {hf > 1.8 ? '安全' : hf >= 1.6 ? '注意' : '危険'}
+              {hf > 1.8 ? t('hfSafe') : hf >= 1.6 ? t('hfWarning') : t('hfDanger')}
             </div>
           )}
         </CardContent>
@@ -160,13 +162,13 @@ export default function PerformanceSummaryKPI() {
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle className="text-sm font-medium text-muted-foreground">
-            ウォレット残高 (Base)
+            {t('walletBalance')}
           </CardTitle>
           <div className="flex items-center gap-1">
             {walletBalance?.fallback_used && (
               <AlertTriangle
                 className="h-4 w-4 text-yellow-500"
-                aria-label="価格またはRPC取得失敗 (フォールバック使用中)"
+                aria-label={t('walletFallbackAlert')}
               />
             )}
             <Wallet className="h-4 w-4 text-muted-foreground" />

--- a/frontend/app/(partner)/partner/notifications/page.tsx
+++ b/frontend/app/(partner)/partner/notifications/page.tsx
@@ -4,6 +4,7 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { Bell } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { getStoredToken } from '@/lib/auth'
@@ -60,22 +61,23 @@ function fmtDatetime(iso: string): string {
   }
 }
 
-const SEVERITY_OPTIONS = [
-  { value: '', label: 'すべて' },
-  { value: 'info', label: 'INFO' },
-  { value: 'warning', label: 'WARNING' },
-  { value: 'alert', label: 'ALERT' },
-  { value: 'emergency', label: 'EMERGENCY' },
-]
-
 // ---- Page ----
 
 export default function PartnerNotificationsPage() {
+  const t = useTranslations('PartnerNotifications')
   const [data, setData] = useState<NotificationLogPage | null>(null)
   const [loading, setLoading] = useState(true)
   const [severity, setSeverity] = useState('')
   const [page, setPage] = useState(1)
   const perPage = 20
+
+  const SEVERITY_OPTIONS = [
+    { value: '', label: t('filterAll') },
+    { value: 'info', label: 'INFO' },
+    { value: 'warning', label: 'WARNING' },
+    { value: 'alert', label: 'ALERT' },
+    { value: 'emergency', label: 'EMERGENCY' },
+  ]
 
   const load = useCallback(async () => {
     const token = getStoredToken()
@@ -113,12 +115,12 @@ export default function PartnerNotificationsPage() {
     <div className="max-w-6xl mx-auto px-4 py-8 space-y-6">
       <h1 className="text-2xl font-bold flex items-center gap-2">
         <Bell className="h-6 w-6" />
-        通知ログ
+        {t('pageTitle')}
       </h1>
 
       {/* Filter bar */}
       <div className="flex items-center gap-3">
-        <label className="text-sm text-muted-foreground">重要度:</label>
+        <label className="text-sm text-muted-foreground">{t('filterLabel')}</label>
         <select
           value={severity}
           onChange={(e) => handleSeverityChange(e.target.value)}
@@ -130,14 +132,14 @@ export default function PartnerNotificationsPage() {
         </select>
         {data && (
           <span className="text-xs text-muted-foreground ml-auto">
-            全 {data.total} 件
+            {t('totalCount', { total: data.total })}
           </span>
         )}
       </div>
 
       <Card>
         <CardHeader className="pb-2">
-          <CardTitle className="text-base">通知一覧</CardTitle>
+          <CardTitle className="text-base">{t('cardTitle')}</CardTitle>
         </CardHeader>
         <CardContent className="p-0">
           {loading ? (
@@ -148,18 +150,18 @@ export default function PartnerNotificationsPage() {
             </div>
           ) : !data || data.items.length === 0 ? (
             <p className="text-sm text-muted-foreground text-center py-12">
-              通知はありません
+              {t('noNotifications')}
             </p>
           ) : (
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b bg-muted/50">
-                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">日時</th>
-                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">重要度</th>
-                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">タイトル</th>
-                    <th className="text-left px-4 py-3 font-medium text-muted-foreground hidden md:table-cell">内容</th>
-                    <th className="text-left px-4 py-3 font-medium text-muted-foreground hidden lg:table-cell">チャンネル</th>
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t('colDate')}</th>
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t('colSeverity')}</th>
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t('colTitle')}</th>
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground hidden md:table-cell">{t('colBody')}</th>
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground hidden lg:table-cell">{t('colChannel')}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -198,7 +200,7 @@ export default function PartnerNotificationsPage() {
             disabled={page <= 1}
             className="px-3 py-1.5 text-sm border rounded-md disabled:opacity-40 hover:bg-muted transition-colors"
           >
-            前へ
+            {t('prevPage')}
           </button>
           <span className="text-sm text-muted-foreground">
             {page} / {totalPages}
@@ -208,7 +210,7 @@ export default function PartnerNotificationsPage() {
             disabled={page >= totalPages}
             className="px-3 py-1.5 text-sm border rounded-md disabled:opacity-40 hover:bg-muted transition-colors"
           >
-            次へ
+            {t('nextPage')}
           </button>
         </div>
       )}

--- a/frontend/app/(partner)/partner/referral/[id]/page.tsx
+++ b/frontend/app/(partner)/partner/referral/[id]/page.tsx
@@ -5,24 +5,13 @@ import { useCallback, useEffect, useState } from 'react'
 import { useParams } from 'next/navigation'
 import Link from 'next/link'
 import { ChevronLeft, DollarSign, TrendingUp } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { KPICard } from '@/components/shared/KPICard'
 import { getStoredToken } from '@/lib/auth'
 import { getReferralTransactions, type ReferralTransaction } from '@/lib/api/referral'
 import { getPartnerUserStats, type PartnerUserStats } from '@/lib/api/partner'
-
-const TYPE_LABELS: Record<string, string> = {
-  deposit: '入金',
-  withdraw: '出金',
-  borrow: '借入',
-  repay: '返済',
-  supply: '供給',
-}
-
-function formatType(type: string): string {
-  return TYPE_LABELS[type] ?? type
-}
 
 function fmtUsd(v: string | null | undefined): string {
   if (v == null) return '—'
@@ -44,9 +33,22 @@ function returnTrend(v: string | null | undefined): 'up' | 'down' | 'flat' {
 }
 
 export default function ReferralUserDetailPage() {
+  const t = useTranslations('PartnerReferralDetail')
   const params = useParams()
   const userId = Number(params.id)
   const token = getStoredToken()
+
+  const TYPE_LABELS: Record<string, string> = {
+    deposit: t('typeDeposit'),
+    withdraw: t('typeWithdraw'),
+    borrow: t('typeBorrow'),
+    repay: t('typeRepay'),
+    supply: t('typeSupply'),
+  }
+
+  function formatType(type: string): string {
+    return TYPE_LABELS[type] ?? type
+  }
 
   const [transactions, setTransactions] = useState<ReferralTransaction[]>([])
   const [loading, setLoading] = useState(true)
@@ -97,11 +99,11 @@ export default function ReferralUserDetailPage() {
           className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
         >
           <ChevronLeft className="h-4 w-4" />
-          紹介一覧に戻る
+          {t('backToList')}
         </Link>
       </div>
 
-      <h1 className="text-2xl font-bold">運用状況詳細</h1>
+      <h1 className="text-2xl font-bold">{t('pageTitle')}</h1>
 
       {/* KPI section */}
       <section className="grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -112,13 +114,13 @@ export default function ReferralUserDetailPage() {
         ) : (
           <>
             <KPICard
-              label="今日の運用残高"
+              label={t('kpiTodayBalance')}
               value={fmtUsd(stats?.today_amount)}
               prefix="$"
               icon={DollarSign}
             />
             <KPICard
-              label="今月の利回り"
+              label={t('kpiMonthReturn')}
               value={fmtPct(stats?.month_return_pct)}
               suffix="%"
               trend={returnTrend(stats?.month_return_pct)}
@@ -135,7 +137,7 @@ export default function ReferralUserDetailPage() {
 
       <Card>
         <CardHeader className="pb-3">
-          <CardTitle className="text-base">取引履歴一覧</CardTitle>
+          <CardTitle className="text-base">{t('transactionTitle')}</CardTitle>
         </CardHeader>
         <CardContent className="p-0">
           {loading ? (
@@ -145,15 +147,15 @@ export default function ReferralUserDetailPage() {
               ))}
             </div>
           ) : transactions.length === 0 ? (
-            <p className="text-sm text-muted-foreground text-center py-8">データなし</p>
+            <p className="text-sm text-muted-foreground text-center py-8">{t('noData')}</p>
           ) : (
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b bg-muted/50">
-                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">種別</th>
-                    <th className="text-right px-4 py-3 font-medium text-muted-foreground">金額</th>
-                    <th className="text-right px-4 py-3 font-medium text-muted-foreground">日時</th>
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t('colType')}</th>
+                    <th className="text-right px-4 py-3 font-medium text-muted-foreground">{t('colAmount')}</th>
+                    <th className="text-right px-4 py-3 font-medium text-muted-foreground">{t('colDate')}</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/frontend/app/(partner)/partner/users/[id]/page.tsx
+++ b/frontend/app/(partner)/partner/users/[id]/page.tsx
@@ -5,6 +5,7 @@
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
 import { ChevronLeft, DollarSign, TrendingUp } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { KPICard } from '@/components/shared/KPICard'
@@ -49,6 +50,7 @@ const ACTION_COLORS: Record<string, string> = {
 // ---- Page ----
 
 export default function PartnerUserDetailPage() {
+  const t = useTranslations('PartnerUserDetail')
   const params = useParams()
   const userId = Number(params.id)
 
@@ -70,11 +72,11 @@ export default function PartnerUserDetailPage() {
           className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
         >
           <ChevronLeft className="h-4 w-4" />
-          テスター一覧に戻る
+          {t('backToList')}
         </Link>
       </div>
 
-      <h1 className="text-2xl font-bold">テスター詳細</h1>
+      <h1 className="text-2xl font-bold">{t('pageTitle')}</h1>
 
       {/* KPI Cards */}
       <section className="grid grid-cols-1 gap-4 sm:grid-cols-3">
@@ -85,13 +87,13 @@ export default function PartnerUserDetailPage() {
         ) : (
           <>
             <KPICard
-              label="今日の運用残高"
+              label={t('kpiTodayBalance')}
               value={fmtUsd(stats?.today_amount)}
               prefix="$"
               icon={DollarSign}
             />
             <KPICard
-              label="今月の利回り"
+              label={t('kpiMonthReturn')}
               value={fmtPct(stats?.month_return_pct)}
               suffix="%"
               trend={returnTrend(stats?.month_return_pct)}
@@ -103,7 +105,7 @@ export default function PartnerUserDetailPage() {
               icon={TrendingUp}
             />
             <KPICard
-              label="昨日の利回り"
+              label={t('kpiYesterdayReturn')}
               value={fmtPct(stats?.yesterday_return_pct)}
               suffix="%"
               trend={returnTrend(stats?.yesterday_return_pct)}
@@ -122,7 +124,7 @@ export default function PartnerUserDetailPage() {
       <section>
         <Card>
           <CardHeader>
-            <CardTitle className="text-base">AI 判定履歴（直近 5 件）</CardTitle>
+            <CardTitle className="text-base">{t('aiHistoryTitle')}</CardTitle>
           </CardHeader>
           <CardContent className="p-0">
             {decisionsLoading ? (
@@ -132,20 +134,20 @@ export default function PartnerUserDetailPage() {
                 ))}
               </div>
             ) : !decisions || decisions.items.length === 0 ? (
-              <p className="text-sm text-muted-foreground text-center py-8">データなし</p>
+              <p className="text-sm text-muted-foreground text-center py-8">{t('noData')}</p>
             ) : (
               <div className="overflow-x-auto">
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b bg-muted/50">
                       <th className="text-left px-4 py-3 font-medium text-muted-foreground">
-                        判定
+                        {t('colDecision')}
                       </th>
                       <th className="text-right px-4 py-3 font-medium text-muted-foreground">
-                        確信度
+                        {t('colConfidence')}
                       </th>
                       <th className="text-right px-4 py-3 font-medium text-muted-foreground">
-                        日時
+                        {t('colDate')}
                       </th>
                     </tr>
                   </thead>
@@ -183,7 +185,7 @@ export default function PartnerUserDetailPage() {
       </section>
 
       <p className="text-xs text-muted-foreground text-center pb-4">
-        ※表示される利回りは参考値であり、将来の収益を保証するものではありません
+        {t('disclaimer')}
       </p>
     </div>
   )

--- a/frontend/app/(partner)/partner/users/_components/UserEditModal.tsx
+++ b/frontend/app/(partner)/partner/users/_components/UserEditModal.tsx
@@ -3,6 +3,7 @@
 // Unauthorized copying or distribution is strictly prohibited.
 
 import { useState, useEffect } from 'react'
+import { useTranslations } from 'next-intl'
 import {
   Dialog,
   DialogContent,
@@ -65,6 +66,7 @@ function Field({
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function UserEditModal({ user, onClose, onUpdated }: UserEditModalProps) {
+  const t = useTranslations('PartnerUserEditModal')
   const [email, setEmail] = useState('')
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
@@ -104,7 +106,7 @@ export function UserEditModal({ user, onClose, onUpdated }: UserEditModalProps) 
     if (isActive !== user.is_active) payload.is_active = isActive
 
     if (Object.keys(payload).length === 0) {
-      setError('変更がありません')
+      setError(t('noChanges'))
       setLoading(false)
       return
     }
@@ -118,7 +120,7 @@ export function UserEditModal({ user, onClose, onUpdated }: UserEditModalProps) 
       setTimeout(handleClose, 800)
     } catch (e: unknown) {
       const err = e as { message?: string }
-      setError(err.message ?? '更新に失敗しました')
+      setError(err.message ?? t('updateFailed'))
     } finally {
       setLoading(false)
     }
@@ -128,9 +130,9 @@ export function UserEditModal({ user, onClose, onUpdated }: UserEditModalProps) 
     <Dialog open={user !== null} onOpenChange={(o) => { if (!o) handleClose() }}>
       <DialogContent className="max-w-md bg-gray-950 border-gray-800">
         <DialogHeader>
-          <DialogTitle className="text-gray-100">ログイン情報を編集</DialogTitle>
+          <DialogTitle className="text-gray-100">{t('title')}</DialogTitle>
           <DialogDescription className="text-gray-500 text-xs">
-            {user?.username} のアカウント情報を変更します
+            {user?.username ? t('description', { username: user.username }) : ''}
           </DialogDescription>
         </DialogHeader>
 
@@ -139,28 +141,28 @@ export function UserEditModal({ user, onClose, onUpdated }: UserEditModalProps) 
             {/* Fields */}
             <div className="rounded-lg bg-gray-800/50 p-4 space-y-3">
               <Field
-                label="メールアドレス"
+                label={t('labelEmail')}
                 type="email"
                 value={email}
                 onChange={setEmail}
               />
               <Field
-                label="ユーザー名"
+                label={t('labelUsername')}
                 value={username}
                 onChange={setUsername}
               />
               <Field
-                label="新しいパスワード"
+                label={t('labelPassword')}
                 type="password"
                 value={password}
                 onChange={setPassword}
-                placeholder="空欄 = 変更しない"
-                hint="8文字以上。空欄のままにすると変更されません。"
+                placeholder={t('passwordPlaceholder')}
+                hint={t('passwordHint')}
               />
 
               {/* is_active toggle */}
               <div>
-                <label className="text-xs text-gray-400 mb-2 block">ステータス</label>
+                <label className="text-xs text-gray-400 mb-2 block">{t('labelStatus')}</label>
                 <div className="flex gap-2">
                   <button
                     type="button"
@@ -171,7 +173,7 @@ export function UserEditModal({ user, onClose, onUpdated }: UserEditModalProps) 
                         : 'border-gray-700 bg-gray-800 text-gray-500 hover:border-gray-600'
                     }`}
                   >
-                    アクティブ
+                    {t('statusActive')}
                   </button>
                   <button
                     type="button"
@@ -182,7 +184,7 @@ export function UserEditModal({ user, onClose, onUpdated }: UserEditModalProps) 
                         : 'border-gray-700 bg-gray-800 text-gray-500 hover:border-gray-600'
                     }`}
                   >
-                    非アクティブ
+                    {t('statusInactive')}
                   </button>
                 </div>
               </div>
@@ -193,7 +195,7 @@ export function UserEditModal({ user, onClose, onUpdated }: UserEditModalProps) 
               <p className="text-xs text-red-400 px-1">{error}</p>
             )}
             {success && (
-              <p className="text-xs text-green-400 px-1">保存しました</p>
+              <p className="text-xs text-green-400 px-1">{t('saved')}</p>
             )}
 
             {/* Actions */}
@@ -205,7 +207,7 @@ export function UserEditModal({ user, onClose, onUpdated }: UserEditModalProps) 
                 disabled={loading}
                 className="border-gray-600 text-gray-300 hover:bg-gray-800"
               >
-                キャンセル
+                {t('cancel')}
               </Button>
               <Button
                 size="sm"
@@ -213,7 +215,7 @@ export function UserEditModal({ user, onClose, onUpdated }: UserEditModalProps) 
                 disabled={loading}
                 className="bg-blue-600 hover:bg-blue-700 text-white"
               >
-                {loading ? '保存中...' : '保存'}
+                {loading ? t('saving') : t('save')}
               </Button>
             </div>
           </div>

--- a/frontend/e2e/wave14-partner-i18n.spec.ts
+++ b/frontend/e2e/wave14-partner-i18n.spec.ts
@@ -1,0 +1,340 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+/**
+ * E2E spec: wave14 partner pages i18n — Gate 4
+ * PR #717 / feat/wave14-partner-pages-i18n
+ *
+ * 検証範囲:
+ *   TC1: /partner/notifications が 404/5xx を返さない
+ *   TC2: /partner/notifications に JP テキスト "通知ログ" が表示される
+ *   TC3: /partner/notifications の重要度フィルタ "すべて" が表示される
+ *        (PartnerNotifications.filterAll)
+ *   TC4: /partner/notifications のテーブルヘッダ "重要度" が表示される
+ *        (PartnerNotifications.colSeverity)
+ *   TC5: /partner/dashboard に "現在の運用残高" が表示される
+ *        (PartnerPerformanceKPI.currentBalance)
+ *   TC6: /partner/dashboard に "全体損益" が表示される
+ *        (PartnerPerformanceKPI.totalPnl)
+ *   TC7: /partner/users/1 が 404/5xx を返さない
+ *   TC8: /partner/users/1 に "テスター詳細" が表示される
+ *        (PartnerUserDetail.pageTitle)
+ *   TC9: /partner/referral/1 が 404/5xx を返さない
+ *   TC10: /partner/referral/1 に "運用状況詳細" が表示される
+ *        (PartnerReferralDetail.pageTitle)
+ *   TC11: /partner/* 全体で翻訳キーリテラル漏れなし (e.g. "PartnerNotifications.pageTitle")
+ *   TC12: /partner/notifications に英語ハードコード残存なし
+ *
+ * NOTE:
+ *   - route group "(partner)" は URL に含まれない
+ *   - app/(partner)/layout.tsx に NextIntlClientProvider 配線済み (PR #671)
+ *   - page.route() によるモックで本番 API 呼び出しなし
+ */
+
+import { test, expect, type Page } from '@playwright/test'
+import { setupPartnerAuth } from './helpers/partner-auth'
+
+// ── Mock helpers ──────────────────────────────────────────────────────────────
+
+const MOCK_NOTIFICATION_PAGE = {
+  items: [
+    {
+      id: 1,
+      channel: 'slack',
+      severity: 'info',
+      title: 'テスト通知',
+      body: 'テスト本文',
+      partner_id: 1,
+      user_id: null,
+      created_at: '2026-06-01T10:00:00+00:00',
+    },
+  ],
+  total: 1,
+  page: 1,
+  per_page: 20,
+}
+
+const MOCK_PARTNER_STATS = {
+  today_amount: '10000.00',
+  month_return_pct: '1.50',
+  yesterday_return_pct: '0.80',
+}
+
+const MOCK_REFERRAL_TXS: unknown[] = []
+
+const MOCK_PERFORMANCE = {
+  total_supply_usd: '50000.0',
+  total_allocated_usd: '48000.0',
+  health_factor: '2.10',
+  testers: [],
+}
+
+async function setupWave14Mocks(page: Page): Promise<void> {
+  // Notifications
+  await page.route('**/api/partner/notifications**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_NOTIFICATION_PAGE),
+    })
+  })
+
+  // Performance KPI (dashboard)
+  await page.route('**/api/partner/performance**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_PERFORMANCE),
+    })
+  })
+
+  // Allocations (dashboard AllocationTable + Chart)
+  await page.route('**/api/partner/allocations**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    })
+  })
+
+  // Wallet balance (dashboard PerformanceSummaryKPI)
+  await page.route('**/api/wallet/balance**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        total_usd: '1200.5',
+        eth_balance: '0.35',
+        usdc_balance: '850.00',
+        fallback_used: false,
+      }),
+    })
+  })
+
+  // User stats (users/[id])
+  await page.route('**/api/partner/users/*/stats**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_PARTNER_STATS),
+    })
+  })
+
+  // AI decisions (users/[id] last 5)
+  await page.route('**/api/ai/decisions**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [], total: 0 }),
+    })
+  })
+
+  // Referral transactions (referral/[id])
+  await page.route('**/api/referral/transactions**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_REFERRAL_TXS),
+    })
+  })
+
+  // Monthly chart data (dashboard)
+  await page.route('**/api/partner/monthly**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    })
+  })
+}
+
+/** DOM テキストノードから pattern にマッチするものを返す（script/style 除外）*/
+async function findTextNodes(page: Page, pattern: RegExp): Promise<string[]> {
+  return page.evaluate((src: string) => {
+    const re = new RegExp(src, 'i')
+    const SKIP = new Set(['SCRIPT', 'STYLE', 'NOSCRIPT'])
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+      acceptNode(node) {
+        const tag = node.parentElement?.tagName ?? ''
+        return SKIP.has(tag) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
+      },
+    })
+    const matches: string[] = []
+    let node: Node | null
+    while ((node = walker.nextNode())) {
+      const text = (node.textContent ?? '').trim()
+      if (text && re.test(text)) matches.push(text)
+    }
+    return matches
+  }, pattern.source)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('[wave14] partner pages i18n', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupPartnerAuth(page)
+    await setupWave14Mocks(page)
+  })
+
+  // ── /partner/notifications ──
+
+  test('TC1: /partner/notifications が 500 を返さない', async ({ page }) => {
+    const [response] = await Promise.all([
+      page.waitForResponse((r) => r.url().includes('/partner/notifications') || r.status() < 500),
+      page.goto('/partner/notifications'),
+    ])
+    await page.waitForLoadState('domcontentloaded')
+    const url = page.url()
+    // 認証リダイレクト (→/login) の場合は graceful skip
+    if (!url.includes('/partner/notifications')) {
+      test.skip(true, `認証リダイレクト: ${url}`)
+    }
+    expect(response.status()).toBeLessThan(500)
+  })
+
+  test('TC2: /partner/notifications に "通知ログ" が表示される', async ({ page }) => {
+    await page.goto('/partner/notifications')
+    await page.waitForLoadState('domcontentloaded')
+    await page.waitForTimeout(600)
+    const url = page.url()
+    if (!url.includes('/partner/notifications')) {
+      test.skip(true, `認証リダイレクト: ${url}`)
+    }
+    await expect(page.getByText('通知ログ')).toBeVisible()
+  })
+
+  test('TC3: /partner/notifications の重要度フィルタ "すべて" が表示される', async ({ page }) => {
+    await page.goto('/partner/notifications')
+    await page.waitForLoadState('domcontentloaded')
+    await page.waitForTimeout(600)
+    const url = page.url()
+    if (!url.includes('/partner/notifications')) {
+      test.skip(true, `認証リダイレクト: ${url}`)
+    }
+    // <option> 要素でフィルタが描画されること
+    await expect(page.getByRole('option', { name: 'すべて' })).toBeAttached()
+  })
+
+  test('TC4: /partner/notifications のテーブルヘッダに "重要度" が表示される', async ({ page }) => {
+    await page.goto('/partner/notifications')
+    await page.waitForLoadState('domcontentloaded')
+    await page.waitForTimeout(800)
+    const url = page.url()
+    if (!url.includes('/partner/notifications')) {
+      test.skip(true, `認証リダイレクト: ${url}`)
+    }
+    await expect(page.getByRole('columnheader', { name: '重要度' })).toBeVisible()
+  })
+
+  // ── /partner/dashboard ──
+
+  test('TC5: /partner/dashboard に "現在の運用残高" が表示される', async ({ page }) => {
+    await page.goto('/partner/dashboard')
+    await page.waitForLoadState('domcontentloaded')
+    await page.waitForTimeout(800)
+    const url = page.url()
+    if (!url.includes('/partner/dashboard')) {
+      test.skip(true, `認証リダイレクト: ${url}`)
+    }
+    await expect(page.getByText('現在の運用残高')).toBeVisible()
+  })
+
+  test('TC6: /partner/dashboard に "全体損益" が表示される', async ({ page }) => {
+    await page.goto('/partner/dashboard')
+    await page.waitForLoadState('domcontentloaded')
+    await page.waitForTimeout(800)
+    const url = page.url()
+    if (!url.includes('/partner/dashboard')) {
+      test.skip(true, `認証リダイレクト: ${url}`)
+    }
+    await expect(page.getByText('全体損益')).toBeVisible()
+  })
+
+  // ── /partner/users/[id] ──
+
+  test('TC7: /partner/users/1 が 500 を返さない', async ({ page }) => {
+    const response = await page.goto('/partner/users/1')
+    await page.waitForLoadState('domcontentloaded')
+    const url = page.url()
+    if (!url.includes('/partner/users/1')) {
+      test.skip(true, `認証リダイレクト: ${url}`)
+    }
+    expect(response?.status() ?? 200).toBeLessThan(500)
+  })
+
+  test('TC8: /partner/users/1 に "テスター詳細" が表示される', async ({ page }) => {
+    await page.goto('/partner/users/1')
+    await page.waitForLoadState('domcontentloaded')
+    await page.waitForTimeout(600)
+    const url = page.url()
+    if (!url.includes('/partner/users/1')) {
+      test.skip(true, `認証リダイレクト: ${url}`)
+    }
+    await expect(page.getByText('テスター詳細')).toBeVisible()
+  })
+
+  // ── /partner/referral/[id] ──
+
+  test('TC9: /partner/referral/1 が 500 を返さない', async ({ page }) => {
+    const response = await page.goto('/partner/referral/1')
+    await page.waitForLoadState('domcontentloaded')
+    const url = page.url()
+    if (!url.includes('/partner/referral/1')) {
+      test.skip(true, `認証リダイレクト: ${url}`)
+    }
+    expect(response?.status() ?? 200).toBeLessThan(500)
+  })
+
+  test('TC10: /partner/referral/1 に "運用状況詳細" が表示される', async ({ page }) => {
+    await page.goto('/partner/referral/1')
+    await page.waitForLoadState('domcontentloaded')
+    await page.waitForTimeout(600)
+    const url = page.url()
+    if (!url.includes('/partner/referral/1')) {
+      test.skip(true, `認証リダイレクト: ${url}`)
+    }
+    await expect(page.getByText('運用状況詳細')).toBeVisible()
+  })
+
+  // ── 全体チェック ──
+
+  test('TC11: /partner/notifications で翻訳キーリテラル漏れなし', async ({ page }) => {
+    await page.goto('/partner/notifications')
+    await page.waitForLoadState('domcontentloaded')
+    await page.waitForTimeout(800)
+    const url = page.url()
+    if (!url.includes('/partner/notifications')) {
+      test.skip(true, `認証リダイレクト: ${url}`)
+    }
+    // "PartnerNotifications.xxx" 形式のキーリテラルが DOM に露出していないこと
+    const keyLiterals = await findTextNodes(page, /PartnerNotifications\.[A-Za-z]+/)
+    expect(
+      keyLiterals.length,
+      `翻訳キーリテラルが画面に露出: ${keyLiterals.slice(0, 3).join(', ')}`,
+    ).toBe(0)
+  })
+
+  test('TC12: /partner/notifications に英語ハードコード UI テキスト残存なし', async ({ page }) => {
+    await page.goto('/partner/notifications')
+    await page.waitForLoadState('domcontentloaded')
+    await page.waitForTimeout(800)
+    const url = page.url()
+    if (!url.includes('/partner/notifications')) {
+      test.skip(true, `認証リダイレクト: ${url}`)
+    }
+    // 既知の英語ハードコードが存在しないこと
+    const hardcodedEN = [
+      '通知ログ', // should be JP
+    ]
+    // Check by verifying JP strings are present (not EN equivalents)
+    const bodyText = await page.evaluate(() => (document.body as HTMLElement).innerText ?? '')
+    expect(bodyText).toContain('通知ログ')
+
+    // "Notification Log" 英語がそのまま表示されていないこと
+    const englishMatches = await findTextNodes(page, /\bNotification Log\b/)
+    expect(
+      englishMatches.length,
+      `英語 "Notification Log" が残存: ${englishMatches.slice(0, 3).join(', ')}`,
+    ).toBe(0)
+  })
+})

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2945,5 +2945,102 @@
   "AdminActionDistributionChart": {
     "title": "BUY/SELL/HOLD Distribution",
     "noData": "No data"
+  },
+  "PartnerNotifications": {
+    "pageTitle": "Notification Log",
+    "filterLabel": "Severity:",
+    "filterAll": "All",
+    "totalCount": "{total} total",
+    "cardTitle": "Notifications",
+    "noNotifications": "No notifications",
+    "colDate": "Date",
+    "colSeverity": "Severity",
+    "colTitle": "Title",
+    "colBody": "Body",
+    "colChannel": "Channel",
+    "prevPage": "Previous",
+    "nextPage": "Next"
+  },
+  "PartnerMonthlyChart": {
+    "noData": "No data",
+    "tooltipLabel": "Monthly Return"
+  },
+  "PartnerPerformanceKPI": {
+    "currentBalance": "Current Balance",
+    "totalPnl": "Total P&L",
+    "testerCount": "Testers",
+    "testerUnit": "users",
+    "healthFactor": "Health Factor",
+    "hfSafe": "Safe",
+    "hfWarning": "Warning",
+    "hfDanger": "Danger",
+    "walletBalance": "Wallet Balance (Base)",
+    "walletFallbackAlert": "Price or RPC fetch failed (using fallback)"
+  },
+  "PartnerAllocationTable": {
+    "cardTitle": "Fund Allocation List",
+    "readOnlyBadge": "Read-only (deprecated)",
+    "noData": "No allocation data",
+    "colName": "Name",
+    "colPrincipal": "Principal (USD)",
+    "colCurrent": "Current (USD)",
+    "colPnl": "P&L (USD)",
+    "colReturn": "Return",
+    "colTier": "Tier",
+    "colDate": "Allocated At",
+    "tierLower": "General",
+    "tierMiddle": "Middle",
+    "tierUpper": "Upper"
+  },
+  "PartnerAllocationChart": {
+    "noData": "No data",
+    "tooltipLabel": "Allocation Amount"
+  },
+  "PartnerUserDetail": {
+    "backToList": "Back to tester list",
+    "pageTitle": "Tester Details",
+    "kpiTodayBalance": "Today's Balance",
+    "kpiMonthReturn": "Monthly Return",
+    "kpiYesterdayReturn": "Yesterday's Return",
+    "aiHistoryTitle": "AI Decision History (Last 5)",
+    "noData": "No data",
+    "colDecision": "Decision",
+    "colConfidence": "Confidence",
+    "colDate": "Date",
+    "disclaimer": "* Returns shown are for reference only and do not guarantee future performance."
+  },
+  "PartnerReferralDetail": {
+    "backToList": "Back to referral list",
+    "pageTitle": "Operation Details",
+    "kpiTodayBalance": "Today's Balance",
+    "kpiMonthReturn": "Monthly Return",
+    "transactionTitle": "Transaction History",
+    "noData": "No data",
+    "colType": "Type",
+    "colAmount": "Amount",
+    "colDate": "Date",
+    "typeDeposit": "Deposit",
+    "typeWithdraw": "Withdraw",
+    "typeBorrow": "Borrow",
+    "typeRepay": "Repay",
+    "typeSupply": "Supply"
+  },
+  "PartnerUserEditModal": {
+    "title": "Edit Login Info",
+    "description": "Update account information for {username}",
+    "labelEmail": "Email Address",
+    "labelUsername": "Username",
+    "labelPassword": "New Password",
+    "passwordPlaceholder": "Leave blank to keep unchanged",
+    "passwordHint": "At least 8 characters. Leave blank to keep current password.",
+    "labelStatus": "Status",
+    "statusActive": "Active",
+    "statusInactive": "Inactive",
+    "noChanges": "No changes",
+    "updateFailed": "Update failed",
+    "saved": "Saved",
+    "cancel": "Cancel",
+    "save": "Save",
+    "saving": "Saving..."
   }
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -2945,5 +2945,102 @@
   "AdminActionDistributionChart": {
     "title": "BUY/SELL/HOLD分布",
     "noData": "データなし"
+  },
+  "PartnerNotifications": {
+    "pageTitle": "通知ログ",
+    "filterLabel": "重要度:",
+    "filterAll": "すべて",
+    "totalCount": "全 {total} 件",
+    "cardTitle": "通知一覧",
+    "noNotifications": "通知はありません",
+    "colDate": "日時",
+    "colSeverity": "重要度",
+    "colTitle": "タイトル",
+    "colBody": "内容",
+    "colChannel": "チャンネル",
+    "prevPage": "前へ",
+    "nextPage": "次へ"
+  },
+  "PartnerMonthlyChart": {
+    "noData": "データがありません",
+    "tooltipLabel": "月次利回り"
+  },
+  "PartnerPerformanceKPI": {
+    "currentBalance": "現在の運用残高",
+    "totalPnl": "全体損益",
+    "testerCount": "テスター数",
+    "testerUnit": "人",
+    "healthFactor": "Health Factor",
+    "hfSafe": "安全",
+    "hfWarning": "注意",
+    "hfDanger": "危険",
+    "walletBalance": "ウォレット残高 (Base)",
+    "walletFallbackAlert": "価格またはRPC取得失敗 (フォールバック使用中)"
+  },
+  "PartnerAllocationTable": {
+    "cardTitle": "資金割り振り一覧",
+    "readOnlyBadge": "閲覧のみ（廃止予定）",
+    "noData": "割り振りデータがありません",
+    "colName": "名前",
+    "colPrincipal": "元本 (USD)",
+    "colCurrent": "現在値 (USD)",
+    "colPnl": "損益 (USD)",
+    "colReturn": "利回り",
+    "colTier": "ティア",
+    "colDate": "割当日",
+    "tierLower": "一般",
+    "tierMiddle": "ミドル",
+    "tierUpper": "アッパー"
+  },
+  "PartnerAllocationChart": {
+    "noData": "データがありません",
+    "tooltipLabel": "割り当て額"
+  },
+  "PartnerUserDetail": {
+    "backToList": "テスター一覧に戻る",
+    "pageTitle": "テスター詳細",
+    "kpiTodayBalance": "今日の運用残高",
+    "kpiMonthReturn": "今月の利回り",
+    "kpiYesterdayReturn": "昨日の利回り",
+    "aiHistoryTitle": "AI 判定履歴（直近 5 件）",
+    "noData": "データなし",
+    "colDecision": "判定",
+    "colConfidence": "確信度",
+    "colDate": "日時",
+    "disclaimer": "※表示される利回りは参考値であり、将来の収益を保証するものではありません"
+  },
+  "PartnerReferralDetail": {
+    "backToList": "紹介一覧に戻る",
+    "pageTitle": "運用状況詳細",
+    "kpiTodayBalance": "今日の運用残高",
+    "kpiMonthReturn": "今月の利回り",
+    "transactionTitle": "取引履歴一覧",
+    "noData": "データなし",
+    "colType": "種別",
+    "colAmount": "金額",
+    "colDate": "日時",
+    "typeDeposit": "入金",
+    "typeWithdraw": "出金",
+    "typeBorrow": "借入",
+    "typeRepay": "返済",
+    "typeSupply": "供給"
+  },
+  "PartnerUserEditModal": {
+    "title": "ログイン情報を編集",
+    "description": "{username} のアカウント情報を変更します",
+    "labelEmail": "メールアドレス",
+    "labelUsername": "ユーザー名",
+    "labelPassword": "新しいパスワード",
+    "passwordPlaceholder": "空欄 = 変更しない",
+    "passwordHint": "8文字以上。空欄のままにすると変更されません。",
+    "labelStatus": "ステータス",
+    "statusActive": "アクティブ",
+    "statusInactive": "非アクティブ",
+    "noChanges": "変更がありません",
+    "updateFailed": "更新に失敗しました",
+    "saved": "保存しました",
+    "cancel": "キャンセル",
+    "save": "保存",
+    "saving": "保存中..."
   }
 }


### PR DESCRIPTION
## Summary

- 8 partner-route files の全ハードコード日本語文字列を `next-intl` `useTranslations()` に置換
- `frontend/messages/{en,ja}.json` に 8 新 namespace を追加（各 81 キー、en/ja 完全一致）
- `(partner)/layout.tsx` の `NextIntlClientProvider` 配線は既設済みのため変更なし

## Namespaces added

| Namespace | Keys | File |
|---|---|---|
| `PartnerNotifications` | 13 | `partner/notifications/page.tsx` |
| `PartnerMonthlyChart` | 2 | `dashboard/_components/MonthlyChartRecharts.tsx` |
| `PartnerPerformanceKPI` | 10 | `dashboard/_components/PerformanceSummaryKPI.tsx` |
| `PartnerAllocationTable` | 13 | `dashboard/_components/AllocationTable.tsx` |
| `PartnerAllocationChart` | 2 | `dashboard/_components/AllocationChartRecharts.tsx` |
| `PartnerUserDetail` | 11 | `partner/users/[id]/page.tsx` |
| `PartnerReferralDetail` | 14 | `partner/referral/[id]/page.tsx` |
| `PartnerUserEditModal` | 16 | `partner/users/_components/UserEditModal.tsx` |

## Implementation notes

- `SEVERITY_OPTIONS` and `TYPE_LABELS` moved inside component body (module-level `t()` is not allowed with next-intl)
- `TierBadge` updated to accept `tierLabels` prop (was module-level const with hardcoded JP strings)
- recharts components (`MonthlyChartRecharts`, `AllocationChartRecharts`) already use `'use client'` — `useTranslations` added without layout change
- Remaining JP text in files: developer-only inline comments (not rendered to UI)

## DoD

- [x] 全8ファイル コメント外JP文字ゼロ（CJK grep 確認済み）
- [x] en/ja キー数一致（81 keys × 8 NS）
- [x] `tsc --noEmit` 新規エラー 0

🤖 Generated with Claude Code