### PR TITLE
feat(i18n): wave13 admin proposals + knowledge + ai-learning i18n

### DIFF
--- a/frontend/app/(admin)/ai-learning/_components/AILearningCharts.tsx
+++ b/frontend/app/(admin)/ai-learning/_components/AILearningCharts.tsx
@@ -3,6 +3,7 @@
 // Unauthorized copying or distribution is strictly prohibited.
 
 import dynamic from 'next/dynamic'
+import { useTranslations } from 'next-intl'
 import type { FeedbackCountData, SourcePieEntry } from './AILearningChartsRecharts'
 
 // recharts は SSR でクラッシュするため dynamic import + ssr: false が必須
@@ -24,32 +25,34 @@ interface AILearningChartsProps {
 }
 
 export function AILearningCharts({ barData, pieData }: AILearningChartsProps) {
+  const t = useTranslations('AdminAILearningCharts')
+
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
-      {/* フィードバック件数内訳 */}
+      {/* Feedback count breakdown */}
       <div className="border border-gray-200 dark:border-gray-700 rounded-xl p-4 bg-white dark:bg-gray-900">
         <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
-          フィードバック件数内訳（30日）
+          {t('feedbackHeading')}
         </h3>
         {barData.some((d) => d.件数 > 0) ? (
           <FeedbackBarChart data={barData} />
         ) : (
           <div className="h-48 flex items-center justify-center text-gray-400 text-sm">
-            データなし
+            {t('noData')}
           </div>
         )}
       </div>
 
-      {/* フィードバックソース円グラフ */}
+      {/* Source pie chart */}
       <div className="border border-gray-200 dark:border-gray-700 rounded-xl p-4 bg-white dark:bg-gray-900">
         <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
-          ソース内訳
+          {t('sourceHeading')}
         </h3>
         {pieData.some((d) => d.value > 0) ? (
           <SourcePieChart data={pieData} />
         ) : (
           <div className="h-48 flex items-center justify-center text-gray-400 text-sm">
-            データなし
+            {t('noData')}
           </div>
         )}
       </div>

--- a/frontend/app/(admin)/knowledge/search/page.tsx
+++ b/frontend/app/(admin)/knowledge/search/page.tsx
@@ -4,6 +4,7 @@
 
 import Link from "next/link";
 import React from "react";
+import { useTranslations } from "next-intl";
 import AuthGuard from "@/components/AuthGuard";
 import {
   searchKnowledge,
@@ -11,6 +12,7 @@ import {
 } from "@/lib/api/knowledge";
 
 export default function KnowledgeSearchPage() {
+  const t = useTranslations('AdminKnowledgeSearch')
   const [query, setQuery] = React.useState("");
   const [topK, setTopK] = React.useState(5);
   const [results, setResults] = React.useState<KnowledgeSearchResult[]>([]);
@@ -53,70 +55,70 @@ export default function KnowledgeSearchPage() {
   return (
     <AuthGuard adminOnly>
       <>
-        <title>RAG検索 - ナレッジ Hub - Ultra AutoTrade</title>
+        <title>{t('pageTitle')}</title>
 
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", flexWrap: "wrap", gap: 12 }}>
           <div>
-            <h1 style={{ marginBottom: 4 }}>RAG検索</h1>
+            <h1 style={{ marginBottom: 4 }}>{t('pageHeading')}</h1>
             <p style={{ marginTop: 0, color: "#666" }}>
-              登録済みナレッジをベクトル検索で照会します。
+              {t('pageDescription')}
             </p>
           </div>
-          <Link href="/knowledge" style={outlineBtnStyle}>← ナレッジ一覧</Link>
+          <Link href="/knowledge" style={outlineBtnStyle}>{t('navBack')}</Link>
         </div>
 
-        {/* 検索フォーム */}
+        {/* Search form */}
         <section style={cardStyle}>
           <form onSubmit={handleSearch}>
             <div style={{ display: "flex", gap: 8, alignItems: "flex-end", flexWrap: "wrap" }}>
               <div style={{ flex: 1, minWidth: 240 }}>
-                <label style={labelStyle}>検索クエリ</label>
+                <label style={labelStyle}>{t('queryLabel')}</label>
                 <input
                   type="text"
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
-                  placeholder="例: BTC の強気サインを教えて"
+                  placeholder={t('queryPlaceholder')}
                   required
                   style={inputStyle}
                   autoFocus
                 />
               </div>
               <div>
-                <label style={labelStyle}>件数</label>
+                <label style={labelStyle}>{t('countLabel')}</label>
                 <select
                   value={topK}
                   onChange={(e) => setTopK(Number(e.target.value))}
                   style={{ ...inputStyle, width: 80 }}
                 >
                   {[3, 5, 10, 20].map((n) => (
-                    <option key={n} value={n}>{n}件</option>
+                    <option key={n} value={n}>{t('countUnit', { n })}</option>
                   ))}
                 </select>
               </div>
               <button type="submit" disabled={searching || !query.trim()} style={primaryBtnStyle}>
-                {searching ? "検索中..." : "検索"}
+                {searching ? t('searching') : t('searchBtn')}
               </button>
             </div>
           </form>
         </section>
 
-        {/* エラー */}
+        {/* Error */}
         {error && (
           <div style={errorBoxStyle}>{error}</div>
         )}
 
-        {/* 検索結果 */}
+        {/* Results */}
         {lastQuery !== null && !error && (
           <section style={{ marginTop: 20 }}>
             <h2 style={{ fontSize: 16, marginBottom: 12 }}>
-              検索結果
+              {t('resultHeading')}
               <span style={{ fontWeight: 400, color: "#888", fontSize: 13, marginLeft: 8 }}>
-                「{lastQuery}」— {results.length} 件
+                {t('resultSummary', { query: lastQuery, count: results.length })}
               </span>
             </h2>
 
             {results.length === 0 ? (
-              <p style={{ color: "#888" }}>該当するナレッジが見つかりませんでした。</p>
+              <p style={{ color: "#888" }}>{t('noResults')}</p>
             ) : (
               <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
                 {results.map((r, i) => (
@@ -147,7 +149,7 @@ export default function KnowledgeSearchPage() {
                           {i + 1}
                         </span>
                         <span style={{ fontWeight: 600, color: "#111" }}>
-                          {r.title ?? <span style={{ color: "#aaa", fontWeight: 400 }}>（タイトルなし）</span>}
+                          {r.title ?? <span style={{ color: "#aaa", fontWeight: 400 }}>{t('noTitle')}</span>}
                         </span>
                       </div>
                       <span style={{
@@ -161,7 +163,7 @@ export default function KnowledgeSearchPage() {
                         whiteSpace: "nowrap",
                         flexShrink: 0,
                       }}>
-                        類似度 {(r.similarity * 100).toFixed(1)}%
+                        {t('similarity', { pct: (r.similarity * 100).toFixed(1) })}
                       </span>
                     </div>
 
@@ -193,7 +195,7 @@ export default function KnowledgeSearchPage() {
                     </p>
 
                     <div style={{ marginTop: 8, fontSize: 11, color: "#9ca3af" }}>
-                      チャンク ID: {r.chunk_id} / ドキュメント ID: {r.document_id}
+                      {t('chunkInfo', { chunkId: r.chunk_id, docId: r.document_id })}
                     </div>
                   </div>
                 ))}

--- a/frontend/app/(admin)/proposals/_components/ProposalDetailModal.tsx
+++ b/frontend/app/(admin)/proposals/_components/ProposalDetailModal.tsx
@@ -2,6 +2,7 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
 
+import { useTranslations } from 'next-intl'
 import {
   Dialog,
   DialogContent,
@@ -33,14 +34,6 @@ function formatDateTime(iso: string | null): string {
   }
 }
 
-const STATUS_LABEL: Record<string, string> = {
-  pending: '保留中',
-  approved: '承認済み',
-  rejected: '拒否',
-  executed: '実行済み',
-  expired: '期限切れ',
-}
-
 function Row({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <div className="flex justify-between gap-4 py-1.5 border-b border-gray-100 dark:border-gray-800 last:border-0">
@@ -51,12 +44,22 @@ function Row({ label, value }: { label: string; value: React.ReactNode }) {
 }
 
 export function ProposalDetailModal({ proposal, onClose }: ProposalDetailModalProps) {
+  const t = useTranslations('AdminProposalDetailModal')
+
+  const STATUS_LABEL: Record<string, string> = {
+    pending: t('statusPending'),
+    approved: t('statusApproved'),
+    rejected: t('statusRejected'),
+    executed: t('statusExecuted'),
+    expired: t('statusExpired'),
+  }
+
   return (
     <Dialog open={proposal !== null} onOpenChange={(open) => { if (!open) onClose() }}>
       <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700">
         <DialogHeader>
           <DialogTitle className="text-gray-900 dark:text-gray-100">
-            提案詳細 — #{proposal?.id}
+            {t('titlePrefix')}{proposal?.id}
           </DialogTitle>
           <DialogDescription className="text-gray-500">
             {proposal?.username ?? `user_${proposal?.user_id}`}
@@ -76,26 +79,26 @@ export function ProposalDetailModal({ proposal, onClose }: ProposalDetailModalPr
 
             {/* Core fields */}
             <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-3 space-y-0.5">
-              <Row label="金額" value={`${Number(proposal.amount).toLocaleString('ja-JP', { maximumFractionDigits: 6 })} ${proposal.asset}`} />
-              <Row label="USD換算" value={`$${Number(proposal.amount_usd).toLocaleString('ja-JP', { maximumFractionDigits: 2 })}`} />
+              <Row label={t('rowAmount')} value={`${Number(proposal.amount).toLocaleString('ja-JP', { maximumFractionDigits: 6 })} ${proposal.asset}`} />
+              <Row label={t('rowAmountUsd')} value={`$${Number(proposal.amount_usd).toLocaleString('ja-JP', { maximumFractionDigits: 2 })}`} />
               {proposal.expected_hf_after && (
-                <Row label="予想HF" value={Number(proposal.expected_hf_after).toFixed(4)} />
+                <Row label={t('rowExpectedHf')} value={Number(proposal.expected_hf_after).toFixed(4)} />
               )}
               {proposal.estimated_gas_usd && (
-                <Row label="推定ガス代" value={`$${Number(proposal.estimated_gas_usd).toFixed(4)}`} />
+                <Row label={t('rowEstimatedGas')} value={`$${Number(proposal.estimated_gas_usd).toFixed(4)}`} />
               )}
-              <Row label="AI Decision ID" value={proposal.ai_decision_id ?? '—'} />
-              <Row label="作成日時" value={formatDateTime(proposal.created_at)} />
-              <Row label="期限" value={formatDateTime(proposal.expires_at)} />
-              {proposal.approved_at && <Row label="承認日時" value={formatDateTime(proposal.approved_at)} />}
-              {proposal.rejected_at && <Row label="拒否日時" value={formatDateTime(proposal.rejected_at)} />}
-              {proposal.executed_at && <Row label="実行日時" value={formatDateTime(proposal.executed_at)} />}
+              <Row label={t('rowAiDecisionId')} value={proposal.ai_decision_id ?? '—'} />
+              <Row label={t('rowCreatedAt')} value={formatDateTime(proposal.created_at)} />
+              <Row label={t('rowExpires')} value={formatDateTime(proposal.expires_at)} />
+              {proposal.approved_at && <Row label={t('rowApprovedAt')} value={formatDateTime(proposal.approved_at)} />}
+              {proposal.rejected_at && <Row label={t('rowRejectedAt')} value={formatDateTime(proposal.rejected_at)} />}
+              {proposal.executed_at && <Row label={t('rowExecutedAt')} value={formatDateTime(proposal.executed_at)} />}
             </div>
 
             {/* Reason */}
             <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-3">
               <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">
-                AI判定理由
+                {t('sectionReason')}
               </p>
               <p className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
                 {proposal.reason}
@@ -106,7 +109,7 @@ export function ProposalDetailModal({ proposal, onClose }: ProposalDetailModalPr
             {proposal.tx_hash && (
               <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-3">
                 <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">
-                  Tx Hash
+                  {t('sectionTxHash')}
                 </p>
                 <code className="text-xs text-blue-600 dark:text-blue-400 break-all">
                   {proposal.tx_hash}

--- a/frontend/app/(admin)/proposals/_components/ProposalFilters.tsx
+++ b/frontend/app/(admin)/proposals/_components/ProposalFilters.tsx
@@ -67,10 +67,10 @@ export function ProposalFilters({ filters, onChange }: ProposalFiltersProps) {
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="ALL" className="text-xs">{t('operationAll')}</SelectItem>
-            <SelectItem value="SUPPLY" className="text-xs">SUPPLY</SelectItem>
-            <SelectItem value="WITHDRAW" className="text-xs">WITHDRAW</SelectItem>
-            <SelectItem value="BORROW" className="text-xs">BORROW</SelectItem>
-            <SelectItem value="REPAY" className="text-xs">REPAY</SelectItem>
+            <SelectItem value="SUPPLY" className="text-xs">{t('opSupply')}</SelectItem>
+            <SelectItem value="WITHDRAW" className="text-xs">{t('opWithdraw')}</SelectItem>
+            <SelectItem value="BORROW" className="text-xs">{t('opBorrow')}</SelectItem>
+            <SelectItem value="REPAY" className="text-xs">{t('opRepay')}</SelectItem>
           </SelectContent>
         </Select>
 
@@ -84,7 +84,7 @@ export function ProposalFilters({ filters, onChange }: ProposalFiltersProps) {
 
         {/* Date from */}
         <div className="flex items-center gap-1">
-          <span className="text-xs text-gray-500 whitespace-nowrap">From</span>
+          <span className="text-xs text-gray-500 whitespace-nowrap">{t('dateFrom')}</span>
           <Input
             type="date"
             value={filters.dateFrom}
@@ -95,7 +95,7 @@ export function ProposalFilters({ filters, onChange }: ProposalFiltersProps) {
 
         {/* Date to */}
         <div className="flex items-center gap-1">
-          <span className="text-xs text-gray-500 whitespace-nowrap">To</span>
+          <span className="text-xs text-gray-500 whitespace-nowrap">{t('dateTo')}</span>
           <Input
             type="date"
             value={filters.dateTo}

--- a/frontend/app/(admin)/proposals/_components/ProposalFilters.tsx
+++ b/frontend/app/(admin)/proposals/_components/ProposalFilters.tsx
@@ -2,6 +2,7 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
 
+import { useTranslations } from 'next-intl'
 import { Input } from '@/components/ui/input'
 import {
   Select,
@@ -28,13 +29,15 @@ interface ProposalFiltersProps {
 }
 
 export function ProposalFilters({ filters, onChange }: ProposalFiltersProps) {
+  const t = useTranslations('AdminProposalFilters')
+
   function set<K extends keyof ProposalFiltersState>(key: K, value: ProposalFiltersState[K]) {
     onChange({ ...filters, [key]: value })
   }
 
   return (
     <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4">
-      <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">フィルター</h3>
+      <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">{t('heading')}</h3>
       <div className="flex flex-wrap gap-3">
         {/* Status */}
         <Select
@@ -42,15 +45,15 @@ export function ProposalFilters({ filters, onChange }: ProposalFiltersProps) {
           onValueChange={(v) => set('status', v as StatusFilter)}
         >
           <SelectTrigger className="h-8 w-40 text-xs">
-            <SelectValue placeholder="ステータス" />
+            <SelectValue placeholder={t('statusPlaceholder')} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="ALL" className="text-xs">すべて</SelectItem>
-            <SelectItem value="pending" className="text-xs">保留中</SelectItem>
-            <SelectItem value="approved" className="text-xs">承認済み</SelectItem>
-            <SelectItem value="rejected" className="text-xs">拒否</SelectItem>
-            <SelectItem value="executed" className="text-xs">実行済み</SelectItem>
-            <SelectItem value="expired" className="text-xs">期限切れ</SelectItem>
+            <SelectItem value="ALL" className="text-xs">{t('statusAll')}</SelectItem>
+            <SelectItem value="pending" className="text-xs">{t('statusPending')}</SelectItem>
+            <SelectItem value="approved" className="text-xs">{t('statusApproved')}</SelectItem>
+            <SelectItem value="rejected" className="text-xs">{t('statusRejected')}</SelectItem>
+            <SelectItem value="executed" className="text-xs">{t('statusExecuted')}</SelectItem>
+            <SelectItem value="expired" className="text-xs">{t('statusExpired')}</SelectItem>
           </SelectContent>
         </Select>
 
@@ -60,10 +63,10 @@ export function ProposalFilters({ filters, onChange }: ProposalFiltersProps) {
           onValueChange={(v) => set('operation', v as OperationFilter)}
         >
           <SelectTrigger className="h-8 w-40 text-xs">
-            <SelectValue placeholder="操作種別" />
+            <SelectValue placeholder={t('operationPlaceholder')} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="ALL" className="text-xs">すべての操作</SelectItem>
+            <SelectItem value="ALL" className="text-xs">{t('operationAll')}</SelectItem>
             <SelectItem value="SUPPLY" className="text-xs">SUPPLY</SelectItem>
             <SelectItem value="WITHDRAW" className="text-xs">WITHDRAW</SelectItem>
             <SelectItem value="BORROW" className="text-xs">BORROW</SelectItem>
@@ -73,7 +76,7 @@ export function ProposalFilters({ filters, onChange }: ProposalFiltersProps) {
 
         {/* User search */}
         <Input
-          placeholder="ユーザー名 / メールで検索..."
+          placeholder={t('userSearchPlaceholder')}
           value={filters.userSearch}
           onChange={(e) => set('userSearch', e.target.value)}
           className="h-8 w-52 text-xs"
@@ -113,7 +116,7 @@ export function ProposalFilters({ filters, onChange }: ProposalFiltersProps) {
           }
           className="text-xs text-blue-600 dark:text-blue-400 hover:underline self-center"
         >
-          リセット
+          {t('reset')}
         </button>
       </div>
     </div>

--- a/frontend/app/(admin)/proposals/page.tsx
+++ b/frontend/app/(admin)/proposals/page.tsx
@@ -3,6 +3,7 @@
 // Unauthorized copying or distribution is strictly prohibited.
 
 import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useTranslations } from 'next-intl'
 import AuthGuard from '@/components/AuthGuard'
 import { useAuth } from '@/lib/auth'
 import { listAdminProposals } from '@/lib/api/admin-proposals'
@@ -46,6 +47,7 @@ export default function ProposalsPage() {
 
 function ProposalsContent() {
   const { token } = useAuth()
+  const t = useTranslations('AdminProposals')
 
   const [proposals, setProposals] = useState<AdminProposal[]>([])
   const [total, setTotal] = useState(0)
@@ -72,13 +74,13 @@ function ProposalsContent() {
       } catch (err: unknown) {
         const msg = err && typeof err === 'object' && 'message' in err
           ? String((err as { message: unknown }).message)
-          : '提案の取得に失敗しました'
+          : t('fetchError')
         setError(msg)
       } finally {
         setLoading(false)
       }
     },
-    [token]
+    [token, t]
   )
 
   // Initial load
@@ -105,23 +107,23 @@ function ProposalsContent() {
 
   return (
     <>
-      <title>提案管理 - Ultra AutoTrade</title>
+      <title>{t('pageTitle')}</title>
 
       {/* Header */}
       <div className="flex items-center justify-between mb-6 flex-wrap gap-3">
         <div>
           <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100 tracking-tight">
-            提案管理
+            {t('heading')}
           </h1>
           <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            全ユーザーのAI提案一覧・承認状況の確認
+            {t('description')}
           </p>
         </div>
         <button
           onClick={() => fetchProposals(filters, page)}
           className="px-4 py-2 text-sm font-medium bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg transition-colors"
         >
-          再読み込み
+          {t('reload')}
         </button>
       </div>
 
@@ -144,7 +146,7 @@ function ProposalsContent() {
 
       {/* Loading */}
       {loading && (
-        <div className="mb-4 text-sm text-gray-500 text-center py-4">読み込み中...</div>
+        <div className="mb-4 text-sm text-gray-500 text-center py-4">{t('loading')}</div>
       )}
 
       {/* Table */}

--- a/frontend/app/(admin)/users/_components/UserHFChart.tsx
+++ b/frontend/app/(admin)/users/_components/UserHFChart.tsx
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
 
+import { useTranslations } from 'next-intl'
 import {
   LineChart,
   Line,
@@ -23,10 +24,12 @@ interface UserHFChartProps {
 }
 
 export function UserHFChart({ data }: UserHFChartProps) {
+  const t = useTranslations('AdminUserHFChart')
+
   if (data.length === 0) {
     return (
       <div className="h-40 flex items-center justify-center text-gray-500 text-sm">
-        データなし
+        {t('noData')}
       </div>
     )
   }
@@ -63,7 +66,7 @@ export function UserHFChart({ data }: UserHFChartProps) {
           itemStyle={{ color: '#60a5fa' }}
           formatter={(value: number) => [value.toFixed(2), 'HF']}
         />
-        <ReferenceLine y={1.6} stroke="#ef4444" strokeDasharray="4 2" label={{ value: '危険', fill: '#ef4444', fontSize: 10 }} />
+        <ReferenceLine y={1.6} stroke="#ef4444" strokeDasharray="4 2" label={{ value: t('dangerLabel'), fill: '#ef4444', fontSize: 10 }} />
         <Line
           type="monotone"
           dataKey="hf"

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -3063,7 +3063,13 @@
     "operationPlaceholder": "Operation Type",
     "operationAll": "All Operations",
     "userSearchPlaceholder": "Search by username / email...",
-    "reset": "Reset"
+    "reset": "Reset",
+    "opSupply": "Supply",
+    "opWithdraw": "Withdraw",
+    "opBorrow": "Borrow",
+    "opRepay": "Repay",
+    "dateFrom": "From",
+    "dateTo": "To"
   },
   "AdminProposalDetailModal": {
     "titlePrefix": "Proposal Detail — #",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -3042,5 +3042,74 @@
     "cancel": "Cancel",
     "save": "Save",
     "saving": "Saving..."
+  },
+  "AdminProposals": {
+    "pageTitle": "Proposal Management - Ultra AutoTrade",
+    "heading": "Proposal Management",
+    "description": "View all user AI proposals and approval status",
+    "reload": "Reload",
+    "loading": "Loading...",
+    "fetchError": "Failed to fetch proposals"
+  },
+  "AdminProposalFilters": {
+    "heading": "Filters",
+    "statusPlaceholder": "Status",
+    "statusAll": "All",
+    "statusPending": "Pending",
+    "statusApproved": "Approved",
+    "statusRejected": "Rejected",
+    "statusExecuted": "Executed",
+    "statusExpired": "Expired",
+    "operationPlaceholder": "Operation Type",
+    "operationAll": "All Operations",
+    "userSearchPlaceholder": "Search by username / email...",
+    "reset": "Reset"
+  },
+  "AdminProposalDetailModal": {
+    "titlePrefix": "Proposal Detail — #",
+    "statusPending": "Pending",
+    "statusApproved": "Approved",
+    "statusRejected": "Rejected",
+    "statusExecuted": "Executed",
+    "statusExpired": "Expired",
+    "rowAmount": "Amount",
+    "rowAmountUsd": "USD Value",
+    "rowExpectedHf": "Expected HF",
+    "rowEstimatedGas": "Estimated Gas",
+    "rowAiDecisionId": "AI Decision ID",
+    "rowCreatedAt": "Created At",
+    "rowExpires": "Expires",
+    "rowApprovedAt": "Approved At",
+    "rowRejectedAt": "Rejected At",
+    "rowExecutedAt": "Executed At",
+    "sectionReason": "AI Reason",
+    "sectionTxHash": "Tx Hash"
+  },
+  "AdminAILearningCharts": {
+    "feedbackHeading": "Feedback Count Breakdown (30d)",
+    "sourceHeading": "Source Breakdown",
+    "noData": "No data"
+  },
+  "AdminKnowledgeSearch": {
+    "pageTitle": "RAG Search - Knowledge Hub - Ultra AutoTrade",
+    "pageHeading": "RAG Search",
+    "pageDescription": "Search registered knowledge using vector similarity.",
+    "navBack": "← Knowledge List",
+    "queryLabel": "Search Query",
+    "queryPlaceholder": "e.g. Tell me bullish signs for BTC",
+    "countLabel": "Count",
+    "countUnit": "{n} items",
+    "searchBtn": "Search",
+    "searching": "Searching...",
+    "resultHeading": "Search Results",
+    "resultSummary": "\"{query}\" — {count} items",
+    "noResults": "No matching knowledge found.",
+    "similarity": "Similarity {pct}%",
+    "noTitle": "(no title)",
+    "chunkInfo": "Chunk ID: {chunkId} / Document ID: {docId}"
+  },
+  "AdminUserHFChart": {
+    "noData": "No data",
+    "dangerLabel": "Danger"
   }
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -3063,7 +3063,13 @@
     "operationPlaceholder": "操作種別",
     "operationAll": "すべての操作",
     "userSearchPlaceholder": "ユーザー名 / メールで検索...",
-    "reset": "リセット"
+    "reset": "リセット",
+    "opSupply": "供給",
+    "opWithdraw": "引き出し",
+    "opBorrow": "借入",
+    "opRepay": "返済",
+    "dateFrom": "開始日",
+    "dateTo": "終了日"
   },
   "AdminProposalDetailModal": {
     "titlePrefix": "提案詳細 — #",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -3042,5 +3042,74 @@
     "cancel": "キャンセル",
     "save": "保存",
     "saving": "保存中..."
+  },
+  "AdminProposals": {
+    "pageTitle": "提案管理 - Ultra AutoTrade",
+    "heading": "提案管理",
+    "description": "全ユーザーのAI提案一覧・承認状況の確認",
+    "reload": "再読み込み",
+    "loading": "読み込み中...",
+    "fetchError": "提案の取得に失敗しました"
+  },
+  "AdminProposalFilters": {
+    "heading": "フィルター",
+    "statusPlaceholder": "ステータス",
+    "statusAll": "すべて",
+    "statusPending": "保留中",
+    "statusApproved": "承認済み",
+    "statusRejected": "拒否",
+    "statusExecuted": "実行済み",
+    "statusExpired": "期限切れ",
+    "operationPlaceholder": "操作種別",
+    "operationAll": "すべての操作",
+    "userSearchPlaceholder": "ユーザー名 / メールで検索...",
+    "reset": "リセット"
+  },
+  "AdminProposalDetailModal": {
+    "titlePrefix": "提案詳細 — #",
+    "statusPending": "保留中",
+    "statusApproved": "承認済み",
+    "statusRejected": "拒否",
+    "statusExecuted": "実行済み",
+    "statusExpired": "期限切れ",
+    "rowAmount": "金額",
+    "rowAmountUsd": "USD換算",
+    "rowExpectedHf": "予想HF",
+    "rowEstimatedGas": "推定ガス代",
+    "rowAiDecisionId": "AI Decision ID",
+    "rowCreatedAt": "作成日時",
+    "rowExpires": "期限",
+    "rowApprovedAt": "承認日時",
+    "rowRejectedAt": "拒否日時",
+    "rowExecutedAt": "実行日時",
+    "sectionReason": "AI判定理由",
+    "sectionTxHash": "Tx Hash"
+  },
+  "AdminAILearningCharts": {
+    "feedbackHeading": "フィードバック件数内訳（30日）",
+    "sourceHeading": "ソース内訳",
+    "noData": "データなし"
+  },
+  "AdminKnowledgeSearch": {
+    "pageTitle": "RAG検索 - ナレッジ Hub - Ultra AutoTrade",
+    "pageHeading": "RAG検索",
+    "pageDescription": "登録済みナレッジをベクトル検索で照会します。",
+    "navBack": "← ナレッジ一覧",
+    "queryLabel": "検索クエリ",
+    "queryPlaceholder": "例: BTC の強気サインを教えて",
+    "countLabel": "件数",
+    "countUnit": "{n}件",
+    "searchBtn": "検索",
+    "searching": "検索中...",
+    "resultHeading": "検索結果",
+    "resultSummary": "「{query}」— {count} 件",
+    "noResults": "該当するナレッジが見つかりませんでした。",
+    "similarity": "類似度 {pct}%",
+    "noTitle": "（タイトルなし）",
+    "chunkInfo": "チャンク ID: {chunkId} / ドキュメント ID: {docId}"
+  },
+  "AdminUserHFChart": {
+    "noData": "データなし",
+    "dangerLabel": "危険"
   }
 }


### PR DESCRIPTION
## Summary

- 6ファイルのハードコード日本語を next-intl に置換
- Namespaces: AdminProposals, AdminProposalFilters, AdminProposalDetailModal, AdminAILearningCharts, AdminKnowledgeSearch, AdminUserHFChart
- en/ja キー数完全一致 (57 keys / 6 namespaces)
- `(admin)/layout.tsx` の NextIntlClientProvider 配線済みを確認済み

## Files changed

- `frontend/app/(admin)/proposals/page.tsx` — AdminProposals
- `frontend/app/(admin)/proposals/_components/ProposalFilters.tsx` — AdminProposalFilters
- `frontend/app/(admin)/proposals/_components/ProposalDetailModal.tsx` — AdminProposalDetailModal (STATUS_LABEL をコンポーネント内に移動)
- `frontend/app/(admin)/ai-learning/_components/AILearningCharts.tsx` — AdminAILearningCharts
- `frontend/app/(admin)/knowledge/search/page.tsx` — AdminKnowledgeSearch
- `frontend/app/(admin)/users/_components/UserHFChart.tsx` — AdminUserHFChart
- `frontend/messages/en.json` + `frontend/messages/ja.json` — 6 namespaces 追加

## DoD

- [x] 全6ファイル: コメント外JP文字ゼロ (d.件数 はrecharts型フィールドキーのため除外)
- [x] en/ja キー数一致 (全6 namespace)
- [x] tsc --noEmit: 新規エラー 0

🤖 Generated with Claude Code