### PR TITLE
fix(liff-confirm): 未認証時は5チェック前にPrivyログインへ誘導（オンボーディングループ解消）

### DIFF
--- a/frontend/app/(liff)/liff-confirm/page.tsx
+++ b/frontend/app/(liff)/liff-confirm/page.tsx
@@ -33,7 +33,12 @@ export default function LiffConfirmPage() {
     // 旧キー保存セッションを取りこぼし、terms-agree が 401 で「押しても無反応」になっていた）。
     const token = getAuthToken()
     if (!token) {
-      setLoading(false)
+      // 未認証で 5 チェックを先に見せると、submit 時に getAuthToken() が null で
+      // /liff-login へ弾かれ、Privy アカウント作成後また /liff-confirm に戻って
+      // 5 チェックを再表示するループになる (Privy 作成がチェックの「後」に見える)。
+      // 正しい順序は「Privy アカウント作成 → 5 チェック → ホーム」なので、
+      // token が無ければチェックを見せず即 /liff-login (Privy) へ送る。
+      router.replace("/liff-login")
       return
     }
 


### PR DESCRIPTION
## 問題

staging UI テストで以下の2症状を確認:
1. **Privyアカウント作成が（5チェックの前から）消えた**
2. **5チェック確認後「運用を開始する」を押すとまた5チェックに戻るループ**

## 根本原因

`liff-confirm` が **token 無しでも5チェック画面を表示**していた。

未認証で `/liff-confirm` に到達した場合のフロー:
1. `/liff-confirm` → token 無し → そのまま5チェック表示（Privyを飛ばす）
2. 5チェック → 「運用を開始する」→ `getAuthToken()` が null → `/liff-login` へ
3. `/liff-login` → Privyアカウント作成
4. 成功 → `/liff-confirm` へ戻る → **また5チェック表示** ← ループ

本来は **Privy作成 → 5チェック → ホーム** の順序であるべきだが、未認証で先に
チェックを見せるため順序が崩れ、両症状が同時に発生していた。

## 修正

`token` が無ければ5チェックを描画せず、即 `/liff-login`（Privy）へ `router.replace`。
`setLoading(false)` を呼ばないためスピナーのまま遷移し、5チェックは一瞬も表示されない。

## 影響範囲

- token あり・同意済み → `/liff-chat`（変更なし）
- token あり・未同意 → 5チェック表示 → submit → terms-agree → `/liff-chat`（変更なし）
- **token 無し → `/liff-login`（Privy）→ 戻って5チェック → submit → `/liff-chat`（修正）**

🤖 Generated with [Claude Code](https://claude.com/claude-code)