### PR TITLE
feat(staging-v4): v4 開発検証用 staging 環境の雛形（4サービス軽量構成）

### DIFF
--- a/.env.staging-v4.example
+++ b/.env.staging-v4.example
@@ -1,0 +1,127 @@
+# Ultra AutoTrade — v4 Staging Environment Variables
+# Copy to .env.staging-v4 and fill in actual values
+# NEVER commit .env.staging-v4 to git!
+#
+# 2026-06-16 新設 (Asana 1215740593437797):
+#   v4 staging = v3 staging (.env.staging-new) とは完全独立した 3 つ目のスタック。
+#   軽量構成 (4 サービス / single backend, blue/green・loki・promtail なし)。
+#   Shadow Mode専用 / Base Sepoliaテストネット / 完全独立DB (ultra_autotrade_staging_v4)。
+#   ポート: frontend 3002 / nginx 8083 / backend 8030 / postgres 5434
+
+# =============================================================================
+# 環境識別
+# =============================================================================
+APP_ENV=staging
+COMPOSE_PROJECT_NAME=ultra-autotrade-staging-v4
+
+# =============================================================================
+# Shadow Mode（実トレード禁止 — Staging必須設定）
+# =============================================================================
+AI_SHADOW_MODE=true
+REBALANCE_SHADOW_MODE=true
+
+# =============================================================================
+# Database（production / v3 staging とは完全独立 — ultra_autotrade_staging_v4）
+# =============================================================================
+POSTGRES_USER=ultra
+POSTGRES_PASSWORD=CHANGE_ME_STAGING_V4_PASSWORD
+POSTGRES_DB=ultra_autotrade_staging_v4
+# DATABASE_URL は docker-compose.staging-v4.yml で自動設定
+# ローカル接続: postgresql://ultra:password@localhost:5434/ultra_autotrade_staging_v4
+
+# =============================================================================
+# CORS / URL（Cloudflare ダッシュボードで staging-v4 サブドメインを ingress 登録後に有効化）
+# =============================================================================
+CORS_ORIGINS=https://staging-v4.ultra-auto-trade.com,http://localhost:3002
+NEXT_PUBLIC_API_BASE_URL=https://api-staging-v4.ultra-auto-trade.com
+NEXT_PUBLIC_API_URL=https://api-staging-v4.ultra-auto-trade.com
+
+# =============================================================================
+# AI / LLM（productionと同じキーでも動作可。長期的には分離推奨）
+# =============================================================================
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
+PERPLEXITY_API_KEY=pplx-...
+# Claude model names — must match VALID_CLAUDE_MODELS in backend/app/ai/config.py
+AI_CLAUDE_MODEL=claude-sonnet-4-6
+AI_FALLBACK_MODEL=claude-haiku-4-5-20251001
+
+# =============================================================================
+# Exchange（Bybit Sandbox必須）
+# =============================================================================
+BYBIT_API_KEY=...
+BYBIT_API_SECRET=...
+BYBIT_SANDBOX=true
+EXCHANGE_CLIENT_TYPE=bybit
+EXCHANGE_SANDBOX=true
+
+# =============================================================================
+# Aave V3（Base Sepolia テストネット）
+# TODO: production / v3 staging とは物理的に異なる秘密鍵を使用すること (§13)
+# =============================================================================
+AAVE_NETWORK=base-sepolia
+AAVE_RPC_URL=https://base-sepolia.g.alchemy.com/v2/YOUR_KEY
+CHAIN_ID=84532
+AAVE_POOL_ADDRESS=0x...  # Base Sepolia Aave V3 Pool
+AAVE_USDC_ADDRESS=0x...  # Base Sepolia USDC
+AAVE_WALLET_PRIVATE_KEY=0x...TESTNET_ONLY_NEVER_PRODUCTION_KEY...
+AAVE_WALLET_ADDRESS=0x...PUBLIC_ADDRESS...
+AAVE_CLIENT_TYPE=dummy
+AAVE_MAX_SINGLE_TRADE_USD=10.0
+AAVE_MIN_HEALTH_FACTOR=1.6
+AAVE_STATE_FILE_PATH=/var/run/ultra/state.json
+AAVE_MAX_PRICE_DEVIATION_PCT=2.0
+
+# =============================================================================
+# Auth (JWT)
+# =============================================================================
+JWT_SECRET_KEY=CHANGE_ME_STAGING_V4_RANDOM_SECRET
+JWT_ALGORITHM=HS256
+JWT_ACCESS_TOKEN_EXPIRE_MINUTES=1440
+
+# =============================================================================
+# 内部API認証
+# =============================================================================
+INTERNAL_API_TOKEN=CHANGE_ME_STAGING_V4_INTERNAL_TOKEN
+
+# =============================================================================
+# Monitoring & Notifications
+# =============================================================================
+ENABLE_BACKGROUND_MONITORING=1
+ENABLE_DAILY_REPORTS=1
+ENABLE_WEEKLY_REPORTS=1
+MONITORING_INTERVAL_SECONDS=60
+SLACK_WEBHOOK_URL=
+
+# =============================================================================
+# フロントエンド（ビルド時埋め込み）
+# NEXT_PUBLIC_PRIVY_APP_ID は staging-v4.ultra-auto-trade.com を Privy の
+# Allowed Origins に追加すること。未設定/placeholder は deploy 前ガードで弾かれる。
+# =============================================================================
+NEXT_PUBLIC_PRIVY_APP_ID=<privy-app-id>
+NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=
+NEXT_PUBLIC_DEFAULT_CHAIN=base-sepolia
+NEXT_PUBLIC_DEFAULT_CHAIN_ID=84532
+NEXT_PUBLIC_BASE_SEPOLIA_RPC=https://base-sepolia.g.alchemy.com/v2/YOUR_KEY
+NEXT_PUBLIC_PUBLIC_REGISTRATION_ENABLED=false
+# v4 機能検証用 (LINE Mini App)。LIFF ID 未設定時は PWA モードで起動する。
+NEXT_PUBLIC_LIFF_ID=
+# PostHog (任意。版間比較用に app_version は deploy script が git SHA を自動埋め込み)
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
+# =============================================================================
+# Fee Transfer (Non-Custodial / Operator Fee)
+# 実値は絶対にここに記載しない — .env.staging-v4 のみに設定すること (§13)
+# staging ではテストネット専用ウォレットの秘密鍵を使用すること
+# =============================================================================
+FEE_TRANSFER_ENABLED=false
+OPERATOR_FEE_WALLET_KEY=0xYOUR_STAGING_V4_OPERATOR_FEE_WALLET_PRIVATE_KEY_HERE
+
+# =============================================================================
+# Cloudflare
+# CLOUDFLARE_TUNNEL_TOKEN: staging-v4 のトンネル ingress は --token 方式のため
+# Cloudflare ダッシュボードで管理。staging-v4.ultra-auto-trade.com → localhost:8083,
+# api-staging-v4.ultra-auto-trade.com → localhost:8083 を追加すること。
+# =============================================================================
+# CLOUDFLARE_TUNNEL_TOKEN=

--- a/docker-compose.staging-v4.yml
+++ b/docker-compose.staging-v4.yml
@@ -1,0 +1,211 @@
+version: "3.9"
+
+# ============================================================
+# docker-compose.staging-v4.yml
+# v4 開発検証用 Staging 環境（staging-v4.ultra-auto-trade.com / api-staging-v4）
+#
+# 設計方針 (2026-06-16 新設 / Asana 1215740593437797):
+#   - v3 staging (docker-compose.staging.yml) とは完全に独立した 3 つ目のスタック。
+#     v3 は今後も修正が出るため維持し、v4 は別環境で並行開発・検証する。
+#   - 【軽量構成 = 4 サービス】 postgres / backend(single) / nginx / frontend
+#       省くもの: blue/green (backend 2 本目) / loki / promtail
+#       理由: VPS RAM 空き ~3.1Gi に 3 つ目のフルスタック(7 サービス)は OOM リスク。
+#             v4 staging は zero-downtime 不要・ログは `docker logs` で十分なので
+#             運用機能(blue/green・ログ集約)を省いて ~1Gi に収める。機能開発・検証は
+#             全て single backend で可能(機能数 ≠ コンテナ数)。
+#   - Shadow Mode 専用 (AI_SHADOW_MODE=true / REBALANCE_SHADOW_MODE=true)
+#   - Base Sepolia テストネット (AAVE_NETWORK=base-sepolia)
+#   - 完全独立 DB (ultra_autotrade_staging_v4)
+#   - port は production / v3 staging と衝突しないよう 127.0.0.1 バインドで分離:
+#       frontend: 127.0.0.1:3002  (prod 3000 / v3 staging 3001)
+#       nginx   : 127.0.0.1:8083  (prod 8080 / v3 staging 8082)
+#       backend : 127.0.0.1:8030  (prod 8010/8011 / v3 staging 8020/8021)
+#       postgres: 127.0.0.1:5434  (prod 5432 / v3 staging 5433)
+#
+# デプロイ: scripts/deploy_staging_v4.sh
+# 環境変数: .env.staging-v4  (テンプレート: .env.staging-v4.example)
+# COMPOSE_PROJECT_NAME: ultra-autotrade-staging-v4  (.env.staging-v4 に定義)
+#
+# NOTE: ログ集約 (loki/promtail) は持たない。全サービス json-file logging で
+#       `docker logs <container>` で参照する。必要になったら後付けで loki を追加可能。
+# ============================================================
+
+volumes:
+  postgres-data-staging-v4:
+    name: ultra-autotrade-staging-v4_postgres-data
+    driver: local
+  ultra-state-staging-v4:
+    name: ultra-autotrade-staging-v4_ultra-state
+    driver: local
+  ultra-log-staging-v4:
+    name: ultra-autotrade-staging-v4_ultra-log
+    driver: local
+  nginx-log-staging-v4:
+    name: ultra-autotrade-staging-v4_nginx-log
+    driver: local
+
+networks:
+  staging-v4-net:
+    name: ultra-autotrade-staging-v4_default
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: ultra-autotrade-postgres-staging-v4
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-ultra}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-ultra_autotrade_staging_v4}
+    ports:
+      - "127.0.0.1:5434:5432"
+    volumes:
+      - postgres-data-staging-v4:/var/lib/postgresql/data
+    restart: always
+    mem_limit: 512m
+    memswap_limit: 512m
+    networks:
+      - staging-v4-net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-ultra} -d ${POSTGRES_DB:-ultra_autotrade_staging_v4}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  # ===== Init: backend volume permissions =====
+  # state.json 書込のため named volume を appuser(UID=10001) 所有に揃える。
+  # (docker-compose.staging.yml と同型。idempotent で数百 ms。)
+  backend-volume-init:
+    image: alpine:3.19
+    container_name: ultra-autotrade-backend-volume-init-staging-v4
+    command: ["chown", "-R", "10001:10001", "/var/run/ultra", "/var/log/ultra-autotrade"]
+    volumes:
+      - ultra-state-staging-v4:/var/run/ultra
+      - ultra-log-staging-v4:/var/log/ultra-autotrade
+    restart: "no"
+    networks:
+      - staging-v4-net
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1m"
+        max-file: "1"
+
+  # ===== Single Backend =====
+  # v3 staging の blue/green と異なり 1 本のみ。再デプロイ時は数秒のダウンを許容する
+  # (v4 staging は zero-downtime 不要)。host port 8030 は内部検証 (/health 直接ポーリング) 用。
+  backend:
+    container_name: ultra-autotrade-backend-staging-v4
+    build:
+      context: .
+      dockerfile: Dockerfile
+    working_dir: /app/backend
+    command: >
+      sh -c "uvicorn app.main:app
+      --host 0.0.0.0
+      --port 8000
+      --log-level info"
+    env_file:
+      - .env.staging-v4
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-ultra}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ultra_autotrade_staging_v4}
+      AI_SHADOW_MODE: "true"
+      # single backend のため blue/green scheduler ガードは不要。
+      # ACTIVE_BACKEND_COLOR を空にして「自分が active」と扱わせる従来挙動と互換にする。
+      BACKEND_COLOR: "blue"
+      ACTIVE_BACKEND_COLOR: ${ACTIVE_BACKEND_COLOR:-blue}
+    mem_limit: ${BACKEND_MEM_LIMIT:-768m}
+    memswap_limit: ${BACKEND_MEM_LIMIT:-768m}
+    ports:
+      - "127.0.0.1:8030:8000"
+    volumes:
+      - ultra-state-staging-v4:/var/run/ultra:rw
+      - ./backend/data:/app/backend/data:rw
+      - ultra-log-staging-v4:/var/log/ultra-autotrade
+    depends_on:
+      postgres:
+        condition: service_healthy
+      backend-volume-init:
+        condition: service_completed_successfully
+    restart: always
+    networks:
+      - staging-v4-net
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  # ===== Reverse Proxy =====
+  # nginx.conf は production/staging と共有。upstream.staging-v4.conf を
+  # /etc/nginx/conf.d/upstream.conf にマウントし single backend を指す。
+  # 127.0.0.1:8083 にバインド (prod 8080 / v3 staging 8082 と分離)。
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: ultra-autotrade-nginx-staging-v4
+    ports:
+      - "127.0.0.1:8083:8080"
+    volumes:
+      - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./docker/nginx/upstream.staging-v4.conf:/etc/nginx/conf.d/upstream.conf:rw
+      - nginx-log-staging-v4:/var/log/nginx
+    depends_on:
+      - backend
+    restart: always
+    mem_limit: 64m
+    memswap_limit: 64m
+    networks:
+      - staging-v4-net
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  frontend:
+    container_name: ultra-autotrade-frontend-staging-v4
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-https://api-staging-v4.ultra-auto-trade.com}
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-https://api-staging-v4.ultra-auto-trade.com}
+        NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID:-}
+        NEXT_PUBLIC_DEFAULT_CHAIN: ${NEXT_PUBLIC_DEFAULT_CHAIN:-}
+        NEXT_PUBLIC_DEFAULT_CHAIN_ID: ${NEXT_PUBLIC_DEFAULT_CHAIN_ID:-84532}
+        NEXT_PUBLIC_MAINNET_RPC: ${NEXT_PUBLIC_MAINNET_RPC:-}
+        NEXT_PUBLIC_ARBITRUM_ONE_RPC: ${NEXT_PUBLIC_ARBITRUM_ONE_RPC:-}
+        NEXT_PUBLIC_ARBITRUM_SEPOLIA_RPC: ${NEXT_PUBLIC_ARBITRUM_SEPOLIA_RPC:-}
+        NEXT_PUBLIC_BASE_RPC: ${NEXT_PUBLIC_BASE_RPC:-}
+        NEXT_PUBLIC_BASE_SEPOLIA_RPC: ${NEXT_PUBLIC_BASE_SEPOLIA_RPC:-}
+        NEXT_PUBLIC_OPTIMISM_RPC: ${NEXT_PUBLIC_OPTIMISM_RPC:-}
+        NEXT_PUBLIC_VAPID_PUBLIC_KEY: ${NEXT_PUBLIC_VAPID_PUBLIC_KEY:-}
+        NEXT_PUBLIC_LIFF_ID: ${NEXT_PUBLIC_LIFF_ID:-}
+        NEXT_PUBLIC_PRIVY_APP_ID: ${NEXT_PUBLIC_PRIVY_APP_ID:-}
+        NEXT_PUBLIC_POSTHOG_KEY: ${NEXT_PUBLIC_POSTHOG_KEY:-}
+        NEXT_PUBLIC_POSTHOG_HOST: ${NEXT_PUBLIC_POSTHOG_HOST:-https://us.i.posthog.com}
+        NEXT_PUBLIC_APP_VERSION: ${NEXT_PUBLIC_APP_VERSION:-dev}
+        # Next.js ビルド OOM 対策 (CLAUDE.md §2026-05-19 GID 1214828243363427)
+        NODE_BUILD_MAX_OLD_SPACE_SIZE: ${NODE_BUILD_MAX_OLD_SPACE_SIZE:-4096}
+    environment:
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-https://api-staging-v4.ultra-auto-trade.com}
+      # SSR は Docker ネットワーク内の nginx (内部ポート 8080) 経由で backend に到達。
+      BACKEND_BASE_URL: ${BACKEND_BASE_URL:-http://nginx:8080}
+    ports:
+      - "127.0.0.1:3002:3000"
+    depends_on:
+      - nginx
+    restart: always
+    mem_limit: 512m
+    memswap_limit: 512m
+    networks:
+      - staging-v4-net
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/docker/nginx/upstream.staging-v4.conf
+++ b/docker/nginx/upstream.staging-v4.conf
@@ -1,0 +1,1 @@
+set $backend backend:8000;

--- a/scripts/deploy_staging_v4.sh
+++ b/scripts/deploy_staging_v4.sh
@@ -1,0 +1,313 @@
+#!/bin/bash
+set -euo pipefail
+
+# ───────────────────────────────────────────────
+# -v / --volumes フラグ誤使用防止ガード
+# ───────────────────────────────────────────────
+for _arg in "$@"; do
+  if [[ "$_arg" == "-v" || "$_arg" == "--volumes" ]]; then
+    echo "❌ ERROR: -v / --volumes フラグは禁止です。DBボリュームが削除されます。"
+    echo "   down のみ使用してください: docker compose ... down"
+    exit 1
+  fi
+done
+
+# Ultra AutoTrade – v4 staging ワンショットデプロイスクリプト
+# (2026-06-16 新設 / Asana 1215740593437797)
+#
+# 対象環境: staging-v4.ultra-auto-trade.com / api-staging-v4.ultra-auto-trade.com
+# 【軽量構成 = 4 サービス / single backend】
+#   v3 staging (deploy_staging.sh) と異なり blue/green を持たない。再デプロイ時の
+#   数秒のダウンを許容する (v4 staging は zero-downtime 不要)。
+# Shadow Mode専用 (AI_SHADOW_MODE=true / REBALANCE_SHADOW_MODE=true)
+# ポート: frontend 127.0.0.1:3002 / nginx 127.0.0.1:8083 / backend 127.0.0.1:8030 / postgres 127.0.0.1:5434
+#
+# 使い方:
+#   ./scripts/deploy_staging_v4.sh                  # フルデプロイ
+#   ./scripts/deploy_staging_v4.sh --frontend-only  # フロントエンドのみ
+#   ./scripts/deploy_staging_v4.sh --backend-only   # バックエンドのみ再ビルド＆再起動
+#   ./scripts/deploy_staging_v4.sh --no-build       # ビルドなし（up -d のみ）
+#   ./scripts/deploy_staging_v4.sh --help
+
+# ───────────────────────────────────────────────
+# 定数
+# ───────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+COMPOSE_FILE="docker-compose.staging-v4.yml"
+ENV_FILE=".env.staging-v4"
+FRONTEND_CONTAINER="ultra-autotrade-frontend-staging-v4"
+BACKEND_CONTAINER="ultra-autotrade-backend-staging-v4"
+NGINX_CONTAINER="ultra-autotrade-nginx-staging-v4"
+POSTGRES_CONTAINER="ultra-autotrade-postgres-staging-v4"
+HEALTH_TIMEOUT=60
+
+BACKEND_PORT=8030
+NGINX_PORT=8083
+FRONTEND_PORT=3002
+
+LOCK_FILE="${PROJECT_ROOT}/.deploy-staging-v4.lock"
+LOG_FILE="${PROJECT_ROOT}/logs/deploy_staging_v4.log"
+
+# ───────────────────────────────────────────────
+# ヘルパー
+# ───────────────────────────────────────────────
+mkdir -p "$(dirname "${LOG_FILE}")"
+log()  { echo "[deploy-staging-v4] $*" | tee -a "${LOG_FILE}"; }
+err()  { echo "[deploy-staging-v4] ERROR: $*" | tee -a "${LOG_FILE}" >&2; }
+
+slack_notify() {
+  local msg="$1"
+  if [[ -n "${SLACK_WEBHOOK_URL:-}" ]]; then
+    curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+      -H "Content-Type: application/json" \
+      -d "{\"text\": \"${msg}\"}" >/dev/null || true
+  fi
+}
+
+show_help() {
+  cat <<'EOF'
+deploy_staging_v4.sh — Ultra AutoTrade v4 staging デプロイ（軽量 single backend 構成）
+
+使い方:
+  ./scripts/deploy_staging_v4.sh [OPTIONS]
+
+オプション:
+  --frontend-only   フロントエンドのみリビルド＆再起動
+  --backend-only    バックエンドのみリビルド＆再起動（数秒のダウンあり）
+  --no-build        ビルドなしで up -d のみ実行
+  --help            このヘルプを表示
+
+注意:
+  - git root から実行すること
+  - .env.staging-v4 が同ディレクトリに存在していること（テンプレート: .env.staging-v4.example）
+  - Shadow Mode (AI_SHADOW_MODE=true) が必須
+  - ポート: frontend 3002 / nginx 8083 / backend 8030 / postgres 5434
+EOF
+  exit 0
+}
+
+resolve_dc() {
+  if docker compose version >/dev/null 2>&1; then
+    echo "docker compose"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    echo "docker-compose"
+  else
+    err "docker compose または docker-compose が見つかりません"
+    exit 1
+  fi
+}
+
+wait_healthy() {
+  local url="$1"
+  local label="$2"
+  local deadline=$(( $(date +%s) + HEALTH_TIMEOUT ))
+
+  log "ヘルスチェック待ち: ${label} (最大 ${HEALTH_TIMEOUT}s)"
+  while true; do
+    if curl -sf --max-time 3 "${url}" >/dev/null 2>&1; then
+      log "${label} OK"
+      return 0
+    fi
+    if [[ $(date +%s) -ge ${deadline} ]]; then
+      err "${label} がタイムアウトしました (${url})"
+      return 1
+    fi
+    sleep 3
+  done
+}
+
+# ───────────────────────────────────────────────
+# 引数パース
+# ───────────────────────────────────────────────
+FRONTEND_ONLY=false
+BACKEND_ONLY=false
+NO_BUILD=false
+
+for arg in "$@"; do
+  case "${arg}" in
+    --frontend-only) FRONTEND_ONLY=true ;;
+    --backend-only)  BACKEND_ONLY=true ;;
+    --no-build)      NO_BUILD=true ;;
+    --help)          show_help ;;
+    *) err "不明なオプション: ${arg}"; exit 1 ;;
+  esac
+done
+
+# ───────────────────────────────────────────────
+# 前提チェック
+# ───────────────────────────────────────────────
+cd "${PROJECT_ROOT}"
+log "project root: ${PROJECT_ROOT}"
+
+if [[ ! -f "${COMPOSE_FILE}" ]]; then
+  err "${COMPOSE_FILE} が見つかりません（${PROJECT_ROOT}）"
+  exit 1
+fi
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  err "${ENV_FILE} が見つかりません — デプロイを中止します（テンプレート: ${ENV_FILE}.example）"
+  exit 1
+fi
+
+# === デプロイの同時実行排除 (flock) ===
+exec 200>"${LOCK_FILE}"
+if ! flock -n 200; then
+  err "別のデプロイが進行中です: ${LOCK_FILE}"
+  exit 1
+fi
+
+# Shadow Mode チェック（staging必須）
+SHADOW_CHECK=$(grep "^AI_SHADOW_MODE=" "${ENV_FILE}" | cut -d= -f2 | tr -d '"' | tr -d "'" || echo "")
+if [[ "${SHADOW_CHECK}" != "true" ]]; then
+  err "AI_SHADOW_MODE=true が ${ENV_FILE} に設定されていません。"
+  err "Staging環境ではShadow Modeが必須です。デプロイを中止します。"
+  exit 1
+fi
+log "✅ Shadow Mode確認: AI_SHADOW_MODE=${SHADOW_CHECK}"
+
+DC=$(resolve_dc)
+log "docker compose コマンド: ${DC}"
+
+# ───────────────────────────────────────────────
+# 共通ステップ
+# ───────────────────────────────────────────────
+log "git pull origin main"
+git pull origin main
+
+log "${ENV_FILE} を読み込み（ビルド ARG 用）"
+# shellcheck disable=SC2046
+export $(grep -v '^#' "${ENV_FILE}" | grep '=' | xargs)
+
+# デプロイ版識別子: PostHog の app_version に git short SHA を埋め込む。
+export NEXT_PUBLIC_APP_VERSION="$(git rev-parse --short HEAD 2>/dev/null || echo dev)"
+log "NEXT_PUBLIC_APP_VERSION=${NEXT_PUBLIC_APP_VERSION} を frontend build ARG に埋め込み"
+
+# ───────────────────────────────────────────────
+# 失敗時ハンドラ
+# ───────────────────────────────────────────────
+on_failure() {
+  err "デプロイ失敗。コンテナログ末尾:"
+  ${DC} -f "${COMPOSE_FILE}" logs --tail=20 2>/dev/null || true
+  slack_notify "❌ [deploy_staging_v4.sh] v4 Stagingデプロイ失敗\n原因: ヘルスチェックタイムアウトまたはビルドエラー"
+  exit 1
+}
+trap on_failure ERR
+
+# ───────────────────────────────────────────────
+# モード別デプロイ
+# ───────────────────────────────────────────────
+if "${FRONTEND_ONLY}"; then
+  log "フロントエンドのみデプロイ (v4 staging)"
+
+  ${DC} -f "${COMPOSE_FILE}" stop frontend
+  docker rm -f "${FRONTEND_CONTAINER}" 2>/dev/null || true
+
+  if ! "${NO_BUILD}"; then
+    log "frontend をビルド中..."
+    ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" build --no-cache frontend
+    log "古いビルドキャッシュを削除（1時間以上前のエントリ）..."
+    docker builder prune --filter until=1h -f 2>/dev/null || true
+  fi
+
+  ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" \
+    up -d --no-deps --force-recreate frontend
+
+  wait_healthy "http://127.0.0.1:${FRONTEND_PORT}" "frontend(staging-v4)" || on_failure
+
+elif "${BACKEND_ONLY}"; then
+  log "バックエンドのみデプロイ (v4 staging / 数秒のダウンあり)"
+
+  if ! "${NO_BUILD}"; then
+    log "backend をビルド中..."
+    ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" build backend
+  fi
+
+  ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" \
+    up -d --no-deps --force-recreate backend
+
+  wait_healthy "http://127.0.0.1:${BACKEND_PORT}/health"  "backend (direct)" || on_failure
+  wait_healthy "http://127.0.0.1:${NGINX_PORT}/health"    "nginx → backend"  || on_failure
+
+else
+  log "フルデプロイ開始（v4 Staging環境 / 4 サービス軽量構成）"
+
+  log "孤立コンテナを含めて停止・削除"
+  ${DC} -f "${COMPOSE_FILE}" down --remove-orphans
+
+  # staging-v4 コンテナのみ強制削除
+  docker rm -f $(docker ps -aq --filter "name=ultra-autotrade.*staging-v4") 2>/dev/null || true
+
+  if ! "${NO_BUILD}"; then
+    log "frontend / backend をビルド中..."
+    ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" build --no-cache frontend
+    ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" build backend
+
+    log "古いビルドキャッシュを削除（1時間以上前のエントリ）..."
+    docker builder prune --filter until=1h -f 2>/dev/null || true
+  fi
+
+  log "全サービスを起動 (postgres → backend → nginx → frontend)"
+  ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" up -d
+
+  wait_healthy "http://127.0.0.1:${BACKEND_PORT}/health"  "backend (direct)" || on_failure
+  wait_healthy "http://127.0.0.1:${NGINX_PORT}/health"    "nginx → backend"  || on_failure
+  wait_healthy "http://127.0.0.1:${FRONTEND_PORT}"        "frontend(staging-v4)" || on_failure
+fi
+
+# ───────────────────────────────────────────────
+# Shadow Mode確認（デプロイ後）
+# ───────────────────────────────────────────────
+if ! "${FRONTEND_ONLY}"; then
+  log "Shadow Mode最終確認 + スケジューラー状態チェック..."
+  HEALTH_JSON=$(curl -sf --max-time 5 "http://127.0.0.1:${NGINX_PORT}/health" 2>/dev/null || echo '{}')
+  log "health: ${HEALTH_JSON}"
+
+  SCHED_HEALTHY=$(echo "${HEALTH_JSON}" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('scheduler_healthy','unknown'))" 2>/dev/null || echo "unknown")
+  if [ "${SCHED_HEALTHY}" = "False" ] || [ "${SCHED_HEALTHY}" = "false" ]; then
+    log "⚠️  WARNING: scheduler_healthy=false — スケジューラーが overdue 状態です"
+  elif [ "${SCHED_HEALTHY}" = "unknown" ]; then
+    log "⚠️  WARNING: /health からスケジューラー状態を取得できませんでした"
+  else
+    log "scheduler_healthy=${SCHED_HEALTHY} ✓"
+  fi
+
+  SCHED_LAST_ERROR=$(echo "${HEALTH_JSON}" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('scheduler_last_error') or '')" 2>/dev/null || echo "")
+  if [ -n "${SCHED_LAST_ERROR}" ]; then
+    log "⚠️  WARNING: scheduler_last_error 検出: ${SCHED_LAST_ERROR}"
+  else
+    log "scheduler_last_error=なし ✓"
+  fi
+fi
+
+# ───────────────────────────────────────────────
+# 最終ヘルスチェック
+# ───────────────────────────────────────────────
+log "=== 最終ヘルスチェック ==="
+
+if ! "${FRONTEND_ONLY}"; then
+  BE_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://127.0.0.1:${NGINX_PORT}/health" 2>/dev/null || echo "000")
+  if [ "${BE_STATUS}" = "200" ]; then
+    log "✅ backend  http://127.0.0.1:${NGINX_PORT}/health → ${BE_STATUS}"
+  else
+    log "⚠️  WARNING: backend  http://127.0.0.1:${NGINX_PORT}/health → ${BE_STATUS}"
+  fi
+fi
+
+if ! "${BACKEND_ONLY}"; then
+  FE_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://127.0.0.1:${FRONTEND_PORT}" 2>/dev/null || echo "000")
+  if [ "${FE_STATUS}" = "200" ]; then
+    log "✅ frontend http://127.0.0.1:${FRONTEND_PORT} → ${FE_STATUS}"
+  else
+    log "⚠️  WARNING: frontend http://127.0.0.1:${FRONTEND_PORT} → ${FE_STATUS}"
+  fi
+fi
+
+log "=== 最終ヘルスチェック 完了 ==="
+
+log "コンテナ状態:"
+${DC} -f "${COMPOSE_FILE}" ps
+
+slack_notify "✅ [deploy_staging_v4.sh] v4 Stagingデプロイ成功\n環境: staging-v4 (Shadow Mode / single backend)\nブランチ: $(git rev-parse --abbrev-ref HEAD) ($(git rev-parse --short HEAD))"
+
+log "v4 Stagingデプロイ完了"


### PR DESCRIPTION
## 概要

v4 機能の開発・検証用に、**v3 staging とは独立した 3 つ目の staging スタック**の雛形を追加します。v3 は今後も修正が出るため維持し、v4 は別環境で並行開発する方針（前セッションで確定）。

VPS の RAM 空き（~3.1Gi）に配慮し、**軽量構成（4サービス）** としています。

## 構成判断

| | v3 staging（既存） | **v4 staging（本PR）** |
|---|---|---|
| backend | blue + green | **single（1本）** |
| ログ集約 | loki + promtail | **なし**（`docker logs` で参照） |
| その他 | postgres / nginx / frontend | postgres / nginx / frontend |
| サービス数 | 7 | **4** |

> 軽量化するのは「コンテナ構成（運用機能）」であって「機能」ではありません。v4 の全機能は single backend で開発・検証できます（機能数 ≠ コンテナ数）。blue/green は zero-downtime デプロイ用、loki/promtail はログ集約用で、いずれも開発検証には不要。必要になれば後付け可能。

## ポート分離（衝突なし確認済み）

| ポート | production | v3 staging | **v4 staging** |
|---|---|---|---|
| frontend | 3000 | 3001 | **3002** |
| nginx | 8080 | 8082 | **8083** |
| backend | 8010/8011 | 8020/8021 | **8030** |
| postgres | 5432 | 5433 | **5434** |

全て `127.0.0.1` バインド。DB も完全独立（`ultra_autotrade_staging_v4`）。Shadow Mode 専用 / Base Sepolia。

## 追加ファイル

- `docker-compose.staging-v4.yml` — 4サービス（postgres / backend single / nginx / frontend）。`-staging-v4` suffix、独立 volume/network
- `docker/nginx/upstream.staging-v4.conf` — single backend を指す（`set $backend backend:8000;`）。共有 `nginx.conf` の変数 proxy_pass と対
- `scripts/deploy_staging_v4.sh` — single backend 版デプロイ（full / `--frontend-only` / `--backend-only` / `--no-build`）。Shadow Mode チェック・flock・/health 検証付き
- `.env.staging-v4.example` — 環境変数テンプレート（実 `.env.staging-v4` は gitignore で除外）

## 検証

- `bash -n scripts/deploy_staging_v4.sh` → 構文 OK
- `docker compose -f docker-compose.staging-v4.yml --env-file <tmp> config` → OK
- `.env.staging-v4`（実ファイル）は `.gitignore`（`.env.*` + `!.env.*.example`）で追跡されないことを確認

## 残作業（小林さん担当 / Asana [1215740593437797](https://app.asana.com/0/1213741124336104/1215740593437797)）

このPRはリポジトリ側の雛形のみ。実際の環境立ち上げは以下が必要:
1. **Cloudflare ダッシュボード**: `staging-v4.ultra-auto-trade.com` / `api-staging-v4.ultra-auto-trade.com` の DNS + cloudflared ingress（`--token` 方式のためダッシュボード管理）+ CF Access ポリシー
2. **VPS**: `.env.staging-v4` 作成（`.example` ベース・テストネット専用キー） → `./scripts/deploy_staging_v4.sh` 実行

## 影響範囲

- 全て新規ファイル。既存 production / v3 staging の compose・deploy・nginx 設定には**一切変更なし**

🤖 Generated with [Claude Code](https://claude.com/claude-code)