### PR TITLE
feat(delegation): 事前枠承認(委譲枠)DB + grant/revoke API + PolicyEngine gate（Phase0 スライス0-C）

### DIFF
--- a/backend/alembic/versions/dg20260619_add_delegation_grants.py
+++ b/backend/alembic/versions/dg20260619_add_delegation_grants.py
@@ -1,0 +1,77 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""add_delegation_grants
+
+delegation_grants テーブルを追加する（v4 完全おまかせ自動運用 Phase 0 / スライス0-C）。
+
+事前枠承認（委譲枠）を耐久記録する新規テーブル。ユーザーが「この枠・このリスクで任せる」と
+1回 consent した内容を保持し、AUTO 執行時に有効な grant が無ければ fail-closed で拒否する
+真実源になる。上限は % で保持し、実行時に risk_limiter ハード上限へ二重クランプする。
+
+status は application-layer で制御（active / revoked / expired）。models.py を唯一の真実源とし、
+CHECK 制約を本 migration 内で独自定義しない（CLAUDE.md CHECK制約二重管理ルール）。
+
+非破壊・新規テーブル追加のみ。既存テーブルへの影響なし。
+
+Revision ID: dg20260619
+Revises: swa20260618
+Create Date: 2026-06-19 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "dg20260619"
+down_revision: Union[str, Sequence[str], None] = "swa20260618"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create delegation_grants table."""
+    op.create_table(
+        "delegation_grants",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("wallet_address", sa.String(length=42), nullable=True),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="active"),
+        sa.Column("max_single_trade_pct", sa.Numeric(precision=5, scale=2), nullable=False),
+        sa.Column("max_daily_trade_pct", sa.Numeric(precision=5, scale=2), nullable=False),
+        sa.Column("hf_floor", sa.Numeric(precision=6, scale=3), nullable=False),
+        sa.Column("allowed_protocols", sa.JSON(), nullable=False),
+        sa.Column("allowed_assets", sa.JSON(), nullable=False),
+        sa.Column("consent_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("privy_policy_id", sa.String(length=255), nullable=True),
+        sa.Column("privy_signer_id", sa.String(length=255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index("ix_delegation_grants_user_id", "delegation_grants", ["user_id"])
+
+
+def downgrade() -> None:
+    """Drop delegation_grants table."""
+    op.drop_index("ix_delegation_grants_user_id", table_name="delegation_grants")
+    op.drop_table("delegation_grants")

--- a/backend/app/policy/engine.py
+++ b/backend/app/policy/engine.py
@@ -36,6 +36,9 @@ class PolicyContext:
     expected_hf_after: Optional[Decimal] = None
     # 承認時のみ設定。DB クエリで自分自身を除外するために使う。
     proposal_id: Optional[int] = None
+    # True のとき「無承認の AUTO 執行」。有効な委譲枠 (delegation grant) が無ければ拒否する。
+    # 既定 False = 手動承認経路（approve_proposal）は本ルールの影響を受けない。
+    is_auto_execution: bool = False
 
 
 @dataclass
@@ -112,6 +115,18 @@ class PolicyEngine:
             violations.append(
                 f"expected_hf_after {ctx.expected_hf_after} below floor {self._hf_floor}"
             )
+
+        # Rule 8: AUTO 執行は有効な委譲枠 (delegation grant) を必須とする（fail-closed）。
+        # 手動承認経路 (is_auto_execution=False) には影響しない。実際の % 上限クランプは
+        # 執行直前の risk_limiter で行う（本ルールは「枠の存在・有効性」のみを担保する）。
+        if ctx.is_auto_execution and db is not None:
+            from app.users.models import get_active_grant  # noqa: PLC0415
+
+            if get_active_grant(ctx.user_id, db) is None:
+                violations.append(
+                    "auto-execution requires an active delegation grant "
+                    f"(user_id={ctx.user_id}); none found"
+                )
 
         passed = not violations
         if not passed:

--- a/backend/app/users/models.py
+++ b/backend/app/users/models.py
@@ -28,7 +28,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Optional
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, Numeric, String
+from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, Numeric, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
@@ -145,3 +145,120 @@ class AccountDeletionRequest(Base):
 
     def __repr__(self) -> str:
         return f"<AccountDeletionRequest(user_id={self.user_id}, status={self.status})>"
+
+
+# 委譲枠 (delegation grant) の status 値（models.py を唯一の真実源とする /
+# CHECK 制約は migration 内で独自定義しない）。
+DELEGATION_STATUS_ACTIVE = "active"
+DELEGATION_STATUS_REVOKED = "revoked"
+DELEGATION_STATUS_EXPIRED = "expired"
+
+
+class DelegationGrant(Base):
+    """事前枠承認（委譲枠）テーブル。
+
+    v4 完全おまかせ自動運用（Phase 0 / スライス0-C）の事前枠承認を耐久記録する。
+    ユーザーが「この枠・このリスクで任せる」と1回 consent した内容を保持し、
+    AUTO 執行時に有効な grant が無ければ fail-closed で拒否するための真実源になる。
+
+    - 上限は **%** で保持し、実行時に総資産 × risk_limiter ハード上限（単一≤10% /
+      日次≤30% / HF≥1.6）で二重クランプする（DB 値が緩くてもハードが勝つ）。
+    - status は application-layer で制御（active / revoked / expired）。CHECK 制約を
+      migration 内で独自定義しない（models.py が唯一の真実源）。
+    - 1 ユーザーが複数 grant を持ち得る（履歴を残す）。有効判定は get_active_grant() で行う。
+    - 本モジュールは main.py から import され Base.metadata.create_all() でテーブル自動作成。
+      production は alembic migration（down_revision=swa20260618）で適用する。
+
+    手動 CREATE TABLE SQL (新規環境・DB 再構築時):
+        CREATE TABLE IF NOT EXISTS delegation_grants (
+            id                    SERIAL PRIMARY KEY,
+            user_id               INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            wallet_address        VARCHAR(42),
+            status                VARCHAR(16) NOT NULL DEFAULT 'active',
+            max_single_trade_pct  NUMERIC(5,2) NOT NULL,
+            max_daily_trade_pct   NUMERIC(5,2) NOT NULL,
+            hf_floor              NUMERIC(6,3) NOT NULL,
+            allowed_protocols     JSON NOT NULL,
+            allowed_assets        JSON NOT NULL,
+            consent_at            TIMESTAMPTZ NOT NULL,
+            expires_at            TIMESTAMPTZ NOT NULL,
+            revoked_at            TIMESTAMPTZ,
+            privy_policy_id       VARCHAR(255),
+            privy_signer_id       VARCHAR(255),
+            created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        CREATE INDEX IF NOT EXISTS ix_delegation_grants_user_id
+            ON delegation_grants (user_id);
+    """
+
+    __tablename__ = "delegation_grants"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # 委譲対象ウォレット（smart_wallet_address 優先。consent 時点の値を固定保持）
+    wallet_address: Mapped[Optional[str]] = mapped_column(String(42), nullable=True, default=None)
+    status: Mapped[str] = mapped_column(
+        String(16), nullable=False, default=DELEGATION_STATUS_ACTIVE
+    )
+    # 上限は % で保持（実行時に risk_limiter ハード上限へクランプ）
+    max_single_trade_pct: Mapped[Decimal] = mapped_column(
+        Numeric(precision=5, scale=2), nullable=False
+    )
+    max_daily_trade_pct: Mapped[Decimal] = mapped_column(
+        Numeric(precision=5, scale=2), nullable=False
+    )
+    hf_floor: Mapped[Decimal] = mapped_column(Numeric(precision=6, scale=3), nullable=False)
+    allowed_protocols: Mapped[list[str]] = mapped_column(JSON, nullable=False)
+    allowed_assets: Mapped[list[str]] = mapped_column(JSON, nullable=False)
+    consent_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    revoked_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
+    privy_policy_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True, default=None)
+    privy_signer_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True, default=None)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    def __repr__(self) -> str:
+        return f"<DelegationGrant(user_id={self.user_id}, status={self.status})>"
+
+
+def get_active_grant(user_id: int, db: object) -> "Optional[DelegationGrant]":
+    """ユーザーの現在有効な委譲枠を返す。無ければ None（fail-closed の判定に使う）。
+
+    有効条件: status='active' かつ revoked_at IS NULL かつ expires_at > 現在時刻。
+    複数該当する場合は最新（created_at 降順）の 1 件。
+
+    Note:
+        expires_at が過去でも DB の status は 'active' のまま残り得る（遅延 expire）。
+        本関数は expires_at を実時刻で必ず再判定するため、status だけに依存しない。
+    """
+    from sqlalchemy import select  # noqa: PLC0415
+
+    now = datetime.now(timezone.utc)
+    stmt = (
+        select(DelegationGrant)
+        .where(
+            DelegationGrant.user_id == user_id,
+            DelegationGrant.status == DELEGATION_STATUS_ACTIVE,
+            DelegationGrant.revoked_at.is_(None),
+            DelegationGrant.expires_at > now,
+        )
+        .order_by(DelegationGrant.created_at.desc())
+        .limit(1)
+    )
+    return db.scalar(stmt)  # type: ignore[attr-defined,no-any-return]

--- a/backend/app/users/settings_router.py
+++ b/backend/app/users/settings_router.py
@@ -3,7 +3,7 @@
 """ユーザー設定API ルーター定義。"""
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -16,8 +16,20 @@ from app.database import get_db
 from app.partner import allocation_service
 from app.partner.allocation_schemas import MyAllocationResponse
 
-from .models import ACCOUNT_DELETION_STATUS_PENDING, AccountDeletionRequest
-from .settings_schemas import UserSettingsResponse, UserSettingsUpdate
+from .models import (
+    ACCOUNT_DELETION_STATUS_PENDING,
+    DELEGATION_STATUS_ACTIVE,
+    DELEGATION_STATUS_REVOKED,
+    AccountDeletionRequest,
+    DelegationGrant,
+    get_active_grant,
+)
+from .settings_schemas import (
+    DelegationGrantRequest,
+    DelegationGrantResponse,
+    UserSettingsResponse,
+    UserSettingsUpdate,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -259,3 +271,97 @@ def request_account_deletion(
         "requested_at": req.requested_at.isoformat(),
         "already_requested": False,
     }
+
+
+# ---------------------------------------------------------------------------
+# 委譲枠 (delegation grant) — v4 完全おまかせ自動運用 Phase 0 / スライス0-C
+# ユーザーが「この枠・このリスクで任せる」と1回 consent する事前枠承認。
+# AUTO 執行時に有効な grant が無ければ fail-closed で拒否される（PolicyEngine Rule 8）。
+# 実際の % 上限は執行直前に risk_limiter で二重クランプする。
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/delegation",
+    response_model=Optional[DelegationGrantResponse],
+    summary="現在有効な委譲枠を取得",
+)
+def get_delegation_grant(
+    current_user: User = Depends(require_active_user),
+    db: Session = Depends(get_db),
+) -> Optional[DelegationGrantResponse]:
+    """現在有効な委譲枠を返す。無ければ null。"""
+    grant = get_active_grant(current_user.id, db)
+    if grant is None:
+        return None
+    return DelegationGrantResponse.model_validate(grant)
+
+
+@router.post(
+    "/delegation/grant",
+    response_model=DelegationGrantResponse,
+    summary="委譲枠を作成（consent）",
+)
+def create_delegation_grant(
+    request: DelegationGrantRequest,
+    current_user: User = Depends(require_active_user),
+    db: Session = Depends(get_db),
+) -> DelegationGrantResponse:
+    """委譲枠を作成する。既存の有効枠は新規作成前に revoke する（常に1枠のみ有効）。
+
+    上限 % は schema 段階でハードキャップ（単一≤10% / 日次≤30% / HF≥1.6）を検証済み。
+    委譲対象ウォレットは smart_wallet_address を優先、無ければ wallet_address。
+    """
+    now = datetime.now(timezone.utc)
+
+    # 既存の有効枠を revoke（1ユーザー1有効枠を維持）
+    existing = get_active_grant(current_user.id, db)
+    if existing is not None:
+        existing.status = DELEGATION_STATUS_REVOKED
+        existing.revoked_at = now
+
+    wallet = current_user.smart_wallet_address or current_user.wallet_address
+    grant = DelegationGrant(
+        user_id=current_user.id,
+        wallet_address=wallet,
+        status=DELEGATION_STATUS_ACTIVE,
+        max_single_trade_pct=request.max_single_trade_pct,
+        max_daily_trade_pct=request.max_daily_trade_pct,
+        hf_floor=request.hf_floor,
+        allowed_protocols=request.allowed_protocols,
+        allowed_assets=request.allowed_assets,
+        consent_at=now,
+        expires_at=now + timedelta(days=request.expires_in_days),
+    )
+    db.add(grant)
+    db.commit()
+    db.refresh(grant)
+    logger.info(
+        "delegation grant created: user_id=%s, single=%s%%, daily=%s%%, expires_in=%dd",
+        current_user.id,
+        request.max_single_trade_pct,
+        request.max_daily_trade_pct,
+        request.expires_in_days,
+    )
+    return DelegationGrantResponse.model_validate(grant)
+
+
+@router.post(
+    "/delegation/revoke",
+    response_model=Optional[DelegationGrantResponse],
+    summary="委譲枠を取消",
+)
+def revoke_delegation_grant(
+    current_user: User = Depends(require_active_user),
+    db: Session = Depends(get_db),
+) -> Optional[DelegationGrantResponse]:
+    """現在有効な委譲枠を取消する。無ければ null（冪等）。"""
+    grant = get_active_grant(current_user.id, db)
+    if grant is None:
+        return None
+    grant.status = DELEGATION_STATUS_REVOKED
+    grant.revoked_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(grant)
+    logger.info("delegation grant revoked: user_id=%s, grant_id=%s", current_user.id, grant.id)
+    return DelegationGrantResponse.model_validate(grant)

--- a/backend/app/users/settings_schemas.py
+++ b/backend/app/users/settings_schemas.py
@@ -9,6 +9,13 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+# 委譲枠の上限ハードキャップ（risk_limiter STRICT と一致。これを超える値は受け付けない）。
+# 実行時にも risk_limiter で二重クランプするが、入力段階でも fail-fast で弾く。
+DELEGATION_MAX_SINGLE_TRADE_PCT = Decimal("10")
+DELEGATION_MAX_DAILY_TRADE_PCT = Decimal("30")
+DELEGATION_MIN_HF_FLOOR = Decimal("1.6")
+DELEGATION_MAX_EXPIRES_DAYS = 365
+
 
 class UserSettingsResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
@@ -70,3 +77,61 @@ class UserSettingsUpdate(BaseModel):
         if not re.match(r"^[\w\s\-]+$", v):
             raise ValueError("ユーザー名には文字・数字・スペース・_・- のみ使用できます")
         return v.lower()
+
+
+class DelegationGrantRequest(BaseModel):
+    """事前枠承認（委譲枠）の作成リクエスト。
+
+    上限は % で指定。ハードキャップ（単一≤10% / 日次≤30% / HF≥1.6）を超える値は
+    入力段階で 422 にする（実行時にも risk_limiter で二重クランプ）。
+    """
+
+    max_single_trade_pct: Decimal = Field(..., gt=0)
+    max_daily_trade_pct: Decimal = Field(..., gt=0)
+    hf_floor: Decimal = Field(default=DELEGATION_MIN_HF_FLOOR)
+    allowed_protocols: list[str] = Field(..., min_length=1)
+    allowed_assets: list[str] = Field(..., min_length=1)
+    expires_in_days: int = Field(..., ge=1, le=DELEGATION_MAX_EXPIRES_DAYS)
+
+    @field_validator("max_single_trade_pct")
+    @classmethod
+    def _validate_single(cls, v: Decimal) -> Decimal:
+        if v > DELEGATION_MAX_SINGLE_TRADE_PCT:
+            raise ValueError(
+                f"max_single_trade_pct は {DELEGATION_MAX_SINGLE_TRADE_PCT}% 以下にしてください"
+            )
+        return v
+
+    @field_validator("max_daily_trade_pct")
+    @classmethod
+    def _validate_daily(cls, v: Decimal) -> Decimal:
+        if v > DELEGATION_MAX_DAILY_TRADE_PCT:
+            raise ValueError(
+                f"max_daily_trade_pct は {DELEGATION_MAX_DAILY_TRADE_PCT}% 以下にしてください"
+            )
+        return v
+
+    @field_validator("hf_floor")
+    @classmethod
+    def _validate_hf(cls, v: Decimal) -> Decimal:
+        if v < DELEGATION_MIN_HF_FLOOR:
+            raise ValueError(f"hf_floor は {DELEGATION_MIN_HF_FLOOR} 以上にしてください")
+        return v
+
+
+class DelegationGrantResponse(BaseModel):
+    """委譲枠のレスポンス。"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    status: str
+    wallet_address: Optional[str]
+    max_single_trade_pct: Decimal
+    max_daily_trade_pct: Decimal
+    hf_floor: Decimal
+    allowed_protocols: list[str]
+    allowed_assets: list[str]
+    consent_at: datetime
+    expires_at: datetime
+    revoked_at: Optional[datetime]

--- a/backend/tests/test_delegation_grants.py
+++ b/backend/tests/test_delegation_grants.py
@@ -1,0 +1,259 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_delegation_grants.py
+"""委譲枠 (delegation grant) のテスト（v4 完全おまかせ自動運用 Phase 0 / スライス0-C）。
+
+- DelegationGrant モデル + get_active_grant ヘルパー（active/expired/revoked/最新）
+- PolicyEngine Rule 8（AUTO 執行は有効 grant 必須・手動経路は不影響）
+- grant/revoke/get API（consent・取消・上限ハードキャップ検証）
+"""
+
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-delegation")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "deleg_admin@example.com")
+
+from app.database import Base, get_db  # noqa: E402
+from app.main import create_app  # noqa: E402
+from app.policy.engine import PolicyContext, PolicyEngine  # noqa: E402
+from app.users.models import (  # noqa: E402
+    DELEGATION_STATUS_ACTIVE,
+    DELEGATION_STATUS_REVOKED,
+    DelegationGrant,
+    get_active_grant,
+)
+
+
+@pytest.fixture()
+def test_db():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db() -> Generator:
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    yield override_get_db, SessionLocal
+    Base.metadata.drop_all(bind=engine)
+    os.unlink(path)
+
+
+@pytest.fixture()
+def db_session(test_db) -> Generator[Session, None, None]:
+    _, SessionLocal = test_db
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture()
+def client(test_db) -> TestClient:
+    override_get_db, _ = test_db
+    app = create_app()
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app)
+
+
+def register_and_login(client: TestClient, email: str | None = None) -> str:
+    # 初期 admin 登録は INITIAL_ADMIN_EMAIL に一致する最初のユーザーのみ許可される。
+    # conftest が同 env を設定済みのため、実行時の値を読む（各テストは fresh DB）。
+    if email is None:
+        email = os.environ.get("INITIAL_ADMIN_EMAIL", "terms_admin@example.com")
+    client.post(
+        "/auth/register",
+        json={"email": email, "username": "deleguser", "password": "userpassword123"},
+    )
+    r = client.post("/auth/login", json={"email": email, "password": "userpassword123"})
+    return r.json()["access_token"]
+
+
+def _make_grant(user_id: int, **overrides) -> DelegationGrant:
+    now = datetime.now(timezone.utc)
+    defaults = dict(
+        user_id=user_id,
+        wallet_address="0x" + "a" * 40,
+        status=DELEGATION_STATUS_ACTIVE,
+        max_single_trade_pct=Decimal("10"),
+        max_daily_trade_pct=Decimal("30"),
+        hf_floor=Decimal("1.6"),
+        allowed_protocols=["aave"],
+        allowed_assets=["USDC"],
+        consent_at=now,
+        expires_at=now + timedelta(days=30),
+    )
+    defaults.update(overrides)
+    return DelegationGrant(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# get_active_grant ヘルパー
+# ---------------------------------------------------------------------------
+
+
+class TestGetActiveGrant:
+    def test_returns_active_grant(self, db_session: Session) -> None:
+        db_session.add(_make_grant(1))
+        db_session.commit()
+        grant = get_active_grant(1, db_session)
+        assert grant is not None
+        assert grant.status == DELEGATION_STATUS_ACTIVE
+
+    def test_none_when_no_grant(self, db_session: Session) -> None:
+        assert get_active_grant(999, db_session) is None
+
+    def test_expired_grant_not_returned(self, db_session: Session) -> None:
+        past = datetime.now(timezone.utc) - timedelta(days=1)
+        db_session.add(_make_grant(1, expires_at=past))
+        db_session.commit()
+        assert get_active_grant(1, db_session) is None
+
+    def test_revoked_grant_not_returned(self, db_session: Session) -> None:
+        db_session.add(
+            _make_grant(
+                1,
+                status=DELEGATION_STATUS_REVOKED,
+                revoked_at=datetime.now(timezone.utc),
+            )
+        )
+        db_session.commit()
+        assert get_active_grant(1, db_session) is None
+
+    def test_returns_latest_when_multiple(self, db_session: Session) -> None:
+        old = _make_grant(1, max_single_trade_pct=Decimal("5"))
+        db_session.add(old)
+        db_session.commit()
+        new = _make_grant(1, max_single_trade_pct=Decimal("8"))
+        db_session.add(new)
+        db_session.commit()
+        grant = get_active_grant(1, db_session)
+        assert grant is not None
+        assert grant.max_single_trade_pct == Decimal("8")
+
+
+# ---------------------------------------------------------------------------
+# PolicyEngine Rule 8: AUTO 執行は有効 grant 必須
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyEngineAutoGrantRule:
+    def _ctx(self, **kw) -> PolicyContext:
+        base = dict(
+            user_id=1,
+            asset="USDC",
+            operation="SUPPLY",
+            amount_usd=Decimal("100"),
+        )
+        base.update(kw)
+        return PolicyContext(**base)
+
+    def test_auto_without_grant_is_blocked(self, db_session: Session) -> None:
+        engine = PolicyEngine()
+        result = engine.check(self._ctx(is_auto_execution=True), db_session)
+        assert result.blocked
+        assert any("delegation grant" in v for v in result.violations)
+
+    def test_auto_with_active_grant_passes(self, db_session: Session) -> None:
+        db_session.add(_make_grant(1))
+        db_session.commit()
+        engine = PolicyEngine()
+        result = engine.check(self._ctx(is_auto_execution=True), db_session)
+        assert result.passed, result.violations
+
+    def test_manual_path_unaffected_by_missing_grant(self, db_session: Session) -> None:
+        """is_auto_execution=False（手動承認）は grant 不在でも Rule 8 で弾かれない。"""
+        engine = PolicyEngine()
+        result = engine.check(self._ctx(is_auto_execution=False), db_session)
+        assert result.passed, result.violations
+
+
+# ---------------------------------------------------------------------------
+# grant / revoke / get API
+# ---------------------------------------------------------------------------
+
+
+class TestDelegationAPI:
+    _VALID = {
+        "max_single_trade_pct": "10",
+        "max_daily_trade_pct": "30",
+        "hf_floor": "1.6",
+        "allowed_protocols": ["aave", "lido"],
+        "allowed_assets": ["USDC"],
+        "expires_in_days": 30,
+    }
+
+    def test_requires_auth(self, client: TestClient) -> None:
+        assert client.get("/api/user/delegation").status_code == 401
+        assert client.post("/api/user/delegation/grant", json=self._VALID).status_code == 401
+
+    def test_create_get_revoke_flow(self, client: TestClient) -> None:
+        token = register_and_login(client)
+        h = {"Authorization": f"Bearer {token}"}
+
+        # 初期は null
+        assert client.get("/api/user/delegation", headers=h).json() is None
+
+        # consent
+        r = client.post("/api/user/delegation/grant", json=self._VALID, headers=h)
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["status"] == "active"
+        assert data["allowed_protocols"] == ["aave", "lido"]
+
+        # get は有効枠を返す
+        got = client.get("/api/user/delegation", headers=h).json()
+        assert got is not None and got["status"] == "active"
+
+        # revoke
+        rv = client.post("/api/user/delegation/revoke", headers=h).json()
+        assert rv["status"] == "revoked"
+
+        # revoke 後は null
+        assert client.get("/api/user/delegation", headers=h).json() is None
+
+    def test_recreate_revokes_previous(self, client: TestClient) -> None:
+        token = register_and_login(client)
+        h = {"Authorization": f"Bearer {token}"}
+        client.post("/api/user/delegation/grant", json=self._VALID, headers=h)
+        client.post("/api/user/delegation/grant", json=self._VALID, headers=h)
+        # 常に1枠のみ有効（再作成で前枠は revoke される）
+        got = client.get("/api/user/delegation", headers=h).json()
+        assert got is not None and got["status"] == "active"
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("max_single_trade_pct", "10.01"),  # >10
+            ("max_daily_trade_pct", "30.01"),  # >30
+            ("hf_floor", "1.59"),  # <1.6
+            ("expires_in_days", 0),  # <1
+            ("expires_in_days", 999),  # >365
+        ],
+    )
+    def test_bounds_rejected(self, client: TestClient, field: str, value: object) -> None:
+        token = register_and_login(client)
+        h = {"Authorization": f"Bearer {token}"}
+        payload = dict(self._VALID)
+        payload[field] = value
+        r = client.post("/api/user/delegation/grant", json=payload, headers=h)
+        assert r.status_code == 422, r.text
+
+    def test_revoke_idempotent_when_no_grant(self, client: TestClient) -> None:
+        token = register_and_login(client)
+        h = {"Authorization": f"Bearer {token}"}
+        assert client.post("/api/user/delegation/revoke", headers=h).json() is None


### PR DESCRIPTION
## 概要
v4「完全おまかせ自動運用」EPIC の **Phase 0（安全土台先行）/ スライス 0-C**。
ユーザーが「この枠・このリスクで任せる」と1回 consent した内容を耐久記録し、**AUTO 執行時に有効な委譲枠が無ければ fail-closed で拒否**する真実源（`delegation_grants`）を作る。

## 変更
| ファイル | 内容 |
|---|---|
| `app/users/models.py` | `DelegationGrant` モデル + `get_active_grant()` + status 定数。上限は **%** 保持（実行時に risk_limiter で二重クランプ）。status は application-layer 制御・CHECK は migration 内独自定義しない |
| `alembic/versions/dg20260619_*.py` | `delegation_grants` テーブル追加（`down_revision=swa20260618` = 真の単一 head を alembic 解析で確認済）。create_all(test) + alembic(prod) 両対応 |
| `app/policy/engine.py` | `PolicyContext.is_auto_execution`（既定 False）+ **Rule 8「AUTO 執行は有効 grant 必須」**。手動承認経路（`approve_proposal`）は不影響 |
| `app/users/settings_router.py` | `/api/user/delegation`(GET) + `/grant` + `/revoke`。上限ハードキャップ（単一≤10% / 日次≤30% / HF≥1.6）を schema で fail-fast 検証。常に1ユーザー1有効枠（再作成で前枠 revoke）|

## 設計判断
- **凍結ファイル(main.py 等)を一切触らない**: model は `users/models.py`（既存 import 経由で create_all 自動登録）、API は既登録の `settings_router`（prefix `/api/user`）に追加 → backend_deps 申請不要。
- **真の alembic head 確認**: 一見 6 head に見えたが merge migration の tuple 親を解析した結果、**真の単一 head は `swa20260618`**（推測せず確認）。

## テスト
`tests/test_delegation_grants.py` **17件**: `get_active_grant`（active/expired/revoked/最新）/ PolicyEngine Rule 8（AUTO 無 grant→block・有 grant→pass・手動経路は不影響）/ grant・revoke・get API / 上限ハードキャップ 422。**回帰 89 passed**（policy_engine / user_settings / user_mode 含む）。ruff/format/mypy クリーン。

## スコープ注記
本スライスでは **AUTO 執行自体はまだ未配線**（Phase 2-D）。Rule 8 は forward-looking な fail-closed guard として先行導入（dormant・テスト済）。実際の % クランプは執行直前の risk_limiter（0-E2）で行う。

## DoD
- [x] ruff / format / mypy クリーン
- [x] delegation 17 + 回帰 89 passed
- [x] 凍結ファイル不使用（申請不要）
- [x] Decimal 型 / status は models.py 真実源 / CHECK 二重定義なし

Plan: `v4 完全おまかせ自動運用 — 段階実装プラン`（Phase 0 / 0-C）

🤖 Generated with [Claude Code](https://claude.com/claude-code)