### PR TITLE
feat(paymaster): スライス2 UserOp receipt 検証 helper（承認済設計 / 未配線）

### DIFF
--- a/backend/app/proposals/userop_verify.py
+++ b/backend/app/proposals/userop_verify.py
@@ -1,0 +1,123 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/app/proposals/userop_verify.py
+"""ERC-4337 UserOperation receipt 検証 (Privy Smart Wallet AA 移行 / スライス2)。
+
+設計: docs/privy-aa-paymaster-design.md §3 / §6.2 スライス2（hkobayashi 承認済 2026-06-17）。
+
+現行 `_verify_on_chain_receipt`（proposals/router.py）は EOA が直接送信した tx を前提に
+`receipt["from"] == 本人EOA` を検証する。ERC-4337 では実 tx の from が EntryPoint/bundler に
+なるためこの検証が破綻する。本モジュールは bundler の `eth_getUserOperationReceipt` を用いて
+UserOp 単位で success / sender(=本人 Smart Wallet) を検証する代替経路を提供する。
+
+【fail-closed 維持の階層化】
+- 「他人宛て tx を組ませない」主担保は build-tx 側 (verify_supply_onbehalf / verify_withdraw_to)
+  の calldata 検証であり、AA 移行後も不変。
+- 本 helper は「成功したか (success) / 正しい Smart Wallet が実行したか (sender)」を検証する。
+
+【配線状況】本 helper は現時点ではどのライブ経路にも未配線（スライス3 で
+`users.smart_wallet_address` 判別子を追加し submit_partner_tx から呼び出す）。単体テストで
+exercise されており孤立コードではない。実 bundler との結合はスライス7 PoC の receipt 構造
+確認後に行う。
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, Optional, cast
+
+# bundler JSON-RPC メソッド名（ERC-4337 標準）。
+_USEROP_RECEIPT_METHOD = "eth_getUserOperationReceipt"
+
+
+class UserOpVerificationError(ValueError):
+    """UserOp receipt 検証に失敗した（pending / reverted / sender 不一致 / 取得不能）。
+
+    ValueError を継承するため、既存 submit-tx の except 経路（恒久エラー→400/422）と
+    互換に扱える。
+    """
+
+
+def _default_rpc_call(bundler_url: str) -> Callable[[str, list[Any]], dict[str, Any]]:
+    """web3.py HTTPProvider 経由で bundler の JSON-RPC を叩く呼び出し器を返す。
+
+    `eth_getUserOperationReceipt` は標準 eth メソッドではないため
+    `provider.make_request` で生 RPC を送る。
+    """
+    from web3 import Web3  # noqa: PLC0415
+    from web3.types import RPCEndpoint  # noqa: PLC0415
+
+    w3 = Web3(Web3.HTTPProvider(bundler_url))
+
+    def _call(method: str, params: list[Any]) -> dict[str, Any]:
+        return cast(
+            "dict[str, Any]",
+            w3.provider.make_request(RPCEndpoint(method), params),
+        )
+
+    return _call
+
+
+def verify_userop_receipt(
+    user_op_hash: str,
+    expected_sender: str,
+    bundler_url: str,
+    *,
+    poll_interval: float = 3.0,
+    max_wait: float = 60.0,
+    rpc_call: Optional[Callable[[str, list[Any]], dict[str, Any]]] = None,
+) -> dict[str, Any]:
+    """UserOp の receipt を bundler から取得して success / sender を検証する (fail-closed)。
+
+    検証内容:
+    - receipt が pending (result=None) なら poll_interval 秒おきに max_wait 秒まで再試行
+    - max_wait 経過しても pending なら UserOpVerificationError
+    - result["success"] is True 必須（False/欠落 → UserOpVerificationError）
+    - result["sender"].lower() == expected_sender.lower() 必須（不一致 → UserOpVerificationError）
+
+    :param user_op_hash: bundler が返した UserOp ハッシュ (0x + 64 hex)
+    :param expected_sender: 本人の Smart Wallet アドレス (users.smart_wallet_address / slice3)
+    :param bundler_url: bundler JSON-RPC URL (Pimlico 等。環境分離: staging=Base Sepolia / prod=Base)
+    :param rpc_call: テスト用の RPC 呼び出し器注入口（省略時は web3 HTTPProvider）
+    :returns: bundler の UserOperation receipt result dict
+              （success / sender / actualGasCost / receipt 等。actualGasCost は slice6 の費目源）
+    :raises UserOpVerificationError: pending タイムアウト / success!=true / sender 不一致 / RPC error
+    """
+    if rpc_call is None:
+        rpc_call = _default_rpc_call(bundler_url)
+
+    elapsed = 0.0
+    result: Optional[dict[str, Any]] = None
+    while True:
+        resp = rpc_call(_USEROP_RECEIPT_METHOD, [user_op_hash])
+        if resp.get("error"):
+            # bundler が明示エラーを返した場合は再試行せず fail-closed。
+            raise UserOpVerificationError(
+                f"bundler error for userOp {user_op_hash[:12]}...: {resp['error']}"
+            )
+        result = resp.get("result")
+        if result is not None:
+            break
+        if elapsed >= max_wait:
+            break
+        time.sleep(poll_interval)
+        elapsed += poll_interval
+
+    if result is None:
+        raise UserOpVerificationError(
+            f"userOp {user_op_hash[:12]}... は {max_wait:.0f}秒経過後も pending です。"
+            "しばらく待ってから再試行してください。"
+        )
+
+    if result.get("success") is not True:
+        raise UserOpVerificationError(
+            f"userOp {user_op_hash[:12]}... は失敗 (success={result.get('success')!r}) です。"
+        )
+
+    actual_sender = str(result.get("sender") or "")
+    if actual_sender.lower() != expected_sender.lower():
+        raise UserOpVerificationError(
+            f"userOp sender 不一致: expected={expected_sender[:6]}...{expected_sender[-4:]} "
+            f"actual={actual_sender[:6] if actual_sender else '(none)'}"
+        )
+
+    return cast("dict[str, Any]", result)

--- a/backend/tests/test_userop_verify.py
+++ b/backend/tests/test_userop_verify.py
@@ -1,0 +1,103 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_userop_verify.py
+"""verify_userop_receipt（ERC-4337 UserOp receipt 検証 / スライス2）の単体テスト。
+
+bundler JSON-RPC は rpc_call 注入でモックし、ネットワーク・sleep に依存しない。
+設計: docs/privy-aa-paymaster-design.md §6.2 スライス2。
+"""
+
+from typing import Any, Optional
+
+import pytest
+
+import app.proposals.userop_verify as uv
+from app.proposals.userop_verify import UserOpVerificationError, verify_userop_receipt
+
+SENDER = "0x23e5A23b935C6c23d2Ff3A427d37eD80114239f2"
+HASH = "0x" + "a" * 64
+
+
+def _resp(result: Optional[dict] = None, error: Optional[dict] = None) -> dict[str, Any]:
+    if error is not None:
+        return {"error": error}
+    return {"result": result}
+
+
+def _ok_result(success: bool = True, sender: str = SENDER) -> dict[str, Any]:
+    return {
+        "success": success,
+        "sender": sender,
+        "actualGasCost": "0x1234",
+        "userOpHash": HASH,
+    }
+
+
+def test_success_returns_result() -> None:
+    calls: list[tuple[str, list]] = []
+
+    def rpc(method: str, params: list) -> dict:
+        calls.append((method, params))
+        return _resp(result=_ok_result())
+
+    out = verify_userop_receipt(HASH, SENDER, "http://bundler", rpc_call=rpc)
+    assert out["success"] is True
+    assert calls[0][0] == "eth_getUserOperationReceipt"
+    assert calls[0][1] == [HASH]
+
+
+def test_revert_raises() -> None:
+    def rpc(method: str, params: list) -> dict:
+        return _resp(result=_ok_result(success=False))
+
+    with pytest.raises(UserOpVerificationError):
+        verify_userop_receipt(HASH, SENDER, "u", rpc_call=rpc)
+
+
+def test_sender_mismatch_raises() -> None:
+    def rpc(method: str, params: list) -> dict:
+        return _resp(result=_ok_result(sender="0x" + "0" * 40))
+
+    with pytest.raises(UserOpVerificationError):
+        verify_userop_receipt(HASH, SENDER, "u", rpc_call=rpc)
+
+
+def test_sender_case_insensitive_match() -> None:
+    def rpc(method: str, params: list) -> dict:
+        return _resp(result=_ok_result(sender=SENDER.lower()))
+
+    out = verify_userop_receipt(HASH, SENDER.upper(), "u", rpc_call=rpc)
+    assert out["success"] is True
+
+
+def test_bundler_error_raises() -> None:
+    def rpc(method: str, params: list) -> dict:
+        return _resp(error={"code": -32000, "message": "boom"})
+
+    with pytest.raises(UserOpVerificationError):
+        verify_userop_receipt(HASH, SENDER, "u", rpc_call=rpc)
+
+
+def test_pending_then_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(uv.time, "sleep", lambda _s: None)
+    seq = iter([_resp(result=None), _resp(result=None), _resp(result=_ok_result())])
+
+    def rpc(method: str, params: list) -> dict:
+        return next(seq)
+
+    out = verify_userop_receipt(HASH, SENDER, "u", rpc_call=rpc, poll_interval=0.01, max_wait=10.0)
+    assert out["success"] is True
+
+
+def test_pending_timeout_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(uv.time, "sleep", lambda _s: None)
+
+    def rpc(method: str, params: list) -> dict:
+        return _resp(result=None)  # 常に pending
+
+    with pytest.raises(UserOpVerificationError):
+        verify_userop_receipt(HASH, SENDER, "u", rpc_call=rpc, poll_interval=0.01, max_wait=0.05)
+
+
+def test_userop_verification_error_is_valueerror() -> None:
+    # 既存 submit-tx の except(ValueError → 400/422) 経路と互換であること。
+    assert issubclass(UserOpVerificationError, ValueError)


### PR DESCRIPTION
## 概要
Privy Smart Wallet AA 移行 設計 doc（`docs/privy-aa-paymaster-design.md`）§6.2 **スライス2**（2026-06-17 承認済）の核心ロジックを**自己完結モジュール + 単体テスト**として実装。

## 変更
- **`backend/app/proposals/userop_verify.py`**（新規）: `verify_userop_receipt()`
  - bundler の `eth_getUserOperationReceipt` で UserOp を検証（**fail-closed**）
  - `success == true` 必須 / `sender == 本人 Smart Wallet` 必須 / pending は poll → timeout
  - `actualGasCost` を含む result を返す（slice6 の F-9 費目源）
  - `rpc_call` DI でテスト可能。`UserOpVerificationError` は `ValueError` 継承（既存 except 互換）
- **`backend/tests/test_userop_verify.py`**（新規）: 8 ケース（成功 / revert / sender 不一致 / 大小無視 / bundler error / pending→成功 / pending timeout / ValueError 継承）。bundler RPC はモック、ネットワーク・sleep 非依存

## スコープ（重要）
- ✅ **helper のみ**。**ライブ経路には未配線**（既存挙動ゼロ変更。テストで exercise 済 = 孤立コードではない）
- ⏸️ submit-tx への配線は **slice3**（`users.smart_wallet_address` 判別子 + `BUNDLER_RPC_URL` env）
- ⏸️ 実 bundler との結合確認は **slice7 PoC**（Pimlico key）後
- 「他人宛て tx を組ませない」主担保は build-tx 側 `verify_supply_onbehalf`/`verify_withdraw_to` のまま**不変**

## 検証
- ruff check ✅ / ruff format ✅ / mypy ✅ no issues / **pytest 8 passed**

## §7 スライス2 承認ゲート対応
- getUserOperationReceipt 検証ロジック設計 → 実装
- `_verify_on_chain_receipt` の代替（UserOpHash ベース）→ 別モジュールで新設・既存は温存
- fail-closed 維持 → success/sender 必須 + 宛先担保は build-tx 据置

関連: Asana 1215697060370824

🤖 Generated with [Claude Code](https://claude.com/claude-code)