### PR TITLE
fix(i18n): AdminProtocols oracle キーを en.json に追加 (PR #736 漏れ)

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2152,7 +2152,21 @@
     "alerts": "Alerts",
     "noAlerts": "No alerts",
     "lastChecked": "Last checked: {time}",
-    "pendlePositionTitle": "Pendle Position Details"
+    "pendlePositionTitle": "Pendle Position Details",
+    "oracleStatusTitle": "Oracle Multi-Source Verification Status",
+    "oracleStatusDescription": "Monitors price deviation across Chainlink / Pyth / Uniswap V3 TWAP",
+    "oracleLoadError": "Failed to fetch Oracle status",
+    "oracleNoAssets": "No monitored assets configured (AAVE_ORACLE_ASSETS_JSON not set)",
+    "oracleLevelOk": "OK",
+    "oracleLevelWarn": "Warning",
+    "oracleLevelHardStop": "HARD STOP",
+    "oracleAsset": "Asset",
+    "oracleDeviation": "Max Deviation",
+    "oracleChainlink": "Chainlink",
+    "oraclePyth": "Pyth",
+    "oracleTwap": "TWAP (30 min)",
+    "oracleCheckedAt": "Verified at",
+    "oracleDetail": "Details"
   },
   "Register": {
     "title": "Account Registration - Ultra AutoTrade",


### PR DESCRIPTION
## Summary

- PR #736 (rsETH/srsETH blocklist + Chainlink/Pyth/TWAP oracle checker) が `ja.json` に 14 個の oracle キーを追加したが、`en.json` に追加し忘れたため `i18n key existence check` CI が main で失敗していた
- 本 PR はその修正（en.json への oracle キー追加のみ）

## 原因

```
ja.json AdminProtocols keys: 40 件
en.json AdminProtocols keys: 26 件  ← 14件不足
```

不足キー:
- `oracleStatusTitle`, `oracleStatusDescription`, `oracleLoadError`, `oracleNoAssets`
- `oracleLevelOk`, `oracleLevelWarn`, `oracleLevelHardStop`
- `oracleAsset`, `oracleDeviation`, `oracleChainlink`, `oraclePyth`, `oracleTwap`
- `oracleCheckedAt`, `oracleDetail`

## 検証

```
✅ i18n: 新規の欠落なし（baseline 29 件 / 走査 319 ファイル）
en.json: valid (JSON パース OK)
```

## 変更ファイル

- `frontend/messages/en.json` — AdminProtocols に oracle キー 14 件追加

🤖 auto-fix by night-mode: PR #736 en.json oracle キー追加漏れ修正