### PR TITLE
fix(liff-deposit): 入金コピーの誤った「自動ブリッジ」案内を Base 限定警告に修正（資金安全）

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -777,7 +777,7 @@
         "depositAmountPlaceholder": "Enter amount",
         "depositMethodTitle": "How to deposit",
         "depositMethodDesc": "Tap \"Deposit\" to reveal your deposit address. Send USDC from your exchange (e.g. SBI VC Trade) or wallet.",
-        "depositMethodNote1": "USDC on other networks (e.g. Ethereum) is automatically bridged to Base",
+        "depositMethodNote1": "Important: Always send USDC on the Base (Base Mainnet) network. Funds sent on other networks (e.g. Ethereum) will NOT arrive",
         "depositMethodNote2": "Very small amounts may not transfer (recommended minimum: ~$30)",
         "depositMethodNote3": "The amount entered is an estimate; set the actual transfer amount in your wallet",
         "depositAddressLabel": "Deposit address (Base Mainnet)",
@@ -1253,12 +1253,12 @@
     "fundDesc": "Send USDC from your exchange (e.g. SBI VC Trade) or wallet. Assets are delivered directly to your wallet — never held on our server.",
     "fundBullet1": "Destination: your own wallet (non-custodial)",
     "fundBullet2": "Recommended amount: ${gate} USDC or more",
-    "fundBullet3": "Destination chain: {chain} (USDC from other networks is auto-converted)",
+    "fundBullet3": "Destination chain: {chain} (be sure to send on this network)",
     "processingButton": "Processing...",
     "showAddressButton": "Show deposit address",
     "goToDashboard": "Go to Dashboard",
     "fundError": "An error occurred during the deposit process. Please try again.",
-    "footerNote": "Deposits are processed via Privy's deposit address. USDC from other chains is automatically bridged. Network and bridge fees may apply."
+    "footerNote": "Deposits are processed via Privy's deposit address. Always send USDC on the Base network — funds sent on other chains will NOT arrive. Network fees may apply."
   },
   "Withdraw": {
     "pageTitle": "USDC Withdraw",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -777,7 +777,7 @@
         "depositAmountPlaceholder": "金額を入力",
         "depositMethodTitle": "入金方法",
         "depositMethodDesc": "「入金する」を押すと入金用アドレスが表示されます。取引所（例: SBI VCトレード）やお持ちのウォレットから USDC を送金してください。",
-        "depositMethodNote1": "Ethereum など別ネットワークの USDC も自動で Base に変換されて着金します",
+        "depositMethodNote1": "【重要】必ず Base（Base Mainnet）ネットワークで USDC を送金してください。Ethereum など他のネットワークで送ると着金しません",
         "depositMethodNote2": "少額すぎると送金できない場合があります（目安: 数十ドル以上）",
         "depositMethodNote3": "入力した金額は送金額の目安です（実際の送金額はご自身で指定します）",
         "depositAddressLabel": "入金用アドレス（Base Mainnet）",
@@ -1253,12 +1253,12 @@
     "fundDesc": "取引所（例: SBI VCトレード）やお持ちのウォレットから USDC を送金して入金できます。資産はサーバーには預けられず、あなたのウォレットに直接届きます。",
     "fundBullet1": "入金先: あなた自身のウォレット（ノンカストディアル）",
     "fundBullet2": "推奨金額: ${gate} USDC 以上",
-    "fundBullet3": "着金チェーン: {chain}（別ネットワークの USDC も自動変換）",
+    "fundBullet3": "着金チェーン: {chain}（必ずこのネットワークで送金してください）",
     "processingButton": "処理中...",
     "showAddressButton": "入金アドレスを表示",
     "goToDashboard": "ダッシュボードへ",
     "fundError": "入金処理中にエラーが発生しました。もう一度お試しください。",
-    "footerNote": "入金はPrivyの入金アドレス経由で処理され、別チェーンの USDC は自動でブリッジされます。ネットワーク・ブリッジ手数料がかかる場合があります。"
+    "footerNote": "入金はPrivyの入金アドレス経由で処理されます。必ず Base ネットワークで USDC を送金してください（他チェーンで送ると着金しません）。送金時のネットワーク手数料がかかる場合があります。"
   },
   "Withdraw": {
     "pageTitle": "USDC 出金",


### PR DESCRIPTION
## 背景（資金安全に関わる重要修正）
入金UIが3箇所（ja/en）で **「Ethereum など別ネットワークの USDC も自動で Base に変換/ブリッジされて着金」** と案内していたが、**その自動ブリッジ機能の実装はリポジトリのどこにも存在しない**。

検証（全て該当なし）:
- `depositForBurn` / `TokenMessenger` / `MessageTransmitter`（CCTP）
- LiFi / Socket / Across / Stargate / Hop（ブリッジSDK）
- backend に cross-chain / bridge サービス無し
- DepositPanel は入金アドレス表示 + Privy `fundWallet`(Baseオンランプ)のみ
- 残高読取(`useUsdcBalance`)は **Base の USDC しか見ない**

→ 実態は **Base 上の USDC 送金のみ着金**。利用者が Ethereum 等の他チェーンで送ると着金せず、アプリから見えず Aave 運用にも乗らない（**資金が宙に浮く重大リスク**）。同一アドレスが全EVMチェーンで有効なため誤送が起きやすい。

## 修正
入金コピー6文字列（ja/en × `depositMethodNote1`/`fundBullet3`/`footerNote`）を安全側へ:
- 「自動変換/自動ブリッジ」記述を**削除**
- 「**必ず Base（Base Mainnet）ネットワークで USDC を送金。他チェーンは着金しない**」**警告**に変更
- 既存の正しいラベル（`USDC · Base Mainnet` / `入金用アドレス（Base Mainnet）`）との矛盾も解消

## 検証
- JSON 妥当（ja/en）/ 値のみ変更（キー不変）
- i18n キー一致チェック PASS
- frontend(messages 2ファイル)のみ・backend/migration 非該当

## 補足（要チーム判断）
将来 CCTP 等の自動ブリッジを実装する計画があるなら、**実装完了後に**改めて案内コピーを戻す運用が安全。現状は未実装機能を案内していたため撤回が正。

⚠️ **auto-merge しない** — レビュー後に人間がマージ