### PR TITLE
fix(liff): HOLD 時の信頼度表示を平易な文言に変更

### DIFF
--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -359,7 +359,8 @@ export default function LiffChatPage() {
             >
               {t("home.aiJudgment")}
             </span>
-            {confidence > 0 && (
+            {/* BUY/SELL のみヘッダー右上に信頼度を表示（HOLD はアクション下に文章で説明） */}
+            {confidence > 0 && (isBuy || isSell) && (
               <span className="ml-auto text-[#736f7e] text-xs">{confidence}% {t("home.confidenceLabel")}</span>
             )}
           </div>
@@ -372,6 +373,13 @@ export default function LiffChatPage() {
           >
             {aiJudgment ? action : t("home.noSignal")}
           </div>
+
+          {/* HOLD 時: 弱シグナルのため様子見である旨を平易に説明（投資リテラシーの低いユーザー向け） */}
+          {aiJudgment && action === "HOLD" && confidence > 0 && (
+            <p className="mt-1 text-[#736f7e] text-xs leading-relaxed">
+              {t("home.holdWeakSignalLabel", { confidence })}
+            </p>
+          )}
 
           {/* なぜ{action}？理由トグル（aiJudgment がある場合のみ表示） */}
           {aiJudgment && (

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -683,6 +683,7 @@
       "lastMonthComparison": "vs last month",
       "aiJudgment": "AI JUDGMENT",
       "confidenceLabel": "confidence",
+      "holdWeakSignalLabel": "Holding — buy/sell signal too weak (confidence {confidence}%)",
       "approve": "Approve",
       "reject": "Dismiss",
       "whyAction": "Why {action}?",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -683,6 +683,7 @@
       "lastMonthComparison": "先月比",
       "aiJudgment": "AI JUDGMENT",
       "confidenceLabel": "信頼度",
+      "holdWeakSignalLabel": "売買シグナルが弱いため様子見中（確信度 {confidence}%）",
       "approve": "承認する",
       "reject": "見送る",
       "whyAction": "なぜ{action}？",


### PR DESCRIPTION
## 背景

liff-chat の HOLD 表示時に「**32% 信頼度**」と出ているが、投資リテラシーの低い UAT ユーザーには「HOLD に 32% しか自信がない→じゃあ動いてよ」と誤読される。

実際の意味は **BUY/SELL のシグナルが弱すぎる（< 40%）ため、AI が自動的に様子見（HOLD）に切り替えた** 結果（`backend/app/ai/service.py` で confidence < 40 → 強制 HOLD）。ラベルの意味と表示コンテキストが逆に伝わっていた。

## 変更内容

| 状態 | 変更前 | 変更後 |
|---|---|---|
| **HOLD** | ヘッダー右上に `32% 信頼度` | アクション下に `売買シグナルが弱いため様子見中（確信度 32%）` |
| **BUY/SELL** | ヘッダー右上に `32% 信頼度` | 変更なし |

- ヘッダー右上の信頼度バッジは `isBuy \|\| isSell` のときのみ表示
- HOLD かつ `confidence > 0` のとき、大きな「HOLD」表示の直下に平易な説明文を表示
- i18n キー `home.holdWeakSignalLabel` を ja/en に追加（`{confidence}` 補間）

信頼度は従来どおり WebSocket (`/api/ai/ws/decisions`) でリアルタイム更新される。

## Gate 結果
- ✅ i18n キー整合 (`check-i18n-keys.mjs`): 新規欠落なし
- ✅ `tsc --noEmit`: exit 0
- ✅ `npm run build`: exit 0

Closes: Asana https://app.asana.com/1/817733952351708/project/1213741124336104/task/1215849982919465

🤖 Generated with [Claude Code](https://claude.com/claude-code)