### PR TITLE
fix(liff): オンボーディングボタン + Privy UI を Arobix ブランド色（紫系）に統一

### DIFF
--- a/frontend/app/(liff)/liff-confirm/page.tsx
+++ b/frontend/app/(liff)/liff-confirm/page.tsx
@@ -230,7 +230,7 @@ export default function LiffConfirmPage() {
           onClick={handleSubmit}
           className={`w-full py-4 rounded-xl font-semibold text-base transition-all duration-200 ${
             allChecked && !submitting
-              ? "bg-[#1D9E75] text-white hover:bg-[#1D9E75]/90 active:scale-95"
+              ? "bg-gradient-to-r from-[#b9a4f2] via-[#ecaccd] to-[#fbd9a0] text-[#2a2440] hover:brightness-95 active:scale-95"
               : "bg-zinc-800 text-zinc-600 cursor-not-allowed"
           }`}
         >

--- a/frontend/lib/wallet/PrivyRootClient.tsx
+++ b/frontend/lib/wallet/PrivyRootClient.tsx
@@ -38,8 +38,10 @@ export function PrivyRootClient({ children }: { children: ReactNode }) {
         // 外部 wallet 不要で onboarding できるようにする。LINE は OAuth 設定別途必要 (別 Lane)。
         loginMethods: ['email', 'google', 'apple', 'wallet'],
         appearance: {
+          // Arobix ブランド統一: アプリの primary CTA（紫系グラデ）に合わせ、
+          // Privy モーダルの accentColor を Arobix purple に揃える。
           theme: 'dark',
-          accentColor: '#6366f1',
+          accentColor: '#6e56cf',
         },
         supportedChains: [base, baseSepolia],
         defaultChain,


### PR DESCRIPTION
## 背景（staging 実機 2026-06-14）
- オンボーディング（liff-confirm）の「運用を開始する」ボタンが**旧緑 `#1D9E75`** のまま。ヘッダーは Arobix テーマで紫系グラデに自動上書きされるのに、ボタンの緑は上書き対象外で残り、**新グラデヘッダー＋旧緑ボタン**でちぐはぐだった。
- Privy モーダルの `accentColor` が `#6366f1`（インディゴ）でアプリと不一致。

## 修正
- 「運用を開始する」ボタンを **Arobix グラデ**（FAB/ヘッダーと同じ `#b9a4f2→#ecaccd→#fbd9a0`）＋**濃色テキスト `#2a2440`** に。
  - ※ `arobix-root` は `text-white` を暗色化するため、白文字ソリッドではなく**グラデ＋濃色テキスト**（FAB と同パターン）にして文字色崩れを回避。
- Privy `appearance.accentColor` を `#6366f1` → **`#6e56cf`（Arobix purple）** に統一。

## スコープ注記（フォロー）
他の primary CTA（入金ボタン等）は**まだ緑 `#1D9E75`**。アプリ全体の緑→紫移行は影響範囲が広く、`text-white` 暗色化との兼ね合いもあるため、**theme レベルでの一括対応を別タスク推奨**。本 PR はユーザーが指摘したオンボーディングボタン＋Privy に限定。

## Gate
- ✅ `npx tsc --noEmit` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)