### PR TITLE
feat(paymaster): スライス4c-1 — liff-chat 消費者署名を UserOp 化 (SCW 分岐)

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/ProposalSignSheet.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/ProposalSignSheet.tsx
@@ -7,10 +7,21 @@
 
 import { useState, useCallback } from "react"
 import { usePrivy, useWallets } from "@privy-io/react-auth"
+import { useSmartWallets } from "@privy-io/react-auth/smart-wallets"
 import { useTranslations } from "next-intl"
 import { ethers } from "ethers"
 import { Loader2, Lock, CheckCircle2 } from "lucide-react"
-import { buildPartnerTx, submitPartnerTx } from "@/lib/api/admin-proposals"
+import { buildPartnerTx, submitPartnerTx, type UnsignedTx } from "@/lib/api/admin-proposals"
+
+// build-tx の UnsignedTx を Smart Wallet UserOp の call 形式 (to/data/value) に変換する。
+// approve/supply/withdraw はいずれも 0 ETH value。
+function toCall(tx: UnsignedTx): { to: `0x${string}`; data: `0x${string}`; value: bigint } {
+  return {
+    to: tx.to as `0x${string}`,
+    data: tx.data as `0x${string}`,
+    value: 0n,
+  }
+}
 
 // /api/proposals/pending の要素 (ProposalResponse) のうち本シートが使う最小集合。
 // Decimal 系は JSON では文字列で返る (CLAUDE.md: Decimal は文字列で返却)。
@@ -48,6 +59,8 @@ export function ProposalSignSheet({
 }: ProposalSignSheetProps) {
   const { login } = usePrivy()
   const { wallets } = useWallets()
+  // Smart Wallet (AA) client。設定済 (SCW ユーザー) なら UserOp 経路、未設定なら EOA 経路。
+  const { client: scwClient } = useSmartWallets()
   const t = useTranslations("Liff.exec")
   const [signingStatus, setSigningStatus] = useState<SigningStatus>("idle")
   const [error, setError] = useState<string | null>(null)
@@ -72,86 +85,101 @@ export function ProposalSignSheet({
     setSigningStatus("signing")
 
     try {
-      // Privy embedded wallet (TEE) のみ。外部 wallet は秘密鍵管理懸念で除外。
-      const wallet = wallets.find((w) => w.walletClientType === "privy")
-      if (!wallet) {
-        await login()
-        setSigningStatus("idle")
-        return
-      }
-
-      // Step 1: サーバーから未署名 tx を取得。build-tx は onBehalfOf / to == 本人 wallet を
-      // サーバー側で検証して返す (非カストディアル method2)。
+      // Step 1: サーバーから未署名 tx を取得。build-tx は onBehalfOf / to == 本人 wallet
+      // (EOA または Smart Wallet) をサーバー側で検証して返す (非カストディアル)。
       const txData = await buildPartnerTx(proposal.id, token)
 
-      const eip1193 = await wallet.getEthereumProvider()
-      const ethProvider = new ethers.BrowserProvider(
-        eip1193 as unknown as ethers.Eip1193Provider,
-      )
+      let finalHash: string
 
-      let finalTxHash: string
-
-      if (txData.operation === "SUPPLY" && txData.approve_tx && txData.supply_tx) {
-        // SUPPLY: approve → supply の順に本人が署名・送信。
-        const approveTxHash = (await eip1193.request({
-          method: "eth_sendTransaction",
-          params: [
-            {
-              to: txData.approve_tx.to,
-              data: txData.approve_tx.data,
-              from: txData.approve_tx.from,
-              value: "0x0",
-            },
-          ],
-        })) as string
-
-        const approveReceipt = await ethProvider.waitForTransaction(approveTxHash)
-        if (approveReceipt === null || approveReceipt.status === 0) {
-          throw new Error(t("revertError"))
+      if (scwClient) {
+        // ── Smart Wallet (ERC-4337 AA) 経路: ガスは paymaster が肩代わり (ETH 不要)。──
+        // approve + supply は 1 UserOp にバッチ。返り値は userOpHash → submit-tx (slice3b) が
+        // bundler の eth_getUserOperationReceipt で success / sender(=SCW) を検証する。
+        let calls: { to: `0x${string}`; data: `0x${string}`; value: bigint }[]
+        if (txData.operation === "SUPPLY" && txData.approve_tx && txData.supply_tx) {
+          calls = [toCall(txData.approve_tx), toCall(txData.supply_tx)]
+        } else if (txData.operation === "WITHDRAW" && txData.withdraw_tx) {
+          calls = [toCall(txData.withdraw_tx)]
+        } else {
+          throw new Error(t("unsupportedOperation", { operation: txData.operation }))
         }
-
         setSigningStatus("confirming")
-        finalTxHash = (await eip1193.request({
-          method: "eth_sendTransaction",
-          params: [
-            {
-              to: txData.supply_tx.to,
-              data: txData.supply_tx.data,
-              from: txData.supply_tx.from,
-              value: "0x0",
-            },
-          ],
-        })) as string
-      } else if (txData.operation === "WITHDRAW" && txData.withdraw_tx) {
-        finalTxHash = (await eip1193.request({
-          method: "eth_sendTransaction",
-          params: [
-            {
-              to: txData.withdraw_tx.to,
-              data: txData.withdraw_tx.data,
-              from: txData.withdraw_tx.from,
-              value: "0x0",
-            },
-          ],
-        })) as string
+        finalHash = await scwClient.sendUserOperation({ calls })
       } else {
-        throw new Error(t("unsupportedOperation", { operation: txData.operation }))
+        // ── EOA 経路 (従来・unchanged): 本人が ETH ガスを払って eth_sendTransaction。──
+        // Privy embedded wallet (TEE) のみ。外部 wallet は秘密鍵管理懸念で除外。
+        const wallet = wallets.find((w) => w.walletClientType === "privy")
+        if (!wallet) {
+          await login()
+          setSigningStatus("idle")
+          return
+        }
+        const eip1193 = await wallet.getEthereumProvider()
+        const ethProvider = new ethers.BrowserProvider(
+          eip1193 as unknown as ethers.Eip1193Provider,
+        )
+
+        if (txData.operation === "SUPPLY" && txData.approve_tx && txData.supply_tx) {
+          const approveTxHash = (await eip1193.request({
+            method: "eth_sendTransaction",
+            params: [
+              {
+                to: txData.approve_tx.to,
+                data: txData.approve_tx.data,
+                from: txData.approve_tx.from,
+                value: "0x0",
+              },
+            ],
+          })) as string
+
+          const approveReceipt = await ethProvider.waitForTransaction(approveTxHash)
+          if (approveReceipt === null || approveReceipt.status === 0) {
+            throw new Error(t("revertError"))
+          }
+
+          setSigningStatus("confirming")
+          finalHash = (await eip1193.request({
+            method: "eth_sendTransaction",
+            params: [
+              {
+                to: txData.supply_tx.to,
+                data: txData.supply_tx.data,
+                from: txData.supply_tx.from,
+                value: "0x0",
+              },
+            ],
+          })) as string
+        } else if (txData.operation === "WITHDRAW" && txData.withdraw_tx) {
+          finalHash = (await eip1193.request({
+            method: "eth_sendTransaction",
+            params: [
+              {
+                to: txData.withdraw_tx.to,
+                data: txData.withdraw_tx.data,
+                from: txData.withdraw_tx.from,
+                value: "0x0",
+              },
+            ],
+          })) as string
+        } else {
+          throw new Error(t("unsupportedOperation", { operation: txData.operation }))
+        }
       }
 
       setSigningStatus("confirming")
 
-      // Step 3: submit-tx で最終 tx_hash を報告。サーバーが on-chain receipt を
-      // 検証する (from == 本人 wallet / status == 1)。
-      await submitPartnerTx(proposal.id, finalTxHash, txData.wallet_address, token)
+      // Step 3: submit-tx で最終 hash を報告。SCW ユーザーは userOpHash を bundler receipt で、
+      // EOA ユーザーは tx_hash を on-chain receipt で検証する (slice3b の経路分岐)。
+      await submitPartnerTx(proposal.id, finalHash, txData.wallet_address, token)
 
       setSigningStatus("success")
-      onExecuted(finalTxHash)
+      onExecuted(finalHash)
     } catch (err) {
       setSigningStatus("error")
       const msg = err instanceof Error ? err.message : t("signFailed")
       setError(msg.includes("rejected") ? t("signCanceled") : msg)
     }
-  }, [wallets, login, proposal.id, token, onExecuted, t])
+  }, [scwClient, wallets, login, proposal.id, token, onExecuted, t])
 
   if (!open) return null
 


### PR DESCRIPTION
## 概要
設計 doc §6.2 **スライス4c**（承認 2026-06-18）の**消費者経路（最優先）**。`ProposalSignSheet`（liff-chat）の署名を Smart Wallet (AA) ユーザーは UserOp、EOA ユーザーは従来 `eth_sendTransaction` に分岐する。

## 変更（`ProposalSignSheet.tsx`）
- **SCW ユーザー**（`useSmartWallets().client` あり）: `client.sendUserOperation({ calls })` で実行
  - SUPPLY は **approve+supply を 1 UserOp にバッチ**（AA の利点）
  - ガスは **paymaster 肩代わり（ETH 不要）**
  - 返り値 **userOpHash** → submit-tx → slice3b が bundler の `eth_getUserOperationReceipt` で success/sender(=SCW) を検証
- **EOA ユーザー**（client なし）: 従来の `eth_sendTransaction` 経路（**完全に不変**）
- `toCall()`: build-tx の `UnsignedTx` を UserOp call (to/data/value=0n) に変換

## 設計整合（重要）
Privy `client.sendUserOperation` は **userOpHash** を返す（**型確認済 / tsc 0**）→ slice3b の userOpHash 前提・PoC と一致。Privy の `sendTransaction` は tx_hash を返すため**不採用**。

## 検証
- tsc 0 / eslint 0 / **next build 87/87**

## ⚠️ 要 staging 検証（本 PR は型・ビルド整合まで）
staging-v4 で **実 SCW・ETH ゼロ wallet の supply/withdraw 完走**（sendUserOperation→userOpHash→bundler receipt verify）を確認すること。SCW 未登録ユーザーは EOA 経路のまま（**挙動不変**）。

## スコープ
liff-chat のみ。残り3経路（liff-approve / partner/proposals / user/withdraw）は後続 PR。

関連: docs/privy-aa-paymaster-design.md / Asana 1215697060370824

🤖 Generated with [Claude Code](https://claude.com/claude-code)