### PR TITLE
fix(liff): liff-confirm 利用規約本文のフォント・背景色を修正

### DIFF
--- a/frontend/app/(liff)/liff-confirm/page.tsx
+++ b/frontend/app/(liff)/liff-confirm/page.tsx
@@ -192,7 +192,7 @@ export default function LiffConfirmPage() {
               {isExpanded && (
                 <div className="px-4 pb-4">
                   {id === "terms_full" ? (
-                    <div className="max-h-52 overflow-y-auto rounded-lg border border-zinc-700 bg-zinc-800/50 p-3 text-zinc-400 text-xs leading-relaxed whitespace-pre-line">
+                    <div className="max-h-52 overflow-y-auto rounded-lg border border-zinc-700 bg-zinc-800 p-3 text-zinc-300 text-xs leading-relaxed whitespace-pre-line">
                       {t(`items.${id}.detail`)}
                     </div>
                   ) : (


### PR DESCRIPTION
## 問題

オンボーディングフロー（`/liff-confirm`）の利用規約本文（1つ目のチェック項目）が、フォントと背景色がおかしい状態になっていた。

**根本原因:**
- `bg-zinc-800/50`（Tailwind の opacity 修飾子付きクラス）は arobix テーマの CSS セレクタ `.arobix-root .bg-zinc-800` に**マッチしない**
- そのため arobix の上書き（`#ede4d4` 温かみのあるベージュ）が効かず、`rgb(39 39 42 / 0.5)` の暗いグレー半透明がそのまま表示されていた
- `text-zinc-400` は arobix 内で `#736f7e`（中程度のグレー）にマップされ、暗い背景上では低コントラスト

## 修正

`frontend/app/(liff)/liff-confirm/page.tsx` L195:
- `bg-zinc-800/50` → `bg-zinc-800`：opacity 修飾子を除去して arobix 上書きを適用（`#ede4d4` ベージュ背景）
- `text-zinc-400` → `text-zinc-300`：arobix 内で `#2a2440`（ダーク）にマップされ、ベージュ背景上でコントラスト比 ~13:1 を確保

## テスト計画
- [ ] `/liff-confirm` を開き、利用規約項目（1つ目）を展開して本文が読みやすく表示されることを確認
- [ ] 他の5つの項目（self_custody / defi_risk 等）の表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012k4yazAk5msEgW8VkcFFyp