### PR TITLE
feat(liff-chat): v4 消費者の半自動実行導線 + 資産推移/holdings 配線

### DIFF
--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -21,7 +21,7 @@ from app.auth.dependencies import (
     require_partner,
     require_viewer,
 )
-from app.auth.models import User
+from app.auth.models import User, UserRole
 from app.auth.models import User as UserModel
 from app.database import get_db
 from app.policy.engine import PolicyContext, get_policy_engine
@@ -642,15 +642,25 @@ def list_proposal_history(
 @router.post("/{proposal_id}/approve", response_model=ProposalResponse, summary="提案承認・実行")
 def approve_proposal(
     proposal_id: int,
-    current_user: User = Depends(require_partner),
+    current_user: User = Depends(require_active_user),
     db: Session = Depends(get_db),
 ) -> ProposalResponse:
-    """提案を承認してAave操作を実行する（本人・admin・partner）。"""
+    """提案を承認してAave操作を実行する（本人・admin・partner）。
+
+    VIEWER (一般消費者 = liff-chat ユーザー) は自分の提案のみ承認可能。
+    admin/partner は運用代行として他ユーザーの提案も操作可能。
+    """
     stmt = select(Proposal).where(Proposal.id == proposal_id)
     proposal = db.scalars(stmt).first()
-    # admin/partner は他ユーザーの提案も操作可能。一般ユーザーは require_partner で弾かれる。
     if proposal is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Proposal not found")
+    # VIEWER は自分の提案のみ。admin/partner は全提案を操作可能。
+    _is_privileged = current_user.role in (UserRole.ADMIN.value, UserRole.PARTNER.value)
+    if not _is_privileged and proposal.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to access this proposal",
+        )
     if proposal.status != "pending":
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -714,15 +724,25 @@ def approve_proposal(
 @router.post("/{proposal_id}/reject", response_model=ProposalResponse, summary="提案拒否")
 def reject_proposal(
     proposal_id: int,
-    current_user: User = Depends(require_partner),
+    current_user: User = Depends(require_active_user),
     db: Session = Depends(get_db),
 ) -> ProposalResponse:
-    """提案を拒否する（本人・admin・partner）。"""
+    """提案を拒否する（本人・admin・partner）。
+
+    VIEWER (一般消費者 = liff-chat ユーザー) は自分の提案のみ拒否可能。
+    admin/partner は運用代行として他ユーザーの提案も操作可能。
+    """
     stmt = select(Proposal).where(Proposal.id == proposal_id)
     proposal = db.scalars(stmt).first()
-    # admin/partner は他ユーザーの提案も操作可能。一般ユーザーは require_partner で弾かれる。
     if proposal is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Proposal not found")
+    # VIEWER は自分の提案のみ。admin/partner は全提案を操作可能。
+    _is_privileged = current_user.role in (UserRole.ADMIN.value, UserRole.PARTNER.value)
+    if not _is_privileged and proposal.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to access this proposal",
+        )
     if proposal.status != "pending":
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -743,7 +763,7 @@ def reject_proposal(
 )
 def build_partner_tx(
     proposal_id: int,
-    current_user: User = Depends(require_partner),
+    current_user: User = Depends(require_active_user),
     db: Session = Depends(get_db),
 ) -> PartnerUnsignedTxs:
     """
@@ -925,7 +945,7 @@ def _verify_on_chain_receipt(
 def submit_partner_tx(
     proposal_id: int,
     body: SubmitTxRequest,
-    current_user: User = Depends(require_partner),
+    current_user: User = Depends(require_active_user),
     db: Session = Depends(get_db),
 ) -> ProposalResponse:
     """

--- a/backend/tests/test_proposals_api.py
+++ b/backend/tests/test_proposals_api.py
@@ -338,8 +338,12 @@ class TestPartnerProposalBoundaries:
         assert r.json()["status"] in ("approved", "executed", "failed")
         assert r.json()["approved_at"] is not None
 
-    def test_viewer_cannot_approve_proposal(self, client: TestClient) -> None:
-        """viewer は POST /api/proposals/{id}/approve で 403 になる。"""
+    def test_viewer_cannot_approve_others_proposal(self, client: TestClient) -> None:
+        """viewer は他ユーザー (user_id=1=admin) の提案を承認できず 403 になる。
+
+        v4 で viewer は自分の提案のみ承認可能になったが、他人の提案は引き続き 403。
+        SAMPLE_PROPOSAL は user_id=1 (admin) 所有のため、新規 viewer は非所有者。
+        """
         admin_token = get_admin_token(client)
         create_r = client.post(
             "/api/proposals",
@@ -356,8 +360,8 @@ class TestPartnerProposalBoundaries:
         )
         assert r.status_code == 403
 
-    def test_viewer_cannot_reject_proposal(self, client: TestClient) -> None:
-        """viewer は POST /api/proposals/{id}/reject で 403 になる。"""
+    def test_viewer_cannot_reject_others_proposal(self, client: TestClient) -> None:
+        """viewer は他ユーザー (user_id=1=admin) の提案を拒否できず 403 になる。"""
         admin_token = get_admin_token(client)
         create_r = client.post(
             "/api/proposals",
@@ -373,3 +377,76 @@ class TestPartnerProposalBoundaries:
             headers={"Authorization": f"Bearer {viewer_token}"},
         )
         assert r.status_code == 403
+
+    def test_viewer_can_reject_own_proposal(self, client: TestClient) -> None:
+        """v4: viewer (liff-chat 消費者) は自分の提案を拒否できる (200)。"""
+        admin_token = get_admin_token(client)
+        viewer_r = client.post(
+            "/users",
+            json={
+                "email": "viewer_own_rej@test.com",
+                "username": "viewer_own_rej",
+                "password": "viewerpass123",
+                "role": "viewer",
+            },
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        viewer_id = viewer_r.json()["id"]
+        create_r = client.post(
+            "/api/proposals",
+            json={**SAMPLE_PROPOSAL, "user_id": viewer_id},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert create_r.status_code == 201
+        proposal_id = create_r.json()["id"]
+
+        viewer_token = client.post(
+            "/auth/login",
+            json={"email": "viewer_own_rej@test.com", "password": "viewerpass123"},
+        ).json()["access_token"]
+
+        r = client.post(
+            f"/api/proposals/{proposal_id}/reject",
+            headers={"Authorization": f"Bearer {viewer_token}"},
+        )
+        assert r.status_code == 200
+        assert r.json()["status"] == "rejected"
+
+    def test_viewer_can_approve_own_proposal(self, client: TestClient) -> None:
+        """v4: viewer (liff-chat 消費者) は自分の提案を承認できる (200)。
+
+        AUTO_EXECUTION_ENABLED=false のため status は 'approved' に遷移し、
+        非カストディアル方式2 では submit-tx で実 tx を立てる。
+        """
+        admin_token = get_admin_token(client)
+        viewer_r = client.post(
+            "/users",
+            json={
+                "email": "viewer_own_app@test.com",
+                "username": "viewer_own_app",
+                "password": "viewerpass123",
+                "role": "viewer",
+            },
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        viewer_id = viewer_r.json()["id"]
+        create_r = client.post(
+            "/api/proposals",
+            json={**SAMPLE_PROPOSAL, "user_id": viewer_id},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert create_r.status_code == 201
+        proposal_id = create_r.json()["id"]
+
+        viewer_token = client.post(
+            "/auth/login",
+            json={"email": "viewer_own_app@test.com", "password": "viewerpass123"},
+        ).json()["access_token"]
+
+        r = client.post(
+            f"/api/proposals/{proposal_id}/approve",
+            headers={"Authorization": f"Bearer {viewer_token}"},
+        )
+        assert r.status_code == 200
+        assert r.json()["status"] in ("approved", "executed", "failed")
+        assert r.json()["approved_at"] is not None

--- a/frontend/app/(liff)/liff-chat/_components/AssetChart.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/AssetChart.tsx
@@ -22,6 +22,26 @@ interface DataPoint {
   value: number
 }
 
+// バックエンド GET /api/portfolio/history のレスポンス要素 (PortfolioSnapshotResponse)。
+// Decimal は JSON では文字列で返るため value は Number() でラップする。
+interface PortfolioSnapshot {
+  total_value_usd: string | number
+  recorded_at: string
+}
+
+interface PortfolioHistoryResponse {
+  items?: PortfolioSnapshot[]
+}
+
+// UI の期間タブ (1M/3M/6M/1Y) を backend の period 値 (7d/30d/90d/all) に対応付ける。
+// backend は 7d/30d/90d/all のみ受け付けるため、6M/1Y は "all" に丸める。
+const PERIOD_MAP: Record<Props["period"], string> = {
+  "1M": "30d",
+  "3M": "90d",
+  "6M": "all",
+  "1Y": "all",
+}
+
 export default function AssetChart({ period }: Props) {
   const t = useTranslations("Liff.panels")
   const [data, setData] = useState<DataPoint[]>([])
@@ -33,14 +53,24 @@ export default function AssetChart({ period }: Props) {
         ? (localStorage.getItem("auth_token") ?? "")
         : ""
     const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ""
+    const backendPeriod = PERIOD_MAP[period]
 
-    fetch(`${API_BASE}/api/user/asset-history?period=${period}`, {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-    })
+    // 資産推移は PortfolioSnapshot の総資産額 (total_value_usd) を時系列で描く。
+    // v3 (REBALANCE_SHADOW_MODE=true) では snapshot が無く items=[] が正 → 「データなし」表示。
+    fetch(
+      `${API_BASE}/api/portfolio/history?period=${backendPeriod}&interval=daily`,
+      { headers: token ? { Authorization: `Bearer ${token}` } : {} },
+    )
       .then((r) => (r.ok ? r.json() : null))
-      .then((d: { data?: DataPoint[] } | null) => {
-        if (d?.data && d.data.length > 0) {
-          setData(d.data)
+      .then((d: PortfolioHistoryResponse | null) => {
+        const items = d?.items ?? []
+        if (items.length > 0) {
+          setData(
+            items.map((it) => ({
+              date: it.recorded_at,
+              value: Number(it.total_value_usd),
+            })),
+          )
         } else {
           setData([])
         }

--- a/frontend/app/(liff)/liff-chat/_components/ProposalActionCard.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/ProposalActionCard.tsx
@@ -1,0 +1,106 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// frontend/app/(liff)/liff-chat/_components/ProposalActionCard.tsx
+// 保留中の AI 提案を arobix カードで表示し、承認 (→署名シート) / 見送り を提供する。
+"use client"
+
+import { useState } from "react"
+import { useTranslations } from "next-intl"
+import { ArrowUp, ArrowDown } from "lucide-react"
+import type { ChatProposal } from "./ProposalSignSheet"
+
+interface ProposalActionCardProps {
+  proposal: ChatProposal
+  rejecting: boolean
+  onApprove: () => void
+  onReject: () => void
+}
+
+export function ProposalActionCard({
+  proposal,
+  rejecting,
+  onApprove,
+  onReject,
+}: ProposalActionCardProps) {
+  const t = useTranslations("Liff")
+  const [expanded, setExpanded] = useState(false)
+
+  const isSupply = proposal.operation === "SUPPLY"
+  const OperationIcon = isSupply ? ArrowUp : ArrowDown
+  const amountUsd = Number(proposal.amount_usd).toLocaleString("ja-JP", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  })
+  const amountFormatted = Number(proposal.amount).toLocaleString("ja-JP", {
+    maximumFractionDigits: 4,
+  })
+
+  const reason = proposal.reason ?? ""
+  const isLong = reason.length > 120
+  const displayReason = !isLong || expanded ? reason : reason.slice(0, 120) + "…"
+
+  return (
+    <div className="ax-card-warm rounded-2xl mx-4 mt-4 p-4 border-2 border-[#1D9E75]/40">
+      {/* header */}
+      <div className="flex items-center gap-2 mb-2">
+        <span
+          className={`flex items-center gap-1 text-sm font-bold ${
+            isSupply ? "text-[#1D9E75]" : "text-red-600"
+          }`}
+        >
+          <OperationIcon className="w-4 h-4" />
+          {isSupply ? t("exec.supply") : t("exec.withdraw")}
+        </span>
+        <span className="text-[#1c1a27] text-sm font-semibold">{proposal.asset}</span>
+        {(proposal.confidence ?? 0) > 0 && (
+          <span className="ml-auto text-[#736f7e] text-xs">
+            {proposal.confidence}% {t("home.confidenceLabel")}
+          </span>
+        )}
+      </div>
+
+      {/* amount */}
+      <div className="mb-2">
+        <span className="text-[#1c1a27] text-2xl font-bold">{amountUsd}</span>
+        <span className="text-[#736f7e] text-xs ml-1">
+          ({amountFormatted} {proposal.asset})
+        </span>
+      </div>
+
+      {/* reason */}
+      {reason && (
+        <p className="text-[#736f7e] text-xs leading-relaxed mb-3 whitespace-pre-wrap">
+          {displayReason}
+          {isLong && (
+            <button
+              onClick={() => setExpanded((v) => !v)}
+              className="ml-1 underline"
+            >
+              {expanded ? t("exec.collapse") : t("exec.expand")}
+            </button>
+          )}
+        </p>
+      )}
+
+      {/* actions */}
+      <div className="flex gap-3 mt-3">
+        <button
+          onClick={onReject}
+          disabled={rejecting}
+          className="flex-1 py-2.5 rounded-xl border border-[#1c1a27]/20 text-[#1c1a27]
+                     font-semibold disabled:opacity-40 transition-colors"
+        >
+          {rejecting ? t("exec.rejecting") : t("home.reject")}
+        </button>
+        <button
+          onClick={onApprove}
+          disabled={rejecting}
+          className="flex-1 py-2.5 rounded-xl bg-[#1D9E75] active:bg-[#178a64] text-white
+                     font-bold disabled:opacity-50 transition-colors"
+        >
+          {t("home.approve")}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/ProposalSignSheet.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/ProposalSignSheet.tsx
@@ -1,0 +1,255 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// frontend/app/(liff)/liff-chat/_components/ProposalSignSheet.tsx
+// 消費者 (liff-chat) 向け半自動実行シート: 提案確認 → Privy 自己署名 → submit-tx。
+// arobix warm-light テーマ。実行配線は liff-approve の ApproveConfirmSheet と同一
+// (build-tx → 本人 Privy wallet 署名 → submit-tx で on-chain receipt 検証)。
+"use client"
+
+import { useState, useCallback } from "react"
+import { usePrivy, useWallets } from "@privy-io/react-auth"
+import { useTranslations } from "next-intl"
+import { ethers } from "ethers"
+import { Loader2, Lock, CheckCircle2 } from "lucide-react"
+import { buildPartnerTx, submitPartnerTx } from "@/lib/api/admin-proposals"
+
+// /api/proposals/pending の要素 (ProposalResponse) のうち本シートが使う最小集合。
+// Decimal 系は JSON では文字列で返る (CLAUDE.md: Decimal は文字列で返却)。
+// confidence は ai_decision 由来で ProposalResponse には含まれないため optional。
+export interface ChatProposal {
+  id: number
+  operation: "SUPPLY" | "WITHDRAW"
+  asset: string
+  amount: string
+  amount_usd: string
+  reason: string
+  expected_hf_after: string | null
+  estimated_gas_usd: string | null
+  confidence?: number
+  status: string
+  created_at: string
+}
+
+type SigningStatus = "idle" | "signing" | "confirming" | "success" | "error"
+
+interface ProposalSignSheetProps {
+  proposal: ChatProposal
+  token: string
+  open: boolean
+  onClose: () => void
+  onExecuted: (txHash: string) => void
+}
+
+export function ProposalSignSheet({
+  proposal,
+  token,
+  open,
+  onClose,
+  onExecuted,
+}: ProposalSignSheetProps) {
+  const { login } = usePrivy()
+  const { wallets } = useWallets()
+  const t = useTranslations("Liff.exec")
+  const [signingStatus, setSigningStatus] = useState<SigningStatus>("idle")
+  const [error, setError] = useState<string | null>(null)
+
+  const amountUsd = Number(proposal.amount_usd).toLocaleString("ja-JP", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  })
+  const amountFormatted = Number(proposal.amount).toLocaleString("ja-JP", {
+    maximumFractionDigits: 4,
+  })
+  const hfAfter = proposal.expected_hf_after
+    ? Number(proposal.expected_hf_after).toFixed(2)
+    : null
+  const gasUsd = proposal.estimated_gas_usd
+    ? `~$${Number(proposal.estimated_gas_usd).toFixed(2)}`
+    : null
+
+  const handleSignAndExecute = useCallback(async () => {
+    setError(null)
+    setSigningStatus("signing")
+
+    try {
+      // Privy embedded wallet (TEE) のみ。外部 wallet は秘密鍵管理懸念で除外。
+      const wallet = wallets.find((w) => w.walletClientType === "privy")
+      if (!wallet) {
+        await login()
+        setSigningStatus("idle")
+        return
+      }
+
+      // Step 1: サーバーから未署名 tx を取得。build-tx は onBehalfOf / to == 本人 wallet を
+      // サーバー側で検証して返す (非カストディアル method2)。
+      const txData = await buildPartnerTx(proposal.id, token)
+
+      const eip1193 = await wallet.getEthereumProvider()
+      const ethProvider = new ethers.BrowserProvider(
+        eip1193 as unknown as ethers.Eip1193Provider,
+      )
+
+      let finalTxHash: string
+
+      if (txData.operation === "SUPPLY" && txData.approve_tx && txData.supply_tx) {
+        // SUPPLY: approve → supply の順に本人が署名・送信。
+        const approveTxHash = (await eip1193.request({
+          method: "eth_sendTransaction",
+          params: [
+            {
+              to: txData.approve_tx.to,
+              data: txData.approve_tx.data,
+              from: txData.approve_tx.from,
+              value: "0x0",
+            },
+          ],
+        })) as string
+
+        const approveReceipt = await ethProvider.waitForTransaction(approveTxHash)
+        if (approveReceipt === null || approveReceipt.status === 0) {
+          throw new Error(t("revertError"))
+        }
+
+        setSigningStatus("confirming")
+        finalTxHash = (await eip1193.request({
+          method: "eth_sendTransaction",
+          params: [
+            {
+              to: txData.supply_tx.to,
+              data: txData.supply_tx.data,
+              from: txData.supply_tx.from,
+              value: "0x0",
+            },
+          ],
+        })) as string
+      } else if (txData.operation === "WITHDRAW" && txData.withdraw_tx) {
+        finalTxHash = (await eip1193.request({
+          method: "eth_sendTransaction",
+          params: [
+            {
+              to: txData.withdraw_tx.to,
+              data: txData.withdraw_tx.data,
+              from: txData.withdraw_tx.from,
+              value: "0x0",
+            },
+          ],
+        })) as string
+      } else {
+        throw new Error(t("unsupportedOperation", { operation: txData.operation }))
+      }
+
+      setSigningStatus("confirming")
+
+      // Step 3: submit-tx で最終 tx_hash を報告。サーバーが on-chain receipt を
+      // 検証する (from == 本人 wallet / status == 1)。
+      await submitPartnerTx(proposal.id, finalTxHash, txData.wallet_address, token)
+
+      setSigningStatus("success")
+      onExecuted(finalTxHash)
+    } catch (err) {
+      setSigningStatus("error")
+      const msg = err instanceof Error ? err.message : t("signFailed")
+      setError(msg.includes("rejected") ? t("signCanceled") : msg)
+    }
+  }, [wallets, login, proposal.id, token, onExecuted, t])
+
+  if (!open) return null
+
+  const isBusy = signingStatus === "signing" || signingStatus === "confirming"
+  const isSupply = proposal.operation === "SUPPLY"
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center">
+      <div
+        className="absolute inset-0 bg-black/60"
+        onClick={!isBusy ? onClose : undefined}
+      />
+      <div className="relative w-[375px] mx-auto ax-card-warm rounded-t-2xl p-5 ax-safe-bottom max-h-[85vh] overflow-y-auto">
+        {/* drag handle */}
+        <div className="mx-auto mb-4 h-1 w-8 rounded-full bg-[#1c1a27]/15" />
+
+        <h3 className="text-[#1c1a27] font-bold text-lg mb-4">{t("signConfirmTitle")}</h3>
+
+        {/* detail rows */}
+        <div className="space-y-3 mb-4">
+          <DetailRow label={t("operation")}>
+            <span className={isSupply ? "text-[#1D9E75] font-semibold" : "text-red-600 font-semibold"}>
+              {isSupply ? t("supply") : t("withdraw")}
+            </span>
+          </DetailRow>
+          <DetailRow label={t("amount")}>
+            <span className="text-[#1c1a27] font-semibold">{amountUsd}</span>
+            <span className="text-[#736f7e] text-xs ml-1">
+              ({amountFormatted} {proposal.asset})
+            </span>
+          </DetailRow>
+          {hfAfter && (
+            <DetailRow label={t("hfAfter")}>
+              <span className="text-[#1c1a27]">{hfAfter}</span>
+            </DetailRow>
+          )}
+          {gasUsd && (
+            <DetailRow label={t("gasEstimate")}>
+              <span className="text-[#736f7e]">{gasUsd}</span>
+            </DetailRow>
+          )}
+        </div>
+
+        {/* signing status */}
+        {(signingStatus === "signing" || signingStatus === "confirming") && (
+          <div className="flex items-center gap-2 text-sm text-[#736f7e] mb-3">
+            <Loader2 className="h-4 w-4 animate-spin text-[#1D9E75]" />
+            <span>{signingStatus === "signing" ? t("requestingSignature") : t("waitingConfirmation")}</span>
+          </div>
+        )}
+        {signingStatus === "success" && (
+          <div className="flex items-center gap-2 text-sm mb-3">
+            <CheckCircle2 className="h-4 w-4 text-[#1D9E75]" />
+            <span className="text-[#1D9E75] font-medium">{t("txSuccess")}</span>
+          </div>
+        )}
+        {error && <p className="text-red-600 text-xs mb-3">{error}</p>}
+
+        {/* sign button */}
+        <button
+          onClick={handleSignAndExecute}
+          disabled={isBusy || signingStatus === "success"}
+          className="w-full flex items-center justify-center gap-2 py-3 rounded-xl bg-[#1D9E75]
+                     active:bg-[#178a64] text-white font-bold disabled:opacity-50 transition-colors"
+        >
+          {isBusy ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Lock className="h-4 w-4" />
+          )}
+          {isBusy ? t("processing") : signingStatus === "success" ? t("executed") : t("signExecute")}
+        </button>
+
+        {/* cancel */}
+        <button
+          onClick={onClose}
+          disabled={isBusy}
+          className="mt-2 w-full py-3 rounded-xl border border-[#1c1a27]/20 text-[#1c1a27]
+                     font-semibold disabled:opacity-40 transition-colors"
+        >
+          {t("cancel")}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function DetailRow({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex justify-between items-baseline gap-2">
+      <span className="text-xs text-[#736f7e] shrink-0">{label}</span>
+      <span className="text-sm text-right">{children}</span>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -22,6 +22,8 @@ import { NotificationPanel } from "./_components/panels/NotificationPanel"
 import { AccountPanel } from "./_components/panels/AccountPanel"
 import { TermsPanel } from "./_components/panels/TermsPanel"
 import { ChatPanel } from "./_components/ChatPanel"
+import { ProposalActionCard } from "./_components/ProposalActionCard"
+import { ProposalSignSheet, type ChatProposal } from "./_components/ProposalSignSheet"
 
 // recharts は SSR クラッシュ防止のため dynamic import
 const AssetChart = dynamic(() => import("./_components/AssetChart"), {
@@ -50,6 +52,46 @@ interface CoinHolding {
   apy_pct: number
 }
 
+// GET /api/portfolio/current の positions_json 要素 (バックエンドは List[Any] = 非構造)。
+// v4 で実投資 (Aave リバランス) が動いた際に snapshot へ書かれる想定。
+// producer が確定するまでフィールド名揺れを許容して defensive にマッピングする。
+interface PortfolioPositionRaw {
+  asset?: string
+  symbol?: string
+  protocol?: string
+  amount_usd?: number | string
+  value_usd?: number | string
+  supply_usd?: number | string
+  apy_pct?: number | string
+  apy?: number | string
+}
+
+interface PortfolioCurrentResponse {
+  positions_json?: PortfolioPositionRaw[] | null
+  has_data?: boolean
+}
+
+// positions_json (非構造) を CoinHolding[] に正規化する。
+// asset を欠く要素は捨てる。金額/APY は Decimal 文字列で来ても Number() で数値化する。
+function mapPositionsToHoldings(
+  positions: PortfolioPositionRaw[] | null | undefined,
+): CoinHolding[] {
+  if (!Array.isArray(positions)) return []
+  return positions
+    .map((p) => {
+      const asset = p.asset ?? p.symbol ?? ""
+      const amount = p.amount_usd ?? p.value_usd ?? p.supply_usd ?? 0
+      const apy = p.apy_pct ?? p.apy ?? 0
+      return {
+        asset,
+        protocol: p.protocol ?? "Aave V3",
+        amount_usd: Number(amount),
+        apy_pct: Number(apy),
+      }
+    })
+    .filter((c) => c.asset !== "" && Number.isFinite(c.amount_usd))
+}
+
 // ────────────────────────────────────────────
 // ページ本体
 // ────────────────────────────────────────────
@@ -70,6 +112,13 @@ export default function LiffChatPage() {
   // ── 新規 state（ホームコンテンツ）
   const [aiJudgment, setAiJudgment] = useState<AiJudgment | null>(null)
   const [coins, setCoins] = useState<CoinHolding[]>([])
+
+  // ── 半自動実行 state（保留中提案の承認→自己署名→submit-tx / Asana 1215743441691795）
+  const [pendingProposal, setPendingProposal] = useState<ChatProposal | null>(null)
+  const [signSheetOpen, setSignSheetOpen] = useState(false)
+  const [rejecting, setRejecting] = useState(false)
+  const authToken =
+    typeof window !== "undefined" ? (localStorage.getItem("auth_token") ?? "") : ""
   const [graphPeriod, setGraphPeriod] = useState<"1M" | "3M" | "6M" | "1Y">("3M")
   const [graphOpen, setGraphOpen] = useState(false)
   const [chatOpen, setChatOpen] = useState(false)
@@ -110,11 +159,21 @@ export default function LiffChatPage() {
       })
       .catch(() => {})
 
-    // 運用中コイン
-    fetch(`${API_BASE}/api/user/holdings`, { headers })
+    // 運用中コイン: 最新ポートフォリオ snapshot の positions_json を表示する。
+    // /api/user/holdings は不在のため /api/portfolio/current を使う (Asana 1215723024139228)。
+    // v3 (shadow mode) は positions_json が空 → 「運用中のコインがありません」が正。
+    fetch(`${API_BASE}/api/portfolio/current`, { headers })
       .then((r) => (r.ok ? r.json() : null))
-      .then((d: { items?: CoinHolding[] } | null) => {
-        if (Array.isArray(d?.items)) setCoins(d!.items!)
+      .then((d: PortfolioCurrentResponse | null) => {
+        setCoins(mapPositionsToHoldings(d?.positions_json))
+      })
+      .catch(() => {})
+
+    // 保留中の提案（最新 1 件）。あれば承認/見送りの実行導線を表示する。
+    fetch(`${API_BASE}/api/proposals/pending`, { headers })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d: { items?: ChatProposal[] } | null) => {
+        if (d?.items?.[0]) setPendingProposal(d.items[0])
       })
       .catch(() => {})
   }, [])
@@ -171,6 +230,35 @@ export default function LiffChatPage() {
       setStopLoading(false)
       setTimeout(() => setToast(null), 2800)
     }
+  }
+
+  // ── 提案 見送り: POST /api/proposals/{id}/reject（VIEWER は自分の提案のみ可）
+  async function handleRejectProposal() {
+    if (!pendingProposal || !authToken) return
+    const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ""
+    setRejecting(true)
+    try {
+      const res = await fetch(
+        `${API_BASE}/api/proposals/${pendingProposal.id}/reject`,
+        { method: "POST", headers: { Authorization: `Bearer ${authToken}` } },
+      )
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      setPendingProposal(null)
+      setToast(t("exec.rejected"))
+    } catch {
+      setToast(t("exec.rejectFailed"))
+    } finally {
+      setRejecting(false)
+      setTimeout(() => setToast(null), 2800)
+    }
+  }
+
+  // ── 提案 実行完了（署名シートからの成功コールバック）
+  function handleProposalExecuted() {
+    setSignSheetOpen(false)
+    setPendingProposal(null)
+    setToast(t("exec.executeSuccess"))
+    setTimeout(() => setToast(null), 2800)
   }
 
   // ── AI カード色設定
@@ -327,6 +415,16 @@ export default function LiffChatPage() {
           )}
         </div>
 
+        {/* 保留中の提案（承認→自己署名→実行 / 見送り） */}
+        {pendingProposal && (
+          <ProposalActionCard
+            proposal={pendingProposal}
+            rejecting={rejecting}
+            onApprove={() => setSignSheetOpen(true)}
+            onReject={handleRejectProposal}
+          />
+        )}
+
         {/* 運用中コイン一覧 */}
         <div className="mx-4 mt-4">
           <h3 className="text-[#736f7e] text-xs font-semibold mb-3">{t("home.operatingCoins")}</h3>
@@ -474,6 +572,17 @@ export default function LiffChatPage() {
           </span>
         )}
       </button>
+
+      {/* ── 提案 署名シート（承認→Privy 自己署名→submit-tx） */}
+      {pendingProposal && (
+        <ProposalSignSheet
+          proposal={pendingProposal}
+          token={authToken}
+          open={signSheetOpen}
+          onClose={() => setSignSheetOpen(false)}
+          onExecuted={handleProposalExecuted}
+        />
+      )}
 
       {/* ── チャットパネル */}
       {chatOpen && <ChatPanel onClose={() => setChatOpen(false)} />}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -646,6 +646,32 @@
     "closeDetail": "Close"
   },
   "Liff": {
+    "exec": {
+      "operation": "Operation",
+      "supply": "Supply",
+      "withdraw": "Withdraw",
+      "amount": "Amount",
+      "hfAfter": "Health Factor after",
+      "gasEstimate": "Est. gas",
+      "signConfirmTitle": "Execute this proposal?",
+      "processing": "Processing...",
+      "signExecute": "Sign & execute",
+      "executed": "Executed ✓",
+      "cancel": "Cancel",
+      "requestingSignature": "Waiting for wallet signature...",
+      "waitingConfirmation": "Waiting for transaction confirmation...",
+      "txSuccess": "Execution complete",
+      "revertError": "The approve transaction reverted. Please check your balance and gas.",
+      "unsupportedOperation": "Unsupported operation: {operation}",
+      "signFailed": "Signing failed",
+      "signCanceled": "Signature canceled",
+      "collapse": "Collapse",
+      "expand": "Show more",
+      "rejecting": "Dismissing...",
+      "rejected": "Proposal dismissed",
+      "rejectFailed": "Failed to dismiss. Please try again later.",
+      "executeSuccess": "Proposal executed"
+    },
     "header": {
       "menuAriaLabel": "Open menu",
       "logoAriaLabel": "UAT",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -646,6 +646,32 @@
     "closeDetail": "閉じる"
   },
   "Liff": {
+    "exec": {
+      "operation": "操作",
+      "supply": "入金 (Supply)",
+      "withdraw": "出金 (Withdraw)",
+      "amount": "金額",
+      "hfAfter": "実行後 Health Factor",
+      "gasEstimate": "ガス概算",
+      "signConfirmTitle": "この提案を実行しますか？",
+      "processing": "処理中...",
+      "signExecute": "署名して実行",
+      "executed": "実行しました ✓",
+      "cancel": "キャンセル",
+      "requestingSignature": "ウォレットの署名を待っています...",
+      "waitingConfirmation": "トランザクションの確定を待っています...",
+      "txSuccess": "実行が完了しました",
+      "revertError": "approve トランザクションが revert しました。残高・ガス代を確認してください。",
+      "unsupportedOperation": "未対応の操作: {operation}",
+      "signFailed": "署名処理に失敗しました",
+      "signCanceled": "署名がキャンセルされました",
+      "collapse": "閉じる",
+      "expand": "もっと見る",
+      "rejecting": "見送り中...",
+      "rejected": "提案を見送りました",
+      "rejectFailed": "見送りに失敗しました。時間をおいて再度お試しください",
+      "executeSuccess": "提案を実行しました"
+    },
     "header": {
       "menuAriaLabel": "メニューを開く",
       "logoAriaLabel": "UAT",


### PR DESCRIPTION
## 概要
v4 の liff-chat 消費者向け 2 タスクを実装。

- **Task 1** (Asana 1215743441691795): 消費者に半自動実行導線を配線（承認→自己署名→submit-tx）
- **Task 2** (Asana 1215723024139228): 資産推移(asset-history) + 運用中コイン(holdings) を実 EP に配線

## Task 1: 半自動実行（backend RBAC + frontend）

### backend（RBAC 緩和 + オーナーシップ検証）
消費者(LINE/Privy 登録 = **VIEWER**)は実行系4EP が `require_partner` で 403 拒否されていた。これを `require_active_user` に緩和し、安全に消費者の自己実行を解禁:

| EP | 変更 |
|---|---|
| `build-tx` / `submit-tx` | `require_partner`→`require_active_user`（オーナーシップ検証は既存= owner-or-admin に限定済み） |
| `approve` / `reject` | `require_partner`→`require_active_user` + **新規オーナーシップ検証**（VIEWER は自分の提案のみ / admin・partner は運用代行で全提案可） |

非カストディアルの安全装置（build-tx の onBehalfOf 検証 / submit-tx の on-chain receipt 検証 / 本人 Privy ウォレット署名）は**一切変更なし**。VIEWER は自分のウォレットで自分の提案のみ実行可能。

> RBAC 緩和方針は実装前にユーザー承認済み（VIEWER解禁+自己提案限定）。

### frontend
- `ProposalActionCard`（arobix）: 保留中提案を表示、承認/見送り
- `ProposalSignSheet`（arobix）: 本人 Privy 署名（build-tx → 署名 → submit-tx）。実行配線は liff-approve の ApproveConfirmSheet と同一ロジック

## Task 2: 資産推移 + holdings（frontend のみ）
- `AssetChart`: `/api/user/asset-history`(不在) → `/api/portfolio/history`。UI 期間(1M/3M/6M/1Y)→backend period(30d/90d/all) マップ
- holdings: `/api/user/holdings`(不在) → `/api/portfolio/current` の `positions_json` を defensive マッピング
- v3 (shadow mode) は実投資が無く positions/snapshot が空 = 「データなし」「運用中コインなし」が正

## DoD
- ✅ ruff check / format（backend）
- ✅ mypy `app/proposals/router.py` — no issues
- ✅ pytest `test_proposals_api.py` ほか proposals 43 passed（viewer 自己提案可 / 他人 403 の新テスト含む）
- ✅ tsc --noEmit exit 0
- ✅ next build 87/87 static pages
- ✅ i18n checker pass（Liff.exec ja/en 24キー parity）

## 補足
- positions_json の producer（実 Aave リバランスで snapshot 書込）は「v4 で実投資が動いたら」の別作業。本 PR はフロントを既存 EP に配線するところまで（v3 では空表示が正のまま）。
- 全自動（ノータッチ）化の Privy 委任署名 / paymaster は本 PR スコープ外。

Closes: Asana 1215743441691795, Asana 1215723024139228

🤖 Generated with [Claude Code](https://claude.com/claude-code)