### PR TITLE
feat(paymaster): スライス4a — PrivyRootClient に SmartWalletsProvider 配線

### DIFF
--- a/frontend/lib/wallet/PrivyRootClient.tsx
+++ b/frontend/lib/wallet/PrivyRootClient.tsx
@@ -3,6 +3,7 @@
 // Unauthorized copying or distribution is strictly prohibited.
 
 import { PrivyProvider } from '@privy-io/react-auth'
+import { SmartWalletsProvider } from '@privy-io/react-auth/smart-wallets'
 import { base, baseSepolia } from 'wagmi/chains'
 import { WagmiProvider } from 'wagmi'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -52,11 +53,17 @@ export function PrivyRootClient({ children }: { children: ReactNode }) {
         },
       }}
     >
-      <WagmiProvider config={wagmiConfig}>
-        <QueryClientProvider client={queryClient}>
-          {children}
-        </QueryClientProvider>
-      </WagmiProvider>
+      {/* SmartWalletsProvider: Privy Smart Wallet (ERC-4337 AA) を有効化する (slice4a)。
+          bundler/paymaster は Privy ダッシュボード設定 (track C) から供給される。
+          useSmartWallets() が SCW client を返し、slice4c で署名経路が UserOp 送信に使う。
+          非カストディアル不変条件: SCW の owner はユーザー embedded EOA のみ (§1.5)。 */}
+      <SmartWalletsProvider>
+        <WagmiProvider config={wagmiConfig}>
+          <QueryClientProvider client={queryClient}>
+            {children}
+          </QueryClientProvider>
+        </WagmiProvider>
+      </SmartWalletsProvider>
     </PrivyProvider>
   )
 }


### PR DESCRIPTION
## 概要
設計 doc §6.2 **スライス4a**（承認 2026-06-18）。slice5(#799 permissionless) を前提に Privy Smart Wallet (ERC-4337 AA) を有効化。

## 変更
`lib/wallet/PrivyRootClient.tsx`: `PrivyProvider` 内で children を `<SmartWalletsProvider>` で包む。
- bundler/paymaster は **Privy ダッシュボード設定（track C 済）**から供給
- `useSmartWallets()` が SCW client を返す（slice4c で署名経路が UserOp 送信に使用）
- 非 Privy 経路（appId 未設定 = PWA degrade）は従来どおり Provider なし

## 非カストディアル不変条件（§1.5）
SCW の owner = ユーザー embedded EOA のみ。UATa は owner にならない。

## 検証
- tsc exit 0 / eslint 0
- **next build 87/87 static pages**（全 Privy 画面の根のため全体ビルド確認）
- `useSmartWallets` 未呼び出し（slice4c で消費するまで**挙動変化なし**）

## 次工程
4b SCW 登録 EP → 4c 署名4経路 UserOp 化（liff-chat 消費者経路から先行）→ staging-v4 実機検証。

関連: docs/privy-aa-paymaster-design.md / Asana 1215697060370824

🤖 Generated with [Claude Code](https://claude.com/claude-code)