### PR TITLE
fix(liff-chat): ヘッダーロゴを中央配置

### DIFF
--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -168,10 +168,10 @@ export default function LiffChatPage() {
     <div className="w-[375px] mx-auto h-dvh ax-bg-app text-[#1c1a27] flex flex-col overflow-hidden relative">
 
       {/* ── ヘッダー（arobix グラデ） */}
-      <header className="h-14 bg-gradient-to-r from-[#b9a4f2] via-[#ecaccd] to-[#fbd9a0] flex items-center justify-between px-4 flex-shrink-0">
+      <header className="h-14 bg-gradient-to-r from-[#b9a4f2] via-[#ecaccd] to-[#fbd9a0] grid grid-cols-3 items-center px-4 flex-shrink-0">
         <button
           onClick={() => { setMenuOpen(true); track(EV.MENU_OPEN) }}
-          className="text-[#1c1a27] p-1 hover:bg-black/5 rounded-lg transition-colors"
+          className="text-[#1c1a27] p-1 hover:bg-black/5 rounded-lg transition-colors justify-self-start"
           aria-label={t("header.menuAriaLabel")}
         >
           <Menu className="w-6 h-6" />
@@ -181,7 +181,7 @@ export default function LiffChatPage() {
           height="36"
           viewBox="0 0 100 100"
           aria-label={t("header.logoAriaLabel")}
-          className="flex-shrink-0"
+          className="flex-shrink-0 justify-self-center"
         >
           {/* ベゼル: フラットグレー */}
           <circle cx="50" cy="50" r="49" fill="#CCCCCC" />
@@ -201,7 +201,7 @@ export default function LiffChatPage() {
             />
           </g>
         </svg>
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-1 justify-self-end">
           {/* JP/EN トグルボタン */}
           <button
             onClick={() => { const next = language === "ja" ? "en" : "ja"; setLanguage(next); track(EV.LANGUAGE_TOGGLE, { language: next }) }}


### PR DESCRIPTION
## 概要
liff-chat ヘッダーのロゴが**左寄り**になっていたのを**中央配置**に修正。

## 原因
ヘッダーが `flex items-center justify-between` だったため、右グループ（EN トグル + 人アイコン）が左（ハンバーガー単体）より広く、中央要素のロゴが左へ押されていた。

## 修正
`grid grid-cols-3 items-center` + `justify-self-*` に変更:
- ハンバーガー → `justify-self-start`（左）
- ロゴ SVG → `justify-self-center`（**中央固定**）
- EN/人アイコン → `justify-self-end`（右）

3等分グリッドの中央列にロゴを置くため、左右グループの幅に関係なくロゴが**真ん中**に来る。

## DoD
- `tsc --noEmit`: 0 errors
- page.tsx は凍結ファイル外（Path Access Control 対象外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)