### PR TITLE
feat(policy): Privy Policy Engine 設計doc + ウォレットポリシースキーマ/バリデータ (scaffold)

### DIFF
--- a/backend/app/policy/wallet_policy.py
+++ b/backend/app/policy/wallet_policy.py
@@ -1,0 +1,332 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/app/policy/wallet_policy.py
+"""
+Privy server-side policy の宣言的スキーマとバリデータ。
+
+Phase 1 (scaffold): 純粋なデータクラスとバリデーション関数のみ。
+Privy API 呼出・tx 送信・署名・秘密鍵は一切含まない。
+既存 PolicyEngine (engine.py) を import/改変しない。
+
+二層ポリシー構造における位置づけ:
+  - 本モジュール: application-layer の宣言的スキーマ定義
+  - engine.py:    application-layer の hard rule 検算
+  - Phase 3 (HUMAN-REVIEW-REQUIRED): Privy API 呼出層 (別モジュール)
+"""
+
+import re
+from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
+from typing import Literal, Optional, Union
+
+# 金融計算規則 (Security Rule 11): 全金融値は Decimal 型のみ。float 禁止。
+
+# ---- 定数 ----
+
+_ETH_ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
+_CONDITIONAL_OPERATORS: frozenset[str] = frozenset(
+    {"eq", "neq", "gt", "lt", "gte", "lte", "in", "not_in"}
+)
+_LIST_OPERATORS: frozenset[str] = frozenset({"in", "not_in"})
+_SCALAR_OPERATORS: frozenset[str] = _CONDITIONAL_OPERATORS - _LIST_OPERATORS
+
+
+# ---- バリデーションエラー ----
+
+
+class WalletPolicyValidationError(ValueError):
+    """WalletPolicySpec のバリデーション違反。"""
+
+    def __init__(self, violations: list[str]) -> None:
+        self.violations = violations
+        super().__init__("; ".join(violations))
+
+
+# ---- ルール定義 ----
+
+
+@dataclass(frozen=True)
+class WalletAllowlistRule:
+    """
+    宛先コントラクトアドレス / 資産シンボルの allowlist。
+    Privy server policy の allowlist 設定に対応する。
+
+    注意: Privy は動的自己参照 (onBehalfOf == msg.sender) を未サポート。
+    calldata 本人一致検証は aave/client.py の _decode_pool_calldata で担保する。
+    """
+
+    allowed_contracts: frozenset[str]
+    """許可コントラクトアドレス。小文字 0x... 形式で保持される。"""
+
+    allowed_assets: frozenset[str]
+    """許可資産シンボル。大文字で保持される (例: "USDC")。"""
+
+
+@dataclass(frozen=True)
+class SpendingLimitRule:
+    """
+    期間内送金上限。Privy server policy の spending_limit 設定に対応する。
+    金融計算規則 (Rule 11): 全フィールドは Decimal 型必須。float 禁止。
+    """
+
+    per_transaction_usd: Decimal
+    """単一 tx の USD 上限。正値必須。"""
+
+    per_day_usd: Decimal
+    """日次 USD 上限。per_transaction_usd 以上必須。"""
+
+    per_week_usd: Optional[Decimal] = None
+    """週次 USD 上限 (省略可)。指定時は per_day_usd 以上必須。"""
+
+
+@dataclass(frozen=True)
+class ConditionalSignRule:
+    """
+    条件付き署名ルール。Privy server policy の conditional_sign 設定に対応する。
+    Privy は静的リテラル値のみ比較可能 (動的自己参照は未サポート)。
+    """
+
+    field_path: str
+    """チェック対象 calldata フィールドパス (空不可)。"""
+
+    operator: Literal["eq", "neq", "gt", "lt", "gte", "lte", "in", "not_in"]
+    """比較演算子。"""
+
+    value: Union[str, list[str]]
+    """
+    比較値 (静的リテラルのみ)。
+    in / not_in 演算子のとき list[str]、それ以外のとき str。
+    """
+
+    description: str
+    """ルール説明 (監査ログ用)。空不可。"""
+
+
+@dataclass(frozen=True)
+class WalletPolicySpec:
+    """
+    Privy server-side policy の完全仕様。
+    `validate_wallet_policy_spec()` でバリデーションしてから使用する。
+    """
+
+    wallet_address: str
+    """対象ウォレットアドレス (0x prefix + 40 hex 文字)。"""
+
+    policy_id: str
+    """識別子 (監査ログ用、空不可)。"""
+
+    allowlist: Optional[WalletAllowlistRule] = None
+    """allowlist ルール (省略可)。"""
+
+    spending_limit: Optional[SpendingLimitRule] = None
+    """spending limit ルール (省略可)。"""
+
+    conditional_signs: list[ConditionalSignRule] = field(default_factory=list)
+    """条件付き署名ルール (0 個以上)。"""
+
+
+# ---- ファクトリ関数 ----
+
+
+def make_allowlist_rule(
+    allowed_contracts: list[str],
+    allowed_assets: list[str],
+) -> WalletAllowlistRule:
+    """
+    WalletAllowlistRule を構築し、正規化する。
+    - コントラクトアドレスは小文字に正規化
+    - 資産シンボルは大文字に正規化
+    バリデーションは `validate_wallet_policy_spec()` で行う。
+    """
+    return WalletAllowlistRule(
+        allowed_contracts=frozenset(addr.lower() for addr in allowed_contracts),
+        allowed_assets=frozenset(asset.upper() for asset in allowed_assets),
+    )
+
+
+def make_spending_limit_rule(
+    per_transaction_usd: Union[str, Decimal],
+    per_day_usd: Union[str, Decimal],
+    per_week_usd: Optional[Union[str, Decimal]] = None,
+) -> SpendingLimitRule:
+    """
+    SpendingLimitRule を構築する。
+    文字列も受け付けるが内部では Decimal 型に変換する (Rule 11 準拠)。
+    バリデーションは `validate_wallet_policy_spec()` で行う。
+    """
+    return SpendingLimitRule(
+        per_transaction_usd=_coerce_decimal(per_transaction_usd, "per_transaction_usd"),
+        per_day_usd=_coerce_decimal(per_day_usd, "per_day_usd"),
+        per_week_usd=_coerce_decimal(per_week_usd, "per_week_usd")
+        if per_week_usd is not None
+        else None,
+    )
+
+
+# ---- バリデータ ----
+
+
+def validate_wallet_policy_spec(spec: WalletPolicySpec) -> None:
+    """
+    WalletPolicySpec の整合性・値域・型を検証する。
+    違反がある場合は WalletPolicyValidationError を送出する。
+    """
+    violations: list[str] = []
+
+    _validate_wallet_address(spec.wallet_address, violations)
+    _validate_policy_id(spec.policy_id, violations)
+
+    has_rules = (
+        spec.allowlist is not None
+        or spec.spending_limit is not None
+        or bool(spec.conditional_signs)
+    )
+    if not has_rules:
+        violations.append(
+            "WalletPolicySpec must contain at least one rule "
+            "(allowlist, spending_limit, or conditional_signs)"
+        )
+
+    if spec.allowlist is not None:
+        _validate_allowlist_rule(spec.allowlist, violations)
+
+    if spec.spending_limit is not None:
+        _validate_spending_limit_rule(spec.spending_limit, violations)
+
+    for i, csr in enumerate(spec.conditional_signs):
+        _validate_conditional_sign_rule(csr, i, violations)
+
+    if violations:
+        raise WalletPolicyValidationError(violations)
+
+
+# ---- プライベートバリデーション関数 ----
+
+
+def _validate_wallet_address(addr: str, violations: list[str]) -> None:
+    if not _ETH_ADDRESS_RE.match(addr):
+        violations.append(
+            f"wallet_address '{addr}' is not a valid Ethereum address (expected 0x + 40 hex chars)"
+        )
+
+
+def _validate_policy_id(policy_id: str, violations: list[str]) -> None:
+    if not policy_id.strip():
+        violations.append("policy_id must not be empty")
+
+
+def _validate_allowlist_rule(rule: WalletAllowlistRule, violations: list[str]) -> None:
+    if not rule.allowed_contracts:
+        violations.append(
+            "allowlist.allowed_contracts must not be empty "
+            "(empty allowlist implies allow-all, which is unsafe)"
+        )
+    else:
+        for addr in rule.allowed_contracts:
+            if not _ETH_ADDRESS_RE.match(addr):
+                violations.append(
+                    f"allowlist.allowed_contracts contains invalid address '{addr}' "
+                    "(expected lowercase 0x + 40 hex chars)"
+                )
+
+    if not rule.allowed_assets:
+        violations.append("allowlist.allowed_assets must not be empty")
+
+
+def _validate_spending_limit_rule(rule: SpendingLimitRule, violations: list[str]) -> None:
+    # 型チェック (Rule 11: Decimal 型強制)
+    for field_name, value in [
+        ("per_transaction_usd", rule.per_transaction_usd),
+        ("per_day_usd", rule.per_day_usd),
+    ]:
+        if not isinstance(value, Decimal):
+            violations.append(
+                f"spending_limit.{field_name} must be Decimal type (got {type(value).__name__})"
+            )
+        elif value <= Decimal("0"):
+            violations.append(f"spending_limit.{field_name} must be positive (got {value})")
+
+    if rule.per_week_usd is not None:
+        if not isinstance(rule.per_week_usd, Decimal):
+            violations.append(
+                f"spending_limit.per_week_usd must be Decimal type "
+                f"(got {type(rule.per_week_usd).__name__})"
+            )
+        elif rule.per_week_usd <= Decimal("0"):
+            violations.append(
+                f"spending_limit.per_week_usd must be positive (got {rule.per_week_usd})"
+            )
+
+    # 矛盾チェック (型エラーがある場合は比較しない)
+    tx_ok = isinstance(rule.per_transaction_usd, Decimal) and rule.per_transaction_usd > Decimal(
+        "0"
+    )
+    day_ok = isinstance(rule.per_day_usd, Decimal) and rule.per_day_usd > Decimal("0")
+    week_ok = (
+        rule.per_week_usd is not None
+        and isinstance(rule.per_week_usd, Decimal)
+        and rule.per_week_usd > Decimal("0")
+    )
+
+    if tx_ok and day_ok and rule.per_transaction_usd > rule.per_day_usd:
+        violations.append(
+            f"spending_limit: per_transaction_usd ({rule.per_transaction_usd}) "
+            f"must not exceed per_day_usd ({rule.per_day_usd})"
+        )
+
+    if (
+        day_ok
+        and week_ok
+        and rule.per_week_usd is not None
+        and rule.per_day_usd > rule.per_week_usd
+    ):
+        violations.append(
+            f"spending_limit: per_day_usd ({rule.per_day_usd}) "
+            f"must not exceed per_week_usd ({rule.per_week_usd})"
+        )
+
+
+def _validate_conditional_sign_rule(
+    rule: ConditionalSignRule, index: int, violations: list[str]
+) -> None:
+    prefix = f"conditional_signs[{index}]"
+
+    if not rule.field_path.strip():
+        violations.append(f"{prefix}.field_path must not be empty")
+
+    if rule.operator not in _CONDITIONAL_OPERATORS:
+        violations.append(
+            f"{prefix}.operator '{rule.operator}' is not valid; "
+            f"must be one of {sorted(_CONDITIONAL_OPERATORS)}"
+        )
+
+    if not rule.description.strip():
+        violations.append(f"{prefix}.description must not be empty")
+
+    if rule.operator in _LIST_OPERATORS:
+        if not isinstance(rule.value, list):
+            violations.append(
+                f"{prefix}.value must be list[str] when operator is '{rule.operator}' "
+                f"(got {type(rule.value).__name__})"
+            )
+        elif not rule.value:
+            violations.append(
+                f"{prefix}.value list must not be empty when operator is '{rule.operator}'"
+            )
+    else:
+        if isinstance(rule.value, list):
+            violations.append(
+                f"{prefix}.value must be str when operator is '{rule.operator}' (got list)"
+            )
+
+
+# ---- プライベートヘルパー ----
+
+
+def _coerce_decimal(value: Union[str, Decimal], field_name: str) -> Decimal:
+    """文字列または Decimal を Decimal に変換する。変換失敗時は ValueError を送出。"""
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(value)
+    except InvalidOperation as exc:
+        raise ValueError(f"{field_name}: cannot convert '{value}' to Decimal") from exc

--- a/backend/tests/test_wallet_policy.py
+++ b/backend/tests/test_wallet_policy.py
@@ -1,0 +1,493 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_wallet_policy.py
+"""
+WalletPolicySpec / バリデータ / 各ルールの pass/fail ユニットテスト。
+
+Privy API 呼出なし・DB 不要・純粋関数テスト。
+金融値 Decimal 型強制 (Rule 11) の境界値テストを含む。
+"""
+
+import os
+from decimal import Decimal
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-wallet-policy")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "terms_admin@example.com")
+
+from app.policy.wallet_policy import (  # noqa: E402
+    ConditionalSignRule,
+    SpendingLimitRule,
+    WalletAllowlistRule,
+    WalletPolicySpec,
+    WalletPolicyValidationError,
+    _coerce_decimal,
+    make_allowlist_rule,
+    make_spending_limit_rule,
+    validate_wallet_policy_spec,
+)
+
+# ---------------------------------------------------------------------------
+# ヘルパー
+# ---------------------------------------------------------------------------
+
+_VALID_WALLET = "0xabcdef1234567890abcdef1234567890abcdef12"
+_VALID_CONTRACT = "0x1111111111111111111111111111111111111111"
+_VALID_ASSET = "USDC"
+_VALID_POLICY_ID = "policy-001"
+
+
+def _valid_allowlist() -> WalletAllowlistRule:
+    return make_allowlist_rule(
+        allowed_contracts=[_VALID_CONTRACT],
+        allowed_assets=[_VALID_ASSET],
+    )
+
+
+def _valid_spending_limit() -> SpendingLimitRule:
+    return make_spending_limit_rule(
+        per_transaction_usd=Decimal("1000"),
+        per_day_usd=Decimal("5000"),
+        per_week_usd=Decimal("20000"),
+    )
+
+
+def _valid_conditional_sign() -> ConditionalSignRule:
+    return ConditionalSignRule(
+        field_path="args.asset",
+        operator="eq",
+        value="0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        description="USDC のみ許可",
+    )
+
+
+def _valid_spec(**overrides) -> WalletPolicySpec:
+    defaults: dict = dict(
+        wallet_address=_VALID_WALLET,
+        policy_id=_VALID_POLICY_ID,
+        allowlist=_valid_allowlist(),
+        spending_limit=_valid_spending_limit(),
+        conditional_signs=[],
+    )
+    defaults.update(overrides)
+    return WalletPolicySpec(**defaults)
+
+
+def _assert_violation_contains(spec: WalletPolicySpec, keyword: str) -> None:
+    """バリデーション違反メッセージに keyword が含まれることを確認。"""
+    with pytest.raises(WalletPolicyValidationError) as exc_info:
+        validate_wallet_policy_spec(spec)
+    messages = " ".join(exc_info.value.violations)
+    assert keyword in messages, f"Expected '{keyword}' in violations: {exc_info.value.violations}"
+
+
+# ---------------------------------------------------------------------------
+# WalletAllowlistRule のテスト
+# ---------------------------------------------------------------------------
+
+
+class TestWalletAllowlistRule:
+    def test_valid_allowlist_passes(self) -> None:
+        rule = make_allowlist_rule(
+            allowed_contracts=[_VALID_CONTRACT],
+            allowed_assets=[_VALID_ASSET],
+        )
+        spec = _valid_spec(allowlist=rule, spending_limit=None)
+        validate_wallet_policy_spec(spec)  # 例外なし
+
+    def test_contract_address_normalized_to_lowercase(self) -> None:
+        rule = make_allowlist_rule(
+            allowed_contracts=["0xABCDEF1234567890ABCDEF1234567890ABCDEF12"],
+            allowed_assets=["usdc"],
+        )
+        assert "0xabcdef1234567890abcdef1234567890abcdef12" in rule.allowed_contracts
+        assert "USDC" in rule.allowed_assets
+
+    def test_asset_normalized_to_uppercase(self) -> None:
+        rule = make_allowlist_rule(
+            allowed_contracts=[_VALID_CONTRACT],
+            allowed_assets=["usdc", "weth"],
+        )
+        assert "USDC" in rule.allowed_assets
+        assert "WETH" in rule.allowed_assets
+        # 小文字は含まれない
+        assert "usdc" not in rule.allowed_assets
+
+    def test_empty_contracts_fails(self) -> None:
+        rule = WalletAllowlistRule(
+            allowed_contracts=frozenset(),
+            allowed_assets=frozenset({_VALID_ASSET}),
+        )
+        spec = _valid_spec(allowlist=rule, spending_limit=None)
+        _assert_violation_contains(spec, "allowed_contracts must not be empty")
+
+    def test_empty_assets_fails(self) -> None:
+        rule = WalletAllowlistRule(
+            allowed_contracts=frozenset({_VALID_CONTRACT}),
+            allowed_assets=frozenset(),
+        )
+        spec = _valid_spec(allowlist=rule, spending_limit=None)
+        _assert_violation_contains(spec, "allowed_assets must not be empty")
+
+    def test_invalid_contract_address_fails(self) -> None:
+        rule = WalletAllowlistRule(
+            allowed_contracts=frozenset({"not-an-address"}),
+            allowed_assets=frozenset({_VALID_ASSET}),
+        )
+        spec = _valid_spec(allowlist=rule, spending_limit=None)
+        _assert_violation_contains(spec, "invalid address")
+
+    def test_multiple_contracts_allowed(self) -> None:
+        rule = make_allowlist_rule(
+            allowed_contracts=[_VALID_CONTRACT, "0x2222222222222222222222222222222222222222"],
+            allowed_assets=[_VALID_ASSET, "WETH"],
+        )
+        spec = _valid_spec(allowlist=rule, spending_limit=None)
+        validate_wallet_policy_spec(spec)  # 例外なし
+
+
+# ---------------------------------------------------------------------------
+# SpendingLimitRule のテスト
+# ---------------------------------------------------------------------------
+
+
+class TestSpendingLimitRule:
+    def test_valid_spending_limit_passes(self) -> None:
+        rule = make_spending_limit_rule(
+            per_transaction_usd=Decimal("1000"),
+            per_day_usd=Decimal("5000"),
+        )
+        spec = _valid_spec(allowlist=None, spending_limit=rule)
+        validate_wallet_policy_spec(spec)  # 例外なし
+
+    def test_decimal_coercion_from_string(self) -> None:
+        rule = make_spending_limit_rule(
+            per_transaction_usd="1000",
+            per_day_usd="5000",
+        )
+        assert isinstance(rule.per_transaction_usd, Decimal)
+        assert isinstance(rule.per_day_usd, Decimal)
+        assert rule.per_transaction_usd == Decimal("1000")
+
+    def test_decimal_type_enforced_rule11(self) -> None:
+        """Rule 11: float を直接渡した場合は型エラー (Decimal で包んでからオブジェクト生成)。"""
+        # SpendingLimitRule は frozen dataclass のため float のまま入れると違反検出
+        rule = SpendingLimitRule(
+            per_transaction_usd=1000.0,  # type: ignore[arg-type]
+            per_day_usd=5000.0,  # type: ignore[arg-type]
+        )
+        spec = _valid_spec(allowlist=None, spending_limit=rule)
+        _assert_violation_contains(spec, "must be Decimal type")
+
+    def test_zero_per_transaction_fails(self) -> None:
+        rule = SpendingLimitRule(
+            per_transaction_usd=Decimal("0"),
+            per_day_usd=Decimal("5000"),
+        )
+        spec = _valid_spec(allowlist=None, spending_limit=rule)
+        _assert_violation_contains(spec, "must be positive")
+
+    def test_negative_per_day_fails(self) -> None:
+        rule = SpendingLimitRule(
+            per_transaction_usd=Decimal("100"),
+            per_day_usd=Decimal("-1"),
+        )
+        spec = _valid_spec(allowlist=None, spending_limit=rule)
+        _assert_violation_contains(spec, "must be positive")
+
+    def test_per_transaction_exceeds_per_day_fails(self) -> None:
+        """単一 tx 上限が日次上限を超える矛盾。"""
+        rule = SpendingLimitRule(
+            per_transaction_usd=Decimal("6000"),
+            per_day_usd=Decimal("5000"),
+        )
+        spec = _valid_spec(allowlist=None, spending_limit=rule)
+        _assert_violation_contains(spec, "per_transaction_usd")
+
+    def test_per_day_exceeds_per_week_fails(self) -> None:
+        """日次上限が週次上限を超える矛盾。"""
+        rule = SpendingLimitRule(
+            per_transaction_usd=Decimal("1000"),
+            per_day_usd=Decimal("10000"),
+            per_week_usd=Decimal("5000"),
+        )
+        spec = _valid_spec(allowlist=None, spending_limit=rule)
+        _assert_violation_contains(spec, "per_day_usd")
+
+    def test_boundary_per_transaction_equals_per_day_passes(self) -> None:
+        """単一 tx == 日次上限は許容 (1日1取引のみのポリシー)。"""
+        rule = SpendingLimitRule(
+            per_transaction_usd=Decimal("5000"),
+            per_day_usd=Decimal("5000"),
+        )
+        spec = _valid_spec(allowlist=None, spending_limit=rule)
+        validate_wallet_policy_spec(spec)  # 例外なし
+
+    def test_boundary_per_day_equals_per_week_passes(self) -> None:
+        """日次 == 週次は許容。"""
+        rule = SpendingLimitRule(
+            per_transaction_usd=Decimal("1000"),
+            per_day_usd=Decimal("7000"),
+            per_week_usd=Decimal("7000"),
+        )
+        spec = _valid_spec(allowlist=None, spending_limit=rule)
+        validate_wallet_policy_spec(spec)  # 例外なし
+
+    def test_per_week_optional_none_passes(self) -> None:
+        rule = make_spending_limit_rule(
+            per_transaction_usd=Decimal("1000"),
+            per_day_usd=Decimal("5000"),
+            per_week_usd=None,
+        )
+        spec = _valid_spec(allowlist=None, spending_limit=rule)
+        validate_wallet_policy_spec(spec)  # 例外なし
+
+    def test_coerce_decimal_invalid_string_raises(self) -> None:
+        with pytest.raises(ValueError, match="cannot convert"):
+            _coerce_decimal("not-a-number", "test_field")
+
+    def test_coerce_decimal_passthrough_decimal(self) -> None:
+        d = Decimal("123.45")
+        assert _coerce_decimal(d, "test_field") is d
+
+
+# ---------------------------------------------------------------------------
+# ConditionalSignRule のテスト
+# ---------------------------------------------------------------------------
+
+
+class TestConditionalSignRule:
+    def test_valid_eq_rule_passes(self) -> None:
+        rule = ConditionalSignRule(
+            field_path="args.asset",
+            operator="eq",
+            value="0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            description="USDC asset check",
+        )
+        spec = _valid_spec(allowlist=None, spending_limit=None, conditional_signs=[rule])
+        validate_wallet_policy_spec(spec)  # 例外なし
+
+    def test_valid_in_rule_with_list_passes(self) -> None:
+        rule = ConditionalSignRule(
+            field_path="args.operation",
+            operator="in",
+            value=["SUPPLY", "WITHDRAW"],
+            description="SUPPLY または WITHDRAW のみ",
+        )
+        spec = _valid_spec(allowlist=None, spending_limit=None, conditional_signs=[rule])
+        validate_wallet_policy_spec(spec)  # 例外なし
+
+    def test_empty_field_path_fails(self) -> None:
+        rule = ConditionalSignRule(
+            field_path="",
+            operator="eq",
+            value="foo",
+            description="desc",
+        )
+        spec = _valid_spec(allowlist=None, spending_limit=None, conditional_signs=[rule])
+        _assert_violation_contains(spec, "field_path must not be empty")
+
+    def test_invalid_operator_fails(self) -> None:
+        rule = ConditionalSignRule(
+            field_path="args.asset",
+            operator="contains",  # type: ignore[arg-type]
+            value="foo",
+            description="desc",
+        )
+        spec = _valid_spec(allowlist=None, spending_limit=None, conditional_signs=[rule])
+        _assert_violation_contains(spec, "operator")
+
+    def test_in_operator_requires_list_fails(self) -> None:
+        rule = ConditionalSignRule(
+            field_path="args.asset",
+            operator="in",
+            value="USDC",  # str ではなく list が必要
+            description="desc",
+        )
+        spec = _valid_spec(allowlist=None, spending_limit=None, conditional_signs=[rule])
+        _assert_violation_contains(spec, "list[str]")
+
+    def test_in_operator_empty_list_fails(self) -> None:
+        rule = ConditionalSignRule(
+            field_path="args.asset",
+            operator="in",
+            value=[],
+            description="desc",
+        )
+        spec = _valid_spec(allowlist=None, spending_limit=None, conditional_signs=[rule])
+        _assert_violation_contains(spec, "must not be empty")
+
+    def test_eq_operator_with_list_fails(self) -> None:
+        rule = ConditionalSignRule(
+            field_path="args.asset",
+            operator="eq",
+            value=["USDC"],  # eq は str が必要
+            description="desc",
+        )
+        spec = _valid_spec(allowlist=None, spending_limit=None, conditional_signs=[rule])
+        _assert_violation_contains(spec, "must be str")
+
+    def test_empty_description_fails(self) -> None:
+        rule = ConditionalSignRule(
+            field_path="args.asset",
+            operator="eq",
+            value="USDC",
+            description="",
+        )
+        spec = _valid_spec(allowlist=None, spending_limit=None, conditional_signs=[rule])
+        _assert_violation_contains(spec, "description must not be empty")
+
+    def test_all_scalar_operators_pass(self) -> None:
+        for op in ["eq", "neq", "gt", "lt", "gte", "lte"]:
+            rule = ConditionalSignRule(
+                field_path="args.amount",
+                operator=op,  # type: ignore[arg-type]
+                value="100",
+                description=f"{op} check",
+            )
+            spec = _valid_spec(allowlist=None, spending_limit=None, conditional_signs=[rule])
+            validate_wallet_policy_spec(spec)  # 例外なし
+
+    def test_not_in_operator_passes(self) -> None:
+        rule = ConditionalSignRule(
+            field_path="args.asset",
+            operator="not_in",
+            value=["DAI", "USDT"],
+            description="DAI と USDT を除外",
+        )
+        spec = _valid_spec(allowlist=None, spending_limit=None, conditional_signs=[rule])
+        validate_wallet_policy_spec(spec)  # 例外なし
+
+    def test_multiple_conditional_signs_pass(self) -> None:
+        rules = [
+            ConditionalSignRule("args.asset", "eq", "USDC", "asset check"),
+            ConditionalSignRule("args.operation", "in", ["SUPPLY", "WITHDRAW"], "op check"),
+        ]
+        spec = _valid_spec(allowlist=None, spending_limit=None, conditional_signs=rules)
+        validate_wallet_policy_spec(spec)  # 例外なし
+
+    def test_index_reported_in_violation(self) -> None:
+        """複数ルールのうち 2 番目が失敗した場合、インデックス [1] が報告されること。"""
+        rules = [
+            ConditionalSignRule("args.asset", "eq", "USDC", "valid"),
+            ConditionalSignRule("", "eq", "foo", "desc"),  # field_path 空
+        ]
+        spec = _valid_spec(allowlist=None, spending_limit=None, conditional_signs=rules)
+        _assert_violation_contains(spec, "conditional_signs[1]")
+
+
+# ---------------------------------------------------------------------------
+# WalletPolicySpec 全体バリデーション
+# ---------------------------------------------------------------------------
+
+
+class TestWalletPolicySpec:
+    def test_valid_full_spec_passes(self) -> None:
+        spec = _valid_spec()
+        validate_wallet_policy_spec(spec)  # 例外なし
+
+    def test_invalid_wallet_address_fails(self) -> None:
+        spec = _valid_spec(wallet_address="0xBAD")
+        _assert_violation_contains(spec, "valid Ethereum address")
+
+    def test_wallet_address_without_0x_fails(self) -> None:
+        spec = _valid_spec(wallet_address="abcdef1234567890abcdef1234567890abcdef12")
+        _assert_violation_contains(spec, "valid Ethereum address")
+
+    def test_empty_policy_id_fails(self) -> None:
+        spec = _valid_spec(policy_id="")
+        _assert_violation_contains(spec, "policy_id must not be empty")
+
+    def test_whitespace_policy_id_fails(self) -> None:
+        spec = _valid_spec(policy_id="   ")
+        _assert_violation_contains(spec, "policy_id must not be empty")
+
+    def test_no_rules_at_all_fails(self) -> None:
+        spec = _valid_spec(allowlist=None, spending_limit=None, conditional_signs=[])
+        _assert_violation_contains(spec, "at least one rule")
+
+    def test_only_allowlist_sufficient(self) -> None:
+        spec = _valid_spec(spending_limit=None, conditional_signs=[])
+        validate_wallet_policy_spec(spec)  # 例外なし
+
+    def test_only_spending_limit_sufficient(self) -> None:
+        spec = _valid_spec(allowlist=None, conditional_signs=[])
+        validate_wallet_policy_spec(spec)  # 例外なし
+
+    def test_only_conditional_signs_sufficient(self) -> None:
+        spec = _valid_spec(
+            allowlist=None,
+            spending_limit=None,
+            conditional_signs=[_valid_conditional_sign()],
+        )
+        validate_wallet_policy_spec(spec)  # 例外なし
+
+    def test_multiple_violations_reported(self) -> None:
+        """複数の違反がある場合、全て報告されること。"""
+        spec = WalletPolicySpec(
+            wallet_address="0xBAD",
+            policy_id="",
+            allowlist=None,
+            spending_limit=None,
+            conditional_signs=[],
+        )
+        with pytest.raises(WalletPolicyValidationError) as exc_info:
+            validate_wallet_policy_spec(spec)
+        assert len(exc_info.value.violations) >= 3  # address + policy_id + no rules
+
+    def test_wallet_policy_validation_error_message(self) -> None:
+        """WalletPolicyValidationError.violations が violations リストを持つ。"""
+        spec = _valid_spec(wallet_address="0xBAD", policy_id="")
+        with pytest.raises(WalletPolicyValidationError) as exc_info:
+            validate_wallet_policy_spec(spec)
+        assert isinstance(exc_info.value.violations, list)
+        assert len(exc_info.value.violations) >= 1
+
+    def test_valid_wallet_address_checksum_uppercase_accepted(self) -> None:
+        """大文字 hex も有効な Ethereum アドレス形式として受け付ける。"""
+        spec = _valid_spec(wallet_address="0xABCDEF1234567890ABCDEF1234567890ABCDEF12")
+        validate_wallet_policy_spec(spec)  # 例外なし
+
+    def test_frozen_dataclass_immutable(self) -> None:
+        """frozen=True により変更不可であることを確認。"""
+        spec = _valid_spec()
+        with pytest.raises((AttributeError, TypeError)):
+            spec.policy_id = "modified"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# 安全境界テスト: Privy/tx/秘密鍵が混入していないこと
+# ---------------------------------------------------------------------------
+
+
+class TestSafetyBoundary:
+    """
+    wallet_policy.py が Privy API 呼出・tx 送信・秘密鍵に依存しないことの
+    ランタイム確認。モジュールのインポートと純粋関数実行のみ検証。
+    """
+
+    def test_module_imports_no_requests(self) -> None:
+        """requests / httpx が wallet_policy に混入していないことを確認。"""
+        import app.policy.wallet_policy as wpm
+
+        # wallet_policy モジュール自体の __dict__ に requests/httpx がないこと
+        module_dict = vars(wpm)
+        assert "requests" not in module_dict
+        assert "httpx" not in module_dict
+
+    def test_no_transaction_or_key_attributes(self) -> None:
+        """WalletPolicySpec に秘密鍵・tx 送信に関する属性がないこと。"""
+        import app.policy.wallet_policy as wpm
+
+        forbidden = ["private_key", "send_raw", "sign_transaction", "privy_api"]
+        module_attrs = dir(wpm)
+        for attr in forbidden:
+            assert attr not in module_attrs, f"Forbidden attribute '{attr}' found in wallet_policy"
+
+    def test_pure_function_no_side_effects(self) -> None:
+        """バリデーション関数が外部副作用なしで動作すること。"""
+        spec = _valid_spec()
+        # 複数回実行しても同じ結果 (純粋関数)
+        validate_wallet_policy_spec(spec)
+        validate_wallet_policy_spec(spec)
+        # 例外なしで完了すれば OK

--- a/docs/56_privy_policy_engine_design.md
+++ b/docs/56_privy_policy_engine_design.md
@@ -1,0 +1,293 @@
+# Privy Policy Engine 設計ドキュメント
+
+**バージョン**: 1.0.0-scaffold
+**作成日**: 2026-06-15
+**対象ブランチ**: docs/privy-policy-engine-design
+**ステータス**: Phase 1 (scaffold) 実装済み — Phase 2-4 は HUMAN-REVIEW-REQUIRED
+
+---
+
+## 目次
+
+1. [統合方針](#1-統合方針)
+2. [既存安全装置との二重化マップ](#2-既存安全装置との二重化マップ)
+3. [重大所見: 既存 PolicyEngine 未配線](#3-重大所見-既存-policyengine-未配線)
+4. [ポリシー定義スキーマ案](#4-ポリシー定義スキーマ案)
+5. [段階実装計画](#5-段階実装計画)
+6. [要確認事項](#6-要確認事項)
+
+---
+
+## 1. 統合方針
+
+### 1.1 二層構造の整理
+
+Ultra AutoTrade のポリシー制御は **異なる保証境界を持つ 2 層**で構成する。
+これらは補完関係であり、片方で代替できるものではない。
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Privy signer-layer policy (Privy サーバーサイド)           │
+│  ・allowlist: 宛先コントラクト / 資産 の静的許可リスト      │
+│  ・spending limit: 期間内送金上限 (静的リテラル)            │
+│  ・conditional sign: 条件付き署名 (静的値のみ)              │
+│  ・保証: 秘密鍵に到達する前の最終防衛線                     │
+│  ・制約: 動的自己参照 (onBehalfOf == msg.sender) は未サポート│
+└──────────────────────────┬──────────────────────────────────┘
+                           │ 補完関係 (代替不可)
+┌──────────────────────────▼──────────────────────────────────┐
+│  application-layer PolicyEngine (backend/app/policy/)        │
+│  ・engine.py: hard rule (HF floor / velocity cap / cooldown) │
+│  ・wallet_policy.py: 宣言的ポリシースキーマ (本スライス)    │
+│  ・保証: DB 参照・複合条件・動的ユーザー属性を扱える        │
+│  ・制約: 秘密鍵に触れない; calldata 再検証は aave/client.py │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 1.2 配置方針
+
+Privy server-side policy の宣言的スキーマ (`WalletPolicySpec`) を
+`backend/app/policy/wallet_policy.py` として **既存 `engine.py` と同一パッケージに併置**する。
+
+理由:
+- `engine.py` と同一の Decimal/env 規律を踏襲できる
+- 将来の `PolicyEngine.check()` 配線時に import が自然
+- Privy API 呼出層 (Phase 3) は別モジュールに分離し、スキーマ層は純粋に保つ
+
+---
+
+## 2. 既存安全装置との二重化マップ
+
+以下の実装位置はすべて grep 実値による確認済み情報。推測値は含まない。
+
+| CLAUDE.md Security Rule | application-layer 実装位置 (grep 実値) | Privy server policy で表現可能か | 判定 |
+|---|---|---|---|
+| **HF < 1.6 → HARD_STOP** | `backend/app/automation/monitoring_service.py:193-233`<br>`AaveOperationMode.HARD_STOP` (HF < 1.6 で設定)<br>`emergency_stop` OR logic: 行 239-250 | 可能: spending limit を `0` に設定すれば実質 HARD_STOP に相当。ただし HF の動的取得は Privy 側では不可 | **補完**: Privy は静的フォールバックのみ。動的 HF 監視は application-layer 必須 |
+| **単一取引 10% 上限** | `backend/app/policy/engine.py:21`<br>`_DEFAULT_MAX_POSITION_USD = Decimal("10000")`<br>Rule 3 (`amount_usd > max_position_usd`) 行 100-103 | 可能: `spending_limit.per_transaction` で静的上限を設定できる | **二重化推奨**: Privy 側で絶対上限、engine.py で動的割合計算 |
+| **日次 30% 上限** | `backend/app/policy/engine.py:22`<br>`_DEFAULT_DAILY_CAP_USD = Decimal("50000")`<br>Rule 4 日次 velocity cap: 行 143-151 | 可能: `spending_limit.per_day` で設定できる (静的リテラル) | **二重化推奨**: Privy 側で絶対額上限、engine.py で DB 集計ベースの実績計算 |
+| **cooldown 10 分** | `backend/app/policy/engine.py:24`<br>`_DEFAULT_COOLDOWN_SECONDS = 600`<br>Rule 6 cooldown: 行 166-181 | 不可: Privy spending limit は時間窓指定だが「前回 tx からの間隔」は非サポート | **application-layer 専任**: engine.py の `_check_cooldown()` が唯一の実装 |
+| **emergency_stop OR logic** | `backend/app/automation/monitoring_service.py:239-250`<br>`backend/app/automation/workflow.py:331` (`"emergency_stop"` 返却) | 不可: Privy policy は OR 条件付き状態機械を持たない | **application-layer 専任**: 手動 stop を Privy side では上書き不能 |
+| **HF floor (engine.py)** | `backend/app/policy/engine.py:25`<br>`_DEFAULT_HF_FLOOR = Decimal("1.5")`<br>Rule 7: 行 111-114 | 不可: 動的値 (期待 HF) との比較は Privy 未サポート | **application-layer 専任** |
+
+### 補足: aave/client.py の静的リテラル制約
+
+`backend/app/aave/client.py:1418-1424` のコメントにより、
+Privy Policy Engine は `onBehalfOf == msg.sender` の動的自己参照比較を未サポート
+(value は静的リテラルのみ)。本人一致検証は `build_partner_tx` エンドポイントの
+calldata 再検証 (`_decode_pool_calldata`) で担保している。
+Privy allowlist でこれを代替することはできない。
+
+---
+
+## 3. 重大所見: 既存 PolicyEngine 未配線
+
+### 3.1 確認事実
+
+`backend/app/policy/engine.py` には完全実装済みの `PolicyEngine.check()` が存在するが、
+以下の grep 結果により **本番コードパスに配線されていない**ことを確認した。
+
+```bash
+# 実行コマンド (再現可能)
+grep -rn "get_policy_engine()\|PolicyEngine()\|\.check(" backend/app/ \
+  | grep -v test | grep -v "engine.py"
+# 結果: backend/app/auth/router.py:249: # kyc_service.check(...) のコメント行のみ
+# → PolicyEngine.check() の本番呼出はゼロ件
+```
+
+具体的に未配線の経路:
+
+| 経路 | 現状 | 期待状態 |
+|---|---|---|
+| `POST /{proposal_id}/approve` (`proposals/router.py:642`) | PolicyEngine を呼ばず即 `status="approved"` | approve 前に `engine.check(ctx, db)` を呼び、blocked なら 422 返却 |
+| 提案生成時 (create proposal) | 未確認 (separate grep 必要) | 同上 |
+
+### 3.2 是正提案 (配線案)
+
+以下は **実装提案のみ**。実際の配線は HUMAN-REVIEW-REQUIRED とする。
+
+```python
+# proposals/router.py の approve_proposal 内 (Step 1 前に挿入する案)
+from app.policy.engine import PolicyContext, get_policy_engine  # noqa: PLC0415
+
+def approve_proposal(...):
+    # ...提案取得...
+
+    # [是正案] Step 0: PolicyEngine hard rule チェック
+    policy_ctx = PolicyContext(
+        user_id=proposal.user_id,
+        asset=proposal.asset,
+        operation=proposal.operation,
+        amount_usd=Decimal(str(proposal.amount_usd)),
+        expected_hf_after=Decimal(str(proposal.expected_hf_after))
+            if proposal.expected_hf_after else None,
+        proposal_id=proposal.id,
+    )
+    result = get_policy_engine().check(policy_ctx, db)
+    if result.blocked:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"policy_violations": result.violations},
+        )
+
+    # Step 1: 承認済みにマーク (既存コード)
+    proposal.status = "approved"
+    ...
+```
+
+この配線の実施判断・レビュー・テストは **Phase 2 の HUMAN-REVIEW-REQUIRED スライス**で行う。
+
+---
+
+## 4. ポリシー定義スキーマ案
+
+Privy server-side policy を宣言的に表現するスキーマ。
+実装は `backend/app/policy/wallet_policy.py` として本スライスで作成済み。
+
+### 4.1 `WalletAllowlistRule`
+
+```
+宛先コントラクトアドレス / 資産シンボル の allowlist。
+Privy server policy の allowlist 設定に対応。
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `allowed_contracts` | `frozenset[str]` | 許可コントラクトアドレス (小文字 0x...) |
+| `allowed_assets` | `frozenset[str]` | 許可資産シンボル (大文字) |
+
+バリデーション:
+- `allowed_contracts` は空不可 (空の allowlist は全許可と解釈される危険があるため)
+- コントラクトアドレスは `0x` prefix + 40 hex 文字
+- `allowed_assets` は空不可
+
+### 4.2 `SpendingLimitRule`
+
+```
+期間内送金上限。Privy server policy の spending_limit 設定に対応。
+金融計算規則 (Rule 11): 全フィールドは Decimal 型必須。
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `per_transaction_usd` | `Decimal` | 単一 tx 上限 (USD) |
+| `per_day_usd` | `Decimal` | 日次上限 (USD) |
+| `per_week_usd` | `Optional[Decimal]` | 週次上限 (USD, 省略可) |
+
+バリデーション:
+- 全値は正値 (`> 0`)
+- `per_transaction_usd <= per_day_usd` (単一 tx が日次を超えるのは矛盾)
+- `per_day_usd <= per_week_usd` (指定時: 日次が週次を超えるのは矛盾)
+- engine.py の定数との整合: `per_transaction_usd` は `_DEFAULT_MAX_POSITION_USD`(10000) 以下推奨
+
+### 4.3 `ConditionalSignRule`
+
+```
+条件付き署名ルール。Privy server policy の conditional_sign 設定に対応。
+注意: Privy は静的リテラル値のみ比較可能。動的自己参照は非サポート。
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `field_path` | `str` | チェック対象 calldata フィールドパス |
+| `operator` | `Literal["eq", "neq", "gt", "lt", "gte", "lte", "in", "not_in"]` | 比較演算子 |
+| `value` | `str \| list[str]` | 比較値 (静的リテラルのみ) |
+| `description` | `str` | ルール説明 (監査用) |
+
+バリデーション:
+- `field_path` は空不可
+- `operator` が `in` / `not_in` のとき `value` はリスト型必須
+- `operator` が `eq`/`neq`/`gt`/`lt`/`gte`/`lte` のとき `value` は文字列型必須
+- `value` リストは空不可
+
+### 4.4 `WalletPolicySpec`
+
+全ルールのコンテナ。
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `wallet_address` | `str` | 対象ウォレットアドレス (0x...) |
+| `policy_id` | `str` | 識別子 (監査ログ用) |
+| `allowlist` | `Optional[WalletAllowlistRule]` | allowlist ルール |
+| `spending_limit` | `Optional[SpendingLimitRule]` | spending limit ルール |
+| `conditional_signs` | `list[ConditionalSignRule]` | 条件付き署名ルール (0 個以上) |
+
+バリデーション:
+- `wallet_address` は 0x prefix + 40 hex 文字
+- `policy_id` は空不可
+- 少なくとも 1 つのルール (`allowlist` または `spending_limit` または `conditional_signs` 非空) が必要
+
+---
+
+## 5. 段階実装計画
+
+### Phase 1: 純粋スキーマ + バリデータ (本スライス / Tier B / 自動進行可)
+
+| 成果物 | ステータス |
+|---|---|
+| `docs/56_privy_policy_engine_design.md` (本文書) | 完了 |
+| `backend/app/policy/wallet_policy.py` | 完了 |
+| `backend/tests/test_wallet_policy.py` | 完了 |
+
+**制約**: Privy API 呼出なし / 秘密鍵なし / 既存ファイル無改変
+
+### Phase 2: 既存 PolicyEngine 配線是正 (HUMAN-REVIEW-REQUIRED)
+
+- `proposals/router.py` の `approve_proposal` 前に `engine.check()` を配線
+- 提案生成 endpoint でも同様に配線
+- 回帰テスト: `tests/test_policy_engine.py` / `tests/test_proposal_wallet_propagation.py`
+
+**理由で HUMAN-REVIEW**: 本番承認フローの変更、既存挙動への影響が大きい
+
+### Phase 3: Privy server policy 同期層 (HUMAN-REVIEW-REQUIRED)
+
+- `WalletPolicySpec` を Privy API に送信して server-side policy を設定するクライアント実装
+- 依存追加 (`privy-sdk` または `requests`/`httpx`)
+- 認証トークン管理 (env 変数)
+- 本番 wallet への policy 適用
+
+**理由で HUMAN-REVIEW**: 実資金ウォレットへの設定変更、秘密鍵環境変数追加、外部 API 呼出
+
+### Phase 4: main.py 配線 + 起動時 policy 同期 (HUMAN-REVIEW-REQUIRED)
+
+- startup event hook で `WalletPolicySpec` を Privy に同期する機構
+- `backend/app/main.py` の startup イベントへの登録
+
+**理由で HUMAN-REVIEW**: Tier S ファイル (`main.py`) 変更
+
+---
+
+## 6. 要確認事項
+
+以下は **現時点で確定できない項目**。推測での確定禁止。Phase 3 着手前に人間が確認すること。
+
+### 6.1 Privy server SDK
+
+| 項目 | 現状 | 確認方法 |
+|---|---|---|
+| SDK 言語/パッケージ名 | 不明。公式 docs 要確認 | https://docs.privy.io/guide/server/wallets/policy-engine |
+| Python SDK の有無 | 不明。REST API 直叩きが必要な可能性あり | 上記 docs |
+| 認証方式 | 不明 (API key / JWT / OAuth?) | Privy dashboard → Settings → API Keys |
+| policy API エンドポイント | 不明 | Privy API reference |
+| policy の適用タイミング (即時 vs 非同期) | 不明 | API response schema 確認 |
+
+### 6.2 allowlist / spending limit と aave/client.py の制約の波及
+
+`backend/app/aave/client.py:1418-1424` の確認事項:
+- Privy は静的リテラルのみ比較可能 → Aave V3 Pool コントラクトアドレスは不変なので allowlist には記載可能
+- `onBehalfOf == msg.sender` の動的比較は **Privy 未サポート確定**。calldata 再検証 (`_decode_pool_calldata`) が必須であり、Privy allowlist で代替不可
+- spending limit の `per_transaction_usd` 設定時、USD 換算が Privy 側でできるか不明 (token amount のみの可能性あり)
+
+### 6.3 既存 wallet との整合
+
+- 現在の Aave SUPPLY/WITHDRAW に使用している wallet address が Privy 管理下かどうか未確認
+- `AAVE_WALLET_PRIVATE_KEY` と Privy wallet の共存方針 (non-custodial 移行ロードマップ) 未確定
+
+### 6.4 環境分離
+
+- staging (Base Sepolia) / production (Base Mainnet) で Privy policy を別々に管理するか
+- Privy の環境 (sandbox / production) が staging 環境と一致するか
+
+---
+
+*このドキュメントは Phase 1 (scaffold) 完了時点の設計記録です。*
+*Phase 2 以降の実装前に本文書を更新し、6節の「要確認事項」を解消すること。*


### PR DESCRIPTION
## 概要
v4 epic **[Privy][自律] Privy Policy Engine（24h完全自律化）(GID 1215697791383548)** の **Tier-B 自動進行可スライス**。Privy server-side policy（allowlist / spending limit / 条件付き署名）の宣言的スキーマ + 純粋バリデータ + 設計doc のみ。Privy API実呼出・tx送信・秘密鍵・既存PolicyEngine配線・依存追加・main.py配線は **🛑 HUMAN-REVIEW-REQUIRED** として除外。

## ⚠️ 重大な実地所見（要対応・本PR責務外だが優先度高）
設計のため既存コードを grep した結果、**`backend/app/policy/engine.py` の `PolicyEngine`（HF floor / 単一取引上限 / velocity cap / cooldown / whitelist を実装）が `proposals/router.py` の `approve_proposal` から一切呼ばれていない**ことを確認（`get_policy_engine` callsite 0件・定義のみ、Evaluator が独立検証）。実資金の承認フロー `POST /{proposal_id}/approve` が application-layer hard rule 検算を経ずに `status="approved"` になっている = **Disconnected Safety Scan 該当の孤立安全装置**。docs/56 §3 に是正配線案を記録。Phase 2 HUMAN-REVIEW スライスで優先対応すべき。

## 変更（すべて新規ファイル・既存無改変）
- `docs/56_privy_policy_engine_design.md` — 二層構造図 / 既存安全装置との二重化マップ(grep実値) / 重大所見 / スキーマ案 / 段階実装計画 / Privy SDK【要確認】
- `backend/app/policy/wallet_policy.py` — frozen dataclass ポリシー型3種 + 純粋バリデータ（Decimal強制 / 矛盾検出 / 境界値）。Privy/requests/httpx/private_key import ゼロ
- `backend/tests/test_wallet_policy.py` — 47件（矛盾検出・境界値・Decimal強制・安全境界）

## パイプライン結果
- **Evaluator: APPROVED**（CRITICAL 0 / 安全境界・非侵襲・Decimal・docs健全性・バリデータ論理 実確認PASS、PolicyEngine未配線所見を独立検証）
- **Tester: PASS** — wallet_policy.py coverage **98%**、`tests/ -k policy` **94 passed**（リグレッションなし）、mypy/ruff/ruff-S 全0エラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)