### PR TITLE
fix(deploy): Privy App ID 未設定/placeholder を本番 deploy 前に弾く

### DIFF
--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -373,6 +373,17 @@ if grep -qE '^AAVE_NETWORK=.*sepolia' .env.production; then
   fi
 fi
 
+# Guard 1b: NEXT_PUBLIC_PRIVY_APP_ID 検証 (フロント build に焼き込まれる build-time 値)
+# 未設定/placeholder のまま build すると PrivyRootClient が PrivyProvider を描画せず、
+# ログイン画面で usePrivy が throw → 白画面でログイン不能になる (PrivyRootClient.tsx)。
+# build 前にここで弾く (フロントを焼く full / --frontend-only の両方で必須)。
+_privy_app_id="$(grep -E '^NEXT_PUBLIC_PRIVY_APP_ID=' .env.production | head -1 | cut -d= -f2- | tr -d '"' | tr -d "'" | tr -d '[:space:]' || true)"
+if [[ -z "${_privy_app_id}" || "${_privy_app_id}" == "clplaceholder000000000000000000000" ]]; then
+  echo "❌ FAIL: .env.production の NEXT_PUBLIC_PRIVY_APP_ID が未設定/placeholder"
+  echo "    → Privy ログインが白画面になります。実 App ID を設定してから deploy してください"
+  exit 1
+fi
+
 # Guard 2: 環境分離チェック (バックエンドに関わるキーのみ必須 — フロントエンドのみデプロイ時はスキップ)
 if [[ "${FRONTEND_ONLY}" == "true" ]]; then
   echo "⚠️  WARN: --frontend-only のため環境分離チェックをスキップ (バックエンド変更なし)"


### PR DESCRIPTION
## 概要
`NEXT_PUBLIC_PRIVY_APP_ID` はフロント build に焼き込まれる build-time 値。未設定/placeholder のまま build すると `PrivyRootClient` が `PrivyProvider` を描画せず、ログイン画面で `usePrivy` が throw → **白画面でログイン不能**になる（liff-chat PWA の入口が死ぬ）。

`deploy_production.sh` の Guard 群（既存の APP_ENV / BYBIT_SANDBOX / AAVE_NETWORK 検証と同列）に **Guard 1b** を追加し、build 前に fail-fast させる。full / `--frontend-only` の両方で有効。

## 変更
- `scripts/deploy_production.sh`: `NEXT_PUBLIC_PRIVY_APP_ID` が空 or `clplaceholder…` なら `exit 1`

## DoD
- `bash -n`: 構文 OK
- `shellcheck -S error`: 0 errors

## 補足
- これは**コード側のガード**。本番 VPS の `.env.production` に実 App ID が入っているかの**実値確認は次回 deploy 時にこのガードが担保**する（未設定なら deploy が止まる）。

## Asana
- Closes 1215718095621957（Privy env ビルド時ガード追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)