### PR TITLE
fix(liff-chat): 緊急停止ボタンの i18n キー復活 + Arobix 向けデザイン調整

### DIFF
--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -382,25 +382,24 @@ export default function LiffChatPage() {
         </div>
       </main>
 
-      {/* ── 緊急停止バー（下部固定 / safe-area 対応） */}
-      <div
-        className="fixed bottom-0 left-0 right-0 z-30 w-[375px] mx-auto px-4 pt-2 ax-safe-bottom
-                   bg-gradient-to-t from-zinc-950 via-zinc-950/95 to-transparent"
-      >
+      {/* ── 緊急停止バー（下部固定 / safe-area 対応）
+          Arobix warm-light に馴染むよう、黒背景グラデーションは廃し、
+          細めの赤アウトライン（薄赤フィル）にして主張を抑える。 */}
+      <div className="fixed bottom-0 left-0 right-0 z-30 w-[375px] mx-auto px-4 pt-2 ax-safe-bottom">
         {paused ? (
           <div
             role="status"
-            className="w-full py-3 rounded-xl border border-red-500/60 bg-red-500/10
-                       text-red-300 text-sm font-semibold flex items-center justify-center gap-2"
+            className="w-full py-2 rounded-lg border border-red-400/50 bg-red-500/10
+                       text-red-500 text-xs font-medium flex items-center justify-center gap-1.5"
           >
-            <span className="w-2 h-2 rounded-full bg-red-500" />
+            <span className="w-1.5 h-1.5 rounded-full bg-red-500" />
             {t("home.stoppedStatus")}
           </div>
         ) : (
           <button
             onClick={() => setStopConfirmOpen(true)}
-            className="w-full py-3 rounded-xl bg-red-600 active:bg-red-700 text-white font-bold
-                       shadow-lg transition-colors"
+            className="w-full py-2 rounded-lg border border-red-400 bg-red-500/10
+                       text-red-600 text-sm font-semibold active:bg-red-500/20 transition-colors"
             aria-label={t("home.emergencyStopAriaLabel")}
           >
             {t("home.emergencyStop")}
@@ -431,7 +430,7 @@ export default function LiffChatPage() {
               <button
                 onClick={handleEmergencyStop}
                 disabled={stopLoading}
-                className="flex-1 py-3 rounded-xl bg-red-600 active:bg-red-700 text-white font-bold disabled:opacity-50"
+                className="flex-1 py-3 rounded-xl bg-red-500 active:bg-red-600 text-white font-bold disabled:opacity-50"
               >
                 {stopLoading ? t("home.stopping") : t("home.stopConfirm")}
               </button>

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -617,7 +617,17 @@
       "operatingCoins": "Active Holdings",
       "noCoins": "No active holdings",
       "openChatAriaLabel": "Open chat",
-      "assetChartLoading": "Loading chart..."
+      "assetChartLoading": "Loading chart...",
+      "emergencyStop": "Emergency Stop",
+      "emergencyStopAriaLabel": "Emergency stop autonomous trading",
+      "stoppedStatus": "Autonomous trading is stopped",
+      "stopConfirmTitle": "Stop autonomous trading?",
+      "stopConfirmDesc": "Stopping halts the AI's automatic decisions and execution. To resume, please contact support.",
+      "stopCancel": "Cancel",
+      "stopConfirm": "Stop",
+      "stopping": "Stopping...",
+      "stopSuccess": "Autonomous trading stopped",
+      "stopFailed": "Failed to stop. Please try again later."
     },
     "panels": {
       "assetHistory": "Asset History",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -617,7 +617,17 @@
       "operatingCoins": "運用中コイン",
       "noCoins": "運用中のコインがありません",
       "openChatAriaLabel": "チャットを開く",
-      "assetChartLoading": "グラフを読み込み中..."
+      "assetChartLoading": "グラフを読み込み中...",
+      "emergencyStop": "緊急停止",
+      "emergencyStopAriaLabel": "自律売買を緊急停止する",
+      "stoppedStatus": "自律売買は停止中です",
+      "stopConfirmTitle": "自律売買を停止しますか？",
+      "stopConfirmDesc": "停止すると、AIによる自動の判断・実行が止まります。再開はサポートにご連絡ください。",
+      "stopCancel": "キャンセル",
+      "stopConfirm": "停止する",
+      "stopping": "停止中...",
+      "stopSuccess": "自律売買を停止しました",
+      "stopFailed": "停止に失敗しました。時間をおいて再度お試しください"
     },
     "panels": {
       "assetHistory": "資産推移",


### PR DESCRIPTION
## 症状（staging 実機 2026-06-14）
liff-chat ホーム下部の緊急停止ボタンに **生キー "Liff.home.emergencyStop" が表示**。さらにデザインが Arobix warm-light から浮き、黒背景＋赤ソリッドで主張が強すぎる。

## 原因
1. **i18n キー消失**: #712 で追加した `Liff.home.emergencyStop` 系 **10 キー**が、その後の i18n wave 系 PR（`messages/ja.json`・`en.json` を全体上書き）に**巻き込まれて消えていた**（layout.tsx 重複 import と同根の wave マージ事故）。next-intl はキー未解決時に生キーを描画するため、そのまま表示されていた。
2. **デザイン不整合**: `bg-red-600` ソリッド＋`bg-gradient from-zinc-950`（黒背景）。arobix-root では `text-white`→暗色化（keep-white は `bg-red-500` のみ対象）し読みにくく、黒グラデも warm-light に不適合。

## 修正
- **ja/en に 10 キーを復活**（緊急停止 / Emergency Stop ほか）
- 黒グラデ背景を**廃止**（透明化 → 下は beige ページが見える）
- ボタンを**細い赤アウトライン＋薄赤フィル**に（`py-2` / `text-sm` / 影なし）。停止中表示も同系の細い注記に
- 確認ダイアログ確定ボタン `bg-red-600`→`bg-red-500`（keep-white ルールで白文字維持）

## Gate
- ✅ ja/en JSON 妥当 + 10 キー存在確認
- ✅ `npx tsc --noEmit` exit 0

## 再発防止（フォロー提案）
i18n wave 系 PR が `messages/*.json` を全体上書きする運用のため、機能追加で足した i18n キーが後続 wave に巻き込まれ消えるリスクがある。**CI に「page.tsx が参照する t() キーが messages に存在するか」検査**を追加すべき（別タスク化推奨）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)