### PR TITLE
fix(liff-chat): アカウント画面のウォレットが「未連携」表示になる問題を解消

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
@@ -18,6 +18,7 @@ import {
 import { useTranslations } from "next-intl"
 import { useLanguage } from "@/lib/useLanguage"
 import { getAuthToken, clearAuthToken } from "@/lib/auth/token-key"
+import { useWallet } from "@/hooks/useWallet"
 import { liffFetch } from "@/lib/liff/liff-fetch"
 
 interface UserData {
@@ -51,6 +52,10 @@ export function AccountPanel() {
   const { language } = useLanguage()
   const router = useRouter()
   const { logout: privyLogout, authenticated } = usePrivy()
+  // ウォレット表示の単一情報源化: backend の wallet_address が未記録でも、
+  // Privy embedded（または injected）ウォレットのアドレスを useWallet から拾って
+  // 「未連携」誤表示を防ぐ（Asana 1215576087505209）。
+  const { address: liveWalletAddress } = useWallet()
   // 認証状態。未ログイン時に「ログアウト」/「アカウント削除」等の操作系を出さないためのガード。
   // backend JWT (getAuthToken) か Privy authenticated のどちらかがあれば「ログイン済み」とみなす
   // (UserHeader.tsx の {(user||token)&&…} ガード = commit 5c42868 を LIFF v3 にポート)。
@@ -162,9 +167,10 @@ export function AccountPanel() {
     return t("defaultUser")
   }
 
-  // ウォレットアドレス短縮表示
+  // ウォレットアドレス短縮表示。backend の wallet_address を優先し、
+  // 未記録時は Privy/injected の実ウォレット（liveWalletAddress）にフォールバック。
   const getShortAddress = () => {
-    const addr = userData?.wallet_address
+    const addr = userData?.wallet_address ?? liveWalletAddress
     if (!addr) return null
     return `${addr.slice(0, 6)}…${addr.slice(-4)}`
   }
@@ -187,9 +193,9 @@ export function AccountPanel() {
     return t("modeUnknown")
   }
 
-  // ウォレットアドレスコピー
+  // ウォレットアドレスコピー（表示と同じ単一情報源を使う）
   const handleCopyWallet = async () => {
-    const addr = userData?.wallet_address
+    const addr = userData?.wallet_address ?? liveWalletAddress
     if (!addr) return
     try {
       await navigator.clipboard.writeText(addr)


### PR DESCRIPTION
## 症状（staging 実機 2026-06-14）
Privy でログインし embedded wallet があるのに、アカウント画面のウォレット項目が「未連携」と表示される。

## 真因
`AccountPanel.tsx` が backend の `wallet_address`（/auth/me, /api/user/settings）**だけ**を見ており、`useWallet`（Privy embedded / injected を集約する単一情報源 hook）を使っていなかった。新規 Privy ユーザーは backend に `wallet_address` 未記録のため空 → 「未連携」。

`MyWalletPanel.tsx` は既に `useWallet`（`liveAddress ?? linked.address`）に統合済みで、**AccountPanel だけが取りこぼし**ていた（Asana 1215576087505209「useWallet 単一情報源化」の適用漏れ）。

## 修正
- `useWallet().address`（`liveWalletAddress`）を導入
- 表示 `getShortAddress()` / コピー `handleCopyWallet()` ともに `userData?.wallet_address ?? liveWalletAddress` に変更（backend 優先・未記録時は live ウォレットへフォールバック）
- MyWalletPanel と同じ単一情報源パターンに統一

## 検証
- ✅ `npx tsc --noEmit` exit 0
- staging 反映後、Privy 新規ログイン → アカウント画面でウォレットアドレスが表示されることを確認予定

Closes 1215576087505209

🤖 Generated with [Claude Code](https://claude.com/claude-code)