### PR TITLE
fix(liff-chat): AssetChartの捏造プレースホルダ撤去→データなし表示

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/AssetChart.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/AssetChart.tsx
@@ -22,23 +22,10 @@ interface DataPoint {
   value: number
 }
 
-function makePlaceholder(count: number): DataPoint[] {
-  return Array.from({ length: count }, (_, i) => ({
-    date: `Day${i + 1}`,
-    value: 10000 + Math.sin(i / 5) * 500 + i * 10,
-  }))
-}
-
-const PERIOD_DAYS: Record<Props["period"], number> = {
-  "1M": 30,
-  "3M": 90,
-  "6M": 180,
-  "1Y": 365,
-}
-
 export default function AssetChart({ period }: Props) {
   const t = useTranslations("Liff.panels")
   const [data, setData] = useState<DataPoint[]>([])
+  const [loaded, setLoaded] = useState(false)
 
   useEffect(() => {
     const token =
@@ -55,13 +42,23 @@ export default function AssetChart({ period }: Props) {
         if (d?.data && d.data.length > 0) {
           setData(d.data)
         } else {
-          setData(makePlaceholder(PERIOD_DAYS[period]))
+          setData([])
         }
+        setLoaded(true)
       })
       .catch(() => {
-        setData(makePlaceholder(10))
+        setData([])
+        setLoaded(true)
       })
   }, [period])
+
+  if (loaded && data.length === 0) {
+    return (
+      <div className="h-[200px] w-full flex items-center justify-center">
+        <p className="text-sm text-gray-400">{t("assetHistoryEmpty")}</p>
+      </div>
+    )
+  }
 
   return (
     <div className="h-[200px] w-full">

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -682,6 +682,7 @@
       "statsCurrent": "Current",
       "statsProfit": "Profit",
       "statsYield": "Yield",
+      "assetHistoryEmpty": "No asset data yet",
       "account": {
         "title": "Account",
         "editNamePlaceholder": "Username",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -682,6 +682,7 @@
       "statsCurrent": "現在",
       "statsProfit": "利益",
       "statsYield": "利回り",
+      "assetHistoryEmpty": "まだ運用データがありません",
       "account": {
         "title": "アカウント",
         "editNamePlaceholder": "ユーザー名",


### PR DESCRIPTION
## 概要
liff-chat v3 の AssetChart に含まれていた**捏造チャート（`makePlaceholder` の偽データ `Math.sin` 右肩上がり）**を撤去。実データが取得できない場合（404 / 空 / 通信エラー）は偽グラフではなく「データなし」を表示する。

Closes Asana 1215718131043946

## 変更ファイル
- `frontend/app/(liff)/liff-chat/_components/AssetChart.tsx` — `makePlaceholder`/`Math.sin`/`PERIOD_DAYS` 完全削除。失敗3経路（`!r.ok`→null / 空data / `.catch`）すべて `setData([])`+`setLoaded(true)` に合流。`loaded && data.length===0` で「データなし」表示（recharts は描画しない）
- `frontend/messages/ja.json` — `Liff.panels.assetHistoryEmpty: "まだ運用データがありません"`
- `frontend/messages/en.json` — `Liff.panels.assetHistoryEmpty: "No asset data yet"`

## Gate 結果
- tsc --noEmit: 0 errors
- npm run build: success（recharts dynamic ssr:false 非破壊 / `/liff-chat` 含む 88 pages 生成）
- i18n パリティ: `Liff.panels` ja/en 差分ゼロ
- 捏造データ残存: 0件
- Playwright E2E(Gate4): deferred（staging baseURL 実機で要確認）

## パイプライン
Planner(Opus)→Generator(Sonnet)→Evaluator(Opus: APPROVED 指摘0)→Tester(Sonnet: PASS)

## 注意（共有ファイル）
本PRは `messages/ja.json`/`en.json` の `Liff.panels` セクションに追記。同バッチの #5(opMode)/#6(referral) も ja/en.json の別セクションを編集するため、マージ順は任意だが json 競合に留意。

🤖 Generated with [Claude Code](https://claude.com/claude-code)