### PR TITLE
fix(liff): ログイン画面を arobix ライトデザインに統一

### DIFF
--- a/frontend/app/(liff)/_components/BrowserLoginPrompt.tsx
+++ b/frontend/app/(liff)/_components/BrowserLoginPrompt.tsx
@@ -29,12 +29,12 @@ export function BrowserLoginPrompt({ onSuccess }: BrowserLoginPromptProps) {
   }
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-dvh bg-zinc-950 px-6 text-center">
-      <Wallet className="h-10 w-10 text-green-500 mb-4" />
-      <h2 className="text-zinc-100 text-base font-semibold mb-2">
+    <div className="flex flex-col items-center justify-center min-h-dvh ax-bg-app px-6 text-center">
+      <Wallet className="h-10 w-10 text-[#1D9E75] mb-4" />
+      <h2 className="ax-text-primary text-base font-semibold mb-2">
         {t("title")}
       </h2>
-      <p className="text-zinc-400 text-sm mb-6 leading-relaxed">
+      <p className="ax-text-secondary text-sm mb-6 leading-relaxed">
         {t("description")}
       </p>
 
@@ -42,7 +42,7 @@ export function BrowserLoginPrompt({ onSuccess }: BrowserLoginPromptProps) {
         onClick={handleLogin}
         disabled={signingIn}
         className="w-full max-w-xs flex items-center justify-center gap-2
-                   bg-green-600 hover:bg-green-500 disabled:opacity-50
+                   bg-[#1D9E75] hover:bg-[#1a8f6a] disabled:opacity-50
                    disabled:cursor-not-allowed text-white font-semibold
                    py-3 rounded-xl transition-colors"
       >
@@ -54,9 +54,9 @@ export function BrowserLoginPrompt({ onSuccess }: BrowserLoginPromptProps) {
         {signingIn ? t("signingIn") : t("loginButton")}
       </button>
 
-      {error && <p className="text-red-400 text-xs mt-3 max-w-xs">{error}</p>}
+      {error && <p className="text-red-600 text-xs mt-3 max-w-xs">{error}</p>}
 
-      <p className="text-zinc-600 text-xs mt-6 leading-relaxed">
+      <p className="ax-text-secondary opacity-70 text-xs mt-6 leading-relaxed">
         {t("lineAppHint")}
       </p>
     </div>


### PR DESCRIPTION
## 概要
オンボーディング/ログイン画面（`BrowserLoginPrompt`）が dark (`bg-zinc-950`) のままで、liff-chat の **arobix ライトデザイン**（クリーム背景＋紫ピンクアンバーのグラデ＋緑アクセント）と不一致だった。arobix デザイントークン（`app/arobix/theme.css`）に揃える。

ユーザー確認: A-light（arobix）が liff-chat の正式デザイン。

## 変更（`BrowserLoginPrompt.tsx`）
| | 変更前 | 変更後 |
|---|---|---|
| 背景 | `bg-zinc-950` | `ax-bg-app`（#f7f2ea） |
| 見出し | `text-zinc-100` | `ax-text-primary`（#1c1a27） |
| 本文 | `text-zinc-400` | `ax-text-secondary`（#736f7e） |
| アイコン/ボタン緑 | `green-500/600` | `#1D9E75` / hover `#1a8f6a` |
| エラー | `text-red-400` | `text-red-600`（ライト背景向け） |
| ヒント | `text-zinc-600` | `ax-text-secondary opacity-70` |

## DoD
- `tsc --noEmit`: 0 errors
- `eslint`: 0 problems

## 補足（別件・要判断）
- liff-chat 本体（`page.tsx`）は現状 **dark(`bg-zinc-950`) と arobix グラデが混在**した過渡状態。「liff-chat 全体を完全に arobix ライトへ統一」は本 PR のスコープ外。必要なら別途対応。
- 反映には frontend 再デプロイが必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)