### PR TITLE
fix(wiring): yield_optimizer router を main.py に登録 (#750 配線漏れ)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -94,6 +94,7 @@ from app.users.router import router as users_router
 from app.users.settings_router import router as user_settings_router
 from app.users.withdrawals_router import router as user_withdrawals_router
 from app.webhook.router import router as webhook_router
+from app.yield_optimizer.router import router as yield_optimizer_router
 
 logger = logging.getLogger(__name__)
 # Ensure app.* loggers output at INFO level regardless of root logger config
@@ -277,6 +278,9 @@ def create_app() -> FastAPI:
     app.include_router(admin_users_router)  # Admin Users API
     app.include_router(proposals_router)  # Proposals API
     app.include_router(portfolio_router)  # Portfolio History API
+    app.include_router(
+        yield_optimizer_router
+    )  # Yield Optimizer (Privy Earn / Morpho) — #750 配線漏れ修正
     app.include_router(user_settings_router)  # User Settings API
     # P4 withdraw EP は money を動かす経路のため default-off で配線ガードする。
     # ENABLE_WITHDRAWALS=1/true のときのみ route 登録。未登録時 POST /api/users/withdrawals=404

--- a/docs/integration/backend_deps.md
+++ b/docs/integration/backend_deps.md
@@ -5,6 +5,19 @@
 
 ---
 
+## PR #763 (yield optimizer 配線漏れ修正): yield_optimizer_router 配線 (2026-06-16)
+
+### 変更: yield_optimizer_router を main.py に include_router
+- **対象凍結ファイル**: `backend/app/main.py`
+- **変更内容**:
+  - `from app.yield_optimizer.router import router as yield_optimizer_router` を import 追加
+  - `app.include_router(yield_optimizer_router)` を追加（自前 prefix `/api/yield-optimizer`、portfolio_router と同型）
+- **理由**: #750（Privy Earn / Morpho yield optimizer）が router を追加したが main.py への include_router を忘れた孤立 router。`launch_gate` L5（wiring lint）が検知して本番デプロイを BLOCK していたため配線を補完する。
+- **影響範囲**: ルーター登録のみ。起動シーケンス・既存エンドポイントへの影響なし。`/api/yield-optimizer/*` が有効化される。
+- **承認**: fix/yield-optimizer-router-wiring → main の通常フロー経由（PR #763）
+
+---
+
 ## PR #581 (admin users API): admin_users_router 配線 (2026-06-08)
 
 ### 変更: admin_users_router を main.py に include_router


### PR DESCRIPTION
## 概要
#750（Privy Earn / Morpho yield optimizer）が `yield_optimizer/router.py` を追加したが **`main.py` に `include_router` し忘れ**ていた孤立 router。`launch_gate` L5（wiring lint）がこれを検知し、本番デプロイを BLOCK していた。

## 変更（`backend/app/main.py`）
- import: `from app.yield_optimizer.router import router as yield_optimizer_router`
- 登録: `app.include_router(yield_optimizer_router)`（router は自前 prefix `/api/yield-optimizer` を持つため追加 prefix なし、portfolio_router と同型）

## DoD
- `ruff check`: All checks passed（import 順 isort 修正済み）
- `ruff format --check`: clean
- `py_compile`: OK

## 効果
- launch_gate L5 の「孤立 router 疑い」が解消 → 次回バックエンドフルデプロイで Gate 通過
- `/api/yield-optimizer/*` エンドポイントが有効化

## 背景
本日の frontend-only デプロイ時、L5 がこの孤立を検知して BLOCK。frontend は `SKIP_LAUNCH_GATE=1` で出したが、バックエンドフルデプロイ前に本修正が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)