### PR TITLE
fix(liff): ダッシュボードのclient-side crash解消（SessionExpiryBannerのi18nコンテキスト不在）

### DIFF
--- a/frontend/app/(liff)/layout.tsx
+++ b/frontend/app/(liff)/layout.tsx
@@ -176,7 +176,17 @@ export default function LiffLayout({ children }: { children: React.ReactNode }) 
     <div className="arobix-root">
       <PostHogProvider>
         <PrivyRootClient>
-          <SessionExpiryBanner loginHref="/liff-login" />
+          {/* SessionExpiryBanner は子レイアウト (liff-chat/layout 等) の
+              NextIntlClientProvider の外側に居るため、自前の provider で
+              SharedSessionExpiry namespace を供給する。これが無いと
+              バナー表示時 (nearing_expiry / wiped / expired) に t("relogin") が
+              i18n コンテキスト不在で throw し、ページ全体が client-side crash する。 */}
+          <NextIntlClientProvider
+            locale="ja"
+            messages={{ SharedSessionExpiry: jaMessages.SharedSessionExpiry }}
+          >
+            <SessionExpiryBanner loginHref="/liff-login" />
+          </NextIntlClientProvider>
           {children}
         </PrivyRootClient>
       </PostHogProvider>

--- a/frontend/app/(liff)/layout.tsx
+++ b/frontend/app/(liff)/layout.tsx
@@ -179,8 +179,8 @@ export default function LiffLayout({ children }: { children: React.ReactNode }) 
           {/* SessionExpiryBanner は子レイアウト (liff-chat/layout 等) の
               NextIntlClientProvider の外側に居るため、自前の provider で
               SharedSessionExpiry namespace を供給する。これが無いと
-              バナー表示時 (nearing_expiry / wiped / expired) に t("relogin") が
-              i18n コンテキスト不在で throw し、ページ全体が client-side crash する。 */}
+              バナー表示時 (nearing_expiry / wiped / expired) に relogin ラベルの
+              翻訳が i18n コンテキスト不在で throw し、ページ全体が client-side crash する。 */}
           <NextIntlClientProvider
             locale="ja"
             messages={{ SharedSessionExpiry: jaMessages.SharedSessionExpiry }}


### PR DESCRIPTION
## 問題

オンボーディング完了後、ダッシュボード（/liff-chat）で
**「Application error: a client-side exception has occurred」** が発生。

## 根本原因

`SessionExpiryBanner` は `useTranslations("SharedSessionExpiry")` を使うが、
`(liff)/layout.tsx` で子レイアウト（`liff-chat/layout` 等）の
`NextIntlClientProvider` の**外側**にレンダリングされていた。

`detectSessionState` が非fresh状態（`nearing_expiry` / `wiped` / `expired`）を
返すとバナーが描画され `t("relogin")` を呼ぶが、i18n コンテキストが無いため
throw → ページ全体が crash する。

- **オンボーディング（liff-confirm）**: session=fresh/never_seen → message=null →
  バナー非表示 → `t()` 未呼出 → crash しない
- **ダッシュボード（liff-chat）**: session 状態が非freshになると → バナー表示 →
  `t()` 呼出 → **provider 不在で crash**

SSR ログにも `next-intl` の `ENVIRONMENT_FALLBACK` エラーが記録されていた。

## 修正

`SessionExpiryBanner` を `SharedSessionExpiry` namespace を供給する
`NextIntlClientProvider`（locale="ja"）で包む。`describeSessionState` の
メッセージ本体は日本語ハードコードのため locale=ja で整合。子レイアウトの
言語切替 provider は children 側でそのまま有効（影響なし）。

これで全 liff ページ・全 session 状態でバナーが安全に描画される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)