### PR TITLE
feat(liff-chat): Deposit を USD 化 + MoonPay 重複ボタンを Privy Deposit へ一本化

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
@@ -9,7 +9,6 @@ import { liffFetch } from "@/lib/liff/liff-fetch"
 import { useFundWallet } from "@privy-io/react-auth"
 import { base, baseSepolia } from "wagmi/chains"
 import { useWallet } from "@/hooks/useWallet"
-import { MoonPayWidget } from "./MoonPayWidget"
 
 // ---- 型定義 ---------------------------------------------------------------
 
@@ -159,11 +158,16 @@ export function DepositPanel() {
     if (!address) return
     setIsFunding(true)
     try {
+      // 入力単位は言語で異なる: 英語=USD（USDC と 1:1）/ 日本語=¥（÷155 で USDC 換算）。
+      // Privy fundWallet の amount は USDC 建てのため、ここで USDC へ正規化する
+      // （旧実装は ¥ 値をそのまま USDC として渡していた不具合を修正）。
+      const num = parseFloat(depositAmount) || 0
+      const usdc = language === "en" ? num : num / JPY_PER_USDC
       await fundWallet({
         address,
         options: {
           chain: chainId === 84532 ? baseSepolia : base,
-          amount: depositAmount || "200",
+          amount: usdc > 0 ? usdc.toFixed(2) : "200",
           asset: "USDC",
         },
       })
@@ -176,7 +180,7 @@ export function DepositPanel() {
       setIsFunding(false)
       void fetchBalance()
     }
-  }, [address, chainId, depositAmount, fetchBalance, fundWallet])
+  }, [address, chainId, depositAmount, language, fetchBalance, fundWallet])
 
   // ---- 出金可能額上限（全額ボタン用） ----------------------------------------
 
@@ -187,6 +191,9 @@ export function DepositPanel() {
   const withdrawNum = parseFloat(withdrawAmount) || 0
   const receiveAmount = Math.max(0, withdrawNum - WITHDRAW_FEE)
   const depositNum = parseFloat(depositAmount) || 0
+  // 入力単位: 英語=USD（≈USDC 1:1）/ 日本語=¥（÷155 で USDC 換算）
+  const isEn = language === "en"
+  const depositUsdc = isEn ? depositNum : depositNum / JPY_PER_USDC
 
   // ---- タブ切替 ------------------------------------------------------------
 
@@ -286,7 +293,7 @@ export function DepositPanel() {
           <div>
             <label className="block text-xs text-zinc-400 mb-1">{t("depositAmountLabel")}</label>
             <div className="relative">
-              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400 text-sm">¥</span>
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400 text-sm">{isEn ? "$" : "¥"}</span>
               <input
                 type="number"
                 min="0"
@@ -300,22 +307,22 @@ export function DepositPanel() {
             </div>
             {depositNum > 0 && (
               <p className="text-xs text-zinc-500 mt-1">
-                ≈ ${(depositNum / JPY_PER_USDC).toFixed(2)} USDC
+                ≈ ${depositUsdc.toFixed(2)} USDC
               </p>
             )}
           </div>
 
           {/* クイックボタン */}
           <div className="grid grid-cols-4 gap-2">
-            {[10000, 30000, 50000, 100000].map((amt) => (
+            {(isEn ? [100, 300, 500, 1000] : [10000, 30000, 50000, 100000]).map((amt) => (
               <button
                 key={amt}
                 onClick={() => setDepositAmount(String(amt))}
                 className="bg-zinc-800 hover:bg-zinc-700 text-zinc-200 text-xs py-2 rounded-lg
                            border border-zinc-700 transition-colors"
               >
-                {language === "en"
-                  ? `¥${amt.toLocaleString()}`
+                {isEn
+                  ? `$${amt.toLocaleString()}`
                   : `¥${(amt / 10000).toFixed(0)}${t('unitMan')}`}
               </button>
             ))}
@@ -334,12 +341,9 @@ export function DepositPanel() {
             </ul>
           </div>
 
-          {/* MoonPay ウィジェット（英語モード時のみ表示） */}
-          {language === "en" && (
-            <MoonPayWidget />
-          )}
-
-          {/* 入金ボタン（Privy fundWallet モーダルを開く） */}
+          {/* 入金ボタン（Privy fundWallet モーダルを開く。
+              Privy fundWallet がカード購入・送金・ネットワーク選択を一括で扱うため、
+              旧 MoonPay ウィジェットは重複として削除し、本ボタンに一本化した） */}
           <button
             onClick={() => { void handleFundWallet() }}
             disabled={!address || isFunding}

--- a/frontend/e2e/liff-chat-i18n.spec.ts
+++ b/frontend/e2e/liff-chat-i18n.spec.ts
@@ -10,7 +10,7 @@
  *   TC4: EN 切替後、Liff.home.approve の英語訳 "Approve" が DOM に現れる
  *        （認証ゲートで到達できない場合は gracefully skip）
  *   TC5: EN モード時、localStorage["lang"] が "en" になる
- *   TC6: EN モードで入金/出金パネルを開けた場合、MoonPay ウィジェット ("Buy with card") が表示される
+ *   TC6: EN モードで入金パネルに MoonPay "Buy with card" は表示されない（Privy Deposit へ一本化）
  *   TC7: JP モードで入金/出金パネルを開いた場合、MoonPay ウィジェット ("クレジットカードで購入") は非表示
  *   TC8: localStorage["lang"]="en" を事前設定してリロードすると EN モードが維持される
  *
@@ -138,7 +138,7 @@ test.describe('[LIFF Chat] i18n JP/EN トグル + MoonPay 言語制御', () => {
     expect(lang, 'localStorage["lang"] は "en" であるべき').toBe('en')
   })
 
-  test('TC6: EN モードで入金パネル内に MoonPay ウィジェット "Buy with card" が表示される', async ({ page }) => {
+  test('TC6: EN モードで入金パネルに MoonPay "Buy with card" は表示されない（Privy Deposit へ一本化）', async ({ page }) => {
     const reachable = await visitLiffChat(page)
     test.skip(!reachable, 'LIFF/Privy 認証ゲートで /liff-chat に到達不能のため skip')
 
@@ -153,9 +153,10 @@ test.describe('[LIFF Chat] i18n JP/EN トグル + MoonPay 言語制御', () => {
     const opened = await openDepositPanel(page)
     test.skip(!opened, '入金/出金パネルを開けない環境のため skip')
 
-    // EN モード時: MoonPayWidget の "Buy with card" テキストが表示される
+    // MoonPay 廃止: Privy fundWallet の "Deposit" ボタンが入金導線を一括で担うため、
+    // 重複していた MoonPay "Buy with card" ウィジェットは EN モードでも表示しない。
     const moonpayText = page.getByText('Buy with card', { exact: false }).first()
-    await expect(moonpayText).toBeVisible({ timeout: 5_000 })
+    await expect(moonpayText).not.toBeVisible({ timeout: 3_000 })
   })
 
   test('TC7: JP モードで入金パネル内に MoonPay ウィジェットが表示されない', async ({ page }) => {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -688,7 +688,7 @@
         "withdrawableBalance": "Available balance",
         "balanceLoading": "Loading...",
         "network": "USDC · Base Mainnet",
-        "depositAmountLabel": "Enter amount (JPY estimate)",
+        "depositAmountLabel": "Enter amount (USD)",
         "depositAmountPlaceholder": "Enter amount",
         "depositMethodTitle": "How to deposit",
         "depositMethodDesc": "Tap \"Deposit\" to reveal your deposit address. Send USDC from your exchange (e.g. SBI VC Trade) or wallet.",


### PR DESCRIPTION
## 背景（staging 実機 2026-06-14 / 英語ローンチ前 UX 整理）
英語モードの Deposit で ¥ 表記、かつ「Buy with card」(MoonPay) と「Deposit」(Privy) の 2 ボタンが重複していた。

## 変更
### 1) 通貨表記
- **英語**: 入力 prefix `$`、ラベル "Enter amount (USD)"、プリセット **$100 / $300 / $500 / $1,000**。USDC と 1:1 のため換算表示も実額に。
- **日本語**: ¥（万単位）プリセットは現状維持。

### 2) Privy fundWallet の amount 不具合修正
- 旧実装は入力値をそのまま USDC amount として渡しており、**日本語の ¥ 値がそのまま USDC（¥10,000→10,000 USDC）**になっていた。言語別に USDC 正規化（英語=USD 1:1 / 日本語=¥÷155）してから渡すよう修正。

### 3) 入金ボタンの一本化
- Privy fundWallet はカード購入・送金・ネットワーク選択を一括で扱う上位フローのため、重複していた MoonPay "Buy with card" ウィジェットを削除し **Privy "Deposit" に一本化**。
- E2E **TC6** を「EN で Buy with card は非表示」に更新（TC7 は不変で有効）。

## Gate
- ✅ `npx tsc --noEmit` exit 0
- ✅ ja/en JSON 妥当性 OK

## 注記 / フォロー
- `MoonPayWidget.tsx` は本変更で未参照（孤立）になる。**削除は別 PR**で（孤立コード検出 Gate 5 対象）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)