### PR TITLE
fix(liff-chat): v3 ヘッダー中央のロゴを非表示

### DIFF
--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -292,31 +292,8 @@ export default function LiffChatPage() {
         >
           <Menu className="w-6 h-6" />
         </button>
-        <svg
-          width="36"
-          height="36"
-          viewBox="0 0 100 100"
-          aria-label={t("header.logoAriaLabel")}
-          className="flex-shrink-0 justify-self-center"
-        >
-          {/* ベゼル: フラットグレー */}
-          <circle cx="50" cy="50" r="49" fill="#CCCCCC" />
-          {/* 内面: 赤 — カラータイマー点滅 */}
-          <circle
-            cx="50"
-            cy="50"
-            r="41.5"
-            fill="#E8341A"
-            className="animate-color-timer motion-reduce:animate-none"
-          />
-          {/* U リング: 白 */}
-          <g transform="translate(1.75,1.75) scale(0.965)">
-            <path
-              d="M 82.9 22.4 A 43 43 0 1 1 17.1 22.4 L 28.6 32.0 A 28 28 0 1 0 71.4 32.0 Z"
-              fill="white"
-            />
-          </g>
-        </svg>
+        {/* ヘッダー中央ロゴは非表示（QA AI FAB に集約）。grid-cols-3 維持のため空プレースホルダ */}
+        <div aria-hidden="true" />
         <div className="flex items-center gap-1 justify-self-end">
           {/* JP/EN トグルボタン */}
           <button


### PR DESCRIPTION
## 概要
v3 liff-chat ヘッダー中央のロゴ（アニメ円形ロゴ SVG）を非表示にする。

## 背景
#785 で同じアニメロゴを右下の QA AI FAB に集約したため、ヘッダー中央のロゴは重複していた。

## 変更
- `page.tsx` のヘッダー中央ロゴ SVG を削除
- `grid-cols-3`（左: ハンバーガー / 中央: ロゴ / 右: 言語トグル+アカウント）のレイアウトを保つため、中央セルに空プレースホルダ `<div aria-hidden="true" />` を配置（右の操作系が中央へズレないように）

## 検証
- tsc --noEmit: PASS（exit 0）
- frontend(page.tsx 1ファイル)のみ・backend/migration 非該当

## 確認ポイント（デプロイ後）
- ヘッダー中央のロゴが消えている
- 左のハンバーガー / 右の言語トグル・アカウントアイコンの位置は従来通り
- 右下 QA AI ボタンのロゴは表示されたまま（#785）

⚠️ **auto-merge しない** — レビュー後に人間がマージ