### PR TITLE
feat(liff-confirm): 「運用を開始する」ボタンに「（ウォレット生成）」サブラベルを追記

### DIFF
--- a/frontend/app/(liff)/liff-confirm/page.tsx
+++ b/frontend/app/(liff)/liff-confirm/page.tsx
@@ -240,7 +240,12 @@ export default function LiffConfirmPage() {
               {t("submitting")}
             </span>
           ) : (
-            t("submitBtn")
+            <>
+              {t("submitBtn")}
+              <span className="block text-[9px] font-normal leading-none mt-1 opacity-75">
+                {t("submitBtnSub")}
+              </span>
+            </>
           )}
         </button>
       </div>

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -962,6 +962,7 @@
       "termsLink": "Terms of Service",
       "privacyLink": "Privacy Policy",
       "submitBtn": "Start investing",
+      "submitBtnSub": "(Generating wallet)",
       "submitting": "Saving...",
       "items": {
         "self_custody": {

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -962,6 +962,7 @@
       "termsLink": "利用規約",
       "privacyLink": "プライバシーポリシー",
       "submitBtn": "運用を開始する",
+      "submitBtnSub": "（ウォレット生成）",
       "submitting": "保存中...",
       "items": {
         "self_custody": {


### PR DESCRIPTION
## Summary
- 全チェック完了後の「運用を開始する」ボタンにサブテキスト「（ウォレット生成）」を追加
- フォントサイズは主テキスト（`text-base`/16px）の約半分 `text-[9px]`
- `font-normal` + `opacity-75` で視覚的に控えめに表示
- `py-4` 維持でボタン高さを崩さず（ローディング中表示は変更なし）
- ja/en 両方の翻訳ファイルにキー追加（`submitBtnSub`）

## Test plan
- [ ] 全チェック項目をチェック → ボタンがアクティブになり「運用を開始する」の下に小さく「（ウォレット生成）」が表示されることを確認
- [ ] ボタン高さが変更前と同程度であることを確認
- [ ] ローディング中（submitting）はサブラベルが表示されないことを確認
- [ ] EN表示で "(Generating wallet)" が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)