### PR TITLE
feat(paymaster): スライス3b — Smart Wallet ユーザーの build-tx/submit-tx 経路分岐

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -81,6 +81,14 @@ AAVE_STATE_FILE_PATH=/var/run/ultra/state.json
 AAVE_MAX_PRICE_DEVIATION_PCT=2.0
 
 # =============================================================================
+# Smart Wallet (ERC-4337 AA) / Paymaster — slice3b
+# BUNDLER_RPC_URL: bundler の JSON-RPC URL (Pimlico)。smart_wallet_address 設定済ユーザーの
+#   submit-tx で eth_getUserOperationReceipt 検証に使用。production は Base Mainnet 用。
+#   例: https://api.pimlico.io/v2/8453/rpc?apikey=pim_xxx（ドメイン制限キー推奨 / Asana 1215817638191136）
+# =============================================================================
+BUNDLER_RPC_URL=
+
+# =============================================================================
 # Auth (JWT)
 # =============================================================================
 JWT_SECRET_KEY=CHANGE_ME_PRODUCTION_RANDOM_SECRET

--- a/.env.staging-v4.example
+++ b/.env.staging-v4.example
@@ -73,6 +73,14 @@ AAVE_STATE_FILE_PATH=/var/run/ultra/state.json
 AAVE_MAX_PRICE_DEVIATION_PCT=2.0
 
 # =============================================================================
+# Smart Wallet (ERC-4337 AA) / Paymaster — slice3b
+# BUNDLER_RPC_URL: bundler の JSON-RPC URL (Pimlico)。smart_wallet_address 設定済ユーザーの
+#   submit-tx で eth_getUserOperationReceipt 検証に使用。staging-v4 は Base Sepolia 用。
+#   例: https://api.pimlico.io/v2/84532/rpc?apikey=pim_xxx（PoC PASS 済の Pimlico キー）
+# =============================================================================
+BUNDLER_RPC_URL=
+
+# =============================================================================
 # Auth (JWT)
 # =============================================================================
 JWT_SECRET_KEY=CHANGE_ME_STAGING_V4_RANDOM_SECRET

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -74,6 +74,14 @@ AAVE_STATE_FILE_PATH=/var/run/ultra/state.json
 AAVE_MAX_PRICE_DEVIATION_PCT=2.0
 
 # =============================================================================
+# Smart Wallet (ERC-4337 AA) / Paymaster — slice3b
+# BUNDLER_RPC_URL: bundler の JSON-RPC URL (Pimlico)。smart_wallet_address 設定済ユーザーの
+#   submit-tx で eth_getUserOperationReceipt 検証に使用。staging は Base Sepolia 用。
+#   例: https://api.pimlico.io/v2/84532/rpc?apikey=pim_xxx
+# =============================================================================
+BUNDLER_RPC_URL=
+
+# =============================================================================
 # Auth (JWT)
 # =============================================================================
 JWT_SECRET_KEY=CHANGE_ME_STAGING_RANDOM_SECRET

--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -789,14 +789,20 @@ def build_partner_tx(
             detail=f"Cannot build tx for proposal with status '{proposal.status}'",
         )
 
-    # partner wallet 取得
+    # 実行ウォレット取得。
+    # Smart Wallet (AA) ユーザーは smart_wallet_address で onBehalfOf/to を構築する
+    # (Aave ポジション保有者 = SCW。slice3b)。未設定の EOA ユーザーは従来どおり wallet_address。
     user = db.scalars(select(User).where(User.id == proposal.user_id)).first()
-    if user is None or not user.wallet_address:
+    wallet_address = (
+        user.smart_wallet_address
+        if user is not None and user.smart_wallet_address
+        else (user.wallet_address if user is not None else None)
+    )
+    if user is None or not wallet_address:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Partner wallet_address が未設定です。Privy で wallet を作成してください。",
+            detail="wallet_address / smart_wallet_address が未設定です。Privy で wallet を作成してください。",
         )
-    wallet_address = user.wallet_address
 
     op_map: dict[str, str] = {"SUPPLY": "DEPOSIT", "WITHDRAW": "WITHDRAW"}
     if proposal.operation not in op_map:
@@ -1015,8 +1021,44 @@ def submit_partner_tx(
         rpc_url = None
         pool_address = None
 
-    partner_wallet = body.wallet_address
-    if rpc_url and pool_address:
+    # 実行主体の判定 (slice3b): Smart Wallet (AA) ユーザーは bundler の UserOp receipt で、
+    # EOA ユーザーは従来の on-chain tx receipt で検証する。
+    proposal_user = db.scalars(select(User).where(User.id == proposal.user_id)).first()
+    is_smart_wallet = proposal_user is not None and bool(proposal_user.smart_wallet_address)
+
+    if is_smart_wallet:
+        # AA 経路: body.tx_hash は userOpHash。bundler で success / sender(=SCW) を検証 (fail-closed)。
+        assert proposal_user is not None  # is_smart_wallet=True なら非 None
+        scw_address = proposal_user.smart_wallet_address or ""
+        bundler_url = os.getenv("BUNDLER_RPC_URL", "")
+        if not bundler_url:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="BUNDLER_RPC_URL が未設定です (Smart Wallet 実行の検証不可)。",
+            )
+        from .userop_verify import (  # noqa: PLC0415
+            UserOpVerificationError,
+            verify_userop_receipt,
+        )
+
+        try:
+            verify_userop_receipt(
+                body.tx_hash, expected_sender=scw_address, bundler_url=bundler_url
+            )
+        except UserOpVerificationError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"UserOp receipt 検証失敗: {exc}",
+            ) from exc
+        partner_wallet = scw_address
+        logger.info(
+            "submit-tx: proposal %d UserOp verified via bundler chain=%s userOp=%s",
+            proposal_id,
+            chain_name,
+            body.tx_hash[:12],
+        )
+    elif rpc_url and pool_address:
+        partner_wallet = body.wallet_address
         try:
             _verify_on_chain_receipt(
                 tx_hash=body.tx_hash,
@@ -1036,6 +1078,7 @@ def submit_partner_tx(
                 detail=f"on-chain receipt 検証失敗: {exc}",
             ) from exc
     else:
+        partner_wallet = body.wallet_address
         logger.warning(
             "submit-tx: proposal %d on-chain verification skipped (RPC/chain unavailable)",
             proposal_id,

--- a/backend/tests/test_slice3b_scw_routing.py
+++ b/backend/tests/test_slice3b_scw_routing.py
@@ -1,0 +1,242 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_slice3b_scw_routing.py
+"""slice3b: Smart Wallet (AA) ユーザーの build-tx / submit-tx 経路分岐テスト。
+
+- submit-tx: smart_wallet_address 設定済 → bundler の verify_userop_receipt 経路、
+  未設定 → 従来 _verify_on_chain_receipt 経路。
+- build-tx: smart_wallet_address 設定済 → onBehalfOf/to を SCW アドレスで構築。
+
+設計: docs/privy-aa-paymaster-design.md §6.2 スライス3b。
+"""
+
+import os
+import tempfile
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, update
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-slice3b")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "slice3b_admin@example.com")
+
+from app.auth.models import User  # noqa: E402
+from app.database import Base, get_db  # noqa: E402
+from app.main import create_app  # noqa: E402
+from app.proposals.userop_verify import UserOpVerificationError  # noqa: E402
+
+SCW_ADDRESS = "0x" + "5c" * 20
+EOA_WALLET = "0x1234567890123456789012345678901234567890"
+VALID_HASH = "0x" + "a" * 64
+
+SAMPLE_PROPOSAL = {
+    "user_id": 1,
+    "operation": "SUPPLY",
+    "asset": "USDC",
+    "amount": "500.000000000000000000",
+    "amount_usd": "500.00",
+    "reason": "slice3b routing test",
+}
+
+
+@pytest.fixture()
+def test_db():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db() -> Generator:
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    yield override_get_db, SessionLocal
+    Base.metadata.drop_all(bind=engine)
+    os.unlink(path)
+
+
+@pytest.fixture()
+def client(test_db) -> TestClient:
+    override_get_db, _ = test_db
+    app = create_app()
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app)
+
+
+def get_admin_token(client: TestClient) -> str:
+    email = os.environ.get("INITIAL_ADMIN_EMAIL", "slice3b_admin@example.com")
+    client.post(
+        "/auth/register",
+        json={"email": email, "username": "admin", "password": "adminpassword123"},
+    )
+    r = client.post("/auth/login", json={"email": email, "password": "adminpassword123"})
+    return r.json()["access_token"]
+
+
+def create_proposal(client: TestClient, token: str) -> int:
+    r = client.post(
+        "/api/proposals",
+        json=SAMPLE_PROPOSAL,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+def set_smart_wallet(session_local, user_id: int, addr: str) -> None:
+    db = session_local()
+    try:
+        db.execute(update(User).where(User.id == user_id).values(smart_wallet_address=addr))
+        db.commit()
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# submit-tx 経路分岐
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitTxScwRouting:
+    def test_scw_user_routes_to_userop_verify(self, client: TestClient, test_db) -> None:
+        """smart_wallet_address 設定済ユーザーは verify_userop_receipt(sender=SCW) で検証される。"""
+        _, SessionLocal = test_db
+        token = get_admin_token(client)
+        pid = create_proposal(client, token)
+        set_smart_wallet(SessionLocal, 1, SCW_ADDRESS)
+
+        with (
+            patch.dict(os.environ, {"BUNDLER_RPC_URL": "http://bundler"}),
+            patch(
+                "app.proposals.userop_verify.verify_userop_receipt",
+                return_value={"success": True, "sender": SCW_ADDRESS},
+            ) as m,
+        ):
+            r = client.post(
+                f"/api/proposals/{pid}/submit-tx",
+                json={"tx_hash": VALID_HASH, "wallet_address": EOA_WALLET},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["status"] == "executed"
+        assert (data["expected_from"] or "").lower() == SCW_ADDRESS.lower()
+        m.assert_called_once()
+        assert m.call_args.kwargs["expected_sender"] == SCW_ADDRESS
+
+    def test_scw_user_without_bundler_url_returns_503(self, client: TestClient, test_db) -> None:
+        """smart_wallet ユーザーで BUNDLER_RPC_URL 未設定なら 503 (検証不可で fail-closed)。"""
+        _, SessionLocal = test_db
+        token = get_admin_token(client)
+        pid = create_proposal(client, token)
+        set_smart_wallet(SessionLocal, 1, SCW_ADDRESS)
+
+        env_without = {k: v for k, v in os.environ.items() if k != "BUNDLER_RPC_URL"}
+        with patch.dict(os.environ, env_without, clear=True):
+            r = client.post(
+                f"/api/proposals/{pid}/submit-tx",
+                json={"tx_hash": VALID_HASH, "wallet_address": EOA_WALLET},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert r.status_code == 503, r.text
+
+    def test_scw_user_userop_verify_failure_returns_400(self, client: TestClient, test_db) -> None:
+        """verify_userop_receipt が失敗を投げたら 400 (fail-closed)。"""
+        _, SessionLocal = test_db
+        token = get_admin_token(client)
+        pid = create_proposal(client, token)
+        set_smart_wallet(SessionLocal, 1, SCW_ADDRESS)
+
+        with (
+            patch.dict(os.environ, {"BUNDLER_RPC_URL": "http://bundler"}),
+            patch(
+                "app.proposals.userop_verify.verify_userop_receipt",
+                side_effect=UserOpVerificationError("sender mismatch"),
+            ),
+        ):
+            r = client.post(
+                f"/api/proposals/{pid}/submit-tx",
+                json={"tx_hash": VALID_HASH, "wallet_address": EOA_WALLET},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert r.status_code == 400, r.text
+
+    def test_eoa_user_does_not_use_userop_verify(self, client: TestClient) -> None:
+        """smart_wallet_address 未設定 (EOA) は verify_userop_receipt を呼ばない。"""
+        token = get_admin_token(client)
+        pid = create_proposal(client, token)
+
+        with (
+            patch(
+                "app.proposals.router._verify_on_chain_receipt",
+                return_value={"status": 1, "from": EOA_WALLET, "to": EOA_WALLET},
+            ),
+            patch("app.proposals.userop_verify.verify_userop_receipt") as m_uop,
+        ):
+            r = client.post(
+                f"/api/proposals/{pid}/submit-tx",
+                json={"tx_hash": VALID_HASH, "wallet_address": EOA_WALLET},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "executed"
+        m_uop.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# build-tx onBehalfOf → SCW
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTxScwWallet:
+    def test_build_tx_scw_uses_smart_wallet_address(self, client: TestClient, test_db) -> None:
+        """smart_wallet 設定済ユーザーの build-tx は SCW アドレスで calldata を構築する。"""
+        _, SessionLocal = test_db
+        token = get_admin_token(client)
+        pid = create_proposal(client, token)
+        set_smart_wallet(SessionLocal, 1, SCW_ADDRESS)
+
+        captured: dict[str, str] = {}
+
+        def fake_build_deposit_txs(*, asset_symbol, amount, wallet_address):
+            captured["wallet_address"] = wallet_address
+            tx = {
+                "to": EOA_WALLET,
+                "data": "0x",
+                "from": wallet_address,
+                "chainId": 8453,
+                "value": "0x0",
+            }
+            return {"approve_tx": tx, "supply_tx": tx}
+
+        mock_client = MagicMock()
+        mock_client.build_deposit_txs.side_effect = fake_build_deposit_txs
+        mock_service = MagicMock()
+        mock_service._client = mock_client
+        mock_service._settings.default_asset_symbol = "USDC"
+        mock_multi = MagicMock()
+        mock_multi.get_service.return_value = mock_service
+
+        with (
+            patch("app.aave.service.MultiChainAaveService", return_value=mock_multi),
+            patch("app.aave.client.verify_supply_onbehalf", return_value=True),
+        ):
+            r = client.get(
+                f"/api/proposals/{pid}/build-tx",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert r.status_code == 200, r.text
+        # build_deposit_txs に渡った wallet が SCW であること（onBehalfOf=SCW）。
+        assert captured["wallet_address"].lower() == SCW_ADDRESS.lower()
+        assert r.json()["wallet_address"].lower() == SCW_ADDRESS.lower()


### PR DESCRIPTION
## 概要
設計 doc §6.2 **スライス3b**（承認 2026-06-18・PoC PASS + Privy SW 有効化 後）。
slice2 helper（`verify_userop_receipt` / #794）と slice3a 列（`smart_wallet_address` / #796）を **live 配線**。Smart Wallet (AA) ユーザーと EOA ユーザーを submit-tx/build-tx で経路分岐する。

## 変更
- **build-tx**（`build_partner_tx`）: `smart_wallet_address` 設定済ユーザーは `onBehalfOf`/`to` を **SCW アドレス**で構築（Aave ポジション保有者=SCW）。EOA ユーザーは従来どおり。`verify_supply_onbehalf`/`verify_withdraw_to` 主担保は**対象が SCW に変わるだけで不変**。
- **submit-tx**（`submit_partner_tx`）: SCW ユーザー → bundler の `verify_userop_receipt` で `success`/`sender(=SCW)` を検証（**fail-closed**）。EOA ユーザー → 従来 `_verify_on_chain_receipt`（**不変**）。判別子 = `users.smart_wallet_address is not None`。`BUNDLER_RPC_URL` 未設定なら **503**。
- **env**: `BUNDLER_RPC_URL` を `.env.*.example` 3種に追記（環境分離: staging=Base Sepolia / prod=Base）。
- **tests**: `test_slice3b_scw_routing.py` 5 ケース（SCW→userop 検証 / 503 / 400 / EOA 非該当 / build-tx SCW wallet）。

## 検証
- ruff / format / mypy ✅
- slice3b: **5 passed**
- 回帰: non_custodial_f1f2 + build_tx_onbehalf + proposals_api + userop_verify = **58 passed**（EOA 経路無回帰）

## ⚠️ ライブ化の前提（本 PR マージ ≠ ライブ）
- SCW 経路は `BUNDLER_RPC_URL` 未設定なら 503 / EOA 経路は不変なので、マージしても本番挙動は変わらない（SCW ユーザーが存在し env が設定されて初めて作動）
- **実機検証**: staging-v4 デプロイ + 実 SCW UserOp の supply/withdraw 完走が必要

## 次工程
- **slice4**: frontend SmartWalletsProvider 配線（`useSmartWallets` で全署名4経路を UserOp 化）+ ユーザーへの `smart_wallet_address` 登録経路
- **slice5/6**: SDK 依存 / F-9 expense 再設計

関連: docs/privy-aa-paymaster-design.md / Asana 1215697060370824

🤖 Generated with [Claude Code](https://claude.com/claude-code)