### PR TITLE
feat(i18n): wave18c Recharts + liff-login i18n

### DIFF
--- a/frontend/app/(admin)/ai-decisions/_components/ActionDistributionChartRecharts.tsx
+++ b/frontend/app/(admin)/ai-decisions/_components/ActionDistributionChartRecharts.tsx
@@ -11,6 +11,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts'
+import { useTranslations } from 'next-intl'
 
 export interface PieEntry {
   name: string
@@ -30,6 +31,7 @@ const PIE_COLORS: Record<string, string> = {
 export function ActionDistributionChartRecharts({
   pieData,
 }: ActionDistributionChartRechartsProps) {
+  const t = useTranslations('AdminActionDistChartRecharts')
   return (
     <ResponsiveContainer width="100%" height={220}>
       <PieChart>
@@ -52,7 +54,7 @@ export function ActionDistributionChartRecharts({
           ))}
         </Pie>
         <Tooltip
-          formatter={(value: number, name: string) => [`${value}件`, name]}
+          formatter={(value: number, name: string) => [t('unitCount', { value }), name]}
         />
         <Legend />
       </PieChart>

--- a/frontend/app/(admin)/ai-learning/_components/AILearningChartsRecharts.tsx
+++ b/frontend/app/(admin)/ai-learning/_components/AILearningChartsRecharts.tsx
@@ -16,6 +16,7 @@ import {
   Pie,
   Cell,
 } from 'recharts'
+import { useTranslations } from 'next-intl'
 
 // ──────────────────────────────────────────────────────────────────────────────
 // フィードバック件数バーチャート
@@ -33,6 +34,7 @@ interface FeedbackBarChartProps {
 const BAR_COLORS = ['#6366f1', '#16a34a', '#dc2626']
 
 export function FeedbackBarChart({ data }: FeedbackBarChartProps) {
+  const t = useTranslations('AdminAILearningCharts')
   return (
     <ResponsiveContainer width="100%" height={200}>
       <BarChart data={data} margin={{ top: 4, right: 12, left: 0, bottom: 4 }}>
@@ -40,7 +42,7 @@ export function FeedbackBarChart({ data }: FeedbackBarChartProps) {
         <XAxis dataKey="name" tick={{ fontSize: 12 }} />
         <YAxis tick={{ fontSize: 12 }} allowDecimals={false} />
         <Tooltip
-          formatter={(value: number, name: string) => [`${value}件`, name]}
+          formatter={(value: number, name: string) => [t('unitCount', { value }), name]}
         />
         <Bar dataKey="件数">
           {data.map((_, index) => (
@@ -65,15 +67,15 @@ interface SourcePieChartProps {
   data: SourcePieEntry[]
 }
 
-const SOURCE_LABELS: Record<string, string> = {
-  manual: '手動',
-  auto_howl: '自動(HOWL)',
-  auto_outcome: '自動(実績)',
-}
-
 const PIE_COLORS = ['#6366f1', '#16a34a', '#f59e0b', '#6b7280']
 
 export function SourcePieChart({ data }: SourcePieChartProps) {
+  const t = useTranslations('AdminAILearningCharts')
+  const SOURCE_LABELS: Record<string, string> = {
+    manual: t('labelManual'),
+    auto_howl: t('labelAutoHowl'),
+    auto_outcome: t('labelAutoOutcome'),
+  }
   const labeled = data.map((d) => ({
     ...d,
     name: SOURCE_LABELS[d.name] ?? d.name,
@@ -97,7 +99,7 @@ export function SourcePieChart({ data }: SourcePieChartProps) {
           ))}
         </Pie>
         <Tooltip
-          formatter={(value: number, name: string) => [`${value}件`, name]}
+          formatter={(value: number, name: string) => [t('unitCount', { value }), name]}
         />
         <Legend />
       </PieChart>

--- a/frontend/app/(admin)/fee-management/_components/IncomeChartRecharts.tsx
+++ b/frontend/app/(admin)/fee-management/_components/IncomeChartRecharts.tsx
@@ -11,6 +11,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts'
+import { useTranslations } from 'next-intl'
 
 export interface IncomeChartEntry {
   month: string
@@ -30,6 +31,7 @@ function yFmt(v: number) {
 }
 
 export function IncomeChartRecharts({ data }: IncomeChartRechartsProps) {
+  const t = useTranslations('AdminIncomeChart')
   return (
     <ResponsiveContainer width="100%" height={260}>
       <BarChart data={data} margin={{ top: 4, right: 8, left: 0, bottom: 4 }}>
@@ -49,9 +51,9 @@ export function IncomeChartRecharts({ data }: IncomeChartRechartsProps) {
         <Tooltip
           formatter={(value: number, name: string) => {
             const labels: Record<string, string> = {
-              subscription: 'サブスク',
-              fee: '成果報酬',
-              yield_excess: '超過利益',
+              subscription: t('labelSubscription'),
+              fee: t('labelFee'),
+              yield_excess: t('labelYieldExcess'),
             }
             return [`¥${Math.round(value).toLocaleString()}`, labels[name] ?? name]
           }}
@@ -62,9 +64,9 @@ export function IncomeChartRecharts({ data }: IncomeChartRechartsProps) {
         <Legend
           formatter={(value: string) => {
             const labels: Record<string, string> = {
-              subscription: 'サブスク',
-              fee: '成果報酬',
-              yield_excess: '超過利益',
+              subscription: t('labelSubscription'),
+              fee: t('labelFee'),
+              yield_excess: t('labelYieldExcess'),
             }
             return <span style={{ color: '#a1a1aa', fontSize: 12 }}>{labels[value] ?? value}</span>
           }}

--- a/frontend/app/(admin)/rate-limits/RateLimitsBarChart.tsx
+++ b/frontend/app/(admin)/rate-limits/RateLimitsBarChart.tsx
@@ -5,6 +5,7 @@
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell,
 } from 'recharts'
+import { useTranslations } from 'next-intl'
 
 type ChartEntry = {
   name: string
@@ -20,6 +21,7 @@ function usageColor(pct: number): string {
 }
 
 export default function RateLimitsBarChart({ data }: { data: ChartEntry[] }) {
+  const t = useTranslations('AdminRateLimitsChart')
   return (
     <ResponsiveContainer width="100%" height={220}>
       <BarChart data={data} margin={{ top: 4, right: 16, left: 0, bottom: 40 }}>
@@ -27,10 +29,10 @@ export default function RateLimitsBarChart({ data }: { data: ChartEntry[] }) {
         <XAxis dataKey="name" tick={{ fontSize: 10, fill: '#6b7280' }} angle={-20} textAnchor="end" interval={0} />
         <YAxis domain={[0, 100]} tick={{ fontSize: 11, fill: '#6b7280' }} tickFormatter={(v: number) => `${v}%`} />
         <Tooltip
-          formatter={(v: number) => [`${v.toFixed(1)}%`, '使用率']}
+          formatter={(v: number) => [`${v.toFixed(1)}%`, t('usageRate')]}
           contentStyle={{ fontSize: 12 }}
         />
-        <Bar dataKey="usage_pct" name="使用率" radius={[4, 4, 0, 0]}>
+        <Bar dataKey="usage_pct" name={t('usageRate')} radius={[4, 4, 0, 0]}>
           {data.map((entry, index) => (
             <Cell key={`cell-${index}`} fill={usageColor(entry.usage_pct)} />
           ))}

--- a/frontend/app/(admin)/sentiment/SentimentCharts.tsx
+++ b/frontend/app/(admin)/sentiment/SentimentCharts.tsx
@@ -6,38 +6,41 @@ import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
   ScatterChart, Scatter, ReferenceLine,
 } from 'recharts'
+import { useTranslations } from 'next-intl'
 
 type TrendPoint = { label: string; score: number; post_count: number }
 type CorrelationPoint = { score: number; action: number; label: string }
 
 export function SentimentTrendChart({ data }: { data: TrendPoint[] }) {
+  const t = useTranslations('AdminSentimentCharts')
   return (
     <ResponsiveContainer width="100%" height={240}>
       <LineChart data={data} margin={{ top: 8, right: 16, left: 0, bottom: 4 }}>
         <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
         <XAxis dataKey="label" tick={{ fontSize: 11, fill: '#6b7280' }} interval="preserveStartEnd" />
         <YAxis domain={[-1, 1]} tick={{ fontSize: 11, fill: '#6b7280' }} tickFormatter={(v: number) => v.toFixed(1)} />
-        <Tooltip formatter={(v: number) => [v.toFixed(3), 'スコア']} contentStyle={{ fontSize: 12 }} />
+        <Tooltip formatter={(v: number) => [v.toFixed(3), t('score')]} contentStyle={{ fontSize: 12 }} />
         <ReferenceLine y={0} stroke="#9ca3af" strokeDasharray="4 4" />
         <ReferenceLine y={0.2} stroke="#16a34a" strokeDasharray="2 4" strokeOpacity={0.5} />
         <ReferenceLine y={-0.2} stroke="#dc2626" strokeDasharray="2 4" strokeOpacity={0.5} />
-        <Line type="monotone" dataKey="score" stroke="#2563eb" strokeWidth={2} dot={false} name="センチメントスコア" />
+        <Line type="monotone" dataKey="score" stroke="#2563eb" strokeWidth={2} dot={false} name={t('sentimentScore')} />
       </LineChart>
     </ResponsiveContainer>
   )
 }
 
 export function SentimentCorrelationChart({ data }: { data: CorrelationPoint[] }) {
+  const t = useTranslations('AdminSentimentCharts')
   return (
     <ResponsiveContainer width="100%" height={220}>
       <ScatterChart margin={{ top: 8, right: 16, left: 0, bottom: 4 }}>
         <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
-        <XAxis dataKey="score" type="number" domain={[-1, 1]} name="センチメントスコア" tick={{ fontSize: 11 }} tickFormatter={(v: number) => v.toFixed(1)} />
-        <YAxis dataKey="action" type="number" domain={[-1.5, 1.5]} name="AI判定" tick={{ fontSize: 11 }}
+        <XAxis dataKey="score" type="number" domain={[-1, 1]} name={t('sentimentScore')} tick={{ fontSize: 11 }} tickFormatter={(v: number) => v.toFixed(1)} />
+        <YAxis dataKey="action" type="number" domain={[-1.5, 1.5]} name={t('aiDecision')} tick={{ fontSize: 11 }}
           tickFormatter={(v: number) => v === 1 ? 'BUY' : v === -1 ? 'SELL' : 'HOLD'} />
         <Tooltip cursor={{ strokeDasharray: '3 3' }} contentStyle={{ fontSize: 12 }}
           formatter={(v: number, name: string) => {
-            if (name === 'AI判定') return [v === 1 ? 'BUY' : v === -1 ? 'SELL' : 'HOLD', name]
+            if (name === t('aiDecision')) return [v === 1 ? 'BUY' : v === -1 ? 'SELL' : 'HOLD', name]
             return [typeof v === 'number' ? v.toFixed(3) : v, name]
           }} />
         <Scatter data={data} fill="#2563eb" opacity={0.6} />

--- a/frontend/app/(liff)/liff-login/layout.tsx
+++ b/frontend/app/(liff)/liff-login/layout.tsx
@@ -1,0 +1,12 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// frontend/app/(liff)/liff-login/layout.tsx
+// liff-login 専用 NextIntlClientProvider + LanguageProvider。
+// 共通 LiffIntlLayout を薄いラッパとして参照する。
+"use client"
+
+import type { ReactNode } from "react"
+import { LiffIntlLayout } from "../_components/LiffIntlLayout"
+
+export default function LiffLoginLayout({ children }: { children: ReactNode }) {
+  return <LiffIntlLayout>{children}</LiffIntlLayout>
+}

--- a/frontend/app/(liff)/liff-login/page.tsx
+++ b/frontend/app/(liff)/liff-login/page.tsx
@@ -4,6 +4,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { useLiff } from "@/hooks/useLiff";
 import { BrowserLoginPrompt } from "../_components/BrowserLoginPrompt";
 import { getAuthToken } from "@/lib/auth/token-key";
@@ -11,6 +12,7 @@ import { getAuthToken } from "@/lib/auth/token-key";
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 export default function LiffLoginPage() {
+  const t = useTranslations("LiffLogin");
   const { isReady, isLoggedIn, profile, idToken, error, liffConfigured } =
     useLiff();
 
@@ -81,7 +83,7 @@ export default function LiffLoginPage() {
     if (getAuthToken()) {
       return (
         <div className="flex items-center justify-center min-h-screen">
-          <p className="text-muted-foreground">読み込み中...</p>
+          <p className="text-muted-foreground">{t("loading")}</p>
         </div>
       );
     }
@@ -105,7 +107,7 @@ export default function LiffLoginPage() {
   return (
     <div className="flex items-center justify-center min-h-screen">
       <p className="text-muted-foreground">
-        {isLoggedIn ? "認証中..." : "LINEアプリから開いてください"}
+        {isLoggedIn ? t("authorizing") : t("openInLine")}
       </p>
     </div>
   );

--- a/frontend/app/(liff)/liff-login/page.tsx
+++ b/frontend/app/(liff)/liff-login/page.tsx
@@ -66,7 +66,7 @@ export default function LiffLoginPage() {
   if (!isReady) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <p className="text-muted-foreground">Loading...</p>
+        <p className="text-muted-foreground">{t("loading")}</p>
       </div>
     );
   }

--- a/frontend/components/charts/ActionDistributionChart.tsx
+++ b/frontend/components/charts/ActionDistributionChart.tsx
@@ -34,6 +34,7 @@ type Props = {
 
 export default function ActionDistributionChart({ data }: Props) {
   const t = useTranslations("Charts");
+  const tShared = useTranslations("SharedActionDistChart");
   const [period, setPeriod] = useState<Period>("7d");
 
   const cutoff = new Date(Date.now() - PERIOD_DAYS[period] * 24 * 60 * 60 * 1000);
@@ -75,7 +76,7 @@ export default function ActionDistributionChart({ data }: Props) {
           </button>
         ))}
         <span style={{ fontSize: 12, color: "#9ca3af", alignSelf: "center" }}>
-          {total}件
+          {tShared("totalCount", { total })}
         </span>
       </div>
 
@@ -102,7 +103,10 @@ export default function ActionDistributionChart({ data }: Props) {
             </Pie>
             <Tooltip
               formatter={(value: number, name: string) => [
-                `${value}件 (${chartData.find((d) => d.name === name)?.pct ?? ""}%)`,
+                tShared("unitCountWithPct", {
+                  value,
+                  pct: chartData.find((d) => d.name === name)?.pct ?? "",
+                }),
                 name,
               ]}
               contentStyle={{ fontSize: 12 }}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -3097,9 +3097,10 @@
     "sectionTxHash": "Tx Hash"
   },
   "AdminAILearningCharts": {
-    "feedbackHeading": "Feedback Count Breakdown (30d)",
-    "sourceHeading": "Source Breakdown",
-    "noData": "No data"
+    "unitCount": "{value}",
+    "labelManual": "Manual",
+    "labelAutoHowl": "Auto (HOWL)",
+    "labelAutoOutcome": "Auto (Outcome)"
   },
   "AdminKnowledgeSearch": {
     "pageTitle": "RAG Search - Knowledge Hub - Ultra AutoTrade",
@@ -3451,5 +3452,30 @@
   "SharedConfidenceBar": {
     "label": "Confidence",
     "threshold": "Threshold: {pct}%"
+  },
+  "AdminIncomeChart": {
+    "labelSubscription": "Subscription",
+    "labelFee": "Performance fee",
+    "labelYieldExcess": "Excess yield"
+  },
+  "AdminSentimentCharts": {
+    "score": "Score",
+    "sentimentScore": "Sentiment score",
+    "aiDecision": "AI decision"
+  },
+  "AdminRateLimitsChart": {
+    "usageRate": "Usage rate"
+  },
+  "AdminActionDistChartRecharts": {
+    "unitCount": "{value}"
+  },
+  "SharedActionDistChart": {
+    "totalCount": "{total}",
+    "unitCountWithPct": "{value} ({pct}%)"
+  },
+  "LiffLogin": {
+    "loading": "Loading...",
+    "authorizing": "Authorizing...",
+    "openInLine": "Please open in the LINE app"
   }
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -3097,9 +3097,10 @@
     "sectionTxHash": "Tx Hash"
   },
   "AdminAILearningCharts": {
-    "feedbackHeading": "フィードバック件数内訳（30日）",
-    "sourceHeading": "ソース内訳",
-    "noData": "データなし"
+    "unitCount": "{value}件",
+    "labelManual": "手動",
+    "labelAutoHowl": "自動(HOWL)",
+    "labelAutoOutcome": "自動(実績)"
   },
   "AdminKnowledgeSearch": {
     "pageTitle": "RAG検索 - ナレッジ Hub - Ultra AutoTrade",
@@ -3451,5 +3452,30 @@
   "SharedConfidenceBar": {
     "label": "信頼度",
     "threshold": "閾値: {pct}%"
+  },
+  "AdminIncomeChart": {
+    "labelSubscription": "サブスク",
+    "labelFee": "成果報酬",
+    "labelYieldExcess": "超過利益"
+  },
+  "AdminSentimentCharts": {
+    "score": "スコア",
+    "sentimentScore": "センチメントスコア",
+    "aiDecision": "AI判定"
+  },
+  "AdminRateLimitsChart": {
+    "usageRate": "使用率"
+  },
+  "AdminActionDistChartRecharts": {
+    "unitCount": "{value}件"
+  },
+  "SharedActionDistChart": {
+    "totalCount": "{total}件",
+    "unitCountWithPct": "{value}件 ({pct}%)"
+  },
+  "LiffLogin": {
+    "loading": "読み込み中...",
+    "authorizing": "認証中...",
+    "openInLine": "LINEアプリから開いてください"
   }
 }


### PR DESCRIPTION
## Summary
- AILearningChartsRecharts: chart labels (手動/自動HOWL) + 件 unit → i18n
- IncomeChartRecharts: series labels (サブスク/成果報酬/超過利益) → i18n
- SentimentCharts: chart axis/tooltip labels (スコア/センチメントスコア/AI判定) → i18n
- RateLimitsBarChart: 使用率 → i18n
- ActionDistributionChart/Recharts: 件 unit → i18n
- liff-login: loading/auth messages → i18n + new layout.tsx for NextIntlClientProvider

## New namespaces added
- `AdminAILearningCharts`: unitCount, labelManual, labelAutoHowl, labelAutoOutcome
- `AdminIncomeChart`: labelSubscription, labelFee, labelYieldExcess
- `AdminSentimentCharts`: score, sentimentScore, aiDecision
- `AdminRateLimitsChart`: usageRate
- `AdminActionDistChartRecharts`: unitCount
- `SharedActionDistChart`: totalCount, unitCountWithPct
- `LiffLogin`: loading, authorizing, openInLine

## Notes
- liff-login/layout.tsx created to wire LiffIntlLayout (NextIntlClientProvider) — same pattern as liff-confirm/liff-approve
- 件数 dataKey in AILearningChartsRecharts preserved (API schema key)
- tsc: 0 new errors (33 pre-existing @privy-io/react-auth errors unchanged)

GID: 1215687791466923

🤖 Generated with [Claude Code](https://claude.com/claude-code)