### PR TITLE
fix(automation): CEX 自動発注の裏線を既定で封鎖（Phase0 スライス0-F）

### DIFF
--- a/backend/app/automation/automation_router.py
+++ b/backend/app/automation/automation_router.py
@@ -9,6 +9,7 @@ POST /automation/process-news:
 """
 
 import logging
+import os
 from typing import Any, List
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -77,6 +78,17 @@ def process_news(
     """
     logger.info("POST /automation/process-news called")
 
+    # CEX 自動発注は NEWS_AUTO_EXECUTE_ENABLED=true のとき以外は PROPOSAL_ONLY に固定する。
+    # 旧実装は execution_policy=AUTO_EXECUTE をハードコードしており、内部トークンさえあれば
+    # 承認ゲートなしで exchange_service.execute_trade に到達できた。多層防御の第2層（最重要）:
+    # このエンドポイントが直接叩かれても既定では発注に到達させない（2026-06 CEX 裏線封鎖）。
+    news_auto_exec = os.getenv("NEWS_AUTO_EXECUTE_ENABLED", "false").lower() in ("true", "1", "yes")
+    news_execution_policy = (
+        ExecutionPolicy.AUTO_EXECUTE.value
+        if news_auto_exec
+        else ExecutionPolicy.PROPOSAL_ONLY.value
+    )
+
     try:
         run_result = process_pending_knowledge(
             db,
@@ -85,7 +97,7 @@ def process_news(
             exchange_service=get_exchange_service(),
             monitoring_service=monitoring_service,
             dry_run=dry_run,
-            execution_policy=ExecutionPolicy.AUTO_EXECUTE.value,
+            execution_policy=news_execution_policy,
         )
         monitoring_service.record_news_fetch()
     except Exception as exc:

--- a/backend/app/automation/scheduled_tasks.py
+++ b/backend/app/automation/scheduled_tasks.py
@@ -1120,6 +1120,12 @@ async def process_news_loop(
         try:
             await asyncio.sleep(interval_seconds)
 
+            # 多層防御の第3層: ループが何らかの経路で起動していても、フラグ未設定なら
+            # POST せずスキップ（runtime トグル・別経路起動への保険）。2026-06 CEX 裏線封鎖。
+            if os.getenv("NEWS_AUTO_EXECUTE_ENABLED", "false").lower() not in ("true", "1", "yes"):
+                logger.info("process_news_loop: NEWS_AUTO_EXECUTE_ENABLED not set, skipping POST")
+                continue
+
             token = os.getenv("INTERNAL_API_TOKEN", "")
             if not token:
                 logger.warning("process_news_loop: INTERNAL_API_TOKEN not set, skipping")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -507,11 +507,21 @@ def create_app() -> FastAPI:
                 mmt_interval = int(os.getenv("MMT_UPDATE_INTERVAL", "1800")) // 60
                 asyncio.create_task(start_mmt_background_task(interval_minutes=mmt_interval))
                 logger.info("MMT data feed started (interval: %ds)", mmt_interval * 60)
-            from app.automation.scheduled_tasks import process_news_loop  # noqa: PLC0415
+            # CEX 自動発注ループは NEWS_AUTO_EXECUTE_ENABLED=true のとき以外は起動しない。
+            # 旧実装は承認ゲートなしで 5 分毎に exchange_service.execute_trade を呼べる
+            # 状態で生きていた（既定 sandbox で実害は止まっていたが env 次第で本番約定し得た）。
+            # 多層防御の第1層: ループ自体を既定で起動しない（2026-06 CEX 裏線封鎖）。
+            if os.getenv("NEWS_AUTO_EXECUTE_ENABLED", "false").lower() in ("true", "1", "yes"):
+                from app.automation.scheduled_tasks import process_news_loop  # noqa: PLC0415
 
-            pn_interval = int(os.getenv("PROCESS_NEWS_INTERVAL_SECONDS", "300"))
-            asyncio.create_task(process_news_loop(interval_seconds=pn_interval))
-            logger.info("process_news_loop started (interval=%ds)", pn_interval)
+                pn_interval = int(os.getenv("PROCESS_NEWS_INTERVAL_SECONDS", "300"))
+                asyncio.create_task(process_news_loop(interval_seconds=pn_interval))
+                logger.info("process_news_loop started (interval=%ds)", pn_interval)
+            else:
+                logger.info(
+                    "process_news_loop NOT started: NEWS_AUTO_EXECUTE_ENABLED is not set "
+                    "(CEX auto-execution disabled)"
+                )
         except BaseException as exc:
             logger.error("Failed to start data feed background tasks: %s", exc)
 

--- a/backend/tests/test_automation_news_gate.py
+++ b/backend/tests/test_automation_news_gate.py
@@ -1,0 +1,79 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+"""POST /automation/process-news の CEX 自動発注ゲート（2026-06 CEX 裏線封鎖）。
+
+旧実装は execution_policy=AUTO_EXECUTE をハードコードしており、内部トークンさえあれば
+承認ゲートなしで exchange_service.execute_trade に到達できた。本テストは
+NEWS_AUTO_EXECUTE_ENABLED により execution_policy が切り替わることを検証する。
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.auth.constants import ExecutionPolicy
+
+
+def _fake_run_result() -> MagicMock:
+    """process_pending_knowledge の戻り値スタブ（ProcessNewsResponse 構築に必要な属性）。"""
+    rr = MagicMock()
+    rr.errors = []
+    rr.fetched_count = 0
+    rr.analyzed_count = 0
+    rr.traded_count = 0
+    rr.skipped_count = 0
+    rr.hold_count = 0
+    rr.status = "no_items"
+    return rr
+
+
+def _call_process_news_capturing_policy() -> str:
+    """process_news を呼び、process_pending_knowledge に渡る execution_policy を返す。"""
+    from app.automation import automation_router as ar
+
+    captured: dict[str, str] = {}
+
+    def _fake_ppk(*_args, **kwargs):  # type: ignore[no-untyped-def]
+        captured["execution_policy"] = kwargs["execution_policy"]
+        return _fake_run_result()
+
+    with (
+        patch.object(ar, "process_pending_knowledge", side_effect=_fake_ppk),
+        patch.object(ar, "KnowledgeService", MagicMock()),
+        patch.object(ar, "AIService", MagicMock()),
+        patch.object(ar, "get_exchange_service", MagicMock()),
+    ):
+        ar.process_news(dry_run=True, db=MagicMock(), monitoring_service=MagicMock(), _=None)
+
+    return captured["execution_policy"]
+
+
+def test_process_news_defaults_to_proposal_only_when_flag_unset() -> None:
+    """フラグ未設定時は PROPOSAL_ONLY（発注に到達させない）。"""
+    with patch.dict("os.environ", {}, clear=False):
+        import os
+
+        os.environ.pop("NEWS_AUTO_EXECUTE_ENABLED", None)
+        policy = _call_process_news_capturing_policy()
+    assert policy == ExecutionPolicy.PROPOSAL_ONLY.value
+
+
+def test_process_news_proposal_only_when_flag_false() -> None:
+    """明示的に false でも PROPOSAL_ONLY。"""
+    with patch.dict("os.environ", {"NEWS_AUTO_EXECUTE_ENABLED": "false"}):
+        policy = _call_process_news_capturing_policy()
+    assert policy == ExecutionPolicy.PROPOSAL_ONLY.value
+
+
+def test_process_news_auto_execute_only_when_flag_true() -> None:
+    """明示的に true のときだけ AUTO_EXECUTE。"""
+    with patch.dict("os.environ", {"NEWS_AUTO_EXECUTE_ENABLED": "true"}):
+        policy = _call_process_news_capturing_policy()
+    assert policy == ExecutionPolicy.AUTO_EXECUTE.value
+
+
+@pytest.mark.parametrize("value", ["1", "yes", "TRUE", "True"])
+def test_process_news_truthy_values_enable_auto_execute(value: str) -> None:
+    """true/1/yes（大文字小文字無視）で有効化。"""
+    with patch.dict("os.environ", {"NEWS_AUTO_EXECUTE_ENABLED": value}):
+        policy = _call_process_news_capturing_policy()
+    assert policy == ExecutionPolicy.AUTO_EXECUTE.value

--- a/backend/tests/test_scheduled_tasks.py
+++ b/backend/tests/test_scheduled_tasks.py
@@ -1493,6 +1493,16 @@ class TestProcessNewsLoop:
     - 例外発生時は on_error を呼び 60 秒待機すること
     """
 
+    @pytest.fixture(autouse=True)
+    def _enable_news_auto_execute(self):  # type: ignore[no-untyped-def]
+        """本クラスは POST 挙動を検証するため NEWS_AUTO_EXECUTE_ENABLED を有効化する。
+
+        process_news_loop は CEX 裏線封鎖（2026-06）で、このフラグが true でない限り
+        POST をスキップする。フラグ未設定時のスキップ挙動は専用テストで別途検証する。
+        """
+        with patch.dict("os.environ", {"NEWS_AUTO_EXECUTE_ENABLED": "true"}):
+            yield
+
     @staticmethod
     def _make_httpx_mock(status_code: int = 200) -> tuple[object, AsyncMock]:
         """httpx.AsyncClient のモック (class, client_instance) を返す。"""
@@ -1583,6 +1593,38 @@ class TestProcessNewsLoop:
         with (
             patch("app.automation.scheduled_tasks.asyncio.sleep", side_effect=mock_sleep),
             patch.dict("os.environ", {"INTERNAL_API_TOKEN": ""}),
+            patch("httpx.AsyncClient", mock_class),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await process_news_loop(interval_seconds=1)
+
+        mock_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_news_auto_execute_disabled(self) -> None:
+        """NEWS_AUTO_EXECUTE_ENABLED が未設定/false のとき、token があっても POST しない。
+
+        CEX 裏線封鎖（2026-06）: 承認ゲートなしの自動発注経路を既定で無効化する第3層防御。
+        """
+        from app.automation.scheduled_tasks import process_news_loop
+
+        sleep_count = 0
+
+        async def mock_sleep(seconds: float) -> None:
+            nonlocal sleep_count
+            sleep_count += 1
+            if sleep_count >= 2:
+                raise asyncio.CancelledError()
+
+        mock_class, mock_client = self._make_httpx_mock()
+
+        with (
+            patch("app.automation.scheduled_tasks.asyncio.sleep", side_effect=mock_sleep),
+            # autouse fixture の true を false で上書き（token は設定済みでも POST しないこと）
+            patch.dict(
+                "os.environ",
+                {"INTERNAL_API_TOKEN": "tok", "NEWS_AUTO_EXECUTE_ENABLED": "false"},
+            ),
             patch("httpx.AsyncClient", mock_class),
         ):
             with pytest.raises(asyncio.CancelledError):

--- a/docs/integration/backend_deps.md
+++ b/docs/integration/backend_deps.md
@@ -114,6 +114,18 @@
 
 ## backend/app/main.py
 
+### 変更 #15: process_news_loop 起動を NEWS_AUTO_EXECUTE_ENABLED でガード (PR #814 / 2026-06-19)
+- **コミット範囲**: `fix/cex-auto-execute-disable`
+- **変更内容**: `process_news_loop` の `asyncio.create_task` 起動を
+  `NEWS_AUTO_EXECUTE_ENABLED`（既定 false）の env フラグで条件分岐（13 行）。
+  フラグ未設定時は起動せず info ログのみ。
+- **理由**: CEX 自動発注の裏線封鎖（v4 完全おまかせ自動運用 Phase 0 / スライス0-F）。
+  承認ゲートなしで 5 分毎に `exchange_service.execute_trade` を呼べた経路を安全側に倒す。
+  多層防御の第1層（第2層=automation_router.py、第3層=scheduled_tasks.py は凍結対象外）。
+- **影響範囲**: 既定で CEX 自動発注ループが起動しなくなるのみ。news/RAG/AI Judge/
+  knowledge ・他 startup task への影響なし。
+- **承認**: fix/cex-auto-execute-disable → main (PR #814)
+
 ### 変更 #14: chat_router include_router + ChatMessage table 登録 (PR #643 / 2026-06-12)
 - **コミット範囲**: `feat/chat-history-persistence`
 - **変更内容**: `app.include_router(chat_router, prefix="/api")` を追加 (3 行) +


### PR DESCRIPTION
## 概要
v4「完全おまかせ自動運用」EPIC の **Phase 0（安全土台先行）/ スライス 0-F**。
承認ゲートなしで CEX 自動約定し得た裏線を、`NEWS_AUTO_EXECUTE_ENABLED`（既定 false）で多層封鎖する。

## 背景
`process_news_loop` が 5 分毎に `dry_run=false` で `/automation/process-news` を内部呼び出し → `automation_router` が `execution_policy=AUTO_EXECUTE` をハードコードで渡し → `workflow.exchange_service.execute_trade()` に**人間承認ゲートなし**で到達できた。既定 exchange client が sandbox のため実害は止まっていたが、`EXCHANGE_CLIENT_TYPE`/`APP_ENV` 設定次第で**本番約定し得た**。

## 変更（多層防御）
| 層 | ファイル | 内容 |
|---|---|---|
| 1 | `backend/app/main.py` | フラグ未設定なら `process_news_loop` を起動しない |
| 2（最重要）| `backend/app/automation/automation_router.py` | エンドポイントが直接叩かれても既定 `PROPOSAL_ONLY` に固定（`AUTO_EXECUTE` ハードコード撤去 + `import os`）|
| 3 | `backend/app/automation/scheduled_tasks.py` | ループ内でフラグ再チェックし POST をスキップ（runtime トグル保険）|

## テスト
- `tests/test_scheduled_tasks.py`: `TestProcessNewsLoop` に autouse fixture でフラグ有効化（POST 挙動検証）+ `test_skips_when_news_auto_execute_disabled`（無効時 POST しない）。
- 新規 `tests/test_automation_news_gate.py`: endpoint の policy 切替を検証（未設定/false → `PROPOSAL_ONLY`、true/1/yes/大文字 → `AUTO_EXECUTE`）。
- 回帰: news/RAG/AI Judge/knowledge は不変、**CEX 発注のみ封鎖**。

## DoD
- [x] ruff / ruff format / mypy クリーン
- [x] 関連スイート 107 passed（test_scheduled_tasks / test_automation_news_gate / test_execution_policy_enum / test_safety_wiring）
- [x] フラグ無で loop 未起動 / endpoint 直叩きでも `execute_trade` 未到達

## ⚠️ 既知の残課題（スライス 0-E へ委譲）
`workflow.py:582` の **HF<1.6 emergency override** は内部取得 HF が <1.6 のとき `effective_policy` を `AUTO_EXECUTE` に強制するため、直接 endpoint 呼出時に CEX `execute_trade` へ到達し得る。これは HARD_STOP ルーティング（CEX 経路にしか配線されていない安全装置）の統合課題で、**スライス 0-E（共通安全ゲート抽出 + Aave 自動執行経路への二重ゲート配線）で扱う**。本 PR の scope（投機的スケジューラ/endpoint 裏線の既定封鎖）からは意図的に分離。

Plan: `v4 完全おまかせ自動運用 — 段階実装プラン`（Phase 0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)