### PR TITLE
chore(frontend): bump @privy-io/react-auth 3.29.2 -> 3.30.0 (Privy SDK migration)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@farcaster/mini-app-solana": "^2.0.0",
         "@line/liff": "^2.28.0",
-        "@privy-io/react-auth": "^3.29.2",
+        "@privy-io/react-auth": "^3.30.0",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -4835,11 +4835,11 @@
       "license": "MIT"
     },
     "node_modules/@privy-io/api-base": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@privy-io/api-base/-/api-base-1.9.0.tgz",
-      "integrity": "sha512-8OJ2chadFcgUwr+Kqim0z5paIdadEdMH8pW94WJz0O3s2X4aX7vhN1eqiNZqcdgSIk9FHm8c3A+/epJUwiTYuQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@privy-io/api-base/-/api-base-1.9.1.tgz",
+      "integrity": "sha512-Dq7yyZyVQm71gm3d5o1VH9Ahak9gf/zXx6A6E4bx9VVZEYTevL8J3aJAvIIj1qFenc12UGUpWO3oWkn9Cpr+mw==",
       "dependencies": {
-        "zod": "^3.24.3"
+        "zod": "^3.25.76"
       }
     },
     "node_modules/@privy-io/api-base/node_modules/zod": {
@@ -4858,9 +4858,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@privy-io/are-addresses-equal": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@privy-io/are-addresses-equal/-/are-addresses-equal-0.0.8.tgz",
-      "integrity": "sha512-KbRu4jGE47edxz1xAmpA5e9wMOxT1bnhgu1kVhLyr7AY1shAkEb7GMteyPTB6iis9AXGuMd/JtQk4yfdHqWp5g==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@privy-io/are-addresses-equal/-/are-addresses-equal-0.0.9.tgz",
+      "integrity": "sha512-mLBv7cde8ilPYUBjHl6ke+0H3v2hoa5bdShNT0/wm7NYZByvH7/inNN+iK5nTv7D0Ti2rqcfW3UXNxub9eVOpg==",
       "license": "Apache-2.0",
       "dependencies": {
         "viem": "2.52.0"
@@ -4882,32 +4882,32 @@
       }
     },
     "node_modules/@privy-io/ethereum": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@privy-io/ethereum/-/ethereum-0.1.4.tgz",
-      "integrity": "sha512-YuxGO18eY9miw2CyyxOugOOSoFnsg0uM3KU3/bUwRZmIdOQzzyOuSV2ZoOJmZs2H4u5ofuI4vunjgqw1wOM3ng==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@privy-io/ethereum/-/ethereum-0.1.5.tgz",
+      "integrity": "sha512-zUwW+BmreFBF12EkTsLtf1u2GnFx1NmhE/FipNqjh15azlwcquyCJTH/JILTAo1vON8KYG0Ga96a9dDHbwl/qw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "viem": "2.52.0"
       }
     },
     "node_modules/@privy-io/js-sdk-core": {
-      "version": "0.67.0",
-      "resolved": "https://registry.npmjs.org/@privy-io/js-sdk-core/-/js-sdk-core-0.67.0.tgz",
-      "integrity": "sha512-v9QI/hnucgCHykQutkQd807/bm6NvqNnzf+9fBUwVO1QNFoyOd7aGQ9jDCK441hp5Ecl1EzLs2LARihauJ4RCQ==",
+      "version": "0.67.1",
+      "resolved": "https://registry.npmjs.org/@privy-io/js-sdk-core/-/js-sdk-core-0.67.1.tgz",
+      "integrity": "sha512-I6l/PaUdZbr48+EyXyTPnC3BYO5Kf4/pognvq4/4w0cRXZVz00jCqSqHrSmoB1tIKSO9dT6nzTh10svt/8XHgg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@privy-io/api-base": "1.9.0",
+        "@privy-io/api-base": "1.9.1",
         "@privy-io/api-types": "0.15.0",
         "@privy-io/chains": "0.3.0",
         "@privy-io/encoding": "0.1.3",
-        "@privy-io/ethereum": "0.1.4",
-        "@privy-io/routes": "0.2.4",
+        "@privy-io/ethereum": "0.1.5",
+        "@privy-io/routes": "0.2.5",
         "canonicalize": "^2.0.0",
         "eventemitter3": "^5.0.1",
         "fetch-retry": "^6.0.0",
         "jose": "^4.15.5",
         "js-cookie": "^3.0.5",
-        "libphonenumber-js": "^1.10.44",
+        "libphonenumber-js": "^1.12.10",
         "set-cookie-parser": "^2.6.0"
       },
       "peerDependencies": {
@@ -4930,9 +4930,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@privy-io/react-auth": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@privy-io/react-auth/-/react-auth-3.29.2.tgz",
-      "integrity": "sha512-ADvifcZaIeXfLOTc+JvTAti0uYx2bMrjMGLlfwQWmkwuKw+KG9mUHzq43uf7vIebIweZG/Z82HRkKc+g0Oksfg==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@privy-io/react-auth/-/react-auth-3.30.0.tgz",
+      "integrity": "sha512-ML4YENDKavDHHNthhbv3L3I2tVWw+/7aFklPWL4hBcLb6HY7/2a1Ur1fftFXd4LsJBk17eF0u5Avrv9U2L03GA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@base-org/account": "^1.1.0",
@@ -4940,17 +4940,17 @@
         "@floating-ui/react": "^0.26.22",
         "@hcaptcha/react-hcaptcha": "^1.14.0",
         "@headlessui/react": "^2.2.0",
-        "@heroicons/react": "^2.1.1",
+        "@heroicons/react": "^2.2.0",
         "@marsidev/react-turnstile": "^1.3.1",
-        "@privy-io/api-base": "1.9.0",
+        "@privy-io/api-base": "1.9.1",
         "@privy-io/api-types": "0.15.0",
-        "@privy-io/are-addresses-equal": "0.0.8",
+        "@privy-io/are-addresses-equal": "0.0.9",
         "@privy-io/chains": "0.3.0",
         "@privy-io/encoding": "0.1.3",
-        "@privy-io/ethereum": "0.1.4",
-        "@privy-io/js-sdk-core": "0.67.0",
+        "@privy-io/ethereum": "0.1.5",
+        "@privy-io/js-sdk-core": "0.67.1",
         "@privy-io/popup": "0.0.4",
-        "@privy-io/routes": "0.2.4",
+        "@privy-io/routes": "0.2.5",
         "@privy-io/urls": "0.0.4",
         "@scure/base": "^1.2.5",
         "@simplewebauthn/browser": "^13.2.2",
@@ -5357,9 +5357,9 @@
       }
     },
     "node_modules/@privy-io/routes": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@privy-io/routes/-/routes-0.2.4.tgz",
-      "integrity": "sha512-rPb9z8q7gYSp4ip9I9wuISzf6oo4rTcu3VLmNvRmU4hXfEDzZ2qZhBIwLwwPPvxH+P2pAyaVhlKwV7jOKaeS7A==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@privy-io/routes/-/routes-0.2.5.tgz",
+      "integrity": "sha512-nUMbBV/q4tcjy7g8wgAsM7J+VkB7scLIm6UrZdx9iRsEfwI3mw5rIV6RYaRrHMCZRPPqYfYSzIgeTQFzBDmV4A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@privy-io/api-types": "0.15.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@farcaster/mini-app-solana": "^2.0.0",
     "@line/liff": "^2.28.0",
-    "@privy-io/react-auth": "^3.29.2",
+    "@privy-io/react-auth": "^3.30.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",


### PR DESCRIPTION
## Summary

- `@privy-io/react-auth` を `^3.29.2` から `^3.30.0` へバンプ（Privy SDK 2.0 Migration 対応）
- Breaking Change API は先行 PR で全移行済みのため、ソースコード変更なし
- `package.json` + `package-lock.json` のみの変更（Tier S）

## Breaking Change 対応状況（全 9 項目）

| Breaking Change | 状態 |
|---|---|
| getEthersProvider → getEthereumProvider | 済（コード内に残存 0 件） |
| getWeb3jsProvider → getEthereumProvider | 済（コード内に残存 0 件） |
| delegateWalletAction → useDelegatedActions | 済（コード内に残存 0 件） |
| createPrivyWalletOnLogin → embeddedWallets.createOnLogin | 済（済：PrivyRootClient.tsx で設定済） |
| additionalChains + rpcConfig → supportedChains | 済（PrivyRootClient.tsx で設定済） |
| noPromptOnSignature → showWalletUIs: false | 済（コード内に残存 0 件） |
| onSuccess prop → useLogin callback | 済（コード内に残存 0 件） |
| setActiveWallet 削除 | 済（コード内に残存 0 件） |
| waitForTransactionConfirmation 削除 | 済（コード内に残存 0 件） |
| Solana useSendSolanaTransaction | N/A（プロジェクトで未使用） |

## DoD 結果

- `npm install --legacy-peer-deps`: PASS（3.30.0 インストール確認）
- `npx tsc --noEmit`: PASS（エラー 0 件）
- `npm run build`: `ignoreBuildErrors: true` 設定あり（next.config.js OOM ワークアラウンド）。tsc の 0 エラーが信頼できる DoD 証跡
- 旧 API 残存 grep: 0 件

## 実確定パス構成

- `src/` ディレクトリ: **なし**（`frontend/app/`、`frontend/components/`、`frontend/hooks/`、`frontend/lib/` 構成）
- 旧 Privy バージョン（package-lock.json）: `3.29.2`
- 新 Privy バージョン（インストール済み）: `3.30.0`

## Privy 使用ファイル一覧

- `frontend/lib/wallet/PrivyRootClient.tsx` — PrivyProvider 設定
- `frontend/components/PrivySessionGuard.tsx` — セッション監視
- `frontend/hooks/usePrivyEmbeddedWallet.ts` — Embedded wallet 状態
- `frontend/hooks/useWallet.ts` — wallet 統合 hook
- `frontend/hooks/useLiffBrowserAuth.ts` — LIFF 認証
- `frontend/app/(user)/connect/page.tsx` 他 — 各ページ

---

## WARNING: HUMAN-REVIEW-REQUIRED

**このPRは最高リスク分類です。マージ前に以下を必ず人間が確認してください:**

- Tier S ファイル変更: `frontend/package.json` + `frontend/package-lock.json`
- Privy メジャー依存バンプ（3.29.2 → 3.30.0）
- 認証レイヤ全体に影響する変更

**必須確認事項:**
1. staging 環境での `npm run build` 実行確認
2. ログイン / wallet 接続 / embedded wallet の実機動作確認
3. email / google / apple / wallet ログインフローの全経路テスト

Closes Asana GID 1215697790983385

---

Generated with [Claude Code](https://claude.com/claude-code)