### PR TITLE
fix(staging): watchdog image欠落を毎回Slack通知 + deployログ永続化

### DIFF
--- a/scripts/deploy_staging.sh
+++ b/scripts/deploy_staging.sh
@@ -51,12 +51,14 @@ FRONTEND_PORT=3001
 
 UPSTREAM_CONF="${PROJECT_ROOT}/docker/nginx/upstream.staging.conf"
 LOCK_FILE="${PROJECT_ROOT}/.deploy-staging.lock"
+LOG_FILE="${PROJECT_ROOT}/logs/deploy_staging.log"
 
 # ───────────────────────────────────────────────
 # ヘルパー
 # ───────────────────────────────────────────────
-log()  { echo "[deploy-staging] $*"; }
-err()  { echo "[deploy-staging] ERROR: $*" >&2; }
+mkdir -p "$(dirname "${LOG_FILE}")"
+log()  { echo "[deploy-staging] $*" | tee -a "${LOG_FILE}"; }
+err()  { echo "[deploy-staging] ERROR: $*" | tee -a "${LOG_FILE}" >&2; }
 
 slack_notify() {
   local msg="$1"

--- a/scripts/staging-watchdog.sh
+++ b/scripts/staging-watchdog.sh
@@ -82,7 +82,8 @@ for img in $(docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" config
 done
 if [[ -n "${missing}" ]]; then
   echo "${LOG_PREFIX} ABORT: 必須 image 欠落 →${missing}. build は誘発せず手動対応待ち。"
-  [[ "${should_notify}" == "1" ]] && notify_slack "❌ [staging-watchdog] image 欠落で自動復旧を中止(build抑止):${missing}。手動 build が必要。"
+  # image 欠落は自動復旧不可なので cooldown に関わらず毎回通知する
+  notify_slack "❌ [staging-watchdog] image 欠落で自動復旧を中止(build抑止):${missing}。手動で deploy_staging.sh を実行してください。"
   exit 1
 fi
 


### PR DESCRIPTION
## 概要

staging 運用改善 2点。元は `feat/posthog-event-coverage`（PR #734 で本体マージ済み）に取り残されていた watchdog 修正 `458a1f22` を、最新 main 上に cherry-pick して救出したもの。

## 変更内容

### `scripts/staging-watchdog.sh`
- **image 欠落時の Slack 通知を cooldown 関係なく毎回送る**ように変更
- 背景: image 欠落は自動復旧不可（build 抑止）なので、COOLDOWN による通知抑制で 502 検出が遅延する事故の再発防止
- 通知文も「手動で deploy_staging.sh を実行してください」に明確化

### `scripts/deploy_staging.sh`
- deploy ログを `logs/deploy_staging.log` に永続保存（`tee -a`）
- 背景: 従来 stdout のみで `/tmp` 等に流れて消えていた問題の解消

## 影響範囲
- staging 運用スクリプトのみ。production / アプリコードへの影響なし
- v3 / v4 いずれの staging 運用にも有用（環境分離と無関係）

## テスト
- shell スクリプトのみ・ロジック追加なし（通知条件の緩和 + ログ追記）

🤖 Generated with [Claude Code](https://claude.com/claude-code)