### PR TITLE
feat(liff-chat): DepositパネルのMoonPay「Buy with card」を非表示

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
@@ -10,7 +10,6 @@ import { useFundWallet } from "@privy-io/react-auth"
 import { base, baseSepolia } from "wagmi/chains"
 import { useWallet } from "@/hooks/useWallet"
 import { useUsdcBalance } from "@/hooks/useUsdcBalance"
-import { MoonPayWidget } from "./MoonPayWidget"
 import { track, EV } from "@/lib/posthog"
 
 // ---- 型定義 ---------------------------------------------------------------
@@ -338,17 +337,7 @@ export function DepositPanel() {
             {t("depositBtn")}
           </button>
 
-          {/* MoonPay on-ramp — EN モードのみ（Privy fundWallet の代替経路） */}
-          {isEn && (
-            <>
-              <div className="flex items-center gap-2">
-                <div className="flex-1 h-px bg-zinc-700" />
-                <span className="text-xs text-zinc-500">or</span>
-                <div className="flex-1 h-px bg-zinc-700" />
-              </div>
-              <MoonPayWidget />
-            </>
-          )}
+          {/* MoonPay on-ramp — v3 は日本在住ユーザーのみのため非表示。v4 海外ユーザー対応時に復活予定 */}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- MoonPay on-ramp（「Buy with card」）を非表示
- v3 は英語表示を選んだ日本在住ユーザー限定のため、海外向けカード購入経路は不要
- v4 で海外ユーザー対応時に復活予定（コメントに明記）
- 未使用になった `MoonPayWidget` import を削除（lint clean）
- `isEn` は通貨表示（$/¥切替・クイックボタン金額）で引き続き使用のため維持

## Test plan
- [ ] EN モードでDepositパネルを開き、「or」区切り線とMoonPayウィジェットが表示されないことを確認
- [ ] 「入金する」ボタン（Privy fundWallet）は引き続き動作することを確認
- [ ] JP/ENでの$/¥表示切替・クイックボタン金額切替が正常なことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)