### PR TITLE
fix(intl): SessionExpiryBanner を Provider で包む (#784 ポート漏れ・ダッシュボード crash 解消)

### DIFF
--- a/frontend/components/providers/AdminProviders.tsx
+++ b/frontend/components/providers/AdminProviders.tsx
@@ -47,7 +47,9 @@ function AdminGuard({ children }: { children: React.ReactNode }) {
 export function AdminProviders({ children }: { children: React.ReactNode }) {
   return (
     <AuthProvider>
-      <SessionExpiryBanner loginHref="/login" />
+      <NextIntlClientProvider locale="ja" messages={{ SharedSessionExpiry: jaMessages.SharedSessionExpiry }}>
+        <SessionExpiryBanner loginHref="/login" />
+      </NextIntlClientProvider>
       <AdminGuard>
         <AppShell>
           {children}

--- a/frontend/components/providers/PartnerProviders.tsx
+++ b/frontend/components/providers/PartnerProviders.tsx
@@ -51,7 +51,9 @@ export function PartnerProviders({ children }: { children: React.ReactNode }) {
   return (
     <PrivyRootClient>
       <AuthProvider>
-        <SessionExpiryBanner loginHref="/login" />
+        <NextIntlClientProvider locale="ja" messages={{ SharedSessionExpiry: jaMessages.SharedSessionExpiry }}>
+          <SessionExpiryBanner loginHref="/login" />
+        </NextIntlClientProvider>
         <PartnerGuard>
           <AutomationStatusProvider>
             <AppShell>{children}</AppShell>

--- a/frontend/components/user/UserProviders.tsx
+++ b/frontend/components/user/UserProviders.tsx
@@ -71,7 +71,7 @@ function UserGuardInner({ children }: { children: React.ReactNode }) {
 
 function UserGuard({ children }: { children: React.ReactNode }) {
   return (
-    <NextIntlClientProvider locale="ja" messages={{ ProvidersUser: jaMessages.ProvidersUser }}>
+    <NextIntlClientProvider locale="ja" messages={{ ProvidersUser: jaMessages.ProvidersUser, SharedSessionExpiry: jaMessages.SharedSessionExpiry }}>
       <UserGuardInner>{children}</UserGuardInner>
     </NextIntlClientProvider>
   )
@@ -113,7 +113,9 @@ export function UserProviders({ children }: { children: React.ReactNode }) {
   return (
     <PrivyRootClient>
       <AuthProvider>
-        <SessionExpiryBanner loginHref="/login" />
+        <NextIntlClientProvider locale="ja" messages={{ SharedSessionExpiry: jaMessages.SharedSessionExpiry }}>
+          <SessionExpiryBanner loginHref="/login" />
+        </NextIntlClientProvider>
         <UserGuard>
           <AutomationStatusProvider>
             <SessionExpiryBanner />


### PR DESCRIPTION
## 問題
PR #784 は `(liff)/layout.tsx` の `SessionExpiryBanner` だけを `NextIntlClientProvider` で包んだが、**User/Admin/Partner の各 Providers では未対応**だった。banner が `AuthProvider` 直下（i18n コンテキスト外）でレンダリングされたままで、セッションが `nearing_expiry / wiped / expired` になった瞬間に `useTranslations("SharedSessionExpiry")` がコンテキスト外で呼ばれ、`/user/dashboard` `/partner/dashboard` `/admin/*` が **full-page client crash**（"Application error: a client-side exception has occurred"）していた。

## 修正
`(liff)/layout.tsx:184-189` と同じパターンを3ファイルにポート:
- `components/user/UserProviders.tsx` — 外側 banner を `SharedSessionExpiry` provider で包む + UserGuard provider にも `SharedSessionExpiry` を追加（Guard 内 2個目の banner 用）
- `components/providers/AdminProviders.tsx` — 外側 banner を包む
- `components/providers/PartnerProviders.tsx` — 外側 banner を包む

いずれも `NextIntlClientProvider` / `jaMessages` は import 済み・新規 import なし。

## 検証
- tsc --noEmit: PASS（exit 0）
- `SharedSessionExpiry` キー ja.json:3467 に存在確認
- frontend(providers 3ファイル)のみ・backend/migration 非該当

## 確認ポイント（デプロイ後）
- ログイン後 `/user/dashboard` 等でセッション期限が絡んでも crash しない
- 期限切れ時に SessionExpiryBanner が日本語で正しく表示

⚠️ **auto-merge しない** — レビュー後に人間がマージ