### PR TITLE
fix(liff-chat): 運用モード誇大表現の是正 + 紹介ステータスのenum化(i18n)

### DIFF
--- a/backend/app/referral/schemas.py
+++ b/backend/app/referral/schemas.py
@@ -63,7 +63,7 @@ class ReferredUserDetail(BaseModel):
 
     name: str
     joined_at: datetime
-    status: str  # "運用中" | "登録済み"
+    status: str  # "active" | "registered"
     reward_jpy: str  # ¥1,500 bonus は別タスク: 現在は常に "0"
 
 

--- a/backend/app/referral/service.py
+++ b/backend/app/referral/service.py
@@ -35,9 +35,9 @@ logger = logging.getLogger(__name__)
 # /referral/users/{id}/transactions が返す operation 値のホワイトリスト。
 _ALLOWED_TX_TYPES = ("deposit", "withdraw", "borrow", "repay")
 
-# get_api_referral_info で返す referred_users の status 値
-_STATUS_ACTIVE = "運用中"
-_STATUS_REGISTERED = "登録済み"
+# get_api_referral_info で返す referred_users の status 値 ("active" | "registered")
+_STATUS_ACTIVE = "active"
+_STATUS_REGISTERED = "registered"
 
 
 def _share_base_url() -> str:

--- a/backend/tests/test_api_referral_router.py
+++ b/backend/tests/test_api_referral_router.py
@@ -273,8 +273,8 @@ def test_get_api_referral_earnings_with_referred_users(
     assert len(body["referred_users"]) == 2
 
     statuses = {u["name"]: u["status"] for u in body["referred_users"]}
-    assert statuses["notxuser"] == "登録済み"
-    assert statuses["hastxuser"] == "運用中"
+    assert statuses["notxuser"] == "registered"
+    assert statuses["hastxuser"] == "active"
 
     for u in body["referred_users"]:
         assert "joined_at" in u

--- a/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
@@ -151,7 +151,7 @@ export function ReferralPanel() {
   const monthlyReward = Number(displayInfo.current_month_reward_jpy).toLocaleString("ja-JP")
 
   const operatingCount = displayInfo.referred_users.filter(
-    (u) => u.status === "運用中"
+    (u) => u.status === "active"
   ).length
 
   return (
@@ -380,7 +380,7 @@ function ReferredUserRow({
   user: { name: string; joined_at: string; status: string; reward_jpy: string }
   tPanel: TFn
 }) {
-  const isActive = user.status === "運用中"
+  const isActive = user.status === "active"
   const initial = user.name ? user.name.charAt(0).toUpperCase() : "?"
   const joinedDate = user.joined_at ? user.joined_at.slice(0, 10) : ""
   const rewardJpy = Number(user.reward_jpy).toLocaleString("ja-JP")
@@ -408,7 +408,9 @@ function ReferredUserRow({
               : "text-zinc-400 border-zinc-700"
           }`}
         >
-          {user.status}
+          {user.status === "active"
+            ? tPanel("statusActive")
+            : tPanel("statusRegistered")}
         </span>
         <span className="text-zinc-300 text-xs">¥{rewardJpy}</span>
       </div>

--- a/frontend/e2e/liff-chat-referral.spec.ts
+++ b/frontend/e2e/liff-chat-referral.spec.ts
@@ -33,13 +33,13 @@ const MOCK_EARNINGS = {
     {
       name: '山田太郎',
       joined_at: '2026-05-01T00:00:00+00:00',
-      status: '運用中',
+      status: 'active',
       reward_jpy: '3000',
     },
     {
       name: '佐藤花子',
       joined_at: '2026-05-20T00:00:00+00:00',
-      status: '登録済み',
+      status: 'registered',
       reward_jpy: '1500',
     },
   ],

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -351,8 +351,8 @@
     "pausedDescAlt": "AI analysis and proposals are paused. Resume manually."
   },
   "OperationMode": {
-    "managedLabel": "Full Auto",
-    "managedDesc": "AI makes and executes all decisions automatically. For beginners.",
+    "managedLabel": "Automated",
+    "managedDesc": "AI analyzes the market and displays proposals. Automated trading and rebalancing are coming soon (available in v4).",
     "activeLabel": "Semi Auto",
     "activeDesc": "AI proposes, you approve, then it executes. For intermediate users.",
     "proLabel": "Manual",
@@ -842,8 +842,8 @@
         "loadingMode": "Loading...",
         "modeUnset": "Not set",
         "activeBadge": "Active",
-        "managedLabel": "Fully Automated",
-        "managedDesc": "AI decides and executes automatically. No approval needed. Notified via LINE after execution.",
+        "managedLabel": "Automated",
+        "managedDesc": "AI analyzes the market and displays proposals. Automated trading and rebalancing are coming soon (available in v4).",
         "activeLabel": "Active",
         "activeDesc": "AI proposes. You approve before execution.",
         "toastSwitched": "Switched to \"{mode}\"",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -834,7 +834,9 @@
         "toastLineShareFallback": "LINE share unavailable — text copied",
         "toastShareFailed": "Share failed",
         "shareTextBody": "[Introducing UATa]\nUATa is an AI-powered automated asset management service.\nRegister with referral code \"{code}\":\n{url}",
-        "mailSubject": "[Introducing UATa] AI Automated Asset Management"
+        "mailSubject": "[Introducing UATa] AI Automated Asset Management",
+        "statusActive": "Active",
+        "statusRegistered": "Registered"
       },
       "opMode": {
         "title": "Operation Mode",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -834,7 +834,9 @@
         "toastLineShareFallback": "LINEシェア非対応環境 — テキストをコピーしました",
         "toastShareFailed": "シェアに失敗しました",
         "shareTextBody": "【UATaのご紹介】\nAIが自動で資産運用してくれるサービスです。\n紹介コード「{code}」を使ってアカウント登録できます。\n▼ アカウント開設はこちら\n{url}",
-        "mailSubject": "【UATaのご紹介】AI自動資産運用サービス"
+        "mailSubject": "【UATaのご紹介】AI自動資産運用サービス",
+        "statusActive": "運用中",
+        "statusRegistered": "登録済み"
       },
       "opMode": {
         "title": "運用モード切替",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -351,8 +351,8 @@
     "pausedDescAlt": "AI分析と提案を停止中です。手動で再開してください"
   },
   "OperationMode": {
-    "managedLabel": "フルオート",
-    "managedDesc": "AIが全自動で判断・実行。初心者向け。",
+    "managedLabel": "おまかせ",
+    "managedDesc": "AIが市場を分析し提案を表示します。自動売買・自動リバランスは準備中です（v4提供予定）。",
     "activeLabel": "セミオート",
     "activeDesc": "AIが提案→ユーザーが承認→実行。中級者向け。",
     "proLabel": "マニュアル",
@@ -842,8 +842,8 @@
         "loadingMode": "読み込み中...",
         "modeUnset": "未設定",
         "activeBadge": "設定中",
-        "managedLabel": "完全おまかせ",
-        "managedDesc": "AIが自動で判断・実行。承認不要。実行後にLINEで通知。",
+        "managedLabel": "おまかせ",
+        "managedDesc": "AIが市場を分析し提案を表示します。自動売買・自動リバランスは準備中です（v4提供予定）。",
         "activeLabel": "アクティブ",
         "activeDesc": "AIが提案。自分で承認してから実行。",
         "toastSwitched": "「{mode}」に切り替えました",


### PR DESCRIPTION
## 概要
liff-chat v3 公開前の安全束修正 2件（ja/en.json を共有するため1ブランチ・直列2タスク）。

Closes Asana 1215718202509489
Closes Asana 1215718177129172

## #5 運用モードの誇大表現是正 (1215718202509489)
v3 実態（AIは分析・提案を表示。自動売買/自動リバランスは準備中=v4提供予定）と乖離した「全自動で判断・実行」「承認不要」表現を是正。
- `Liff.panels.opMode`（OpModePanel.tsx が描画）: `managedLabel`「完全おまかせ」→「おまかせ」、`managedDesc`「AIが自動で判断・実行。承認不要…」→「AIが市場を分析し提案を表示します。自動売買・自動リバランスは準備中です（v4提供予定）。」
- `OperationMode`（OperationModeSelector.tsx が描画。当初 dead 判定だったが実 consumer 判明し同時是正）: 同方針。
- ja/en パリティ維持。
> 注: settings/onboarding/policy 画面の `完全おまかせ`/`承認不要`（別名前空間・origin/main既存）は本タスク（op modeパネル）のスコープ外。別タスク候補。

## #6 紹介ステータスの enum化 (1215718177129172)
`referred_users[].status` の日本語直返しを enum化し frontend で i18n マッピング。
- `service.py`: `_STATUS_ACTIVE="active"` / `_STATUS_REGISTERED="registered"`（**DBカラム非存在の動的生成値**=migration不要）
- `schemas.py`: status コメント更新
- `ReferralPanel.tsx`: `=== "運用中"`→`=== "active"`（:154/:383）、`{user.status}` 生表示→`t(statusActive/statusRegistered)` マッピング（:411、未知値は registered フォールバック）
- ja/en.json `Liff.panels.referral`: `statusActive`(運用中/Active) / `statusRegistered`(登録済み/Registered) 新規追加
- `test_api_referral_router.py`: status アサートを enum へ更新
- `e2e/liff-chat-referral.spec.ts`: モック status を enum へ追従（API契約 consumer 更新）

## Gate 結果
- ruff check / format / mypy: 0 errors
- pytest（referral系）: 20 passed（coverage は CI で enforce / ローカルpytest-cov未導入）
- tsc --noEmit: 0 errors / npm run build: success（88 pages）
- i18n パリティ: ja/en 全キー差分ゼロ
- 旧リテラル残存（scope内）: 0 / 誇大表現（scope内）: 0
- Playwright E2E(Gate4): deferred（staging baseURL。spec モック enum化は静的確認済み）
- DB migration: 不要（status は動的生成値）

## パイプライン / 監査
Planner(Opus)→Generator(Sonnet)→Evaluator(Opus: CHANGES_REQUESTED)→Generator(spec追従)→Tester(Sonnet: PASS)
- Evaluator が **API契約変更の consumer 漏れ**（e2e spec のモックが旧日本語 status）を検出 → 追従修正済み。

## 注意（共有ファイル）
`messages/ja.json`/`en.json` を編集。同バッチ #1(panels.assetHistoryEmpty)/#2(home.noSignal)/#4(moonpay削除) も別セクションを編集。マージ順は任意。

🤖 Generated with [Claude Code](https://claude.com/claude-code)