### PR TITLE
fix(layout): root layout.tsx の重複 import 削除 — main ビルド不能を解消

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -6,8 +6,6 @@ import { NextIntlClientProvider } from 'next-intl'
 import { getLocale, getMessages } from 'next-intl/server'
 import { PWAProvider, InstallBanner, UpdatePrompt } from '@/components/pwa'
 import { DemoBanner } from '@/components/DemoBanner'
-import { getLocale, getMessages } from 'next-intl/server'
-import { NextIntlClientProvider } from 'next-intl'
 
 export const metadata: Metadata = {
   title: 'Ultra AutoTrade',


### PR DESCRIPTION
## 緊急度: 🔴 main がビルド不能（全 deploy がブロック）

## 問題
`frontend/app/layout.tsx` に重複 import が混入し、`next build` が SWC パースエラーで全滅していた:

```
x the name `getLocale` is defined multiple times
x the name `getMessages` is defined multiple times
x the name `NextIntlClientProvider` is defined multiple times
```

- wave16 (`c88f8e62`) が root layout に `NextIntlClientProvider` / `getLocale` / `getMessages` を追加済み（5-6行目）
- wave18d (#725, `7c58ea58`) が**同じ import を再追加**（9-10行目）→ 二重定義

これは型エラーではなく**パースエラー**のため `next.config.js` の `ignoreBuildErrors` では抑止されず、`tsc` ゲートだけでは検出漏れしていた。staging deploy (run 27484513893) がこのエラーで失敗し staging が 502 に。本番 deploy も同様に失敗する状態だった。

## 修正
重複した import 2 行（9-10行目）を削除。本体は各シンボルを 1 回ずつ使用（getLocale/getMessages: 43-44行, NextIntlClientProvider: 58行）のため**挙動は不変**。

## 検証
- ✅ `npx tsc --noEmit` exit 0（重複識別子 TS2300 解消）
- `npm run build` 実行中（結果は確認次第追記）

## 再発防止（フォロー）
CI の frontend ゲートに `next build`（または SWC パースチェック）を追加し、型エラーで隠れない parse エラーを検出すべき。

🤖 Generated with [Claude Code](https://claude.com/claude-code)