### PR TITLE
fix(ci): slice3b の assert を None ガードに置換 (S101 / main の Security Check 修復)

### DIFF
--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -1024,12 +1024,10 @@ def submit_partner_tx(
     # 実行主体の判定 (slice3b): Smart Wallet (AA) ユーザーは bundler の UserOp receipt で、
     # EOA ユーザーは従来の on-chain tx receipt で検証する。
     proposal_user = db.scalars(select(User).where(User.id == proposal.user_id)).first()
-    is_smart_wallet = proposal_user is not None and bool(proposal_user.smart_wallet_address)
+    scw_address = proposal_user.smart_wallet_address if proposal_user is not None else None
 
-    if is_smart_wallet:
+    if scw_address:
         # AA 経路: body.tx_hash は userOpHash。bundler で success / sender(=SCW) を検証 (fail-closed)。
-        assert proposal_user is not None  # is_smart_wallet=True なら非 None
-        scw_address = proposal_user.smart_wallet_address or ""
         bundler_url = os.getenv("BUNDLER_RPC_URL", "")
         if not bundler_url:
             raise HTTPException(


### PR DESCRIPTION
## 概要
PR #797（slice3b）が **S101 を含む旧コミットでマージされた**ため、main の Security Check（`ruff check . --select S`）が **S101「Use of assert detected」** で fail する状態になっている。本 PR でそれを修復する。

## 経緯
- #797 の CI Security Check は `assert proposal_user is not None`（slice3b で mypy narrowing 用に追加）で fail していた
- 修正コミットを branch に push したが GitHub の PR head 同期が起きず（既知の sync 不全）、**修正前の commit のまま #797 がマージ**された
- 結果 main に assert が入り Security Check が落ちる

## 変更
`backend/app/proposals/router.py`（submit-tx 経路分岐）:
```python
# before (S101)
is_smart_wallet = proposal_user is not None and bool(proposal_user.smart_wallet_address)
if is_smart_wallet:
    assert proposal_user is not None
    scw_address = proposal_user.smart_wallet_address or ""
# after
scw_address = proposal_user.smart_wallet_address if proposal_user is not None else None
if scw_address:
    ...
```
None ガードで mypy narrowing を維持しつつ assert を除去。**ロジックは完全に等価**（SCW 判定・検証経路不変）。

## 検証
- `ruff check . --select S`（CI と同一）→ **All checks passed**
- mypy ✅ / slice3b tests **5 passed**

関連: #797 / docs/privy-aa-paymaster-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)