### PR TITLE
fix(alembic)+feat(paymaster): 4-head merge + slice3a smart_wallet_address 列

### DIFF
--- a/backend/alembic/versions/m4h20260618_merge_four_heads.py
+++ b/backend/alembic/versions/m4h20260618_merge_four_heads.py
@@ -1,0 +1,46 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""merge_four_heads
+
+alembic head が 4 本に分岐していたため、merge migration で 1 本に統合する。
+m3h20260609（3-head 統合, 2026-06-09）以降に並行マージされた 4 本の feature migration が
+それぞれ head 統合をしなかった結果、再び multi-head 化していた。
+
+統合対象 head:
+  - s9t0u1v2w3x4  (add_proposals_expiry_reminder_sent)
+  - b3invtbl9k0z  (create_invitations_table)
+  - cm20260612    (create_chat_messages_table)
+  - w3x4y5z6a7b8  (add_account_deletion_requests)
+
+`alembic upgrade head` が "Multiple head revisions present" で停止する状態だった。
+deploy_production.sh は upgrade head 失敗時にデプロイを中止する設計のため、
+backend デプロイの前提ブロッカー。本 migration はスキーマ変更を伴わない統合のみ。
+
+Revision ID: m4h20260618
+Revises: s9t0u1v2w3x4, b3invtbl9k0z, cm20260612, w3x4y5z6a7b8
+Create Date: 2026-06-18 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "m4h20260618"
+down_revision: Union[str, Sequence[str], None] = (
+    "s9t0u1v2w3x4",
+    "b3invtbl9k0z",
+    "cm20260612",
+    "w3x4y5z6a7b8",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """head 統合のみ。スキーマ変更なし。"""
+    pass
+
+
+def downgrade() -> None:
+    """統合前の 4 head 状態に戻す。スキーマ変更なし。"""
+    pass

--- a/backend/alembic/versions/swa20260618_add_smart_wallet_address.py
+++ b/backend/alembic/versions/swa20260618_add_smart_wallet_address.py
@@ -1,0 +1,55 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""add_smart_wallet_address
+
+users に smart_wallet_address (ERC-4337 Smart Wallet アドレス) を追加する。
+Privy Smart Wallet AA + paymaster 移行 設計 doc §6.2 スライス3a（hkobayashi 承認 2026-06-18）。
+
+非破壊・追加のみ。列は slice3b（submit-tx 配線）で使うまで未使用（NULL = 全員 EOA 経路のまま）。
+NULL = EOA ユーザー / 設定済 = Smart Wallet ユーザー という判別子になる。
+
+wallet_address (b2c3d4e5f6a7) と同じく String(42) / nullable / unique。
+
+Revision ID: swa20260618
+Revises: m4h20260618
+Create Date: 2026-06-18 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "swa20260618"
+down_revision: Union[str, Sequence[str], None] = "m4h20260618"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add smart_wallet_address column to users table."""
+    op.add_column(
+        "users",
+        sa.Column(
+            "smart_wallet_address",
+            sa.String(length=42),
+            nullable=True,
+        ),
+    )
+    op.create_unique_constraint("uq_users_smart_wallet_address", "users", ["smart_wallet_address"])
+    op.create_index(
+        "ix_users_smart_wallet_address",
+        "users",
+        ["smart_wallet_address"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    """Remove smart_wallet_address column from users table."""
+    op.drop_index("ix_users_smart_wallet_address", table_name="users")
+    op.drop_constraint("uq_users_smart_wallet_address", "users", type_="unique")
+    op.drop_column("users", "smart_wallet_address")

--- a/backend/app/auth/models.py
+++ b/backend/app/auth/models.py
@@ -14,6 +14,11 @@ ALTER TABLE users ADD COLUMN last_judgment_at TIMESTAMP WITH TIME ZONE NULL;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS privy_did VARCHAR(255) NULL;
 CREATE UNIQUE INDEX IF NOT EXISTS ix_users_privy_did ON users (privy_did) WHERE privy_did IS NOT NULL;
 
+-- smart_wallet_address: ERC-4337 Smart Wallet アドレス (Privy AA + paymaster 移行 / slice3a)。
+-- migration: swa20260618_add_smart_wallet_address。NULL=EOA / 設定済=Smart Wallet ユーザー。
+ALTER TABLE users ADD COLUMN IF NOT EXISTS smart_wallet_address VARCHAR(42) NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS ix_users_smart_wallet_address ON users (smart_wallet_address) WHERE smart_wallet_address IS NOT NULL;
+
 -- GID 1214176344039867 (P1): execution_policy CHECK + server_default 強化
 -- DB default は a1b2c3d4e5f6 で 'auto_execute' 設定済み。
 -- CheckConstraint と SQLAlchemy 側 server_default を Alembic migration で同期する。
@@ -259,6 +264,11 @@ class User(Base):
         server_default=ExecutionPolicy.REQUIRE_APPROVAL.value,
     )
     wallet_address: Mapped[Optional[str]] = mapped_column(
+        String(42), unique=True, nullable=True, index=True, default=None
+    )
+    # ERC-4337 Smart Wallet アドレス (Privy AA + paymaster 移行 / slice3a)。
+    # NULL = EOA ユーザー / 設定済 = Smart Wallet ユーザー（slice3b の submit-tx 経路判別子）。
+    smart_wallet_address: Mapped[Optional[str]] = mapped_column(
         String(42), unique=True, nullable=True, index=True, default=None
     )
     privy_did: Mapped[Optional[str]] = mapped_column(


### PR DESCRIPTION
## 概要
2つを1 PR に同梱（後者の前提が前者）:
1. **alembic 4-head 統合**（deploy ブロッカー解消）
2. **slice3a**: `users.smart_wallet_address` 列追加（Privy AA + paymaster 移行の土台）

## 1. alembic 4-head merge（deploy ブロッカー）
main の alembic が **4-head** に分岐しており `alembic upgrade head` が "Multiple head revisions present" で失敗 → **`deploy_production.sh` の backend デプロイをブロック**していた（`m3h20260609` の 3-head 統合以降、並行マージされた 4 本が未統合）。

統合対象 head:
- `s9t0u1v2w3x4`（proposals expiry_reminder_sent）
- `b3invtbl9k0z`（invitations table）
- `cm20260612`（chat_messages table）
- `w3x4y5z6a7b8`（account_deletion_requests）

→ `m4h20260618` merge migration（**no-op・スキーマ無変更**）で 1 head に統合。

## 2. slice3a: smart_wallet_address 列
設計 doc §6.2 スライス3a（承認 2026-06-18）。
- `swa20260618` migration: `String(42)` / nullable / unique（`wallet_address` と同形・部分unique index）
- `app/auth/models.py`: 列 + 冒頭 ALTER TABLE コメント
- **非破壊・追加のみ**。NULL=EOA / 設定済=Smart Wallet ユーザー（**slice3b の submit-tx 経路判別子**）。列は slice3b 配線まで未使用

## 検証
- alembic head **単一**（`swa20260618`、4→1）
- ruff / format / mypy ✅
- pytest: proposals 21 passed / auth・wallet 63 passed（列追加の回帰なし）

## 次工程（本 PR スコープ外）
- **slice3b**: submit-tx を `smart_wallet_address` で経路分岐 → `verify_userop_receipt`（PR #794）に配線 + `BUNDLER_RPC_URL` env
- **slice4**: frontend SmartWalletsProvider 配線（全署名4経路 UserOp 化）
- 前提: PoC PASS ✅ / Privy SW 有効化 ✅（both done 2026-06-18）

関連: docs/privy-aa-paymaster-design.md / Asana 1215697060370824

🤖 Generated with [Claude Code](https://claude.com/claude-code)