### PR TITLE
feat(aave-v4): Ethereum Hub 統合の設計doc + read-only スタブ + pytest (scaffold)

### DIFF
--- a/backend/app/aave_v4/__init__.py
+++ b/backend/app/aave_v4/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/aave_v4/__init__.py
+"""
+Aave V4 Ethereum Hub 統合レイヤー (scaffold) — docs/55_aave_v4_ethereum_hub_integration.md
+
+Status: DRAFT / Phase 0 scaffold のみ。
+- read-only スタブ実装済み (AaveV4ClientBase / DummyAaveV4Client)
+- tx 送信 / write 系メソッドは一切未実装（HUMAN-REVIEW 要承認後に Phase 3 で実装）
+- main.py への配線・依存追加は Phase 1 承認後
+- 既存 backend/app/aave/ (V3) は無改変
+"""
+
+from app.aave_v4.client import AaveV4ClientBase, DummyAaveV4Client
+from app.aave_v4.schemas import AaveV4HubConfig, V4AccountData
+
+__all__ = [
+    "AaveV4ClientBase",
+    "DummyAaveV4Client",
+    "AaveV4HubConfig",
+    "V4AccountData",
+]

--- a/backend/app/aave_v4/client.py
+++ b/backend/app/aave_v4/client.py
@@ -1,0 +1,248 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/aave_v4/client.py
+"""
+Aave V4 Ethereum Hub 統合レイヤー — read-only スタブ
+
+Phase 0 scaffold: シグネチャ定義のみ。tx 送信・write 系は定義しない。
+
+設計詳細: docs/55_aave_v4_ethereum_hub_integration.md
+親設計書: docs/54_aave_v4_migration_design.md
+
+HUMAN-REVIEW 要: 以下は本ファイルに含まない
+  - tx 送信 (supply / withdraw / approve)
+  - 秘密鍵・RPC 読み出し (実行時取得)
+  - main.py 配線 (Phase 4 で実施)
+  - 依存追加 (requirements.txt は Tier S / Phase 1 承認後)
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import abstractmethod
+from decimal import Decimal
+from typing import Optional
+
+from app.aave.client import AaveClientBase, AccountData
+from app.aave_v4.schemas import AaveV4HubConfig, V4AccountData
+
+logger = logging.getLogger(__name__)
+
+# --------------------------------------------------------------------------- #
+# 抽象基底クラス
+# --------------------------------------------------------------------------- #
+
+
+class AaveV4ClientBase(AaveClientBase):
+    """Aave V4 Ethereum Hub 統合クライアントの抽象基底クラス。
+
+    既存 V3 AaveClientBase を継承し、サービス層 (aave/service.py) が
+    型注釈 `AaveClientBase` のまま V4 実装に差し替え可能にする (OCP 準拠)。
+
+    read-only API (get_health_factor / get_account_data / get_pool_utilization) のみ
+    を定義する。V3 と同一シグネチャを維持することで、AAVE_PROTOCOL_VERSION=v4 に
+    切り替えた際にサービス層を無改変にする設計 (docs/55 §2 / docs/54 §3.1)。
+
+    tx 系メソッド (deposit / withdraw) は継承元 AaveClientBase の abstract として
+    残るため、具象実装クラスが Phase 3 (HUMAN-REVIEW 承認後) に実装する。
+    本 Phase 0 では具象実装を提供せず、DummyAaveV4Client のみをテスト用に提供する。
+    """
+
+    @abstractmethod
+    def get_health_factor(self, wallet_address: str) -> Decimal:
+        """ウォレットの Health Factor を取得する。
+
+        V4 Hub での HF 取得 API は 2026-06 時点で UNVERIFIED (docs/55 §1)。
+        確定後に具象クラスで実装する。
+
+        Args:
+            wallet_address: 対象ウォレットアドレス (EIP-55 チェックサム形式)。
+
+        Returns:
+            Decimal: Health Factor。ポジションなしの場合は Decimal("inf")。
+
+        Raises:
+            NotImplementedError: Phase 0 scaffold では具象実装なし。
+            AaveV4ClientError: RPC / Hub API 呼び出し失敗時 (Phase 2 以降)。
+        """
+
+    @abstractmethod
+    def get_account_data(self, wallet_address: str) -> AccountData:
+        """アカウントデータを取得する (V3 AccountData 型で返す)。
+
+        V4 Hub API 確定後は V4AccountData を AccountData にマッピングして返す。
+        サービス層が AccountData を期待するため戻り型は V3 と同一にする。
+
+        Args:
+            wallet_address: 対象ウォレットアドレス。
+
+        Returns:
+            AccountData: V3 互換のアカウントデータ。
+
+        Raises:
+            NotImplementedError: Phase 0 scaffold では具象実装なし。
+        """
+
+    def get_pool_utilization(self, asset_symbol: str) -> Optional[Decimal]:
+        """プール利用率 (0-100) を返す。
+
+        V4 Hub でのプール利用率取得 API は UNVERIFIED (docs/55 §1)。
+        Phase 2 以降に具象実装を追加するまで None を返す (fail-open)。
+
+        Args:
+            asset_symbol: 資産シンボル ("USDC", "WETH" 等)。
+
+        Returns:
+            Optional[Decimal]: 利用率 (0-100)、または None。
+        """
+        logger.debug(
+            "AaveV4ClientBase.get_pool_utilization: V4 Hub API 未確定のため None 返却 "
+            "(docs/55 §1 要確認項目)",
+        )
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# テスト / ローカル開発用ダミー実装
+# --------------------------------------------------------------------------- #
+
+
+class DummyAaveV4Client(AaveV4ClientBase):
+    """Aave V4 テスト・ローカル開発用ダミークライアント。
+
+    実際の RPC 接続は行わない。固定 Decimal 値を返す read-only 実装。
+    既存 DummyAaveClient (backend/app/aave/client.py L356-) に倣い、
+    V4 向けのテスト可能インターフェースを提供する。
+
+    tx 系メソッド (deposit / withdraw) は stub (NotImplementedError) として
+    実装することで AaveClientBase の abstract contract を満たす。
+    ただし本クラスは **read-only テスト専用** であり、実運用での tx 送信は行わない。
+
+    Note:
+        write 操作 / 秘密鍵取得 / RPC 接続は一切行わない。
+        本クラスへの tx 系呼び出しは必ず NotImplementedError を raise する。
+    """
+
+    def __init__(self, config: Optional[AaveV4HubConfig] = None) -> None:
+        """初期化。config は将来の Phase 2 実装用に受け付けるが、ダミーでは使用しない。"""
+        self._config = config or AaveV4HubConfig()
+
+    # ------------------------------------------------------------------ #
+    # read-only メソッド (テスト可能な固定値実装)
+    # ------------------------------------------------------------------ #
+
+    def get_health_factor(self, wallet_address: str = "") -> Decimal:
+        """固定 Health Factor (2.5) を返す。V4 read API 確定前のスタブ値。"""
+        logger.info("DummyAaveV4Client.get_health_factor called (no RPC, V4 scaffold)")
+        return Decimal("2.5")
+
+    def get_account_data(self, wallet_address: str = "") -> AccountData:
+        """固定 AccountData を返す。V3 AccountData と同形。"""
+        logger.info("DummyAaveV4Client.get_account_data called (no RPC, V4 scaffold)")
+        return AccountData(
+            total_collateral_usd=Decimal("10000"),
+            total_debt_usd=Decimal("3000"),
+            available_borrows_usd=Decimal("5000"),
+            health_factor=Decimal("2.5"),
+        )
+
+    def get_pool_utilization(self, asset_symbol: str = "") -> Optional[Decimal]:
+        """固定プール利用率 (75.0%) を返す。V4 API 確定前のスタブ値。"""
+        logger.info("DummyAaveV4Client.get_pool_utilization called (no RPC, V4 scaffold)")
+        return Decimal("75.0")
+
+    def get_v4_account_data(self, wallet_address: str = "") -> V4AccountData:
+        """V4AccountData スキーマで返す補助メソッド (テスト用)。"""
+        logger.info("DummyAaveV4Client.get_v4_account_data called (no RPC, V4 scaffold)")
+        return V4AccountData(
+            total_collateral_usd=Decimal("10000"),
+            total_debt_usd=Decimal("3000"),
+            available_borrows_usd=Decimal("5000"),
+            health_factor=Decimal("2.5"),
+        )
+
+    # ------------------------------------------------------------------ #
+    # tx 系 stub — AaveClientBase abstract を満たすが呼び出し禁止
+    # ------------------------------------------------------------------ #
+
+    def deposit(
+        self,
+        asset_address: str = "",
+        amount: Decimal = Decimal("0"),
+        wallet_address: str = "",
+        private_key: str = "",
+        dry_run: bool = False,
+    ) -> "dict[str, object] | str":
+        """V4 supply / deposit は Phase 3 (HUMAN-REVIEW 承認後) に実装。"""
+        raise NotImplementedError(
+            "V4 deposit は Ethereum Hub アドレス/SDK 確定後に実装 (docs/55 §5 Phase 3)"
+        )
+
+    def withdraw(
+        self,
+        asset_address: str = "",
+        amount: Decimal = Decimal("0"),
+        wallet_address: str = "",
+        private_key: str = "",
+        dry_run: bool = False,
+    ) -> "dict[str, object] | str":
+        """V4 withdraw は Phase 3 (HUMAN-REVIEW 承認後) に実装。"""
+        raise NotImplementedError(
+            "V4 withdraw は Ethereum Hub アドレス/SDK 確定後に実装 (docs/55 §5 Phase 3)"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# 本体スタブ (具象実装 — Phase 2 以降)
+# --------------------------------------------------------------------------- #
+
+
+class AaveV4EthereumHubClient(AaveV4ClientBase):
+    """Aave V4 Ethereum Hub との実通信クライアント (Phase 2 以降実装)。
+
+    Phase 0 scaffold: 全メソッドが NotImplementedError を raise する。
+    Phase 2 (HUMAN-REVIEW 承認後) に web3.py または @aave/client SDK 経由で実装する。
+    SDK / 言語選定は docs/55 §3 の三択比較表 + 人間承認による (HUMAN-REVIEW 必須)。
+
+    Note:
+        秘密鍵・RPC URL は実装時も env 経由のみ (CLAUDE.md Security Rule 1)。
+        コンストラクタでは env 読み出しを行わない (Phase 0 制約)。
+    """
+
+    def __init__(self, config: Optional[AaveV4HubConfig] = None) -> None:
+        """初期化。Phase 0 では config を受け取るのみで RPC 接続は行わない。"""
+        self._config = config or AaveV4HubConfig()
+
+    def get_health_factor(self, wallet_address: str) -> Decimal:
+        """V4 Hub での HF 取得。Phase 2 以降に実装予定。"""
+        raise NotImplementedError("V4 read API は Ethereum Hub アドレス/SDK 確定後に実装 (docs/55)")
+
+    def get_account_data(self, wallet_address: str) -> AccountData:
+        """V4 Hub でのアカウントデータ取得。Phase 2 以降に実装予定。"""
+        raise NotImplementedError("V4 read API は Ethereum Hub アドレス/SDK 確定後に実装 (docs/55)")
+
+    def deposit(
+        self,
+        asset_address: str = "",
+        amount: Decimal = Decimal("0"),
+        wallet_address: str = "",
+        private_key: str = "",
+        dry_run: bool = False,
+    ) -> "dict[str, object] | str":
+        """V4 supply / deposit は Phase 3 (HUMAN-REVIEW 承認後) に実装。"""
+        raise NotImplementedError(
+            "V4 deposit は Ethereum Hub アドレス/SDK 確定後に実装 (docs/55 §5 Phase 3)"
+        )
+
+    def withdraw(
+        self,
+        asset_address: str = "",
+        amount: Decimal = Decimal("0"),
+        wallet_address: str = "",
+        private_key: str = "",
+        dry_run: bool = False,
+    ) -> "dict[str, object] | str":
+        """V4 withdraw は Phase 3 (HUMAN-REVIEW 承認後) に実装。"""
+        raise NotImplementedError(
+            "V4 withdraw は Ethereum Hub アドレス/SDK 確定後に実装 (docs/55 §5 Phase 3)"
+        )

--- a/backend/app/aave_v4/schemas.py
+++ b/backend/app/aave_v4/schemas.py
@@ -1,0 +1,61 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/aave_v4/schemas.py
+"""
+Aave V4 Ethereum Hub 統合レイヤー — 型定義
+
+全金融値は Decimal 型 (CLAUDE.md Security Rule 11: float 禁止)。
+依存追加・tx 実行・main.py 配線は HUMAN-REVIEW 要承認 (docs/55 §4, §5)。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+
+@dataclass
+class AaveV4HubConfig:
+    """Aave V4 Ethereum Hub への接続設定。
+
+    hub_address と rpc_url はアドレス確定後 (Phase 1) に env 経由で供給する。
+    現時点 (Phase 0 scaffold) では空文字列をデフォルトとし、
+    実装クラスが NotImplementedError を raise することで未確定を明示する。
+
+    Attributes:
+        hub_address: Ethereum Hub コントラクトアドレス (EIP-55 チェックサム形式)。
+                     【要確認】Base 上の V4 Hub アドレスは 2026-06 時点で未公開。
+        rpc_url:     Ethereum / Base の RPC エンドポイント。env 経由で供給。
+        chain_id:    接続チェーンの chain ID。
+                     Ethereum Mainnet = 1、Base Mainnet = 8453。
+        timeout_sec: RPC 呼び出しタイムアウト (秒)。
+    """
+
+    hub_address: str = ""
+    rpc_url: str = ""
+    chain_id: int = 0
+    timeout_sec: int = 10
+
+
+@dataclass
+class V4AccountData:
+    """Aave V4 アカウントデータ。
+
+    既存 V3 の AccountData (backend/app/aave/client.py L235-241) と同形。
+    V4 Hub の API 確定後にフィールドを追加・変更する場合は
+    docs/55 §1「【要確認】項目」を先に更新すること。
+
+    全フィールドは Decimal 型 (CLAUDE.md Security Rule 11: float 禁止)。
+
+    Attributes:
+        total_collateral_usd:  総担保額 (USD 建て)。
+        total_debt_usd:        総負債額 (USD 建て)。
+        available_borrows_usd: 追加借入可能額 (USD 建て)。
+        health_factor:         ヘルスファクター。
+                               ポジションなし場合は Decimal("inf")。
+    """
+
+    total_collateral_usd: Decimal = field(default_factory=lambda: Decimal("0"))
+    total_debt_usd: Decimal = field(default_factory=lambda: Decimal("0"))
+    available_borrows_usd: Decimal = field(default_factory=lambda: Decimal("0"))
+    health_factor: Decimal = field(default_factory=lambda: Decimal("0"))

--- a/backend/tests/aave/test_aave_v4_client_stub.py
+++ b/backend/tests/aave/test_aave_v4_client_stub.py
@@ -1,0 +1,315 @@
+# backend/tests/aave/test_aave_v4_client_stub.py
+"""
+Aave V4 クライアント scaffold の単体テスト。
+
+検証項目:
+  (1) DummyAaveV4Client の read メソッドが期待 Decimal を返す
+  (2) 本体スタブ (AaveV4EthereumHubClient) が NotImplementedError を raise
+  (3) client に write/tx メソッド (deposit/withdraw/supply/approve) が
+      テスト外から安全に呼び出せない (NotImplementedError で保護されている) ことを確認
+  (4) schemas (AaveV4HubConfig / V4AccountData) のインスタンス化
+  (5) import app.aave_v4 が既存 V3 モジュールに副作用を与えない独立性
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.aave.client import AccountData
+from app.aave_v4.client import AaveV4EthereumHubClient, DummyAaveV4Client
+from app.aave_v4.schemas import AaveV4HubConfig, V4AccountData  # noqa: F401
+
+# --------------------------------------------------------------------------- #
+# (1) DummyAaveV4Client — read メソッドが期待 Decimal を返す
+# --------------------------------------------------------------------------- #
+
+
+class TestDummyAaveV4ClientReadMethods:
+    """DummyAaveV4Client の read-only メソッドが正しい Decimal を返すことを検証。"""
+
+    def setup_method(self) -> None:
+        self.client = DummyAaveV4Client()
+
+    def test_get_health_factor_returns_decimal(self) -> None:
+        """get_health_factor が Decimal("2.5") を返すこと。"""
+        result = self.client.get_health_factor()
+        assert isinstance(result, Decimal), f"期待 Decimal, 実際: {type(result)}"
+        assert result == Decimal("2.5")
+
+    def test_get_health_factor_with_wallet_address(self) -> None:
+        """wallet_address を渡しても同じ Decimal を返すこと。"""
+        result = self.client.get_health_factor("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF")
+        assert isinstance(result, Decimal)
+        assert result == Decimal("2.5")
+
+    def test_get_account_data_returns_account_data(self) -> None:
+        """get_account_data が V3 互換 AccountData を返すこと。"""
+        result = self.client.get_account_data()
+        assert isinstance(result, AccountData)
+
+    def test_get_account_data_fields_are_decimal(self) -> None:
+        """AccountData の全金融フィールドが Decimal 型であること (float 禁止 Rule 11)。"""
+        result = self.client.get_account_data()
+        assert isinstance(result.total_collateral_usd, Decimal)
+        assert isinstance(result.total_debt_usd, Decimal)
+        assert isinstance(result.available_borrows_usd, Decimal)
+        assert isinstance(result.health_factor, Decimal)
+
+    def test_get_account_data_expected_values(self) -> None:
+        """AccountData が期待固定値を持つこと。"""
+        result = self.client.get_account_data()
+        assert result.total_collateral_usd == Decimal("10000")
+        assert result.total_debt_usd == Decimal("3000")
+        assert result.available_borrows_usd == Decimal("5000")
+        assert result.health_factor == Decimal("2.5")
+
+    def test_get_pool_utilization_returns_decimal(self) -> None:
+        """get_pool_utilization が Decimal を返すこと。"""
+        result = self.client.get_pool_utilization("USDC")
+        assert isinstance(result, Decimal)
+        assert result == Decimal("75.0")
+
+    def test_get_pool_utilization_no_float(self) -> None:
+        """get_pool_utilization が float を返さないこと (Rule 11)。"""
+        result = self.client.get_pool_utilization("WETH")
+        assert not isinstance(result, float)
+
+    def test_get_v4_account_data_returns_v4_schema(self) -> None:
+        """get_v4_account_data が V4AccountData スキーマを返すこと。"""
+        result = self.client.get_v4_account_data()
+        assert isinstance(result, V4AccountData)
+        assert isinstance(result.health_factor, Decimal)
+        assert result.health_factor == Decimal("2.5")
+
+
+# --------------------------------------------------------------------------- #
+# (2) 本体スタブが NotImplementedError を raise
+# --------------------------------------------------------------------------- #
+
+
+class TestAaveV4EthereumHubClientStub:
+    """AaveV4EthereumHubClient が Phase 0 で NotImplementedError を raise することを検証。"""
+
+    def setup_method(self) -> None:
+        self.client = AaveV4EthereumHubClient()
+
+    def test_get_health_factor_raises_not_implemented(self) -> None:
+        """get_health_factor が NotImplementedError を raise すること。"""
+        with pytest.raises(NotImplementedError) as exc_info:
+            self.client.get_health_factor("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF")
+        assert "docs/55" in str(exc_info.value), "エラーメッセージに docs/55 への参照がないこと"
+
+    def test_get_account_data_raises_not_implemented(self) -> None:
+        """get_account_data が NotImplementedError を raise すること。"""
+        with pytest.raises(NotImplementedError) as exc_info:
+            self.client.get_account_data("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF")
+        assert "docs/55" in str(exc_info.value)
+
+    def test_get_pool_utilization_returns_none(self) -> None:
+        """get_pool_utilization は基底クラスの fail-open 実装 (None) を返すこと。"""
+        # AaveV4ClientBase の get_pool_utilization は具象実装あり (None 返却)
+        result = self.client.get_pool_utilization("USDC")
+        assert result is None
+
+    def test_deposit_raises_not_implemented(self) -> None:
+        """deposit が NotImplementedError を raise すること (Phase 3 以降実装)。"""
+        with pytest.raises(NotImplementedError) as exc_info:
+            self.client.deposit()
+        assert "Phase 3" in str(exc_info.value)
+
+    def test_withdraw_raises_not_implemented(self) -> None:
+        """withdraw が NotImplementedError を raise すること (Phase 3 以降実装)。"""
+        with pytest.raises(NotImplementedError) as exc_info:
+            self.client.withdraw()
+        assert "Phase 3" in str(exc_info.value)
+
+    def test_error_message_references_docs55(self) -> None:
+        """全 stub の NotImplementedError メッセージが docs/55 を参照すること。"""
+        for method_name, call in [
+            ("get_health_factor", lambda: self.client.get_health_factor("")),
+            ("get_account_data", lambda: self.client.get_account_data("")),
+            ("deposit", lambda: self.client.deposit()),
+            ("withdraw", lambda: self.client.withdraw()),
+        ]:
+            with pytest.raises(NotImplementedError) as exc_info:
+                call()
+            assert "docs/55" in str(exc_info.value), (
+                f"{method_name} の NotImplementedError に docs/55 参照がない"
+            )
+
+
+# --------------------------------------------------------------------------- #
+# (3) write/tx メソッドが存在しないか、存在しても保護されていることを確認
+# --------------------------------------------------------------------------- #
+
+
+class TestNoWriteMethodsOnDummy:
+    """DummyAaveV4Client に意図しない write API が露出していないことを検証。"""
+
+    def setup_method(self) -> None:
+        self.client = DummyAaveV4Client()
+
+    def test_approve_method_does_not_exist(self) -> None:
+        """approve メソッドが存在しないこと。"""
+        assert not hasattr(self.client, "approve"), (
+            "approve メソッドは Phase 0 に存在してはならない"
+        )
+
+    def test_supply_method_does_not_exist(self) -> None:
+        """supply メソッドが存在しないこと (deposit が AaveClientBase 由来名)。"""
+        assert not hasattr(self.client, "supply"), "supply メソッドは Phase 0 に存在してはならない"
+
+    def test_send_transaction_method_does_not_exist(self) -> None:
+        """send_transaction メソッドが存在しないこと。"""
+        assert not hasattr(self.client, "send_transaction"), (
+            "send_transaction は Phase 0 に存在してはならない"
+        )
+
+    def test_sign_transaction_method_does_not_exist(self) -> None:
+        """sign_transaction メソッドが存在しないこと。"""
+        assert not hasattr(self.client, "sign_transaction"), (
+            "sign_transaction は Phase 0 に存在してはならない"
+        )
+
+    def test_deposit_raises_not_implemented_on_dummy(self) -> None:
+        """DummyAaveV4Client.deposit は NotImplementedError を raise すること。"""
+        with pytest.raises(NotImplementedError):
+            self.client.deposit()
+
+    def test_withdraw_raises_not_implemented_on_dummy(self) -> None:
+        """DummyAaveV4Client.withdraw は NotImplementedError を raise すること。"""
+        with pytest.raises(NotImplementedError):
+            self.client.withdraw()
+
+
+class TestNoWriteMethodsOnStub:
+    """AaveV4EthereumHubClient に意図しない write API が露出していないことを検証。"""
+
+    def setup_method(self) -> None:
+        self.client = AaveV4EthereumHubClient()
+
+    def test_approve_method_does_not_exist(self) -> None:
+        """approve メソッドが存在しないこと。"""
+        assert not hasattr(self.client, "approve")
+
+    def test_supply_method_does_not_exist(self) -> None:
+        """supply メソッドが存在しないこと。"""
+        assert not hasattr(self.client, "supply")
+
+    def test_send_transaction_method_does_not_exist(self) -> None:
+        """send_transaction メソッドが存在しないこと。"""
+        assert not hasattr(self.client, "send_transaction")
+
+
+# --------------------------------------------------------------------------- #
+# (4) schemas のインスタンス化
+# --------------------------------------------------------------------------- #
+
+
+class TestSchemas:
+    """AaveV4HubConfig / V4AccountData が正しくインスタンス化できることを検証。"""
+
+    def test_aave_v4_hub_config_default(self) -> None:
+        """AaveV4HubConfig がデフォルト値でインスタンス化できること。"""
+        config = AaveV4HubConfig()
+        assert config.hub_address == ""
+        assert config.rpc_url == ""
+        assert config.chain_id == 0
+        assert config.timeout_sec == 10
+
+    def test_aave_v4_hub_config_custom(self) -> None:
+        """AaveV4HubConfig にカスタム値を設定できること。"""
+        config = AaveV4HubConfig(
+            hub_address="0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF",
+            rpc_url="https://rpc.example.com",
+            chain_id=8453,
+            timeout_sec=30,
+        )
+        assert config.chain_id == 8453
+        assert config.timeout_sec == 30
+
+    def test_v4_account_data_default(self) -> None:
+        """V4AccountData がデフォルト値でインスタンス化できること。"""
+        data = V4AccountData()
+        assert data.total_collateral_usd == Decimal("0")
+        assert data.health_factor == Decimal("0")
+
+    def test_v4_account_data_fields_are_decimal(self) -> None:
+        """V4AccountData の全金融フィールドが Decimal 型であること。"""
+        data = V4AccountData(
+            total_collateral_usd=Decimal("5000"),
+            total_debt_usd=Decimal("1000"),
+            available_borrows_usd=Decimal("2000"),
+            health_factor=Decimal("3.0"),
+        )
+        assert isinstance(data.total_collateral_usd, Decimal)
+        assert isinstance(data.total_debt_usd, Decimal)
+        assert isinstance(data.available_borrows_usd, Decimal)
+        assert isinstance(data.health_factor, Decimal)
+
+    def test_v4_account_data_no_float(self) -> None:
+        """V4AccountData のフィールドに float が入らないこと (Rule 11)。"""
+        data = V4AccountData(
+            total_collateral_usd=Decimal("5000"),
+            total_debt_usd=Decimal("1000"),
+            available_borrows_usd=Decimal("2000"),
+            health_factor=Decimal("3.0"),
+        )
+        for field_name in (
+            "total_collateral_usd",
+            "total_debt_usd",
+            "available_borrows_usd",
+            "health_factor",
+        ):
+            value = getattr(data, field_name)
+            assert not isinstance(value, float), f"{field_name} が float になっている"
+
+
+# --------------------------------------------------------------------------- #
+# (5) V3 モジュールへの副作用なし (独立性)
+# --------------------------------------------------------------------------- #
+
+
+class TestV3Independence:
+    """app.aave_v4 のインポートが既存 V3 モジュールに副作用を与えないことを検証。"""
+
+    def test_v3_module_import_unaffected(self) -> None:
+        """app.aave.client を import しても V3 AccountData が変わらないこと。"""
+        from app.aave.client import AccountData as V3AccountData
+        from app.aave.client import DummyAaveClient as V3DummyClient
+
+        v3_client = V3DummyClient()
+        result = v3_client.get_account_data("")
+        assert isinstance(result, V3AccountData)
+        assert isinstance(result.health_factor, Decimal)
+
+    def test_v4_dummy_does_not_affect_v3_dummy(self) -> None:
+        """DummyAaveV4Client と DummyAaveClient が独立したインスタンスであること。"""
+        from app.aave.client import DummyAaveClient
+
+        v3 = DummyAaveClient()
+        v4 = DummyAaveV4Client()
+
+        # 両方の read メソッドが独立して動作すること
+        assert v3.get_health_factor() == v4.get_health_factor()  # 同じ固定値
+        assert type(v3) is not type(v4)  # 異なるクラス
+
+    def test_aave_v4_module_exports(self) -> None:
+        """app.aave_v4 の __all__ に期待クラスが含まれること。"""
+        import app.aave_v4 as aave_v4_module
+
+        assert "AaveV4ClientBase" in aave_v4_module.__all__
+        assert "DummyAaveV4Client" in aave_v4_module.__all__
+        assert "AaveV4HubConfig" in aave_v4_module.__all__
+        assert "V4AccountData" in aave_v4_module.__all__
+
+    def test_v3_class_hierarchy_unaffected(self) -> None:
+        """V4 クラス追加後も V3 AaveClientBase のサブクラス関係が変わらないこと。"""
+        from app.aave.client import AaveClientBase, DummyAaveClient
+
+        assert issubclass(DummyAaveClient, AaveClientBase)
+        # V4 クラスも AaveClientBase を継承していることを確認
+        assert issubclass(DummyAaveV4Client, AaveClientBase)
+        assert issubclass(AaveV4EthereumHubClient, AaveClientBase)

--- a/docs/55_aave_v4_ethereum_hub_integration.md
+++ b/docs/55_aave_v4_ethereum_hub_integration.md
@@ -1,0 +1,217 @@
+# 55_aave_v4_ethereum_hub_integration.md
+# Aave V4 Ethereum Hub 統合レイヤー選定書 (EPIC-7 7-1b)
+
+作成日: 2026-06-15
+ブランチ: feat/aave-v4-ethereum-hub-scaffold
+親設計書: docs/54_aave_v4_migration_design.md (EPIC-7 7-1) — 本書は同書の差分のみを記述する
+
+> **親設計書との関係 (必読)**: docs/54 は全体移行設計 (env フラグ / chains.py 拡張 / ABI 差分 /
+> リスク一覧 / rollback) を定義する正本。本書 (docs/55) は **統合レイヤー選定 (A/B/C 三択) と
+> `backend/app/aave_v4/` scaffold の実装詳細** のみを扱う。docs/54 の記述と重複する場合は
+> 本書での再記述を避け、docs/54 を参照すること。
+
+> **Status: Phase 0 scaffold 実装済み / 統合レイヤー未確定 (HUMAN-REVIEW 待ち)**
+> `backend/app/aave_v4/` は新規モジュール（既存 `backend/app/aave/` V3 は無改変）。
+> 依存追加・tx 送信・main.py 配線は HUMAN-REVIEW 要承認 (§4, §5)。
+
+---
+
+## 0. Summary (本書スコープ)
+
+| 項目 | 内容 |
+|---|---|
+| 本書スコープ | `@aave/client` 等の統合レイヤー採用可否 + Ethereum Hub 統合層選定 |
+| 実装状態 | Phase 0 scaffold: read-only スタブのみ (`aave_v4/client.py` / `aave_v4/schemas.py`) |
+| 決定事項 | モジュール配置 = `backend/app/aave_v4/`、V3 との共存方針 (§6 参照) |
+| 未決定事項 | 統合レイヤー三択 (§3)、SDK 依存追加 (§4)、Hub アドレス確定後の実装 (§5 Phase 2-4) |
+| 親設計書 | docs/54 §3.1 (AAVE_PROTOCOL_VERSION フラグ) / §3.2 (chains.py V4 アドレス登録) / §4 (ABI 差分吸収) |
+
+docs/54 と本書の分担:
+
+```
+docs/54: 全体移行設計 (env フラグ / chains.py 拡張 / ABI 吸収 / rollback)
+  └─ docs/55 (本書): 統合レイヤー選定 + aave_v4/ scaffold 実装詳細
+```
+
+---
+
+## 1. 統合層の言語判定
+
+### 1.1 現状の backend 実装
+
+Ultra AutoTrade の backend は **Python 3.11 / FastAPI / web3.py** ベースで実装されている。
+既存 V3 クライアントの実パス: `backend/app/aave/client.py`
+
+重要な実装事実 (grep 済み実値):
+
+- `AaveClientBase(ABC)` — L244: `get_health_factor(wallet_address: str) -> Decimal`
+- `AaveClientBase(ABC)` — L303: `get_account_data(wallet_address: str) -> AccountData`
+- `AaveClientBase(ABC)` — L305: `get_pool_utilization(asset_symbol: str) -> Optional[Decimal]`
+- `AccountData` — L235: dataclass、全フィールド Decimal 型
+- `make_aave_client()` — L1274: factory 関数 (V4 版フラグ分岐の主入口、docs/54 §3.1)
+- web3.py の `encode_abi()` — L1130-1131: web3.py v7 API (v6 との API drift に注意、CLAUDE.md ドリフトカタログ)
+
+### 1.2 `@aave/client` の言語・対応状況
+
+【要確認】以下は 2026-06 時点の調査記録であり、実装前に再確認すること:
+
+| 確認項目 | 状況 | 確認方法 |
+|---|---|---|
+| 正式パッケージ名 | 【要確認】`@aave/protocol-js` か `@aave/client` か不明 | `npm info @aave/client` / Aave GitHub 検索 |
+| 言語 | 【要確認】JS/TS の可能性大 (Aave 公式 SDK は JS/TS が主流) | npm / GitHub 確認 |
+| Python バインディング | 【要確認】公式 Python SDK は確認できず | PyPI `aave` パッケージ調査 |
+| 対応チェーン | 【要確認】Ethereum mainnet のみか Base も対象か | SDK ドキュメント確認 |
+| Hub read API 範囲 | 【要確認】`getUserAccountData` 相当の提供可否 | SDK ドキュメント確認 |
+| V4 対応状況 | 【要確認】V4 Hub/Spoke のメソッドを提供するか | SDK ドキュメント / Changelog 確認 |
+
+> 上記確認を行わずに「`@aave/client` を採用する」と結論を出してはならない。
+> 確認は docs/54 §2.4 の UNVERIFIED 解消と並行して行うこと。
+
+---
+
+## 2. モジュール配置案
+
+### 2.1 採用案: `backend/app/aave_v4/` 新規モジュール (現行)
+
+```
+backend/app/
+├── aave/              ← V3 クライアント (無改変)
+│   ├── client.py      ← AaveClientBase / Web3AaveClient / DummyAaveClient
+│   ├── chains.py      ← CHAIN_REGISTRY (V4 アドレス追加は docs/54 §3.2 参照)
+│   └── ...
+└── aave_v4/           ← V4 統合レイヤー (本 scaffold で新規作成)
+    ├── __init__.py    ← パッケージ exports
+    ├── schemas.py     ← AaveV4HubConfig / V4AccountData (Decimal 型)
+    └── client.py      ← AaveV4ClientBase / AaveV4EthereumHubClient / DummyAaveV4Client
+```
+
+**利点**:
+- 既存 V3 (`aave/`) を一切改変しない → 回帰リスクゼロ
+- `AaveClientBase` 継承で service 層の型注釈を変更不要
+- `AAVE_PROTOCOL_VERSION` フラグで即時 V3 復帰可能 (docs/54 §3.1)
+- テスト (`tests/aave/test_aave_v4_client_stub.py`) が V3 との独立性を検証
+
+**制約**:
+- `make_aave_client()` への V4 分岐追加は Phase 4 (HUMAN-REVIEW 必須)
+- 独自 `aave_v4/` パッケージが将来 `aave/` と乖離するリスク (§6 共存戦略で管理)
+
+### 2.2 代替案
+
+| 案 | 概要 | pros | cons |
+|---|---|---|---|
+| A. V3 `client.py` に直接追加 | `Web3AaveClient` に V4 分岐を追加 | ファイル数増加なし | 既存テスト全件がリグレッション対象。Tier S ファイル改変 (HUMAN-REVIEW) |
+| B. `protocols/aave_v4.py` として追加 | Phase 2 PoC (`protocols/lido.py` に倣う) | protocols 層の一貫性 | Aave は BaseProtocolClient 系列と別系統 (docs/54 §1.5)。二重継承の複雑化 |
+
+---
+
+## 3. 統合層三択比較表
+
+> **本節は選択肢の整理のみ。確定は人間承認 (HUMAN-REVIEW) による。**
+> docs/54 §2.4 の UNVERIFIED 項目が解消するまで選択肢は絞り込まない。
+
+### (A) backend web3.py 直叩き (docs/54 §3-§4 路線)
+
+| 項目 | 内容 |
+|---|---|
+| 概要 | 既存 V3 と同様に web3.py + ABI で V4 Hub/Spoke を直叩き |
+| 追加依存 | なし (web3.py は既存) |
+| 既存安全装置整合 | HF < 1.6 HARD_STOP / cooldown / Decimal: **全て既存実装をそのまま利用可能** |
+| 実装コスト | V4 ABI 定義 + Hub/Spoke アドレス + encode_abi 書き換え |
+| リスク | ABI UNVERIFIED (docs/54 §2.4) / web3.py v7 API drift (CLAUDE.md ドリフトカタログ) |
+| 採用条件 | V4 Spoke ABI が公開後、web3.py で動作検証済みのこと |
+
+### (B) `@aave/client` (JS/TS) を frontend 統合層として使用
+
+| 項目 | 内容 |
+|---|---|
+| 概要 | Next.js frontend で `@aave/client` を呼び出し、backend は read API を呼ぶ |
+| 追加依存 | **frontend に npm パッケージ追加 (Tier S: package.json / HUMAN-REVIEW 必須)** |
+| 既存安全装置整合 | HF < 1.6 HARD_STOP は backend 側にある → frontend 経由 tx は安全装置をバイパスするリスク |
+| 実装コスト | JS SDK 学習 + frontend/backend 間のデータ変換レイヤー |
+| リスク | 安全装置の backend 側配置が保てるか要設計 / SDK 言語が UNVERIFIED (§1.2) |
+| 採用条件 | SDK 言語・V4 対応の公式確認 + 安全装置配置の設計承認 |
+
+### (C) Node.js サイドカー
+
+| 項目 | 内容 |
+|---|---|
+| 概要 | Node.js プロセスで `@aave/client` を動かし、backend (Python) から gRPC/REST で呼ぶ |
+| 追加依存 | Node.js コンテナ追加 (docker-compose.* 変更 / Tier S / HUMAN-REVIEW) + npm パッケージ |
+| 既存安全装置整合 | サイドカー呼び出しは RPC 増加 → latency / SLA リスク |
+| 実装コスト | 最大 (コンテナ + インターフェース + 運用) |
+| リスク | インフラ複雑度増加 / docker-compose Tier S 変更 |
+| 採用条件 | (A) / (B) が技術的に不可な場合の最終手段 |
+
+**現時点の暫定方針**: docs/54 §2.4 の UNVERIFIED が解消し V4 Spoke ABI が取得できれば **(A) が最小変更**。
+選定確定は HUMAN-REVIEW 後。
+
+---
+
+## 4. 依存追加リスト案 (Phase 1 以降 / HUMAN-REVIEW 必須)
+
+> **本 Phase 0 scaffold では依存を一切追加しない。**
+> `backend/requirements.txt` および `frontend/package.json` は Tier S ファイルであり、
+> HUMAN-REVIEW 承認なく変更してはならない (CLAUDE.md Tier 分類)。
+
+| 案 | パッケージ | 追加先 | Tier | HUMAN-REVIEW |
+|---|---|---|---|---|
+| (A) web3.py 直叩き | 不要 (web3 は既存) | — | — | 不要 |
+| (B) @aave/client (JS) | 【要確認】`@aave/client` or `@aave/protocol-js` | `frontend/package.json` | **S** | **必須** |
+| (C) Node サイドカー | 【要確認】SDK 名 | Node.js Dockerfile / compose | **S** | **必須** |
+
+---
+
+## 5. 段階実装計画
+
+| フェーズ | 作業 | 承認要否 | 状態 |
+|---|---|---|---|
+| **Phase 0** (本スライス) | `backend/app/aave_v4/` scaffold、read-only スタブ、pytest | 不要 | **完了** |
+| **Phase 1** | 統合レイヤー三択 確定 + 依存追加 (Tier S) | **HUMAN-REVIEW 必須** | 未着手 |
+| **Phase 2** | read API 実装 (HF / account data / pool utilization) | HUMAN-REVIEW 推奨 | 未着手 |
+| **Phase 3** | write/tx 実装 (supply / withdraw / approve) | **HUMAN-REVIEW 必須** | 未着手 |
+| **Phase 4** | `main.py` 配線 + `make_aave_client()` V4 分岐 | **HUMAN-REVIEW 必須** | 未着手 |
+
+Phase 1 着手前提条件:
+- docs/54 §2.4 の UNVERIFIED (V4 Hub/Spoke ABI) が解消していること
+- Base 上 V4 デプロイアドレスが Aave 公式アドレス帳に掲載されていること (`@aave/client` §1.2 確認含む)
+
+Phase 3 着手前提条件:
+- Phase 2 staging soak (Shadow Mode) で HF 取得が安定していること
+- docs/54 §5 リスク一覧の HF 互換性検証 (Phase 2 での実測) が完了していること
+
+---
+
+## 6. 既存 V3 との共存戦略
+
+### 6.1 原則
+
+- `backend/app/aave/` (V3) は **本 Phase 0 で一切改変しない**
+- `backend/app/aave_v4/` は新規パッケージとして独立
+- V4 への切替は `AAVE_PROTOCOL_VERSION=v4` env フラグのみで制御 (docs/54 §3.1)
+- rollback は `.env.production` / `.env.staging` で `v3` に戻してコンテナ再起動 (数分以内)
+
+### 6.2 分岐方針 (Phase 4 以降)
+
+```
+make_aave_client()               ← backend/app/aave/client.py L1274 (Tier S / HUMAN-REVIEW)
+  └─ AAVE_PROTOCOL_VERSION
+       ├─ "v3" → Web3AaveClient  (現行 / 無改変)
+       └─ "v4" → AaveV4EthereumHubClient  (Phase 2 実装後)
+```
+
+呼出側 (`service.py` / `rebalance_service.py`) は `AaveClientBase` を型注釈とするため、
+V4 実装クラスに差し替えても **service 層の変更は不要** (OCP 準拠)。
+
+### 6.3 本スライスで触ったファイル / 触らなかったファイル
+
+| ファイル | 状態 | 理由 |
+|---|---|---|
+| `backend/app/aave_v4/__init__.py` | **新規作成** | 本スライスの対象 |
+| `backend/app/aave_v4/schemas.py` | **新規作成** | 本スライスの対象 |
+| `backend/app/aave_v4/client.py` | **新規作成** | 本スライスの対象 |
+| `backend/tests/aave/test_aave_v4_client_stub.py` | **新規作成** | 本スライスの対象 |
+| `backend/app/aave/client.py` | **無改変** | HUMAN-REVIEW スライス外 |
+| `backend/app/main.py` | **無改変** | HUMAN-REVIEW スライス / Phase 4 |
+| `backend/requirements.txt` | **無改変** | Tier S / Phase 1 承認後 |
+| `frontend/package.json` | **無改変** | Tier S / Phase 1 承認後 |
+| `docs/54_aave_v4_migration_design.md` | **無改変** | 親設計書 / 本書が差分参照 |


### PR DESCRIPTION
## 概要
Asana GID 1215697791383548 系 v4 epic の基盤タスク **[Aave][インフラ] Aave V4 Ethereum Hub統合 (GID 1215697869383370)** の **Tier-B 自動進行可スライス（read-only scaffold）**。

新SDK依存追加・tx送信・main.py 配線を含む本体は **🛑 HUMAN-REVIEW-REQUIRED** として本PRから除外し、安全に自動実装できる設計doc + read-only スタブ + pytest のみを含む。

## 変更（すべて新規ファイル・既存無改変）
- `docs/55_aave_v4_ethereum_hub_integration.md` — 統合層選定設計doc（親doc 54 を参照、`@aave/client` 言語は【要確認】、段階実装計画 Phase0-4）
- `backend/app/aave_v4/{__init__,schemas,client}.py` — read-only クライアント骨格（`AaveClientBase` 継承、write は `NotImplementedError`、秘密鍵/RPC 参照ゼロ）
- `backend/tests/aave/test_aave_v4_client_stub.py` — 安全保証テスト 32件

## パイプライン結果（Planner→Generator→Evaluator→Tester）
- **Evaluator: APPROVED**（CRITICAL 0 / write 経路封じ込め・既存V3非侵襲・Decimal型・docs健全性 実確認PASS）
- **Tester: PASS** — aave_v4 単体 coverage **100%**、`tests/ -k aave` **436 passed / 4 skipped**（リグレッションなし）、mypy/ruff/ruff-format/ruff-S 全0エラー

## HUMAN-REVIEW で別PR化する範囲（本PR対象外）
- `@aave/client` SDK 言語確定 → 依存追加（requirements.txt or package.json / Tier S）
- Ethereum Hub アドレス登録（chains.py 拡張）
- V4 read 実装 → write/tx（HF<1.6 HARD_STOP 配線）
- main.py include_router 配線（PR統合時に最後 / タスク制約準拠）

🤖 Generated with [Claude Code](https://claude.com/claude-code)