### PR TITLE
feat(aave): LiquidationSentinel — 清算リスク事前計算 + プール赤字監視

### DIFF
--- a/backend/app/aave/chains.py
+++ b/backend/app/aave/chains.py
@@ -38,11 +38,6 @@ class AaveChainConfig:
     oracle_address: Optional[str] = None
     pool_addresses_provider: Optional[str] = None
     is_testnet: bool = False
-    # LiquidationDataProvider アドレス（Aave V3.1 清算リスク計算用 View Contract）
-    # TODO(sentinel): 公式アドレスが確定次第ここに設定する。
-    # 環境変数 AAVE_LIQUIDATION_DATA_PROVIDER_<CHAIN> でオーバーライド可能。
-    # 参照: https://docs.aave.com/developers/deployed-contracts/v3-mainnet
-    liquidation_data_provider_address: Optional[str] = None
 
 
 # チェーンレジストリ
@@ -181,27 +176,6 @@ def get_active_chains() -> list[AaveChainConfig]:
     raw = os.getenv("AAVE_ACTIVE_CHAINS", "base")
     chain_names = [name.strip() for name in raw.split(",") if name.strip()]
     return [get_chain_config(name) for name in chain_names]
-
-
-def get_liquidation_data_provider_address(chain: AaveChainConfig) -> Optional[str]:
-    """
-    チェーンの LiquidationDataProvider アドレスを取得する。
-
-    優先順位:
-    1. 環境変数 AAVE_LIQUIDATION_DATA_PROVIDER_<CHAIN_NAME大文字> （オーバーライド）
-    2. AaveChainConfig.liquidation_data_provider_address （ハードコード値、未設定なら None）
-
-    None の場合は LiquidationDataProvider を使った HF 計算は無効。
-    TODO(sentinel): 各チェーンの公式アドレスが確定次第、CHAIN_REGISTRY に追記する。
-
-    :param chain: 対象チェーンの AaveChainConfig
-    :return: LiquidationDataProvider アドレス文字列、未設定の場合は None
-    """
-    env_key = f"AAVE_LIQUIDATION_DATA_PROVIDER_{chain.chain_name.upper()}"
-    from_env = os.getenv(env_key)
-    if from_env:
-        return from_env
-    return chain.liquidation_data_provider_address
 
 
 def get_rpc_url_for_chain(chain: AaveChainConfig) -> str:

--- a/backend/app/aave/chains.py
+++ b/backend/app/aave/chains.py
@@ -38,6 +38,11 @@ class AaveChainConfig:
     oracle_address: Optional[str] = None
     pool_addresses_provider: Optional[str] = None
     is_testnet: bool = False
+    # LiquidationDataProvider アドレス（Aave V3.1 清算リスク計算用 View Contract）
+    # TODO(sentinel): 公式アドレスが確定次第ここに設定する。
+    # 環境変数 AAVE_LIQUIDATION_DATA_PROVIDER_<CHAIN> でオーバーライド可能。
+    # 参照: https://docs.aave.com/developers/deployed-contracts/v3-mainnet
+    liquidation_data_provider_address: Optional[str] = None
 
 
 # チェーンレジストリ
@@ -176,6 +181,27 @@ def get_active_chains() -> list[AaveChainConfig]:
     raw = os.getenv("AAVE_ACTIVE_CHAINS", "base")
     chain_names = [name.strip() for name in raw.split(",") if name.strip()]
     return [get_chain_config(name) for name in chain_names]
+
+
+def get_liquidation_data_provider_address(chain: AaveChainConfig) -> Optional[str]:
+    """
+    チェーンの LiquidationDataProvider アドレスを取得する。
+
+    優先順位:
+    1. 環境変数 AAVE_LIQUIDATION_DATA_PROVIDER_<CHAIN_NAME大文字> （オーバーライド）
+    2. AaveChainConfig.liquidation_data_provider_address （ハードコード値、未設定なら None）
+
+    None の場合は LiquidationDataProvider を使った HF 計算は無効。
+    TODO(sentinel): 各チェーンの公式アドレスが確定次第、CHAIN_REGISTRY に追記する。
+
+    :param chain: 対象チェーンの AaveChainConfig
+    :return: LiquidationDataProvider アドレス文字列、未設定の場合は None
+    """
+    env_key = f"AAVE_LIQUIDATION_DATA_PROVIDER_{chain.chain_name.upper()}"
+    from_env = os.getenv(env_key)
+    if from_env:
+        return from_env
+    return chain.liquidation_data_provider_address
 
 
 def get_rpc_url_for_chain(chain: AaveChainConfig) -> str:

--- a/backend/app/aave/client.py
+++ b/backend/app/aave/client.py
@@ -239,6 +239,9 @@ class AccountData:
     total_debt_usd: Decimal
     available_borrows_usd: Decimal
     health_factor: Decimal
+    # currentLiquidationThreshold (BPS → ratio): result[3] / 10000
+    # DummyAaveClient は 0.80 固定。Web3AaveClient は RPC から実値を取得。
+    liquidation_threshold: Optional[Decimal] = None
 
 
 class AaveClientBase(ABC):
@@ -396,6 +399,7 @@ class DummyAaveClient(AaveClientBase):
             total_debt_usd=Decimal("3000"),
             available_borrows_usd=Decimal("5000"),
             health_factor=Decimal("2.5"),
+            liquidation_threshold=Decimal("0.80"),
         )
 
     def deposit(
@@ -691,6 +695,11 @@ class Web3AaveClient(AaveClientBase):
             total_collateral_usd = Decimal(result[0]) / _BASE
             total_debt_usd = Decimal(result[1]) / _BASE
             available_borrows_usd = Decimal(result[2]) / _BASE
+            # currentLiquidationThreshold は BPS (basis points, e.g. 8000 = 80%)
+            lt_raw: int = result[3]
+            liquidation_threshold: Optional[Decimal] = (
+                Decimal(lt_raw) / Decimal("10000") if lt_raw > 0 else Decimal("0.75")
+            )
             hf_raw: int = result[5]
             if hf_raw >= 2**256 - 1 or (hf_raw == 0 and result[1] == 0):
                 health_factor = Decimal("inf")
@@ -701,6 +710,7 @@ class Web3AaveClient(AaveClientBase):
                 total_debt_usd=total_debt_usd,
                 available_borrows_usd=available_borrows_usd,
                 health_factor=health_factor,
+                liquidation_threshold=liquidation_threshold,
             )
         except AaveClientError:
             raise

--- a/backend/app/aave/liquidation_sentinel.py
+++ b/backend/app/aave/liquidation_sentinel.py
@@ -1,0 +1,473 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/aave/liquidation_sentinel.py
+"""
+清算リスク事前計算（ストレステスト）とプール赤字蓄積の早期検知。
+
+- get_stress_test(): 価格 -10%/-20% 時の Health Factor を事前計算する。
+- PoolHealthMonitor.check_pool_deficits(): getReserveDeficit() でプール赤字を監視し、
+  閾値超過時に Slack アラートを発火する。
+
+セキュリティ: docs/13_security_design.md
+- 金融計算は Decimal のみ（float 禁止）
+- ログにウォレットアドレスを出さない（マスク必須）
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# プール赤字アラートの閾値（USD 建て）
+DEFICIT_ALERT_THRESHOLD = Decimal("10000")
+
+# 監視対象のデフォルトアセットシンボル
+DEFAULT_DEFICIT_TOKENS = ["USDC", "WETH", "wstETH"]
+
+
+# ---------------------------------------------------------------------------
+# データクラス
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StressTestScenario:
+    """価格ドロップ率 pct に対するストレステスト結果。"""
+
+    price_drop_pct: Decimal
+    """価格下落率（例: 10% 下落 → Decimal("0.10")）"""
+
+    simulated_hf: Optional[Decimal]
+    """シミュレーション後の Health Factor。計算不能時は None。"""
+
+    collateral_after_usd: Optional[Decimal]
+    """価格下落後の担保 USD 評価額。"""
+
+
+@dataclass
+class StressTestResult:
+    """
+    ウォレットのストレステスト結果。
+
+    GET /api/aave/stress-test のレスポンスに使用する。
+    """
+
+    wallet_address: str
+    current_hf: Optional[Decimal]
+    current_collateral_usd: Optional[Decimal]
+    current_debt_usd: Optional[Decimal]
+    liquidation_threshold: Optional[Decimal]
+    scenarios: list[StressTestScenario] = field(default_factory=list)
+    error: Optional[str] = None
+
+
+@dataclass
+class PoolDeficitInfo:
+    """アセット単位のプール赤字情報。"""
+
+    asset_symbol: str
+    deficit_usd: Decimal
+    alert_triggered: bool
+
+
+@dataclass
+class PoolHealthReport:
+    """
+    プール全体の赤字ヘルスレポート。
+
+    GET /api/aave/pool-health のレスポンスに使用する。
+    """
+
+    chain_name: str
+    deficits: list[PoolDeficitInfo] = field(default_factory=list)
+    total_deficit_usd: Decimal = field(default_factory=lambda: Decimal("0"))
+    alert_triggered: bool = False
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# ストレステストロジック
+# ---------------------------------------------------------------------------
+
+
+def simulate_hf_at_price_drop(
+    collateral_usd: Decimal,
+    debt_usd: Decimal,
+    liquidation_threshold: Decimal,
+    price_drop_pct: Decimal,
+) -> Optional[Decimal]:
+    """
+    価格下落後の Health Factor を計算する。
+
+    HF = (collateral * (1 - price_drop_pct) * liquidation_threshold) / debt
+
+    Args:
+        collateral_usd: 現在の担保 USD 評価額（Decimal）
+        debt_usd: 現在の総借入 USD（Decimal）
+        liquidation_threshold: 清算しきい値（例: 0.80 = 80%）
+        price_drop_pct: 価格下落率（例: 0.10 = 10%）
+
+    Returns:
+        Decimal: 計算後の HF。debt=0 の場合は None（清算なし）。
+    """
+    if debt_usd <= Decimal("0"):
+        # 借入なし = 清算リスクなし
+        return None
+
+    price_factor = Decimal("1") - price_drop_pct
+    adjusted_collateral = collateral_usd * price_factor * liquidation_threshold
+
+    try:
+        hf = adjusted_collateral / debt_usd
+    except InvalidOperation:
+        logger.warning(
+            "simulate_hf_at_price_drop: Decimal 計算失敗 collateral=%s debt=%s lt=%s pct=%s",
+            collateral_usd,
+            debt_usd,
+            liquidation_threshold,
+            price_drop_pct,
+        )
+        return None
+
+    return hf
+
+
+def get_stress_test(wallet_address: str) -> StressTestResult:
+    """
+    ウォレットのストレステストを実行し、価格 -10%/-20% 時の HF を返す。
+
+    アカウントデータを Aave Pool から取得し、各価格シナリオで HF をシミュレーションする。
+    RPC 未設定 / DUMMY モードでは dummy データを使用する（fail-open）。
+
+    Args:
+        wallet_address: 対象ウォレットアドレス
+
+    Returns:
+        StressTestResult
+    """
+    from .client import DummyAaveClient, Web3AaveClient  # noqa: PLC0415
+
+    masked_wallet = _mask_address(wallet_address)
+
+    client_type = os.getenv("AAVE_CLIENT_TYPE", "dummy")
+
+    collateral_usd: Optional[Decimal] = None
+    debt_usd: Optional[Decimal] = None
+    current_hf: Optional[Decimal] = None
+    liquidation_threshold: Optional[Decimal] = None
+
+    try:
+        if client_type == "web3":
+            rpc_url = os.getenv("AAVE_RPC_URL", "")
+            pool_address = os.getenv("AAVE_POOL_ADDRESS", "")
+            if not rpc_url or not pool_address:
+                logger.warning(
+                    "[sentinel] AAVE_RPC_URL / AAVE_POOL_ADDRESS 未設定、DUMMY フォールバック wallet=%s",
+                    masked_wallet,
+                )
+                client_type = "dummy"
+            else:
+                client = Web3AaveClient(rpc_url=rpc_url, pool_address=pool_address)
+                account = client.get_account_data(wallet_address)
+                collateral_usd = account.total_collateral_usd
+                debt_usd = account.total_debt_usd
+                current_hf = account.health_factor
+                # Aave Pool の currentLiquidationThreshold は getUserAccountData の
+                # 4番目の出力 (raw uint256 in basis points e.g. 8000=80%)。
+                # AccountData には未追加のため安全側の 0.75 をデフォルトとする。
+                # TODO(sentinel): getUserAccountData の currentLiquidationThreshold を
+                # AccountData に追加して正確な値を取得する。
+                liquidation_threshold = Decimal("0.75")
+
+        if client_type != "web3":
+            dummy = DummyAaveClient()
+            account = dummy.get_account_data(wallet_address)
+            collateral_usd = account.total_collateral_usd
+            debt_usd = account.total_debt_usd
+            current_hf = account.health_factor
+            liquidation_threshold = Decimal("0.80")
+
+        logger.info(
+            "[sentinel] account data wallet=%s collateral=%s debt=%s hf=%s lt=%s",
+            masked_wallet,
+            collateral_usd,
+            debt_usd,
+            current_hf,
+            liquidation_threshold,
+        )
+
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "[sentinel] get_account_data 失敗 wallet=%s error=%s",
+            masked_wallet,
+            type(exc).__name__,
+        )
+        return StressTestResult(
+            wallet_address=wallet_address,
+            current_hf=None,
+            current_collateral_usd=None,
+            current_debt_usd=None,
+            liquidation_threshold=None,
+            error=f"アカウントデータ取得失敗: {type(exc).__name__}",
+        )
+
+    # 価格シナリオ: -10%, -20%
+    scenarios: list[StressTestScenario] = []
+    for drop_pct in [Decimal("0.10"), Decimal("0.20")]:
+        if (
+            collateral_usd is not None
+            and debt_usd is not None
+            and liquidation_threshold is not None
+        ):
+            simulated_hf = simulate_hf_at_price_drop(
+                collateral_usd=collateral_usd,
+                debt_usd=debt_usd,
+                liquidation_threshold=liquidation_threshold,
+                price_drop_pct=drop_pct,
+            )
+            collateral_after = collateral_usd * (Decimal("1") - drop_pct)
+        else:
+            simulated_hf = None
+            collateral_after = None
+
+        scenarios.append(
+            StressTestScenario(
+                price_drop_pct=drop_pct,
+                simulated_hf=simulated_hf,
+                collateral_after_usd=collateral_after,
+            )
+        )
+
+    return StressTestResult(
+        wallet_address=wallet_address,
+        current_hf=current_hf,
+        current_collateral_usd=collateral_usd,
+        current_debt_usd=debt_usd,
+        liquidation_threshold=liquidation_threshold,
+        scenarios=scenarios,
+    )
+
+
+# ---------------------------------------------------------------------------
+# プール赤字モニター
+# ---------------------------------------------------------------------------
+
+
+class PoolHealthMonitor:
+    """
+    Aave プール赤字（getReserveDeficit）を監視し、閾値超過時に Slack アラートを送信する。
+
+    既存 monitor.py の get_health_factor / get_aave_balance と同じレイヤーで動作する。
+    安全装置として fail-open 設計（RPC 障害時は空レポートを返す）。
+    """
+
+    def __init__(
+        self,
+        deficit_alert_threshold: Decimal = DEFICIT_ALERT_THRESHOLD,
+        tokens: Optional[list[str]] = None,
+    ) -> None:
+        self._threshold = deficit_alert_threshold
+        self._tokens = tokens or DEFAULT_DEFICIT_TOKENS
+
+    def check_pool_deficits(self, chain_name: str = "base") -> PoolHealthReport:
+        """
+        対象チェーンのプール赤字を確認し PoolHealthReport を返す。
+
+        赤字が DEFICIT_ALERT_THRESHOLD ($10,000) を超えた場合は Slack 通知する。
+        RPC 未設定または DUMMY モードでは空レポートを返す（fail-open）。
+
+        Args:
+            chain_name: 対象チェーン（chains.py CHAIN_REGISTRY のキー）
+
+        Returns:
+            PoolHealthReport
+        """
+        report = PoolHealthReport(chain_name=chain_name)
+
+        client_type = os.getenv("AAVE_CLIENT_TYPE", "dummy")
+        if client_type != "web3":
+            logger.info(
+                "[pool_health] AAVE_CLIENT_TYPE=%s、赤字チェックはスキップ（dummy モード）",
+                client_type,
+            )
+            return report
+
+        rpc_url = os.getenv("AAVE_RPC_URL", "")
+        pool_address = os.getenv("AAVE_POOL_ADDRESS", "")
+
+        if not rpc_url or not pool_address:
+            logger.warning("[pool_health] AAVE_RPC_URL / AAVE_POOL_ADDRESS 未設定、スキップ")
+            return report
+
+        try:
+            from .chains import get_chain_config  # noqa: PLC0415
+
+            chain_config = get_chain_config(chain_name)
+        except ValueError as exc:
+            logger.warning("[pool_health] チェーン設定取得失敗 chain=%s error=%s", chain_name, exc)
+            report.error = f"チェーン設定エラー: {exc}"
+            return report
+
+        deficits: list[PoolDeficitInfo] = []
+        total_deficit = Decimal("0")
+        alert_triggered = False
+
+        for symbol in self._tokens:
+            token_address = chain_config.tokens.get(symbol)
+            if not token_address:
+                logger.debug(
+                    "[pool_health] chain=%s にトークン %s が見つからないためスキップ",
+                    chain_name,
+                    symbol,
+                )
+                continue
+
+            deficit_usd = self._fetch_reserve_deficit(rpc_url, pool_address, token_address, symbol)
+            if deficit_usd is None:
+                continue
+
+            triggered = deficit_usd > self._threshold
+            deficits.append(
+                PoolDeficitInfo(
+                    asset_symbol=symbol,
+                    deficit_usd=deficit_usd,
+                    alert_triggered=triggered,
+                )
+            )
+            total_deficit += deficit_usd
+            if triggered:
+                alert_triggered = True
+                self._send_deficit_alert(chain_name, symbol, deficit_usd)
+
+        report.deficits = deficits
+        report.total_deficit_usd = total_deficit
+        report.alert_triggered = alert_triggered
+        return report
+
+    def _fetch_reserve_deficit(
+        self,
+        rpc_url: str,
+        pool_address: str,
+        token_address: str,
+        symbol: str,
+    ) -> Optional[Decimal]:
+        """
+        Aave Pool.getReserveDeficit(asset) を呼び出して赤字 USD 相当を返す。
+
+        getReserveDeficit() はプールの unbacked deficit をトークン単位 (wei) で返す。
+        ここでは簡易的に 1 トークン = 1 USD として扱い（USDC 向け設計）。
+        WETH 等は別途オラクル統合が必要な点を TODO で残す。
+
+        NOTE: getReserveDeficit() は Aave V3.1 以降で利用可能。
+        古いプール実装では ABI missing エラーが出るため try-except で fail-open とする。
+        """
+        try:
+            from web3 import Web3  # noqa: PLC0415
+
+            w3 = Web3(Web3.HTTPProvider(rpc_url))
+            checksum_pool = Web3.to_checksum_address(pool_address)
+            checksum_token = Web3.to_checksum_address(token_address)
+
+            pool_contract = w3.eth.contract(
+                address=checksum_pool,
+                abi=_POOL_GET_RESERVE_DEFICIT_ABI,
+            )
+            raw_deficit: int = pool_contract.functions.getReserveDeficit(checksum_token).call()
+
+            # 簡易換算: USDC = 6 decimals, WETH/wstETH = 18 decimals
+            # TODO(sentinel): Aave Price Oracle 統合で正確な USD 換算を行う
+            decimals = 6 if symbol in ("USDC", "USDbC", "EURC") else 18
+            deficit_usd = Decimal(raw_deficit) / Decimal(10**decimals)
+
+            logger.info(
+                "[pool_health] getReserveDeficit symbol=%s deficit=%s USD",
+                symbol,
+                deficit_usd,
+            )
+            return deficit_usd
+
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[pool_health] getReserveDeficit 失敗 symbol=%s error=%s",
+                symbol,
+                type(exc).__name__,
+            )
+            return None
+
+    def _send_deficit_alert(self, chain_name: str, symbol: str, deficit_usd: Decimal) -> None:
+        """
+        プール赤字アラートを Slack に送信する。
+
+        既存 SlackNotificationSender を再利用。送信失敗は fail-open（ログのみ）。
+        """
+        webhook_url = os.getenv("SLACK_WEBHOOK_URL", "")
+        if not webhook_url:
+            logger.warning(
+                "[pool_health] SLACK_WEBHOOK_URL 未設定、アラートをスキップ chain=%s symbol=%s",
+                chain_name,
+                symbol,
+            )
+            return
+
+        try:
+            from app.notifications.schemas import (  # noqa: PLC0415
+                NotificationChannel,
+                NotificationMessage,
+                NotificationSeverity,
+            )
+            from app.notifications.slack_sender import SlackNotificationSender  # noqa: PLC0415
+
+            sender = SlackNotificationSender(webhook_url=webhook_url)
+            msg = NotificationMessage(
+                channel=NotificationChannel.SLACK,
+                severity=NotificationSeverity.ALERT,
+                title=f"[Aave] プール赤字アラート: {symbol} on {chain_name}",
+                body=(
+                    f"チェーン: {chain_name}\n"
+                    f"アセット: {symbol}\n"
+                    f"赤字額（概算）: ${deficit_usd:.2f} USD\n"
+                    f"閾値: ${self._threshold:.0f} USD"
+                ),
+            )
+            sender.send(msg)
+            logger.info(
+                "[pool_health] Slack アラート送信 chain=%s symbol=%s deficit=%s",
+                chain_name,
+                symbol,
+                deficit_usd,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error("[pool_health] Slack 送信エラー: %s", type(exc).__name__)
+
+
+# ---------------------------------------------------------------------------
+# ABI 定義（最小限）
+# ---------------------------------------------------------------------------
+
+# Aave V3.1 Pool.getReserveDeficit(address asset) → (uint256)
+_POOL_GET_RESERVE_DEFICIT_ABI = [
+    {
+        "inputs": [{"internalType": "address", "name": "asset", "type": "address"}],
+        "name": "getReserveDeficit",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    }
+]
+
+
+# ---------------------------------------------------------------------------
+# ユーティリティ
+# ---------------------------------------------------------------------------
+
+
+def _mask_address(address: str) -> str:
+    """ウォレットアドレスを先頭6文字+末尾4文字にマスクする（ログ安全化）。"""
+    if not address or len(address) < 10:
+        return "****"
+    return f"{address[:6]}...{address[-4:]}"

--- a/backend/app/aave/liquidation_sentinel.py
+++ b/backend/app/aave/liquidation_sentinel.py
@@ -27,7 +27,13 @@ logger = logging.getLogger(__name__)
 DEFICIT_ALERT_THRESHOLD = Decimal("10000")
 
 # 監視対象のデフォルトアセットシンボル
-DEFAULT_DEFICIT_TOKENS = ["USDC", "WETH", "wstETH"]
+# NOTE: USDC のみとしている理由:
+#   WETH / wstETH は getReserveDeficit() がトークン単位 (18 decimals) で返すが、
+#   Price Oracle 統合なしでは「1 トークン = 1 USD」と扱うことになり、
+#   実際の USD 価値（例: 1 WETH ≈ $3000）より桁違いに小さい値で閾値比較してしまい
+#   アラートが実質不発火になる安全上の問題がある。
+#   WETH / wstETH は Aave Price Oracle 統合後に追加する。（TODO: oracle integration）
+DEFAULT_DEFICIT_TOKENS = ["USDC"]
 
 
 # ---------------------------------------------------------------------------
@@ -110,11 +116,19 @@ def simulate_hf_at_price_drop(
         collateral_usd: 現在の担保 USD 評価額（Decimal）
         debt_usd: 現在の総借入 USD（Decimal）
         liquidation_threshold: 清算しきい値（例: 0.80 = 80%）
-        price_drop_pct: 価格下落率（例: 0.10 = 10%）
+        price_drop_pct: 価格下落率（0 <= pct < 1。例: 0.10 = 10%）
 
     Returns:
         Decimal: 計算後の HF。debt=0 の場合は None（清算なし）。
+
+    Raises:
+        ValueError: price_drop_pct が [0, 1) の範囲外の場合。
     """
+    if not (Decimal("0") <= price_drop_pct < Decimal("1")):
+        raise ValueError(
+            f"price_drop_pct は 0 以上 1 未満の Decimal である必要があります。got: {price_drop_pct}"
+        )
+
     if debt_usd <= Decimal("0"):
         # 借入なし = 清算リスクなし
         return None
@@ -143,6 +157,9 @@ def get_stress_test(wallet_address: str) -> StressTestResult:
 
     アカウントデータを Aave Pool から取得し、各価格シナリオで HF をシミュレーションする。
     RPC 未設定 / DUMMY モードでは dummy データを使用する（fail-open）。
+
+    AccountData.liquidation_threshold を優先使用する。
+    未設定の場合は安全側 fallback として 0.75 を使用し、ログに記録する。
 
     Args:
         wallet_address: 対象ウォレットアドレス
@@ -177,12 +194,14 @@ def get_stress_test(wallet_address: str) -> StressTestResult:
                 collateral_usd = account.total_collateral_usd
                 debt_usd = account.total_debt_usd
                 current_hf = account.health_factor
-                # Aave Pool の currentLiquidationThreshold は getUserAccountData の
-                # 4番目の出力 (raw uint256 in basis points e.g. 8000=80%)。
-                # AccountData には未追加のため安全側の 0.75 をデフォルトとする。
-                # TODO(sentinel): getUserAccountData の currentLiquidationThreshold を
-                # AccountData に追加して正確な値を取得する。
-                liquidation_threshold = Decimal("0.75")
+                # AccountData.liquidation_threshold は RPC から取得した実値 (result[3]/10000)。
+                # 取得できなかった場合（None）は安全側 fallback として 0.75 を使用する。
+                liquidation_threshold = account.liquidation_threshold or Decimal("0.75")
+                if account.liquidation_threshold is None:
+                    logger.warning(
+                        "[sentinel] liquidation_threshold 未取得、安全側 fallback 0.75 を使用 wallet=%s",
+                        masked_wallet,
+                    )
 
         if client_type != "web3":
             dummy = DummyAaveClient()
@@ -190,7 +209,7 @@ def get_stress_test(wallet_address: str) -> StressTestResult:
             collateral_usd = account.total_collateral_usd
             debt_usd = account.total_debt_usd
             current_hf = account.health_factor
-            liquidation_threshold = Decimal("0.80")
+            liquidation_threshold = account.liquidation_threshold or Decimal("0.80")
 
         logger.info(
             "[sentinel] account data wallet=%s collateral=%s debt=%s hf=%s lt=%s",
@@ -264,6 +283,9 @@ class PoolHealthMonitor:
 
     既存 monitor.py の get_health_factor / get_aave_balance と同じレイヤーで動作する。
     安全装置として fail-open 設計（RPC 障害時は空レポートを返す）。
+
+    NOTE: 監視対象は現在 USDC のみ（DEFAULT_DEFICIT_TOKENS 参照）。
+    WETH / wstETH は Aave Price Oracle 統合後に追加する。
     """
 
     def __init__(
@@ -360,8 +382,10 @@ class PoolHealthMonitor:
         Aave Pool.getReserveDeficit(asset) を呼び出して赤字 USD 相当を返す。
 
         getReserveDeficit() はプールの unbacked deficit をトークン単位 (wei) で返す。
-        ここでは簡易的に 1 トークン = 1 USD として扱い（USDC 向け設計）。
-        WETH 等は別途オラクル統合が必要な点を TODO で残す。
+        現在は USDC (6 decimals) のみを対象とし、1 USDC = 1 USD として換算する。
+
+        WETH / wstETH (18 decimals) は Price Oracle 統合後に追加する予定。
+        理由: Price Oracle なしでは 1 token = 1 USD となり、実際の USD 価値と桁違いになる。
 
         NOTE: getReserveDeficit() は Aave V3.1 以降で利用可能。
         古いプール実装では ABI missing エラーが出るため try-except で fail-open とする。
@@ -379,8 +403,8 @@ class PoolHealthMonitor:
             )
             raw_deficit: int = pool_contract.functions.getReserveDeficit(checksum_token).call()
 
-            # 簡易換算: USDC = 6 decimals, WETH/wstETH = 18 decimals
-            # TODO(sentinel): Aave Price Oracle 統合で正確な USD 換算を行う
+            # USDC = 6 decimals。他のステーブルコイン（USDbC, EURC）も 6 decimals。
+            # TODO(sentinel): Aave Price Oracle 統合で WETH/wstETH の正確な USD 換算を行う
             decimals = 6 if symbol in ("USDC", "USDbC", "EURC") else 18
             deficit_usd = Decimal(raw_deficit) / Decimal(10**decimals)
 

--- a/backend/app/aave/router.py
+++ b/backend/app/aave/router.py
@@ -21,6 +21,10 @@ from .schemas import (
     AaveRebalanceRequest,
     AaveRebalanceResponse,
     OracleStatusResponse,
+    PoolDeficitInfoResponse,
+    PoolHealthResponse,
+    StressTestResponse,
+    StressTestScenarioResponse,
 )
 from .service import AaveService, MultiChainAaveService
 
@@ -214,4 +218,110 @@ def get_monitor_status(
         balance=balance,
         client_type=os.getenv("AAVE_CLIENT_TYPE", "dummy"),
         fetched_at=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+@router.get(
+    "/stress-test",
+    response_model=StressTestResponse,
+    summary="価格 -10%/-20% 時の Health Factor を事前計算する（清算リスクストレステスト）",
+)
+def get_stress_test(
+    current_user: User = Depends(require_viewer),
+) -> StressTestResponse:
+    """
+    AAVE_WALLET_ADDRESS のポジションに対して価格下落シナリオを適用し、
+    HF シミュレーション結果を返す。
+
+    - シナリオ 1: 担保価格 -10%
+    - シナリオ 2: 担保価格 -20%
+
+    金融計算はすべて Decimal で実行（float 禁止）。
+    RPC 未設定時は DummyAaveClient のデータでシミュレーションする（fail-open）。
+    """
+    import os  # noqa: PLC0415
+
+    from .liquidation_sentinel import get_stress_test as _get_stress_test  # noqa: PLC0415
+
+    wallet = os.getenv("AAVE_WALLET_ADDRESS", "")
+    if not wallet:
+        return StressTestResponse(
+            wallet_address="",
+            current_hf=None,
+            current_collateral_usd=None,
+            current_debt_usd=None,
+            liquidation_threshold=None,
+            error="AAVE_WALLET_ADDRESS が設定されていません。",
+        )
+
+    result = _get_stress_test(wallet)
+
+    scenarios = [
+        StressTestScenarioResponse(
+            price_drop_pct=str(sc.price_drop_pct),
+            simulated_hf=str(sc.simulated_hf) if sc.simulated_hf is not None else None,
+            collateral_after_usd=(
+                str(sc.collateral_after_usd) if sc.collateral_after_usd is not None else None
+            ),
+        )
+        for sc in result.scenarios
+    ]
+
+    return StressTestResponse(
+        wallet_address=result.wallet_address,
+        current_hf=str(result.current_hf) if result.current_hf is not None else None,
+        current_collateral_usd=(
+            str(result.current_collateral_usd)
+            if result.current_collateral_usd is not None
+            else None
+        ),
+        current_debt_usd=(
+            str(result.current_debt_usd) if result.current_debt_usd is not None else None
+        ),
+        liquidation_threshold=(
+            str(result.liquidation_threshold) if result.liquidation_threshold is not None else None
+        ),
+        scenarios=scenarios,
+        error=result.error,
+    )
+
+
+@router.get(
+    "/pool-health",
+    response_model=PoolHealthResponse,
+    summary="Aave プール赤字蓄積を監視する（getReserveDeficit）",
+)
+def get_pool_health(
+    current_user: User = Depends(require_viewer),
+) -> PoolHealthResponse:
+    """
+    AAVE_ACTIVE_CHAINS の先頭チェーンに対して getReserveDeficit() を呼び出し、
+    USDC/WETH/wstETH のプール赤字を返す。
+
+    赤字が $10,000 を超えた場合は Slack アラートも発火する。
+    AAVE_CLIENT_TYPE=dummy の場合は空レポートを返す（fail-open）。
+    """
+    import os  # noqa: PLC0415
+
+    from .liquidation_sentinel import PoolHealthMonitor  # noqa: PLC0415
+
+    chain_name = os.getenv("AAVE_ACTIVE_CHAINS", "base").split(",")[0].strip()
+    monitor = PoolHealthMonitor()
+    report = monitor.check_pool_deficits(chain_name=chain_name)
+
+    deficits = [
+        PoolDeficitInfoResponse(
+            asset_symbol=d.asset_symbol,
+            deficit_usd=str(d.deficit_usd),
+            alert_triggered=d.alert_triggered,
+        )
+        for d in report.deficits
+    ]
+
+    return PoolHealthResponse(
+        chain_name=report.chain_name,
+        deficits=deficits,
+        total_deficit_usd=str(report.total_deficit_usd),
+        alert_triggered=report.alert_triggered,
+        error=report.error,
     )

--- a/backend/app/aave/router.py
+++ b/backend/app/aave/router.py
@@ -256,6 +256,12 @@ def get_stress_test(
 
     result = _get_stress_test(wallet)
 
+    from .liquidation_sentinel import _mask_address  # noqa: PLC0415
+
+    # SECURITY: ウォレットアドレスを先頭6文字+末尾4文字にマスクしてからレスポンスに含める。
+    # 生の wallet_address を API レスポンスで露出させない（docs/13_security_design.md Rule 8）。
+    masked_wallet = _mask_address(result.wallet_address)
+
     scenarios = [
         StressTestScenarioResponse(
             price_drop_pct=str(sc.price_drop_pct),
@@ -268,7 +274,7 @@ def get_stress_test(
     ]
 
     return StressTestResponse(
-        wallet_address=result.wallet_address,
+        wallet_address=masked_wallet,
         current_hf=str(result.current_hf) if result.current_hf is not None else None,
         current_collateral_usd=(
             str(result.current_collateral_usd)

--- a/backend/app/aave/schemas.py
+++ b/backend/app/aave/schemas.py
@@ -271,3 +271,60 @@ class AaveMonitorStatus(BaseModel):
     @classmethod
     def _serialize_hf(cls, v: Optional[Decimal]) -> Optional[str]:
         return str(v) if v is not None else None
+
+
+# ===== LiquidationSentinel: ストレステスト + プール赤字ヘルス =====
+
+
+class StressTestScenarioResponse(BaseModel):
+    """ストレステストの各シナリオ（価格ドロップ率）に対するレスポンス。"""
+
+    price_drop_pct: str = Field(description="価格下落率（文字列 Decimal 例: '0.10' = 10%）")
+    simulated_hf: Optional[str] = Field(
+        None, description="シミュレーション後の Health Factor。計算不能時は null。"
+    )
+    collateral_after_usd: Optional[str] = Field(
+        None, description="価格下落後の担保 USD 評価額（Decimal 文字列）。"
+    )
+
+
+class StressTestResponse(BaseModel):
+    """GET /api/aave/stress-test のレスポンス。"""
+
+    wallet_address: str = Field(description="対象ウォレットアドレス。")
+    current_hf: Optional[str] = Field(None, description="現在の Health Factor（Decimal 文字列）。")
+    current_collateral_usd: Optional[str] = Field(
+        None, description="現在の担保 USD 評価額（Decimal 文字列）。"
+    )
+    current_debt_usd: Optional[str] = Field(
+        None, description="現在の総借入 USD（Decimal 文字列）。"
+    )
+    liquidation_threshold: Optional[str] = Field(
+        None, description="清算しきい値（Decimal 文字列、例: '0.75'）。"
+    )
+    scenarios: list[StressTestScenarioResponse] = Field(
+        default_factory=list,
+        description="価格下落シナリオ（-10%, -20%）ごとのシミュレーション結果。",
+    )
+    error: Optional[str] = Field(None, description="エラーが発生した場合のメッセージ。")
+
+
+class PoolDeficitInfoResponse(BaseModel):
+    """アセット単位のプール赤字情報レスポンス。"""
+
+    asset_symbol: str = Field(description="アセットシンボル（例: USDC, WETH）。")
+    deficit_usd: str = Field(description="赤字額（概算 USD、Decimal 文字列）。")
+    alert_triggered: bool = Field(description="閾値を超えてアラートが発火したか。")
+
+
+class PoolHealthResponse(BaseModel):
+    """GET /api/aave/pool-health のレスポンス。"""
+
+    chain_name: str = Field(description="対象チェーン名。")
+    deficits: list[PoolDeficitInfoResponse] = Field(
+        default_factory=list,
+        description="アセットごとの赤字情報。",
+    )
+    total_deficit_usd: str = Field(description="総赤字額（概算 USD、Decimal 文字列）。")
+    alert_triggered: bool = Field(description="いずれかのアセットでアラートが発火したか。")
+    error: Optional[str] = Field(None, description="エラーが発生した場合のメッセージ。")

--- a/backend/app/automation/scheduled_tasks.py
+++ b/backend/app/automation/scheduled_tasks.py
@@ -47,6 +47,10 @@ RSS_FETCH_INTERVAL_SECONDS = 1800  # 30 分
 # 複合リスク監視間隔（秒）
 COMPOUND_RISK_INTERVAL_SECONDS = 600  # 10 分
 
+# プール赤字監視間隔（秒）
+# ENABLE_POOL_HEALTH_MONITOR=1 設定時のみ有効（main.py lifespan 配線は human 承認 PR が必要）
+POOL_HEALTH_CHECK_INTERVAL_SECONDS = 3600  # 1 時間
+
 # DCA 頻度→秒数マッピング
 DCA_FREQUENCY_SECONDS = {
     "hourly": 3600,
@@ -1402,6 +1406,67 @@ async def compound_risk_monitor_loop(
             await asyncio.sleep(600)
 
 
+async def pool_health_check_loop(
+    *,
+    interval_seconds: int = POOL_HEALTH_CHECK_INTERVAL_SECONDS,
+    on_error: Optional[Callable[[Exception], None]] = None,
+) -> None:
+    """
+    Aave プール赤字（getReserveDeficit）を定期監視するバックグラウンドループ。
+
+    interval_seconds ごとに PoolHealthMonitor.check_pool_deficits() を呼び出し、
+    赤字が DEFICIT_ALERT_THRESHOLD ($10,000) を超えた場合は Slack アラートを発火する。
+
+    起動方法:
+        ScheduledTaskManager.start_pool_health_check() 経由で呼び出す。
+        直接呼び出しは禁止（二重起動防止のためマネージャ経由にすること）。
+
+    本番への配線（main.py lifespan）は ENABLE_POOL_HEALTH_MONITOR=1 設定後に
+    別途 human 承認 PR で追加すること。
+
+    現在の監視対象: USDC のみ。
+    WETH / wstETH は Aave Price Oracle 統合後に追加する（MAJOR #1 参照）。
+    """
+    logger.info("pool_health_check_loop started (interval=%ds)", interval_seconds)
+
+    while True:
+        try:
+            import os  # noqa: PLC0415
+
+            from app.aave.liquidation_sentinel import PoolHealthMonitor  # noqa: PLC0415
+
+            chain_name = os.getenv("AAVE_ACTIVE_CHAINS", "base").split(",")[0].strip()
+            monitor = PoolHealthMonitor()
+            report = monitor.check_pool_deficits(chain_name=chain_name)
+
+            if report.alert_triggered:
+                logger.warning(
+                    "pool_health_check_loop: アラート発火 chain=%s total_deficit=%s",
+                    chain_name,
+                    report.total_deficit_usd,
+                )
+            else:
+                logger.info(
+                    "pool_health_check_loop: チェック完了 chain=%s total_deficit=%s",
+                    chain_name,
+                    report.total_deficit_usd,
+                )
+
+        except asyncio.CancelledError:
+            logger.info("pool_health_check_loop cancelled")
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.error("pool_health_check_loop エラー: %s", exc, exc_info=True)
+
+            if on_error:
+                try:
+                    on_error(exc)
+                except Exception as callback_exc:
+                    logger.error("Error in on_error callback: %s", callback_exc)
+
+        await asyncio.sleep(interval_seconds)
+
+
 class ScheduledTaskManager:
     """
     スケジュールタスクのライフサイクル管理。
@@ -1428,6 +1493,11 @@ class ScheduledTaskManager:
         self._monthly_fee_batch_task: Optional[asyncio.Task[None]] = None
         self._monthly_line_report_task: Optional[asyncio.Task[None]] = None
         self._expiry_reminder_task: Optional[asyncio.Task[None]] = None
+        # プール赤字監視タスク（MAJOR #3: LiquidationSentinel）
+        # 起動は main.py への startup 配線で行う（別途 human 承認 PR が必要）。
+        # env フラグ ENABLE_POOL_HEALTH_MONITOR=1 でのみ有効化すること。
+        # 二重起動を防ぐために is_pool_health_check_running を確認してから start を呼ぶこと。
+        self._pool_health_check_task: Optional[asyncio.Task[None]] = None
 
     @property
     def is_daily_running(self) -> bool:
@@ -1505,6 +1575,11 @@ class ScheduledTaskManager:
     def is_expiry_reminder_running(self) -> bool:
         """期限切れリマインダータスクが動作中かどうか。"""
         return self._expiry_reminder_task is not None and not self._expiry_reminder_task.done()
+
+    @property
+    def is_pool_health_check_running(self) -> bool:
+        """プール赤字監視タスクが動作中かどうか。"""
+        return self._pool_health_check_task is not None and not self._pool_health_check_task.done()
 
     async def start_monthly_line_report(
         self,
@@ -2323,6 +2398,67 @@ class ScheduledTaskManager:
         self._expiry_reminder_task = None
         logger.info("Proposal expiry reminder task stopped")
 
+    async def start_pool_health_check(
+        self,
+        *,
+        interval_seconds: int = POOL_HEALTH_CHECK_INTERVAL_SECONDS,
+        on_error: Optional[Callable[[Exception], None]] = None,
+    ) -> None:
+        """
+        プール赤字監視タスクを開始する。
+
+        Aave Pool.getReserveDeficit() を定期実行し、赤字が $10,000 を超えた場合に
+        Slack アラートを発火する。
+
+        IMPORTANT: このメソッドは main.py の lifespan からは呼ばれない。
+        起動するには以下の手順が必要:
+          1. ENABLE_POOL_HEALTH_MONITOR=1 を .env に設定する
+          2. 別途 human 承認 PR で main.py/lifespan に以下を追加する:
+               import os
+               if os.getenv("ENABLE_POOL_HEALTH_MONITOR") == "1":
+                   await manager.start_pool_health_check()
+          3. 二重起動防止のために is_pool_health_check_running を確認してから呼ぶこと。
+
+        現在の監視対象: USDC のみ（WETH/wstETH は Price Oracle 統合後に追加予定）。
+        """
+        if self.is_pool_health_check_running:
+            logger.warning(
+                "Pool health check task already running — double-start prevented. "
+                "Check ENABLE_POOL_HEALTH_MONITOR env flag and lifespan wiring."
+            )
+            return
+
+        logger.info("Starting pool health check task (interval=%ds)", interval_seconds)
+        self._pool_health_check_task = asyncio.create_task(
+            pool_health_check_loop(
+                interval_seconds=interval_seconds,
+                on_error=on_error,
+            )
+        )
+        logger.info("Pool health check task started")
+
+    async def stop_pool_health_check(self, timeout: float = 5.0) -> None:
+        """プール赤字監視タスクを停止する。"""
+        if not self.is_pool_health_check_running:
+            logger.debug("Pool health check not running - nothing to stop")
+            return
+
+        logger.info("Stopping pool health check task")
+        assert self._pool_health_check_task is not None  # noqa: S101
+        self._pool_health_check_task.cancel()
+
+        try:
+            await asyncio.wait_for(self._pool_health_check_task, timeout=timeout)
+        except asyncio.CancelledError:
+            logger.info("Pool health check task cancelled successfully")
+        except asyncio.TimeoutError:
+            logger.warning("Pool health check task did not stop within %.1fs timeout", timeout)
+        except Exception as exc:
+            logger.error("Error while stopping pool health check task: %s", exc)
+
+        self._pool_health_check_task = None
+        logger.info("Pool health check task stopped")
+
     async def stop_all(self, timeout: float = 5.0) -> None:
         """
         全てのスケジュールタスクを停止する。
@@ -2348,6 +2484,7 @@ class ScheduledTaskManager:
             self.stop_monthly_fee_batch(timeout=timeout),
             self.stop_monthly_line_report(timeout=timeout),
             self.stop_expiry_reminder(timeout=timeout),
+            self.stop_pool_health_check(timeout=timeout),
             return_exceptions=True,
         )
 

--- a/backend/tests/aave/test_liquidation_sentinel.py
+++ b/backend/tests/aave/test_liquidation_sentinel.py
@@ -1,0 +1,348 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/aave/test_liquidation_sentinel.py
+"""
+LiquidationSentinel のユニットテスト。
+
+全外部呼び出し（RPC / Slack）はモック。金融計算は Decimal 精度で検証。
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from app.aave.liquidation_sentinel import (
+    DEFICIT_ALERT_THRESHOLD,
+    PoolHealthMonitor,
+    PoolHealthReport,
+    StressTestResult,
+    StressTestScenario,
+    _mask_address,
+    get_stress_test,
+    simulate_hf_at_price_drop,
+)
+
+# ---------------------------------------------------------------------------
+# simulate_hf_at_price_drop — ユニットテスト
+# ---------------------------------------------------------------------------
+
+
+class TestSimulateHfAtPriceDropBasic:
+    """simulate_hf_at_price_drop の基本計算テスト。"""
+
+    def test_10pct_drop_hf2(self) -> None:
+        """
+        Collateral=$10000, Debt=$4000, LT=0.80, -10%
+        HF = (10000 * 0.90 * 0.80) / 4000 = 7200 / 4000 = 1.80
+        """
+        result = simulate_hf_at_price_drop(
+            collateral_usd=Decimal("10000"),
+            debt_usd=Decimal("4000"),
+            liquidation_threshold=Decimal("0.80"),
+            price_drop_pct=Decimal("0.10"),
+        )
+        assert result is not None
+        expected = Decimal("7200") / Decimal("4000")  # 1.80
+        assert result == expected
+
+    def test_20pct_drop_hf2(self) -> None:
+        """
+        Collateral=$10000, Debt=$4000, LT=0.80, -20%
+        HF = (10000 * 0.80 * 0.80) / 4000 = 6400 / 4000 = 1.60
+        """
+        result = simulate_hf_at_price_drop(
+            collateral_usd=Decimal("10000"),
+            debt_usd=Decimal("4000"),
+            liquidation_threshold=Decimal("0.80"),
+            price_drop_pct=Decimal("0.20"),
+        )
+        assert result is not None
+        expected = Decimal("6400") / Decimal("4000")  # 1.60
+        assert result == expected
+
+    def test_hf_at_hf2_no_debt(self) -> None:
+        """debt_usd=0 の場合は None を返す（清算リスクなし）。"""
+        result = simulate_hf_at_price_drop(
+            collateral_usd=Decimal("10000"),
+            debt_usd=Decimal("0"),
+            liquidation_threshold=Decimal("0.80"),
+            price_drop_pct=Decimal("0.10"),
+        )
+        assert result is None
+
+    def test_decimal_precision_not_float(self) -> None:
+        """結果は Decimal 型であること（float 混入禁止）。"""
+        result = simulate_hf_at_price_drop(
+            collateral_usd=Decimal("10000"),
+            debt_usd=Decimal("3333"),
+            liquidation_threshold=Decimal("0.80"),
+            price_drop_pct=Decimal("0.10"),
+        )
+        assert result is not None
+        assert isinstance(result, Decimal)
+
+
+class TestSimulateHfAtPriceDropEdge:
+    """境界値テスト。"""
+
+    def test_hf_equals_2_0_initial(self) -> None:
+        """
+        HF=2.0、Collateral=$10000、LT=0.80 のとき debt を逆算して検証。
+        HF = 2.0 = (10000 * 0.80) / debt → debt = 4000
+        -10% 時: HF = (10000 * 0.90 * 0.80) / 4000 = 1.80
+        """
+        collateral = Decimal("10000")
+        # HF = (collateral * LT) / debt = 2.0 → debt = (10000 * 0.80) / 2.0 = 4000
+        lt = Decimal("0.80")
+        debt = collateral * lt / Decimal("2.0")
+        assert debt == Decimal("4000.0")
+
+        result_10 = simulate_hf_at_price_drop(
+            collateral_usd=collateral,
+            debt_usd=debt,
+            liquidation_threshold=lt,
+            price_drop_pct=Decimal("0.10"),
+        )
+        assert result_10 == Decimal("1.8")
+
+        result_20 = simulate_hf_at_price_drop(
+            collateral_usd=collateral,
+            debt_usd=debt,
+            liquidation_threshold=lt,
+            price_drop_pct=Decimal("0.20"),
+        )
+        assert result_20 == Decimal("1.6")
+
+    def test_liquidation_risk_under_1(self) -> None:
+        """
+        -20% で HF < 1.0 になるケース（清算域）。
+        Collateral=$5000, Debt=$4000, LT=0.80
+        HF_now = (5000 * 0.80) / 4000 = 1.00
+        -20%: HF = (5000 * 0.80 * 0.80) / 4000 = 0.80 (清算リスク)
+        """
+        result = simulate_hf_at_price_drop(
+            collateral_usd=Decimal("5000"),
+            debt_usd=Decimal("4000"),
+            liquidation_threshold=Decimal("0.80"),
+            price_drop_pct=Decimal("0.20"),
+        )
+        assert result is not None
+        assert result < Decimal("1.0")
+
+
+# ---------------------------------------------------------------------------
+# get_stress_test — モックテスト
+# ---------------------------------------------------------------------------
+
+
+class TestGetStressTest:
+    """get_stress_test のモックテスト（外部 RPC 呼び出しなし）。"""
+
+    def test_dummy_mode_returns_result(self) -> None:
+        """AAVE_CLIENT_TYPE=dummy の場合、DummyAaveClient のデータでシミュレーション。"""
+        with patch.dict("os.environ", {"AAVE_CLIENT_TYPE": "dummy"}):
+            result = get_stress_test("0xDEADBEEF1234567890abcdef1234567890abcdef")
+        assert isinstance(result, StressTestResult)
+        assert result.error is None
+        # DummyAaveClient は collateral=10000, debt=3000, hf=2.5 を返す
+        assert result.current_collateral_usd == Decimal("10000")
+        assert result.current_debt_usd == Decimal("3000")
+        # 2 シナリオ（-10%, -20%）があること
+        assert len(result.scenarios) == 2
+        # 各シナリオの simulated_hf は Decimal 型
+        for sc in result.scenarios:
+            assert isinstance(sc, StressTestScenario)
+            assert sc.simulated_hf is None or isinstance(sc.simulated_hf, Decimal)
+
+    def test_dummy_mode_10pct_scenario(self) -> None:
+        """
+        DummyAaveClient: collateral=10000, debt=3000, LT=0.80
+        -10%: HF = (10000 * 0.90 * 0.80) / 3000 = 7200/3000 = 2.40
+        """
+        with patch.dict("os.environ", {"AAVE_CLIENT_TYPE": "dummy"}):
+            result = get_stress_test("0xDEADBEEF1234567890abcdef1234567890abcdef")
+        assert result.scenarios[0].price_drop_pct == Decimal("0.10")
+        expected_hf = Decimal("7200") / Decimal("3000")
+        assert result.scenarios[0].simulated_hf == expected_hf
+
+    def test_dummy_mode_20pct_scenario(self) -> None:
+        """
+        DummyAaveClient: collateral=10000, debt=3000, LT=0.80
+        -20%: HF = (10000 * 0.80 * 0.80) / 3000 = 6400/3000
+        """
+        with patch.dict("os.environ", {"AAVE_CLIENT_TYPE": "dummy"}):
+            result = get_stress_test("0xDEADBEEF1234567890abcdef1234567890abcdef")
+        assert result.scenarios[1].price_drop_pct == Decimal("0.20")
+        expected_hf = Decimal("6400") / Decimal("3000")
+        assert result.scenarios[1].simulated_hf == expected_hf
+
+    def test_web3_mode_missing_rpc_falls_back_to_dummy(self) -> None:
+        """web3 モードで RPC_URL 未設定の場合、dummy フォールバック。"""
+        with patch.dict(
+            "os.environ",
+            {"AAVE_CLIENT_TYPE": "web3", "AAVE_RPC_URL": "", "AAVE_POOL_ADDRESS": ""},
+        ):
+            result = get_stress_test("0xDEADBEEF1234567890abcdef1234567890abcdef")
+        # フォールバック後は dummy データが返る
+        assert result.error is None
+        assert result.current_collateral_usd is not None
+
+
+# ---------------------------------------------------------------------------
+# PoolHealthMonitor — モックテスト
+# ---------------------------------------------------------------------------
+
+
+class TestPoolHealthMonitorDummyMode:
+    """DUMMY モードでは空レポートが返ること。"""
+
+    def test_dummy_mode_returns_empty_report(self) -> None:
+        with patch.dict("os.environ", {"AAVE_CLIENT_TYPE": "dummy"}):
+            monitor = PoolHealthMonitor()
+            report = monitor.check_pool_deficits("base")
+        assert isinstance(report, PoolHealthReport)
+        assert report.deficits == []
+        assert report.alert_triggered is False
+        assert report.error is None
+
+
+class TestPoolHealthMonitorDeficitAlert:
+    """deficit 閾値アラートのテスト。"""
+
+    def _make_monitor_with_mock_fetch(
+        self, deficit_value: Decimal
+    ) -> tuple[PoolHealthMonitor, Any]:
+        """deficit_value を返すモック付き PoolHealthMonitor を生成するヘルパー。"""
+        monitor = PoolHealthMonitor()
+        mock_fetch = MagicMock(return_value=deficit_value)
+        return monitor, mock_fetch
+
+    def test_deficit_below_threshold_no_alert(self) -> None:
+        """deficit $9999 → アラートなし。"""
+        monitor = PoolHealthMonitor()
+
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "AAVE_CLIENT_TYPE": "web3",
+                    "AAVE_RPC_URL": "http://fake-rpc",
+                    "AAVE_POOL_ADDRESS": "0xFakePool",
+                },
+            ),
+            patch.object(monitor, "_fetch_reserve_deficit", return_value=Decimal("9999")),
+            patch.object(monitor, "_send_deficit_alert") as mock_alert,
+        ):
+            # tokens に USDC のみ使用（base chain には USDC が存在）
+            monitor._tokens = ["USDC"]
+            report = monitor.check_pool_deficits("base")
+
+        assert report.alert_triggered is False
+        mock_alert.assert_not_called()
+        assert len(report.deficits) == 1
+        assert report.deficits[0].alert_triggered is False
+        assert report.deficits[0].deficit_usd == Decimal("9999")
+
+    def test_deficit_above_threshold_triggers_alert(self) -> None:
+        """deficit $10001 → Slack アラート発火。"""
+        monitor = PoolHealthMonitor()
+
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "AAVE_CLIENT_TYPE": "web3",
+                    "AAVE_RPC_URL": "http://fake-rpc",
+                    "AAVE_POOL_ADDRESS": "0xFakePool",
+                },
+            ),
+            patch.object(monitor, "_fetch_reserve_deficit", return_value=Decimal("10001")),
+            patch.object(monitor, "_send_deficit_alert") as mock_alert,
+        ):
+            monitor._tokens = ["USDC"]
+            report = monitor.check_pool_deficits("base")
+
+        assert report.alert_triggered is True
+        mock_alert.assert_called_once_with("base", "USDC", Decimal("10001"))
+        assert len(report.deficits) == 1
+        assert report.deficits[0].alert_triggered is True
+
+    def test_deficit_exactly_at_threshold_no_alert(self) -> None:
+        """deficit = $10000 (閾値ちょうど) → アラートなし（threshold は「超える」ときのみ）。"""
+        monitor = PoolHealthMonitor()
+
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "AAVE_CLIENT_TYPE": "web3",
+                    "AAVE_RPC_URL": "http://fake-rpc",
+                    "AAVE_POOL_ADDRESS": "0xFakePool",
+                },
+            ),
+            patch.object(monitor, "_fetch_reserve_deficit", return_value=Decimal("10000")),
+            patch.object(monitor, "_send_deficit_alert") as mock_alert,
+        ):
+            monitor._tokens = ["USDC"]
+            report = monitor.check_pool_deficits("base")
+
+        assert report.alert_triggered is False
+        mock_alert.assert_not_called()
+
+
+class TestPoolHealthMonitorSendAlert:
+    """_send_deficit_alert の Slack 送信テスト。"""
+
+    def test_send_alert_calls_slack_sender(self) -> None:
+        """SLACK_WEBHOOK_URL が設定されている場合、SlackNotificationSender.send が呼ばれる。"""
+        monitor = PoolHealthMonitor()
+
+        with (
+            patch.dict("os.environ", {"SLACK_WEBHOOK_URL": "https://hooks.slack.com/test"}),
+            patch("app.notifications.slack_sender.SlackNotificationSender.send") as mock_send,
+        ):
+            monitor._send_deficit_alert("base", "USDC", Decimal("15000"))
+
+        mock_send.assert_called_once()
+
+    def test_send_alert_no_webhook_no_error(self) -> None:
+        """SLACK_WEBHOOK_URL 未設定でも例外を投げない（fail-open）。"""
+        monitor = PoolHealthMonitor()
+
+        with patch.dict("os.environ", {}, clear=True):
+            # 例外なしで完了すること
+            monitor._send_deficit_alert("base", "USDC", Decimal("15000"))
+
+
+# ---------------------------------------------------------------------------
+# ユーティリティ
+# ---------------------------------------------------------------------------
+
+
+class TestMaskAddress:
+    def test_mask_normal_address(self) -> None:
+        addr = "0x1234567890abcdef1234567890abcdef12345678"
+        result = _mask_address(addr)
+        assert result == "0x1234...5678"
+
+    def test_mask_short_address(self) -> None:
+        result = _mask_address("0x1")
+        assert result == "****"
+
+    def test_mask_empty(self) -> None:
+        result = _mask_address("")
+        assert result == "****"
+
+
+# ---------------------------------------------------------------------------
+# DEFICIT_ALERT_THRESHOLD 定数確認
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_threshold_is_decimal(self) -> None:
+        """DEFICIT_ALERT_THRESHOLD は Decimal 型であること（float 禁止）。"""
+        assert isinstance(DEFICIT_ALERT_THRESHOLD, Decimal)
+        assert DEFICIT_ALERT_THRESHOLD == Decimal("10000")

--- a/backend/tests/aave/test_liquidation_sentinel.py
+++ b/backend/tests/aave/test_liquidation_sentinel.py
@@ -13,6 +13,8 @@ from decimal import Decimal
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from app.aave.liquidation_sentinel import (
     DEFICIT_ALERT_THRESHOLD,
     PoolHealthMonitor,
@@ -82,6 +84,64 @@ class TestSimulateHfAtPriceDropBasic:
         )
         assert result is not None
         assert isinstance(result, Decimal)
+
+
+class TestSimulateHfAtPriceDropGuard:
+    """price_drop_pct の入力ガードテスト（MINOR #5）。"""
+
+    def test_pct_equal_to_1_raises_value_error(self) -> None:
+        """pct=1.0 は「価格がゼロ」を意味し、範囲外なので ValueError を投げること。"""
+        with pytest.raises(ValueError, match="price_drop_pct"):
+            simulate_hf_at_price_drop(
+                collateral_usd=Decimal("10000"),
+                debt_usd=Decimal("4000"),
+                liquidation_threshold=Decimal("0.80"),
+                price_drop_pct=Decimal("1.0"),
+            )
+
+    def test_pct_greater_than_1_raises_value_error(self) -> None:
+        """pct > 1 は範囲外なので ValueError を投げること。"""
+        with pytest.raises(ValueError, match="price_drop_pct"):
+            simulate_hf_at_price_drop(
+                collateral_usd=Decimal("10000"),
+                debt_usd=Decimal("4000"),
+                liquidation_threshold=Decimal("0.80"),
+                price_drop_pct=Decimal("1.5"),
+            )
+
+    def test_pct_negative_raises_value_error(self) -> None:
+        """pct < 0 は範囲外なので ValueError を投げること。"""
+        with pytest.raises(ValueError, match="price_drop_pct"):
+            simulate_hf_at_price_drop(
+                collateral_usd=Decimal("10000"),
+                debt_usd=Decimal("4000"),
+                liquidation_threshold=Decimal("0.80"),
+                price_drop_pct=Decimal("-0.01"),
+            )
+
+    def test_pct_zero_is_valid(self) -> None:
+        """pct=0.0 は 「価格変化なし」であり有効（ValueError を投げない）。"""
+        result = simulate_hf_at_price_drop(
+            collateral_usd=Decimal("10000"),
+            debt_usd=Decimal("4000"),
+            liquidation_threshold=Decimal("0.80"),
+            price_drop_pct=Decimal("0.0"),
+        )
+        # HF = (10000 * 1.0 * 0.80) / 4000 = 2.0
+        assert result is not None
+        assert result == Decimal("2.0")
+
+    def test_pct_upper_boundary_just_below_1(self) -> None:
+        """pct=0.99 は有効（上限境界の 1 未満）。"""
+        result = simulate_hf_at_price_drop(
+            collateral_usd=Decimal("10000"),
+            debt_usd=Decimal("4000"),
+            liquidation_threshold=Decimal("0.80"),
+            price_drop_pct=Decimal("0.99"),
+        )
+        # HF = (10000 * 0.01 * 0.80) / 4000 = 80 / 4000 = 0.02
+        assert result is not None
+        assert result == Decimal("80") / Decimal("4000")
 
 
 class TestSimulateHfAtPriceDropEdge:
@@ -346,3 +406,48 @@ class TestConstants:
         """DEFICIT_ALERT_THRESHOLD は Decimal 型であること（float 禁止）。"""
         assert isinstance(DEFICIT_ALERT_THRESHOLD, Decimal)
         assert DEFICIT_ALERT_THRESHOLD == Decimal("10000")
+
+
+# ---------------------------------------------------------------------------
+# liquidation_threshold の取得テスト（MAJOR #4: DummyAaveClient 経由）
+# ---------------------------------------------------------------------------
+
+
+class TestLiquidationThresholdFromAccount:
+    """AccountData.liquidation_threshold が実際の HF 計算に使われることを検証。"""
+
+    def test_dummy_mode_uses_account_lt_from_client(self) -> None:
+        """
+        DummyAaveClient.get_account_data() は liquidation_threshold=0.80 を返す。
+        get_stress_test() でその値が -10% シナリオの HF 計算に使用されること。
+        collateral=10000, debt=3000, LT=0.80
+        -10%: HF = (10000 * 0.90 * 0.80) / 3000 = 7200 / 3000 = 2.40
+        """
+        with patch.dict("os.environ", {"AAVE_CLIENT_TYPE": "dummy"}):
+            result = get_stress_test("0xDEADBEEF1234567890abcdef1234567890abcdef")
+
+        assert result.liquidation_threshold == Decimal("0.80")
+        # -10% シナリオ
+        sc_10 = result.scenarios[0]
+        expected_hf_10 = Decimal("7200") / Decimal("3000")
+        assert sc_10.simulated_hf == expected_hf_10, (
+            f"Expected HF={expected_hf_10} for -10% drop with LT=0.80, got {sc_10.simulated_hf}"
+        )
+
+    def test_dummy_mode_lt_is_decimal_not_float(self) -> None:
+        """liquidation_threshold は Decimal 型であること（float 禁止）。"""
+        with patch.dict("os.environ", {"AAVE_CLIENT_TYPE": "dummy"}):
+            result = get_stress_test("0xDEADBEEF1234567890abcdef1234567890abcdef")
+
+        assert isinstance(result.liquidation_threshold, Decimal)
+
+    def test_default_deficit_tokens_is_usdc_only(self) -> None:
+        """
+        DEFAULT_DEFICIT_TOKENS は USDC のみであることを確認（MAJOR #1）。
+        WETH / wstETH は Price Oracle 統合後に追加する方針。
+        """
+        from app.aave.liquidation_sentinel import DEFAULT_DEFICIT_TOKENS
+
+        assert DEFAULT_DEFICIT_TOKENS == ["USDC"], (
+            "WETH/wstETH は Aave Price Oracle 統合後に追加する。今は USDC のみ。"
+        )

--- a/frontend/app/(admin)/protocols/page.tsx
+++ b/frontend/app/(admin)/protocols/page.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/lib/api/protocols'
 import PendlePositionCard from '@/components/pendle/PendlePositionCard'
 import OracleStatusPanel from '@/components/admin/OracleStatusPanel'
+import PoolHealthPanel from '@/components/admin/PoolHealthPanel'
 
 // ── Static protocol metadata (表示順 / 表示名 / フェーズ) ──────────────────
 // risk_level / tvl_usd / is_operational / alerts は API から取得する。
@@ -380,6 +381,14 @@ export default function ProtocolsPage() {
 
         {/* Oracle 多重検証ステータスパネル（rsETH/srsETH 再発防止） */}
         <OracleStatusPanel />
+
+        {/* Aave プール赤字監視（LiquidationSentinel） */}
+        <div style={{ marginTop: 24 }}>
+          <h2 style={{ margin: '0 0 12px', fontSize: 16, fontWeight: 600 }}>
+            {t('poolHealthTitle')}
+          </h2>
+          <PoolHealthPanel />
+        </div>
       </div>
     </AuthGuard>
   )

--- a/frontend/components/admin/PoolHealthPanel.tsx
+++ b/frontend/components/admin/PoolHealthPanel.tsx
@@ -1,0 +1,127 @@
+'use client'
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+// frontend/components/admin/PoolHealthPanel.tsx
+/**
+ * Aave プール赤字監視パネル。
+ * GET /api/aave/pool-health の結果を表示する。
+ * ダミーデータ禁止 — データ未取得時は「データなし」表示。
+ */
+
+import { useEffect, useState, useCallback } from 'react'
+import { useTranslations } from 'next-intl'
+import { getPoolHealth, type PoolHealthResult } from '@/lib/api/aave'
+
+export default function PoolHealthPanel() {
+  const t = useTranslations('PoolHealthPanel')
+  const [data, setData] = useState<PoolHealthResult | null>(null)
+  const [loadError, setLoadError] = useState(false)
+  const [loading, setLoading] = useState(true)
+
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    try {
+      const result = await getPoolHealth()
+      setData(result)
+      setLoadError(false)
+    } catch {
+      setData(null)
+      setLoadError(true)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchData()
+    const interval = setInterval(fetchData, 60_000)
+    return () => clearInterval(interval)
+  }, [fetchData])
+
+  const noData = t('noData')
+
+  function formatDeficit(deficitUsd: string): string {
+    const n = Number(deficitUsd)
+    if (!Number.isFinite(n)) return noData
+    if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`
+    if (n >= 1_000) return `$${(n / 1_000).toFixed(2)}K`
+    return `$${n.toFixed(2)}`
+  }
+
+  return (
+    <div className="rounded-xl border border-zinc-700/40 bg-zinc-800/20 p-5">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-base font-semibold text-zinc-100">{t('title')}</h2>
+        {data?.alert_triggered && (
+          <span className="inline-flex items-center rounded-full border border-red-500/30 bg-red-500/20 px-2 py-0.5 text-xs font-semibold text-red-400">
+            {t('alertActive')}
+          </span>
+        )}
+      </div>
+
+      {loading && (
+        <p className="text-sm text-zinc-500">{t('loading')}</p>
+      )}
+
+      {!loading && loadError && (
+        <div className="rounded-lg bg-red-500/10 border border-red-500/20 px-3 py-2 text-sm text-red-400">
+          {t('loadError')}
+        </div>
+      )}
+
+      {!loading && data?.error && (
+        <div className="rounded-lg bg-amber-500/10 border border-amber-500/20 px-3 py-2 text-sm text-amber-300 mb-3">
+          {data.error}
+        </div>
+      )}
+
+      {!loading && !loadError && data && (
+        <>
+          <div className="flex items-center justify-between py-2 border-b border-zinc-800">
+            <span className="text-sm text-zinc-500">{t('chain')}</span>
+            <span className="text-sm font-medium text-zinc-200">{data.chain_name}</span>
+          </div>
+          <div className="flex items-center justify-between py-2 border-b border-zinc-800">
+            <span className="text-sm text-zinc-500">{t('totalDeficit')}</span>
+            <span className={`text-sm font-medium ${data.alert_triggered ? 'text-red-400' : 'text-zinc-200'}`}>
+              {formatDeficit(data.total_deficit_usd)}
+            </span>
+          </div>
+
+          {data.deficits.length === 0 ? (
+            <p className="mt-3 text-sm text-zinc-600">{t('noDeficits')}</p>
+          ) : (
+            <div className="mt-3 space-y-2">
+              <p className="text-xs font-medium text-zinc-500 mb-1">{t('assetBreakdown')}</p>
+              {data.deficits.map((d) => (
+                <div
+                  key={d.asset_symbol}
+                  className={`flex items-center justify-between px-3 py-2 rounded-lg border ${
+                    d.alert_triggered
+                      ? 'border-red-500/30 bg-red-500/10'
+                      : 'border-zinc-700/30 bg-zinc-800/30'
+                  }`}
+                >
+                  <span className="text-sm font-medium text-zinc-300">{d.asset_symbol}</span>
+                  <div className="flex items-center gap-2">
+                    <span className={`text-sm ${d.alert_triggered ? 'text-red-400' : 'text-zinc-300'}`}>
+                      {formatDeficit(d.deficit_usd)}
+                    </span>
+                    {d.alert_triggered && (
+                      <span className="text-xs text-red-400">{t('alert')}</span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+          <p className="mt-3 text-[11px] text-zinc-600">{t('autoRefresh')}</p>
+        </>
+      )}
+
+      {!loading && !loadError && !data && (
+        <p className="text-sm text-zinc-600">{noData}</p>
+      )}
+    </div>
+  )
+}

--- a/frontend/lib/api/aave.ts
+++ b/frontend/lib/api/aave.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+// frontend/lib/api/aave.ts
+/**
+ * Aave 関連 API クライアント
+ * - getStressTest(): GET /api/aave/stress-test
+ * - getPoolHealth(): GET /api/aave/pool-health
+ */
+
+import { getJson } from "./http";
+
+// ---------------------------------------------------------------------------
+// ストレステスト
+// ---------------------------------------------------------------------------
+
+export interface StressTestScenario {
+  price_drop_pct: string; // Decimal 文字列 (例: "0.10")
+  simulated_hf: string | null; // シミュレーション後 HF（Decimal 文字列）
+  collateral_after_usd: string | null; // 担保 USD 評価額（Decimal 文字列）
+}
+
+export interface StressTestResult {
+  wallet_address: string;
+  current_hf: string | null; // Decimal 文字列
+  current_collateral_usd: string | null; // Decimal 文字列
+  current_debt_usd: string | null; // Decimal 文字列
+  liquidation_threshold: string | null; // Decimal 文字列 (例: "0.80")
+  scenarios: StressTestScenario[];
+  error: string | null;
+}
+
+export async function getStressTest(): Promise<StressTestResult> {
+  return getJson<StressTestResult>("/api/aave/stress-test");
+}
+
+// ---------------------------------------------------------------------------
+// プール赤字ヘルス
+// ---------------------------------------------------------------------------
+
+export interface PoolDeficitInfo {
+  asset_symbol: string; // 例: "USDC", "WETH"
+  deficit_usd: string; // Decimal 文字列
+  alert_triggered: boolean;
+}
+
+export interface PoolHealthResult {
+  chain_name: string;
+  deficits: PoolDeficitInfo[];
+  total_deficit_usd: string; // Decimal 文字列
+  alert_triggered: boolean;
+  error: string | null;
+}
+
+export async function getPoolHealth(): Promise<PoolHealthResult> {
+  return getJson<PoolHealthResult>("/api/aave/pool-health");
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2213,7 +2213,21 @@
     "oraclePyth": "Pyth",
     "oracleTwap": "TWAP (30 min)",
     "oracleCheckedAt": "Verified at",
-    "oracleDetail": "Details"
+    "oracleDetail": "Details",
+    "poolHealthTitle": "Aave Pool Deficit Monitor"
+  },
+  "PoolHealthPanel": {
+    "title": "Pool Deficit Monitor (getReserveDeficit)",
+    "alertActive": "Alert Active",
+    "chain": "Chain",
+    "totalDeficit": "Total Deficit (approx.)",
+    "noDeficits": "No deficits",
+    "assetBreakdown": "Asset Breakdown",
+    "alert": "Alert",
+    "loading": "Loading...",
+    "loadError": "Failed to load pool health data. Please reload.",
+    "noData": "No data",
+    "autoRefresh": "Auto-refreshes every 60 seconds"
   },
   "Register": {
     "title": "Account Registration - Ultra AutoTrade",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -2213,7 +2213,21 @@
     "oraclePyth": "Pyth",
     "oracleTwap": "TWAP (30分)",
     "oracleCheckedAt": "検証日時",
-    "oracleDetail": "詳細"
+    "oracleDetail": "詳細",
+    "poolHealthTitle": "Aave プール赤字監視"
+  },
+  "PoolHealthPanel": {
+    "title": "プール赤字監視（getReserveDeficit）",
+    "alertActive": "アラート発火中",
+    "chain": "チェーン",
+    "totalDeficit": "総赤字額（概算）",
+    "noDeficits": "赤字なし",
+    "assetBreakdown": "アセット別内訳",
+    "alert": "アラート",
+    "loading": "読み込み中...",
+    "loadError": "プール赤字情報の取得に失敗しました。再読み込みしてください。",
+    "noData": "データなし",
+    "autoRefresh": "60秒ごとに自動更新"
   },
   "Register": {
     "title": "アカウント登録 - Ultra AutoTrade",


### PR DESCRIPTION
## 概要

Aave V3 清算リスクの事前計算機能とプール赤字蓄積の早期検知機能を実装。

- 価格 -10%/-20% 時の Health Factor を Decimal 計算でシミュレーション
- `getReserveDeficit()` で USDC のプール赤字を監視（$10,000 超で Slack アラート）
- 既存 Slack 通知ユーティリティ（SlackNotificationSender）を再利用

## Evaluator CHANGES_REQUESTED 対応（commit d283c3e5）

### MAJOR #1 対応済み: DEFAULT_DEFICIT_TOKENS を ["USDC"] のみに限定
- WETH/wstETH は Price Oracle なしでは 1 token=1 USD と扱うことになり桁違いになる
- コードコメントで「Aave Price Oracle 統合後に追加」と明記

### MAJOR #2 対応済み: wallet_address を router 層でマスク
- `_mask_address()` を router の stress-test エンドポイントで適用
- API レスポンスに生アドレスを露出しない（Security Rule 8 準拠）

### MAJOR #3 対応済み: scheduled_tasks.py に pool_health_check_loop 追加
- `pool_health_check_loop()` 非同期ループ関数追加（1 時間間隔）
- `ScheduledTaskManager.start_pool_health_check()` / `stop_pool_health_check()` 追加
- `stop_all()` に `stop_pool_health_check` を追加
- **main.py への startup 配線は未実施（Tier S、人間承認後の別 PR が必要）**
- 有効化方法: `.env` に `ENABLE_POOL_HEALTH_MONITOR=1` を設定した上で、lifespan に以下を追加:
  ```python
  import os
  if os.getenv("ENABLE_POOL_HEALTH_MONITOR") == "1":
      await manager.start_pool_health_check()
  ```
  **注意: 二重起動防止のため `is_pool_health_check_running` を確認してから呼ぶこと**

### MAJOR #4 対応済み: liquidation_threshold を getUserAccountData result[3] から取得
- `AccountData` に `liquidation_threshold: Optional[Decimal] = None` を追加
- `Web3AaveClient.get_account_data()`: `result[3]` (BPS) / 10000 で取得、`lt_raw=0` のみ 0.75 fallback
- `DummyAaveClient.get_account_data()`: `liquidation_threshold=Decimal("0.80")` を返す
- `get_stress_test()`: `account.liquidation_threshold or Decimal("0.75")` で優先使用

### MINOR #5 対応済み: price_drop_pct に 0 <= pct < 1 ガード追加
- 範囲外（pct=1.0 含む）は `ValueError` を raise
- 境界テスト追加: pct=1.0, pct>1, pct<0, pct=0.0, pct=0.99（5 ケース）

### MINOR #6 対応済み: chains.py から孤立コード削除
- `liquidation_data_provider_address` フィールドと `get_liquidation_data_provider_address()` を削除

## 変更ファイル

- `backend/app/aave/liquidation_sentinel.py` (新規 + MAJOR #1/4/5 修正)
- `backend/app/aave/client.py` (MAJOR #4: AccountData 拡張)
- `backend/app/aave/chains.py` (MINOR #6: 孤立コード削除)
- `backend/app/aave/schemas.py` (StressTestResponse / PoolHealthResponse)
- `backend/app/aave/router.py` (stress-test / pool-health エンドポイント + MAJOR #2 マスク)
- `backend/app/automation/scheduled_tasks.py` (Tier S — MAJOR #3: ループ関数追加のみ、main.py 配線なし)
- `backend/tests/aave/test_liquidation_sentinel.py` (28 テスト: MAJOR #1/4/5 対応分を追加)
- `frontend/lib/api/aave.ts` (新規)
- `frontend/components/admin/PoolHealthPanel.tsx` (新規)
- `frontend/app/(admin)/protocols/page.tsx` (PoolHealthPanel 組み込み)
- `frontend/messages/ja.json` / `en.json` (i18n キー追加)

## DoD 結果

- `ruff check`: PASS (0 errors)
- `ruff format --check`: PASS
- `mypy app/aave/ app/automation/scheduled_tasks.py`: PASS (31 files, no issues)
- `pytest tests/aave/test_liquidation_sentinel.py -v`: **28/28 PASSED**
- float 混入チェック: 0 件

## セキュリティ

- 金融計算はすべて `Decimal` のみ（float 禁止 — 検証済み）
- ウォレットアドレスは router 層で `_mask_address()` によりマスク（先頭6+末尾4文字）
- Slack 通知失敗は fail-open
- RPC 障害時も fail-open（空レポートを返す）

## 保留事項（人間承認後の別 PR が必要）

1. **pool_health_check_loop の main.py startup 配線**: `ENABLE_POOL_HEALTH_MONITOR=1` 設定後に別 PR で追加（Tier S、今回は意図的に未配線）
2. **WETH/wstETH の赤字監視**: Aave Price Oracle 統合後に `DEFAULT_DEFICIT_TOKENS` を拡張する予定

⚠️ HUMAN-REVIEW-REQUIRED: Aave/HealthFactor/Decimal 高リスク。マージは人間承認必須。

Closes asana GID 1215697594406576