### PR TITLE
feat(i18n): wave17 small components + providers + liff layout i18n

### DIFF
--- a/frontend/app/(admin)/components-preview/page.tsx
+++ b/frontend/app/(admin)/components-preview/page.tsx
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
 
+import { useTranslations } from 'next-intl'
 import { DollarSign } from 'lucide-react'
 import AuthGuard from '@/components/AuthGuard'
 import {
@@ -18,29 +19,30 @@ import {
 } from '@/components/shared'
 
 export default function ComponentsPreviewPage() {
+  const t = useTranslations('AdminComponentsPreview')
   return (
     <AuthGuard adminOnly>
     <div className="container mx-auto p-8 space-y-10">
-      <h1 className="text-3xl font-bold">共通コンポーネントプレビュー</h1>
+      <h1 className="text-3xl font-bold">{t('title')}</h1>
 
       {/* HealthFactorGauge */}
       <section className="space-y-4">
         <h2 className="text-xl font-semibold border-b pb-2">HealthFactorGauge</h2>
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
           <div className="p-4 border rounded-lg space-y-2">
-            <p className="text-xs text-muted-foreground">size=sm, 安全 (2.5)</p>
+            <p className="text-xs text-muted-foreground">{t('hfSm')}</p>
             <HealthFactorGauge value={2.5} size="sm" />
           </div>
           <div className="p-4 border rounded-lg space-y-2">
-            <p className="text-xs text-muted-foreground">size=md, 注意 (1.8)</p>
+            <p className="text-xs text-muted-foreground">{t('hfMd')}</p>
             <HealthFactorGauge value={1.8} size="md" />
           </div>
           <div className="p-4 border rounded-lg space-y-2">
-            <p className="text-xs text-muted-foreground">size=lg, 危険 (1.3)</p>
+            <p className="text-xs text-muted-foreground">{t('hfLg')}</p>
             <HealthFactorGauge value={1.3} size="lg" />
           </div>
           <div className="p-4 border rounded-lg space-y-2">
-            <p className="text-xs text-muted-foreground">value=null (借入なし)</p>
+            <p className="text-xs text-muted-foreground">{t('hfNull')}</p>
             <HealthFactorGauge value={null} />
           </div>
         </div>
@@ -72,19 +74,19 @@ export default function ComponentsPreviewPage() {
         <h2 className="text-xl font-semibold border-b pb-2">ConfidenceBar</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
           <div className="p-4 border rounded-lg space-y-2">
-            <p className="text-xs text-muted-foreground">85% (閾値70以上=緑)</p>
+            <p className="text-xs text-muted-foreground">{t('cbHigh')}</p>
             <ConfidenceBar value={85} />
           </div>
           <div className="p-4 border rounded-lg space-y-2">
-            <p className="text-xs text-muted-foreground">45% (閾値70未満=青)</p>
+            <p className="text-xs text-muted-foreground">{t('cbLow')}</p>
             <ConfidenceBar value={45} />
           </div>
           <div className="p-4 border rounded-lg space-y-2">
-            <p className="text-xs text-muted-foreground">showLabel=false</p>
+            <p className="text-xs text-muted-foreground">{t('cbNoLabel')}</p>
             <ConfidenceBar value={60} showLabel={false} />
           </div>
           <div className="p-4 border rounded-lg space-y-2">
-            <p className="text-xs text-muted-foreground">threshold=50, value=55</p>
+            <p className="text-xs text-muted-foreground">{t('cbThreshold')}</p>
             <ConfidenceBar value={55} threshold={50} />
           </div>
         </div>
@@ -104,7 +106,7 @@ export default function ComponentsPreviewPage() {
             />
           </div>
           <p className="text-xs text-muted-foreground italic">
-            ※ floating variant は画面右下に固定表示されます
+            {t('floatingNote')}
           </p>
         </div>
       </section>
@@ -148,7 +150,7 @@ export default function ComponentsPreviewPage() {
         <h2 className="text-xl font-semibold border-b pb-2">KPICard</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
           <KPICard
-            label="総資産"
+            label={t('kpiTotalAsset')}
             value="12,345"
             prefix="$"
             trend="up"
@@ -156,23 +158,23 @@ export default function ComponentsPreviewPage() {
             icon={DollarSign}
           />
           <KPICard
-            label="本日の損益"
+            label={t('kpiDailyPnl')}
             value="-234"
             prefix="$"
             trend="down"
             trendValue="-1.8%"
           />
           <KPICard
-            label="勝率"
+            label={t('kpiWinRate')}
             value="68.4"
             suffix="%"
             trend="flat"
             trendValue="±0%"
           />
           <KPICard
-            label="取引回数"
+            label={t('kpiTradeCount')}
             value={42}
-            suffix="回"
+            suffix={t('kpiTradeCountSuffix')}
           />
         </div>
       </section>
@@ -182,11 +184,11 @@ export default function ComponentsPreviewPage() {
         <h2 className="text-xl font-semibold border-b pb-2">WalletAddressMask</h2>
         <div className="flex flex-wrap gap-6">
           <div className="space-y-1">
-            <p className="text-xs text-muted-foreground">デフォルト (chars=6)</p>
+            <p className="text-xs text-muted-foreground">{t('walletDefaultChars')}</p>
             <WalletAddressMask address="0x742d35Cc6634C0532925a3b844Bc454e4438f44e" />
           </div>
           <div className="space-y-1">
-            <p className="text-xs text-muted-foreground">chars=10</p>
+            <p className="text-xs text-muted-foreground">{t('walletChars10')}</p>
             <WalletAddressMask address="0x742d35Cc6634C0532925a3b844Bc454e4438f44e" chars={10} />
           </div>
         </div>
@@ -197,11 +199,11 @@ export default function ComponentsPreviewPage() {
         <h2 className="text-xl font-semibold border-b pb-2">DateRangeFilter</h2>
         <div className="space-y-4">
           <div className="space-y-2">
-            <p className="text-xs text-muted-foreground">presets=true (デフォルト)</p>
+            <p className="text-xs text-muted-foreground">{t('datePresetsOn')}</p>
             <DateRangeFilter onChange={(range) => console.log('range:', range)} />
           </div>
           <div className="space-y-2">
-            <p className="text-xs text-muted-foreground">presets=false (カスタム入力のみ)</p>
+            <p className="text-xs text-muted-foreground">{t('datePresetsOff')}</p>
             <DateRangeFilter onChange={(range) => console.log('range:', range)} presets={false} />
           </div>
         </div>

--- a/frontend/app/(liff)/layout.tsx
+++ b/frontend/app/(liff)/layout.tsx
@@ -4,7 +4,7 @@
 import '../arobix/theme.css'
 import { useEffect } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
-import { NextIntlClientProvider, useTranslations } from 'next-intl'
+import { useTranslations, NextIntlClientProvider } from 'next-intl'
 import { useLiff } from '@/hooks/useLiff'
 import { useLiffAutoReAuth } from '@/hooks/useLiffAutoReAuth'
 import { useLiffTermsGate } from '@/hooks/useLiffTermsGate'
@@ -12,6 +12,56 @@ import { SessionExpiryBanner } from '@/components/SessionExpiryBanner'
 import { PrivyRootClient } from '@/lib/wallet/PrivyRootClient'
 import { getAuthToken } from '@/lib/auth/token-key'
 import jaMessages from '@/messages/ja.json'
+
+// Inline provider helpers for layout-level strings that live outside the liff-chat IntlWrapper.
+// These wrappers each supply the minimum messages needed so useTranslations works without a parent provider.
+
+function LiffLayoutLoadingSimple() {
+  const t = useTranslations('LiffLayout')
+  return <p className="text-zinc-400">{t('loadingInit')}</p>
+}
+
+function LiffLayoutReauthing() {
+  const t = useTranslations('LiffLayout')
+  return <p className="text-zinc-400">{t('reauthing')}</p>
+}
+
+function LiffLayoutLineOnly() {
+  const t = useTranslations('LiffLayout')
+  return <p className="text-zinc-400 text-sm">{t('lineAppOnly')}</p>
+}
+
+function LiffLayoutLoadingRedirect() {
+  const t = useTranslations('LiffLayout')
+  return <p className="text-zinc-400">{t('loadingRedirect')}</p>
+}
+
+function LiffLayoutLoadingTerms() {
+  const t = useTranslations('LiffLayout')
+  return <p className="text-zinc-400">{t('loadingTerms')}</p>
+}
+
+function LiffLayoutInitError({ error }: { error: string }) {
+  const t = useTranslations('LiffLayout')
+  return <p className="text-red-400">{t('liffInitError', { error })}</p>
+}
+
+function withLiffLayoutIntl<P extends object>(Component: React.ComponentType<P>) {
+  return function Wrapped(props: P) {
+    return (
+      <NextIntlClientProvider locale="ja" messages={{ LiffLayout: jaMessages.LiffLayout }}>
+        <Component {...props} />
+      </NextIntlClientProvider>
+    )
+  }
+}
+
+const LiffLoadingSimple = withLiffLayoutIntl(LiffLayoutLoadingSimple)
+const LiffReauthing = withLiffLayoutIntl(LiffLayoutReauthing)
+const LiffLineOnly = withLiffLayoutIntl(LiffLayoutLineOnly)
+const LiffLoadingRedirect = withLiffLayoutIntl(LiffLayoutLoadingRedirect)
+const LiffLoadingTerms = withLiffLayoutIntl(LiffLayoutLoadingTerms)
+const LiffInitError = withLiffLayoutIntl(LiffLayoutInitError)
 
 // degrade ガードを適用しない経路。
 // - liff-login : ログイン導線そのもの (未ログインで来る前提)
@@ -23,25 +73,6 @@ const AUTH_GUARD_EXEMPT = ['/liff-login', '/liff-sign-poc']
 // 誘導する (法的同意の 1 経路依存を解消; Asana 1215360586206558)。
 // パートナー承認系 (liff-approve / liff-fee-approve 等) は別系統のため対象外。
 const TERMS_GATE_PATHS = ['/liff-chat']
-
-// LiffLayoutLoading: layout レベルのローディング表示 (LiffIntlLayout の外側で使用するため
-// inline Provider パターンを採用する)
-function LiffLayoutLoadingInner() {
-  const t = useTranslations('LiffLayout')
-  return <p className="text-zinc-400">{t('reauthing')}</p>
-}
-
-function LiffLayoutLoading() {
-  // NOTE: このコンポーネントは LiffIntlLayout の外側で使われる。
-  // (liff)/layout.tsx は PrivyRootClient / LiffIntlLayout の親にあたるため
-  // inline Provider で NextIntlClientProvider を自己完結させる。
-  const messages = { LiffLayout: jaMessages.LiffLayout }
-  return (
-    <NextIntlClientProvider locale="ja" messages={messages}>
-      <LiffLayoutLoadingInner />
-    </NextIntlClientProvider>
-  )
-}
 
 export default function LiffLayout({ children }: { children: React.ReactNode }) {
   const { isInitialized, isLoggedIn, error, liffConfigured } = useLiff()
@@ -72,7 +103,7 @@ export default function LiffLayout({ children }: { children: React.ReactNode }) 
     return (
       <div className="arobix-root">
         <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center">
-          <p className="text-red-400">LIFF初期化エラー: {error}</p>
+          <LiffInitError error={error} />
         </div>
       </div>
     )
@@ -82,7 +113,7 @@ export default function LiffLayout({ children }: { children: React.ReactNode }) 
     return (
       <div className="arobix-root">
         <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center">
-          <p className="text-zinc-400">読み込み中...</p>
+          <LiffLoadingSimple />
         </div>
       </div>
     )
@@ -92,7 +123,7 @@ export default function LiffLayout({ children }: { children: React.ReactNode }) 
     return (
       <div className="arobix-root">
         <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center">
-          <LiffLayoutLoading />
+          <LiffReauthing />
         </div>
       </div>
     )
@@ -109,7 +140,7 @@ export default function LiffLayout({ children }: { children: React.ReactNode }) 
     return (
       <div className="arobix-root">
         <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center px-4">
-          <p className="text-zinc-400 text-sm">LINEアプリから開いてください</p>
+          <LiffLineOnly />
         </div>
       </div>
     )
@@ -122,7 +153,7 @@ export default function LiffLayout({ children }: { children: React.ReactNode }) 
     router.replace('/liff-login')
     return (
       <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center">
-        <p className="text-zinc-400">読み込み中...</p>
+        <LiffLoadingRedirect />
       </div>
     )
   }
@@ -134,7 +165,7 @@ export default function LiffLayout({ children }: { children: React.ReactNode }) 
     return (
       <div className="arobix-root">
         <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center">
-          <p className="text-zinc-400">読み込み中...</p>
+          <LiffLoadingTerms />
         </div>
       </div>
     )

--- a/frontend/components/SessionExpiryBanner.tsx
+++ b/frontend/components/SessionExpiryBanner.tsx
@@ -11,6 +11,7 @@
 
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useSessionMonitor } from "@/hooks/useSessionMonitor";
 import { describeSessionState } from "@/lib/auth/session-monitor";
 
@@ -27,6 +28,7 @@ export type SessionExpiryBannerProps = {
 export function SessionExpiryBanner({
   loginHref = "/login",
 }: SessionExpiryBannerProps) {
+  const t = useTranslations("SharedSessionExpiry");
   const snapshot = useSessionMonitor();
   const message = describeSessionState(snapshot);
 
@@ -72,7 +74,7 @@ export function SessionExpiryBanner({
           textDecoration: "none",
         }}
       >
-        再ログイン
+        {t("relogin")}
       </a>
     </div>
   );

--- a/frontend/components/charts/AccuracyChart.tsx
+++ b/frontend/components/charts/AccuracyChart.tsx
@@ -3,6 +3,7 @@
 // Unauthorized copying or distribution is strictly prohibited.
 
 import React from "react";
+import { useTranslations } from "next-intl";
 import {
   LineChart,
   Line,
@@ -38,6 +39,7 @@ function formatLabel(iso: string): string {
 }
 
 export default function AccuracyChart({ data }: Props) {
+  const t = useTranslations("SharedAccuracyChart");
   const byDay: Record<string, { total: number; agreed: number }> = {};
   for (const p of data) {
     if (!p.phase_b) continue;
@@ -55,7 +57,7 @@ export default function AccuracyChart({ data }: Props) {
   if (chartData.length === 0) {
     return (
       <div style={{ color: "#9ca3af", fontSize: 13, padding: "24px 0", textAlign: "center" }}>
-        Two-Phase判定データがありません
+        {t("noData")}
       </div>
     );
   }
@@ -78,10 +80,10 @@ export default function AccuracyChart({ data }: Props) {
           y={80}
           stroke="#f59e0b"
           strokeDasharray="4 4"
-          label={{ value: "目標80%", fontSize: 10, fill: "#f59e0b" }}
+          label={{ value: t("targetLabel"), fontSize: 10, fill: "#f59e0b" }}
         />
         <Tooltip
-          formatter={(v: number) => [`${v}%`, "Two-Phase一致率"]}
+          formatter={(v: number) => [`${v}%`, t("agreementRate")]}
           labelStyle={{ fontSize: 12 }}
           contentStyle={{ fontSize: 12 }}
         />
@@ -91,7 +93,7 @@ export default function AccuracyChart({ data }: Props) {
           stroke="#2563eb"
           strokeWidth={2}
           dot={{ r: 4 }}
-          name="Two-Phase一致率"
+          name={t("agreementRate")}
         />
       </LineChart>
     </ResponsiveContainer>

--- a/frontend/components/dashboard/KpiCards.tsx
+++ b/frontend/components/dashboard/KpiCards.tsx
@@ -1,9 +1,12 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
+'use client'
 import React from "react";
+import { useTranslations } from "next-intl";
 import type { AutomationStatus, DashboardSnapshot } from "../../lib/types";
 
 export default function KpiCards({ status, snapshot }: { status: AutomationStatus; snapshot?: DashboardSnapshot }) {
+  const t = useTranslations("DashboardKpiCards");
   const paused = status.is_trading_paused;
   const hf = status.last_health_factor ?? null;
   const change24h = status.last_price_change_24h ?? null;
@@ -11,28 +14,28 @@ export default function KpiCards({ status, snapshot }: { status: AutomationStatu
 
   return (
     <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 12 }}>
-      <Card title="取引状態">
-        <div style={{ fontSize: 20, fontWeight: 700 }}>{paused ? "停止中" : "稼働中"}</div>
+      <Card title={t("tradingStatus")}>
+        <div style={{ fontSize: 20, fontWeight: 700 }}>{paused ? t("stopped") : t("running")}</div>
         <div style={{ color: "#666", marginTop: 4 }}>is_trading_paused</div>
       </Card>
 
-      <Card title="安全度">
+      <Card title={t("safetyScore")}>
         <div style={{ fontSize: 20, fontWeight: 700 }}>{hf === null ? "N/A" : String(hf)}</div>
         <div style={{ color: "#666", marginTop: 4 }}>last_health_factor</div>
       </Card>
 
-      <Card title="ポートフォリオ 24時間">
+      <Card title={t("portfolio24h")}>
         <div style={{ fontSize: 20, fontWeight: 700 }}>{change24h === null ? "N/A" : `${change24h}%`}</div>
         <div style={{ color: "#666", marginTop: 4 }}>last_price_change_24h</div>
       </Card>
 
-      <Card title="最新イベントレベル">
+      <Card title={t("latestEventLevel")}>
         <div style={{ fontSize: 20, fontWeight: 700 }}>{level ?? "N/A"}</div>
         <div style={{ color: "#666", marginTop: 4 }}>last_event_level</div>
       </Card>
 
       {snapshot?.generated_at ? (
-        <Card title="スナップショット生成日時">
+        <Card title={t("snapshotGeneratedAt")}>
           <div style={{ fontSize: 14, fontWeight: 700 }}>{new Date(snapshot.generated_at).toISOString()}</div>
           <div style={{ color: "#666", marginTop: 4 }}>generated_at (UTC)</div>
         </Card>

--- a/frontend/components/dashboard/ReportSummaryPanel.tsx
+++ b/frontend/components/dashboard/ReportSummaryPanel.tsx
@@ -1,9 +1,12 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
+'use client'
 import React from "react";
+import { useTranslations } from "next-intl";
 import type { AutomationReportSummary } from "../../lib/types";
 
 export default function ReportSummaryPanel({ report }: { report: AutomationReportSummary }) {
+  const t = useTranslations("DashboardReportSummary");
   return (
     <section style={sectionStyle}>
       <header style={headerStyle}>
@@ -13,14 +16,14 @@ export default function ReportSummaryPanel({ report }: { report: AutomationRepor
 
       <div style={{ marginTop: 10 }}>
         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 12 }}>
-          <Card title="期間">{String(report.period ?? "N/A")}</Card>
-          <Card title="生成日時">{String(report.generated_at ?? "N/A")}</Card>
+          <Card title={t("cardPeriod")}>{String(report.period ?? "N/A")}</Card>
+          <Card title={t("cardGeneratedAt")}>{String(report.generated_at ?? "N/A")}</Card>
         </div>
       </div>
 
       {Array.isArray(report.highlights) && report.highlights.length > 0 ? (
         <div style={{ marginTop: 12 }}>
-          <div style={{ fontSize: 12, color: "#666", marginBottom: 6 }}>ハイライト</div>
+          <div style={{ fontSize: 12, color: "#666", marginBottom: 6 }}>{t("highlights")}</div>
           <ul style={{ marginTop: 0 }}>
             {report.highlights.map((h, idx) => (
               <li key={idx} style={{ marginBottom: 6 }}>{h}</li>
@@ -30,7 +33,7 @@ export default function ReportSummaryPanel({ report }: { report: AutomationRepor
       ) : null}
 
       <details style={{ marginTop: 12 }}>
-        <summary style={{ cursor: "pointer" }}>生データ（JSON）</summary>
+        <summary style={{ cursor: "pointer" }}>{t("rawData")}</summary>
         <pre style={preStyle}>{JSON.stringify(report, null, 2)}</pre>
       </details>
     </section>

--- a/frontend/components/dashboard/StatusPanel.tsx
+++ b/frontend/components/dashboard/StatusPanel.tsx
@@ -1,9 +1,12 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
+'use client'
 import React from "react";
+import { useTranslations } from "next-intl";
 import type { AutomationStatus } from "../../lib/types";
 
 export default function StatusPanel({ status }: { status: AutomationStatus }) {
+  const t = useTranslations("DashboardStatusPanel");
   return (
     <section style={sectionStyle}>
       <header style={headerStyle}>
@@ -16,7 +19,7 @@ export default function StatusPanel({ status }: { status: AutomationStatus }) {
       </div>
 
       <details style={{ marginTop: 12 }}>
-        <summary style={{ cursor: "pointer" }}>生データ（JSON）</summary>
+        <summary style={{ cursor: "pointer" }}>{t("rawData")}</summary>
         <pre style={preStyle}>{JSON.stringify(status, null, 2)}</pre>
       </details>
     </section>

--- a/frontend/components/pendle/PendleYieldChart.tsx
+++ b/frontend/components/pendle/PendleYieldChart.tsx
@@ -5,6 +5,7 @@
 //   dynamic(() => import('./PendleYieldChart'), { ssr: false })
 // to prevent SSR crash (recharts は SSR 非対応)
 
+import { useTranslations } from 'next-intl'
 import {
   LineChart,
   Line,
@@ -40,10 +41,11 @@ function formatDate(isoDate: string): string {
 }
 
 export default function PendleYieldChart({ data, title }: Props) {
+  const t = useTranslations("PendleYieldChart")
   if (!data || data.length === 0) {
     return (
       <div className="flex items-center justify-center h-40 text-sm text-zinc-500">
-        APYデータなし
+        {t("noData")}
       </div>
     )
   }

--- a/frontend/components/providers/AdminProviders.tsx
+++ b/frontend/components/providers/AdminProviders.tsx
@@ -4,12 +4,15 @@
 
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import { useTranslations, NextIntlClientProvider } from 'next-intl'
 import { AuthProvider, useAuth } from '@/lib/auth'
 import AppShell from '@/components/layout/AppShell'
 import { SessionExpiryBanner } from '@/components/SessionExpiryBanner'
 import { Toaster } from 'sonner'
+import jaMessages from '@/messages/ja.json'
 
-function AdminGuard({ children }: { children: React.ReactNode }) {
+function AdminGuardInner({ children }: { children: React.ReactNode }) {
+  const t = useTranslations('ProvidersAdmin')
   const { isAuthenticated, isAdmin, isPartner, isLoading } = useAuth()
   const router = useRouter()
 
@@ -25,12 +28,20 @@ function AdminGuard({ children }: { children: React.ReactNode }) {
   }, [isLoading, isAuthenticated, isAdmin, isPartner, router])
 
   if (isLoading) {
-    return <div style={{ padding: 40, textAlign: 'center' }}>読み込み中...</div>
+    return <div style={{ padding: 40, textAlign: 'center' }}>{t('loading')}</div>
   }
   if (!isAuthenticated || !isAdmin) {
     return null
   }
   return <>{children}</>
+}
+
+function AdminGuard({ children }: { children: React.ReactNode }) {
+  return (
+    <NextIntlClientProvider locale="ja" messages={{ ProvidersAdmin: jaMessages.ProvidersAdmin }}>
+      <AdminGuardInner>{children}</AdminGuardInner>
+    </NextIntlClientProvider>
+  )
 }
 
 export function AdminProviders({ children }: { children: React.ReactNode }) {

--- a/frontend/components/providers/PartnerProviders.tsx
+++ b/frontend/components/providers/PartnerProviders.tsx
@@ -4,6 +4,7 @@
 
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import { useTranslations, NextIntlClientProvider } from 'next-intl'
 import { AuthProvider, useAuth } from '@/lib/auth'
 import AppShell from '@/components/layout/AppShell'
 import { AutomationStatusProvider } from '@/components/user/UserProviders'
@@ -11,8 +12,10 @@ import { EmergencyStopFloat } from '@/components/shared/EmergencyStopFloat'
 import { PrivyRootClient } from '@/lib/wallet/PrivyRootClient'
 import { SessionExpiryBanner } from '@/components/SessionExpiryBanner'
 import { Toaster } from 'sonner'
+import jaMessages from '@/messages/ja.json'
 
-function PartnerGuard({ children }: { children: React.ReactNode }) {
+function PartnerGuardInner({ children }: { children: React.ReactNode }) {
+  const t = useTranslations('ProvidersPartner')
   const { isAuthenticated, isPartner, isLoading } = useAuth()
   const router = useRouter()
 
@@ -28,12 +31,20 @@ function PartnerGuard({ children }: { children: React.ReactNode }) {
   }, [isLoading, isAuthenticated, isPartner, router])
 
   if (isLoading) {
-    return <div style={{ padding: 40, textAlign: 'center' }}>読み込み中...</div>
+    return <div style={{ padding: 40, textAlign: 'center' }}>{t('loading')}</div>
   }
   if (!isAuthenticated || !isPartner) {
     return null
   }
   return <>{children}</>
+}
+
+function PartnerGuard({ children }: { children: React.ReactNode }) {
+  return (
+    <NextIntlClientProvider locale="ja" messages={{ ProvidersPartner: jaMessages.ProvidersPartner }}>
+      <PartnerGuardInner>{children}</PartnerGuardInner>
+    </NextIntlClientProvider>
+  )
 }
 
 export function PartnerProviders({ children }: { children: React.ReactNode }) {

--- a/frontend/components/shared/TradeActionBadge.tsx
+++ b/frontend/components/shared/TradeActionBadge.tsx
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
 
+import { useTranslations } from 'next-intl'
 import { TrendingUp, TrendingDown, Minus } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
@@ -12,23 +13,24 @@ export interface TradeActionBadgeProps {
 
 const actionConfig = {
   BUY: {
-    label: '購入する',
+    labelKey: 'labelBuy' as const,
     icon: TrendingUp,
     className: 'bg-green-100 text-green-800 border-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800',
   },
   SELL: {
-    label: '売る',
+    labelKey: 'labelSell' as const,
     icon: TrendingDown,
     className: 'bg-red-100 text-red-800 border-red-200 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800',
   },
   HOLD: {
-    label: 'HOLD',
+    labelKey: 'labelHold' as const,
     icon: Minus,
     className: 'bg-gray-100 dark:bg-gray-800 text-gray-700 border-gray-200 dark:bg-gray-800/50 dark:text-gray-400 dark:border-gray-700',
   },
 } as const
 
 export function TradeActionBadge({ action }: TradeActionBadgeProps) {
+  const t = useTranslations('SharedTradeActionBadge')
   const config = actionConfig[action]
   const Icon = config.icon
 
@@ -38,7 +40,7 @@ export function TradeActionBadge({ action }: TradeActionBadgeProps) {
       className={cn('flex items-center gap-1 font-semibold', config.className)}
     >
       <Icon className="h-3 w-3" />
-      {config.label}
+      {t(config.labelKey)}
     </Badge>
   )
 }

--- a/frontend/components/user/BrowserTermsGate.tsx
+++ b/frontend/components/user/BrowserTermsGate.tsx
@@ -20,6 +20,7 @@
 
 import { useEffect } from "react"
 import { usePathname, useRouter } from "next/navigation"
+import { useTranslations } from "next-intl"
 import { useLiffTermsGate } from "@/hooks/useLiffTermsGate"
 import { getAuthToken } from "@/lib/auth/token-key"
 
@@ -30,6 +31,7 @@ const GATE_EXEMPT_PATHS = ["/user/terms-accept"]
 const BROWSER_ACCEPTED_VERSIONS: readonly string[] = ["liff-v3", "2.0"]
 
 export function BrowserTermsGate({ children }: { children: React.ReactNode }) {
+  const t = useTranslations("UserBrowserTermsGate")
   const pathname = usePathname()
   const router = useRouter()
 
@@ -52,7 +54,7 @@ export function BrowserTermsGate({ children }: { children: React.ReactNode }) {
   if (gateState === "loading") {
     return (
       <div className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center">
-        <p className="text-zinc-400">読み込み中...</p>
+        <p className="text-zinc-400">{t("loading")}</p>
       </div>
     )
   }

--- a/frontend/components/user/UserProviders.tsx
+++ b/frontend/components/user/UserProviders.tsx
@@ -4,6 +4,7 @@
 
 import { createContext, useContext, useState, useEffect, useCallback } from 'react'
 import { useRouter, usePathname } from 'next/navigation'
+import { useTranslations, NextIntlClientProvider } from 'next-intl'
 import { AuthProvider, useAuth } from '@/lib/auth'
 import { SessionExpiryBanner } from '@/components/SessionExpiryBanner'
 import { Toaster } from 'sonner'
@@ -11,6 +12,7 @@ import { fetchAutomationStatus } from '@/lib/api/automation'
 import { PrivyRootClient } from '@/lib/wallet/PrivyRootClient'
 import { PrivySessionGuard } from '@/components/PrivySessionGuard'
 import type { AutomationStatus } from '@/lib/types'
+import jaMessages from '@/messages/ja.json'
 
 const isPrivyConfigured =
   !!process.env.NEXT_PUBLIC_PRIVY_APP_ID &&
@@ -43,7 +45,8 @@ function toSystemStatus(s: AutomationStatus): SystemStatus {
 /** UserGuard を適用しないパス（Privy オンボーディング経路） */
 const GUARD_EXEMPT_PATHS = ['/connect']
 
-function UserGuard({ children }: { children: React.ReactNode }) {
+function UserGuardInner({ children }: { children: React.ReactNode }) {
+  const t = useTranslations('ProvidersUser')
   const { isAuthenticated, isLoading } = useAuth()
   const router = useRouter()
   const pathname = usePathname()
@@ -58,12 +61,20 @@ function UserGuard({ children }: { children: React.ReactNode }) {
   }, [isLoading, isAuthenticated, router, isExempt])
 
   if (isLoading) {
-    return <div style={{ padding: 40, textAlign: 'center' }}>読み込み中...</div>
+    return <div style={{ padding: 40, textAlign: 'center' }}>{t('loading')}</div>
   }
   if (!isExempt && !isAuthenticated) {
     return null
   }
   return <>{children}</>
+}
+
+function UserGuard({ children }: { children: React.ReactNode }) {
+  return (
+    <NextIntlClientProvider locale="ja" messages={{ ProvidersUser: jaMessages.ProvidersUser }}>
+      <UserGuardInner>{children}</UserGuardInner>
+    </NextIntlClientProvider>
+  )
 }
 
 export function AutomationStatusProvider({ children }: { children: React.ReactNode }) {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2780,7 +2780,12 @@
     "lineAppHint": "If you are using the LINE app, please reopen from the menu."
   },
   "LiffLayout": {
-    "reauthing": "Restoring session..."
+    "liffInitError": "LIFF init error: {error}",
+    "loadingInit": "Loading...",
+    "reauthing": "Restoring session...",
+    "lineAppOnly": "Please open in LINE app",
+    "loadingRedirect": "Loading...",
+    "loadingTerms": "Loading..."
   },
   "NotFound": {
     "title": "Page Not Found",
@@ -3320,5 +3325,72 @@
     "totalGain": "Total P&L",
     "avgPerTrade": "Avg {sign}¥{amount} / trade",
     "disclaimer": "* Past performance is not a guarantee of future results."
+  },
+  "SharedAccuracyChart": {
+    "noData": "No Two-Phase data available",
+    "targetLabel": "Target 80%",
+    "agreementRate": "Two-Phase Agreement Rate"
+  },
+  "SharedTradeActionBadge": {
+    "labelBuy": "Buy",
+    "labelSell": "Sell",
+    "labelHold": "HOLD"
+  },
+  "SharedSessionExpiry": {
+    "relogin": "Re-login"
+  },
+  "PendleYieldChart": {
+    "noData": "No APY data"
+  },
+  "DashboardReportSummary": {
+    "cardPeriod": "Period",
+    "cardGeneratedAt": "Generated At",
+    "highlights": "Highlights",
+    "rawData": "Raw Data (JSON)"
+  },
+  "DashboardStatusPanel": {
+    "rawData": "Raw Data (JSON)"
+  },
+  "ProvidersPartner": {
+    "loading": "Loading..."
+  },
+  "ProvidersUser": {
+    "loading": "Loading..."
+  },
+  "DashboardKpiCards": {
+    "tradingStatus": "Trading Status",
+    "stopped": "Stopped",
+    "running": "Running",
+    "safetyScore": "Safety Score",
+    "portfolio24h": "Portfolio 24h",
+    "latestEventLevel": "Latest Event Level",
+    "snapshotGeneratedAt": "Snapshot Generated At"
+  },
+  "UserBrowserTermsGate": {
+    "loading": "Loading..."
+  },
+  "ProvidersAdmin": {
+    "loading": "Loading..."
+  },
+  "AdminComponentsPreview": {
+    "title": "Shared Components Preview",
+    "hfSm": "size=sm, Safe (2.5)",
+    "hfMd": "size=md, Warning (1.8)",
+    "hfLg": "size=lg, Danger (1.3)",
+    "hfNull": "value=null (no borrow)",
+    "cbHigh": "85% (threshold 70+ = green)",
+    "cbLow": "45% (threshold 70- = blue)",
+    "cbNoLabel": "showLabel=false",
+    "cbThreshold": "threshold=50, value=55",
+    "floatingNote": "※ floating variant is fixed at bottom right",
+    "kpiTotalAsset": "Total Assets",
+    "kpiDailyPnl": "Today's P&L",
+    "kpiWinRate": "Win Rate",
+    "kpiTradeCount": "Trade Count",
+    "kpiTradeCountSuffix": "",
+    "walletDefaultChars": "Default (chars=6)",
+    "walletChars10": "chars=10",
+    "datePresetsOn": "presets=true (default)",
+    "datePresetsOff": "presets=false (custom input only)"
   }
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -2780,7 +2780,12 @@
     "lineAppHint": "LINEアプリからご利用の場合は、メニューから開き直してください。"
   },
   "LiffLayout": {
-    "reauthing": "セッションを復元しています..."
+    "liffInitError": "LIFF初期化エラー: {error}",
+    "loadingInit": "読み込み中...",
+    "reauthing": "セッションを復元しています...",
+    "lineAppOnly": "LINEアプリから開いてください",
+    "loadingRedirect": "読み込み中...",
+    "loadingTerms": "読み込み中..."
   },
   "NotFound": {
     "title": "ページが見つかりません",
@@ -3320,5 +3325,72 @@
     "totalGain": "累計損益",
     "avgPerTrade": "平均 {sign}¥{amount} / 回",
     "disclaimer": "※ 実績であり保証ではありません。過去の成績は将来の結果を保証しません。"
+  },
+  "SharedAccuracyChart": {
+    "noData": "Two-Phase判定データがありません",
+    "targetLabel": "目標80%",
+    "agreementRate": "Two-Phase一致率"
+  },
+  "SharedTradeActionBadge": {
+    "labelBuy": "購入する",
+    "labelSell": "売る",
+    "labelHold": "HOLD"
+  },
+  "SharedSessionExpiry": {
+    "relogin": "再ログイン"
+  },
+  "PendleYieldChart": {
+    "noData": "APYデータなし"
+  },
+  "DashboardReportSummary": {
+    "cardPeriod": "期間",
+    "cardGeneratedAt": "生成日時",
+    "highlights": "ハイライト",
+    "rawData": "生データ（JSON）"
+  },
+  "DashboardStatusPanel": {
+    "rawData": "生データ（JSON）"
+  },
+  "ProvidersPartner": {
+    "loading": "読み込み中..."
+  },
+  "ProvidersUser": {
+    "loading": "読み込み中..."
+  },
+  "DashboardKpiCards": {
+    "tradingStatus": "取引状態",
+    "stopped": "停止中",
+    "running": "稼働中",
+    "safetyScore": "安全度",
+    "portfolio24h": "ポートフォリオ 24時間",
+    "latestEventLevel": "最新イベントレベル",
+    "snapshotGeneratedAt": "スナップショット生成日時"
+  },
+  "UserBrowserTermsGate": {
+    "loading": "読み込み中..."
+  },
+  "ProvidersAdmin": {
+    "loading": "読み込み中..."
+  },
+  "AdminComponentsPreview": {
+    "title": "共通コンポーネントプレビュー",
+    "hfSm": "size=sm, 安全 (2.5)",
+    "hfMd": "size=md, 注意 (1.8)",
+    "hfLg": "size=lg, 危険 (1.3)",
+    "hfNull": "value=null (借入なし)",
+    "cbHigh": "85% (閾値70以上=緑)",
+    "cbLow": "45% (閾値70未満=青)",
+    "cbNoLabel": "showLabel=false",
+    "cbThreshold": "threshold=50, value=55",
+    "floatingNote": "※ floating variant は画面右下に固定表示されます",
+    "kpiTotalAsset": "総資産",
+    "kpiDailyPnl": "本日の損益",
+    "kpiWinRate": "勝率",
+    "kpiTradeCount": "取引回数",
+    "kpiTradeCountSuffix": "回",
+    "walletDefaultChars": "デフォルト (chars=6)",
+    "walletChars10": "chars=10",
+    "datePresetsOn": "presets=true (デフォルト)",
+    "datePresetsOff": "presets=false (カスタム入力のみ)"
   }
 }


### PR DESCRIPTION
## Summary

- 13 コンポーネント/ページ + `(liff)/layout.tsx` 残存文字列の next-intl 化
- 13 個の新 namespace 追加 (en/ja 各 2356 keys, 完全一致)
- `NotificationPanel.tsx` は既に完了済みのため変更なし

## 変更ファイル

| ファイル | namespace | JP strings |
|---|---|---|
| `components/charts/AccuracyChart.tsx` | SharedAccuracyChart | 3 |
| `components/shared/TradeActionBadge.tsx` | SharedTradeActionBadge | 2 |
| `components/SessionExpiryBanner.tsx` | SharedSessionExpiry | 1 |
| `components/pendle/PendleYieldChart.tsx` | PendleYieldChart | 1 |
| `components/dashboard/ReportSummaryPanel.tsx` | DashboardReportSummary | 4 |
| `components/dashboard/StatusPanel.tsx` | DashboardStatusPanel | 1 |
| `components/providers/PartnerProviders.tsx` | ProvidersPartner | 1 |
| `components/user/UserProviders.tsx` | ProvidersUser | 1 |
| `components/dashboard/KpiCards.tsx` | DashboardKpiCards | 7 |
| `components/user/BrowserTermsGate.tsx` | UserBrowserTermsGate | 1 |
| `components/providers/AdminProviders.tsx` | ProvidersAdmin | 1 |
| `app/(admin)/components-preview/page.tsx` | AdminComponentsPreview | 19 |
| `app/(liff)/layout.tsx` | LiffLayout (新規) | 5 |

## Providers ファイルの対処パターン

`AdminProviders` / `PartnerProviders` / `UserProviders` は `AuthProvider` より外側に Provider を追加できないため、Guard コンポーネントを `XxxGuardInner` + `XxxGuard` に分割し `XxxGuard` 内で `NextIntlClientProvider` を inline 供給するパターンを採用。

## `(liff)/layout.tsx` の対処パターン

5 箇所の JP 文字列はいずれも `liff-chat` 配下の `IntlWrapper` の外側にある。`withLiffLayoutIntl` HOC を定義して各 fallback コンポーネントに最小 messages を供給するパターンで対処。

## DoD チェック
- [x] 全対象ファイルでコメント外 JP 文字ゼロ
- [x] en/ja キー数一致 (2356)
- [x] `tsc --noEmit` 新規エラー 0

🤖 Generated with Claude Code