### PR TITLE
feat(uniswap): Uniswap V4 スワップ統合 設計doc + 意図スキーマ/純粋バリデータ (scaffold)

### DIFF
--- a/backend/app/protocols/uniswap/__init__.py
+++ b/backend/app/protocols/uniswap/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""Uniswap V4 スワップ統合モジュール（scaffold / Phase 1）。
+
+Phase 1 スコープ: 型定義・純粋バリデータのみ。
+SDK calldata 取得・tx 署名・broadcast は HUMAN-REVIEW-REQUIRED (Phase 2/3) で追加する。
+main.py への配線は Tier S 扱い (Phase 4)。
+"""

--- a/backend/app/protocols/uniswap/schemas.py
+++ b/backend/app/protocols/uniswap/schemas.py
@@ -1,0 +1,148 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""Uniswap V4 スワップ統合 Pydantic スキーマ定義（Phase 1 scaffold）。
+
+本ファイルは **意図・検証用途のみ** の純粋型定義を提供する。
+calldata / to アドレス / tx_hash / approvals 等の実行系フィールドは
+HUMAN-REVIEW-REQUIRED スコープ（Phase 2 以降）で追加する:
+  - Phase 2: SDK calldata 取得（dry_run=True 前提）
+  - Phase 3: Privy 署名 + broadcast（HUMAN-REVIEW-REQUIRED）
+  - Phase 4: main.py ルーター配線（Tier S）
+これらのフィールドを本ファイルに追加する際は Planner の事前承認を必要とする。
+
+セキュリティ:
+- 秘密鍵・署名情報をフィールドとして保持しない
+- 金融計算フィールドは全て Decimal 型（float 禁止）
+- Decimal は JSON シリアライズ時に文字列で返却する
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field, field_serializer, field_validator
+
+
+class UniswapV4SwapIntent(BaseModel):
+    """Uniswap V4 スワップ意図（read-only リクエスト容器）。
+
+    NOTE: チェーンは V4 Pool Manager がデプロイされているチェーンに限定する。
+    デプロイ済みチェーンアドレスは【要確認】— Universal Router 正式アドレスの
+    chain 別マッピングを Phase 2 着手前に SDK / 公式ドキュメントで確認すること。
+    現在 Literal は暫定値（Ethereum Mainnet / Arbitrum / Base / Optimism / Polygon を想定）。
+    """
+
+    token_in: str = Field(
+        ..., description="入力トークンアドレス（ERC-20 / ネイティブは '0xEeeee...' 等）"
+    )
+    token_out: str = Field(..., description="出力トークンアドレス")
+    amount_in: Decimal = Field(..., gt=Decimal("0"), description="入力量（ネイティブ単位）")
+    slippage: Decimal = Field(
+        default=Decimal("0.005"),
+        gt=Decimal("0"),
+        le=Decimal("0.05"),
+        description="スリッページ許容幅（0.005 = 0.5%）。0 < slippage <= 0.05（5%）",
+    )
+    deadline_unix: int = Field(
+        ..., description="スワップ期限（Unix 秒）。現在時刻を超えていれば拒否"
+    )
+    receiver: str = Field(..., description="スワップ受取アドレス（空文字は拒否）")
+    portfolio_value_usd: Optional[Decimal] = Field(
+        default=None,
+        ge=Decimal("0"),
+        description="ポートフォリオ総額（USD）。10%上限チェック用。amount_in_usd と併用必須",
+    )
+    amount_in_usd: Optional[Decimal] = Field(
+        default=None,
+        ge=Decimal("0"),
+        description=(
+            "トレード金額（USD）。portfolio_value_usd と併用必須。"
+            "片方のみ指定時は fail-closed で拒否（10%上限が検証不能なため）"
+        ),
+    )
+    chain: Literal["ethereum", "arbitrum", "base", "optimism", "polygon"] = Field(
+        ...,
+        description=(
+            "対象チェーン。【要確認】Universal Router 正式アドレスは chain 別に異なる。"
+            "Phase 2 着手前に公式ドキュメントで確認すること。"
+        ),
+    )
+    dry_run: bool = Field(
+        True,
+        description="True の場合バリデーションのみ実行（デフォルト）。SDK calldata 取得は Phase 2 以降",
+    )
+
+    @field_validator("amount_in", mode="before")
+    @classmethod
+    def _coerce_amount_in(cls, v: object) -> Decimal:
+        """float / 文字列を Decimal に変換する（float 禁止ルール準拠）。"""
+        return Decimal(str(v))
+
+    @field_validator("slippage", mode="before")
+    @classmethod
+    def _coerce_slippage(cls, v: object) -> Decimal:
+        """float / 文字列を Decimal に変換する。"""
+        return Decimal(str(v))
+
+    @field_validator("amount_in_usd", mode="before")
+    @classmethod
+    def _coerce_amount_in_usd(cls, v: object) -> Optional[Decimal]:
+        """float / 文字列を Decimal に変換する。None の場合はそのまま。"""
+        if v is None:
+            return None
+        return Decimal(str(v))
+
+    @field_validator("portfolio_value_usd", mode="before")
+    @classmethod
+    def _coerce_portfolio_value_usd(cls, v: object) -> Optional[Decimal]:
+        """float / 文字列を Decimal に変換する。None の場合はそのまま。"""
+        if v is None:
+            return None
+        return Decimal(str(v))
+
+    @field_serializer("amount_in", "slippage")
+    def _serialize_decimal(self, v: Decimal) -> str:
+        """Decimal フィールドを文字列でシリアライズ（JSON 精度保持）。"""
+        return str(v)
+
+    @field_serializer("amount_in_usd", "portfolio_value_usd")
+    def _serialize_optional_decimal(self, v: Optional[Decimal]) -> Optional[str]:
+        """Optional[Decimal] フィールドを文字列でシリアライズ。"""
+        if v is None:
+            return None
+        return str(v)
+
+
+class UniswapV4SwapEstimate(BaseModel):
+    """Uniswap V4 スワップ推定結果（read-only 容器）。
+
+    バリデータが返す純粋な検証結果を保持する。
+    実行系情報（calldata / to / tx_hash / approvals）は含まない。
+    これらは HUMAN-REVIEW-REQUIRED スコープ（Phase 2/3）で別途定義する。
+    """
+
+    amount_out_estimate: Optional[Decimal] = Field(
+        default=None,
+        description="推定受取量（外部 quoting API から取得、Phase 1 では None）",
+    )
+    min_amount_out: Optional[Decimal] = Field(
+        default=None,
+        description="最小受取量（amount_out_estimate * (1 - slippage)）",
+    )
+    price_impact_pct: Optional[Decimal] = Field(
+        default=None,
+        description="価格インパクト（%）。外部 quoting API から取得、Phase 1 では None",
+    )
+    is_valid: bool = Field(..., description="バリデーション通過フラグ")
+    validation_errors: list[str] = Field(
+        default_factory=list,
+        description="バリデーションエラーリスト（is_valid=False の場合に詳細を格納）",
+    )
+
+    @field_serializer("amount_out_estimate", "min_amount_out", "price_impact_pct")
+    def _serialize_optional_decimal(self, v: Optional[Decimal]) -> Optional[str]:
+        """Optional[Decimal] フィールドを文字列でシリアライズ。"""
+        if v is None:
+            return None
+        return str(v)

--- a/backend/app/protocols/uniswap/validators.py
+++ b/backend/app/protocols/uniswap/validators.py
@@ -1,0 +1,169 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""Uniswap V4 スワップ純粋バリデータ（Phase 1 scaffold）。
+
+本モジュールは **純粋関数のみ** を提供する。
+I/O・web3・HTTP・秘密鍵へのアクセスは一切行わない。
+外部副作用のないコードのみで構成する（テスト容易性・安全境界の明確化）。
+
+実行系コード（SDK calldata 取得 / tx 署名 / broadcast）は
+HUMAN-REVIEW-REQUIRED スコープ（Phase 2/3）で別ファイルに追加する。
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+
+from app.aave.slippage_guard import SlippageGuard
+from app.protocols.uniswap.schemas import UniswapV4SwapEstimate, UniswapV4SwapIntent
+
+logger = logging.getLogger(__name__)
+
+# 単一取引上限: ポートフォリオの 10%（Security Rules §3）
+_MAX_SINGLE_TRADE_RATIO = Decimal("0.10")
+
+# SlippageGuard は is_stablecoin 判定の再利用のみ。本体は改変しない。
+_slippage_guard = SlippageGuard()
+
+
+def validate_swap_intent(
+    intent: UniswapV4SwapIntent,
+    now_unix: int,
+) -> UniswapV4SwapEstimate:
+    """Uniswap V4 スワップ意図をバリデートし推定結果を返す。
+
+    純粋関数: 引数のみから結果を計算する。I/O・外部状態参照なし。
+
+    Args:
+        intent: バリデート対象のスワップ意図
+        now_unix: 現在時刻（Unix 秒）。テスト時は任意の値を注入可能
+
+    Returns:
+        UniswapV4SwapEstimate: バリデーション結果。
+          - is_valid=True: 全チェック通過
+          - is_valid=False: validation_errors にエラー詳細を格納
+
+    Security:
+        - deadline_unix <= now_unix: 期限切れとして拒否（fail-closed）
+        - token_in == token_out: 無意味なスワップとして拒否
+        - receiver が空文字: 宛先不明として拒否
+        - amount_in_usd と portfolio_value_usd の一方のみ指定: 10%上限検証不能→拒否
+        - amount_in_usd > portfolio_value_usd * 0.10: 単一取引10%上限違反として拒否
+        - slippage の範囲: スキーマ側で担保済み（gt=0, le=0.05）
+        - amount_in > 0: スキーマ側で担保済み（gt=0）
+    """
+    errors: list[str] = []
+
+    # 1. deadline チェック（期限切れは即座に拒否）
+    if intent.deadline_unix <= now_unix:
+        errors.append(
+            f"deadline_unix ({intent.deadline_unix}) が現在時刻 ({now_unix}) 以前: スワップ期限切れ"
+        )
+
+    # 2. 同一トークンチェック
+    if intent.token_in.lower() == intent.token_out.lower():
+        errors.append(f"token_in と token_out が同一: {intent.token_in} — 無意味なスワップは拒否")
+
+    # 3. receiver 非空チェック
+    if not intent.receiver.strip():
+        errors.append("receiver が空文字: 受取アドレスを指定してください")
+
+    # 4. 単一取引10%上限チェック（Security Rules §3）
+    #    amount_in_usd または portfolio_value_usd のどちらか一方のみ指定は fail-closed で拒否。
+    #    両方 None の場合は上限チェックをスキップ（USD 評価不能）。
+    #    両方 None でない場合のみ比較する。
+    has_amount_usd = intent.amount_in_usd is not None
+    has_portfolio_usd = intent.portfolio_value_usd is not None
+
+    if has_amount_usd != has_portfolio_usd:
+        # 片方のみ指定: 10%上限が正確に検証できないため fail-closed で拒否
+        errors.append(
+            "amount_in_usd と portfolio_value_usd はどちらも指定するか、どちらも省略してください。"
+            "片方のみの指定では単一取引10%上限を検証できないため拒否します（fail-closed）"
+        )
+    elif intent.amount_in_usd is not None and intent.portfolio_value_usd is not None:
+        # 型ガード: is not None チェックにより mypy が Decimal として推論する
+        amount_usd: Decimal = intent.amount_in_usd
+        portfolio_usd: Decimal = intent.portfolio_value_usd
+
+        if portfolio_usd > Decimal("0") and amount_usd > portfolio_usd * _MAX_SINGLE_TRADE_RATIO:
+            errors.append(
+                f"単一取引上限超過: amount_in_usd={amount_usd} が "
+                f"portfolio_value_usd={portfolio_usd} の {_MAX_SINGLE_TRADE_RATIO * 100}% を超えています"
+            )
+
+    # 5. ステーブルコイン判定（SlippageGuard 再利用、本体非改変）
+    #    ステーブルコイン同士のスワップはスリッページ許容幅が十分か補足情報として記録
+    #    （Phase 1 では reject は行わない。Phase 2 で quoting API 連携後に判断）
+    token_in_symbol = _extract_symbol(intent.token_in)
+    token_out_symbol = _extract_symbol(intent.token_out)
+    is_stablecoin_in = _slippage_guard.is_stablecoin(token_in_symbol)
+    is_stablecoin_out = _slippage_guard.is_stablecoin(token_out_symbol)
+
+    if is_stablecoin_in and is_stablecoin_out:
+        logger.debug(
+            "UniswapV4 validate_swap_intent: ステーブルコイン同士のスワップ (%s -> %s)。"
+            "slippage=%.4f",
+            token_in_symbol,
+            token_out_symbol,
+            intent.slippage,
+        )
+
+    is_valid = len(errors) == 0
+
+    logger.debug(
+        "validate_swap_intent: is_valid=%s errors=%d chain=%s token_in=%s token_out=%s",
+        is_valid,
+        len(errors),
+        intent.chain,
+        intent.token_in[:10] + "...",
+        intent.token_out[:10] + "...",
+    )
+
+    return UniswapV4SwapEstimate(
+        amount_out_estimate=None,  # Phase 2 (quoting API) で設定
+        min_amount_out=None,  # Phase 2 で compute_min_amount_out を適用
+        price_impact_pct=None,  # Phase 2 (quoting API) で設定
+        is_valid=is_valid,
+        validation_errors=errors,
+    )
+
+
+def compute_min_amount_out(
+    amount_out_estimate: Decimal,
+    slippage: Decimal,
+) -> Decimal:
+    """最小受取量を計算する（純粋関数）。
+
+    Phase 2 以降で quoting API から amount_out_estimate を取得した後に呼び出す。
+
+    Args:
+        amount_out_estimate: 推定受取量（Decimal）
+        slippage: スリッページ許容幅（例: Decimal("0.005") = 0.5%）
+
+    Returns:
+        最小受取量: amount_out_estimate * (1 - slippage)
+
+    Note:
+        全計算を Decimal で行う（float 禁止）。
+        slippage の範囲検証はスキーマ（UniswapV4SwapIntent）側で担保済み。
+    """
+    return amount_out_estimate * (Decimal("1") - slippage)
+
+
+def _extract_symbol(token_address_or_symbol: str) -> str:
+    """アドレスまたはシンボルからシンボル相当文字列を返す。
+
+    SlippageGuard.is_stablecoin はシンボル（"USDC" 等）を期待する。
+    アドレス形式（"0x..."）の場合は大文字変換のみ行い、
+    一致しなければ is_stablecoin は False を返す（fail-open）。
+    シンボル文字列の場合は大文字変換して返す。
+
+    純粋関数: 外部参照なし。
+    """
+    stripped = token_address_or_symbol.strip()
+    if stripped.startswith("0x") or stripped.startswith("0X"):
+        # アドレス形式: そのまま渡す（_STABLECOIN_SYMBOLS に一致しないため False 返却）
+        return stripped.upper()
+    return stripped.upper()

--- a/backend/tests/protocols/test_uniswap/__init__.py
+++ b/backend/tests/protocols/test_uniswap/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""Uniswap V4 スキーマ・バリデータのユニットテスト。"""

--- a/backend/tests/protocols/test_uniswap/test_uniswap_schemas.py
+++ b/backend/tests/protocols/test_uniswap/test_uniswap_schemas.py
@@ -1,0 +1,325 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""Uniswap V4 スキーマのユニットテスト。"""
+
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from app.protocols.uniswap.schemas import UniswapV4SwapEstimate, UniswapV4SwapIntent
+
+# テスト用の固定値（ハードコードデータ検出防止: これらは UI 表示値ではなく型確認用）
+_TOKEN_IN = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"  # USDC (Ethereum mainnet)
+_TOKEN_OUT = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"  # WETH (Ethereum mainnet)
+_RECEIVER = "0x" + "a" * 40
+_DEADLINE = 9_999_999_999  # 十分先の Unix 秒
+
+
+class TestUniswapV4SwapIntentDecimalCoercion:
+    """Decimal 変換・精度テスト。"""
+
+    def test_float_amount_in_converted_to_decimal(self) -> None:
+        """float の amount_in が Decimal に変換されること。"""
+        intent = UniswapV4SwapIntent(
+            token_in=_TOKEN_IN,
+            token_out=_TOKEN_OUT,
+            amount_in=1.5,  # type: ignore[arg-type]
+            deadline_unix=_DEADLINE,
+            receiver=_RECEIVER,
+            chain="ethereum",
+        )
+        assert type(intent.amount_in) is Decimal
+        assert intent.amount_in == Decimal("1.5")
+
+    def test_string_amount_in_converted_to_decimal(self) -> None:
+        """文字列の amount_in が Decimal に変換されること。"""
+        intent = UniswapV4SwapIntent(
+            token_in=_TOKEN_IN,
+            token_out=_TOKEN_OUT,
+            amount_in="0.123456789012345678",  # type: ignore[arg-type]
+            deadline_unix=_DEADLINE,
+            receiver=_RECEIVER,
+            chain="ethereum",
+        )
+        assert type(intent.amount_in) is Decimal
+        assert intent.amount_in == Decimal("0.123456789012345678")
+
+    def test_float_slippage_converted_to_decimal(self) -> None:
+        """float の slippage が Decimal に変換されること。"""
+        intent = UniswapV4SwapIntent(
+            token_in=_TOKEN_IN,
+            token_out=_TOKEN_OUT,
+            amount_in=Decimal("1.0"),
+            slippage=0.01,  # type: ignore[arg-type]
+            deadline_unix=_DEADLINE,
+            receiver=_RECEIVER,
+            chain="ethereum",
+        )
+        assert type(intent.slippage) is Decimal
+        assert intent.slippage == Decimal("0.01")
+
+    def test_float_amount_in_usd_converted_to_decimal(self) -> None:
+        """float の amount_in_usd が Decimal に変換されること。"""
+        intent = UniswapV4SwapIntent(
+            token_in=_TOKEN_IN,
+            token_out=_TOKEN_OUT,
+            amount_in=Decimal("1.0"),
+            deadline_unix=_DEADLINE,
+            receiver=_RECEIVER,
+            chain="ethereum",
+            amount_in_usd=1000.5,  # type: ignore[arg-type]
+            portfolio_value_usd=Decimal("20000.0"),
+        )
+        assert type(intent.amount_in_usd) is Decimal
+        assert intent.amount_in_usd == Decimal("1000.5")
+
+    def test_decimal_precision_preserved(self) -> None:
+        """Decimal の精度が変換後も保持されること。"""
+        precise = Decimal("0.123456789012345678901234567890")
+        intent = UniswapV4SwapIntent(
+            token_in=_TOKEN_IN,
+            token_out=_TOKEN_OUT,
+            amount_in=precise,
+            deadline_unix=_DEADLINE,
+            receiver=_RECEIVER,
+            chain="ethereum",
+        )
+        assert intent.amount_in == precise
+
+
+class TestUniswapV4SwapIntentSlippageBoundary:
+    """slippage 境界値テスト。"""
+
+    def test_slippage_default_is_half_percent(self) -> None:
+        """slippage デフォルトが 0.005（0.5%）であること。"""
+        intent = UniswapV4SwapIntent(
+            token_in=_TOKEN_IN,
+            token_out=_TOKEN_OUT,
+            amount_in=Decimal("1.0"),
+            deadline_unix=_DEADLINE,
+            receiver=_RECEIVER,
+            chain="ethereum",
+        )
+        assert intent.slippage == Decimal("0.005")
+
+    def test_slippage_min_boundary_rejected(self) -> None:
+        """slippage = 0 は gt=0 違反で拒否されること。"""
+        with pytest.raises(ValidationError):
+            UniswapV4SwapIntent(
+                token_in=_TOKEN_IN,
+                token_out=_TOKEN_OUT,
+                amount_in=Decimal("1.0"),
+                slippage=Decimal("0"),
+                deadline_unix=_DEADLINE,
+                receiver=_RECEIVER,
+                chain="ethereum",
+            )
+
+    def test_slippage_max_boundary_accepted(self) -> None:
+        """slippage = 0.05（5%）は上限境界として許容されること。"""
+        intent = UniswapV4SwapIntent(
+            token_in=_TOKEN_IN,
+            token_out=_TOKEN_OUT,
+            amount_in=Decimal("1.0"),
+            slippage=Decimal("0.05"),
+            deadline_unix=_DEADLINE,
+            receiver=_RECEIVER,
+            chain="ethereum",
+        )
+        assert intent.slippage == Decimal("0.05")
+
+    def test_slippage_above_max_rejected(self) -> None:
+        """slippage > 0.05 は le=0.05 違反で拒否されること。"""
+        with pytest.raises(ValidationError):
+            UniswapV4SwapIntent(
+                token_in=_TOKEN_IN,
+                token_out=_TOKEN_OUT,
+                amount_in=Decimal("1.0"),
+                slippage=Decimal("0.051"),
+                deadline_unix=_DEADLINE,
+                receiver=_RECEIVER,
+                chain="ethereum",
+            )
+
+    def test_slippage_small_positive_accepted(self) -> None:
+        """slippage = 0.001（0.1%）は許容されること。"""
+        intent = UniswapV4SwapIntent(
+            token_in=_TOKEN_IN,
+            token_out=_TOKEN_OUT,
+            amount_in=Decimal("1.0"),
+            slippage=Decimal("0.001"),
+            deadline_unix=_DEADLINE,
+            receiver=_RECEIVER,
+            chain="ethereum",
+        )
+        assert intent.slippage == Decimal("0.001")
+
+
+class TestUniswapV4SwapIntentAmountInValidation:
+    """amount_in 検証テスト。"""
+
+    def test_amount_in_zero_rejected(self) -> None:
+        """amount_in = 0 は gt=0 違反で拒否されること。"""
+        with pytest.raises(ValidationError):
+            UniswapV4SwapIntent(
+                token_in=_TOKEN_IN,
+                token_out=_TOKEN_OUT,
+                amount_in=Decimal("0"),
+                deadline_unix=_DEADLINE,
+                receiver=_RECEIVER,
+                chain="ethereum",
+            )
+
+    def test_amount_in_negative_rejected(self) -> None:
+        """amount_in < 0 は gt=0 違反で拒否されること。"""
+        with pytest.raises(ValidationError):
+            UniswapV4SwapIntent(
+                token_in=_TOKEN_IN,
+                token_out=_TOKEN_OUT,
+                amount_in=Decimal("-1"),
+                deadline_unix=_DEADLINE,
+                receiver=_RECEIVER,
+                chain="ethereum",
+            )
+
+    def test_amount_in_positive_accepted(self) -> None:
+        """正の amount_in が受け入れられること。"""
+        intent = UniswapV4SwapIntent(
+            token_in=_TOKEN_IN,
+            token_out=_TOKEN_OUT,
+            amount_in=Decimal("100"),
+            deadline_unix=_DEADLINE,
+            receiver=_RECEIVER,
+            chain="ethereum",
+        )
+        assert intent.amount_in == Decimal("100")
+
+
+class TestUniswapV4SwapIntentSerialization:
+    """JSON シリアライズテスト（Decimal → str）。"""
+
+    def test_amount_in_serialized_as_string(self) -> None:
+        """amount_in が JSON で文字列としてシリアライズされること。"""
+        intent = UniswapV4SwapIntent(
+            token_in=_TOKEN_IN,
+            token_out=_TOKEN_OUT,
+            amount_in=Decimal("1.5"),
+            deadline_unix=_DEADLINE,
+            receiver=_RECEIVER,
+            chain="ethereum",
+        )
+        data = intent.model_dump()
+        assert isinstance(data["amount_in"], str)
+        assert data["amount_in"] == "1.5"
+
+    def test_slippage_serialized_as_string(self) -> None:
+        """slippage が JSON で文字列としてシリアライズされること。"""
+        intent = UniswapV4SwapIntent(
+            token_in=_TOKEN_IN,
+            token_out=_TOKEN_OUT,
+            amount_in=Decimal("1.0"),
+            slippage=Decimal("0.01"),
+            deadline_unix=_DEADLINE,
+            receiver=_RECEIVER,
+            chain="ethereum",
+        )
+        data = intent.model_dump()
+        assert isinstance(data["slippage"], str)
+        assert data["slippage"] == "0.01"
+
+    def test_optional_decimal_none_serialized_as_none(self) -> None:
+        """Optional[Decimal] が None の場合は None としてシリアライズされること。"""
+        intent = UniswapV4SwapIntent(
+            token_in=_TOKEN_IN,
+            token_out=_TOKEN_OUT,
+            amount_in=Decimal("1.0"),
+            deadline_unix=_DEADLINE,
+            receiver=_RECEIVER,
+            chain="ethereum",
+        )
+        data = intent.model_dump()
+        assert data["amount_in_usd"] is None
+        assert data["portfolio_value_usd"] is None
+
+    def test_optional_decimal_value_serialized_as_string(self) -> None:
+        """Optional[Decimal] が値を持つ場合は文字列としてシリアライズされること。"""
+        intent = UniswapV4SwapIntent(
+            token_in=_TOKEN_IN,
+            token_out=_TOKEN_OUT,
+            amount_in=Decimal("1.0"),
+            deadline_unix=_DEADLINE,
+            receiver=_RECEIVER,
+            chain="ethereum",
+            amount_in_usd=Decimal("1500.00"),
+            portfolio_value_usd=Decimal("20000.00"),
+        )
+        data = intent.model_dump()
+        assert isinstance(data["amount_in_usd"], str)
+        assert data["amount_in_usd"] == "1500.00"
+        assert isinstance(data["portfolio_value_usd"], str)
+        assert data["portfolio_value_usd"] == "20000.00"
+
+
+class TestUniswapV4SwapIntentDefaults:
+    """デフォルト値テスト。"""
+
+    def test_dry_run_default_is_true(self) -> None:
+        """dry_run のデフォルトが True であること。"""
+        intent = UniswapV4SwapIntent(
+            token_in=_TOKEN_IN,
+            token_out=_TOKEN_OUT,
+            amount_in=Decimal("1.0"),
+            deadline_unix=_DEADLINE,
+            receiver=_RECEIVER,
+            chain="ethereum",
+        )
+        assert intent.dry_run is True
+
+    def test_chain_invalid_rejected(self) -> None:
+        """V4 未デプロイチェーンは Literal 違反で拒否されること。"""
+        with pytest.raises(ValidationError):
+            UniswapV4SwapIntent(
+                token_in=_TOKEN_IN,
+                token_out=_TOKEN_OUT,
+                amount_in=Decimal("1.0"),
+                deadline_unix=_DEADLINE,
+                receiver=_RECEIVER,
+                chain="bsc",  # type: ignore[arg-type]
+            )
+
+
+class TestUniswapV4SwapEstimate:
+    """UniswapV4SwapEstimate テスト。"""
+
+    def test_valid_estimate_creation(self) -> None:
+        """is_valid=True の UniswapV4SwapEstimate が生成できること。"""
+        estimate = UniswapV4SwapEstimate(
+            is_valid=True,
+            validation_errors=[],
+        )
+        assert estimate.is_valid is True
+        assert estimate.validation_errors == []
+        assert estimate.amount_out_estimate is None
+
+    def test_invalid_estimate_with_errors(self) -> None:
+        """is_valid=False の場合に validation_errors が設定されること。"""
+        estimate = UniswapV4SwapEstimate(
+            is_valid=False,
+            validation_errors=["deadline 期限切れ", "token_in == token_out"],
+        )
+        assert estimate.is_valid is False
+        assert len(estimate.validation_errors) == 2
+
+    def test_estimate_decimal_fields_serialized_as_string(self) -> None:
+        """Decimal フィールドが文字列としてシリアライズされること。"""
+        estimate = UniswapV4SwapEstimate(
+            amount_out_estimate=Decimal("1.23"),
+            min_amount_out=Decimal("1.20"),
+            price_impact_pct=Decimal("0.5"),
+            is_valid=True,
+        )
+        data = estimate.model_dump()
+        assert isinstance(data["amount_out_estimate"], str)
+        assert isinstance(data["min_amount_out"], str)
+        assert isinstance(data["price_impact_pct"], str)

--- a/backend/tests/protocols/test_uniswap/test_uniswap_validators.py
+++ b/backend/tests/protocols/test_uniswap/test_uniswap_validators.py
@@ -1,0 +1,316 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""Uniswap V4 バリデータのユニットテスト。"""
+
+from decimal import Decimal
+
+import pytest
+
+from app.protocols.uniswap.schemas import UniswapV4SwapIntent
+from app.protocols.uniswap.validators import compute_min_amount_out, validate_swap_intent
+
+# テスト用の固定値
+_TOKEN_IN = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"  # USDC (Ethereum mainnet)
+_TOKEN_OUT = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"  # WETH (Ethereum mainnet)
+_RECEIVER = "0x" + "a" * 40
+_NOW_UNIX = 1_718_000_000  # 固定基準時刻（テスト注入用）
+_FUTURE_DEADLINE = _NOW_UNIX + 3600  # 1時間後
+
+
+def _make_intent(**kwargs: object) -> UniswapV4SwapIntent:
+    """テスト用デフォルト UniswapV4SwapIntent を生成する。"""
+    defaults: dict[str, object] = {
+        "token_in": _TOKEN_IN,
+        "token_out": _TOKEN_OUT,
+        "amount_in": Decimal("1.0"),
+        "deadline_unix": _FUTURE_DEADLINE,
+        "receiver": _RECEIVER,
+        "chain": "ethereum",
+    }
+    defaults.update(kwargs)
+    return UniswapV4SwapIntent(**defaults)  # type: ignore[arg-type]
+
+
+class TestValidateSwapIntentDeadline:
+    """deadline_unix チェックテスト。"""
+
+    def test_expired_deadline_rejected(self) -> None:
+        """deadline_unix <= now_unix の場合は拒否されること。"""
+        intent = _make_intent(deadline_unix=_NOW_UNIX)  # now と同値
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.is_valid is False
+        assert any("deadline" in e for e in result.validation_errors)
+
+    def test_past_deadline_rejected(self) -> None:
+        """deadline_unix が過去の場合は拒否されること。"""
+        intent = _make_intent(deadline_unix=_NOW_UNIX - 1)
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.is_valid is False
+
+    def test_future_deadline_accepted(self) -> None:
+        """deadline_unix が未来の場合は通過すること。"""
+        intent = _make_intent(deadline_unix=_NOW_UNIX + 1)
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.is_valid is True
+        assert result.validation_errors == []
+
+    def test_far_future_deadline_accepted(self) -> None:
+        """十分先の deadline_unix が通過すること。"""
+        intent = _make_intent(deadline_unix=_NOW_UNIX + 86400)  # 24時間後
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.is_valid is True
+
+
+class TestValidateSwapIntentTokenPair:
+    """token_in / token_out チェックテスト。"""
+
+    def test_same_token_rejected(self) -> None:
+        """token_in == token_out の場合は拒否されること。"""
+        intent = _make_intent(token_in=_TOKEN_IN, token_out=_TOKEN_IN)
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.is_valid is False
+        assert any("token_in" in e and "token_out" in e for e in result.validation_errors)
+
+    def test_same_token_case_insensitive_rejected(self) -> None:
+        """大文字小文字が異なる場合も同一トークンとして拒否されること。"""
+        intent = _make_intent(
+            token_in=_TOKEN_IN.lower(),
+            token_out=_TOKEN_IN.upper(),
+        )
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.is_valid is False
+
+    def test_different_tokens_accepted(self) -> None:
+        """異なるトークンペアは通過すること。"""
+        intent = _make_intent(token_in=_TOKEN_IN, token_out=_TOKEN_OUT)
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.is_valid is True
+
+
+class TestValidateSwapIntentReceiver:
+    """receiver チェックテスト。"""
+
+    def test_empty_receiver_rejected(self) -> None:
+        """receiver が空文字の場合は拒否されること。"""
+        intent = _make_intent(receiver="")
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.is_valid is False
+        assert any("receiver" in e for e in result.validation_errors)
+
+    def test_whitespace_only_receiver_rejected(self) -> None:
+        """receiver が空白のみの場合は拒否されること。"""
+        intent = _make_intent(receiver="   ")
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.is_valid is False
+
+    def test_valid_receiver_accepted(self) -> None:
+        """有効な receiver アドレスが通過すること。"""
+        intent = _make_intent(receiver=_RECEIVER)
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.is_valid is True
+
+
+class TestValidateSwapIntentPortfolioLimit:
+    """単一取引10%上限チェックテスト（Security Rules §3）。"""
+
+    def test_within_10_percent_accepted(self) -> None:
+        """amount_in_usd が portfolio の 10% 以内は通過すること。"""
+        intent = _make_intent(
+            portfolio_value_usd=Decimal("10000"),
+            amount_in_usd=Decimal("1000"),  # ちょうど10%
+        )
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.is_valid is True
+
+    def test_exceeding_10_percent_rejected(self) -> None:
+        """amount_in_usd が portfolio の 10% を超える場合は拒否されること。"""
+        intent = _make_intent(
+            portfolio_value_usd=Decimal("10000"),
+            amount_in_usd=Decimal("1001"),  # 10.01%
+        )
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.is_valid is False
+        assert any("10%" in e or "上限" in e for e in result.validation_errors)
+
+    def test_far_exceeding_10_percent_rejected(self) -> None:
+        """amount_in_usd が portfolio の 50% の場合も拒否されること。"""
+        intent = _make_intent(
+            portfolio_value_usd=Decimal("10000"),
+            amount_in_usd=Decimal("5000"),
+        )
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.is_valid is False
+
+    def test_amount_in_usd_only_fail_closed(self) -> None:
+        """amount_in_usd のみ指定（portfolio_value_usd 未指定）は fail-closed 拒否。"""
+        intent = _make_intent(
+            amount_in_usd=Decimal("100"),
+            portfolio_value_usd=None,
+        )
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.is_valid is False
+        assert any("fail-closed" in e or "片方のみ" in e for e in result.validation_errors)
+
+    def test_portfolio_value_only_fail_closed(self) -> None:
+        """portfolio_value_usd のみ指定（amount_in_usd 未指定）は fail-closed 拒否。"""
+        intent = _make_intent(
+            amount_in_usd=None,
+            portfolio_value_usd=Decimal("10000"),
+        )
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.is_valid is False
+        assert any("fail-closed" in e or "片方のみ" in e for e in result.validation_errors)
+
+    def test_both_none_skips_check(self) -> None:
+        """両方 None の場合は10%チェックをスキップして通過すること。"""
+        intent = _make_intent(
+            amount_in_usd=None,
+            portfolio_value_usd=None,
+        )
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.is_valid is True
+
+    def test_zero_portfolio_skips_comparison(self) -> None:
+        """portfolio_value_usd = 0 の場合は比較をスキップして通過すること（ゼロ除算防止）。"""
+        intent = _make_intent(
+            portfolio_value_usd=Decimal("0"),
+            amount_in_usd=Decimal("0"),
+        )
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.is_valid is True
+
+
+class TestComputeMinAmountOut:
+    """compute_min_amount_out のテスト。"""
+
+    def test_basic_calculation(self) -> None:
+        """基本的な計算が正しいこと。"""
+        result = compute_min_amount_out(
+            amount_out_estimate=Decimal("1.0"),
+            slippage=Decimal("0.005"),
+        )
+        assert result == Decimal("0.995")
+
+    def test_decimal_precision(self) -> None:
+        """Decimal 精度が保持されること（float 精度劣化なし）。"""
+        result = compute_min_amount_out(
+            amount_out_estimate=Decimal("3.141592653589793238"),
+            slippage=Decimal("0.005"),
+        )
+        expected = Decimal("3.141592653589793238") * (Decimal("1") - Decimal("0.005"))
+        assert result == expected
+
+    def test_result_type_is_decimal(self) -> None:
+        """結果が Decimal 型であること（float 返却禁止）。"""
+        result = compute_min_amount_out(
+            amount_out_estimate=Decimal("100"),
+            slippage=Decimal("0.01"),
+        )
+        assert type(result) is Decimal
+
+    def test_max_slippage_boundary(self) -> None:
+        """slippage = 0.05（5%）の境界値計算。"""
+        result = compute_min_amount_out(
+            amount_out_estimate=Decimal("100"),
+            slippage=Decimal("0.05"),
+        )
+        assert result == Decimal("95")
+
+    def test_small_slippage(self) -> None:
+        """slippage = 0.001（0.1%）の計算。"""
+        result = compute_min_amount_out(
+            amount_out_estimate=Decimal("1000"),
+            slippage=Decimal("0.001"),
+        )
+        assert result == Decimal("999")
+
+    def test_large_amount_precision(self) -> None:
+        """大きな amount での精度保持。"""
+        result = compute_min_amount_out(
+            amount_out_estimate=Decimal("1000000.000000000000000001"),
+            slippage=Decimal("0.005"),
+        )
+        expected = Decimal("1000000.000000000000000001") * Decimal("0.995")
+        assert result == expected
+
+
+class TestStablecoinDetectionReuse:
+    """SlippageGuard.is_stablecoin 再利用テスト。"""
+
+    def test_stablecoin_pair_passes_validation(self) -> None:
+        """ステーブルコインシンボル同士のスワップはバリデーション自体を通過すること。
+
+        Phase 1 では reject しない（補足情報の記録のみ）。
+        token はシンボル文字列（"USDC" 等）で指定してテスト。
+        """
+        intent = UniswapV4SwapIntent(
+            token_in="USDC",
+            token_out="USDT",
+            amount_in=Decimal("1000"),
+            deadline_unix=_FUTURE_DEADLINE,
+            receiver=_RECEIVER,
+            chain="base",
+        )
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        # Phase 1: ステーブルコイン同士でも reject しない
+        assert result.is_valid is True
+
+    def test_non_stablecoin_accepted(self) -> None:
+        """非ステーブルコインのアドレス形式は is_stablecoin=False となり通常通過すること。"""
+        intent = _make_intent(token_in=_TOKEN_IN, token_out=_TOKEN_OUT)
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.is_valid is True
+
+
+class TestMultipleErrorAccumulation:
+    """複数エラー同時検出テスト。"""
+
+    def test_multiple_errors_accumulated(self) -> None:
+        """複数の問題が同時に存在する場合、全エラーが収集されること。"""
+        intent = UniswapV4SwapIntent(
+            token_in=_TOKEN_IN,
+            token_out=_TOKEN_IN,  # 同一トークン
+            amount_in=Decimal("1.0"),
+            deadline_unix=_NOW_UNIX,  # 期限切れ
+            receiver="",  # 空 receiver
+            chain="ethereum",
+        )
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.is_valid is False
+        # deadline + token_in==token_out + receiver の3エラーを期待
+        assert len(result.validation_errors) >= 2
+
+    def test_estimate_fields_are_none_in_phase1(self) -> None:
+        """Phase 1 では amount_out_estimate / min_amount_out が None であること。"""
+        intent = _make_intent()
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert result.amount_out_estimate is None
+        assert result.min_amount_out is None
+        assert result.price_impact_pct is None
+
+
+class TestReturnType:
+    """戻り値型テスト。"""
+
+    def test_returns_estimate_instance(self) -> None:
+        """validate_swap_intent が UniswapV4SwapEstimate を返すこと。"""
+        from app.protocols.uniswap.schemas import UniswapV4SwapEstimate
+
+        intent = _make_intent()
+        result = validate_swap_intent(intent, now_unix=_NOW_UNIX)
+        assert isinstance(result, UniswapV4SwapEstimate)
+
+    @pytest.mark.parametrize(
+        "slippage,amount",
+        [
+            (Decimal("0.001"), Decimal("100")),
+            (Decimal("0.005"), Decimal("1000")),
+            (Decimal("0.05"), Decimal("999")),
+        ],
+    )
+    def test_compute_min_amount_out_parametrized(self, slippage: Decimal, amount: Decimal) -> None:
+        """parametrize で複数スリッページ/量を確認。"""
+        result = compute_min_amount_out(amount, slippage)
+        expected = amount * (Decimal("1") - slippage)
+        assert result == expected
+        assert type(result) is Decimal

--- a/docs/57_privy_uniswap_v4_swap_design.md
+++ b/docs/57_privy_uniswap_v4_swap_design.md
@@ -1,0 +1,247 @@
+# 57 Privy + Uniswap V4 スワップ統合 設計ドキュメント
+
+> 作成: 2026-06-15  
+> スコープ: Phase 1 scaffold (型定義・純粋バリデータ)  
+> ブランチ: `feat/privy-uniswap-v4-swap-design`  
+> 関連 PR: 本ブランチ参照
+
+---
+
+## 1. 現状の取引経路マップ
+
+Ultra AutoTrade が現在統合している取引経路を以下に示す。
+Uniswap 本実装は **不在**（本スライスが初回 scaffold）。
+
+| プロトコル | 経路 | 実装状態 |
+|---|---|---|
+| **Aave V3** | Polygon / Arbitrum — supply / borrow / repay / withdraw | `backend/app/aave/` 実装済み |
+| **Bybit (ccxt)** | spot 取引 / 板情報 | `backend/app/exchange/` 実装済み |
+| **OKX (ccxt)** | spot バックアップ | `backend/app/exchange/` 実装済み |
+| **DCA** | Bybit 定期積立 | `backend/app/dca/` 実装済み |
+| **Pendle RouterV4** | YT/PT swap / add_liquidity (hosted SDK calldata) | `backend/app/protocols/pendle/` 実装済み |
+| **Lido** | ETH staking / stETH 取得 | `backend/app/protocols/lido/` 実装済み |
+| **Uniswap V4** | ERC-20 汎用スワップ | **本スライス: Phase 1 scaffold のみ** |
+
+---
+
+## 2. Pendle RouterV4 hosted-SDK パターンの参照
+
+Pendle RouterV4 実装（`backend/app/protocols/pendle/client.py`）は以下のパターンを確立している。
+Uniswap V4 統合も同型の段階設計が妥当と判断する。
+
+### Pendle パターン（参照実装）
+
+| 側面 | Pendle RouterV4 の実装 |
+|---|---|
+| calldata 生成 | Pendle hosted SDK (`/sdk/api/v1`) — 外部 HTTP。ローカル ABI encode 不要 |
+| デフォルト実行モード | `dry_run=True`（シミュレーションのみ）。`False` は明示指定が必要 |
+| 宛先照合 | SDK レスポンスの `tx.to` と既知 Router アドレスを照合（C2 検証） |
+| 秘密鍵 | router.py / main.py 配線 (Tier S) まで触れない |
+| スリッページ | `RouterV4SwapRequest.slippage`（0 < x <= 0.05）+ `min_amount_out` 二層防御 |
+| 10%上限 | `amount_in_usd / portfolio_value_usd` 両指定時のみ検証。片方欠落は fail-closed |
+
+### Uniswap V4 への適用方針
+
+Pendle と同様に段階設計（Phase 1→4）を採用する（詳細は §6「段階実装計画」参照）。
+`dry_run=True` をデフォルトとし、SDK calldata 取得・署名・broadcast は
+HUMAN-REVIEW-REQUIRED として段階的に実装する。
+
+---
+
+## 3. Uniswap V4 アーキテクチャ概要
+
+### V4 の主要変更点（V3 との差分）
+
+| 項目 | Uniswap V3 | Uniswap V4 |
+|---|---|---|
+| Pool 管理 | 各 Pool が独立コントラクト | **PoolManager 単一コントラクト**（全 pool を集約） |
+| Pool Key | address で識別 | `PoolKey`（token0/1 + fee + tickSpacing + hooks） |
+| Hooks | なし | **hooks**: 独自ロジックを Pool ライフサイクルに注入可能 |
+| ルーター | SwapRouter02 | **Universal Router**（V2/V3/V4 を統合） |
+| ガス | Pool ごとにトークン転送 | flash accounting で一括決済（ガス削減） |
+
+### Privy 署名経路
+
+Privy による署名検証は `backend/app/auth/privy_verifier.py` に実装済み。
+ウォレット秘密鍵は Privy Embedded Wallet 側で管理し、
+バックエンドは秘密鍵を保持しない設計（Security Rules §1 準拠）。
+
+Uniswap V4 の tx 署名 Phase 3 では、以下の経路を想定する:
+1. フロントエンドが Privy SDK を通じて署名リクエストを送信
+2. バックエンドは calldata + to アドレスを返却（秘密鍵は扱わない）
+3. フロントエンドが Privy Embedded Wallet で署名 + broadcast
+
+---
+
+## 4. 【要確認】5 項目（推測確定禁止）
+
+**以下は Phase 2 着手前に実機確認・公式ドキュメント照合が必要な未確定事項。**
+推測で実装を進めないこと（CLAUDE.md 鉄則 9）。
+
+### C1. calldata 生成方式
+
+| 候補 | 概要 | 要確認点 |
+|---|---|---|
+| **Uniswap hosted quoting API** | `https://api.uniswap.org/v2/quote` 等 — Pendle 同型 | レート制限・認証要否・V4 対応状況 |
+| **ローカル ABI encode** | web3.py で Universal Router calldata を生成 | V4 の `Commands` + `inputs` バイト列の仕様 |
+| **Uniswap SDK (TypeScript)** | Python backend から subprocess/HTTP で呼び出す | デプロイアーキテクチャ・レイテンシ |
+
+**推奨確認先**: Uniswap Developer Docs (https://docs.uniswap.org) / GitHub `Uniswap/v4-core` / `Uniswap/universal-router`
+
+### C2. SDK 言語とバックエンド連携方式
+
+Uniswap 公式 SDK は TypeScript (`@uniswap/v4-sdk`)。
+Python backend から呼び出す場合の方式を確認:
+
+- HTTP microservice（Node.js wrapper）経由
+- subprocess 呼び出し（レイテンシ・エラーハンドリング考慮必要）
+- Python 非公式 SDK の採用可否（Pendle 同様 hosted API のみ使用する代替）
+
+### C3. Universal Router 正式アドレス（chain 別）
+
+| Chain | PoolManager アドレス | Universal Router アドレス |
+|---|---|---|
+| Ethereum Mainnet | **【要確認】** | **【要確認】** |
+| Arbitrum | **【要確認】** | **【要確認】** |
+| Base | **【要確認】** | **【要確認】** |
+| Optimism | **【要確認】** | **【要確認】** |
+| Polygon | **【要確認】** | **【要確認】** |
+
+**推奨確認先**: `https://docs.uniswap.org/contracts/v4/deployments`
+Phase 2 着手前にアドレスを確定し、`backend/app/protocols/uniswap/config.py`（新規）にクラス定数として定義すること。
+
+### C4. PoolKey / hooks パラメータ表現
+
+V4 スワップには `PoolKey` 構造体が必要:
+```
+struct PoolKey {
+    Currency currency0;
+    Currency currency1;
+    uint24 fee;
+    int24 tickSpacing;
+    IHooks hooks;
+}
+```
+hooks なし（デフォルト）の場合の `IHooks` アドレス（`address(0)` か別の定数か）を確認。
+
+### C5. Privy 署名 broadcast 経路
+
+Phase 3 で実装する署名経路の詳細:
+- Privy Embedded Wallet でフロントエンドが直接 broadcast するか
+- バックエンドが RPC 経由で broadcast するか（秘密鍵不要な場合のみ許容）
+- `eth_sendRawTransaction` の RPC エンドポイント（chain 別）
+
+---
+
+## 5. スリッページ保護設計（二層防御）
+
+```
+Layer 1: リクエスト内 slippage（0 < slippage <= 0.05）
+         UniswapV4SwapIntent.slippage フィールドで制約
+         validators.compute_min_amount_out() で min_amount_out 計算
+
+Layer 2: SlippageGuard 再利用（backend/app/aave/slippage_guard.py）
+         操作前後の価格変動監視（Phase 3 以降で適用）
+         is_stablecoin() でステーブルコイン判定を再利用
+```
+
+**実装方針**:
+- `slippage_guard.py` を **import 再利用**（本体改変なし）
+- `is_stablecoin()` はシンボル文字列（"USDC" 等）を引数とする
+  → アドレス形式の場合は False 扱い（Phase 1 では補足情報のみ）
+
+---
+
+## 6. 段階実装計画
+
+### Phase 1: 型定義・純粋バリデータ（本スライス / Tier B 自動進行）
+
+| ファイル | 内容 |
+|---|---|
+| `backend/app/protocols/uniswap/schemas.py` | `UniswapV4SwapIntent` / `UniswapV4SwapEstimate` |
+| `backend/app/protocols/uniswap/validators.py` | 純粋関数バリデータ（I/O なし） |
+| `backend/tests/protocols/test_uniswap/` | pytest ユニットテスト |
+| `docs/57_privy_uniswap_v4_swap_design.md` | 本ドキュメント |
+
+DoD: ruff / mypy / pytest 全通過。安全境界グリーン（web3/秘密鍵/calldata なし）。
+
+### Phase 2: SDK calldata 取得（HUMAN-REVIEW-REQUIRED）
+
+前提: C1/C3/C4 未確定事項の確認完了後に着手。
+
+| ファイル | 内容 |
+|---|---|
+| `backend/app/protocols/uniswap/client.py`（新規） | quoting API 呼び出し。`dry_run=True` 前提 |
+| `backend/app/protocols/uniswap/config.py`（新規） | chain 別 Router アドレス定数 |
+
+制約: 秘密鍵不使用。calldata 取得のみ（broadcast なし）。
+
+### Phase 3: 署名 + broadcast（HUMAN-REVIEW-REQUIRED）
+
+前提: Phase 2 完了 + C5（Privy 経路）確認完了。
+
+- Privy Embedded Wallet 連携（フロントエンド主体、バックエンドは calldata 提供のみ）
+- tx 送信後の receipt / event log 確認ロジック
+
+### Phase 4: main.py ルーター配線（Tier S / シリアル実装）
+
+前提: Phase 3 ステージング検証完了 + セキュリティレビュー通過。
+
+- `backend/app/main.py`（Tier S）へのルーター登録
+- RBAC（admin / partner ロール別アクセス制御）
+- Rate Limit・Cooldown（Aave 同等基準）
+
+---
+
+## 7. 単一取引10%上限の実装方針
+
+Security Rules §3「Max single trade: 10% of total assets」に基づく。
+
+```python
+# validators.validate_swap_intent() 内の実装
+if has_amount_usd != has_portfolio_usd:
+    # 片方のみ: 検証不能 → fail-closed 拒否
+    errors.append("fail-closed: 片方のみ指定では10%上限を検証できない")
+elif has_amount_usd and has_portfolio_usd:
+    if amount_in_usd > portfolio_value_usd * Decimal("0.10"):
+        errors.append("単一取引上限超過: 10% を超えている")
+# 両方 None: USD 評価不能のためスキップ（ネイティブ量のみの場合）
+```
+
+両方 None の場合（ネイティブ量 `amount_in` のみ指定）はチェックをスキップする。
+Phase 2 以降で quoting API から USD 換算を取得し、`amount_in_usd` に設定することを推奨。
+
+---
+
+## 8. 安全境界（Phase 1 の保証）
+
+以下を grep で実証（セルフ DoD の一部）:
+
+```bash
+# 実行系/秘密鍵/calldata が含まれないこと
+grep -rniI "private_key|web3|eth_account|broadcast|requests\.|httpx|calldata|sign_transaction" \
+  backend/app/protocols/uniswap/ || echo "安全境界OK"
+
+# float 使用禁止
+grep -rn "float" backend/app/protocols/uniswap/ || echo "float不使用OK"
+
+# main.py 未配線
+grep -nE "uniswap" backend/app/main.py || echo "main.py未配線OK"
+
+# slippage_guard.py 無改変
+git diff -- backend/app/aave/slippage_guard.py | head -1 || echo "slippage_guard無改変OK"
+```
+
+---
+
+## 9. 参照
+
+| ドキュメント / ファイル | 用途 |
+|---|---|
+| `backend/app/protocols/pendle/schemas.py` | RouterV4SwapRequest の Decimal/field_validator パターン |
+| `backend/app/protocols/pendle/client.py` | hosted SDK calldata 取得パターン |
+| `backend/app/aave/slippage_guard.py` | SlippageGuard 再利用（import のみ） |
+| `backend/app/auth/privy_verifier.py` | Privy 署名検証（Phase 3 参照） |
+| `docs/13_security_design.md` | Security Rules 全文 |
+| `docs/34_phase2_protocols_guide.md` | Pendle RouterV4 SDK 設計詳細 |
+| `CLAUDE.md § Security Rules` | float 禁止 / Decimal 必須 / 秘密鍵 env のみ |


### PR DESCRIPTION
## 概要
v4 epic **[Privy][効率] Privy Swap統合（Uniswap V4）(GID 1215697731958398)** の **Tier-B 自動進行可スライス**。Privy 埋め込みウォレットからの Uniswap V4 スワップ意図を表現する read-only スキーマ + 純粋バリデータ + 設計doc のみ。Uniswap SDK実呼出・calldata生成・tx署名・broadcast・秘密鍵・依存追加・router/main.py配線は **🛑 HUMAN-REVIEW-REQUIRED** として除外。

## 変更（すべて新規ファイル・既存無改変）
- `docs/57_privy_uniswap_v4_swap_design.md` — 既存取引経路マップ / Pendle RouterV4 hosted-SDK calldata パターン引用 / Uniswap V4構造(PoolManager+hooks+Universal Router) / 【要確認】5項目(SDK言語・Routerアドレス等) / SlippageGuard二層防御 / 段階実装計画
- `backend/app/protocols/uniswap/{__init__,schemas,validators}.py` — `UniswapV4SwapIntent`/`UniswapV4SwapEstimate`(Decimal強制) + `validate_swap_intent`/`compute_min_amount_out`(純粋関数)。web3/calldata/private_key import ゼロ、既存 `SlippageGuard` は import再利用・本体無改変
- `backend/tests/protocols/test_uniswap/*` — 53件(slippage境界/deadline切れreject/10%上限fail-closed/Decimal精度)

## パイプライン結果
- **Evaluator: APPROVED**（CRITICAL 0 / 安全境界・非侵襲・Decimal・fail-closed論理・docs健全性 実確認PASS）
- **Tester: PASS** — uniswap coverage **99%**、`tests/protocols/` **589 passed**（リグレッションなし）、mypy/ruff/ruff-S 全0エラー

## Phase 4 申し送り（Evaluator 指摘・本PR責務外）
- 10%上限(Security Rule 3): `amount_in_usd`/`portfolio_value_usd` 両方 None 時は上限チェックがスキップされる。実 broadcast 経路を組む Phase 4 で `portfolio_value_usd` 必須化 or USD換算の上流強制を入れること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)