### PR TITLE
fix(liff-confirm): liff-chat ループバック修正 + ウォレット生成フォントサイズ拡大

### DIFF
--- a/frontend/app/(liff)/liff-confirm/page.tsx
+++ b/frontend/app/(liff)/liff-confirm/page.tsx
@@ -8,6 +8,7 @@ import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { CheckCircle, ChevronDown, ExternalLink } from "lucide-react"
 import { getAuthToken } from "@/lib/auth/token-key"
+import { TERMS_JUST_ACCEPTED_KEY } from "@/hooks/useLiffTermsGate"
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ""
 
@@ -73,6 +74,9 @@ export default function LiffConfirmPage() {
         },
       })
       if (res.ok) {
+        // terms gate の sessionStorage 高速パス: Cloudflare キャッシュやネットワーク
+        // 失敗によるループを防ぐ（useLiffTermsGate.ts と対になる）。
+        sessionStorage.setItem(TERMS_JUST_ACCEPTED_KEY, "liff-v3")
         router.replace("/liff-chat")
       } else if (res.status === 401) {
         // セッション切れ — 再ログインへ誘導
@@ -242,7 +246,7 @@ export default function LiffConfirmPage() {
           ) : (
             <>
               {t("submitBtn")}
-              <span className="block text-[9px] font-normal leading-none mt-1 opacity-75">
+              <span className="block text-[11px] font-normal leading-none mt-1 opacity-75">
                 {t("submitBtnSub")}
               </span>
             </>

--- a/frontend/hooks/useLiffTermsGate.ts
+++ b/frontend/hooks/useLiffTermsGate.ts
@@ -25,6 +25,13 @@ import { getAuthToken } from "@/lib/auth/token-key"
 /** liff-confirm / settings_router (LIFF_TERMS_VERSION) と一致させること。 */
 const LIFF_TERMS_VERSION = "liff-v3"
 
+/**
+ * terms-agree POST 直後に sessionStorage へ書き込むキー。
+ * 書き込み後の最初の useLiffTermsGate 呼び出しで即 "accepted" を返し、
+ * Cloudflare キャッシュや一時ネットワーク失敗によるループを防ぐ。
+ */
+export const TERMS_JUST_ACCEPTED_KEY = "liff_terms_just_accepted"
+
 /** ブラウザ wallet 経路の同意バージョン (POST /auth/terms/accept で記録)。 */
 const BROWSER_TERMS_VERSION = "2.0"
 
@@ -62,12 +69,25 @@ export function useLiffTermsGate(
       return
     }
 
+    // terms-agree POST 直後のセッション内高速パス: ネットワーク失敗やキャッシュ返却に
+    // よるループを防ぐ。sessionStorage は同一タブのみ有効で、タブを閉じると消える。
+    const justAccepted =
+      typeof sessionStorage !== "undefined"
+        ? sessionStorage.getItem(TERMS_JUST_ACCEPTED_KEY)
+        : null
+    if (justAccepted != null && acceptedVersions.includes(justAccepted)) {
+      sessionStorage.removeItem(TERMS_JUST_ACCEPTED_KEY)
+      setState("accepted")
+      return
+    }
+
     const apiBase = process.env.NEXT_PUBLIC_API_URL ?? ""
     let cancelled = false
     setState("loading")
 
     fetch(`${apiBase}/api/user/settings`, {
       headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
     })
       .then((r) => (r.ok ? r.json() : null))
       .then((data: { terms_version?: string | null } | null) => {


### PR DESCRIPTION
## 修正内容

### 1. liff-confirm → liff-chat → liff-confirm ループバック修正

**症状**: 5項目チェック後「運用を開始する」クリック → liff-confirm に戻る

**根本原因**:
- staging `NEXT_PUBLIC_API_URL=https://api-staging.ultra-auto-trade.com`（Cloudflare経由）
- `terms-agree` POST 成功後に liff-chat へ遷移
- `useLiffTermsGate` が `GET /api/user/settings` を fetch
- Cloudflare キャッシュ or 遷移直後の一時ネットワーク失敗で古い `terms_version` が返る
- fail-closed 設計 (`catch → "not-accepted"`) が発動して liff-confirm へリダイレクト → ループ

**修正**:
```
terms-agree POST 成功
  └→ sessionStorage.setItem("liff_terms_just_accepted", "liff-v3")
  └→ router.replace("/liff-chat")

useLiffTermsGate (liff-chat)
  └→ sessionStorage に "liff_terms_just_accepted" があれば即 "accepted" を返す（1回限り）
  └→ GET /api/user/settings に cache: "no-store" 追加（Cloudflare キャッシュ対策）
```

sessionStorage は同一タブ・1回限りで、サーバー側の同意状態は変わらず。

### 2.「（ウォレット生成）」サブラベル フォントサイズ拡大

`text-[9px]` → `text-[11px]`

## Test plan

- [ ] 5項目チェック → 「運用を開始する」クリック → liff-chat に正しく遷移すること
- [ ] ループバックが発生しないこと
- [ ] リロード後も terms 判定が正常に動作すること（sessionStorage はタブを閉じると消えるため再 fetch が走り DB で判定）
- [ ] 「（ウォレット生成）」文字サイズが以前より大きくなっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)