### PR TITLE
fix(liff): ハンバーガーメニューのタイトルが暗紫で読めない問題を修正（テーマ上書き）

### DIFF
--- a/frontend/app/arobix/theme.css
+++ b/frontend/app/arobix/theme.css
@@ -168,6 +168,12 @@
 .arobix-root .bg-red-500.text-white,
 .arobix-root .bg-red-500 .text-white { color: white !important; }
 
+/* Keep light text on intentionally DARK surfaces (ハンバーガーメニュー / ボトムナビ = bg #1b1a23).
+   上の `.text-white → #2a2440` 反転は「ライト背景前提」だが、これらは意図的にダーク面なので
+   反転を打ち消し白系を維持する（さもないとメニュー各タイトルが暗紫で読めなくなる）。 */
+.arobix-root .bg-\[\#1b1a23\] .text-white,
+.arobix-root .bg-\[\#1b1a23\].text-white { color: #fbf7f0 !important; }
+
 /* Keep text-transparent for logo-shine / bg-clip-text */
 .arobix-root .text-transparent { color: transparent !important; }
 


### PR DESCRIPTION
## 症状
ハンバーガーメニューの各タイトル（MY WALLET / 入金 / 紹介キャンペーン …）が**暗い紫でほぼ読めない**。サブタイトルは読める、という非対称。デプロイしても直らなかった。

## 真因（キャッシュでも古ビルドでもなかった）
`app/arobix/theme.css:157` の
```css
.arobix-root .text-white { color: #2a2440 !important; }
```
が原因。これは arobix ライトテーマの「白文字→暗色へ反転」規則だが、**意図的にダークなハンバーガーメニュー/ボトムナビ（`bg-[#1b1a23]`）の `text-white` にも効いてしまい**、タイトル（`text-white`）が `#2a2440`（暗紫）に化けていた。
- サブタイトルは `text-white/55`（別クラス `.text-white\/55`）で上書き対象外 → 読めていた
- → 「タイトルだけ暗い」非対称の正体

コードは全ビルドで `text-white` のまま正しく、**キャッシュ/古ビルドではなくテーマCSSの過剰上書き**が全ビルドで効いていた。

## 修正
既存の「色付きボタン上の白文字を維持する例外」（`.bg-[#1D9E75]`/`.bg-red-500`）と同じパターンで、**ダーク面 `bg-[#1b1a23]` 内の `text-white` を `#fbf7f0`（テーマの --text-on-dark）で維持**する例外を追加。メニュータイトル + 閉じる× + ボトムナビの白文字がまとめて正しく明色になる。

## 検証
- CSS のみ（`theme.css` +6行）・frontend・backend/migration 非該当
- スコープは `bg-[#1b1a23]` 配下に限定（ダーク面のみ）。ライト面の反転は維持

## 確認ポイント（デプロイ後）
- メニュー各タイトルが**白くくっきり**読める
- 閉じる×・ボトムナビの白文字も維持
- ライト画面（カード等）の文字色は従来通り

⚠️ **auto-merge しない** — レビュー後に人間がマージ