### PR TITLE
feat(paymaster): スライス4b — Smart Wallet アドレス登録経路 (案a)

### DIFF
--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -45,6 +45,8 @@ from .schemas import (
     RegisterResponse,
     RegisterWithReferralRequest,
     RiskModeUpdateRequest,
+    SmartWalletLinkRequest,
+    SmartWalletLinkResponse,
     TermsAcceptRequest,
     TermsStatusResponse,
     TokenResponse,
@@ -786,6 +788,72 @@ def wallet_link(
         wallet_address=address_lower,
         linked_at=linked_at,
     )
+
+
+@router.post(
+    "/wallet/smart-link",
+    response_model=SmartWalletLinkResponse,
+    summary="認証済みユーザーに Smart Wallet (SCW) アドレスを登録 (slice4b)",
+)
+def smart_wallet_link(
+    request: SmartWalletLinkRequest,
+    user: User = Depends(require_active_user),
+    db: Session = Depends(get_db),
+) -> SmartWalletLinkResponse:
+    """
+    JWT 認証済みユーザーに ERC-4337 Smart Wallet (SCW) アドレスを登録する (slice4b 案a)。
+
+    SCW はコントラクトで EOA 署名できないため署名検証は行わない。非カストディアル設計
+    (submit-tx の UserOp sender==登録SCW 検証 / unique 制約 / VIEWER は自己提案のみ) で安全。
+    冪等: 同一アドレス再登録は 200 で no-op。
+
+    レスポンス:
+    - 200: 登録成功 (または冪等 no-op)
+    - 401: 未認証
+    - 409: 別ユーザーが同じ smart_wallet_address を登録済み
+    - 422: アドレス形式不正
+    """
+    import re  # noqa: PLC0415
+
+    addr = request.smart_wallet_address
+    if not re.fullmatch(r"0x[0-9a-fA-F]{40}", addr):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Invalid smart_wallet_address format",
+        )
+
+    addr_lower = addr.lower()
+
+    # 冪等: 既に自分が同一アドレスを登録済みなら no-op。
+    if user.smart_wallet_address and user.smart_wallet_address.lower() == addr_lower:
+        return SmartWalletLinkResponse(
+            user_id=user.id, smart_wallet_address=user.smart_wallet_address
+        )
+
+    # unique 制約: 別ユーザーが登録済みなら 409 (横取り防止)。
+    existing = AuthService.get_user_by_smart_wallet(db, addr_lower)
+    if existing is not None and existing.id != user.id:
+        logger.warning(
+            "Smart wallet link conflict: jwt_user=%d existing_user=%d scw=%s...",
+            user.id,
+            existing.id,
+            addr_lower[:10],
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="smart_wallet_address already linked to another user",
+        )
+
+    user.smart_wallet_address = addr_lower
+    db.commit()
+    db.refresh(user)
+    logger.info(
+        "Smart wallet linked: user_id=%d scw=%s...%s",
+        user.id,
+        addr_lower[:10],
+        addr_lower[-4:],
+    )
+    return SmartWalletLinkResponse(user_id=user.id, smart_wallet_address=user.smart_wallet_address)
 
 
 class WalletUnlinkResponse(BaseModel):

--- a/backend/app/auth/schemas.py
+++ b/backend/app/auth/schemas.py
@@ -326,3 +326,25 @@ class WalletLinkResponse(BaseModel):
     linked_at: str  # ISO8601 文字列
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class SmartWalletLinkRequest(BaseModel):
+    """認証済みユーザーへの Smart Wallet (ERC-4337 SCW) アドレス登録 (POST /auth/wallet/smart-link)。
+
+    SCW はコントラクトのため EOA 署名による所有証明ができない。非カストディアル設計
+    (submit-tx の UserOp sender==登録SCW 検証 / unique 制約 / VIEWER は自己提案のみ) により、
+    JWT 認証済みユーザーが自分の SCW を登録する方式で安全 (slice4b 案a)。
+    """
+
+    smart_wallet_address: str = Field(
+        ..., min_length=42, max_length=42, description="Smart Wallet contract address (0x...)"
+    )
+
+
+class SmartWalletLinkResponse(BaseModel):
+    """Smart Wallet 登録レスポンス。"""
+
+    user_id: int
+    smart_wallet_address: str
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -350,6 +350,13 @@ class AuthService:
         return db.query(User).filter(User.wallet_address == wallet_address.lower()).first()
 
     @classmethod
+    def get_user_by_smart_wallet(cls, db: Session, smart_wallet_address: str) -> Optional[User]:
+        """Smart Wallet (ERC-4337 SCW) アドレスでユーザーを取得する (slice4b)。"""
+        return (
+            db.query(User).filter(User.smart_wallet_address == smart_wallet_address.lower()).first()
+        )
+
+    @classmethod
     def verify_wallet_signature(cls, wallet_address: str, message: str, signature: str) -> bool:
         """
         ウォレット署名を検証する。

--- a/backend/tests/test_smart_wallet_link.py
+++ b/backend/tests/test_smart_wallet_link.py
@@ -1,0 +1,144 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_smart_wallet_link.py
+"""slice4b: POST /auth/wallet/smart-link (Smart Wallet アドレス登録) のテスト。
+
+非カストディアル設計 (案a): JWT 認証ユーザーが自分の SCW を登録。署名検証なし、
+unique 制約 + 冪等。設計: docs/privy-aa-paymaster-design.md §6.2 スライス4b。
+"""
+
+import os
+import tempfile
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-scwlink")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "scwlink_admin@example.com")
+
+from app.database import Base, get_db  # noqa: E402
+from app.main import create_app  # noqa: E402
+
+SCW = "0x" + "ab" * 20
+SCW_MIXED = "0x" + "Ab" * 20  # 同一アドレスの大小混在表記
+SCW2 = "0x" + "cd" * 20
+BAD_HEX = "0x" + "zz" * 20  # 42 文字だが非 hex
+
+
+@pytest.fixture()
+def test_db():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db() -> Generator:
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    yield override_get_db
+    Base.metadata.drop_all(bind=engine)
+    os.unlink(path)
+
+
+@pytest.fixture()
+def client(test_db) -> TestClient:
+    app = create_app()
+    app.dependency_overrides[get_db] = test_db
+    return TestClient(app)
+
+
+def get_admin_token(client: TestClient) -> str:
+    email = os.environ.get("INITIAL_ADMIN_EMAIL", "scwlink_admin@example.com")
+    client.post(
+        "/auth/register",
+        json={"email": email, "username": "admin", "password": "adminpassword123"},
+    )
+    r = client.post("/auth/login", json={"email": email, "password": "adminpassword123"})
+    return r.json()["access_token"]
+
+
+def create_viewer_and_login(client: TestClient, admin_token: str, email: str) -> str:
+    client.post(
+        "/users",
+        json={
+            "email": email,
+            "username": email.split("@")[0],
+            "password": "viewerpass123",
+            "role": "viewer",
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    r = client.post("/auth/login", json={"email": email, "password": "viewerpass123"})
+    return r.json()["access_token"]
+
+
+def _post(client: TestClient, token: str | None, addr: str):
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    return client.post(
+        "/auth/wallet/smart-link", json={"smart_wallet_address": addr}, headers=headers
+    )
+
+
+def test_register_success_lowercased(client: TestClient) -> None:
+    token = get_admin_token(client)
+    r = _post(client, token, SCW)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["smart_wallet_address"] == SCW.lower()
+
+
+def test_idempotent_same_address(client: TestClient) -> None:
+    token = get_admin_token(client)
+    assert _post(client, token, SCW).status_code == 200
+    # 同一アドレス再登録 → no-op 200
+    r2 = _post(client, token, SCW)
+    assert r2.status_code == 200, r2.text
+
+
+def test_case_insensitive_idempotent(client: TestClient) -> None:
+    token = get_admin_token(client)
+    assert _post(client, token, SCW).status_code == 200
+    # 大小混在の同一アドレス → no-op 200
+    r2 = _post(client, token, SCW_MIXED)
+    assert r2.status_code == 200, r2.text
+
+
+def test_conflict_409_other_user(client: TestClient) -> None:
+    admin = get_admin_token(client)
+    assert _post(client, admin, SCW).status_code == 200
+    viewer = create_viewer_and_login(client, admin, "scw_viewer@example.com")
+    r = _post(client, viewer, SCW)
+    assert r.status_code == 409, r.text
+
+
+def test_invalid_hex_format_422(client: TestClient) -> None:
+    token = get_admin_token(client)
+    r = _post(client, token, BAD_HEX)
+    assert r.status_code == 422, r.text
+
+
+def test_too_short_422(client: TestClient) -> None:
+    token = get_admin_token(client)
+    r = _post(client, token, "0x123")  # min_length=42 → Pydantic 422
+    assert r.status_code == 422, r.text
+
+
+def test_unauthenticated_401(client: TestClient) -> None:
+    r = _post(client, None, SCW)
+    assert r.status_code in (401, 403), r.text
+
+
+def test_viewer_can_register_own(client: TestClient) -> None:
+    """VIEWER (消費者) も自分の SCW を登録できる。"""
+    admin = get_admin_token(client)
+    viewer = create_viewer_and_login(client, admin, "scw_viewer2@example.com")
+    r = _post(client, viewer, SCW2)
+    assert r.status_code == 200, r.text
+    assert r.json()["smart_wallet_address"] == SCW2.lower()

--- a/frontend/lib/api/smart-wallet.ts
+++ b/frontend/lib/api/smart-wallet.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// frontend/lib/api/smart-wallet.ts
+// Smart Wallet (ERC-4337 SCW) アドレスを backend に登録する (slice4b)。
+
+/**
+ * 認証済みユーザーの SCW アドレスを backend に登録する。
+ * POST /auth/wallet/smart-link（require_active_user）。冪等・unique 制約は backend 側。
+ * submit-tx (slice3b) はこの登録アドレスを UserOp sender として検証する。
+ */
+export async function registerSmartWallet(
+  address: string,
+  token: string,
+): Promise<Response> {
+  const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ""
+  return fetch(`${API_BASE}/auth/wallet/smart-link`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ smart_wallet_address: address }),
+  })
+}

--- a/frontend/lib/wallet/PrivyRootClient.tsx
+++ b/frontend/lib/wallet/PrivyRootClient.tsx
@@ -9,6 +9,7 @@ import { WagmiProvider } from 'wagmi'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactNode, useState } from 'react'
 import { wagmiConfig } from './config'
+import { SmartWalletRegistrar } from './SmartWalletRegistrar'
 
 const appId = process.env.NEXT_PUBLIC_PRIVY_APP_ID || ''
 
@@ -58,6 +59,8 @@ export function PrivyRootClient({ children }: { children: ReactNode }) {
           useSmartWallets() が SCW client を返し、slice4c で署名経路が UserOp 送信に使う。
           非カストディアル不変条件: SCW の owner はユーザー embedded EOA のみ (§1.5)。 */}
       <SmartWalletsProvider>
+        {/* SCW が用意でき次第 backend に自動登録する (slice4b)。描画なし。 */}
+        <SmartWalletRegistrar />
         <WagmiProvider config={wagmiConfig}>
           <QueryClientProvider client={queryClient}>
             {children}

--- a/frontend/lib/wallet/SmartWalletRegistrar.tsx
+++ b/frontend/lib/wallet/SmartWalletRegistrar.tsx
@@ -1,0 +1,36 @@
+'use client'
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// frontend/lib/wallet/SmartWalletRegistrar.tsx
+// Privy Smart Wallet (SCW) が用意でき次第、その address を backend に自動登録する (slice4b)。
+// SmartWalletsProvider 配下にマウントする（useSmartWallets を使うため）。描画はしない。
+
+import { useEffect, useRef } from 'react'
+import { usePrivy } from '@privy-io/react-auth'
+import { useSmartWallets } from '@privy-io/react-auth/smart-wallets'
+import { getAuthToken } from '@/lib/auth/token-key'
+import { registerSmartWallet } from '@/lib/api/smart-wallet'
+
+export function SmartWalletRegistrar(): null {
+  const { authenticated } = usePrivy()
+  const { client } = useSmartWallets()
+  // 登録済みアドレスを記録し、同一アドレスの再 POST を抑止する（backend も冪等だが無駄打ち回避）。
+  const registeredRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    const address = client?.account?.address
+    const token = getAuthToken()
+    if (!address || !token) return
+    if (registeredRef.current === address) return
+    registeredRef.current = address
+    // 失敗時は ref を戻して次回再試行可能にする（fail-open: UI は止めない）。
+    registerSmartWallet(address, token)
+      .then((res) => {
+        if (!res.ok) registeredRef.current = null
+      })
+      .catch(() => {
+        registeredRef.current = null
+      })
+  }, [client, authenticated])
+
+  return null
+}


### PR DESCRIPTION
## 概要
設計 doc §6.2 **スライス4b**（承認 2026-06-18・方式=**案a**）。`useSmartWallets()` の SCW アドレスを backend `users.smart_wallet_address` に登録する経路。slice3b の submit-tx 検証・slice4c の署名経路の前提。

## backend
- **`POST /auth/wallet/smart-link`**（`require_active_user`）: `SmartWalletLinkRequest{smart_wallet_address}`
  - 形式検証（0x+40hex → 422）/ **unique**（別ユーザー登録済 → 409）/ **冪等**（同一 → no-op 200）/ lower 格納
  - SCW はコントラクトで EOA 署名不可のため**署名検証なし**。非カストディアル設計（submit-tx の `sender==登録SCW` 検証 / unique / VIEWER は自己提案のみ）で安全
- `AuthService.get_user_by_smart_wallet` 追加（`get_user_by_wallet` 踏襲）
- `test_smart_wallet_link.py`: **8 ケース**（成功/冪等/大小無視/409/422×2/401/VIEWER 可）

## frontend
- `lib/api/smart-wallet.ts`: `registerSmartWallet(address, token)`
- `lib/wallet/SmartWalletRegistrar.tsx`: `useSmartWallets` の SCW を取得し次第 backend に**自動登録**（冪等・fail-open・描画なし）。`PrivyRootClient` の `SmartWalletsProvider` 配下にマウント

## 検証
- ruff / format / mypy ✅
- pytest auth + slice4b **65 passed**
- tsc 0 / eslint 0 / **next build 87/87**

## 次工程
**slice4c**: 署名4経路を UserOp 化（`useSmartWallets().client.sendTransaction`）。liff-chat 消費者経路（`ProposalSignSheet`）から先行 → staging-v4 実機検証。

関連: docs/privy-aa-paymaster-design.md / Asana 1215697060370824

🤖 Generated with [Claude Code](https://claude.com/claude-code)