### PR TITLE
feat(paymaster): スライス7 PoC harness — Pimlico sponsored UserOp (Base Sepolia)

### DIFF
--- a/docs/privy-aa-paymaster-design.md
+++ b/docs/privy-aa-paymaster-design.md
@@ -59,10 +59,11 @@ session key / SCW owner 設計次第でカストディが silent に移る secur
 
 - **ライブラリ**: `frontend/lib/wallet/PrivyRootClient.tsx` — `@privy-io/react-auth ^3.29.2`
 - **SmartWalletsProvider**: 未配線（通常の EOA embedded wallet のみ）
-- **署名経路 3 箇所**:
+- **署名経路 4 箇所**（2026-06-17 更新: liff-chat 消費者導線を追加）:
   - `frontend/app/(partner)/partner/proposals/page.tsx:108`
   - `frontend/app/(liff)/liff-approve/_components/ApproveConfirmSheet.tsx:103`
   - `frontend/app/(user)/withdraw/page.tsx:395`
+  - `frontend/app/(liff)/liff-chat/_components/ProposalSignSheet.tsx`（PR #787 で追加。消費者 VIEWER の build-tx→自己署名→submit-tx。スライス4 で UserOp 化対象）
 - **注意**: `frontend/app/arobix/onboarding/page.tsx:47` に "Smart Wallet" テキストが存在するが実装ゼロ
 
 ### 2.4 F-9 expense_jpy 現状
@@ -196,7 +197,7 @@ paymaster 移行完了後、以下を明文化する:
 | スライス | 内容 | ファイル | ステータス |
 |---|---|---|---|
 | スライス1 | 本設計 doc | `docs/privy-aa-paymaster-design.md` | 完了（本 doc） |
-| スライス7 | PoC テスト新規追加（Base Sepolia UserOp 確認） | `backend/tests/` または `frontend/tests/` 新規ファイル | 未着手 |
+| スライス7 | PoC harness 新規追加（Base Sepolia sponsored UserOp 確認） | `frontend/scripts/poc/paymaster-poc.mjs` | **コード実装済（2026-06-17）**。viem のみ・新規依存ゼロ。SCW counterfactual 生成 + bundler 到達まで確認済。実行は Pimlico key（小林さん）待ち |
 
 ### 6.2 HUMAN-REVIEW-REQUIRED（人間の承認後に着手）
 
@@ -207,7 +208,7 @@ paymaster 移行完了後、以下を明文化する:
 |---|---|---|---|
 | スライス2 | UserOp receipt 検証 helper 新規 + submit-tx 配線 | `backend/app/proposals/router.py`（L834 `_verify_on_chain_receipt`）、`backend/app/aave/client.py`（L1451/L1473） | 🛑 DeFi 安全装置の変更 |
 | スライス3 | `onBehalfOf` → Smart Wallet address 対応 + `users.smart_wallet_address` migration | `backend/app/proposals/router.py`、`backend/migrations/versions/*.py`（新規）、`backend/app/database.py` | 🛑 Tier S（migration） |
-| スライス4 | フロント SmartWalletsProvider 配線 + sponsored UserOp 送信 | `frontend/lib/wallet/PrivyRootClient.tsx`、`frontend/app/(partner)/partner/proposals/page.tsx`、`frontend/app/(liff)/liff-approve/_components/ApproveConfirmSheet.tsx`、`frontend/app/(user)/withdraw/page.tsx` | 🛑 Aave tx 経路変更（全署名経路 3 箇所） |
+| スライス4 | フロント SmartWalletsProvider 配線 + sponsored UserOp 送信 | `frontend/lib/wallet/PrivyRootClient.tsx`、`frontend/app/(partner)/partner/proposals/page.tsx`、`frontend/app/(liff)/liff-approve/_components/ApproveConfirmSheet.tsx`、`frontend/app/(user)/withdraw/page.tsx`、`frontend/app/(liff)/liff-chat/_components/ProposalSignSheet.tsx` | 🛑 Aave tx 経路変更（全署名経路 4 箇所） |
 | スライス5 | 依存追加（paymaster SDK） | `frontend/package.json`、`frontend/package-lock.json` | 🛑 Tier S（package.json） |
 | スライス6 | F-9 expense_jpy 再設計・二重計上防止 | `backend/app/automation/workflow.py`（L817）、`backend/app/api/v1/fees.py`（L360） | 🛑 金融計算・Decimal 変更 |
 

--- a/frontend/scripts/poc/paymaster-poc.mjs
+++ b/frontend/scripts/poc/paymaster-poc.mjs
@@ -1,0 +1,147 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// frontend/scripts/poc/paymaster-poc.mjs
+//
+// スライス7 PoC — Privy Smart Wallet AA/ERC-4337 + Paymaster 設計 doc
+//   (docs/privy-aa-paymaster-design.md / Asana 1215697060370824)
+//
+// 目的: paymaster ベンダー(Pimlico)で sponsored UserOp が Base Sepolia 上で
+//       status=1 を返し、getUserOperationReceipt から actualGasCost を取得できるかを
+//       headless に検証する。これは設計 doc の核心リスク2/3(receipt 検証経路 /
+//       UserOpHash ベース)を de-risk し、スライス4 承認ゲートの前提(status=1 確認)を満たす。
+//
+// 新規依存ゼロ: 既存の viem(^2.47, `viem/account-abstraction` 同梱)のみを使用する。
+//   → package.json を触らない(スライス5=Tier S を回避)。本 PoC は新規ファイルのみ。
+//
+// 【このPoCが検証すること】
+//   1. Base Sepolia 上で Coinbase Smart Account(SCW) を counterfactual 生成
+//   2. paymaster(Pimlico)経由で sponsored UserOp を送信(SCW owner=throwaway EOA が署名)
+//   3. bundler から userOpHash を取得
+//   4. waitForUserOperationReceipt で success=true と actualGasCost を確認
+//      (actualGasCost は F-9 expense 再設計・案A の per-UserOp 実費ソース)
+//
+// 【このPoCが検証しないこと(スライス4 で実施)】
+//   - Privy embedded EOA を SCW owner にする本番署名経路の配線(client-side, SmartWalletsProvider)
+//   - 既存 build-tx / verify_supply_onbehalf / submit-tx の onBehalfOf=SCW 対応
+//
+// ── 実行方法 ──────────────────────────────────────────────
+//   cd frontend
+//   PIMLICO_API_KEY=pim_xxx node scripts/poc/paymaster-poc.mjs
+//
+//   必須 env(小林さん外部セットアップ):
+//     PIMLICO_API_KEY            … Pimlico ダッシュボードの API キー(Base Sepolia)
+//   任意 env:
+//     PIMLICO_BUNDLER_URL        … 上記の代わりに完全な bundler URL を直接指定
+//     PIMLICO_SPONSORSHIP_POLICY_ID … verifying paymaster のスポンサーポリシー id(必要な場合)
+//     BASE_SEPOLIA_RPC_URL       … chain 読み取り用 RPC(既定: https://sepolia.base.org)
+//     POC_OWNER_PRIVATE_KEY      … SCW owner の EOA 秘密鍵(既定: 毎回ランダム生成)
+//
+//   キー未設定時は SKIP(exit 0)。小林さんが Pimlico key を用意し次第、staging で実行する。
+// ──────────────────────────────────────────────────────────
+
+import { createPublicClient, http, formatEther } from "viem"
+import { baseSepolia } from "viem/chains"
+import { privateKeyToAccount, generatePrivateKey } from "viem/accounts"
+import {
+  createBundlerClient,
+  toCoinbaseSmartAccount,
+} from "viem/account-abstraction"
+
+function mask(s) {
+  if (!s) return "(unset)"
+  return s.length <= 10 ? "******" : `${s.slice(0, 6)}...${s.slice(-4)}`
+}
+
+async function main() {
+  const apiKey = process.env.PIMLICO_API_KEY
+  const bundlerUrl =
+    process.env.PIMLICO_BUNDLER_URL ||
+    (apiKey
+      ? `https://api.pimlico.io/v2/base-sepolia/rpc?apikey=${apiKey}`
+      : null)
+
+  if (!bundlerUrl) {
+    console.log("⏭️  SKIP: PIMLICO_API_KEY / PIMLICO_BUNDLER_URL 未設定。")
+    console.log("   小林さん外部セットアップ後に実行:")
+    console.log("     1) Pimlico ダッシュボードで Base Sepolia の API キーを発行")
+    console.log("     2) (必要なら) verifying paymaster の sponsorship policy を作成")
+    console.log("     3) PIMLICO_API_KEY=pim_xxx node scripts/poc/paymaster-poc.mjs")
+    process.exit(0)
+  }
+
+  const rpcUrl = process.env.BASE_SEPOLIA_RPC_URL || "https://sepolia.base.org"
+  const ownerKey = process.env.POC_OWNER_PRIVATE_KEY || generatePrivateKey()
+  const policyId = process.env.PIMLICO_SPONSORSHIP_POLICY_ID
+
+  console.log("── Paymaster PoC (Base Sepolia / Pimlico) ──")
+  console.log("  chain        : base-sepolia (84532)")
+  console.log("  rpc          :", rpcUrl)
+  console.log("  bundler      :", bundlerUrl.replace(apiKey ?? "__none__", mask(apiKey)))
+  console.log("  owner EOA key:", mask(ownerKey), process.env.POC_OWNER_PRIVATE_KEY ? "(env)" : "(generated)")
+  console.log("  policy id    :", policyId ? mask(policyId) : "(none)")
+
+  const publicClient = createPublicClient({
+    chain: baseSepolia,
+    transport: http(rpcUrl),
+  })
+
+  const owner = privateKeyToAccount(ownerKey)
+
+  // 非カストディアル不変条件: owner = ユーザー EOA(本 PoC では throwaway)。
+  // UATa サーバー鍵は owner にしない(本番では Privy embedded EOA が owner)。
+  const account = await toCoinbaseSmartAccount({
+    client: publicClient,
+    owners: [owner],
+    version: "1.1",
+  })
+  console.log("  SCW address  :", account.address, "(counterfactual)")
+
+  const bundlerClient = createBundlerClient({
+    account,
+    client: publicClient,
+    transport: http(bundlerUrl),
+    // Pimlico の v2 エンドポイントは bundler + paymaster(ERC-7677 pm_*)を兼ねる。
+    paymaster: true,
+    ...(policyId
+      ? { paymasterContext: { sponsorshipPolicyId: policyId } }
+      : {}),
+  })
+
+  // 最小の sponsored UserOp: SCW 自身への 0 value / 空 data 呼び出し。
+  // 初回 UserOp で SCW がデプロイされる(ガスは paymaster が肩代わり → owner ETH 不要)。
+  console.log("\n→ sponsored UserOp を送信中...")
+  const t0 = Date.now()
+  const userOpHash = await bundlerClient.sendUserOperation({
+    calls: [{ to: account.address, value: 0n, data: "0x" }],
+  })
+  console.log("  userOpHash   :", userOpHash)
+
+  console.log("→ getUserOperationReceipt を待機中...")
+  const receipt = await bundlerClient.waitForUserOperationReceipt({
+    hash: userOpHash,
+  })
+  const elapsed = ((Date.now() - t0) / 1000).toFixed(1)
+
+  const gasWei = receipt.actualGasCost ?? 0n
+  console.log("\n── 結果 ──")
+  console.log("  success      :", receipt.success)
+  console.log("  txHash       :", receipt.receipt?.transactionHash)
+  console.log("  actualGasCost:", gasWei.toString(), "wei (", formatEther(gasWei), "ETH )")
+  console.log("  elapsed      :", elapsed, "s")
+  console.log(
+    "  → actualGasCost は F-9 expense 再設計(案A)の per-UserOp 実費ソース",
+  )
+
+  if (receipt.success !== true) {
+    console.error("\n❌ FAIL: UserOp receipt.success !== true")
+    process.exit(1)
+  }
+  console.log("\n✅ PASS: sponsored UserOp が status=1 で確定。paymaster 経路 OK。")
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error("\n❌ PoC エラー:")
+  console.error(err?.shortMessage || err?.message || err)
+  if (err?.details) console.error("  details:", err.details)
+  process.exit(1)
+})


### PR DESCRIPTION
## 概要
Privy Smart Wallet AA/ERC-4337 + Paymaster 設計 doc（`docs/privy-aa-paymaster-design.md`）の **スライス7 PoC**（唯一の HUMAN-REVIEW 不要スライス）を実装。消費者の ETH 不要化（出金/ガス UX ブロッカー）の前提検証。

## 背景
- 現状 Aave tx はユーザー EOA が直接署名（ETH 必須）→ 新規消費者のオンボーディング摩擦。
- **EOA に ERC-4337 paymaster は適用不可** → Privy Smart Wallet (AA) 移行が paymaster の前提（PR #389 の EOA 雛形が CLOSED された根本理由）。
- スライス2-6 は安全装置/Tier S/金融計算の変更で HUMAN-REVIEW + 小林さん外部セットアップ待ち。本 PoC でその前提（sponsored UserOp が status=1 / actualGasCost 取得可）を先に de-risk。

## 変更
- `frontend/scripts/poc/paymaster-poc.mjs`（新規, viem のみ・**新規依存ゼロ=Tier S 回避**）
  - Coinbase Smart Account を counterfactual 生成（owner=throwaway EOA、非カストディアル不変条件）
  - Pimlico bundler+paymaster 経由で sponsored UserOp 送信（`paymaster: true`、policy id 任意対応）
  - `waitForUserOperationReceipt` で `success` / `actualGasCost` を確認（actualGasCost は F-9 案A の per-UserOp 実費ソース）
  - `PIMLICO_API_KEY` 未設定時は SKIP（exit 0）
- `docs/privy-aa-paymaster-design.md`: スライス7 ステータス更新 + 署名経路 3→4 箇所（PR #787 の `ProposalSignSheet.tsx` を スライス4 対象に追記）

## 検証
ローカルで以下を確認:
- 依存解決・構文 OK（SKIP 経路 exit 0）
- 実 Base Sepolia RPC で **SCW アドレス counterfactual 導出**（`0x23e5…39f2`）
- bundler への送信が Pimlico に到達（ダミーキーで `Unauthorized` = 想定どおりの停止点）

→ 実 `PIMLICO_API_KEY` で sponsored UserOp 送信 → receipt 検証まで通る状態。

## 小林さん外部セットアップ（実行の前提）
1. Pimlico ダッシュボードで Base Sepolia の API キー発行
2. （必要なら）verifying paymaster の sponsorship policy 作成
3. `cd frontend && PIMLICO_API_KEY=pim_xxx node scripts/poc/paymaster-poc.mjs`

## 次工程（本 PR スコープ外 / HUMAN-REVIEW-REQUIRED）
スライス2（receipt 検証書換）/3（onBehalfOf→SCW + migration）/4（SmartWalletsProvider 配線・全署名4経路 UserOp 化）/5（SDK 依存）/6（F-9 再設計）。各承認ゲートは設計 doc §7 参照。

関連: Asana 1215697060370824 / 1215079129137410

🤖 Generated with [Claude Code](https://claude.com/claude-code)