### PR TITLE
feat(safety): AUTO 執行経路に既存安全装置を結線（スライス2-D-A）

### DIFF
--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -251,6 +251,27 @@ def _record_failed_transaction(
     db.add(tx)
 
 
+def _daily_traded_usd_for_user(
+    user_id: int, db: Session, exclude_proposal_id: Optional[int] = None
+) -> Decimal:
+    """当日(UTC)に approved/executed になった当該ユーザーの提案額合計(USD)。
+
+    risk_limiter %クランプ / HARD_STOP の日次%判定の分母加算に使う。
+    PolicyEngine._check_velocity と同じ集計条件(approved/executed・当日・自分以外)を踏襲する。
+    """
+    now = datetime.now(timezone.utc)
+    day_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    stmt = select(func.sum(Proposal.amount_usd)).where(
+        Proposal.user_id == user_id,
+        Proposal.status.in_(["approved", "executed"]),
+        Proposal.approved_at >= day_start,
+    )
+    if exclude_proposal_id is not None:
+        stmt = stmt.where(Proposal.id != exclude_proposal_id)
+    raw = db.scalar(stmt)
+    return Decimal(str(raw)) if raw is not None else Decimal("0")
+
+
 def _execute_aave_for_proposal(proposal: Proposal, db: Session) -> None:
     """
     承認された提案に対して Aave 操作を実行し、proposal を更新する。
@@ -361,7 +382,20 @@ def _execute_aave_for_proposal(proposal: Proposal, db: Session) -> None:
     except Exception as _hf_exc:  # noqa: BLE001
         logger.warning("proposal %d: HF fetch for safety gate failed: %s", proposal.id, _hf_exc)
 
-    _hard_stop = evaluate_hard_stop(get_monitoring_service(), _hf_for_gate)
+    # 日次既執行額（HARD_STOP 日次%判定 / risk_limiter %クランプの分母加算用）。
+    _daily_traded = _daily_traded_usd_for_user(
+        proposal.user_id, db, exclude_proposal_id=proposal.id
+    )
+    # per-user 総資産の取得元は未実装（Phase 2-D 後続 sub-task）。None の間は %判定をスキップし、
+    # PolicyEngine 絶対額上限 +（後続スライスの）Privy policy で担保する（fail-safe）。
+    _total_assets: Optional[Decimal] = None
+
+    _hard_stop = evaluate_hard_stop(
+        get_monitoring_service(),
+        _hf_for_gate,
+        daily_traded_usd=_daily_traded,
+        total_assets_usd=_total_assets,
+    )
     if _hard_stop.blocked:
         logger.warning(
             "proposal %d: execution HELD by safety gate (source=%s, reason=%s) — "
@@ -369,6 +403,25 @@ def _execute_aave_for_proposal(proposal: Proposal, db: Session) -> None:
             proposal.id,
             _hard_stop.source,
             _hard_stop.reason,
+        )
+        return
+
+    # risk_limiter %クランプ（スライス2-D-A）: 単一/日次% と HF をハード上限に対し執行直前に再検査。
+    # 違反は HARD_STOP と同様 transient 扱いで 'approved' 据え置き（条件変化後に再執行可能）。
+    from app.aave.risk_limiter import check_trade_within_limits  # noqa: PLC0415
+
+    _limit_violation = check_trade_within_limits(
+        amount_usd=Decimal(str(proposal.amount_usd)),
+        total_assets_usd=_total_assets,
+        daily_traded_usd=_daily_traded,
+        hf=_hf_for_gate,
+    )
+    if _limit_violation is not None:
+        logger.warning(
+            "proposal %d: execution HELD by risk_limiter (%s) — "
+            "status remains 'approved' for retry after condition clears",
+            proposal.id,
+            _limit_violation,
         )
         return
 
@@ -695,6 +748,9 @@ def approve_proposal(
             detail=f"Cannot approve proposal with status '{proposal.status}'",
         )
 
+    # AUTO 執行フラグは PolicyContext (Rule8: AUTO 執行は有効委譲枠必須) より前に評価する。
+    auto_execution_enabled = os.getenv("AUTO_EXECUTION_ENABLED", "false").lower() == "true"
+
     # Step 1: PolicyEngine hard rule 検算（承認前に必ず通す）
     ctx = PolicyContext(
         user_id=proposal.user_id,
@@ -705,6 +761,7 @@ def approve_proposal(
         if proposal.expected_hf_after is not None
         else None,
         proposal_id=proposal.id,
+        is_auto_execution=auto_execution_enabled,
     )
     policy_result = get_policy_engine().check(ctx, db)
     if policy_result.blocked:
@@ -725,7 +782,7 @@ def approve_proposal(
     # Step 2: Aave 自動実行 (AUTO_EXECUTION_ENABLED=true の場合のみ)
     # non-custodial 方式2 では default=false。partner 手動署名 (submit_partner_tx) のみが実 tx を立てる。
     # AAVE_WALLET_PRIVATE_KEY が署名する経路はこのフラグで完全に無効化される。
-    auto_execution_enabled = os.getenv("AUTO_EXECUTION_ENABLED", "false").lower() == "true"
+    # （auto_execution_enabled は上の PolicyContext 構築前に評価済み）
     if auto_execution_enabled:
         from .execution_route import RouteMismatchError  # noqa: PLC0415
 

--- a/backend/tests/test_non_custodial_f1f2.py
+++ b/backend/tests/test_non_custodial_f1f2.py
@@ -90,6 +90,38 @@ def create_proposal(client: TestClient, token: str) -> int:
     return r.json()["id"]
 
 
+def _create_active_grant(engine: object, user_id: int = 1) -> None:
+    """AUTO 執行に必須の有効委譲枠を作る（PolicyEngine Rule8 / スライス2-D-A）。
+
+    AUTO_EXECUTION_ENABLED=true の承認は有効な delegation grant が無いと
+    fail-closed で 422 拒否される。
+    """
+    from datetime import datetime, timedelta, timezone  # noqa: PLC0415
+    from decimal import Decimal  # noqa: PLC0415
+
+    from sqlalchemy.orm import Session  # noqa: PLC0415
+
+    from app.users.models import DelegationGrant  # noqa: PLC0415
+
+    now = datetime.now(timezone.utc)
+    with Session(engine) as db:  # type: ignore[arg-type]
+        db.add(
+            DelegationGrant(
+                user_id=user_id,
+                wallet_address="0x" + "a" * 40,
+                status="active",
+                max_single_trade_pct=Decimal("10"),
+                max_daily_trade_pct=Decimal("30"),
+                hf_floor=Decimal("1.6"),
+                allowed_protocols=["aave"],
+                allowed_assets=["USDC"],
+                consent_at=now,
+                expires_at=now + timedelta(days=30),
+            )
+        )
+        db.commit()
+
+
 # ---------------------------------------------------------------------------
 # F1: AUTO_EXECUTION_ENABLED feature flag
 # ---------------------------------------------------------------------------
@@ -129,9 +161,13 @@ class TestF1AutoExecutionFlag:
         assert r.status_code == 200
         assert r.json()["status"] == "approved"
 
-    def test_approve_with_flag_true_attempts_aave_execution(self, client: TestClient) -> None:
+    def test_approve_with_flag_true_attempts_aave_execution(
+        self, client: TestClient, test_db
+    ) -> None:
         """AUTO_EXECUTION_ENABLED=true では Aave 実行を試みる (RPC 未設定で failed になる)。"""
+        _override, engine = test_db
         token = get_admin_token(client)
+        _create_active_grant(engine, user_id=1)  # Rule8: AUTO は有効委譲枠必須
         proposal_id = create_proposal(client, token)
 
         with patch.dict(os.environ, {"AUTO_EXECUTION_ENABLED": "true"}):

--- a/backend/tests/test_phase2d_a_wiring.py
+++ b/backend/tests/test_phase2d_a_wiring.py
@@ -1,0 +1,290 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_phase2d_a_wiring.py
+"""スライス2-D-A: 既存安全装置の AUTO 執行経路への結線。
+
+検証:
+- PolicyEngine Rule8 発火: AUTO_EXECUTION_ENABLED=true で有効な委譲枠が無い承認は 422 拒否。
+- 手動承認 (AUTO 無効) は委譲枠なしでも通る（Rule8 は AUTO 経路のみ）。
+- risk_limiter %クランプ結線: check_trade_within_limits が違反を返すと execute_rebalance を
+  呼ばず status を 'approved' 据え置き（transient）。
+- _daily_traded_usd_for_user: 当日 approved/executed 合計（自分以外）。
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-phase2d-a")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "phase2da_admin@example.com")
+
+from app.aave.schemas import (  # noqa: E402
+    AaveOperationResult,
+    AaveOperationStatus,
+    AaveOperationType,
+)
+from app.auth.models import User  # noqa: E402
+from app.automation.safety_gate import HardStopResult  # noqa: E402
+from app.database import Base, get_db  # noqa: E402
+from app.main import create_app  # noqa: E402
+from app.proposals.models import Proposal  # noqa: E402
+
+_WALLET = "0xPhase2dA00000000000000000000000000000001"
+
+
+# --------------------------------------------------------------------------- #
+# 単体（in-memory db_session）
+# --------------------------------------------------------------------------- #
+@pytest.fixture()
+def db_session() -> Generator[Session, None, None]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestSession()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        os.unlink(path)
+
+
+def _make_user(db: Session, uid: int = 11) -> User:
+    user = User(
+        id=uid,
+        email=f"phase2da{uid}@test.com",
+        username=f"phase2da{uid}",
+        hashed_password="x",
+        role="partner",
+        is_active=True,
+        wallet_address=_WALLET,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _make_proposal(db: Session, user_id: int, status: str = "approved") -> Proposal:
+    proposal = Proposal(
+        user_id=user_id,
+        operation="SUPPLY",
+        asset="USDC",
+        amount=Decimal("1000"),
+        amount_usd=Decimal("1000.00"),
+        reason="phase2d-a test",
+        status=status,
+        approved_at=datetime.now(timezone.utc),
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    db.add(proposal)
+    db.flush()
+    return proposal
+
+
+def _fake_result() -> AaveOperationResult:
+    return AaveOperationResult(
+        operation=AaveOperationType.DEPOSIT,
+        status=AaveOperationStatus.SUCCESS,
+        asset_symbol="USDC",
+        amount=Decimal("1000"),
+        tx_hash="0xphase2da",
+    )
+
+
+def test_risk_limiter_holds_execution(db_session: Session) -> None:
+    """check_trade_within_limits が違反を返すと execute せず 'approved' 据え置き。"""
+    from app.proposals.router import _execute_aave_for_proposal
+
+    user = _make_user(db_session)
+    proposal = _make_proposal(db_session, user_id=user.id)
+    db_session.commit()
+
+    called: list[bool] = []
+
+    def _mock_execute(**kwargs: object) -> AaveOperationResult:
+        called.append(True)
+        return _fake_result()
+
+    with (
+        patch(
+            "app.automation.safety_gate.evaluate_hard_stop",
+            return_value=HardStopResult(blocked=False),
+        ),
+        patch(
+            "app.aave.risk_limiter.check_trade_within_limits",
+            return_value="single trade exceeds 10% of total assets",
+        ),
+        patch(
+            "app.aave.service.MultiChainAaveService.execute_rebalance",
+            side_effect=_mock_execute,
+        ),
+    ):
+        _execute_aave_for_proposal(proposal, db_session)
+
+    assert called == []  # execute_rebalance は呼ばれない
+    assert proposal.status == "approved"  # transient: failed にしない
+    assert proposal.tx_hash is None
+
+
+def test_risk_limiter_pass_allows_execution(db_session: Session) -> None:
+    """違反なし（None）なら従来通り execute まで進む。"""
+    from app.proposals.router import _execute_aave_for_proposal
+
+    user = _make_user(db_session)
+    proposal = _make_proposal(db_session, user_id=user.id)
+    db_session.commit()
+
+    called: list[bool] = []
+
+    def _mock_execute(**kwargs: object) -> AaveOperationResult:
+        called.append(True)
+        return _fake_result()
+
+    with (
+        patch(
+            "app.automation.safety_gate.evaluate_hard_stop",
+            return_value=HardStopResult(blocked=False),
+        ),
+        patch(
+            "app.aave.risk_limiter.check_trade_within_limits",
+            return_value=None,
+        ),
+        patch(
+            "app.aave.service.MultiChainAaveService.execute_rebalance",
+            side_effect=_mock_execute,
+        ),
+    ):
+        _execute_aave_for_proposal(proposal, db_session)
+
+    assert called == [True]
+    assert proposal.status == "executed"
+
+
+def test_daily_traded_usd_for_user(db_session: Session) -> None:
+    """当日 approved/executed の合計（自分以外を除外）。"""
+    from app.proposals.router import _daily_traded_usd_for_user
+
+    user = _make_user(db_session)
+    p1 = _make_proposal(db_session, user_id=user.id, status="approved")
+    p2 = _make_proposal(db_session, user_id=user.id, status="executed")
+    _self = _make_proposal(db_session, user_id=user.id, status="approved")
+    # pending は集計対象外
+    _make_proposal(db_session, user_id=user.id, status="pending")
+    db_session.commit()
+
+    total = _daily_traded_usd_for_user(user.id, db_session, exclude_proposal_id=_self.id)
+    # p1 + p2 = 2000（_self 除外, pending 除外）
+    assert total == Decimal("2000.00")
+    assert p1.id != p2.id
+
+
+# --------------------------------------------------------------------------- #
+# 統合（approve エンドポイント / Rule8）
+# --------------------------------------------------------------------------- #
+@pytest.fixture()
+def test_db() -> Generator:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db() -> Generator:
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    yield override_get_db, SessionLocal
+    Base.metadata.drop_all(bind=engine)
+    os.unlink(path)
+
+
+@pytest.fixture()
+def client(test_db: tuple) -> TestClient:
+    override_get_db, _ = test_db
+    app = create_app()
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app)
+
+
+def _admin_token(client: TestClient, session_local: object) -> str:
+    email = os.environ["INITIAL_ADMIN_EMAIL"]
+    client.post(
+        "/auth/register",
+        json={"email": email, "username": "admin", "password": "adminpassword123"},
+    )
+    r = client.post("/auth/login", json={"email": email, "password": "adminpassword123"})
+    token = r.json()["access_token"]
+    db = session_local()
+    try:
+        admin = db.query(User).filter(User.email == email).first()
+        if admin and not admin.wallet_address:
+            admin.wallet_address = "0xTestAdminWallet0000000000000000000000000"
+            db.commit()
+    finally:
+        db.close()
+    return token
+
+
+def _create_proposal(client: TestClient, token: str) -> int:
+    r = client.post(
+        "/api/proposals",
+        json={
+            "user_id": 1,
+            "operation": "SUPPLY",
+            "asset": "USDC",
+            "amount": "1000.000000000000000000",
+            "amount_usd": "1000.00",
+            "reason": "phase2d-a rule8",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 201, r.text
+    return int(r.json()["id"])
+
+
+def test_auto_execution_without_grant_blocked(client: TestClient, test_db: tuple) -> None:
+    """AUTO 有効 + 委譲枠なし → Rule8 で 422 fail-closed。"""
+    _override, SessionLocal = test_db
+    token = _admin_token(client, SessionLocal)
+    proposal_id = _create_proposal(client, token)
+
+    with patch.dict(os.environ, {"AUTO_EXECUTION_ENABLED": "true"}):
+        r = client.post(
+            f"/api/proposals/{proposal_id}/approve",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert r.status_code == 422
+    detail = r.json()["detail"]
+    assert detail["code"] == "POLICY_VIOLATION"
+    assert any("delegation grant" in v for v in detail["violations"])
+
+
+def test_manual_approve_without_grant_ok(client: TestClient, test_db: tuple) -> None:
+    """AUTO 無効（既定）は委譲枠なしでも承認できる（Rule8 は AUTO 経路のみ）。"""
+    _override, SessionLocal = test_db
+    token = _admin_token(client, SessionLocal)
+    proposal_id = _create_proposal(client, token)
+
+    # AUTO_EXECUTION_ENABLED 未設定 = false。手動署名待ちで approved になる。
+    r = client.post(
+        f"/api/proposals/{proposal_id}/approve",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "approved"

--- a/backend/tests/test_proposal_execute_failure.py
+++ b/backend/tests/test_proposal_execute_failure.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Generator
 from unittest.mock import patch
@@ -108,10 +109,42 @@ def _create_proposal(client: TestClient, token: str) -> int:
     return int(r.json()["id"])
 
 
+def _create_active_grant(session_local: object, user_id: int = 1) -> None:
+    """AUTO 執行に必須の有効な委譲枠を作る（PolicyEngine Rule8 / スライス2-D-A）。
+
+    AUTO_EXECUTION_ENABLED=true の承認は有効な delegation grant が無いと
+    fail-closed で 422 拒否される。本テスト群は AUTO 執行成功/失敗を検証するため、
+    枠の存在を前提条件としてセットアップする。
+    """
+    from app.users.models import DelegationGrant  # noqa: PLC0415
+
+    now = datetime.now(timezone.utc)
+    db = session_local()
+    try:
+        db.add(
+            DelegationGrant(
+                user_id=user_id,
+                wallet_address="0x" + "a" * 40,
+                status="active",
+                max_single_trade_pct=Decimal("10"),
+                max_daily_trade_pct=Decimal("30"),
+                hf_floor=Decimal("1.6"),
+                allowed_protocols=["aave"],
+                allowed_assets=["USDC"],
+                consent_at=now,
+                expires_at=now + timedelta(days=30),
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
 def test_aave_execution_success_marks_proposal_executed(client: TestClient, test_db: tuple) -> None:
     """Aave 実行成功 → proposal.status='executed', transaction(status='completed') 記録。"""
     _override, SessionLocal = test_db
     token = _admin_token(client, SessionLocal)
+    _create_active_grant(SessionLocal, user_id=1)
     proposal_id = _create_proposal(client, token)
 
     fake_result = AaveOperationResult(
@@ -162,6 +195,7 @@ def test_aave_execution_failure_marks_proposal_failed(client: TestClient, test_d
     """Aave 実行失敗 → proposal.status='failed', error_message 記録, transaction(status='failed') 記録。"""
     _override, SessionLocal = test_db
     token = _admin_token(client, SessionLocal)
+    _create_active_grant(SessionLocal, user_id=1)
     proposal_id = _create_proposal(client, token)
 
     boom = RuntimeError("RPC connection refused")
@@ -214,6 +248,7 @@ def test_aave_execution_failure_sends_slack_notification(
     """Aave 実行失敗時に通知サービスの send() が呼ばれることを検証（mock）。"""
     _override, SessionLocal = test_db
     token = _admin_token(client, SessionLocal)
+    _create_active_grant(SessionLocal, user_id=1)
     proposal_id = _create_proposal(client, token)
 
     boom = RuntimeError("web3 provider unreachable")


### PR DESCRIPTION
## 概要

v4 完全おまかせ自動運用 **Phase 2-D の先行スライス 2-D-A**。Phase 1 署名委譲スパイク（経路A GO確定・PR #822）を受け、AUTO 執行配線の前段として **実装済みだが未配線だった安全装置を AUTO 執行経路に結線**する。

`AUTO_EXECUTION_ENABLED=false` の現状では**休眠（本番無影響）**、AUTO 有効時のみ発火。Privy 不要・on-chain 不要・pytest で完結。

## 変更内容

| # | 結線 | 箇所 |
|---|---|---|
| 1 | **PolicyEngine Rule8 発火** | `approve_proposal` で `PolicyContext(is_auto_execution=...)` を渡す。AUTO 執行は有効な delegation grant 必須、無ければ fail-closed で 422 拒否 |
| 2 | **risk_limiter %クランプ結線** | `_execute_aave_for_proposal` の execute 直前に `check_trade_within_limits`(#820) を挿入。違反は HARD_STOP 同様 transient 扱いで `approved` 据え置き |
| 3 | **HARD_STOP 引数充足** | `evaluate_hard_stop` に `daily_traded_usd`/`total_assets_usd` を供給し日次%判定を有効化 |
| 4 | ヘルパー追加 | `_daily_traded_usd_for_user`（`PolicyEngine._check_velocity` と同条件の日次集計） |

## fail-safe 設計の注記
per-user 総資産の取得元は未実装。`total_assets_usd=None` の間は **%判定をスキップし、PolicyEngine 絶対額上限 +（後続スライスの）Privy policy で担保**（保守側に倒れる）。総資産配線は後続 sub-task。

## テスト / DoD
- 新規 `test_phase2d_a_wiring.py`: Rule8 発火 / 手動承認は枠なしでも不変 / risk_limiter HELD / 日次集計
- AUTO 有効既存テスト4件に有効委譲枠セットアップを追加（Rule8 の前提条件。挙動変更は意図的）
- ✅ backend 全テスト **4330 passed / 21 skipped**
- ✅ ruff check . / ruff format --check . / mypy app/(295 files) all clean

## 安全性
- AUTO 経路は本 PR 後「枠が無ければ実行不可・%/HF/日次・HARD_STOP を必ず通過」になる（安全を**足す**のみ）
- 手動承認経路（`is_auto_execution=False`）は一切不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)