### PR TITLE
feat(portfolio): 統合ポートフォリオ集約 設計doc + read-only集約スキーマ/純粋関数 (scaffold)

### DIFF
--- a/backend/app/portfolio/aggregation.py
+++ b/backend/app/portfolio/aggregation.py
@@ -1,0 +1,129 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""
+統合ポートフォリオ集約関数
+
+3ソース (Aave V3 / Privy Wallet / Bybit CEX) の SourceBalance を受け取り、
+UnifiedPortfolioView を返す純粋関数モジュール。
+
+設計書: docs/59_unified_portfolio_dashboard_design.md
+
+【厳守】
+- 実 API / web3 / ccxt / aave / requests / httpx を一切 import しない
+- 全金融計算は Decimal 型 (float 禁止 / CLAUDE.md Security Rule 11)
+- fail-open: available=False または欠落ソースも grand_total から除外するが
+  他ソースの表示は継続する
+- ゼロ除算ガード: grand_total=0 の場合 allocation_pct は全て 0
+"""
+
+from decimal import Decimal
+
+from app.portfolio.aggregation_schemas import (
+    SourceAllocation,
+    SourceBalance,
+    UnifiedPortfolioInput,
+    UnifiedPortfolioView,
+)
+
+# ソース定義順序 (表示順固定)
+_SOURCE_ORDER = ("aave", "wallet", "cex")
+
+
+def _get_source_usd(source: SourceBalance | None) -> Decimal:
+    """ソースが存在しかつ available=True の場合のみ total_usd を返す。
+
+    欠落 (None) または available=False の場合は Decimal("0") を返す。
+    これにより fail-open かつ grand_total への誤算入を防ぐ。
+    """
+    if source is None:
+        return Decimal("0")
+    if not source.available:
+        return Decimal("0")
+    return source.total_usd
+
+
+def _calc_allocation_pct(source_usd: Decimal, grand_total: Decimal) -> Decimal:
+    """配分比率 (%) を計算する。grand_total=0 の場合は 0 を返す (ゼロ除算ガード)。
+
+    Args:
+        source_usd: ソースの USD 残高
+        grand_total: 全ソース合算 USD
+
+    Returns:
+        配分比率 (0-100)。grand_total=0 の場合は Decimal("0")。
+    """
+    if grand_total == Decimal("0"):
+        return Decimal("0")
+    return (source_usd / grand_total * Decimal("100")).quantize(Decimal("0.01"))
+
+
+def aggregate_portfolio(input: UnifiedPortfolioInput) -> UnifiedPortfolioView:  # noqa: A002
+    """3ソースの残高を集約して UnifiedPortfolioView を生成する。
+
+    fail-open 設計:
+    - 各ソースが None (取得失敗) または available=False の場合、
+      そのソースの USD は grand_total から除外される
+    - 他ソースが正常な場合は degraded=True で表示を継続する
+
+    二重計上なし:
+    - wallet.total_usd は Aave supply 分を含まない
+      (wallet_balance_service.py L13 に明記)
+    - aave_net_usd は total_collateral_usd - total_debt_usd (純資産)
+      入力側で計算済みの total_usd を使用
+
+    Args:
+        input: 3ソースの SourceBalance (各 Optional)
+
+    Returns:
+        UnifiedPortfolioView: 集約済みポートフォリオビュー
+    """
+    # --- 各ソースの有効 USD を取得 (fail-open) ---
+    aave_usd = _get_source_usd(input.aave)
+    wallet_usd = _get_source_usd(input.wallet)
+    cex_usd = _get_source_usd(input.cex)
+
+    # --- grand_total 合算 (available ソースのみ) ---
+    grand_total = aave_usd + wallet_usd + cex_usd
+
+    # --- ソース別配分計算 ---
+    def _make_allocation(key: str, source: SourceBalance | None, usd: Decimal) -> SourceAllocation:
+        available = source.available if source is not None else False
+        return SourceAllocation(
+            source=key,
+            total_usd=usd,
+            allocation_pct=_calc_allocation_pct(usd, grand_total),
+            available=available,
+        )
+
+    allocations = [
+        _make_allocation("aave", input.aave, aave_usd),
+        _make_allocation("wallet", input.wallet, wallet_usd),
+        _make_allocation("cex", input.cex, cex_usd),
+    ]
+
+    # --- sources_available カウント ---
+    # available=True かつ欠落でないソースを数える
+    sources_available = sum(
+        1 for src in (input.aave, input.wallet, input.cex) if src is not None and src.available
+    )
+
+    # --- degraded フラグ ---
+    # 1ソース以上が欠落 (None) または available=False の場合 True
+    degraded = sources_available < 3  # sources_total=3 固定
+
+    # --- Health Factor: Aave ソースが available な場合のみ透過 ---
+    health_factor: Decimal | None = None
+    if input.aave is not None and input.aave.available and input.aave.health_factor is not None:
+        health_factor = input.aave.health_factor
+
+    return UnifiedPortfolioView(
+        grand_total_usd=grand_total,
+        aave_net_usd=aave_usd,
+        wallet_usd=wallet_usd,
+        cex_usd=cex_usd,
+        health_factor=health_factor,
+        allocations=allocations,
+        sources_available=sources_available,
+        sources_total=3,
+        degraded=degraded,
+    )

--- a/backend/app/portfolio/aggregation_schemas.py
+++ b/backend/app/portfolio/aggregation_schemas.py
@@ -1,0 +1,157 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""
+統合ポートフォリオ集約スキーマ
+
+3ソース (Aave V3 / Privy Wallet / Bybit CEX) を横断する統合ポートフォリオビュー用の
+Pydantic v2 スキーマ定義。
+
+設計書: docs/59_unified_portfolio_dashboard_design.md
+
+注意:
+- 既存の app.portfolio.schemas (Aave単一ソース履歴用) とは別ファイル。混在禁止。
+- 全 Decimal フィールドは field_serializer で文字列シリアライズ (CLAUDE.md Security Rule 11)
+- HF 無限大処理は既存 _cap_hf_inf 思想踏襲 (backend/app/portfolio/schemas.py L12-15)
+"""
+
+from decimal import Decimal
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, field_serializer, field_validator
+
+
+def _cap_hf_inf(v: Optional[Decimal]) -> Optional[Decimal]:
+    """Health Factor の無限大 (Decimal('inf')) を 999.0 にキャップする。
+
+    参照: backend/app/portfolio/schemas.py の同名関数 (L12-15)
+    """
+    if v is not None and isinstance(v, Decimal) and not v.is_finite():
+        return Decimal("999.0")
+    return v
+
+
+class SourceBalance(BaseModel):
+    """ソース別残高。集約関数 (aggregation.py) への入力単位。
+
+    available=False の場合、そのソースのデータ取得は失敗しているが
+    fail-open 設計により他ソースの表示は継続する。
+    """
+
+    model_config = ConfigDict()
+
+    source: Literal["aave", "wallet", "cex"]
+    total_usd: Decimal
+    """ソース内合計 USD。
+    - aave: total_collateral_usd - total_debt_usd (純資産)
+    - wallet: eth_usd_value + usdc_usd_value (Aave supply 分を含まない)
+    - cex: balance_usdt (USDT ≈ USD 1:1)
+    """
+    available: bool = True
+    """データ取得成功フラグ。False = fail-open フォールバック値。"""
+
+    # Aave 専用フィールド
+    supply_usd: Optional[Decimal] = None
+    """Aave 担保総額 (total_collateral_usd)。aave ソース専用。"""
+    borrow_usd: Optional[Decimal] = None
+    """Aave 借入総額 (total_debt_usd)。aave ソース専用。"""
+    health_factor: Optional[Decimal] = None
+    """Aave 健全性指標。aave ソース専用。Decimal('inf') は _cap_hf_inf でキャップ。"""
+
+    @field_validator("health_factor", mode="before")
+    @classmethod
+    def cap_infinity_hf(cls, v: Optional[Decimal]) -> Optional[Decimal]:
+        return _cap_hf_inf(v)
+
+    @field_serializer("total_usd")
+    def serialize_total_usd(self, v: Decimal) -> str:
+        return str(v)
+
+    @field_serializer("supply_usd")
+    def serialize_supply_usd(self, v: Optional[Decimal]) -> Optional[str]:
+        return str(v) if v is not None else None
+
+    @field_serializer("borrow_usd")
+    def serialize_borrow_usd(self, v: Optional[Decimal]) -> Optional[str]:
+        return str(v) if v is not None else None
+
+    @field_serializer("health_factor")
+    def serialize_health_factor(self, v: Optional[Decimal]) -> Optional[str]:
+        return str(v) if v is not None else None
+
+
+class UnifiedPortfolioInput(BaseModel):
+    """集約関数 aggregate_portfolio() への入力。
+
+    各ソースが Optional。欠落 = そのソースの取得が失敗したことを示す (fail-open)。
+    欠落ソースは grand_total から除外され、degraded=True が設定される。
+    """
+
+    model_config = ConfigDict()
+
+    aave: Optional[SourceBalance] = None
+    """Aave V3 ポジション。None = Aave データ取得失敗。"""
+    wallet: Optional[SourceBalance] = None
+    """Privy Wallet 残高 (Base mainnet ETH + USDC)。None = Wallet データ取得失敗。"""
+    cex: Optional[SourceBalance] = None
+    """Bybit CEX 残高 (USDT)。None = CEX データ取得失敗。"""
+
+
+class SourceAllocation(BaseModel):
+    """ソース別配分情報。UnifiedPortfolioView.allocations の要素。"""
+
+    model_config = ConfigDict()
+
+    source: str
+    """ソース識別子。"aave" | "wallet" | "cex"。"""
+    total_usd: Decimal
+    """ソース残高 (USD)。"""
+    allocation_pct: Decimal
+    """ポートフォリオ全体に対する比率 (%)。grand_total=0 の場合は 0。"""
+    available: bool
+    """データ取得成功フラグ。"""
+
+    @field_serializer("total_usd", "allocation_pct")
+    def serialize_decimal(self, v: Decimal) -> str:
+        return str(v)
+
+
+class UnifiedPortfolioView(BaseModel):
+    """統合ポートフォリオビュー。aggregate_portfolio() の出力。
+
+    fail-open: 1ソース以上欠落しても他ソースの値を返す。
+    欠落ソースの USD は grand_total から除外される。
+    """
+
+    model_config = ConfigDict()
+
+    grand_total_usd: Decimal
+    """3ソース合算 USD 総額 (available=True のソースのみ)。"""
+    aave_net_usd: Decimal
+    """Aave 純資産 USD (unavailable / 欠落時は 0)。"""
+    wallet_usd: Decimal
+    """Wallet 残高 USD (unavailable / 欠落時は 0)。"""
+    cex_usd: Decimal
+    """CEX 残高 USD (unavailable / 欠落時は 0)。"""
+    health_factor: Optional[Decimal] = None
+    """Health Factor。Aave ソースが available な場合のみ設定。それ以外は None。"""
+    allocations: list[SourceAllocation]
+    """ソース別配分リスト。"""
+    sources_available: int
+    """正常取得できたソース数 (0-3)。"""
+    sources_total: int = 3
+    """総ソース数 (常に3)。"""
+    degraded: bool
+    """1ソース以上欠落している場合 True。表示側での警告表示用。"""
+
+    @field_validator("health_factor", mode="before")
+    @classmethod
+    def cap_infinity_hf(cls, v: Optional[Decimal]) -> Optional[Decimal]:
+        return _cap_hf_inf(v)
+
+    @field_serializer("grand_total_usd", "aave_net_usd", "wallet_usd", "cex_usd")
+    def serialize_usd(self, v: Decimal) -> str:
+        return str(v)
+
+    @field_serializer("health_factor")
+    def serialize_health_factor(self, v: Optional[Decimal]) -> Optional[str]:
+        return str(v) if v is not None else None

--- a/backend/tests/test_portfolio_aggregation.py
+++ b/backend/tests/test_portfolio_aggregation.py
@@ -1,0 +1,390 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+"""
+tests/test_portfolio_aggregation.py
+
+統合ポートフォリオ集約関数 (app.portfolio.aggregation) のユニットテスト。
+
+テスト観点:
+1. 3ソース全揃い: grand_total/allocation合計≈100/HF透過
+2. 1ソース欠落 (wallet=None): degraded=True, sources_available=2
+3. 全ソース 0 USD: allocation 全0, ゼロ除算なし
+4. HF 無限大入力: 999.0 にキャップされること
+5. available=False ソースが grand_total から除外されること
+6. Decimal 精度: float 混入なし
+7. aave_net_usd が wallet/cex と二重計上されないこと (独立性)
+8. allocation_pct 合計が 100 になること (丸め誤差考慮)
+"""
+
+from decimal import Decimal
+
+from app.portfolio.aggregation import aggregate_portfolio
+from app.portfolio.aggregation_schemas import (
+    SourceBalance,
+    UnifiedPortfolioInput,
+    UnifiedPortfolioView,
+)
+
+# ---------------------------------------------------------------------------
+# ヘルパー: テスト用 SourceBalance 生成
+# ---------------------------------------------------------------------------
+
+
+def _aave(
+    total_usd: str = "7000",
+    supply_usd: str = "10000",
+    borrow_usd: str = "3000",
+    health_factor: str = "2.5",
+    available: bool = True,
+) -> SourceBalance:
+    return SourceBalance(
+        source="aave",
+        total_usd=Decimal(total_usd),
+        available=available,
+        supply_usd=Decimal(supply_usd),
+        borrow_usd=Decimal(borrow_usd),
+        health_factor=Decimal(health_factor),
+    )
+
+
+def _wallet(
+    total_usd: str = "2000",
+    available: bool = True,
+) -> SourceBalance:
+    return SourceBalance(
+        source="wallet",
+        total_usd=Decimal(total_usd),
+        available=available,
+    )
+
+
+def _cex(
+    total_usd: str = "1000",
+    available: bool = True,
+) -> SourceBalance:
+    return SourceBalance(
+        source="cex",
+        total_usd=Decimal(total_usd),
+        available=available,
+    )
+
+
+# ---------------------------------------------------------------------------
+# テストケース 1: 3ソース全揃い
+# ---------------------------------------------------------------------------
+
+
+class TestAllSourcesAvailable:
+    def test_grand_total_correct(self) -> None:
+        """aave(7000) + wallet(2000) + cex(1000) = 10000."""
+        inp = UnifiedPortfolioInput(aave=_aave(), wallet=_wallet(), cex=_cex())
+        result = aggregate_portfolio(inp)
+        assert result.grand_total_usd == Decimal("10000")
+
+    def test_individual_usds(self) -> None:
+        inp = UnifiedPortfolioInput(aave=_aave(), wallet=_wallet(), cex=_cex())
+        result = aggregate_portfolio(inp)
+        assert result.aave_net_usd == Decimal("7000")
+        assert result.wallet_usd == Decimal("2000")
+        assert result.cex_usd == Decimal("1000")
+
+    def test_health_factor_transparent(self) -> None:
+        """HF は Aave ソースから透過される。"""
+        inp = UnifiedPortfolioInput(aave=_aave(health_factor="2.5"), wallet=_wallet(), cex=_cex())
+        result = aggregate_portfolio(inp)
+        assert result.health_factor == Decimal("2.5")
+
+    def test_not_degraded(self) -> None:
+        """全ソース available=True なら degraded=False。"""
+        inp = UnifiedPortfolioInput(aave=_aave(), wallet=_wallet(), cex=_cex())
+        result = aggregate_portfolio(inp)
+        assert result.degraded is False
+        assert result.sources_available == 3
+        assert result.sources_total == 3
+
+    def test_allocation_pct_sum_approximately_100(self) -> None:
+        """allocation_pct の合計が 100 に近いこと (丸め誤差 0.1 以内)。"""
+        inp = UnifiedPortfolioInput(aave=_aave(), wallet=_wallet(), cex=_cex())
+        result = aggregate_portfolio(inp)
+        total_pct = sum(a.allocation_pct for a in result.allocations)
+        assert abs(total_pct - Decimal("100")) <= Decimal("0.1")
+
+    def test_allocation_values(self) -> None:
+        """aave=70%, wallet=20%, cex=10%。"""
+        inp = UnifiedPortfolioInput(aave=_aave(), wallet=_wallet(), cex=_cex())
+        result = aggregate_portfolio(inp)
+        alloc = {a.source: a.allocation_pct for a in result.allocations}
+        assert alloc["aave"] == Decimal("70.00")
+        assert alloc["wallet"] == Decimal("20.00")
+        assert alloc["cex"] == Decimal("10.00")
+
+    def test_all_allocations_available_true(self) -> None:
+        inp = UnifiedPortfolioInput(aave=_aave(), wallet=_wallet(), cex=_cex())
+        result = aggregate_portfolio(inp)
+        for alloc in result.allocations:
+            assert alloc.available is True
+
+    def test_return_type(self) -> None:
+        inp = UnifiedPortfolioInput(aave=_aave(), wallet=_wallet(), cex=_cex())
+        result = aggregate_portfolio(inp)
+        assert isinstance(result, UnifiedPortfolioView)
+
+
+# ---------------------------------------------------------------------------
+# テストケース 2: 1ソース欠落 (wallet=None)
+# ---------------------------------------------------------------------------
+
+
+class TestOneSourceMissing:
+    def test_degraded_true(self) -> None:
+        """wallet=None → degraded=True。"""
+        inp = UnifiedPortfolioInput(aave=_aave(), wallet=None, cex=_cex())
+        result = aggregate_portfolio(inp)
+        assert result.degraded is True
+
+    def test_sources_available_2(self) -> None:
+        inp = UnifiedPortfolioInput(aave=_aave(), wallet=None, cex=_cex())
+        result = aggregate_portfolio(inp)
+        assert result.sources_available == 2
+
+    def test_grand_total_excludes_missing_source(self) -> None:
+        """wallet=None → grand_total は aave + cex のみ。"""
+        inp = UnifiedPortfolioInput(aave=_aave("7000"), wallet=None, cex=_cex("1000"))
+        result = aggregate_portfolio(inp)
+        assert result.grand_total_usd == Decimal("8000")
+
+    def test_wallet_usd_is_zero(self) -> None:
+        inp = UnifiedPortfolioInput(aave=_aave(), wallet=None, cex=_cex())
+        result = aggregate_portfolio(inp)
+        assert result.wallet_usd == Decimal("0")
+
+    def test_wallet_allocation_available_false(self) -> None:
+        """欠落ソースの available は False として allocations に含まれる。"""
+        inp = UnifiedPortfolioInput(aave=_aave(), wallet=None, cex=_cex())
+        result = aggregate_portfolio(inp)
+        wallet_alloc = next(a for a in result.allocations if a.source == "wallet")
+        assert wallet_alloc.available is False
+        assert wallet_alloc.total_usd == Decimal("0")
+
+    def test_hf_still_present_if_aave_available(self) -> None:
+        """Aave が available なら wallet 欠落でも HF は透過される。"""
+        inp = UnifiedPortfolioInput(aave=_aave(health_factor="3.0"), wallet=None, cex=_cex())
+        result = aggregate_portfolio(inp)
+        assert result.health_factor == Decimal("3.0")
+
+    def test_aave_missing_hf_is_none(self) -> None:
+        """Aave が None なら HF は None。"""
+        inp = UnifiedPortfolioInput(aave=None, wallet=_wallet(), cex=_cex())
+        result = aggregate_portfolio(inp)
+        assert result.health_factor is None
+
+
+# ---------------------------------------------------------------------------
+# テストケース 3: 全ソース 0 USD / ゼロ除算なし
+# ---------------------------------------------------------------------------
+
+
+class TestAllZeroUsd:
+    def test_no_zero_division_error(self) -> None:
+        """全ソース 0 USD でもゼロ除算が発生しないこと。"""
+        inp = UnifiedPortfolioInput(
+            aave=_aave("0"),
+            wallet=_wallet("0"),
+            cex=_cex("0"),
+        )
+        result = aggregate_portfolio(inp)  # 例外なし
+        assert result.grand_total_usd == Decimal("0")
+
+    def test_all_allocation_pct_zero(self) -> None:
+        """全 0 USD のとき allocation_pct は全て 0。"""
+        inp = UnifiedPortfolioInput(
+            aave=_aave("0"),
+            wallet=_wallet("0"),
+            cex=_cex("0"),
+        )
+        result = aggregate_portfolio(inp)
+        for alloc in result.allocations:
+            assert alloc.allocation_pct == Decimal("0")
+
+    def test_not_degraded_when_all_zero_but_available(self) -> None:
+        """全 0 USD でも available=True なら degraded=False。"""
+        inp = UnifiedPortfolioInput(
+            aave=_aave("0"),
+            wallet=_wallet("0"),
+            cex=_cex("0"),
+        )
+        result = aggregate_portfolio(inp)
+        assert result.degraded is False
+        assert result.sources_available == 3
+
+
+# ---------------------------------------------------------------------------
+# テストケース 4: HF 無限大入力
+# ---------------------------------------------------------------------------
+
+
+class TestHealthFactorInfinity:
+    def test_hf_inf_capped_to_999(self) -> None:
+        """Decimal('inf') は 999.0 にキャップされること。"""
+        inp = UnifiedPortfolioInput(
+            aave=_aave(health_factor="inf"),
+            wallet=_wallet(),
+            cex=_cex(),
+        )
+        result = aggregate_portfolio(inp)
+        assert result.health_factor == Decimal("999.0")
+
+    def test_hf_finite_not_capped(self) -> None:
+        """有限 HF はそのまま透過される。"""
+        inp = UnifiedPortfolioInput(
+            aave=_aave(health_factor="1.8"),
+            wallet=_wallet(),
+            cex=_cex(),
+        )
+        result = aggregate_portfolio(inp)
+        assert result.health_factor == Decimal("1.8")
+
+
+# ---------------------------------------------------------------------------
+# テストケース 5: available=False ソースが grand_total から除外されること
+# ---------------------------------------------------------------------------
+
+
+class TestSourceUnavailable:
+    def test_unavailable_source_excluded_from_grand_total(self) -> None:
+        """available=False のソースは grand_total に含まれない。"""
+        inp = UnifiedPortfolioInput(
+            aave=_aave("7000", available=True),
+            wallet=_wallet("2000", available=False),  # fail-open フォールバック
+            cex=_cex("1000", available=True),
+        )
+        result = aggregate_portfolio(inp)
+        assert result.grand_total_usd == Decimal("8000")  # wallet 除外
+        assert result.wallet_usd == Decimal("0")
+
+    def test_unavailable_source_sets_degraded(self) -> None:
+        """available=False のソースがあると degraded=True。"""
+        inp = UnifiedPortfolioInput(
+            aave=_aave(available=True),
+            wallet=_wallet(available=False),
+            cex=_cex(available=True),
+        )
+        result = aggregate_portfolio(inp)
+        assert result.degraded is True
+        assert result.sources_available == 2
+
+    def test_unavailable_aave_hf_not_transparent(self) -> None:
+        """Aave が available=False の場合、HF は None になる。"""
+        inp = UnifiedPortfolioInput(
+            aave=_aave(health_factor="2.5", available=False),
+            wallet=_wallet(),
+            cex=_cex(),
+        )
+        result = aggregate_portfolio(inp)
+        assert result.health_factor is None
+
+    def test_all_sources_unavailable(self) -> None:
+        """全ソース available=False → grand_total=0, degraded=True, sources_available=0。"""
+        inp = UnifiedPortfolioInput(
+            aave=_aave(available=False),
+            wallet=_wallet(available=False),
+            cex=_cex(available=False),
+        )
+        result = aggregate_portfolio(inp)
+        assert result.grand_total_usd == Decimal("0")
+        assert result.degraded is True
+        assert result.sources_available == 0
+
+
+# ---------------------------------------------------------------------------
+# テストケース 6: Decimal 精度 (float 混入チェック)
+# ---------------------------------------------------------------------------
+
+
+class TestDecimalPrecision:
+    def test_grand_total_is_decimal(self) -> None:
+        inp = UnifiedPortfolioInput(aave=_aave(), wallet=_wallet(), cex=_cex())
+        result = aggregate_portfolio(inp)
+        assert isinstance(result.grand_total_usd, Decimal)
+
+    def test_allocation_pct_is_decimal(self) -> None:
+        inp = UnifiedPortfolioInput(aave=_aave(), wallet=_wallet(), cex=_cex())
+        result = aggregate_portfolio(inp)
+        for alloc in result.allocations:
+            assert isinstance(alloc.allocation_pct, Decimal)
+
+    def test_no_float_in_output(self) -> None:
+        """出力に float 型の値が混入していないこと。"""
+        inp = UnifiedPortfolioInput(aave=_aave(), wallet=_wallet(), cex=_cex())
+        result = aggregate_portfolio(inp)
+        assert isinstance(result.aave_net_usd, Decimal)
+        assert isinstance(result.wallet_usd, Decimal)
+        assert isinstance(result.cex_usd, Decimal)
+        if result.health_factor is not None:
+            assert isinstance(result.health_factor, Decimal)
+
+    def test_allocation_pct_quantized_to_2dp(self) -> None:
+        """allocation_pct は小数点以下2桁にquantize されること。"""
+        inp = UnifiedPortfolioInput(
+            aave=_aave("3333"),
+            wallet=_wallet("3333"),
+            cex=_cex("3334"),
+        )
+        result = aggregate_portfolio(inp)
+        for alloc in result.allocations:
+            # 小数点以下2桁以内であること
+            assert alloc.allocation_pct == alloc.allocation_pct.quantize(Decimal("0.01"))
+
+
+# ---------------------------------------------------------------------------
+# テストケース 7: 二重計上なし (wallet と aave の独立性)
+# ---------------------------------------------------------------------------
+
+
+class TestNoDoubleCounting:
+    def test_wallet_and_aave_are_independent(self) -> None:
+        """wallet.total_usd と aave.total_usd は独立して合算される。
+
+        wallet_balance_service.py L13 により wallet には Aave supply 分が含まれない。
+        集約関数はそれぞれの total_usd をそのまま使用し、内部で減算・補正しない。
+        """
+        aave_src = _aave(total_usd="7000", supply_usd="10000", borrow_usd="3000")
+        wallet_src = _wallet(total_usd="2000")
+        cex_src = _cex(total_usd="1000")
+        inp = UnifiedPortfolioInput(aave=aave_src, wallet=wallet_src, cex=cex_src)
+        result = aggregate_portfolio(inp)
+        # 合計は 7000 + 2000 + 1000 = 10000 (supply_usd=10000 は合算されない)
+        assert result.grand_total_usd == Decimal("10000")
+        assert result.aave_net_usd == Decimal("7000")
+        assert result.wallet_usd == Decimal("2000")
+
+
+# ---------------------------------------------------------------------------
+# テストケース 8: allocations の長さとソース順序
+# ---------------------------------------------------------------------------
+
+
+class TestAllocationsStructure:
+    def test_allocations_length_always_3(self) -> None:
+        """欠落ソースがあっても allocations の長さは常に 3。"""
+        inp = UnifiedPortfolioInput(aave=_aave(), wallet=None, cex=_cex())
+        result = aggregate_portfolio(inp)
+        assert len(result.allocations) == 3
+
+    def test_allocations_source_order(self) -> None:
+        """allocations のソース順序は aave → wallet → cex。"""
+        inp = UnifiedPortfolioInput(aave=_aave(), wallet=_wallet(), cex=_cex())
+        result = aggregate_portfolio(inp)
+        assert [a.source for a in result.allocations] == ["aave", "wallet", "cex"]
+
+    def test_all_sources_none(self) -> None:
+        """全ソース None でも allocations は3要素 (全て available=False, usd=0)。"""
+        inp = UnifiedPortfolioInput(aave=None, wallet=None, cex=None)
+        result = aggregate_portfolio(inp)
+        assert len(result.allocations) == 3
+        assert result.grand_total_usd == Decimal("0")
+        assert result.sources_available == 0
+        assert result.degraded is True
+        for alloc in result.allocations:
+            assert alloc.available is False
+            assert alloc.total_usd == Decimal("0")
+            assert alloc.allocation_pct == Decimal("0")

--- a/docs/59_unified_portfolio_dashboard_design.md
+++ b/docs/59_unified_portfolio_dashboard_design.md
@@ -1,0 +1,245 @@
+# 59_unified_portfolio_dashboard_design.md
+# 統合ポートフォリオダッシュボード 設計書
+
+作成日: 2026-06-15
+Asana: feat/unified-portfolio-aggregation-design
+ブランチ: feat/unified-portfolio-aggregation-design
+関連docs: docs/04_api_design.md / docs/13_security_design.md / docs/34_phase2_protocols_guide.md
+関連モジュール: backend/app/portfolio/ / backend/app/aave/client.py / backend/app/partner/wallet_balance_schemas.py / backend/app/exchange/schemas.py
+
+> **Status: DRAFT (Phase 1 / 設計 + 純粋集約関数のみ)**。本ドキュメントは設計の正本であり、
+> 実API呼出endpoint・frontend実装・main.py配線は後続HUMANレビュースライスで行う。
+
+---
+
+## 0. Summary
+
+Ultra AutoTrade は現在ポートフォリオをAave V3 単一ソース（履歴スナップショット）のみで管理している
+(`backend/app/portfolio/` モジュール)。実際の資産は以下3ソースに分散している:
+
+1. **Aave V3** — 担保・借入・純資産 (DeFi)
+2. **Privy ウォレット** — Base mainnet 上の ETH + USDC 現物 (Aave supply 分を含まない)
+3. **Bybit CEX** — USDT 残高 (中央集権取引所)
+
+本設計書は「統合ポートフォリオビュー」として3ソースを横断集約する方式を定義する。
+
+---
+
+## 1. 現状把握 (実コード grep / 行番号付き)
+
+### 1.1 Aave AccountData — `backend/app/aave/client.py`
+
+| 行 | フィールド | 型 | 備考 |
+|---|---|---|---|
+| L235 | `class AccountData` | dataclass | |
+| L238 | `total_collateral_usd` | `Decimal` | Aave V3 Pool getUserAccountData 由来 |
+| L239 | `total_debt_usd` | `Decimal` | |
+| L240 | `available_borrows_usd` | `Decimal` | |
+| L241 | `health_factor` | `Decimal` | `Decimal("inf")` が来ることがある (L696) |
+
+ネットワーク: 本番は Base mainnet / staging は Base Sepolia。`AAVE_NETWORK` env で切替。
+
+### 1.2 Privy Wallet Balance — `backend/app/partner/wallet_balance_schemas.py`
+
+| 行 | フィールド | 型 | 備考 |
+|---|---|---|---|
+| L19 | `class WalletBalanceResponse` | Pydantic BaseModel | |
+| L28 | `eth_usd_value` | `Decimal` | eth_balance * eth_usd_price |
+| L31 | `usdc_usd_value` | `Decimal` | usdc_balance (1:1) |
+| L32 | `total_usd` | `Decimal` | eth_usd_value + usdc_usd_value |
+
+**重要**: `backend/app/partner/wallet_balance_service.py` L13 に明記 —
+「NOTE: Aave supply 分は **含まない**。ウォレットに「入っている」分のみ。」
+
+チェーン: Base mainnet 固定 (`backend/app/partner/wallet_balance_service.py` L31-36)。
+fail-open 設計: `_all_fallback_response()` (L198) で全フィールド Decimal("0") を返す。
+
+### 1.3 Bybit CEX Exchange Status — `backend/app/exchange/schemas.py`
+
+| 行 | フィールド | 型 | 備考 |
+|---|---|---|---|
+| L107 | `class ExchangeStatusResponse` | Pydantic BaseModel | |
+| L122 | `balance_usdt` | `Optional[Decimal]` | fetch_balance() 失敗時は None |
+
+`backend/app/exchange/service.py` L255: `balance_usdt` は `None` の場合がある。
+USDT ≈ USD 1:1 として換算する (stablecoin 前提)。
+
+---
+
+## 2. 統合スキーマ設計
+
+### 2.1 設計原則
+
+- **Decimal-only**: 全金融計算は `Decimal` 型。`float` 使用禁止 (Security Rule 11)
+- **fail-open per source**: 各ソースが利用不可でも他ソースを表示し続ける (`available: bool`)
+- **二重計上なし**: Wallet残高はAave supply分を含まない (wallet_balance_service.py L13 確認済み)
+- **HFはAave由来透過**: Health Factor は Aave ソースが存在する場合のみ表示。集約値は算出しない
+
+### 2.2 UnifiedPortfolioInput (集約関数への入力)
+
+```
+UnifiedPortfolioInput:
+  aave:   Optional[SourceBalance]   # 欠落 = Aave取得失敗
+  wallet: Optional[SourceBalance]   # 欠落 = Wallet取得失敗
+  cex:    Optional[SourceBalance]   # 欠落 = CEX取得失敗
+```
+
+### 2.3 SourceBalance (ソース別残高)
+
+```
+SourceBalance:
+  source:        Literal["aave", "wallet", "cex"]
+  total_usd:     Decimal                  # ソース内合計USD
+  available:     bool                     # データ取得成功フラグ
+  supply_usd:    Optional[Decimal]        # Aave専用: 担保総額
+  borrow_usd:    Optional[Decimal]        # Aave専用: 借入総額
+  health_factor: Optional[Decimal]        # Aave専用: 健全性指標
+```
+
+Aave の `total_usd` は `total_collateral_usd - total_debt_usd` (純資産)。
+
+### 2.4 UnifiedPortfolioView (集約出力)
+
+```
+UnifiedPortfolioView:
+  grand_total_usd:    Decimal                  # 3ソース合算USD
+  aave_net_usd:       Decimal                  # Aave 純資産 (0 if unavailable)
+  wallet_usd:         Decimal                  # Wallet 残高 (0 if unavailable)
+  cex_usd:            Decimal                  # CEX 残高 (0 if unavailable)
+  health_factor:      Optional[Decimal]        # Aave由来のみ
+  allocations:        list[SourceAllocation]   # ソース別配分
+  sources_available:  int                      # 正常取得ソース数 (0-3)
+  sources_total:      int                      # 総ソース数 (常に3)
+  degraded:           bool                     # 1ソース以上欠落 = True
+```
+
+### 2.5 SourceAllocation (配分情報)
+
+```
+SourceAllocation:
+  source:         str        # "aave" | "wallet" | "cex"
+  total_usd:      Decimal
+  allocation_pct: Decimal    # source_usd / grand_total * 100 (grand_total=0時は 0)
+  available:      bool
+```
+
+### 2.6 HF無限大処理
+
+既存の `_cap_hf_inf()` 思想 (`backend/app/portfolio/schemas.py` L12-15) を踏襲:
+`Decimal("inf")` または非有限値 → `Decimal("999.0")` にキャップしてシリアライズ。
+`aggregation_schemas.py` 内で同名関数として実装する。
+
+---
+
+## 3. 既存 portfolio モジュールとの関係
+
+### 3.1 既存モジュール (`backend/app/portfolio/`)
+
+| ファイル | 役割 | 本タスクとの関係 |
+|---|---|---|
+| `models.py` | DBモデル (portfolio_snapshots テーブル) | 無改変。参照のみ |
+| `schemas.py` | Aave単一ソース向けPydanticスキーマ | 無改変。`_cap_hf_inf` 思想を借用 |
+| `snapshot_service.py` | Aave HF定期スナップショット保存 | 無改変 |
+| `router.py` | `/api/portfolio/*` エンドポイント | 無改変 |
+| `__init__.py` | パッケージ初期化 | 無改変 |
+
+### 3.2 本タスクで追加するファイル
+
+| ファイル | 役割 |
+|---|---|
+| `aggregation_schemas.py` | 3ソース横断集約用Pydanticスキーマ (新規) |
+| `aggregation.py` | 純粋集約関数 (新規、実API非依存) |
+
+### 3.3 設計の分離理由
+
+既存 portfolio = Aave単一ソースの **履歴スナップショット** (時系列・DB書込)。
+本タスク = 3ソース横断の **現在ビュー集約** (ステートレス純粋関数)。
+
+既存 router/service/snapshot への改変は行わない。
+実API呼出 endpoint の追加は HUMAN-REVIEW-REQUIRED スライス (段階実装 Step 2) で行う。
+
+---
+
+## 4. Frontend コンポーネント構成案 (案のみ / 実装はしない)
+
+### 4.1 制約事項 (CLAUDE.md Frontend ルール厳守)
+
+- 全テキスト日本語 (`frontend/public/locales/ja/common.json` への i18n キー追加必須)
+- recharts 使用時は `dynamic(() => import('./UnifiedPortfolioChartRecharts'), { ssr: false })` 必須
+- role 分離: admin / partner / viewer で表示項目を分ける
+- Decimal → `Number()` でラップしてから `.toFixed()` を呼ぶ (API レスポンスは文字列)
+- ダミーデータ禁止: データ未取得時は「データなし」表示
+
+### 4.2 新規コンポーネント案
+
+```
+frontend/components/portfolio/
+  UnifiedPortfolioCard.tsx          # 3ソース合算カード (grand_total表示)
+  UnifiedPortfolioChartRecharts.tsx # 配分円グラフ (recharts / SSR:false)
+  SourceStatusBadge.tsx             # available: bool を色付きバッジ表示
+```
+
+### 4.3 既存コンポーネントとの関係
+
+- 既存 `PortfolioSnapshot` 系コンポーネント (Aave 履歴) は独立維持
+- 新規 `UnifiedPortfolioCard` は admin ダッシュボード (`app/(admin)/dashboard/page.tsx`) に追加予定
+- viewer には `sources_available` / `degraded` フラグを表示しない (admin限定)
+
+---
+
+## 5. 段階実装計画
+
+### Step 1: 本 PR (Tier B / 自動進行可)
+- [x] 本設計ドキュメント (`docs/59_unified_portfolio_dashboard_design.md`)
+- [x] 集約スキーマ (`backend/app/portfolio/aggregation_schemas.py`)
+- [x] 純粋集約関数 (`backend/app/portfolio/aggregation.py`)
+- [x] pytest (`backend/tests/test_portfolio_aggregation.py`)
+- 既存ファイル無改変 / 実API非依存 / frontend未着手
+
+### Step 2: HUMAN-REVIEW-REQUIRED (実API集約エンドポイント)
+- `GET /api/portfolio/unified` エンドポイント新設
+- 3ソースの実API呼出 (Aave client / wallet fetch / exchange.get_status())
+- `backend/app/portfolio/router.py` 拡張
+- `backend/app/main.py` 配線確認 (portfolio_router は L74/L279 に既登録)
+- 適切な RBAC (admin/partner 向け)
+
+### Step 3: HUMAN-REVIEW-REQUIRED (Frontend 実装)
+- `UnifiedPortfolioCard.tsx` / `UnifiedPortfolioChartRecharts.tsx` 実装
+- i18n キー追加 (`frontend/public/locales/ja/common.json`)
+- admin ダッシュボードへの組み込み
+- E2E テスト追加
+
+---
+
+## 6. 【要確認】未解決事項
+
+以下は設計段階で確認が必要な事項。Step 2/3 着手前に人間確認が必要。
+
+| 番号 | 項目 | 詳細 |
+|---|---|---|
+| Q1 | Privy専用残高endpoint | wallet_balance_service には `fetch()` 関数あり (L212)。`/api/partner/wallet-balance` ルートが既存か確認必要 |
+| Q2 | Bybit balance breakdown | `balance_usdt` (USDT残高) のみで十分か、他通貨 (BTC/ETH) も集約するか |
+| Q3 | ユーザー単位集約 | 統合ビューは per-partner 按分か admin-level 全体ビューか |
+| Q4 | 複数wallet集約 | 将来的に複数walletアドレスを集約するか (現在は1ユーザー1wallet前提) |
+| Q5 | CEX残高のrole分離 | CEX残高 (Bybit) を viewer に表示するか admin 限定にするか |
+| Q6 | チェーン前提の差 | Aave = Base mainnet / Base Sepolia (env切替) / Wallet = Base mainnet 固定。staging環境では wallet がBase mainnetを見るため実額と乖離する可能性あり |
+
+### Q6 チェーン前提差 詳細
+
+| ソース | 本番チェーン | staging チェーン | 備考 |
+|---|---|---|---|
+| Aave | Base mainnet | Base Sepolia (`AAVE_NETWORK=base_sepolia`) | env切替 |
+| Privy Wallet | Base mainnet | Base mainnet (固定) | staging でも実残高を見る |
+| Bybit CEX | 本番API | staging でも本番APIを見る | Bybit staging 環境なし |
+
+staging では Aave だけ testnet、Wallet/CEX は mainnet の値を返すため、
+統合ビューの `grand_total` が staging で混在する。Step 2 でこの差異を明示するエラーハンドリングが必要。
+
+---
+
+## 7. セキュリティ考慮事項
+
+- Health Factor < 1.6 の場合は HARD_STOP (CLAUDE.md Security Rule 2)。集約関数はHFをそのまま透過するのみで安全装置の判断はしない
+- `grand_total_usd` は表示用途のみ。自動取引判断の入力には使用しない
+- Decimal シリアライズ: API レスポンスは文字列で返す (`field_serializer` 使用)
+- 認証情報 (Bybit API key 等) は aggregation.py には一切持ち込まない


### PR DESCRIPTION
## 概要
v4 epic north star **[Privy+Aave][UX] 統合ポートフォリオダッシュボード (GID 1215698091414471)** の **Tier-B 自動進行可スライス**。Privy wallet / Aave / Bybit の3ソースを1ビューに統合する backend read-only 集約スキーマ + 純粋集約関数 + 設計doc のみ。実API呼出endpoint・frontend実装・main.py配線・新規取得層は **🛑 HUMAN-REVIEW-REQUIRED** として除外。

## 変更（すべて新規ファイル・既存無改変）
- `docs/59_unified_portfolio_dashboard_design.md` — 3ソース実体マッピング(grep行番号付き: Aave AccountData / partner WalletBalanceResponse / exchange get_status) / 統合スキーマ / frontend構成案(実装しない) / 段階実装計画 / 【要確認】Q1-6(chain前提差: Aave=base-sepolia / wallet=Base mainnet 含む)
- `backend/app/portfolio/{aggregation_schemas,aggregation}.py` — `UnifiedPortfolioInput`/`UnifiedPortfolioView`(Decimal強制) + `aggregate_portfolio`(純粋関数、fail-open/二重計上なし/ゼロ除算ガード/HF∞→999キャップ)。aave/ccxt/web3/httpx import ゼロ
- `backend/tests/test_portfolio_aggregation.py` — 32件(3ソース全揃い/1ソース欠落degraded/全0ゼロ除算/HF∞/available=False除外/Decimal精度)

## 設計の核心
- **二重計上なし**: wallet 残高は Aave supply を含まない（`partner/wallet_balance_service.py` NOTE 準拠）ため単純合算が正しい
- **fail-open**: 1ソース欠落/available=False でも他ソースを表示し `degraded=True`（実資金監視の継続性）

## パイプライン結果
- **Evaluator: APPROVED**（CRITICAL 0 / 純粋関数境界・非侵襲・Decimal・集約ロジック健全性5項目精読・docs grep行番号照合 全PASS）
- **Tester: PASS** — aggregation.py coverage **100%**、`tests/ -k portfolio` **84 passed**（リグレッションなし）、mypy/ruff/ruff-S 全0エラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)