### PR TITLE
feat(i18n): wave18a shared + transparency components i18n

### DIFF
--- a/frontend/components/partner/AiActivityCard.tsx
+++ b/frontend/components/partner/AiActivityCard.tsx
@@ -3,6 +3,7 @@
 // frontend/components/partner/AiActivityCard.tsx
 'use client'
 
+import { useTranslations } from 'next-intl'
 import { Brain } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -17,23 +18,24 @@ function actionColor(action: string): string {
   return 'text-yellow-600 bg-yellow-50 border-yellow-200 dark:bg-yellow-950/30 dark:border-yellow-800 dark:text-yellow-400'
 }
 
-function actionLabel(action: string): string {
-  if (action === 'BUY') return '買い'
-  if (action === 'SELL') return '売り'
-  return '様子見'
-}
-
-function formatElapsed(iso: string): string {
-  const diff = Math.floor((Date.now() - new Date(iso).getTime()) / 60_000)
-  if (diff < 1) return 'たった今'
-  if (diff < 60) return `${diff}分前`
-  return `${Math.floor(diff / 60)}時間前`
-}
-
 // ─── Main Component ───────────────────────────────────────────────────────────
 
 export function AiActivityCard({ className }: { className?: string }) {
+  const t = useTranslations('PartnerAiActivityCard')
   const { data, loading, isNewDecision } = useLatestAiDecision()
+
+  function actionLabel(action: string): string {
+    if (action === 'BUY') return t('buy')
+    if (action === 'SELL') return t('sell')
+    return t('hold')
+  }
+
+  function formatElapsed(iso: string): string {
+    const diff = Math.floor((Date.now() - new Date(iso).getTime()) / 60_000)
+    if (diff < 1) return t('justNow')
+    if (diff < 60) return t('minutesAgo', { n: diff })
+    return t('hoursAgo', { n: Math.floor(diff / 60) })
+  }
 
   if (loading) {
     return (
@@ -100,7 +102,7 @@ export function AiActivityCard({ className }: { className?: string }) {
                 data-testid="ai-activity-agreed"
                 className="rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-medium text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400"
               >
-                Claude+GPT 一致
+                {t('claudeGptAgreed')}
               </span>
             )}
 

--- a/frontend/components/shared/ConfidenceBar.tsx
+++ b/frontend/components/shared/ConfidenceBar.tsx
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
 
+import { useTranslations } from 'next-intl'
 import { cn } from '@/lib/utils'
 
 export interface ConfidenceBarProps {
@@ -11,6 +12,7 @@ export interface ConfidenceBarProps {
 }
 
 export function ConfidenceBar({ value, threshold = 70, showLabel = true }: ConfidenceBarProps) {
+  const t = useTranslations('SharedConfidenceBar')
   const clamped = Math.min(100, Math.max(0, value))
   const isAboveThreshold = clamped >= threshold
 
@@ -18,7 +20,7 @@ export function ConfidenceBar({ value, threshold = 70, showLabel = true }: Confi
     <div className="flex flex-col gap-1 w-full">
       {showLabel && (
         <div className="flex justify-between text-sm">
-          <span className="text-muted-foreground">信頼度</span>
+          <span className="text-muted-foreground">{t('label')}</span>
           <span className={cn('font-medium', isAboveThreshold ? 'text-green-600 dark:text-green-400' : 'text-blue-600 dark:text-blue-400')}>
             {clamped}%
           </span>
@@ -37,7 +39,7 @@ export function ConfidenceBar({ value, threshold = 70, showLabel = true }: Confi
       </div>
       {threshold && (
         <div className="flex justify-end text-xs text-muted-foreground">
-          <span>閾値: {threshold}%</span>
+          <span>{t('threshold', { pct: threshold })}</span>
         </div>
       )}
     </div>

--- a/frontend/components/shared/DateRangeFilter.tsx
+++ b/frontend/components/shared/DateRangeFilter.tsx
@@ -3,6 +3,7 @@
 // Unauthorized copying or distribution is strictly prohibited.
 
 import { useState } from 'react'
+import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
@@ -13,12 +14,7 @@ export interface DateRangeFilterProps {
 
 type PresetKey = '7d' | '30d' | '90d' | 'all'
 
-const presetOptions: { key: PresetKey; label: string }[] = [
-  { key: '7d', label: '7日' },
-  { key: '30d', label: '30日' },
-  { key: '90d', label: '90日' },
-  { key: 'all', label: 'ALL' },
-]
+const presetKeys: PresetKey[] = ['7d', '30d', '90d', 'all']
 
 function getPresetRange(key: PresetKey): { from: Date; to: Date } | 'all' {
   if (key === 'all') return 'all'
@@ -33,7 +29,15 @@ function toInputDate(date: Date): string {
   return date.toISOString().split('T')[0]
 }
 
+const presetLabelKey: Record<PresetKey, 'days7' | 'days30' | 'days90' | 'all'> = {
+  '7d': 'days7',
+  '30d': 'days30',
+  '90d': 'days90',
+  'all': 'all',
+}
+
 export function DateRangeFilter({ onChange, presets = true }: DateRangeFilterProps) {
+  const t = useTranslations('SharedDateRangeFilter')
   const [activePreset, setActivePreset] = useState<PresetKey | null>('30d')
   const today = new Date()
   const thirtyDaysAgo = new Date()
@@ -63,18 +67,18 @@ export function DateRangeFilter({ onChange, presets = true }: DateRangeFilterPro
     <div className="flex flex-wrap items-center gap-2">
       {presets && (
         <div className="flex items-center gap-1">
-          {presetOptions.map((preset) => (
+          {presetKeys.map((key) => (
             <Button
-              key={preset.key}
-              variant={activePreset === preset.key ? 'default' : 'outline'}
+              key={key}
+              variant={activePreset === key ? 'default' : 'outline'}
               size="sm"
-              onClick={() => handlePreset(preset.key)}
+              onClick={() => handlePreset(key)}
               className={cn(
                 'h-8 px-3 text-xs',
-                activePreset === preset.key && 'font-semibold'
+                activePreset === key && 'font-semibold'
               )}
             >
-              {preset.label}
+              {t(presetLabelKey[key])}
             </Button>
           ))}
         </div>

--- a/frontend/components/shared/HealthFactorGauge.tsx
+++ b/frontend/components/shared/HealthFactorGauge.tsx
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
 
+import { useTranslations } from 'next-intl'
 import { cn } from '@/lib/utils'
 export interface HealthFactorGaugeProps {
   value: number | null
@@ -27,17 +28,19 @@ const sizeMap = {
 } as const
 
 export function HealthFactorGauge({ value, size = 'md', className }: HealthFactorGaugeProps) {
+  const t = useTranslations('SharedHealthFactorGauge')
+
   function getHealthLabel(v: number): string {
-    if (v >= 2.0) return '安全'
-    if (v >= 1.6) return '注意'
-    return '危険'
+    if (v >= 2.0) return t('safe')
+    if (v >= 1.6) return t('caution')
+    return t('danger')
   }
 
   if (value === null) {
     return (
       <div className={cn('flex flex-col gap-1', className)}>
         <span className="text-sm text-muted-foreground">Health Factor</span>
-        <span className="text-sm font-medium text-muted-foreground truncate">借入なし</span>
+        <span className="text-sm font-medium text-muted-foreground truncate">{t('noBorrow')}</span>
       </div>
     )
   }

--- a/frontend/components/shared/SafetyScoreGauge.tsx
+++ b/frontend/components/shared/SafetyScoreGauge.tsx
@@ -1,6 +1,8 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
+'use client'
 
+import { useTranslations } from 'next-intl'
 import { cn } from '@/lib/utils'
 
 export interface SafetyScoreGaugeProps {
@@ -10,12 +12,14 @@ export interface SafetyScoreGaugeProps {
   className?: string
 }
 
-function getScoreConfig(score: number): { label: string; color: string; stroke: string; bg: string } {
+type ScoreKey = 'safe' | 'caution' | 'danger'
+
+function getScoreConfig(score: number): { labelKey: ScoreKey; color: string; stroke: string; bg: string } {
   if (score >= 61)
-    return { label: '安全', color: 'text-green-400', stroke: '#4ade80', bg: 'bg-green-500/10' }
+    return { labelKey: 'safe', color: 'text-green-400', stroke: '#4ade80', bg: 'bg-green-500/10' }
   if (score >= 31)
-    return { label: '注意', color: 'text-yellow-400', stroke: '#facc15', bg: 'bg-yellow-500/10' }
-  return { label: '危険', color: 'text-red-400', stroke: '#f87171', bg: 'bg-red-500/10' }
+    return { labelKey: 'caution', color: 'text-yellow-400', stroke: '#facc15', bg: 'bg-yellow-500/10' }
+  return { labelKey: 'danger', color: 'text-red-400', stroke: '#f87171', bg: 'bg-red-500/10' }
 }
 
 const sizeConfig = {
@@ -38,8 +42,9 @@ export function SafetyScoreGauge({
   showLabel = true,
   className,
 }: SafetyScoreGaugeProps) {
+  const t = useTranslations('SharedSafetyScoreGauge')
   const clamped = Math.max(0, Math.min(100, Math.round(score)))
-  const { label, color, stroke, bg } = getScoreConfig(clamped)
+  const { labelKey, color, stroke, bg } = getScoreConfig(clamped)
   const { wh, r, strokeW, textSize } = sizeConfig[size]
 
   const circumference = 2 * Math.PI * r
@@ -84,8 +89,8 @@ export function SafetyScoreGauge({
       {/* Label */}
       {showLabel && (
         <div>
-          <p className={cn('font-bold', textSize, color)}>{clamped}点</p>
-          <p className={cn('text-sm font-medium', color)}>{label}</p>
+          <p className={cn('font-bold', textSize, color)}>{t('scoreLabel', { score: clamped })}</p>
+          <p className={cn('text-sm font-medium', color)}>{t(labelKey)}</p>
         </div>
       )}
     </div>

--- a/frontend/components/transparency/ReasonCard.tsx
+++ b/frontend/components/transparency/ReasonCard.tsx
@@ -2,6 +2,7 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
 
+import { useTranslations } from 'next-intl'
 import { cn } from '@/lib/utils'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import type { ExplanationData, ExplanationStep } from './types'
@@ -54,12 +55,13 @@ function StepItem({ step }: { step: ExplanationStep }) {
 }
 
 export function ReasonCard({ explanation, className }: ReasonCardProps) {
+  const t = useTranslations('TransparencyReasonCard')
   if (!explanation || typeof explanation !== 'object') return null
   return (
     <Card className={className}>
       <CardHeader className="pb-2">
         <CardTitle className="text-base">
-          判断理由 — {explanation.action}（確信度 {explanation.confidence}%）
+          {t('cardTitle', { action: explanation.action, confidence: explanation.confidence })}
         </CardTitle>
       </CardHeader>
       <CardContent>

--- a/frontend/components/transparency/SignalLight.tsx
+++ b/frontend/components/transparency/SignalLight.tsx
@@ -2,6 +2,7 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
 
+import { useTranslations } from 'next-intl'
 import { cn } from '@/lib/utils'
 import { Card, CardContent } from '@/components/ui/card'
 import type { SignalData } from './types'
@@ -43,6 +44,7 @@ const WEATHER_CONFIG = {
 }
 
 export function SignalLight({ signal, className }: SignalLightProps) {
+  const t = useTranslations('TransparencySignalLight')
   if (!signal || !signal.weather) return null
   const config = WEATHER_CONFIG[signal.weather as keyof typeof WEATHER_CONFIG] ?? WEATHER_CONFIG.cloudy
 
@@ -61,12 +63,12 @@ export function SignalLight({ signal, className }: SignalLightProps) {
           </p>
         </div>
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <span>確信度:</span>
+          <span>{t('confidenceLabel')}</span>
           <span className="font-semibold">{signal.confidence}%</span>
         </div>
         {signal.updated_at && (
           <p className="text-xs text-muted-foreground">
-            更新: {new Date(signal.updated_at).toLocaleString('ja-JP')}
+            {t('updatedLabel')} {new Date(signal.updated_at).toLocaleString('ja-JP')}
           </p>
         )}
       </CardContent>

--- a/frontend/components/transparency/WhatIfSimulation.tsx
+++ b/frontend/components/transparency/WhatIfSimulation.tsx
@@ -2,6 +2,7 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
 
+import { useTranslations } from 'next-intl'
 import { cn } from '@/lib/utils'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import type { SimulationData, ScenarioResult } from './types'
@@ -12,6 +13,7 @@ interface WhatIfSimulationProps {
 }
 
 function ScenarioCard({ scenario, isBest }: { scenario: ScenarioResult; isBest: boolean }) {
+  const t = useTranslations('TransparencyWhatIfSimulation')
   const changePositive = Number(scenario.yield_change_pct ?? 0) >= 0
 
   return (
@@ -25,20 +27,20 @@ function ScenarioCard({ scenario, isBest }: { scenario: ScenarioResult; isBest: 
         <p className="text-sm font-semibold">{scenario.label}</p>
         {isBest && (
           <span className="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold border-primary text-primary">
-            ベスト
+            {t('best')}
           </span>
         )}
       </div>
       <p className="text-xs text-muted-foreground">{scenario.description}</p>
       <div className="flex flex-col gap-1 text-sm mt-1">
         <div className="flex justify-between">
-          <span className="text-muted-foreground">収益変化</span>
+          <span className="text-muted-foreground">{t('yieldChange')}</span>
           <span className={cn('font-medium', changePositive ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400')}>
             {changePositive ? '+' : ''}{Number(scenario.yield_change_pct ?? 0).toFixed(1)}%
           </span>
         </div>
         <div className="flex justify-between">
-          <span className="text-muted-foreground">確率</span>
+          <span className="text-muted-foreground">{t('probability')}</span>
           <span>{scenario.probability}%</span>
         </div>
       </div>
@@ -47,6 +49,7 @@ function ScenarioCard({ scenario, isBest }: { scenario: ScenarioResult; isBest: 
 }
 
 export function WhatIfSimulation({ data, className }: WhatIfSimulationProps) {
+  const t = useTranslations('TransparencyWhatIfSimulation')
   if (!data) return null
   const scenarios = data.scenarios ?? []
   const colCount = scenarios.length
@@ -54,7 +57,7 @@ export function WhatIfSimulation({ data, className }: WhatIfSimulationProps) {
   return (
     <Card className={className}>
       <CardHeader className="pb-2">
-        <CardTitle className="text-base">シナリオ分析</CardTitle>
+        <CardTitle className="text-base">{t('scenarioAnalysis')}</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         <div

--- a/frontend/components/user/AiFeedItem.tsx
+++ b/frontend/components/user/AiFeedItem.tsx
@@ -1,5 +1,8 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
+'use client'
+
+import { useTranslations } from 'next-intl'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
@@ -23,6 +26,7 @@ const actionConfig: Record<string, { label: string; className: string }> = {
 }
 
 export function AiFeedItem({ event }: { event: AiEvent }) {
+  const t = useTranslations('UserAiFeedItem')
   const action = String(event.action ?? 'HOLD').toUpperCase()
   const config = actionConfig[action] ?? { label: action, className: 'bg-gray-100 dark:bg-gray-800 text-gray-700 border-gray-200 dark:border-gray-700' }
 
@@ -43,12 +47,12 @@ export function AiFeedItem({ event }: { event: AiEvent }) {
             )}
             {event.agreed === true && (
               <Badge variant="outline" className="text-xs bg-green-100 text-green-800 border-green-200">
-                ✓ Claude・GPT一致
+                {t('claudeGptAgreed')}
               </Badge>
             )}
             {event.agreed === false && (
               <Badge variant="outline" className="text-xs bg-yellow-100 text-yellow-800 border-yellow-200">
-                △ 判定相違
+                {t('disagreement')}
               </Badge>
             )}
           </div>
@@ -58,7 +62,7 @@ export function AiFeedItem({ event }: { event: AiEvent }) {
           return (
             <div className="space-y-1">
               <div className="flex justify-between text-xs text-muted-foreground">
-                <span>信頼度</span>
+                <span>{t('confidence')}</span>
                 <span>{confidence}%</span>
               </div>
               <div className="h-1.5 w-full rounded-full bg-muted overflow-hidden">

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1989,10 +1989,7 @@
     "dialogConfirm": "Generate",
     "toastSuccess": "Report generated successfully",
     "toastErrorPrefix": "Error: {msg}",
-    "generateFailed": "Failed to generate report",
-    "mockNote1": "Normal operation. HF stable throughout.",
-    "mockNote2": "HF dropped below 1.6, triggering emergency stop. Auto-recovered at 03:14 JST. Operator notified.",
-    "mockNote3": "Weekly summary. Includes emergency stop on 3/20. Overall HF is satisfactory."
+    "generateFailed": "Failed to generate report"
   },
   "Terms": {
     "back": "Back",
@@ -2046,16 +2043,7 @@
     "detailFieldComponent": "Component",
     "detailFieldMessage": "Message",
     "detailFieldMetricId": "Metric ID",
-    "detailFieldMetricValue": "Metric Value",
-    "mockMsg1": "Emergency stop triggered. Health Factor fell below threshold.",
-    "mockMsg2": "Health Factor reached critical level. Immediate action required.",
-    "mockMsg3": "Daily trade limit at 80%. Watch remaining trade capacity.",
-    "mockMsg4": "GPT-4o cross-validation timeout. Proceeded with Claude decision only.",
-    "mockMsg5": "BUY signal executed. Order sent to Bybit Sandbox.",
-    "mockMsg6": "Knowledge base update complete. 12 new chunks added.",
-    "mockMsg7": "Aave operation skipped due to cooldown period.",
-    "mockMsg8": "Rebalance complete: deposited USDC 500 into Aave V3.",
-    "mockUnit": ""
+    "detailFieldMetricValue": "Metric Value"
   },
   "AdminTrades": {
     "pageTitle": "Trade History",
@@ -2418,10 +2406,7 @@
     "sampleData": "Sample data",
     "chartConfidence": "Confidence Trend (Last 7 days)",
     "chartActionDist": "Action Distribution",
-    "chartTwoPhase": "Two-Phase Agreement Rate",
-    "mockReason1": "Bullish trend continues. RSI not overheated.",
-    "mockReason2": "Health Factor 1.62 — approaching threshold, on hold.",
-    "mockReason3": "Phase mismatch detected. Adopted safer HOLD decision."
+    "chartTwoPhase": "Two-Phase Agreement Rate"
   },
   "UserDetailPanel": {
     "dialogTitle": "User Detail",
@@ -2628,8 +2613,7 @@
     "riskAggressive": "Aggressive",
     "statusNormal": "Normal",
     "statusWarning": "Warning",
-    "statusDanger": "Danger",
-    "suspendedTooltip": "Suspended"
+    "statusDanger": "Danger"
   },
   "SharedEmergencyStopButton": {
     "buttonLabel": "Emergency Stop",
@@ -3418,5 +3402,54 @@
   },
   "AdminUserPositions": {
     "noPositions": "No positions"
+  },
+  "SharedSafetyScoreGauge": {
+    "safe": "Safe",
+    "caution": "Caution",
+    "danger": "Danger",
+    "scoreLabel": "{score} pts"
+  },
+  "SharedHealthFactorGauge": {
+    "safe": "Safe",
+    "caution": "Caution",
+    "danger": "Danger",
+    "noBorrow": "No borrowing"
+  },
+  "PartnerAiActivityCard": {
+    "buy": "Buy",
+    "sell": "Sell",
+    "hold": "Hold",
+    "minutesAgo": "{n} min ago",
+    "hoursAgo": "{n} hr ago",
+    "justNow": "Just now",
+    "claudeGptAgreed": "Claude+GPT Agreed"
+  },
+  "UserAiFeedItem": {
+    "claudeGptAgreed": "✓ Claude・GPT Agreed",
+    "disagreement": "△ Disagreement",
+    "confidence": "Confidence"
+  },
+  "TransparencyWhatIfSimulation": {
+    "best": "Best",
+    "yieldChange": "Yield Change",
+    "probability": "Probability",
+    "scenarioAnalysis": "Scenario Analysis"
+  },
+  "TransparencyReasonCard": {
+    "cardTitle": "Reasoning — {action} (Confidence {confidence}%)"
+  },
+  "TransparencySignalLight": {
+    "confidenceLabel": "Confidence:",
+    "updatedLabel": "Updated:"
+  },
+  "SharedDateRangeFilter": {
+    "days7": "7d",
+    "days30": "30d",
+    "days90": "90d",
+    "all": "ALL"
+  },
+  "SharedConfidenceBar": {
+    "label": "Confidence",
+    "threshold": "Threshold: {pct}%"
   }
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -1989,10 +1989,7 @@
     "dialogConfirm": "生成する",
     "toastSuccess": "レポートを生成しました",
     "toastErrorPrefix": "エラー: {msg}",
-    "generateFailed": "生成に失敗しました",
-    "mockNote1": "通常運用。HFは安定して推移。",
-    "mockNote2": "HFが1.6を下回り緊急停止が発動。03:14 JST に自動復旧。担当者への通知済み。",
-    "mockNote3": "週次まとめ。3/20の緊急停止を含む。全体的なHFは良好。"
+    "generateFailed": "生成に失敗しました"
   },
   "Terms": {
     "back": "戻る",
@@ -2046,16 +2043,7 @@
     "detailFieldComponent": "コンポーネント",
     "detailFieldMessage": "メッセージ",
     "detailFieldMetricId": "メトリクスID",
-    "detailFieldMetricValue": "メトリクス値",
-    "mockMsg1": "緊急停止フラグが発動しました。Health Factor が閾値を下回りました。",
-    "mockMsg2": "Health Factor が危険水準に到達しました。即時対応が必要です。",
-    "mockMsg3": "1日の取引制限の80%に到達しました。残りの取引枠に注意してください。",
-    "mockMsg4": "GPT-4o クロス検証タイムアウト。Claude の判断のみで実行しました。",
-    "mockMsg5": "BUY シグナルを実行しました。Bybit Sandbox に注文を送信しました。",
-    "mockMsg6": "ナレッジベースの更新が完了しました。新規チャンク 12 件を追加しました。",
-    "mockMsg7": "クールダウン期間中のため、Aave 操作をスキップしました。",
-    "mockMsg8": "リバランス完了: USDC 500 を Aave V3 に預入しました。",
-    "mockUnit": "件"
+    "detailFieldMetricValue": "メトリクス値"
   },
   "AdminTrades": {
     "pageTitle": "取引履歴",
@@ -2418,10 +2406,7 @@
     "sampleData": "サンプルデータ",
     "chartConfidence": "信頼度トレンド（直近7日）",
     "chartActionDist": "判定アクション分布",
-    "chartTwoPhase": "Two-Phase一致率",
-    "mockReason1": "強気トレンド継続。RSI過熱なし。",
-    "mockReason2": "Health Factor 1.62 — 閾値接近のため保留。",
-    "mockReason3": "フェーズ間で不一致。安全側のHOLDを採用。"
+    "chartTwoPhase": "Two-Phase一致率"
   },
   "UserDetailPanel": {
     "dialogTitle": "ユーザー詳細",
@@ -2628,8 +2613,7 @@
     "riskAggressive": "積極",
     "statusNormal": "正常",
     "statusWarning": "警告",
-    "statusDanger": "危険",
-    "suspendedTooltip": "停止中"
+    "statusDanger": "危険"
   },
   "SharedEmergencyStopButton": {
     "buttonLabel": "緊急停止",
@@ -3418,5 +3402,54 @@
   },
   "AdminUserPositions": {
     "noPositions": "ポジションなし"
+  },
+  "SharedSafetyScoreGauge": {
+    "safe": "安全",
+    "caution": "注意",
+    "danger": "危険",
+    "scoreLabel": "{score}点"
+  },
+  "SharedHealthFactorGauge": {
+    "safe": "安全",
+    "caution": "注意",
+    "danger": "危険",
+    "noBorrow": "借入なし"
+  },
+  "PartnerAiActivityCard": {
+    "buy": "買い",
+    "sell": "売り",
+    "hold": "様子見",
+    "minutesAgo": "{n}分前",
+    "hoursAgo": "{n}時間前",
+    "justNow": "たった今",
+    "claudeGptAgreed": "Claude+GPT 一致"
+  },
+  "UserAiFeedItem": {
+    "claudeGptAgreed": "✓ Claude・GPT一致",
+    "disagreement": "△ 判定相違",
+    "confidence": "信頼度"
+  },
+  "TransparencyWhatIfSimulation": {
+    "best": "ベスト",
+    "yieldChange": "収益変化",
+    "probability": "確率",
+    "scenarioAnalysis": "シナリオ分析"
+  },
+  "TransparencyReasonCard": {
+    "cardTitle": "判断理由 — {action}（確信度 {confidence}%）"
+  },
+  "TransparencySignalLight": {
+    "confidenceLabel": "確信度:",
+    "updatedLabel": "更新:"
+  },
+  "SharedDateRangeFilter": {
+    "days7": "7日",
+    "days30": "30日",
+    "days90": "90日",
+    "all": "ALL"
+  },
+  "SharedConfidenceBar": {
+    "label": "信頼度",
+    "threshold": "閾値: {pct}%"
   }
 }


### PR DESCRIPTION
## Summary
- SafetyScoreGauge, HealthFactorGauge: status labels (安全/注意/危険) → i18n (SharedSafetyScoreGauge, SharedHealthFactorGauge)
- ConfidenceBar: label + threshold strings → i18n (SharedConfidenceBar)
- AiActivityCard: action labels + relative time strings → i18n (PartnerAiActivityCard)
- AiFeedItem: consensus labels + confidence label → i18n (UserAiFeedItem)
- WhatIfSimulation, ReasonCard, SignalLight: transparency labels → i18n (TransparencyWhatIfSimulation, TransparencyReasonCard, TransparencySignalLight)
- DateRangeFilter: preset labels (7日/30日/90日) → i18n (SharedDateRangeFilter)
- ja.json / en.json: 9 new namespaces added, key counts match

GID: 1215687791466923