### PR TITLE
feat(i18n): wave18b admin pages + components i18n

### DIFF
--- a/frontend/app/(admin)/ai-monitor/page.tsx
+++ b/frontend/app/(admin)/ai-monitor/page.tsx
@@ -63,43 +63,7 @@ function mapApiDecisionToRecord(d: ApiDecisionItem): AiDecisionRecord {
   };
 }
 
-// ─── Mock data (shown when API returns 404) ───────────────────────────────────
-
-const MOCK_RECORDS: AiDecisionRecord[] = [
-  {
-    id: 1,
-    timestamp: new Date(Date.now() - 1000 * 60 * 5).toISOString(),
-    pair: "BTC/USDT",
-    phase_a: "BUY",
-    phase_b: "BUY",
-    final_decision: "BUY",
-    confidence: 0.87,
-    executed: true,
-    reason: "強気トレンド継続。RSI過熱なし。",
-  },
-  {
-    id: 2,
-    timestamp: new Date(Date.now() - 1000 * 60 * 35).toISOString(),
-    pair: "ETH/USDT",
-    phase_a: "HOLD",
-    phase_b: null,
-    final_decision: "HOLD",
-    confidence: 0.72,
-    executed: false,
-    reason: "Health Factor 1.62 — 閾値接近のため保留。",
-  },
-  {
-    id: 3,
-    timestamp: new Date(Date.now() - 1000 * 60 * 65).toISOString(),
-    pair: "BTC/USDT",
-    phase_a: "SELL",
-    phase_b: "HOLD",
-    final_decision: "HOLD",
-    confidence: 0.61,
-    executed: false,
-    reason: "フェーズ間で不一致。安全側のHOLDを採用。",
-  },
-];
+// ─── Mock data builder (reason strings resolved at render time via t()) ──────
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -166,6 +130,43 @@ const POLL_INTERVAL_SEC = 30;
 function AiMonitorContent() {
   const t = useTranslations("AiMonitor");
   const { token } = useAuth();
+
+  const MOCK_RECORDS: AiDecisionRecord[] = [
+    {
+      id: 1,
+      timestamp: new Date(Date.now() - 1000 * 60 * 5).toISOString(),
+      pair: "BTC/USDT",
+      phase_a: "BUY",
+      phase_b: "BUY",
+      final_decision: "BUY",
+      confidence: 0.87,
+      executed: true,
+      reason: t("mockReason1"),
+    },
+    {
+      id: 2,
+      timestamp: new Date(Date.now() - 1000 * 60 * 35).toISOString(),
+      pair: "ETH/USDT",
+      phase_a: "HOLD",
+      phase_b: null,
+      final_decision: "HOLD",
+      confidence: 0.72,
+      executed: false,
+      reason: t("mockReason2"),
+    },
+    {
+      id: 3,
+      timestamp: new Date(Date.now() - 1000 * 60 * 65).toISOString(),
+      pair: "BTC/USDT",
+      phase_a: "SELL",
+      phase_b: "HOLD",
+      final_decision: "HOLD",
+      confidence: 0.61,
+      executed: false,
+      reason: t("mockReason3"),
+    },
+  ];
+
   const [records, setRecords] = useState<AiDecisionRecord[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/frontend/app/(admin)/events/page.tsx
+++ b/frontend/app/(admin)/events/page.tsx
@@ -42,88 +42,8 @@ interface MonitoringEvent {
 }
 
 // -----------------------------------------------------------------------
-// Mock data (fallback when API is unavailable)
+// Mock data builder (message strings resolved at render time via t())
 // -----------------------------------------------------------------------
-
-const MOCK_EVENTS: MonitoringEvent[] = [
-  {
-    id: 'evt-001',
-    timestamp: '2026-03-22T10:45:00Z',
-    level: 'EMERGENCY',
-    component: 'RuleEngine',
-    message: '緊急停止フラグが発動しました。Health Factor が閾値を下回りました。',
-    metric_id: 'health_factor',
-    metric_value: 1.42,
-    metric_unit: '',
-  },
-  {
-    id: 'evt-002',
-    timestamp: '2026-03-22T10:30:00Z',
-    level: 'CRITICAL',
-    component: 'AaveClient',
-    message: 'Health Factor が危険水準に到達しました。即時対応が必要です。',
-    metric_id: 'health_factor',
-    metric_value: 1.55,
-    metric_unit: '',
-  },
-  {
-    id: 'evt-003',
-    timestamp: '2026-03-22T09:15:00Z',
-    level: 'ALERT',
-    component: 'ExchangeService',
-    message: '1日の取引制限の80%に到達しました。残りの取引枠に注意してください。',
-    metric_id: 'daily_trades_used',
-    metric_value: 24,
-    metric_unit: '件',
-  },
-  {
-    id: 'evt-004',
-    timestamp: '2026-03-22T08:50:00Z',
-    level: 'WARNING',
-    component: 'AIJudge',
-    message: 'GPT-4o クロス検証タイムアウト。Claude の判断のみで実行しました。',
-    metric_id: 'latency_ms',
-    metric_value: 5200,
-    metric_unit: 'ms',
-  },
-  {
-    id: 'evt-005',
-    timestamp: '2026-03-22T08:00:00Z',
-    level: 'INFO',
-    component: 'AutomationWorkflow',
-    message: 'BUY シグナルを実行しました。Bybit Sandbox に注文を送信しました。',
-    metric_id: 'order_usd',
-    metric_value: 150,
-    metric_unit: 'USD',
-  },
-  {
-    id: 'evt-006',
-    timestamp: '2026-03-22T07:30:00Z',
-    level: 'INFO',
-    component: 'KnowledgeService',
-    message: 'ナレッジベースの更新が完了しました。新規チャンク 12 件を追加しました。',
-    metric_id: 'chunks_added',
-    metric_value: 12,
-    metric_unit: '件',
-  },
-  {
-    id: 'evt-007',
-    timestamp: '2026-03-21T23:00:00Z',
-    level: 'WARNING',
-    component: 'RuleEngine',
-    message: 'クールダウン期間中のため、Aave 操作をスキップしました。',
-  },
-  {
-    id: 'evt-008',
-    timestamp: '2026-03-21T18:45:00Z',
-    level: 'INFO',
-    component: 'AaveClient',
-    message: 'リバランス完了: USDC 500 を Aave V3 に預入しました。',
-    metric_id: 'deposited_usdc',
-    metric_value: 500,
-    metric_unit: 'USDC',
-  },
-]
 
 // -----------------------------------------------------------------------
 // Level styles
@@ -190,6 +110,86 @@ function extractEvents(data: unknown): MonitoringEvent[] {
 function EventsContent() {
   const t = useTranslations('AdminEvents')
   const { token } = useAuth()
+
+  const MOCK_EVENTS: MonitoringEvent[] = [
+    {
+      id: 'evt-001',
+      timestamp: '2026-03-22T10:45:00Z',
+      level: 'EMERGENCY',
+      component: 'RuleEngine',
+      message: t('mockMsg1'),
+      metric_id: 'health_factor',
+      metric_value: 1.42,
+      metric_unit: '',
+    },
+    {
+      id: 'evt-002',
+      timestamp: '2026-03-22T10:30:00Z',
+      level: 'CRITICAL',
+      component: 'AaveClient',
+      message: t('mockMsg2'),
+      metric_id: 'health_factor',
+      metric_value: 1.55,
+      metric_unit: '',
+    },
+    {
+      id: 'evt-003',
+      timestamp: '2026-03-22T09:15:00Z',
+      level: 'ALERT',
+      component: 'ExchangeService',
+      message: t('mockMsg3'),
+      metric_id: 'daily_trades_used',
+      metric_value: 24,
+      metric_unit: t('mockUnit'),
+    },
+    {
+      id: 'evt-004',
+      timestamp: '2026-03-22T08:50:00Z',
+      level: 'WARNING',
+      component: 'AIJudge',
+      message: t('mockMsg4'),
+      metric_id: 'latency_ms',
+      metric_value: 5200,
+      metric_unit: 'ms',
+    },
+    {
+      id: 'evt-005',
+      timestamp: '2026-03-22T08:00:00Z',
+      level: 'INFO',
+      component: 'AutomationWorkflow',
+      message: t('mockMsg5'),
+      metric_id: 'order_usd',
+      metric_value: 150,
+      metric_unit: 'USD',
+    },
+    {
+      id: 'evt-006',
+      timestamp: '2026-03-22T07:30:00Z',
+      level: 'INFO',
+      component: 'KnowledgeService',
+      message: t('mockMsg6'),
+      metric_id: 'chunks_added',
+      metric_value: 12,
+      metric_unit: t('mockUnit'),
+    },
+    {
+      id: 'evt-007',
+      timestamp: '2026-03-21T23:00:00Z',
+      level: 'WARNING',
+      component: 'RuleEngine',
+      message: t('mockMsg7'),
+    },
+    {
+      id: 'evt-008',
+      timestamp: '2026-03-21T18:45:00Z',
+      level: 'INFO',
+      component: 'AaveClient',
+      message: t('mockMsg8'),
+      metric_id: 'deposited_usdc',
+      metric_value: 500,
+      metric_unit: 'USDC',
+    },
+  ]
 
   const [events, setEvents] = useState<MonitoringEvent[]>([])
   const [loading, setLoading] = useState(true)

--- a/frontend/app/(admin)/proposals/_components/ProposalKPIs.tsx
+++ b/frontend/app/(admin)/proposals/_components/ProposalKPIs.tsx
@@ -4,12 +4,14 @@
 
 import { useEffect, useState } from 'react'
 import { Clock, CheckCircle, XCircle, Timer } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 import { KPICard } from '@/components/shared/KPICard'
 import { useAuth } from '@/lib/auth'
 import { fetchAdminProposalStats } from '@/lib/api/admin-proposals'
 import type { AdminProposalStats } from '@/lib/api/admin-proposals'
 
 export function ProposalKPIs() {
+  const t = useTranslations('AdminProposalKPIs')
   const { token } = useAuth()
   const [stats, setStats] = useState<AdminProposalStats | null>(null)
 
@@ -29,10 +31,10 @@ export function ProposalKPIs() {
 
   return (
     <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-      <KPICard label="承認待ち" value={pending} suffix="件" icon={Clock} />
-      <KPICard label="本日承認" value={todayApproved} suffix="件" icon={CheckCircle} />
-      <KPICard label="本日拒否" value={todayRejected} suffix="件" icon={XCircle} />
-      <KPICard label="タイムアウト" value={expired} suffix="件" icon={Timer} />
+      <KPICard label={t('pending')} value={pending} suffix={t('countSuffix')} icon={Clock} />
+      <KPICard label={t('todayApproved')} value={todayApproved} suffix={t('countSuffix')} icon={CheckCircle} />
+      <KPICard label={t('todayRejected')} value={todayRejected} suffix={t('countSuffix')} icon={XCircle} />
+      <KPICard label={t('timeout')} value={expired} suffix={t('countSuffix')} icon={Timer} />
     </div>
   )
 }

--- a/frontend/app/(admin)/reports/page.tsx
+++ b/frontend/app/(admin)/reports/page.tsx
@@ -43,11 +43,12 @@ interface ReportDetail {
 }
 
 // ── Mock Data ──────────────────────────────────────────────────────────────
+// (note strings resolved at render time via t() — see buildMockReports())
 
-const MOCK_REPORTS: ReportDetail[] = [
+const MOCK_REPORT_TEMPLATES = [
   {
     id: "rpt-001",
-    period_type: "daily",
+    period_type: "daily" as const,
     period_start: "2026-03-21T00:00:00+09:00",
     period_end: "2026-03-21T23:59:59+09:00",
     event_counts: { INFO: 42, WARNING: 3, ALERT: 1, CRITICAL: 0, EMERGENCY: 0 },
@@ -55,7 +56,7 @@ const MOCK_REPORTS: ReportDetail[] = [
     hf_max: 2.15,
     hf_last: 2.01,
     emergency_occurred: false,
-    notes: "通常運用。HFは安定して推移。",
+    noteKey: "mockNote1" as const,
     metric_aggregates: [
       { metric_id: "health_factor", count: 288, min_value: 1.72, max_value: 2.15, avg_value: 1.94, unit: null },
       { metric_id: "usdc_balance", count: 288, min_value: 9800.0, max_value: 10200.0, avg_value: 10020.5, unit: "USDC" },
@@ -64,7 +65,7 @@ const MOCK_REPORTS: ReportDetail[] = [
   },
   {
     id: "rpt-002",
-    period_type: "daily",
+    period_type: "daily" as const,
     period_start: "2026-03-20T00:00:00+09:00",
     period_end: "2026-03-20T23:59:59+09:00",
     event_counts: { INFO: 38, WARNING: 8, ALERT: 4, CRITICAL: 2, EMERGENCY: 1 },
@@ -72,7 +73,7 @@ const MOCK_REPORTS: ReportDetail[] = [
     hf_max: 1.98,
     hf_last: 1.71,
     emergency_occurred: true,
-    notes: "HFが1.6を下回り緊急停止が発動。03:14 JST に自動復旧。担当者への通知済み。",
+    noteKey: "mockNote2" as const,
     metric_aggregates: [
       { metric_id: "health_factor", count: 288, min_value: 1.48, max_value: 1.98, avg_value: 1.68, unit: null },
       { metric_id: "usdc_balance", count: 288, min_value: 9200.0, max_value: 10100.0, avg_value: 9710.3, unit: "USDC" },
@@ -82,7 +83,7 @@ const MOCK_REPORTS: ReportDetail[] = [
   },
   {
     id: "rpt-003",
-    period_type: "weekly",
+    period_type: "weekly" as const,
     period_start: "2026-03-14T00:00:00+09:00",
     period_end: "2026-03-20T23:59:59+09:00",
     event_counts: { INFO: 310, WARNING: 21, ALERT: 7, CRITICAL: 2, EMERGENCY: 1 },
@@ -90,7 +91,7 @@ const MOCK_REPORTS: ReportDetail[] = [
     hf_max: 2.31,
     hf_last: 1.71,
     emergency_occurred: true,
-    notes: "週次まとめ。3/20の緊急停止を含む。全体的なHFは良好。",
+    noteKey: "mockNote3" as const,
     metric_aggregates: [
       { metric_id: "health_factor", count: 2016, min_value: 1.48, max_value: 2.31, avg_value: 1.92, unit: null },
       { metric_id: "usdc_balance", count: 2016, min_value: 9200.0, max_value: 10500.0, avg_value: 10045.8, unit: "USDC" },
@@ -411,6 +412,11 @@ function ReportViewerContent() {
   const [generating, setGenerating] = React.useState(false);
   const [toast, setToast] = React.useState<{ message: string; type: "success" | "error" } | null>(null);
 
+  const mockReports: ReportDetail[] = MOCK_REPORT_TEMPLATES.map((tmpl) => ({
+    ...tmpl,
+    notes: t(tmpl.noteKey),
+  }));
+
   const loadReports = React.useCallback(async () => {
     setLoading(true);
     setFetchError(null);
@@ -420,11 +426,12 @@ function ReportViewerContent() {
       setReports(data);
     } catch {
       // Fallback to mock data
-      setReports(MOCK_REPORTS);
+      setReports(mockReports);
       setFetchError(t("fetchError"));
     } finally {
       setLoading(false);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [token, t]);
 
   React.useEffect(() => {

--- a/frontend/app/(admin)/users/_components/UserPositions.tsx
+++ b/frontend/app/(admin)/users/_components/UserPositions.tsx
@@ -2,6 +2,8 @@
 // Copyright (c) 2026 Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
 
+import { useTranslations } from 'next-intl'
+
 interface Position {
   asset: string
   supplied: number
@@ -23,9 +25,10 @@ function formatUSD(value: number): string {
 }
 
 export function UserPositions({ positions }: UserPositionsProps) {
+  const t = useTranslations('AdminUserPositions')
   if (positions.length === 0) {
     return (
-      <div className="text-sm text-gray-500 py-3 text-center">ポジションなし</div>
+      <div className="text-sm text-gray-500 py-3 text-center">{t('noPositions')}</div>
     )
   }
 

--- a/frontend/app/(admin)/users/_components/UserTable.tsx
+++ b/frontend/app/(admin)/users/_components/UserTable.tsx
@@ -121,7 +121,7 @@ export function UserTable({ users, onSelectUser }: UserTableProps) {
               <TableCell className="py-3">
                 <div className="flex items-center gap-2">
                   {user.isPaused && (
-                    <span className="inline-block w-1.5 h-1.5 rounded-full bg-orange-400 flex-shrink-0" title="停止中" />
+                    <span className="inline-block w-1.5 h-1.5 rounded-full bg-orange-400 flex-shrink-0" title={t('suspendedTooltip')} />
                   )}
                   <WalletAddressMask address={user.address} chars={6} />
                 </div>

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1989,7 +1989,10 @@
     "dialogConfirm": "Generate",
     "toastSuccess": "Report generated successfully",
     "toastErrorPrefix": "Error: {msg}",
-    "generateFailed": "Failed to generate report"
+    "generateFailed": "Failed to generate report",
+    "mockNote1": "Normal operation. HF stable throughout.",
+    "mockNote2": "HF dropped below 1.6, triggering emergency stop. Auto-recovered at 03:14 JST. Operator notified.",
+    "mockNote3": "Weekly summary. Includes emergency stop on 3/20. Overall HF is satisfactory."
   },
   "Terms": {
     "back": "Back",
@@ -2043,7 +2046,16 @@
     "detailFieldComponent": "Component",
     "detailFieldMessage": "Message",
     "detailFieldMetricId": "Metric ID",
-    "detailFieldMetricValue": "Metric Value"
+    "detailFieldMetricValue": "Metric Value",
+    "mockMsg1": "Emergency stop triggered. Health Factor fell below threshold.",
+    "mockMsg2": "Health Factor reached critical level. Immediate action required.",
+    "mockMsg3": "Daily trade limit at 80%. Watch remaining trade capacity.",
+    "mockMsg4": "GPT-4o cross-validation timeout. Proceeded with Claude decision only.",
+    "mockMsg5": "BUY signal executed. Order sent to Bybit Sandbox.",
+    "mockMsg6": "Knowledge base update complete. 12 new chunks added.",
+    "mockMsg7": "Aave operation skipped due to cooldown period.",
+    "mockMsg8": "Rebalance complete: deposited USDC 500 into Aave V3.",
+    "mockUnit": ""
   },
   "AdminTrades": {
     "pageTitle": "Trade History",
@@ -2406,7 +2418,10 @@
     "sampleData": "Sample data",
     "chartConfidence": "Confidence Trend (Last 7 days)",
     "chartActionDist": "Action Distribution",
-    "chartTwoPhase": "Two-Phase Agreement Rate"
+    "chartTwoPhase": "Two-Phase Agreement Rate",
+    "mockReason1": "Bullish trend continues. RSI not overheated.",
+    "mockReason2": "Health Factor 1.62 — approaching threshold, on hold.",
+    "mockReason3": "Phase mismatch detected. Adopted safer HOLD decision."
   },
   "UserDetailPanel": {
     "dialogTitle": "User Detail",
@@ -2613,7 +2628,8 @@
     "riskAggressive": "Aggressive",
     "statusNormal": "Normal",
     "statusWarning": "Warning",
-    "statusDanger": "Danger"
+    "statusDanger": "Danger",
+    "suspendedTooltip": "Suspended"
   },
   "SharedEmergencyStopButton": {
     "buttonLabel": "Emergency Stop",
@@ -3392,5 +3408,15 @@
     "walletChars10": "chars=10",
     "datePresetsOn": "presets=true (default)",
     "datePresetsOff": "presets=false (custom input only)"
+  },
+  "AdminProposalKPIs": {
+    "pending": "Pending Approval",
+    "todayApproved": "Approved Today",
+    "todayRejected": "Rejected Today",
+    "timeout": "Timed Out",
+    "countSuffix": ""
+  },
+  "AdminUserPositions": {
+    "noPositions": "No positions"
   }
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -1989,7 +1989,10 @@
     "dialogConfirm": "生成する",
     "toastSuccess": "レポートを生成しました",
     "toastErrorPrefix": "エラー: {msg}",
-    "generateFailed": "生成に失敗しました"
+    "generateFailed": "生成に失敗しました",
+    "mockNote1": "通常運用。HFは安定して推移。",
+    "mockNote2": "HFが1.6を下回り緊急停止が発動。03:14 JST に自動復旧。担当者への通知済み。",
+    "mockNote3": "週次まとめ。3/20の緊急停止を含む。全体的なHFは良好。"
   },
   "Terms": {
     "back": "戻る",
@@ -2043,7 +2046,16 @@
     "detailFieldComponent": "コンポーネント",
     "detailFieldMessage": "メッセージ",
     "detailFieldMetricId": "メトリクスID",
-    "detailFieldMetricValue": "メトリクス値"
+    "detailFieldMetricValue": "メトリクス値",
+    "mockMsg1": "緊急停止フラグが発動しました。Health Factor が閾値を下回りました。",
+    "mockMsg2": "Health Factor が危険水準に到達しました。即時対応が必要です。",
+    "mockMsg3": "1日の取引制限の80%に到達しました。残りの取引枠に注意してください。",
+    "mockMsg4": "GPT-4o クロス検証タイムアウト。Claude の判断のみで実行しました。",
+    "mockMsg5": "BUY シグナルを実行しました。Bybit Sandbox に注文を送信しました。",
+    "mockMsg6": "ナレッジベースの更新が完了しました。新規チャンク 12 件を追加しました。",
+    "mockMsg7": "クールダウン期間中のため、Aave 操作をスキップしました。",
+    "mockMsg8": "リバランス完了: USDC 500 を Aave V3 に預入しました。",
+    "mockUnit": "件"
   },
   "AdminTrades": {
     "pageTitle": "取引履歴",
@@ -2406,7 +2418,10 @@
     "sampleData": "サンプルデータ",
     "chartConfidence": "信頼度トレンド（直近7日）",
     "chartActionDist": "判定アクション分布",
-    "chartTwoPhase": "Two-Phase一致率"
+    "chartTwoPhase": "Two-Phase一致率",
+    "mockReason1": "強気トレンド継続。RSI過熱なし。",
+    "mockReason2": "Health Factor 1.62 — 閾値接近のため保留。",
+    "mockReason3": "フェーズ間で不一致。安全側のHOLDを採用。"
   },
   "UserDetailPanel": {
     "dialogTitle": "ユーザー詳細",
@@ -2613,7 +2628,8 @@
     "riskAggressive": "積極",
     "statusNormal": "正常",
     "statusWarning": "警告",
-    "statusDanger": "危険"
+    "statusDanger": "危険",
+    "suspendedTooltip": "停止中"
   },
   "SharedEmergencyStopButton": {
     "buttonLabel": "緊急停止",
@@ -3392,5 +3408,15 @@
     "walletChars10": "chars=10",
     "datePresetsOn": "presets=true (デフォルト)",
     "datePresetsOff": "presets=false (カスタム入力のみ)"
+  },
+  "AdminProposalKPIs": {
+    "pending": "承認待ち",
+    "todayApproved": "本日承認",
+    "todayRejected": "本日拒否",
+    "timeout": "タイムアウト",
+    "countSuffix": "件"
+  },
+  "AdminUserPositions": {
+    "noPositions": "ポジションなし"
   }
 }


### PR DESCRIPTION
## Summary
- ProposalKPIs: KPI labels (承認待ち/本日承認等) → i18n (new namespace AdminProposalKPIs)
- UserTable: title="停止中" → t('suspendedTooltip') added to existing AdminUserTable namespace
- UserPositions: ポジションなし → i18n (new namespace AdminUserPositions)
- ai-monitor/page: mock data reason strings → AiMonitor.mockReason1/2/3 (MOCK_RECORDS moved inside component to access t())
- ai-learning/page: no actionable JP strings remaining in code (comments and recharts dataKey only)
- events/page: MOCK_EVENTS messages/unit → AdminEvents.mockMsg1-8 + mockUnit (MOCK_EVENTS moved inside EventsContent)
- reports/page: MOCK_REPORTS notes → AdminReports.mockNote1/2/3 (template pattern + buildMockReports inside component)

GID: 1215687791466923