### PR TITLE
feat(liff-chat): EN モードに MoonPay on-ramp を追加

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
@@ -10,6 +10,7 @@ import { useFundWallet } from "@privy-io/react-auth"
 import { base, baseSepolia } from "wagmi/chains"
 import { useWallet } from "@/hooks/useWallet"
 import { useUsdcBalance } from "@/hooks/useUsdcBalance"
+import { MoonPayWidget } from "./MoonPayWidget"
 import { track, EV } from "@/lib/posthog"
 
 // ---- 型定義 ---------------------------------------------------------------
@@ -324,9 +325,8 @@ export function DepositPanel() {
             </ul>
           </div>
 
-          {/* 入金ボタン（Privy fundWallet モーダルを開く。
-              Privy fundWallet がカード購入・送金・ネットワーク選択を一括で扱うため、
-              旧 MoonPay ウィジェットは重複として削除し、本ボタンに一本化した） */}
+          {/* 入金ボタン（Privy fundWallet モーダルを開く。カード購入・送金・
+              ネットワーク選択を一括で扱う。EN モードでは下に MoonPay on-ramp も提示する） */}
           <button
             onClick={() => { void handleFundWallet() }}
             disabled={!address || isFunding}
@@ -337,6 +337,18 @@ export function DepositPanel() {
             {isFunding && <Loader2 className="w-4 h-4 animate-spin" />}
             {t("depositBtn")}
           </button>
+
+          {/* MoonPay on-ramp — EN モードのみ（Privy fundWallet の代替経路） */}
+          {isEn && (
+            <>
+              <div className="flex items-center gap-2">
+                <div className="flex-1 h-px bg-zinc-700" />
+                <span className="text-xs text-zinc-500">or</span>
+                <div className="flex-1 h-px bg-zinc-700" />
+              </div>
+              <MoonPayWidget />
+            </>
+          )}
         </div>
       )}
 

--- a/frontend/app/(liff)/liff-chat/_components/panels/MoonPayWidget.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/MoonPayWidget.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// frontend/app/(liff)/liff-chat/_components/panels/MoonPayWidget.tsx
+// MoonPay 入金ウィジェット（EN モード時のみ表示）。
+// @moonpay/moonpay-react 等の npm 依存を追加せず iframe/プレースホルダ実装。
+// MoonPay 有効化は Privy ダッシュボード操作で行うため、ここは UI のみ。
+"use client"
+
+import { ExternalLink } from "lucide-react"
+import { useTranslations } from "next-intl"
+
+// MoonPay の公式購入 URL。実際の API キー統合は別途 Privy ダッシュボードで行う。
+const MOONPAY_URL = "https://buy.moonpay.com"
+
+export function MoonPayWidget() {
+  const t = useTranslations("Liff.panels.deposit")
+
+  const handleOpen = () => {
+    if (typeof window !== "undefined") {
+      window.open(MOONPAY_URL, "_blank", "noopener,noreferrer")
+    }
+  }
+
+  return (
+    <div className="bg-zinc-800 border border-zinc-700 rounded-xl px-4 py-4 space-y-3">
+      {/* ヘッダー */}
+      <div className="flex items-center gap-2">
+        {/* MoonPay カラーアクセント */}
+        <div className="w-6 h-6 rounded-full bg-gradient-to-br from-purple-500 to-blue-500 flex-shrink-0" />
+        <p className="text-sm font-semibold text-white">{t("moonpayTitle")}</p>
+      </div>
+
+      <p className="text-xs text-zinc-400 leading-relaxed">
+        {t("moonpayDesc")}
+      </p>
+
+      <button
+        onClick={handleOpen}
+        className="w-full flex items-center justify-center gap-2
+                   bg-gradient-to-r from-purple-600 to-blue-600
+                   hover:from-purple-500 hover:to-blue-500
+                   text-white font-semibold py-3 rounded-xl
+                   transition-all active:scale-[0.98]"
+      >
+        <span>{t("moonpayTitle")}</span>
+        <ExternalLink className="w-4 h-4" />
+      </button>
+    </div>
+  )
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -760,6 +760,8 @@
         "depositAddressNote": "Send USDC to this address. It will be automatically deposited into Aave once received.",
         "depositNoWallet": "No wallet address registered",
         "depositBtn": "Deposit",
+        "moonpayTitle": "Buy with card",
+        "moonpayDesc": "Purchase USDC with a credit or debit card via MoonPay.",
         "withdrawAmountLabel": "Enter amount (USDC)",
         "withdrawAmountPlaceholder": "Enter amount",
         "withdrawDestLabel": "Destination",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -760,6 +760,8 @@
         "depositAddressNote": "このアドレスに USDC を送金してください。着金後、自動で Aave 運用に反映されます。",
         "depositNoWallet": "ウォレットアドレスが登録されていません",
         "depositBtn": "入金する",
+        "moonpayTitle": "クレジットカードで購入",
+        "moonpayDesc": "MoonPay を使って、クレジットカードまたはデビットカードで USDC を購入できます。",
         "withdrawAmountLabel": "金額を入力（USDC）",
         "withdrawAmountPlaceholder": "金額を入力",
         "withdrawDestLabel": "出金先",


### PR DESCRIPTION
## 概要
EN モードの入金に **MoonPay カード購入（on-ramp）** を Privy fundWallet の代替経路として追加。JP モードは従来どおり Privy ボタンのみ。

## 背景・#757 との関係
#757 で MoonPayWidget は「Privy fundWallet に一本化」として削除されたが、EN/一部地域では Privy on-ramp の代替として MoonPay を提示したい（別 CLI セッション発の要望）。**#757 の削除を意図的に部分的に巻き戻す**形で、EN 限定・「or」区切りで再追加する。

## 変更
- `MoonPayWidget.tsx` を**再作成**（#757 削除分を git 履歴から復元。配色は現 DepositPanel(dark) に合わせる）
- `moonpay` i18n キー（`moonpayTitle`/`moonpayDesc`）を **en/ja に復活**
- `DepositPanel.tsx`: import + `{isEn && <MoonPayWidget/>}`（「or」区切り線つき）、旧「一本化」コメントを是正

## 表示
- JP: Privy「入金する」ボタンのみ
- EN: Privy ボタン → or → MoonPay

## DoD
- `tsc --noEmit`: 0 errors
- `eslint`: 0 errors（1 warning は既存の `t` dep）
- i18n ja/en parity OK
- `npm run build`: 実行中（別途確認）

## 注意
- **配色は dark のまま**（現 DepositPanel に整合）。liff-chat 全体の arobix ライト化は別タスク(c)で一括対応予定。
- 単独 CLI セッション版は #757 削除済みの古い base で作られ build が壊れるため、本 PR が現 main ベースの正規版。そちらは破棄推奨。

## Asana
- 関連: 1215718131043785（MoonPay削除 #757）を一部巻き戻し

🤖 Generated with [Claude Code](https://claude.com/claude-code)