### PR TITLE
feat(risk): check_trade_within_limits 純関数（Phase 2-D %クランプ下準備）

### DIFF
--- a/backend/app/aave/risk_limiter.py
+++ b/backend/app/aave/risk_limiter.py
@@ -201,3 +201,50 @@ def notify_slack_if_custom(limits: EffectiveLimits) -> None:
                 logger.warning("risk_limiter: Slack notification returned status %d", resp.status)
     except Exception as exc:  # noqa: BLE001
         logger.warning("risk_limiter: Slack notification failed: %s", exc)
+
+
+def check_trade_within_limits(
+    amount_usd: Decimal,
+    total_assets_usd: Optional[Decimal],
+    daily_traded_usd: Decimal,
+    hf: Optional[Decimal],
+    limits: Optional[EffectiveLimits] = None,
+) -> Optional[str]:
+    """単一取引/日次/HF をハード上限に対して検査し、違反理由を返す（無ければ None）。
+
+    純関数。executor / 自動執行経路の執行前ゲートで再利用する（v4 Phase 2-D で配線予定）。
+    上限値は get_effective_limits() のハードクランプ済み値を使う（env が緩くても勝てない）。
+
+    Args:
+        amount_usd: 今回の取引額（USD）。
+        total_assets_usd: ユーザー総資産（USD）。% 判定の分母。None または 0 の場合は
+            % 判定を行わない（初回入金など分母が無いケース。絶対額上限は別層=PolicyEngine で担保）。
+        daily_traded_usd: 当日既執行額（USD）。日次 % 判定に加算する。
+        hf: 現在の Health Factor。None/inf は HF 判定をスキップ。
+        limits: 明示指定が無ければ get_effective_limits() を使う。
+
+    Returns:
+        違反理由文字列（最初の1件）。違反なしは None。
+    """
+    eff = limits if limits is not None else get_effective_limits()
+
+    # HF floor（inf/None はスキップ）
+    if hf is not None and hf != Decimal("inf") and hf < eff.hf_min:
+        return f"hf {hf} below floor {eff.hf_min}"
+
+    # % 判定は総資産（分母）が正のときのみ。0/None は絶対額上限(PolicyEngine)に委ねる。
+    if total_assets_usd is not None and total_assets_usd > Decimal("0"):
+        single_max_usd = total_assets_usd * eff.single_trade_pct_max / Decimal("100")
+        if amount_usd > single_max_usd:
+            return (
+                f"single trade {amount_usd} exceeds {eff.single_trade_pct_max}% of "
+                f"total assets ({single_max_usd})"
+            )
+        daily_max_usd = total_assets_usd * eff.daily_trade_pct_max / Decimal("100")
+        if daily_traded_usd + amount_usd > daily_max_usd:
+            return (
+                f"daily trade {daily_traded_usd + amount_usd} exceeds "
+                f"{eff.daily_trade_pct_max}% of total assets ({daily_max_usd})"
+            )
+
+    return None

--- a/backend/tests/test_risk_limiter_check.py
+++ b/backend/tests/test_risk_limiter_check.py
@@ -1,0 +1,107 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_risk_limiter_check.py
+"""check_trade_within_limits の単体テスト（v4 Phase 2-D の %クランプ下準備）。
+
+純関数として 単一≤10% / 日次≤30% / HF≥floor を検査し、違反理由 or None を返すことを検証。
+strict default（CUSTOM_LIMITER_ENABLED 未設定）= HF1.6 / single10% / daily30% を前提にする。
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from app.aave.risk_limiter import check_trade_within_limits
+
+
+@pytest.fixture(autouse=True)
+def _force_strict_limits(monkeypatch: pytest.MonkeyPatch) -> None:
+    # custom limiter を無効化して strict default（10%/30%/1.6）を固定する。
+    monkeypatch.delenv("CUSTOM_LIMITER_ENABLED", raising=False)
+
+
+def test_within_limits_returns_none() -> None:
+    # total=10000, single≤1000(10%), daily≤3000(30%)
+    assert (
+        check_trade_within_limits(
+            amount_usd=Decimal("1000"),
+            total_assets_usd=Decimal("10000"),
+            daily_traded_usd=Decimal("0"),
+            hf=Decimal("2.0"),
+        )
+        is None
+    )
+
+
+def test_single_trade_over_10pct_blocked() -> None:
+    reason = check_trade_within_limits(
+        amount_usd=Decimal("1000.01"),
+        total_assets_usd=Decimal("10000"),
+        daily_traded_usd=Decimal("0"),
+        hf=Decimal("2.0"),
+    )
+    assert reason is not None and "single trade" in reason
+
+
+def test_daily_over_30pct_blocked() -> None:
+    # 既に 2500 執行済み + 600 = 3100 > 3000(30%)
+    reason = check_trade_within_limits(
+        amount_usd=Decimal("600"),
+        total_assets_usd=Decimal("10000"),
+        daily_traded_usd=Decimal("2500"),
+        hf=Decimal("2.0"),
+    )
+    assert reason is not None and "daily trade" in reason
+
+
+def test_hf_below_floor_blocked() -> None:
+    reason = check_trade_within_limits(
+        amount_usd=Decimal("1"),
+        total_assets_usd=Decimal("10000"),
+        daily_traded_usd=Decimal("0"),
+        hf=Decimal("1.59"),
+    )
+    assert reason is not None and "hf" in reason
+
+
+def test_hf_inf_and_none_skip_hf_check() -> None:
+    # HF=inf / None は HF 判定をスキップ（借入なし等）
+    assert (
+        check_trade_within_limits(
+            amount_usd=Decimal("100"),
+            total_assets_usd=Decimal("10000"),
+            daily_traded_usd=Decimal("0"),
+            hf=Decimal("inf"),
+        )
+        is None
+    )
+    assert (
+        check_trade_within_limits(
+            amount_usd=Decimal("100"),
+            total_assets_usd=Decimal("10000"),
+            daily_traded_usd=Decimal("0"),
+            hf=None,
+        )
+        is None
+    )
+
+
+def test_zero_or_none_total_skips_pct_check() -> None:
+    # 総資産 0/None は % 判定をスキップ（絶対額上限は PolicyEngine が担保）。HF のみ評価。
+    assert (
+        check_trade_within_limits(
+            amount_usd=Decimal("999999"),
+            total_assets_usd=Decimal("0"),
+            daily_traded_usd=Decimal("0"),
+            hf=Decimal("2.0"),
+        )
+        is None
+    )
+    assert (
+        check_trade_within_limits(
+            amount_usd=Decimal("999999"),
+            total_assets_usd=None,
+            daily_traded_usd=Decimal("0"),
+            hf=Decimal("2.0"),
+        )
+        is None
+    )


### PR DESCRIPTION
## 概要
v4「完全おまかせ自動運用」**Phase 2-D のブロッキング DoD（risk_limiter %クランプ）を ready-to-wire** にするための純関数を `risk_limiter.py` に追加。署名経路（経路A/B）に依存しない数式のみなので、Phase 1 スパイク結果を待たずに先行できる独立 PR（Tier B 相当・既存ロジック不変）。

## 変更
- `check_trade_within_limits(amount_usd, total_assets_usd, daily_traded_usd, hf, limits=None) -> Optional[str]`
  - 単一≤10% / 日次≤30% / HF≥floor を `get_effective_limits()` のハードクランプ済み値で検査し違反理由 or None を返す。
  - **総資産 0/None は % 判定スキップ**（初回入金等で分母が無いケース。絶対額上限は PolicyEngine が担保）。HF=inf/None は HF 判定スキップ。
- 既存 `RebalanceService` のインラインは**変更しない**（0-E1 と同じ「新関数追加・低リスク」方針）。Phase 2-D の `auto_executor` と 3-B1 の `executor` が本関数を使う。

## Gate
新規 6 件 + risk_limiter 系回帰 19 passed。ruff/format/mypy クリーン。凍結ファイル不使用。

Plan: `v4 完全おまかせ自動運用 — 段階実装プラン`（Phase 2-D 下準備）

🤖 Generated with [Claude Code](https://claude.com/claude-code)