### PR TITLE
feat(liff-chat): UI 全体を arobix ライトデザインに統一

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/ChatPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/ChatPanel.tsx
@@ -84,7 +84,7 @@ function MessageBubble({ message }: { message: Message }) {
       <div
         className={`max-w-[78%] px-4 py-2.5 rounded-2xl text-sm leading-relaxed whitespace-pre-wrap ${
           isAI
-            ? "bg-zinc-800 text-white rounded-tl-none"
+            ? "ax-card-warm text-[#1c1a27] rounded-tl-none"
             : "bg-[#1D9E75] text-white rounded-tr-none"
         }`}
       >
@@ -219,36 +219,36 @@ export function ChatPanel({ onClose }: Props) {
 
       {/* パネル本体 */}
       <div
-        className="fixed bottom-0 left-0 right-0 z-50 bg-zinc-950
+        className="fixed bottom-0 left-0 right-0 z-50 ax-bg-app
                    h-[88vh] rounded-t-2xl flex flex-col
                    animate-in slide-in-from-bottom duration-300"
       >
         {/* ドラッグハンドル */}
         <div className="flex justify-center pt-3 pb-1 flex-shrink-0">
-          <div className="w-8 h-1 rounded-full bg-zinc-700" />
+          <div className="w-8 h-1 rounded-full bg-[#1c1a27]/10" />
         </div>
 
         {/* ヘッダー */}
-        <div className="flex items-center bg-[#1a3d2e] px-4 py-3 flex-shrink-0">
+        <div className="flex items-center bg-gradient-to-r from-[#b9a4f2] via-[#ecaccd] to-[#fbd9a0] px-4 py-3 flex-shrink-0">
           <button
             onClick={onClose}
-            className="text-white mr-3 p-0.5 hover:bg-white/10 rounded transition-colors"
+            className="text-[#1c1a27] mr-3 p-0.5 hover:bg-black/5 rounded transition-colors"
             aria-label={t("closeAriaLabel")}
           >
             <ChevronLeft className="w-5 h-5" />
           </button>
           <div className="flex-1 min-w-0">
-            <div className="text-white font-semibold text-base leading-none">
+            <div className="text-[#1c1a27] font-semibold text-base leading-none">
               {t("panelTitle")}
             </div>
             <div className="flex items-center gap-1.5 mt-0.5">
-              <div className="w-1.5 h-1.5 rounded-full bg-[#4ade9a]" />
-              <span className="text-zinc-400 text-xs">{t("onlineStatus")}</span>
+              <div className="w-1.5 h-1.5 rounded-full bg-[#1D9E75]" />
+              <span className="text-[#2a2440]/70 text-xs">{t("onlineStatus")}</span>
             </div>
           </div>
           <button
             onClick={handleHistoryOpen}
-            className="text-zinc-400 p-1 hover:text-zinc-200 hover:bg-white/10 rounded transition-colors"
+            className="text-[#2a2440]/70 p-1 hover:text-[#1c1a27] hover:bg-black/5 rounded transition-colors"
             aria-label={t("historyAriaLabel")}
           >
             <History className="w-5 h-5" />
@@ -267,12 +267,12 @@ export function ChatPanel({ onClose }: Props) {
               <div className="w-7 h-7 rounded-full flex items-center justify-center text-[#2a2440] text-xs font-bold mr-2 mt-0.5 flex-shrink-0" style={{background: 'linear-gradient(135deg, #b9a4f2 0%, #ecaccd 52%, #fbd9a0 100%)'}}>
                 AI
               </div>
-              <div className="bg-zinc-800 rounded-2xl rounded-tl-none px-4 py-2.5 max-w-[80%]">
+              <div className="ax-card-warm rounded-2xl rounded-tl-none px-4 py-2.5 max-w-[80%]">
                 <div className="flex gap-1 items-center h-4">
                   {[0, 1, 2].map((i) => (
                     <div
                       key={i}
-                      className="w-1.5 h-1.5 rounded-full bg-zinc-500 animate-bounce"
+                      className="w-1.5 h-1.5 rounded-full bg-[#736f7e] animate-bounce"
                       style={{ animationDelay: `${i * 0.15}s` }}
                     />
                   ))}
@@ -285,8 +285,8 @@ export function ChatPanel({ onClose }: Props) {
         </div>
 
         {/* サジェストボタン（固定底部）*/}
-        <div className="flex-shrink-0 px-4 pt-3 border-t border-zinc-800 ax-safe-bottom">
-          <p className="text-zinc-600 text-xs mb-2">{t("suggestLabel")}</p>
+        <div className="flex-shrink-0 px-4 pt-3 border-t border-[#1c1a27]/15 ax-safe-bottom">
+          <p className="text-[#736f7e] text-xs mb-2">{t("suggestLabel")}</p>
           <div className="grid grid-cols-2 gap-2">
             {SUGGEST_CONFIG.map((cfg) => {
               const label = t(cfg.labelKey)
@@ -296,9 +296,9 @@ export function ChatPanel({ onClose }: Props) {
                   key={cfg.id}
                   onClick={() => handleSuggest({ id: cfg.id, label, prompt, placeholderKey: cfg.placeholderKey })}
                   disabled={loading}
-                  className="bg-zinc-800 hover:bg-zinc-700 active:bg-zinc-600 disabled:opacity-40
-                             text-zinc-100 text-xs px-3 py-2.5 rounded-xl text-left transition-colors
-                             border border-zinc-700 hover:border-zinc-600"
+                  className="ax-card-warm hover:bg-black/5 active:bg-black/5 disabled:opacity-40
+                             text-[#1c1a27] text-xs px-3 py-2.5 rounded-xl text-left transition-colors
+                             border border-[#1c1a27]/15 hover:border-[#1c1a27]/15"
                 >
                   {label}
                 </button>

--- a/frontend/app/(liff)/liff-chat/_components/HamburgerMenu.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/HamburgerMenu.tsx
@@ -48,13 +48,13 @@ export function HamburgerMenu({ open, onClose, onPanelOpen }: HamburgerMenuProps
 
       {/* サイドパネル本体 */}
       <div
-        className={`fixed top-0 left-0 h-full z-50 w-72 bg-[#1a3d2e] flex flex-col
+        className={`fixed top-0 left-0 h-full z-50 w-72 bg-[#1b1a23] flex flex-col
                     transform transition-transform duration-300 ease-in-out
                     ${open ? "translate-x-0" : "-translate-x-full"}`}
       >
         {/* ヘッダー */}
         <div className="flex items-center justify-between px-4 py-4 border-b border-white/10">
-          <span className="text-[#4ade9a] font-bold text-lg">{t("title")}</span>
+          <span className="text-[#fbd9a0] font-bold text-lg">{t("title")}</span>
           <button
             onClick={onClose}
             className="text-white text-xl leading-none w-8 h-8 flex items-center justify-center hover:bg-white/10 rounded-full transition-colors"
@@ -72,19 +72,19 @@ export function HamburgerMenu({ open, onClose, onPanelOpen }: HamburgerMenuProps
               onClick={() => { onPanelOpen(item.id); onClose() }}
               className="flex items-center w-full px-4 py-4 border-b border-white/10 hover:bg-white/5 active:bg-white/10 transition-colors"
             >
-              <item.icon className="w-5 h-5 text-[#4ade9a] mr-3 flex-shrink-0" />
+              <item.icon className="w-5 h-5 text-[#fbd9a0] mr-3 flex-shrink-0" />
               <div className="flex-1 text-left">
                 <div className="text-white font-medium text-sm">{item.label}</div>
-                <div className="text-zinc-400 text-xs mt-0.5">{item.sub}</div>
+                <div className="text-white/55 text-xs mt-0.5">{item.sub}</div>
               </div>
-              <ChevronRight className="w-4 h-4 text-zinc-600 flex-shrink-0" />
+              <ChevronRight className="w-4 h-4 text-white/40 flex-shrink-0" />
             </button>
           ))}
         </div>
 
         {/* フッター */}
         <div className="mt-auto px-4 py-4">
-          <p className="text-zinc-600 text-xs text-center">{t("footer")}</p>
+          <p className="text-white/40 text-xs text-center">{t("footer")}</p>
         </div>
       </div>
     </>

--- a/frontend/app/(liff)/liff-chat/_components/SlideUpPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/SlideUpPanel.tsx
@@ -27,19 +27,19 @@ export function SlideUpPanel({
       <div
         style={{ maxHeight }}
         className="fixed bottom-0 left-0 right-0 z-50
-                   bg-zinc-900 rounded-t-2xl border-t border-zinc-800
+                   ax-bg-app rounded-t-2xl border-t border-[#1c1a27]/15
                    overflow-y-auto
                    animate-in slide-in-from-bottom duration-300"
       >
         {/* ドラッグハンドル + ヘッダー */}
-        <div className="sticky top-0 bg-zinc-900 pt-3 pb-0 px-4">
-          <div className="mx-auto mb-3 h-1 w-8 rounded-full bg-zinc-700" />
+        <div className="sticky top-0 ax-bg-app pt-3 pb-0 px-4">
+          <div className="mx-auto mb-3 h-1 w-8 rounded-full bg-[#1c1a27]/10" />
           {/* パネルヘッダー */}
-          <div className="flex items-center bg-[#1a3d2e] -mx-4 px-4 py-3 mb-4">
-            <button onClick={onClose} className="text-white mr-2">
+          <div className="flex items-center bg-gradient-to-r from-[#b9a4f2] via-[#ecaccd] to-[#fbd9a0] -mx-4 px-4 py-3 mb-4">
+            <button onClick={onClose} className="text-[#1c1a27] mr-2">
               <ChevronLeft className="w-5 h-5" />
             </button>
-            <h2 className="text-white font-semibold text-base">{title}</h2>
+            <h2 className="text-[#1c1a27] font-semibold text-base">{title}</h2>
           </div>
         </div>
         <div className="px-4 pb-8">{children}</div>

--- a/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
@@ -431,7 +431,7 @@ export function AccountPanel() {
   return (
     <div className="space-y-4">
       {/* プロフィールカード */}
-      <div className="bg-[#1a3d2e] rounded-2xl p-4">
+      <div className="bg-gradient-to-br from-[#b9a4f2] via-[#ecaccd] to-[#fbd9a0] rounded-2xl p-4">
         <div className="flex items-center gap-3">
           {/* アバター（画像 or イニシャル）＋ 変更ボタン */}
           <div className="relative flex-shrink-0">
@@ -439,7 +439,7 @@ export function AccountPanel() {
               type="button"
               onClick={handlePickAvatar}
               aria-label={t("changeIconAriaLabel")}
-              className="w-14 h-14 rounded-full overflow-hidden bg-[#1D9E75]/20 border border-[#1D9E75] flex items-center justify-center text-[#4ade9a] text-xl font-bold"
+              className="w-14 h-14 rounded-full overflow-hidden bg-[#1D9E75]/20 border border-[#1D9E75] flex items-center justify-center text-[#1D9E75] text-xl font-bold"
             >
               {avatarData ? (
                 // eslint-disable-next-line @next/next/no-img-element
@@ -475,7 +475,7 @@ export function AccountPanel() {
                   maxLength={40}
                   placeholder={t("editNamePlaceholder")}
                   aria-label={t("editNameAriaLabel")}
-                  className="flex-1 min-w-0 bg-zinc-800 text-white px-2.5 py-1.5 rounded-lg text-sm outline-none focus:ring-1 focus:ring-[#1D9E75]"
+                  className="flex-1 min-w-0 ax-card-warm text-[#1c1a27] px-2.5 py-1.5 rounded-lg text-sm outline-none focus:ring-1 focus:ring-[#1D9E75]"
                 />
                 <button
                   type="button"
@@ -491,39 +491,39 @@ export function AccountPanel() {
                   onClick={() => setEditingName(false)}
                   disabled={nameSaving}
                   aria-label={t("cancelEditAriaLabel")}
-                  className="w-7 h-7 rounded-lg bg-zinc-800 flex items-center justify-center disabled:opacity-40"
+                  className="w-7 h-7 rounded-lg ax-card-warm flex items-center justify-center disabled:opacity-40"
                 >
-                  <X className="w-4 h-4 text-zinc-400" />
+                  <X className="w-4 h-4 text-[#736f7e]" />
                 </button>
               </div>
             ) : (
               <div className="flex items-center gap-1.5">
-                <p className="text-white font-semibold truncate">{getDisplayName()}</p>
+                <p className="text-[#1c1a27] font-semibold truncate">{getDisplayName()}</p>
                 <button
                   type="button"
                   onClick={handleStartEditName}
                   aria-label={t("editNameEditAriaLabel")}
-                  className="flex-shrink-0 text-zinc-500 hover:text-[#4ade9a] transition-colors"
+                  className="flex-shrink-0 text-[#736f7e] hover:text-[#1D9E75] transition-colors"
                 >
                   <Pencil className="w-3.5 h-3.5" />
                 </button>
               </div>
             )}
             {userData?.email && (
-              <p className="text-zinc-300 text-sm truncate">{userData.email}</p>
+              <p className="text-[#736f7e] text-sm truncate">{userData.email}</p>
             )}
             {avatarData && !editingName && (
               <button
                 type="button"
                 onClick={handleClearAvatar}
-                className="text-zinc-500 hover:text-zinc-300 text-xs mt-1 transition-colors"
+                className="text-[#736f7e] hover:text-[#1c1a27] text-xs mt-1 transition-colors"
               >
                 {t("resetIcon")}
               </button>
             )}
             {/* ログイン方法バッジ（LIFF = LINE ログイン） */}
             <div className="flex flex-wrap gap-1 mt-1">
-              <span className="bg-zinc-800 text-zinc-300 text-xs px-2 py-0.5 rounded-full">
+              <span className="ax-card-warm text-[#1c1a27] text-xs px-2 py-0.5 rounded-full">
                 {t("lineLoginBadge")}
               </span>
             </div>
@@ -532,64 +532,64 @@ export function AccountPanel() {
       </div>
 
       {/* 運用情報セクション */}
-      <div className="bg-zinc-900 rounded-xl overflow-hidden">
+      <div className="ax-card-warm rounded-xl overflow-hidden">
         {/* 運用開始日 */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800">
-          <span className="text-zinc-400 text-sm">{t("startedAt")}</span>
-          <span className="text-white text-sm">{getStartedAt()}</span>
+        <div className="flex items-center justify-between px-4 py-3 border-b border-[#1c1a27]/15">
+          <span className="text-[#736f7e] text-sm">{t("startedAt")}</span>
+          <span className="text-[#1c1a27] text-sm">{getStartedAt()}</span>
         </div>
 
         {/* 運用モード */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800">
-          <span className="text-zinc-400 text-sm">{t("opMode")}</span>
-          <span className="text-white text-sm">{getModeLabel()}</span>
+        <div className="flex items-center justify-between px-4 py-3 border-b border-[#1c1a27]/15">
+          <span className="text-[#736f7e] text-sm">{t("opMode")}</span>
+          <span className="text-[#1c1a27] text-sm">{getModeLabel()}</span>
         </div>
 
         {/* ウォレットアドレス */}
         <div className="flex items-center justify-between px-4 py-3">
-          <span className="text-zinc-400 text-sm">{t("wallet")}</span>
+          <span className="text-[#736f7e] text-sm">{t("wallet")}</span>
           {shortAddress ? (
             <button
               onClick={handleCopyWallet}
-              className="flex items-center gap-1.5 text-zinc-300 text-sm"
+              className="flex items-center gap-1.5 text-[#1c1a27] text-sm"
             >
               <span className="font-mono text-xs">{shortAddress}</span>
               {copied ? (
-                <Check className="w-3.5 h-3.5 text-[#4ade9a]" />
+                <Check className="w-3.5 h-3.5 text-[#1D9E75]" />
               ) : (
-                <Copy className="w-3.5 h-3.5 text-zinc-500" />
+                <Copy className="w-3.5 h-3.5 text-[#736f7e]" />
               )}
             </button>
           ) : (
-            <span className="text-zinc-600 text-sm">{t("walletNotLinked")}</span>
+            <span className="text-[#736f7e] text-sm">{t("walletNotLinked")}</span>
           )}
         </div>
       </div>
 
       {/* 法人情報セクション（アコーディオン） */}
-      <div className="bg-zinc-900 rounded-xl overflow-hidden">
+      <div className="ax-card-warm rounded-xl overflow-hidden">
         <button
           onClick={() => setCorpExpanded((v) => !v)}
           className="flex items-center justify-between w-full px-4 py-3.5"
         >
           <div className="flex items-center gap-2">
-            <Building2 className="w-4 h-4 text-zinc-400" />
-            <span className="text-zinc-300 text-sm font-medium">{t("corpSectionTitle")}</span>
+            <Building2 className="w-4 h-4 text-[#736f7e]" />
+            <span className="text-[#1c1a27] text-sm font-medium">{t("corpSectionTitle")}</span>
           </div>
           <ChevronDown
-            className={`w-4 h-4 text-zinc-500 transition-transform duration-200 ${
+            className={`w-4 h-4 text-[#736f7e] transition-transform duration-200 ${
               corpExpanded ? "rotate-180" : ""
             }`}
           />
         </button>
 
         {corpExpanded && (
-          <div className="px-4 pb-4 space-y-3 border-t border-zinc-800 pt-3">
+          <div className="px-4 pb-4 space-y-3 border-t border-[#1c1a27]/15 pt-3">
             <input
               placeholder={t("corpNamePlaceholder")}
               value={corpForm.name}
               onChange={(e) => setCorpForm((p) => ({ ...p, name: e.target.value }))}
-              className="w-full bg-zinc-800 text-white px-3 py-2.5 rounded-lg text-sm placeholder-zinc-500 outline-none focus:ring-1 focus:ring-[#1D9E75]"
+              className="w-full ax-card-warm-soft text-[#1c1a27] px-3 py-2.5 rounded-lg text-sm placeholder-[#736f7e] border border-[#1c1a27]/15 outline-none focus:ring-1 focus:ring-[#1D9E75]"
             />
             <input
               placeholder={t("corpNumberPlaceholder")}
@@ -597,18 +597,18 @@ export function AccountPanel() {
               onChange={(e) => setCorpForm((p) => ({ ...p, number: e.target.value }))}
               maxLength={13}
               inputMode="numeric"
-              className="w-full bg-zinc-800 text-white px-3 py-2.5 rounded-lg text-sm placeholder-zinc-500 outline-none focus:ring-1 focus:ring-[#1D9E75]"
+              className="w-full ax-card-warm-soft text-[#1c1a27] px-3 py-2.5 rounded-lg text-sm placeholder-[#736f7e] border border-[#1c1a27]/15 outline-none focus:ring-1 focus:ring-[#1D9E75]"
             />
             <input
               placeholder={t("corpRepPlaceholder")}
               value={corpForm.rep}
               onChange={(e) => setCorpForm((p) => ({ ...p, rep: e.target.value }))}
-              className="w-full bg-zinc-800 text-white px-3 py-2.5 rounded-lg text-sm placeholder-zinc-500 outline-none focus:ring-1 focus:ring-[#1D9E75]"
+              className="w-full ax-card-warm-soft text-[#1c1a27] px-3 py-2.5 rounded-lg text-sm placeholder-[#736f7e] border border-[#1c1a27]/15 outline-none focus:ring-1 focus:ring-[#1D9E75]"
             />
 
             {/* 決算月グリッド */}
             <div>
-              <p className="text-zinc-400 text-xs mb-2">{t("corpFiscalMonthLabel")}</p>
+              <p className="text-[#736f7e] text-xs mb-2">{t("corpFiscalMonthLabel")}</p>
               <div className="grid grid-cols-6 gap-1.5">
                 {Array.from({ length: 12 }, (_, i) => i + 1).map((m) => (
                   <button
@@ -617,7 +617,7 @@ export function AccountPanel() {
                     className={`py-2 rounded-lg text-sm font-medium transition-colors ${
                       corpForm.month === m
                         ? "bg-[#1D9E75] text-white"
-                        : "bg-zinc-800 text-zinc-400 hover:bg-zinc-700"
+                        : "ax-card-warm-soft text-[#736f7e] border border-[#1c1a27]/15 hover:bg-black/5"
                     }`}
                   >
                     {t("corpFiscalMonthUnit", { m })}
@@ -643,17 +643,17 @@ export function AccountPanel() {
           {/* ログアウトボタン */}
           <button
             onClick={handleLogout}
-            className="flex items-center gap-3 w-full px-4 py-4 bg-zinc-900 rounded-xl hover:bg-zinc-800 transition-colors"
+            className="flex items-center gap-3 w-full px-4 py-4 ax-card-warm rounded-xl hover:bg-black/5 transition-colors"
           >
-            <LogOut className="w-5 h-5 text-red-400" />
-            <span className="text-red-400 font-medium">{t("logoutBtn")}</span>
+            <LogOut className="w-5 h-5 text-red-600" />
+            <span className="text-red-600 font-medium">{t("logoutBtn")}</span>
           </button>
 
           {/* アカウント削除ボタン */}
           <div className="flex justify-center pb-2">
             <button
               onClick={() => setDeleteSheet(true)}
-              className="flex items-center gap-2 px-4 py-2 text-zinc-600 hover:text-zinc-400 transition-colors"
+              className="flex items-center gap-2 px-4 py-2 text-[#736f7e] hover:text-[#1c1a27] transition-colors"
             >
               <Trash2 className="w-4 h-4" />
               <span className="text-xs">{t("deleteAccountBtn")}</span>
@@ -670,25 +670,25 @@ export function AccountPanel() {
             onClick={() => setDeleteSheet(false)}
           />
           <div
-            className="fixed bottom-0 left-0 right-0 z-[70] bg-zinc-900 rounded-t-2xl px-4 pb-8 pt-4
+            className="fixed bottom-0 left-0 right-0 z-[70] ax-card-warm rounded-t-2xl px-4 pb-8 pt-4
                         animate-in slide-in-from-bottom duration-300"
           >
-            <div className="mx-auto mb-4 h-1 w-8 rounded-full bg-zinc-700" />
-            <h3 className="text-white font-semibold mb-2">{t("deleteSheetTitle")}</h3>
-            <p className="text-zinc-400 text-sm mb-6">
+            <div className="mx-auto mb-4 h-1 w-8 rounded-full bg-[#1c1a27]/10" />
+            <h3 className="text-[#1c1a27] font-semibold mb-2">{t("deleteSheetTitle")}</h3>
+            <p className="text-[#736f7e] text-sm mb-6">
               {t("deleteSheetDesc")}
             </p>
             <button
               onClick={handleDeleteRequest}
               disabled={deleteSubmitting}
-              className="w-full py-3.5 bg-red-600/20 border border-red-600 text-red-400 rounded-xl font-medium mb-3 disabled:opacity-50"
+              className="w-full py-3.5 bg-red-600/20 border border-red-600 text-red-600 rounded-xl font-medium mb-3 disabled:opacity-50"
             >
               {deleteSubmitting ? t("deleteSubmittingBtn") : t("deleteSubmitBtn")}
             </button>
             <button
               onClick={() => setDeleteSheet(false)}
               disabled={deleteSubmitting}
-              className="w-full py-3.5 border border-zinc-700 text-zinc-400 rounded-xl font-medium disabled:opacity-50"
+              className="w-full py-3.5 border border-[#1c1a27]/15 text-[#736f7e] rounded-xl font-medium disabled:opacity-50"
             >
               {t("deleteCancelBtn")}
             </button>
@@ -698,7 +698,7 @@ export function AccountPanel() {
 
       {/* トースト */}
       {toastMsg && (
-        <div className="fixed bottom-24 left-1/2 -translate-x-1/2 z-[80] bg-zinc-700 text-white px-4 py-2 rounded-full text-sm whitespace-nowrap">
+        <div className="fixed bottom-24 left-1/2 -translate-x-1/2 z-[80] bg-[#1b1a23] text-[#fbf7f0] px-4 py-2 rounded-full text-sm whitespace-nowrap">
           {toastMsg}
         </div>
       )}

--- a/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
@@ -51,19 +51,19 @@ function ConfirmSheet({ open, title, executeLabel, cancelLabel, rows, onConfirm,
         className="fixed inset-0 z-[60] bg-black/60"
         onClick={!busy ? onCancel : undefined}
       />
-      <div className="fixed bottom-0 left-0 right-0 z-[70] bg-zinc-900 rounded-t-2xl border-t border-zinc-800 px-4 pb-8 pt-3 animate-in slide-in-from-bottom duration-300">
-        <div className="mx-auto mb-4 h-1 w-8 rounded-full bg-zinc-700" />
-        <h2 className="text-base font-semibold text-zinc-100 mb-4">{title}</h2>
+      <div className="fixed bottom-0 left-0 right-0 z-[70] ax-card-warm rounded-t-2xl border-t border-[#1c1a27]/15 px-4 pb-8 pt-3 animate-in slide-in-from-bottom duration-300">
+        <div className="mx-auto mb-4 h-1 w-8 rounded-full bg-[#1c1a27]/10" />
+        <h2 className="text-base font-semibold text-[#1c1a27] mb-4">{title}</h2>
         <div className="space-y-3 mb-6">
           {rows.map((r) => (
             <div key={r.label} className="flex justify-between items-baseline gap-2">
-              <span className="text-xs text-zinc-500 shrink-0">{r.label}</span>
-              <span className="text-sm text-zinc-100 text-right">{r.value}</span>
+              <span className="text-xs text-[#736f7e] shrink-0">{r.label}</span>
+              <span className="text-sm text-[#1c1a27] text-right">{r.value}</span>
             </div>
           ))}
         </div>
         {error && (
-          <div className="flex items-start gap-2 mb-3 text-red-400 text-xs">
+          <div className="flex items-start gap-2 mb-3 text-red-600 text-xs">
             <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
             <span>{error}</span>
           </div>
@@ -81,8 +81,8 @@ function ConfirmSheet({ open, title, executeLabel, cancelLabel, rows, onConfirm,
         <button
           onClick={onCancel}
           disabled={busy}
-          className="mt-2 w-full py-3 rounded-xl border border-zinc-600 text-zinc-300
-                     hover:bg-zinc-800 disabled:opacity-50 disabled:cursor-not-allowed
+          className="mt-2 w-full py-3 rounded-xl border border-[#1c1a27]/15 text-[#736f7e]
+                     hover:bg-black/5 disabled:opacity-50 disabled:cursor-not-allowed
                      text-sm font-medium transition-colors"
         >
           {cancelLabel}
@@ -227,7 +227,7 @@ export function DepositPanel() {
     <div className="pb-2">
       {/* タブ（v3 は出金非表示。WITHDRAW_ENABLED=false の間はタブ自体を出さず入金のみ） */}
       {WITHDRAW_ENABLED && (
-        <div className="flex border-b border-zinc-800 mb-4">
+        <div className="flex border-b border-[#1c1a27]/15 mb-4">
           {(["deposit", "withdraw"] as Tab[]).map((tabKey) => (
             <button
               key={tabKey}
@@ -236,7 +236,7 @@ export function DepositPanel() {
                 "flex-1 py-2 text-sm font-medium transition-colors",
                 tab === tabKey
                   ? "border-b-2 border-[#1D9E75] text-[#1D9E75]"
-                  : "text-zinc-400",
+                  : "text-[#736f7e]",
               ].join(" ")}
             >
               {tabKey === "deposit" ? t("tabDeposit") : t("tabWithdraw")}
@@ -246,25 +246,25 @@ export function DepositPanel() {
       )}
 
       {/* 残高カード */}
-      <div className="bg-[#1a3d2e] rounded-xl px-4 py-4 mb-4">
-        <p className="text-xs text-zinc-400 mb-1">{balanceLabel}</p>
+      <div className="bg-gradient-to-br from-[#b9a4f2] via-[#ecaccd] to-[#fbd9a0] rounded-xl px-4 py-4 mb-4">
+        <p className="text-xs text-[#736f7e] mb-1">{balanceLabel}</p>
         {balanceLoading ? (
           <div className="flex items-center gap-2">
-            <Loader2 className="w-4 h-4 animate-spin text-zinc-400" />
-            <span className="text-zinc-400 text-sm">{t("balanceLoading")}</span>
+            <Loader2 className="w-4 h-4 animate-spin text-[#736f7e]" />
+            <span className="text-[#736f7e] text-sm">{t("balanceLoading")}</span>
           </div>
         ) : (
-          <p className="text-2xl font-bold text-white">
+          <p className="text-2xl font-bold text-[#1c1a27]">
             {balance != null ? `$${balance.toFixed(2)}` : "---"}
-            <span className="text-sm font-normal text-zinc-400 ml-2">USDC</span>
+            <span className="text-sm font-normal text-[#736f7e] ml-2">USDC</span>
           </p>
         )}
-        <p className="text-xs text-zinc-500 mt-1">{t("network")}</p>
+        <p className="text-xs text-[#736f7e] mt-1">{t("network")}</p>
       </div>
 
       {/* 成功メッセージ */}
       {successMsg && (
-        <div className="bg-[#1a3d2e] border border-[#1D9E75] rounded-xl px-4 py-3 mb-4 text-sm text-[#4ade9a]">
+        <div className="ax-card-warm border border-[#1D9E75] rounded-xl px-4 py-3 mb-4 text-sm text-[#1D9E75]">
           {successMsg}
         </div>
       )}
@@ -274,22 +274,22 @@ export function DepositPanel() {
         <div className="space-y-4">
           {/* 金額入力（送金額の目安） */}
           <div>
-            <label className="block text-xs text-zinc-400 mb-1">{t("depositAmountLabel")}</label>
+            <label className="block text-xs text-[#736f7e] mb-1">{t("depositAmountLabel")}</label>
             <div className="relative">
-              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400 text-sm">{isEn ? "$" : "¥"}</span>
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[#736f7e] text-sm">{isEn ? "$" : "¥"}</span>
               <input
                 type="number"
                 min="0"
                 placeholder={t("depositAmountPlaceholder")}
                 value={depositAmount}
                 onChange={(e) => setDepositAmount(e.target.value)}
-                className="w-full bg-zinc-800 text-white text-lg pl-7 pr-4 py-3 rounded-xl
-                           border border-zinc-700 focus:border-[#1D9E75] focus:outline-none
-                           placeholder-zinc-600"
+                className="w-full ax-card-warm text-[#1c1a27] text-lg pl-7 pr-4 py-3 rounded-xl
+                           border border-[#1c1a27]/15 focus:border-[#1D9E75] focus:outline-none
+                           placeholder-[#736f7e]"
               />
             </div>
             {depositNum > 0 && (
-              <p className="text-xs text-zinc-500 mt-1">
+              <p className="text-xs text-[#736f7e] mt-1">
                 ≈ ${depositUsdc.toFixed(2)} USDC
               </p>
             )}
@@ -301,8 +301,8 @@ export function DepositPanel() {
               <button
                 key={amt}
                 onClick={() => setDepositAmount(String(amt))}
-                className="bg-zinc-800 hover:bg-zinc-700 text-zinc-200 text-xs py-2 rounded-lg
-                           border border-zinc-700 transition-colors"
+                className="ax-card-warm hover:bg-black/5 text-[#1c1a27] text-xs py-2 rounded-lg
+                           border border-[#1c1a27]/15 transition-colors"
               >
                 {isEn
                   ? `$${amt.toLocaleString()}`
@@ -312,12 +312,12 @@ export function DepositPanel() {
           </div>
 
           {/* 入金方法の案内 */}
-          <div className="bg-zinc-800 border border-zinc-700 rounded-xl px-4 py-3 space-y-2">
-            <p className="text-xs font-medium text-zinc-300">{t("depositMethodTitle")}</p>
-            <p className="text-xs text-zinc-400 leading-relaxed">
+          <div className="ax-card-warm border border-[#1c1a27]/15 rounded-xl px-4 py-3 space-y-2">
+            <p className="text-xs font-medium text-[#1c1a27]">{t("depositMethodTitle")}</p>
+            <p className="text-xs text-[#736f7e] leading-relaxed">
               {t("depositMethodDesc")}
             </p>
-            <ul className="text-xs text-zinc-500 leading-relaxed space-y-0.5 list-disc list-inside">
+            <ul className="text-xs text-[#736f7e] leading-relaxed space-y-0.5 list-disc list-inside">
               <li>{t("depositMethodNote1")}</li>
               <li>{t("depositMethodNote2")}</li>
               <li>{t("depositMethodNote3")}</li>
@@ -345,9 +345,9 @@ export function DepositPanel() {
         <div className="space-y-4">
           {/* 金額入力 */}
           <div>
-            <label className="block text-xs text-zinc-400 mb-1">{t("withdrawAmountLabel")}</label>
+            <label className="block text-xs text-[#736f7e] mb-1">{t("withdrawAmountLabel")}</label>
             <div className="relative">
-              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400 text-sm">$</span>
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[#736f7e] text-sm">$</span>
               <input
                 type="number"
                 min="0"
@@ -355,9 +355,9 @@ export function DepositPanel() {
                 placeholder={t("withdrawAmountPlaceholder")}
                 value={withdrawAmount}
                 onChange={(e) => setWithdrawAmount(e.target.value)}
-                className="w-full bg-zinc-800 text-white text-lg pl-7 pr-4 py-3 rounded-xl
-                           border border-zinc-700 focus:border-[#1D9E75] focus:outline-none
-                           placeholder-zinc-600"
+                className="w-full ax-card-warm text-[#1c1a27] text-lg pl-7 pr-4 py-3 rounded-xl
+                           border border-[#1c1a27]/15 focus:border-[#1D9E75] focus:outline-none
+                           placeholder-[#736f7e]"
               />
             </div>
           </div>
@@ -368,16 +368,16 @@ export function DepositPanel() {
               <button
                 key={amt}
                 onClick={() => setWithdrawAmount(String(amt))}
-                className="bg-zinc-800 hover:bg-zinc-700 text-zinc-200 text-xs py-2 rounded-lg
-                           border border-zinc-700 transition-colors"
+                className="ax-card-warm hover:bg-black/5 text-[#1c1a27] text-xs py-2 rounded-lg
+                           border border-[#1c1a27]/15 transition-colors"
               >
                 ${amt}
               </button>
             ))}
             <button
               onClick={() => setWithdrawAmount(maxWithdraw > 0 ? maxWithdraw.toFixed(2) : "")}
-              className="bg-zinc-800 hover:bg-zinc-700 text-zinc-200 text-xs py-2 rounded-lg
-                         border border-zinc-700 transition-colors"
+              className="ax-card-warm hover:bg-black/5 text-[#1c1a27] text-xs py-2 rounded-lg
+                         border border-[#1c1a27]/15 transition-colors"
             >
               {t("quickMax")}
             </button>
@@ -385,33 +385,33 @@ export function DepositPanel() {
 
           {/* 出金先（変更不可） */}
           <div>
-            <label className="block text-xs text-zinc-400 mb-1">{t("withdrawDestLabel")}</label>
-            <div className="bg-zinc-800 border border-zinc-700 rounded-xl px-4 py-3">
-              <p className="text-sm text-zinc-300 font-mono">
+            <label className="block text-xs text-[#736f7e] mb-1">{t("withdrawDestLabel")}</label>
+            <div className="ax-card-warm border border-[#1c1a27]/15 rounded-xl px-4 py-3">
+              <p className="text-sm text-[#1c1a27] font-mono">
                 {walletAddress
                   ? `${walletAddress.slice(0, 6)}...${walletAddress.slice(-4)}`
                   : t("withdrawDestDefault")}
               </p>
-              <p className="text-xs text-zinc-500 mt-0.5">{t("withdrawDestImmutable")}</p>
+              <p className="text-xs text-[#736f7e] mt-0.5">{t("withdrawDestImmutable")}</p>
             </div>
           </div>
 
           {/* 手数料・受取予定額 */}
-          <div className="bg-zinc-800 border border-zinc-700 rounded-xl px-4 py-3 space-y-2">
-            <div className="flex justify-between text-xs text-zinc-400">
+          <div className="ax-card-warm border border-[#1c1a27]/15 rounded-xl px-4 py-3 space-y-2">
+            <div className="flex justify-between text-xs text-[#736f7e]">
               <span>{t("networkFeeLabel")}</span>
               <span>≈ ${WITHDRAW_FEE.toFixed(2)}</span>
             </div>
             <div className="flex justify-between text-sm font-semibold">
-              <span className="text-zinc-300">{t("receiveAmountLabel")}</span>
-              <span className="text-white">
+              <span className="text-[#736f7e]">{t("receiveAmountLabel")}</span>
+              <span className="text-[#1c1a27]">
                 {withdrawNum > 0 ? `$${receiveAmount.toFixed(2)} USDC` : "---"}
               </span>
             </div>
           </div>
 
           {/* 警告 */}
-          <div className="flex items-start gap-2 text-yellow-400 text-xs">
+          <div className="flex items-start gap-2 text-yellow-600 text-xs">
             <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
             <p>
               {t("withdrawWarning")}

--- a/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
@@ -92,15 +92,15 @@ export function MyWalletPanel() {
 
   // アドレスの先頭4文字・末尾4文字をハイライト表示
   function renderAddress(addr: string) {
-    if (addr.length <= 8) return <span className="text-[#4ade9a]">{addr}</span>
+    if (addr.length <= 8) return <span className="text-[#1D9E75]">{addr}</span>
     const start = addr.slice(0, 4)
     const mid = addr.slice(4, addr.length - 4)
     const end = addr.slice(-4)
     return (
       <>
-        <span className="text-[#4ade9a]">{start}</span>
-        <span className="text-zinc-300">{mid}</span>
-        <span className="text-[#4ade9a]">{end}</span>
+        <span className="text-[#1D9E75]">{start}</span>
+        <span className="text-[#736f7e]">{mid}</span>
+        <span className="text-[#1D9E75]">{end}</span>
       </>
     )
   }
@@ -108,16 +108,16 @@ export function MyWalletPanel() {
   return (
     <div className="space-y-4">
       {/* ウォレットカード */}
-      <div className="bg-[#1a3d2e] rounded-2xl p-4 space-y-3">
+      <div className="bg-gradient-to-br from-[#b9a4f2] via-[#ecaccd] to-[#fbd9a0] rounded-2xl p-4 space-y-3">
         {/* Non-Custodial バッジ + Base Mainnet */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-1.5">
-            <ShieldCheck className="w-4 h-4 text-[#4ade9a]" />
-            <span className="text-[#4ade9a] text-xs font-semibold">{t("nonCustodial")}</span>
+            <ShieldCheck className="w-4 h-4 text-[#1D9E75]" />
+            <span className="text-[#1D9E75] text-xs font-semibold">{t("nonCustodial")}</span>
           </div>
           <div className="flex items-center gap-1.5">
             <span className="w-2 h-2 rounded-full bg-[#1D9E75] inline-block" />
-            <span className="text-zinc-300 text-xs">{t("baseMainnet")}</span>
+            <span className="text-[#736f7e] text-xs">{t("baseMainnet")}</span>
           </div>
         </div>
 
@@ -127,26 +127,26 @@ export function MyWalletPanel() {
             {renderAddress(address)}
           </div>
         ) : fetchState === "loading" ? (
-          <div className="flex items-center gap-2 text-zinc-500 text-xs">
-            <Loader2 className="w-3.5 h-3.5 animate-spin text-[#4ade9a]" />
+          <div className="flex items-center gap-2 text-[#736f7e] text-xs">
+            <Loader2 className="w-3.5 h-3.5 animate-spin text-[#1D9E75]" />
             <span>{t("addressLoading")}</span>
           </div>
         ) : fetchState === "error" ? (
           // fail-visible: 永久ローディングにせずエラー + リトライ
           <div className="space-y-2">
             <div className="flex items-start gap-2">
-              <AlertTriangle className="w-4 h-4 text-[#e24b4a] flex-shrink-0 mt-0.5" />
-              <p className="text-[#e24b4a] text-xs leading-relaxed">
+              <AlertTriangle className="w-4 h-4 text-red-600 flex-shrink-0 mt-0.5" />
+              <p className="text-red-600 text-xs leading-relaxed">
                 {t("addressError")}
               </p>
             </div>
             <button
               onClick={() => linked.refetch()}
               className="w-full flex items-center justify-center gap-1.5 py-2 rounded-xl
-                         bg-zinc-800/60 hover:bg-zinc-700/60 active:bg-zinc-600/60
-                         transition-colors text-xs text-zinc-200"
+                         bg-[#1b1a23]/80 hover:bg-[#1b1a23] active:bg-[#1b1a23]
+                         transition-colors text-xs text-[#fbf7f0]"
             >
-              <RefreshCw className="w-3.5 h-3.5 text-[#4ade9a]" />
+              <RefreshCw className="w-3.5 h-3.5 text-[#1D9E75]" />
               {t("retryBtn")}
             </button>
           </div>
@@ -154,13 +154,13 @@ export function MyWalletPanel() {
           // empty: 認証済みだがウォレット未接続 → 接続誘導 UI
           <div className="space-y-3 py-1">
             <div className="flex flex-col items-center text-center gap-2">
-              <div className="w-11 h-11 rounded-full bg-zinc-800/60 flex items-center justify-center">
-                <Wallet className="w-5 h-5 text-[#4ade9a]" />
+              <div className="w-11 h-11 rounded-full bg-[#1b1a23]/80 flex items-center justify-center">
+                <Wallet className="w-5 h-5 text-[#1D9E75]" />
               </div>
-              <p className="text-zinc-200 text-sm font-medium">
+              <p className="text-[#1c1a27] text-sm font-medium">
                 {t("walletNotConnected")}
               </p>
-              <p className="text-zinc-500 text-xs leading-relaxed">
+              <p className="text-[#736f7e] text-xs leading-relaxed">
                 {t("walletNotConnectedDesc")}
               </p>
             </div>
@@ -177,10 +177,10 @@ export function MyWalletPanel() {
             <button
               onClick={() => linked.refetch()}
               className="w-full flex items-center justify-center gap-1.5 py-2 rounded-xl
-                         bg-zinc-800/40 hover:bg-zinc-700/50 active:bg-zinc-600/50
-                         transition-colors text-xs text-zinc-400"
+                         bg-[#1b1a23]/70 hover:bg-[#1b1a23] active:bg-[#1b1a23]
+                         transition-colors text-xs text-[#fbf7f0]"
             >
-              <RefreshCw className="w-3.5 h-3.5 text-zinc-400" />
+              <RefreshCw className="w-3.5 h-3.5 text-[#fbf7f0]" />
               {t("reloadBtn")}
             </button>
           </div>
@@ -192,48 +192,48 @@ export function MyWalletPanel() {
             onClick={handleCopy}
             disabled={!address}
             className="flex-1 flex flex-col items-center gap-1 py-2.5 rounded-xl
-                       bg-zinc-800/60 hover:bg-zinc-700/60 active:bg-zinc-600/60
+                       bg-[#1b1a23]/80 hover:bg-[#1b1a23] active:bg-[#1b1a23]
                        disabled:opacity-40 disabled:cursor-not-allowed
                        transition-colors"
           >
-            <Copy className="w-4 h-4 text-[#4ade9a]" />
-            <span className="text-[10px] text-zinc-300">{t("copyLabel")}</span>
+            <Copy className="w-4 h-4 text-[#1D9E75]" />
+            <span className="text-[10px] text-[#fbf7f0]">{t("copyLabel")}</span>
           </button>
 
           <button
             onClick={() => setQrExpanded((v) => !v)}
             disabled={!address}
             className="flex-1 flex flex-col items-center gap-1 py-2.5 rounded-xl
-                       bg-zinc-800/60 hover:bg-zinc-700/60 active:bg-zinc-600/60
+                       bg-[#1b1a23]/80 hover:bg-[#1b1a23] active:bg-[#1b1a23]
                        disabled:opacity-40 disabled:cursor-not-allowed
                        transition-colors"
           >
-            <QrCode className="w-4 h-4 text-[#4ade9a]" />
-            <span className="text-[10px] text-zinc-300">{t("qrLabel")}</span>
+            <QrCode className="w-4 h-4 text-[#1D9E75]" />
+            <span className="text-[10px] text-[#fbf7f0]">{t("qrLabel")}</span>
           </button>
 
           <button
             onClick={handleBasescan}
             disabled={!address}
             className="flex-1 flex flex-col items-center gap-1 py-2.5 rounded-xl
-                       bg-zinc-800/60 hover:bg-zinc-700/60 active:bg-zinc-600/60
+                       bg-[#1b1a23]/80 hover:bg-[#1b1a23] active:bg-[#1b1a23]
                        disabled:opacity-40 disabled:cursor-not-allowed
                        transition-colors"
           >
-            <ExternalLink className="w-4 h-4 text-[#4ade9a]" />
-            <span className="text-[10px] text-zinc-300">{t("basescanLabel")}</span>
+            <ExternalLink className="w-4 h-4 text-[#1D9E75]" />
+            <span className="text-[10px] text-[#fbf7f0]">{t("basescanLabel")}</span>
           </button>
         </div>
       </div>
 
       {/* QRコードセクション */}
       {qrExpanded && address && (
-        <div className="bg-zinc-900 rounded-2xl p-4 space-y-3 border border-zinc-800">
-          <p className="text-zinc-300 text-sm font-medium text-center">{t("qrTitle")}</p>
+        <div className="ax-card-warm rounded-2xl p-4 space-y-3 border border-[#1c1a27]/15">
+          <p className="text-[#736f7e] text-sm font-medium text-center">{t("qrTitle")}</p>
           <div className="flex justify-center">
             <canvas ref={canvasRef} className="rounded-xl bg-white p-2" />
           </div>
-          <p className="text-zinc-500 text-xs text-center">
+          <p className="text-[#736f7e] text-xs text-center">
             {t("qrNote")}
           </p>
         </div>
@@ -241,15 +241,15 @@ export function MyWalletPanel() {
 
       {/* セキュリティ注意書き */}
       <div className="flex items-start gap-2 px-1">
-        <Shield className="w-4 h-4 text-zinc-500 flex-shrink-0 mt-0.5" />
-        <p className="text-zinc-500 text-xs leading-relaxed">
+        <Shield className="w-4 h-4 text-[#736f7e] flex-shrink-0 mt-0.5" />
+        <p className="text-[#736f7e] text-xs leading-relaxed">
           {t("securityNote")}
         </p>
       </div>
 
       {/* トースト */}
       {toastMsg && (
-        <div className="fixed bottom-20 left-1/2 -translate-x-1/2 bg-zinc-800 text-white px-4 py-2 rounded-full text-sm z-[60] shadow-lg">
+        <div className="fixed bottom-20 left-1/2 -translate-x-1/2 bg-[#1b1a23] text-[#fbf7f0] px-4 py-2 rounded-full text-sm z-[60] shadow-lg">
           {toastMsg}
         </div>
       )}

--- a/frontend/app/(liff)/liff-chat/_components/panels/NotificationPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/NotificationPanel.tsx
@@ -54,7 +54,7 @@ function Toggle({
 }) {
   // track 色: ON は緑(#1D9E75)、OFF はグレー。disabled は opacity で薄める
   // (track 自体の色は checked 状態を維持して「ON 固定」が一目で判る見た目にする)。
-  const trackColor = checked ? "bg-[#1D9E75]" : "bg-zinc-700"
+  const trackColor = checked ? "bg-[#1D9E75]" : "bg-[#1c1a27]/15"
   return (
     <button
       type="button"
@@ -84,7 +84,7 @@ function Toggle({
 
 function SectionHeader({ label }: { label: string }) {
   return (
-    <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-2 mt-5 first:mt-0">
+    <p className="text-xs font-semibold text-[#736f7e] uppercase tracking-wider mb-2 mt-5 first:mt-0">
       {label}
     </p>
   )
@@ -110,12 +110,12 @@ function NotificationRow({
   badge?: React.ReactNode
 }) {
   return (
-    <div className="flex items-center justify-between bg-zinc-800 rounded-xl px-4 py-3 mb-2">
+    <div className="flex items-center justify-between ax-card-warm rounded-xl px-4 py-3 mb-2">
       <div className="flex items-center gap-3">
-        <div className="text-[#4ade9a]">{icon}</div>
+        <div className="text-[#1D9E75]">{icon}</div>
         <div>
           <div className="flex items-center gap-2">
-            <span className="text-white text-sm">{label}</span>
+            <span className="text-[#1c1a27] text-sm">{label}</span>
             {badge}
           </div>
         </div>
@@ -235,9 +235,9 @@ export function NotificationPanel() {
 
   const pushBadge =
     pushPermission === "granted" ? (
-      <span className="text-[10px] text-[#4ade9a] font-semibold">{t("pushGranted")}</span>
+      <span className="text-[10px] text-[#1D9E75] font-semibold">{t("pushGranted")}</span>
     ) : (
-      <span className="text-[10px] text-yellow-400 font-semibold">{t("pushNotGranted")}</span>
+      <span className="text-[10px] text-yellow-600 font-semibold">{t("pushNotGranted")}</span>
     )
 
   return (
@@ -246,12 +246,12 @@ export function NotificationPanel() {
       <SectionHeader label={t("channelSection")} />
 
       {/* LINE 通知 */}
-      <div className="flex items-center justify-between bg-zinc-800 rounded-xl px-4 py-3 mb-2">
+      <div className="flex items-center justify-between ax-card-warm rounded-xl px-4 py-3 mb-2">
         <div className="flex items-center gap-3">
-          <MessageCircle className="w-5 h-5 text-[#4ade9a]" />
+          <MessageCircle className="w-5 h-5 text-[#1D9E75]" />
           <div>
-            <div className="text-white text-sm">{t("lineNotification")}</div>
-            <div className="text-[#4ade9a] text-xs">{t("lineConnected")}</div>
+            <div className="text-[#1c1a27] text-sm">{t("lineNotification")}</div>
+            <div className="text-[#1D9E75] text-xs">{t("lineConnected")}</div>
           </div>
         </div>
         <Toggle
@@ -261,12 +261,12 @@ export function NotificationPanel() {
       </div>
 
       {/* PWA プッシュ通知 */}
-      <div className="flex items-center justify-between bg-zinc-800 rounded-xl px-4 py-3 mb-2">
+      <div className="flex items-center justify-between ax-card-warm rounded-xl px-4 py-3 mb-2">
         <div className="flex items-center gap-3">
-          <Bell className="w-5 h-5 text-[#4ade9a]" />
+          <Bell className="w-5 h-5 text-[#1D9E75]" />
           <div>
             <div className="flex items-center gap-2">
-              <span className="text-white text-sm">{t("pushNotification")}</span>
+              <span className="text-[#1c1a27] text-sm">{t("pushNotification")}</span>
               {pushBadge}
             </div>
           </div>
@@ -302,13 +302,13 @@ export function NotificationPanel() {
         checked={settings.preferences.health_factor_warning}
         onChange={(v) => updatePref("health_factor_warning", v)}
       />
-      <div className="flex items-center justify-between bg-zinc-800 rounded-xl px-4 py-3 mb-2">
+      <div className="flex items-center justify-between ax-card-warm rounded-xl px-4 py-3 mb-2">
         <div className="flex items-center gap-3">
-          <ShieldAlert className="w-5 h-5 text-[#4ade9a]" />
+          <ShieldAlert className="w-5 h-5 text-[#1D9E75]" />
           <div>
             <div className="flex items-center gap-2">
-              <span className="text-white text-sm">{t("emergencyStopLabel")}</span>
-              <span className="text-[10px] text-zinc-400 font-semibold bg-zinc-700 px-1.5 py-0.5 rounded">
+              <span className="text-[#1c1a27] text-sm">{t("emergencyStopLabel")}</span>
+              <span className="text-[10px] text-[#fbf7f0] font-semibold bg-[#1b1a23] px-1.5 py-0.5 rounded">
                 {t("immutableBadge")}
               </span>
             </div>
@@ -342,13 +342,13 @@ export function NotificationPanel() {
         type="button"
         onClick={handleTestNotification}
         disabled={testSending}
-        className="w-full py-3 border border-zinc-700 text-zinc-300 rounded-xl text-sm hover:bg-zinc-800 transition-colors mt-4 disabled:opacity-50 disabled:cursor-not-allowed"
+        className="w-full py-3 border border-[#1c1a27]/15 text-[#1c1a27] rounded-xl text-sm hover:bg-black/5 transition-colors mt-4 disabled:opacity-50 disabled:cursor-not-allowed"
       >
         {testSending ? t("testNotificationSending") : t("testNotificationBtn")}
       </button>
 
       {testMessage && (
-        <p className="text-center text-xs mt-2 text-zinc-400">{testMessage}</p>
+        <p className="text-center text-xs mt-2 text-[#736f7e]">{testMessage}</p>
       )}
     </div>
   )

--- a/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
@@ -24,7 +24,7 @@ export function OpModePanel() {
       label: t("managedLabel"),
       desc: t("managedDesc"),
       icon: Bot,
-      color: "text-[#4ade9a]",
+      color: "text-[#1D9E75]",
       bg: "bg-[#1D9E75]/10",
       border: "border-[#1D9E75]",
     },
@@ -33,7 +33,7 @@ export function OpModePanel() {
       label: t("activeLabel"),
       desc: t("activeDesc"),
       icon: MousePointer2,
-      color: "text-blue-400",
+      color: "text-blue-600",
       bg: "bg-blue-500/10",
       border: "border-blue-500",
     },
@@ -97,25 +97,25 @@ export function OpModePanel() {
         <div
           role="status"
           data-testid="opmode-toast"
-          className="fixed top-4 left-1/2 -translate-x-1/2 z-[60] px-4 py-2 rounded-xl bg-zinc-800 border border-zinc-700 text-white text-sm shadow-lg whitespace-nowrap"
+          className="fixed top-4 left-1/2 -translate-x-1/2 z-[60] px-4 py-2 rounded-xl bg-[#1b1a23] border border-[#1c1a27]/15 text-[#fbf7f0] text-sm shadow-lg whitespace-nowrap"
         >
           {toast}
         </div>
       )}
 
       {/* 現在のモード表示カード */}
-      <div className="bg-[#1a3d2e] rounded-2xl px-4 py-4 flex items-center justify-between">
+      <div className="bg-gradient-to-br from-[#b9a4f2] via-[#ecaccd] to-[#fbd9a0] rounded-2xl px-4 py-4 flex items-center justify-between">
         <div>
-          <p className="text-xl font-bold text-white" data-testid="opmode-current">
+          <p className="text-xl font-bold text-[#1c1a27]" data-testid="opmode-current">
             {loading
               ? t("loadingMode")
               : currentMode
               ? MODE_LABEL[currentMode]
               : t("modeUnset")}
           </p>
-          <p className="text-zinc-300 text-sm mt-0.5">{t("currentModeLabel")}</p>
+          <p className="text-[#736f7e] text-sm mt-0.5">{t("currentModeLabel")}</p>
         </div>
-        <span className="text-xs text-[#4ade9a] border border-[#1D9E75] rounded-full px-2 py-1">
+        <span className="text-xs text-[#1D9E75] border border-[#1D9E75] rounded-full px-2 py-1">
           {t("activeBadge")}
         </span>
       </div>
@@ -142,8 +142,8 @@ export function OpModePanel() {
               <div className="flex items-center gap-3">
                 <Icon className={`w-6 h-6 shrink-0 ${mode.color}`} />
                 <div>
-                  <p className="text-white font-bold text-base">{mode.label}</p>
-                  <p className="text-zinc-300 text-sm mt-0.5">{mode.desc}</p>
+                  <p className="text-[#1c1a27] font-bold text-base">{mode.label}</p>
+                  <p className="text-[#736f7e] text-sm mt-0.5">{mode.desc}</p>
                 </div>
               </div>
             </button>

--- a/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
@@ -159,10 +159,10 @@ export function ReferralPanel() {
       {/* トースト */}
       {toast && (
         <div className="fixed top-16 left-1/2 -translate-x-1/2 z-[60]
-                        flex items-center gap-2 bg-zinc-800 border border-zinc-700
-                        text-zinc-100 text-sm px-4 py-2 rounded-xl shadow-lg
+                        flex items-center gap-2 bg-[#1b1a23] border border-[#1c1a27]/15
+                        text-[#fbf7f0] text-sm px-4 py-2 rounded-xl shadow-lg
                         animate-in fade-in duration-200">
-          <CheckCircle className="w-4 h-4 text-[#4ade9a]" />
+          <CheckCircle className="w-4 h-4 text-[#1D9E75]" />
           {toast}
         </div>
       )}
@@ -176,23 +176,23 @@ export function ReferralPanel() {
       )}
 
       {/* 報酬サマリーカード */}
-      <div className="bg-[#1a3d2e] rounded-2xl p-5">
+      <div className="bg-gradient-to-br from-[#b9a4f2] via-[#ecaccd] to-[#fbd9a0] rounded-2xl p-5">
         {loading ? (
           <div className="h-20 flex items-center justify-center">
-            <div className="w-6 h-6 border-2 border-[#4ade9a] border-t-transparent rounded-full animate-spin" />
+            <div className="w-6 h-6 border-2 border-[#1c1a27] border-t-transparent rounded-full animate-spin" />
           </div>
         ) : (
           <>
-            <p className="text-zinc-400 text-xs mb-1">{t("totalRewardLabel")}</p>
-            <p className="text-[#4ade9a] text-3xl font-bold mb-1">
+            <p className="text-[#1c1a27] text-xs mb-1">{t("totalRewardLabel")}</p>
+            <p className="text-[#1c1a27] text-3xl font-bold mb-1">
               ¥{totalReward}
             </p>
-            <p className="text-zinc-400 text-xs mb-5">
+            <p className="text-[#1c1a27] text-xs mb-5">
               {displayInfo.referral_count}{t("referralCountLabel")}
             </p>
 
             {/* 統計 3つ */}
-            <div className="grid grid-cols-3 gap-2 pt-4 border-t border-white/10">
+            <div className="grid grid-cols-3 gap-2 pt-4 border-t border-[#1c1a27]/15">
               <StatCard
                 icon={<Users className="w-4 h-4" />}
                 label={t("statsReferralCount")}
@@ -215,11 +215,11 @@ export function ReferralPanel() {
 
       {/* 紹介コード */}
       <div className="space-y-2">
-        <p className="text-zinc-400 text-xs font-medium px-1">{t("referralCodeLabel")}</p>
+        <p className="text-[#736f7e] text-xs font-medium px-1">{t("referralCodeLabel")}</p>
         {displayInfo.referral_code ? (
           <div className="flex items-center gap-2">
-            <div className="flex-1 bg-zinc-800 rounded-xl px-4 py-3 flex items-center">
-              <span className="text-white font-mono text-2xl tracking-widest">
+            <div className="flex-1 ax-card-warm rounded-xl px-4 py-3 flex items-center">
+              <span className="text-[#1c1a27] font-mono text-2xl tracking-widest">
                 {displayInfo.referral_code}
               </span>
             </div>
@@ -249,7 +249,7 @@ export function ReferralPanel() {
       {/* シェアボタン */}
       {displayInfo.referral_code && (
         <div className="space-y-2">
-          <p className="text-zinc-400 text-xs font-medium px-1">{t("shareSectionLabel")}</p>
+          <p className="text-[#736f7e] text-xs font-medium px-1">{t("shareSectionLabel")}</p>
           <div className="space-y-2">
             <button
               onClick={handleLineShare}
@@ -275,8 +275,8 @@ export function ReferralPanel() {
 
             <button
               onClick={handleCopyLink}
-              className="w-full flex items-center gap-3 bg-zinc-700 hover:bg-zinc-600
-                         text-white font-semibold py-3 px-4 rounded-xl
+              className="w-full flex items-center gap-3 bg-[#1b1a23] hover:bg-[#2a2833]
+                         text-[#fbf7f0] font-semibold py-3 px-4 rounded-xl
                          transition-colors"
             >
               <Copy className="w-5 h-5" />
@@ -289,8 +289,8 @@ export function ReferralPanel() {
 
       {/* 報酬の仕組み */}
       <div className="space-y-2">
-        <p className="text-zinc-400 text-xs font-medium px-1">{t("howItWorksLabel")}</p>
-        <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-4 space-y-4">
+        <p className="text-[#736f7e] text-xs font-medium px-1">{t("howItWorksLabel")}</p>
+        <div className="ax-card-warm border border-[#1c1a27]/15 rounded-2xl p-4 space-y-4">
           <HowItWorksStep
             step={1}
             text={t("howItWorksStep1")}
@@ -310,7 +310,7 @@ export function ReferralPanel() {
       {/* 紹介した友達リスト */}
       {displayInfo.referred_users.length > 0 && (
         <div className="space-y-2">
-          <p className="text-zinc-400 text-xs font-medium px-1">{t("referredUsersLabel")}</p>
+          <p className="text-[#736f7e] text-xs font-medium px-1">{t("referredUsersLabel")}</p>
           <div className="space-y-2">
             {displayInfo.referred_users.map((user, i) => (
               <ReferredUserRow key={i} user={user} tPanel={t} />
@@ -320,7 +320,7 @@ export function ReferralPanel() {
       )}
 
       {!loading && displayInfo.referred_users.length === 0 && displayInfo.referral_code && (
-        <div className="text-center py-8 text-zinc-600 text-sm">
+        <div className="text-center py-8 text-[#736f7e] text-sm">
           {t("noReferredUsers")}
         </div>
       )}
@@ -339,9 +339,9 @@ function StatCard({
 }) {
   return (
     <div className="flex flex-col items-center gap-1">
-      <div className="text-[#4ade9a]">{icon}</div>
-      <p className="text-white font-semibold text-sm">{value}</p>
-      <p className="text-zinc-500 text-[10px]">{label}</p>
+      <div className="text-[#1c1a27]">{icon}</div>
+      <p className="text-[#1c1a27] font-semibold text-sm">{value}</p>
+      <p className="text-[#736f7e] text-[10px]">{label}</p>
     </div>
   )
 }
@@ -357,14 +357,14 @@ function HowItWorksStep({
 }) {
   return (
     <div className="flex items-start gap-3">
-      <div className="w-6 h-6 rounded-full bg-[#1a3d2e] border border-[#1D9E75]
+      <div className="w-6 h-6 rounded-full bg-[#1D9E75]/10 border border-[#1D9E75]
                       flex items-center justify-center flex-shrink-0 mt-0.5">
-        <span className="text-[#4ade9a] text-xs font-bold">{step}</span>
+        <span className="text-[#1D9E75] text-xs font-bold">{step}</span>
       </div>
       <div className="flex-1">
-        <p className="text-white text-sm">{text}</p>
+        <p className="text-[#1c1a27] text-sm">{text}</p>
         {reward && (
-          <p className="text-[#4ade9a] text-xs font-semibold mt-0.5">
+          <p className="text-[#1D9E75] text-xs font-semibold mt-0.5">
             → {reward}
           </p>
         )}
@@ -386,17 +386,17 @@ function ReferredUserRow({
   const rewardJpy = Number(user.reward_jpy).toLocaleString("ja-JP")
 
   return (
-    <div className="flex items-center gap-3 bg-zinc-900 border border-zinc-800 rounded-xl px-4 py-3">
+    <div className="flex items-center gap-3 ax-card-warm border border-[#1c1a27]/15 rounded-xl px-4 py-3">
       {/* アバター */}
-      <div className="w-9 h-9 rounded-full bg-[#1a3d2e] border border-[#1D9E75]
+      <div className="w-9 h-9 rounded-full bg-[#1D9E75]/10 border border-[#1D9E75]
                       flex items-center justify-center flex-shrink-0">
-        <span className="text-[#4ade9a] text-sm font-bold">{initial}</span>
+        <span className="text-[#1D9E75] text-sm font-bold">{initial}</span>
       </div>
 
       {/* 名前・日付 */}
       <div className="flex-1 min-w-0">
-        <p className="text-white text-sm font-medium truncate">{user.name}</p>
-        <p className="text-zinc-500 text-xs mt-0.5">{tPanel("joinedDateLabel")} {joinedDate}</p>
+        <p className="text-[#1c1a27] text-sm font-medium truncate">{user.name}</p>
+        <p className="text-[#736f7e] text-xs mt-0.5">{tPanel("joinedDateLabel")} {joinedDate}</p>
       </div>
 
       {/* ステータス・報酬 */}
@@ -404,15 +404,15 @@ function ReferredUserRow({
         <span
           className={`text-xs border rounded-full px-2 py-0.5 ${
             isActive
-              ? "text-[#4ade9a] border-[#1D9E75]"
-              : "text-zinc-400 border-zinc-700"
+              ? "text-[#1D9E75] border-[#1D9E75]"
+              : "text-[#736f7e] border-[#1c1a27]/15"
           }`}
         >
           {user.status === "active"
             ? tPanel("statusActive")
             : tPanel("statusRegistered")}
         </span>
-        <span className="text-zinc-300 text-xs">¥{rewardJpy}</span>
+        <span className="text-[#736f7e] text-xs">¥{rewardJpy}</span>
       </div>
     </div>
   )

--- a/frontend/app/(liff)/liff-chat/_components/panels/TaxPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TaxPanel.tsx
@@ -71,8 +71,8 @@ export function TaxPanel() {
 
   if (loading) {
     return (
-      <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
-        <Loader2 className="w-6 h-6 animate-spin mb-3 text-zinc-600" />
+      <div className="flex flex-col items-center justify-center py-12 text-[#736f7e]">
+        <Loader2 className="w-6 h-6 animate-spin mb-3 text-[#736f7e]" />
         <p className="text-sm">{t("loading")}</p>
       </div>
     )
@@ -85,7 +85,7 @@ export function TaxPanel() {
   return (
     <div className="pb-4">
       {/* タブ */}
-      <div className="flex border-b border-zinc-800 mb-4">
+      <div className="flex border-b border-[#1c1a27]/15 mb-4">
         {tabs.map((tab, idx) => {
           const isPersonalTab = idx === 0
           const active = hasCorpInfo ? !isPersonalTab : isPersonalTab
@@ -96,10 +96,10 @@ export function TaxPanel() {
               disabled={disabled}
               className={`flex-1 py-3 text-sm font-medium transition-colors ${
                 disabled
-                  ? "text-zinc-600 cursor-not-allowed"
+                  ? "text-[#736f7e] cursor-not-allowed"
                   : active
                   ? "border-b-2 border-[#1D9E75] text-[#1D9E75]"
-                  : "text-zinc-400"
+                  : "text-[#736f7e]"
               }`}
             >
               {tab}
@@ -110,8 +110,8 @@ export function TaxPanel() {
 
       {/* エラーバナー */}
       {error && (
-        <div className="flex items-center gap-2 bg-zinc-800 rounded-xl px-4 py-3 mb-4 text-zinc-400 text-sm">
-          <AlertCircle className="w-4 h-4 text-zinc-500 flex-shrink-0" />
+        <div className="flex items-center gap-2 ax-card-warm rounded-xl px-4 py-3 mb-4 text-[#736f7e] text-sm">
+          <AlertCircle className="w-4 h-4 text-[#736f7e] flex-shrink-0" />
           <span>{error}</span>
         </div>
       )}
@@ -133,7 +133,7 @@ export function TaxPanel() {
 
       {/* 注意書き */}
       <div className="mt-6 px-1">
-        <p className="text-zinc-500 text-xs leading-relaxed">
+        <p className="text-[#736f7e] text-xs leading-relaxed">
           {t("cryptactNote")}
         </p>
       </div>
@@ -151,7 +151,7 @@ interface YearSelectorProps {
 function YearSelector({ selectedYear, onYearChange, currentYear, t }: YearSelectorProps) {
   return (
     <div className="flex items-center gap-3 mb-5">
-      <span className="text-zinc-400 text-sm">{t("yearLabel")}</span>
+      <span className="text-[#736f7e] text-sm">{t("yearLabel")}</span>
       <div className="flex gap-2">
         {[currentYear, currentYear - 1].map((year) => (
           <button
@@ -160,7 +160,7 @@ function YearSelector({ selectedYear, onYearChange, currentYear, t }: YearSelect
             className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${
               selectedYear === year
                 ? "bg-[#1D9E75] text-white"
-                : "bg-zinc-800 text-zinc-400 hover:bg-zinc-700"
+                : "ax-card-warm text-[#736f7e] hover:bg-black/5"
             }`}
           >
             {year}
@@ -183,20 +183,20 @@ function DownloadButton({ label, description, onClick, disabled = false }: Downl
     <button
       onClick={onClick}
       disabled={disabled}
-      className={`w-full flex items-center justify-between bg-zinc-800 px-4 py-4 rounded-xl transition-colors ${
+      className={`w-full flex items-center justify-between ax-card-warm px-4 py-4 rounded-xl transition-colors ${
         disabled
           ? "opacity-40 cursor-not-allowed"
-          : "hover:bg-zinc-700 active:bg-zinc-600"
+          : "hover:bg-black/5 active:bg-black/10"
       }`}
     >
       <div className="flex items-center gap-3">
-        <FileDown className={`w-5 h-5 ${disabled ? "text-zinc-600" : "text-[#4ade9a]"}`} />
+        <FileDown className={`w-5 h-5 ${disabled ? "text-[#736f7e]" : "text-[#1D9E75]"}`} />
         <div className="text-left">
-          <div className="text-white text-sm font-medium">{label}</div>
-          <div className="text-zinc-500 text-xs">{description}</div>
+          <div className="text-[#1c1a27] text-sm font-medium">{label}</div>
+          <div className="text-[#736f7e] text-xs">{description}</div>
         </div>
       </div>
-      <ChevronRight className="w-4 h-4 text-zinc-600" />
+      <ChevronRight className="w-4 h-4 text-[#736f7e]" />
     </button>
   )
 }
@@ -259,18 +259,18 @@ function CorporateTabContent({ fiscalMonth, t }: CorporateTabContentProps) {
   return (
     <div className="space-y-3">
       {/* 決算月表示 */}
-      <div className="flex items-center justify-between bg-zinc-800 rounded-xl px-4 py-3 mb-2">
-        <span className="text-zinc-400 text-sm">{t("corpFiscalMonthLabel")}</span>
-        <span className="text-white text-sm font-semibold">{t("corpFiscalMonthUnit", { month: fiscalMonth })}</span>
+      <div className="flex items-center justify-between ax-card-warm rounded-xl px-4 py-3 mb-2">
+        <span className="text-[#736f7e] text-sm">{t("corpFiscalMonthLabel")}</span>
+        <span className="text-[#1c1a27] text-sm font-semibold">{t("corpFiscalMonthUnit", { month: fiscalMonth })}</span>
       </div>
 
       {/* 準備中: freee/弥生 CSV は税理士承認の仕訳マッピング適用後に提供する。
           個人データを法人フォーマットと偽って返さないため、ここでは DL を出さない。 */}
-      <div className="flex items-start gap-2 bg-zinc-800/60 border border-zinc-700 rounded-xl px-4 py-3 text-sm">
+      <div className="flex items-start gap-2 ax-card-warm border border-[#1c1a27]/15 rounded-xl px-4 py-3 text-sm">
         <AlertCircle className="w-4 h-4 text-[#1D9E75] flex-shrink-0 mt-0.5" />
-        <div className="text-zinc-300 leading-relaxed">
-          <p className="font-medium text-white mb-1">{t("corpCsvPendingTitle")}</p>
-          <p className="text-zinc-400 text-xs">
+        <div className="text-[#736f7e] leading-relaxed">
+          <p className="font-medium text-[#1c1a27] mb-1">{t("corpCsvPendingTitle")}</p>
+          <p className="text-[#736f7e] text-xs">
             {t("corpCsvPendingDesc")}
           </p>
         </div>

--- a/frontend/app/(liff)/liff-chat/_components/panels/TermsPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TermsPanel.tsx
@@ -52,17 +52,17 @@ export function TermsPanel() {
           key={href}
           type="button"
           onClick={() => openExternal(href)}
-          className="flex items-center gap-3 w-full bg-zinc-800 hover:bg-zinc-700 px-4 py-4 rounded-xl transition-colors text-left"
+          className="flex items-center gap-3 w-full ax-card-warm hover:bg-black/5 px-4 py-4 rounded-xl transition-colors text-left"
         >
-          <Icon className="w-5 h-5 text-[#4ade9a] flex-shrink-0" />
+          <Icon className="w-5 h-5 text-[#1D9E75] flex-shrink-0" />
           <div className="flex-1">
-            <div className="text-white text-sm font-medium">{label}</div>
-            <div className="text-zinc-500 text-xs">{desc}</div>
+            <div className="text-[#1c1a27] text-sm font-medium">{label}</div>
+            <div className="text-[#736f7e] text-xs">{desc}</div>
           </div>
-          <ExternalLink className="w-4 h-4 text-zinc-500 flex-shrink-0" />
+          <ExternalLink className="w-4 h-4 text-[#736f7e] flex-shrink-0" />
         </button>
       ))}
-      <p className="text-zinc-600 text-xs text-center pt-2">
+      <p className="text-[#736f7e] text-xs text-center pt-2">
         {t("footer")}
       </p>
     </div>

--- a/frontend/app/(liff)/liff-chat/_components/panels/TxHistoryPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TxHistoryPanel.tsx
@@ -114,22 +114,22 @@ function TxDetailPanel({ tx, onClose }: TxDetailPanelProps) {
   if (tx.tx_hash) detailRows.push({ label: t("detailTxHash"), value: `${tx.tx_hash.slice(0, 8)}...${tx.tx_hash.slice(-6)}` })
 
   return (
-    <div className="fixed inset-0 z-[60] bg-zinc-900 flex flex-col animate-in slide-in-from-right duration-200 w-[375px] mx-auto">
+    <div className="fixed inset-0 z-[60] ax-bg-app flex flex-col animate-in slide-in-from-right duration-200 w-[375px] mx-auto">
       {/* ヘッダー */}
-      <div className="flex items-center bg-[#1a3d2e] px-4 py-3 flex-shrink-0">
-        <button onClick={onClose} className="text-white mr-2">
+      <div className="flex items-center bg-gradient-to-br from-[#b9a4f2] via-[#ecaccd] to-[#fbd9a0] px-4 py-3 flex-shrink-0">
+        <button onClick={onClose} className="text-[#1c1a27] mr-2">
           <ChevronLeft className="w-5 h-5" />
         </button>
-        <h2 className="text-white font-semibold text-base">{t("detailTitle")}</h2>
+        <h2 className="text-[#1c1a27] font-semibold text-base">{t("detailTitle")}</h2>
       </div>
 
       <div className="flex-1 overflow-y-auto px-4 pb-8">
         {/* 金額カード */}
-        <div className="bg-[#1a3d2e] rounded-2xl p-4 mt-4 mb-6">
-          <div className={`text-3xl font-bold ${isSupply ? "text-[#4ade9a]" : "text-orange-400"}`}>
+        <div className="ax-card-warm rounded-2xl p-4 mt-4 mb-6">
+          <div className={`text-3xl font-bold ${isSupply ? "text-[#1D9E75]" : "text-orange-400"}`}>
             {amountDisplay}
           </div>
-          <div className="text-zinc-300 text-sm mt-1">
+          <div className="text-[#736f7e] text-sm mt-1">
             {tx.operation} · {tx.asset}
           </div>
         </div>
@@ -137,9 +137,9 @@ function TxDetailPanel({ tx, onClose }: TxDetailPanelProps) {
         {/* 詳細行 */}
         <div className="space-y-0">
           {detailRows.map((row) => (
-            <div key={row.label} className="flex justify-between items-start py-3 border-b border-zinc-800">
-              <span className="text-zinc-500 text-sm">{row.label}</span>
-              <span className="text-zinc-100 text-sm text-right max-w-[60%] break-all">{row.value}</span>
+            <div key={row.label} className="flex justify-between items-start py-3 border-b border-[#1c1a27]/15">
+              <span className="text-[#736f7e] text-sm">{row.label}</span>
+              <span className="text-[#1c1a27] text-sm text-right max-w-[60%] break-all">{row.value}</span>
             </div>
           ))}
         </div>
@@ -150,7 +150,7 @@ function TxDetailPanel({ tx, onClose }: TxDetailPanelProps) {
             href={`https://basescan.org/tx/${tx.tx_hash}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="mt-6 flex items-center justify-center gap-2 w-full py-3 rounded-xl border border-zinc-700 text-zinc-300 hover:bg-zinc-800 transition-colors text-sm"
+            className="mt-6 flex items-center justify-center gap-2 w-full py-3 rounded-xl border border-[#1c1a27]/15 text-[#736f7e] hover:bg-black/5 transition-colors text-sm"
           >
             <ExternalLink className="w-4 h-4" />
             {t("detailBasescanBtn")}
@@ -258,8 +258,8 @@ export function TxHistoryPanel() {
 
   if (loading) {
     return (
-      <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
-        <Loader2 className="w-6 h-6 mb-3 text-zinc-600 animate-spin" />
+      <div className="flex flex-col items-center justify-center py-12 text-[#736f7e]">
+        <Loader2 className="w-6 h-6 mb-3 text-[#736f7e] animate-spin" />
         <p className="text-sm">{t("loading")}</p>
       </div>
     )
@@ -269,8 +269,8 @@ export function TxHistoryPanel() {
   if (authExpired) {
     return (
       <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
-        <p className="text-sm text-zinc-300 mb-1">{t("authExpiredTitle")}</p>
-        <p className="text-xs text-zinc-500 mb-5">
+        <p className="text-sm text-[#736f7e] mb-1">{t("authExpiredTitle")}</p>
+        <p className="text-xs text-[#736f7e] mb-5">
           {t("authExpiredDesc")}
         </p>
         <button
@@ -289,8 +289,8 @@ export function TxHistoryPanel() {
 
   if (error) {
     return (
-      <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
-        <p className="text-sm text-red-400">{error}</p>
+      <div className="flex flex-col items-center justify-center py-12 text-[#736f7e]">
+        <p className="text-sm text-red-600">{error}</p>
       </div>
     )
   }
@@ -301,7 +301,7 @@ export function TxHistoryPanel() {
       <div className="flex justify-end">
         <button
           onClick={handleCsvDownload}
-          className="flex items-center gap-1.5 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-xs px-3 py-1.5 rounded-lg transition-colors"
+          className="flex items-center gap-1.5 ax-card-warm hover:bg-black/5 text-[#736f7e] text-xs px-3 py-1.5 rounded-lg transition-colors"
         >
           <Download className="w-3.5 h-3.5" />
           {t("csvBtn")}
@@ -314,10 +314,10 @@ export function TxHistoryPanel() {
           {coinSummaries.map((coin) => (
             <div
               key={coin.asset}
-              className="flex-shrink-0 bg-zinc-800 rounded-xl px-3 py-2 min-w-[100px]"
+              className="flex-shrink-0 ax-card-warm rounded-xl px-3 py-2 min-w-[100px]"
             >
-              <div className="text-xs text-zinc-400 font-medium mb-0.5">{coin.asset}</div>
-              <div className="text-[#4ade9a] text-xs">+${coin.total_supply}</div>
+              <div className="text-xs text-[#736f7e] font-medium mb-0.5">{coin.asset}</div>
+              <div className="text-[#1D9E75] text-xs">+${coin.total_supply}</div>
               <div className="text-orange-400 text-xs">-${coin.total_withdraw}</div>
             </div>
           ))}
@@ -333,7 +333,7 @@ export function TxHistoryPanel() {
             className={`flex-shrink-0 text-xs px-3 py-1.5 rounded-full transition-colors ${
               filter === f.id
                 ? "bg-[#1D9E75] text-white"
-                : "bg-zinc-800 text-zinc-400 hover:bg-zinc-700"
+                : "ax-card-warm text-[#736f7e] hover:bg-black/5"
             }`}
           >
             {f.label}
@@ -343,7 +343,7 @@ export function TxHistoryPanel() {
 
       {/* 取引リスト */}
       {filteredTxs.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-12 text-zinc-500">
+        <div className="flex flex-col items-center justify-center py-12 text-[#736f7e]">
           <p className="text-sm">{t("noTxs")}</p>
         </div>
       ) : (
@@ -351,7 +351,7 @@ export function TxHistoryPanel() {
           {grouped.map(({ month, items }) => (
             <div key={month}>
               {/* 月ヘッダー */}
-              <div className="text-zinc-500 text-xs font-semibold py-2 pt-4">
+              <div className="text-[#736f7e] text-xs font-semibold py-2 pt-4">
                 {month}
               </div>
               {/* 行 */}
@@ -361,12 +361,12 @@ export function TxHistoryPanel() {
                   <button
                     key={tx.id}
                     onClick={() => setSelectedTx(tx)}
-                    className="flex items-center w-full py-3 border-b border-zinc-800 text-left hover:bg-zinc-800/50 transition-colors -mx-1 px-1 rounded"
+                    className="flex items-center w-full py-3 border-b border-[#1c1a27]/15 text-left hover:bg-black/5 transition-colors -mx-1 px-1 rounded"
                   >
                     {/* 種別アイコン */}
-                    <div className="mr-3 w-8 h-8 rounded-full flex items-center justify-center bg-zinc-800 flex-shrink-0">
+                    <div className="mr-3 w-8 h-8 rounded-full flex items-center justify-center ax-card-warm flex-shrink-0">
                       {isSupply ? (
-                        <ArrowDown className="w-4 h-4 text-[#4ade9a]" />
+                        <ArrowDown className="w-4 h-4 text-[#1D9E75]" />
                       ) : (
                         <ArrowUp className="w-4 h-4 text-orange-400" />
                       )}
@@ -374,21 +374,21 @@ export function TxHistoryPanel() {
                     {/* 情報 */}
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-1.5">
-                        <span className="text-white text-sm font-medium">
+                        <span className="text-[#1c1a27] text-sm font-medium">
                           {tx.operation}
                         </span>
-                        <span className="bg-zinc-700 text-zinc-300 text-xs px-1.5 py-0.5 rounded">
+                        <span className="bg-[#1c1a27]/10 text-[#736f7e] text-xs px-1.5 py-0.5 rounded">
                           {tx.asset}
                         </span>
                       </div>
-                      <div className="text-zinc-500 text-xs mt-0.5">{formatDate(tx.created_at)}</div>
+                      <div className="text-[#736f7e] text-xs mt-0.5">{formatDate(tx.created_at)}</div>
                     </div>
                     {/* 金額 */}
                     <div className="text-right flex-shrink-0 ml-2">
-                      <div className={`font-medium text-sm ${isSupply ? "text-[#4ade9a]" : "text-orange-400"}`}>
+                      <div className={`font-medium text-sm ${isSupply ? "text-[#1D9E75]" : "text-orange-400"}`}>
                         {formatAmountUsd(tx.amount_usd, tx.operation)}
                       </div>
-                      <div className="text-zinc-500 text-xs mt-0.5">{statusLabel(tx.status)}</div>
+                      <div className="text-[#736f7e] text-xs mt-0.5">{statusLabel(tx.status)}</div>
                     </div>
                   </button>
                 )

--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -28,7 +28,7 @@ const AssetChart = dynamic(() => import("./_components/AssetChart"), {
   ssr: false,
   loading: () => (
     <div className="h-[200px] w-full flex items-center justify-center">
-      <span className="text-zinc-600 text-xs" id="chart-loading-placeholder" />
+      <span className="text-[#736f7e] text-xs" id="chart-loading-placeholder" />
     </div>
   ),
 })
@@ -165,13 +165,13 @@ export default function LiffChatPage() {
   }
 
   return (
-    <div className="w-[375px] mx-auto h-dvh bg-zinc-950 text-zinc-100 flex flex-col overflow-hidden relative">
+    <div className="w-[375px] mx-auto h-dvh ax-bg-app text-[#1c1a27] flex flex-col overflow-hidden relative">
 
-      {/* ── ヘッダー */}
-      <header className="h-14 bg-[#1a3d2e] flex items-center justify-between px-4 flex-shrink-0">
+      {/* ── ヘッダー（arobix グラデ） */}
+      <header className="h-14 bg-gradient-to-r from-[#b9a4f2] via-[#ecaccd] to-[#fbd9a0] flex items-center justify-between px-4 flex-shrink-0">
         <button
           onClick={() => { setMenuOpen(true); track(EV.MENU_OPEN) }}
-          className="text-white p-1 hover:bg-white/10 rounded-lg transition-colors"
+          className="text-[#1c1a27] p-1 hover:bg-black/5 rounded-lg transition-colors"
           aria-label={t("header.menuAriaLabel")}
         >
           <Menu className="w-6 h-6" />
@@ -206,14 +206,14 @@ export default function LiffChatPage() {
           <button
             onClick={() => { const next = language === "ja" ? "en" : "ja"; setLanguage(next); track(EV.LANGUAGE_TOGGLE, { language: next }) }}
             aria-label={t("header.langToggleAriaLabel")}
-            className="text-zinc-300 text-xs font-semibold px-2 py-1 rounded-md
-                       hover:bg-white/10 transition-colors border border-zinc-600"
+            className="text-[#1c1a27] text-xs font-semibold px-2 py-1 rounded-md
+                       hover:bg-black/5 transition-colors border border-[#1c1a27]/30"
           >
             {language === "ja" ? "EN" : "JP"}
           </button>
           <button
             onClick={() => { setActivePanel("account"); track(EV.ACCOUNT_OPEN) }}
-            className="text-white p-1 hover:bg-white/10 rounded-lg transition-colors"
+            className="text-[#1c1a27] p-1 hover:bg-black/5 rounded-lg transition-colors"
             aria-label={t("header.accountAriaLabel")}
           >
             <User className="w-6 h-6" />
@@ -227,11 +227,11 @@ export default function LiffChatPage() {
         {/* CURRENT ASSET カード（タップでグラフパネル） */}
         <button
           onClick={() => { setGraphOpen(true); track(EV.ASSET_GRAPH_OPEN) }}
-          className="bg-[#1a3d2e] rounded-2xl mx-4 mt-4 p-4 text-left w-[calc(100%-2rem)]
-                     active:brightness-90 transition-all"
+          className="bg-gradient-to-br from-[#b9a4f2] via-[#ecaccd] to-[#fbd9a0] rounded-2xl mx-4 mt-4 p-4 text-left w-[calc(100%-2rem)]
+                     active:brightness-95 transition-all"
         >
-          <div className="text-zinc-400 text-xs mb-1">{t("home.currentAsset")}</div>
-          <div className="text-white text-3xl font-bold">
+          <div className="text-[#2a2440]/70 text-xs mb-1">{t("home.currentAsset")}</div>
+          <div className="text-[#1c1a27] text-3xl font-bold">
             {balanceUsd != null
               ? `$${balanceUsd.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
               : "—"}
@@ -242,10 +242,10 @@ export default function LiffChatPage() {
         <div
           className={`rounded-2xl mx-4 mt-4 p-4 transition-all
             ${isBuy
-              ? "bg-zinc-900 border-2 border-[#1D9E75] [animation:pulse_0.8s_ease-in-out_2]"
+              ? "ax-card-warm border-2 border-[#1D9E75] [animation:pulse_0.8s_ease-in-out_2]"
               : isSell
-              ? "bg-zinc-900 border-2 border-red-500 [animation:pulse_0.8s_ease-in-out_2]"
-              : "bg-zinc-900"
+              ? "ax-card-warm border-2 border-red-500 [animation:pulse_0.8s_ease-in-out_2]"
+              : "ax-card-warm"
             }`}
         >
           {/* ヘッダー行 */}
@@ -256,25 +256,25 @@ export default function LiffChatPage() {
                   ? "bg-[#1D9E75] [animation:ping_0.5s_ease-in-out_4]"
                   : isSell
                   ? "bg-red-500"
-                  : "bg-zinc-500"
+                  : "bg-[#736f7e]"
               }`}
             />
             <span
               className={`text-xs font-medium ${
-                isBuy ? "text-[#4ade9a]" : isSell ? "text-red-400" : "text-zinc-400"
+                isBuy ? "text-[#1D9E75]" : isSell ? "text-red-600" : "text-[#736f7e]"
               }`}
             >
               {t("home.aiJudgment")}
             </span>
             {confidence > 0 && (
-              <span className="ml-auto text-zinc-500 text-xs">{confidence}% {t("home.confidenceLabel")}</span>
+              <span className="ml-auto text-[#736f7e] text-xs">{confidence}% {t("home.confidenceLabel")}</span>
             )}
           </div>
 
           {/* アクション表示 */}
           <div
             className={`font-bold text-2xl ${
-              isBuy ? "text-[#4ade9a]" : isSell ? "text-red-400" : "text-white"
+              isBuy ? "text-[#1D9E75]" : isSell ? "text-red-600" : "text-[#1c1a27]"
             }`}
           >
             {aiJudgment ? action : t("home.noSignal")}
@@ -285,13 +285,13 @@ export default function LiffChatPage() {
             <>
               <button
                 onClick={() => { const next = !reasonOpen; setReasonOpen(next); track(EV.REASON_TOGGLE, { action, open: next }) }}
-                className="mt-2 text-zinc-500 text-xs underline"
+                className="mt-2 text-[#736f7e] text-xs underline"
                 aria-expanded={reasonOpen}
               >
                 {t("home.whyAction", { action })}
               </button>
               {reasonOpen && (
-                <p className="mt-2 text-zinc-400 text-xs leading-relaxed whitespace-pre-wrap">
+                <p className="mt-2 text-[#736f7e] text-xs leading-relaxed whitespace-pre-wrap">
                   {aiJudgment.reason ?? t("home.noReason")}
                 </p>
               )}
@@ -301,29 +301,29 @@ export default function LiffChatPage() {
 
         {/* 運用中コイン一覧 */}
         <div className="mx-4 mt-4">
-          <h3 className="text-zinc-400 text-xs font-semibold mb-3">{t("home.operatingCoins")}</h3>
+          <h3 className="text-[#736f7e] text-xs font-semibold mb-3">{t("home.operatingCoins")}</h3>
           <div className="space-y-2">
             {coins.map((coin) => (
               <button
                 key={coin.asset}
-                className="flex items-center w-full bg-zinc-900 rounded-xl px-4 py-3 active:brightness-75 transition-all"
+                className="flex items-center w-full ax-card-warm rounded-xl px-4 py-3 active:brightness-95 transition-all"
               >
                 {/* コインアバター */}
                 <div
-                  className="w-8 h-8 rounded-full bg-[#1D9E75]/20 text-[#4ade9a]
+                  className="w-8 h-8 rounded-full bg-[#1D9E75]/15 text-[#1D9E75]
                                flex items-center justify-center text-xs font-bold mr-3 flex-shrink-0"
                 >
                   {coin.asset.slice(0, 2)}
                 </div>
                 <div className="flex-1 text-left">
-                  <div className="text-white text-sm font-medium">{coin.asset}</div>
-                  <div className="text-zinc-500 text-xs">{coin.protocol}</div>
+                  <div className="text-[#1c1a27] text-sm font-medium">{coin.asset}</div>
+                  <div className="text-[#736f7e] text-xs">{coin.protocol}</div>
                 </div>
                 <div className="text-right">
-                  <div className="text-white text-sm">${coin.amount_usd.toLocaleString()}</div>
+                  <div className="text-[#1c1a27] text-sm">${coin.amount_usd.toLocaleString()}</div>
                   <div
                     className={`text-xs ${
-                      coin.apy_pct >= 0 ? "text-[#4ade9a]" : "text-red-400"
+                      coin.apy_pct >= 0 ? "text-[#1D9E75]" : "text-red-600"
                     }`}
                   >
                     {coin.apy_pct >= 0 ? "+" : ""}
@@ -333,7 +333,7 @@ export default function LiffChatPage() {
               </button>
             ))}
             {coins.length === 0 && (
-              <div className="text-center py-6 text-zinc-600 text-sm">
+              <div className="text-center py-6 text-[#736f7e] text-sm">
                 {t("home.noCoins")}
               </div>
             )}
@@ -373,16 +373,16 @@ export default function LiffChatPage() {
             className="absolute inset-0 bg-black/60"
             onClick={() => !stopLoading && setStopConfirmOpen(false)}
           />
-          <div className="relative w-[375px] mx-auto bg-zinc-900 rounded-t-2xl p-5 ax-safe-bottom">
-            <h3 className="text-white font-bold text-lg mb-1">{t("home.stopConfirmTitle")}</h3>
-            <p className="text-zinc-400 text-sm mb-4 leading-relaxed">
+          <div className="relative w-[375px] mx-auto ax-card-warm rounded-t-2xl p-5 ax-safe-bottom">
+            <h3 className="text-[#1c1a27] font-bold text-lg mb-1">{t("home.stopConfirmTitle")}</h3>
+            <p className="text-[#736f7e] text-sm mb-4 leading-relaxed">
               {t("home.stopConfirmDesc")}
             </p>
             <div className="flex gap-3">
               <button
                 onClick={() => setStopConfirmOpen(false)}
                 disabled={stopLoading}
-                className="flex-1 py-3 rounded-xl border border-zinc-600 text-zinc-300 font-semibold disabled:opacity-40"
+                className="flex-1 py-3 rounded-xl border border-[#1c1a27]/20 text-[#1c1a27] font-semibold disabled:opacity-40"
               >
                 {t("home.stopCancel")}
               </button>
@@ -402,8 +402,8 @@ export default function LiffChatPage() {
       {toast && (
         <div
           role="status"
-          className="fixed top-4 left-1/2 -translate-x-1/2 z-[60] px-4 py-2 rounded-xl bg-zinc-800
-                     border border-zinc-700 text-white text-sm shadow-lg whitespace-nowrap"
+          className="fixed top-4 left-1/2 -translate-x-1/2 z-[60] px-4 py-2 rounded-xl bg-[#1b1a23]
+                     text-[#fbf7f0] text-sm shadow-lg whitespace-nowrap"
         >
           {toast}
         </div>
@@ -446,7 +446,7 @@ export default function LiffChatPage() {
               className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
                 graphPeriod === p
                   ? "bg-[#1D9E75] text-white"
-                  : "bg-zinc-800 text-zinc-400"
+                  : "bg-[#1c1a27]/5 text-[#736f7e]"
               }`}
             >
               {p}
@@ -482,9 +482,9 @@ export default function LiffChatPage() {
               value: "—",
             },
           ].map((s) => (
-            <div key={s.label} className="bg-zinc-800 rounded-xl p-3">
-              <div className="text-zinc-500 text-xs">{s.label}</div>
-              <div className="text-white font-semibold mt-0.5">{s.value}</div>
+            <div key={s.label} className="ax-card-warm rounded-xl p-3">
+              <div className="text-[#736f7e] text-xs">{s.label}</div>
+              <div className="text-[#1c1a27] font-semibold mt-0.5">{s.value}</div>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## 概要
liff-chat の UI を **arobix ライトデザイン**（クリーム背景 + 紫ピンクアンバーのグラデ + 緑アクセント）に全面統一。home + 全12コンポーネントを変換。

### 背景
arobix ライト版は過去に未コミットのローカル source からビルドされ deploy されていたが **git に一度も commit されておらず**、現 main は dark のままだった（PWA キャッシュで light に見えていた）。スクショを正確な目標、`app/arobix/theme.css` のトークンを基準に、現 dark コンポーネントへ配色を適用して再現する。

### 配色マッピング
- 背景 `bg-zinc-950` → `ax-bg-app` (#f7f2ea) / 文字 → `#1c1a27` (primary) / `#736f7e` (secondary)
- ヘッダー・hero/残高カード `bg-[#1a3d2e]` → グラデ `from-[#b9a4f2] via-[#ecaccd] to-[#fbd9a0]`
- カード `bg-zinc-900/800` → `ax-card-warm` (#f5ecdd)
- 緑 `#4ade9a` → `#1D9E75`（ライト視認性）/ 赤 `-400` → `-600` / `bg-[#1D9E75]`・`bg-red-500` は維持
- HamburgerMenu は arobix nav 仕様（dark `#1b1a23` + 白文字）として維持
- 緑/赤/グラデのボタン上の `text-white` は維持

### 変換ファイル（13）
home(page.tsx) + DepositPanel / AccountPanel / ReferralPanel / TaxPanel / TxHistoryPanel / MyWalletPanel / NotificationPanel / OpModePanel / TermsPanel / ChatPanel / HamburgerMenu / SlideUpPanel

## DoD
- `tsc --noEmit`: **0 errors**（全ファイル）
- dark クラス残存: **0**
- `npm run build`: ⚠️ **ローカル未実行** — 作業中に共有 `node_modules/next` が別プロセスにより削除され build 不能。変更は純粋な色クラス置換（import/logic/依存 変更なし）かつ tsc クリーンのため build リスクは極小。**CI と staging デプロイで検証要**。

## レビュー（重要）
- 反映には frontend 再ビルド/デプロイが必要（本番フロントは stale）。
- `deploy_staging.sh` は main 固定のため、本ブランチの staging プレビューは「main マージ後に staging デプロイ」で確認する想定。
- PWA キャッシュのため、確認時はハードリロード推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)