### PR TITLE
fix(liff-chat): アカウント画面の運用モード表示を「おまかせ」に統一

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -700,7 +700,7 @@
         "opMode": "Mode",
         "wallet": "Wallet",
         "walletNotLinked": "Not linked",
-        "modeManagedLabel": "Fully Automated",
+        "modeManagedLabel": "Automated",
         "modeActiveLabel": "Active",
         "modeUnknown": "—",
         "corpSectionTitle": "Use as Corporation",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -700,7 +700,7 @@
         "opMode": "運用モード",
         "wallet": "ウォレット",
         "walletNotLinked": "未連携",
-        "modeManagedLabel": "完全おまかせ",
+        "modeManagedLabel": "おまかせ",
         "modeActiveLabel": "アクティブ",
         "modeUnknown": "—",
         "corpSectionTitle": "法人として使う",


### PR DESCRIPTION
## Summary
- アカウント画面の運用モード表示がOpMode画面と不一致だったのを修正
  - ja: `"完全おまかせ"` → `"おまかせ"`
  - en: `"Fully Automated"` → `"Automated"`
- OpMode画面の `managedLabel`（ja: "おまかせ" / en: "Automated"）と統一

## Test plan
- [ ] アカウント画面の運用モード欄が「おまかせ」と表示されることを確認
- [ ] EN表示で「Automated」と表示されることを確認
- [ ] OpMode切替画面の表示が変わっていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)