### PR TITLE
fix(liff-chat): 言語切替ボタンと表示言語の不整合を修正

### DIFF
--- a/frontend/app/(liff)/liff-chat/layout.tsx
+++ b/frontend/app/(liff)/liff-chat/layout.tsx
@@ -11,35 +11,30 @@ import { LanguageProvider, useLanguage } from "@/lib/useLanguage"
 import jaMessages from "@/messages/ja.json"
 import enMessages from "@/messages/en.json"
 
-// IntlWrapper: LanguageProvider 内側で language を参照し NextIntlClientProvider を設定する
+// IntlWrapper: LanguageProvider 内側で language を参照し NextIntlClientProvider を設定する。
+// mounted フラグをここで管理することで LanguageProvider を安定させ、
+// 「ボタンは JP（language=en）なのに表示は日本語」という不整合を防ぐ。
 function IntlWrapper({ children }: { children: ReactNode }) {
   const { language } = useLanguage()
-  const messages = language === "en" ? enMessages : jaMessages
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  // mount 前は ja 固定（SSR hydration safe）
+  // mount 後は LanguageProvider の実際の言語を使う
+  const locale = mounted ? language : "ja"
+  const messages = locale === "en" ? enMessages : jaMessages
+
   return (
-    <NextIntlClientProvider locale={language} messages={messages}>
+    <NextIntlClientProvider locale={locale} messages={messages}>
       {children}
     </NextIntlClientProvider>
   )
 }
 
 export default function LiffChatLayout({ children }: { children: ReactNode }) {
-  // SSR hydration: mounted フラグで hydration mismatch を防ぐ
-  const [mounted, setMounted] = useState(false)
-  useEffect(() => {
-    setMounted(true)
-  }, [])
-
-  if (!mounted) {
-    // SSR / hydration 前は ja で描画（後から正しい言語に切り替わる）
-    return (
-      <LanguageProvider>
-        <NextIntlClientProvider locale="ja" messages={jaMessages}>
-          {children}
-        </NextIntlClientProvider>
-      </LanguageProvider>
-    )
-  }
-
   return (
     <LanguageProvider>
       <IntlWrapper>{children}</IntlWrapper>


### PR DESCRIPTION
## 問題

言語を EN に切り替えた直後、ボタンは「JP」（language=en）を示しているのに
画面テキストが日本語のまま表示される不整合が発生していた。

## 根本原因

`LiffChatLayout` が `mounted` state で 2 つの別ツリーを切り替えていた。

```tsx
// Before（バグあり）
if (!mounted) {
  return <LanguageProvider><NextIntlClientProvider locale="ja">...</NextIntlClientProvider></LanguageProvider>
}
return <LanguageProvider><IntlWrapper>...</IntlWrapper></LanguageProvider>
```

`LanguageProvider` の `useEffect`（localStorage から language=en を読む）が
`LiffChatLayout` の `useEffect`（mounted=true にする）より先に走ると、
language=en になった後も `NextIntlClientProvider` が locale=ja のままになる
ウィンドウが生じていた。

## 修正

`mounted` フラグを `IntlWrapper` 内側に移動し、`LanguageProvider` を常にトップに固定。

```tsx
// After（修正済み）
function IntlWrapper({ children }) {
  const { language } = useLanguage()
  const [mounted, setMounted] = useState(false)
  useEffect(() => { setMounted(true) }, [])
  const locale = mounted ? language : "ja"
  ...
}

export default function LiffChatLayout({ children }) {
  return (
    <LanguageProvider>
      <IntlWrapper>{children}</IntlWrapper>
    </LanguageProvider>
  )
}
```

`LanguageProvider` が一度だけマウントされ再生成されないため、
language state と NextIntlClientProvider の locale が常に同期する。

## Test plan

- [ ] liff-chat を開き言語を EN に切り替える → ボタン「JP」と画面テキスト英語が同時に反映されること
- [ ] リロード後も EN が維持されること
- [ ] 日本語 → 英語 → 日本語 の往復で不整合が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)