### PR TITLE
feat(privy): authorization-signature(P-256) の Python 実装（スライス2-D-B.1）

### DIFF
--- a/backend/app/privy/__init__.py
+++ b/backend/app/privy/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.

--- a/backend/app/privy/auth_signature.py
+++ b/backend/app/privy/auth_signature.py
@@ -1,0 +1,135 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/app/privy/auth_signature.py
+"""Privy authorization-signature (P-256) の生成（v4 Phase 2-D-B）。
+
+`@privy-io/node` の `formatRequestForAuthorizationSignature` + `generateAuthorizationSignature`
+を Python で再実装したもの。サーバが委譲署名（wallet action: signMessage / sendCalls 等）を
+Privy REST API に投げる際に必要な `privy-authorization-signature` ヘッダ値を計算する。
+
+仕様（Node SDK lib/authorization.js と一致）::
+
+    input = {
+        "version": 1,
+        "method": <"POST"|"PUT"|"PATCH"|"DELETE">,
+        "url": <リクエスト URL・末尾スラッシュなし>,
+        "body": <リクエストボディ object・空 object は "" に置換>,
+        "headers": {"privy-app-id": <app id>, ...(idempotency/expiry)},
+    }
+    payload = canonicalize(input)            # RFC 8785 JCS
+    signature = base64(DER(P256_ECDSA(sha256(payload))))
+    header "privy-authorization-signature" = ",".join(signatures)
+
+canonicalize は Node SDK が npm `canonicalize`(RFC 8785 JCS) を使う。JCS は
+キー再帰ソート / 配列順保持 / 余計な空白なし。ASCII ペイロード（アドレス・enum 文字列・
+整数のみ。float なし）では `json.dumps(sort_keys=True, separators=(",", ":"),
+ensure_ascii=False)` が JCS と完全一致する（Node オラクルで byte 一致検証済み:
+tests/test_privy_auth_signature.py）。**非 ASCII 文字や float を body に含めないこと**。
+
+ECDSA P-256 は非決定的（k 乱択）のため署名 byte は毎回変わるが、Privy は公開鍵で検証する
+ため任意の正当な署名で受理される。検証は (1) canonicalize payload の byte 一致 (2) 公開鍵での
+verify ラウンドトリップ で行う。
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, Optional
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import load_der_private_key
+
+_SIGNABLE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+
+def _jcs(obj: Any) -> str:
+    """RFC 8785 JCS 互換の正規化文字列を返す（ASCII ペイロード前提）。
+
+    Node SDK の `canonicalize` と一致することを Node オラクルで検証している。
+    float / 非 ASCII を含む object は JCS と乖離しうるため使用しない。
+    """
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def build_signing_input(
+    *,
+    method: str,
+    url: str,
+    body: Any,
+    app_id: str,
+    idempotency_key: Optional[str] = None,
+    request_expiry: Optional[int] = None,
+) -> dict[str, Any]:
+    """署名対象 input object を Node SDK の prepareRequest と同一構造で組み立てる。"""
+    if method.upper() not in _SIGNABLE_METHODS:
+        raise ValueError(
+            f"method {method!r} is not signable (need one of {sorted(_SIGNABLE_METHODS)})"
+        )
+    serialized_body: Any = body
+    # 空 object は "" にする（Node SDK 特例）。
+    if isinstance(serialized_body, dict) and len(serialized_body) == 0:
+        serialized_body = ""
+    headers: dict[str, str] = {"privy-app-id": app_id}
+    if idempotency_key:
+        headers["privy-idempotency-key"] = idempotency_key
+    if request_expiry is not None:
+        headers["privy-request-expiry"] = str(request_expiry)
+    return {
+        "version": 1,
+        "method": method.upper(),
+        "url": url,
+        "body": serialized_body,
+        "headers": headers,
+    }
+
+
+def canonical_payload(signing_input: dict[str, Any]) -> bytes:
+    """署名 input を canonicalize して UTF-8 bytes（=署名対象 payload）にする。"""
+    return _jcs(signing_input).encode("utf-8")
+
+
+def load_authorization_private_key(b64_pkcs8: str) -> ec.EllipticCurvePrivateKey:
+    """base64-encoded PKCS8(DER, PEM ヘッダなし) の P-256 秘密鍵をロードする。
+
+    形式は Node SDK の `authorization_private_keys` と同一
+    （`openssl pkcs8 -topk8 -nocrypt -outform DER | base64`）。
+    """
+    der = base64.b64decode(b64_pkcs8)
+    key = load_der_private_key(der, password=None)
+    if not isinstance(key, ec.EllipticCurvePrivateKey):
+        raise ValueError("authorization key is not an EC (P-256) private key")
+    return key
+
+
+def sign_payload(payload: bytes, private_key: ec.EllipticCurvePrivateKey) -> str:
+    """payload を sha256 + P-256 ECDSA で署名し DER→base64 文字列を返す。"""
+    der_sig = private_key.sign(payload, ec.ECDSA(hashes.SHA256()))
+    return base64.b64encode(der_sig).decode("ascii")
+
+
+def authorization_signature_header(
+    *,
+    method: str,
+    url: str,
+    body: Any,
+    app_id: str,
+    authorization_private_keys: list[str],
+    idempotency_key: Optional[str] = None,
+    request_expiry: Optional[int] = None,
+) -> str:
+    """`privy-authorization-signature` ヘッダ値を計算する（複数鍵はカンマ連結）。"""
+    signing_input = build_signing_input(
+        method=method,
+        url=url,
+        body=body,
+        app_id=app_id,
+        idempotency_key=idempotency_key,
+        request_expiry=request_expiry,
+    )
+    payload = canonical_payload(signing_input)
+    signatures: list[str] = []
+    for sk in authorization_private_keys:
+        key = load_authorization_private_key(sk)
+        signatures.append(sign_payload(payload, key))
+    return ",".join(signatures)

--- a/backend/tests/test_privy_auth_signature.py
+++ b/backend/tests/test_privy_auth_signature.py
@@ -1,0 +1,169 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_privy_auth_signature.py
+"""Privy authorization-signature(P-256) の Python 実装検証（v4 Phase 2-D-B）。
+
+Node SDK `@privy-io/node` の canonicalize(RFC 8785 JCS) 出力を **正解オラクル**として
+ハードコードし、Python の canonical_payload が byte 一致することを検証する。
+オラクルは dev VPS の harness `canon_oracle.mjs`（npm canonicalize 使用）で生成した実値。
+
+検証:
+1. canonicalize byte 一致（policy作成 / 空body / 混在型 の3サンプル）
+2. SHA-256 一致
+3. PKCS8 DER base64 鍵のロード + sign→verify ラウンドトリップ
+4. 空 object body → "" 特例
+5. 署名不能 method の拒否
+"""
+
+from __future__ import annotations
+
+import base64
+from hashlib import sha256
+
+import pytest
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+)
+
+from app.privy.auth_signature import (
+    authorization_signature_header,
+    build_signing_input,
+    canonical_payload,
+    load_authorization_private_key,
+    sign_payload,
+)
+
+# --- Node オラクル実値（canon_oracle.mjs 出力, npm canonicalize=RFC8785 JCS） ---
+_ORACLE = {
+    "policy_create": {
+        "input": dict(
+            method="POST",
+            url="https://api.privy.io/v1/policies",
+            app_id="cmnv54q5f03ex0cjley894xrp",
+            body={
+                "version": "1.0",
+                "name": "uata-spike-aave",
+                "chain_type": "ethereum",
+                "rules": [
+                    {
+                        "name": "allow-aave",
+                        "method": "eth_sendTransaction",
+                        "action": "ALLOW",
+                        "conditions": [
+                            {
+                                "field_source": "ethereum_transaction",
+                                "field": "to",
+                                "operator": "eq",
+                                "value": "0x8bAB6d1b75f19e9eD9fCe8b9BD338844fF79aE27",
+                            }
+                        ],
+                    }
+                ],
+            },
+        ),
+        "canon": (
+            '{"body":{"chain_type":"ethereum","name":"uata-spike-aave","rules":'
+            '[{"action":"ALLOW","conditions":[{"field":"to","field_source":'
+            '"ethereum_transaction","operator":"eq","value":'
+            '"0x8bAB6d1b75f19e9eD9fCe8b9BD338844fF79aE27"}],"method":'
+            '"eth_sendTransaction","name":"allow-aave"}],"version":"1.0"},'
+            '"headers":{"privy-app-id":"cmnv54q5f03ex0cjley894xrp"},'
+            '"method":"POST","url":"https://api.privy.io/v1/policies","version":1}'
+        ),
+        "sha256": "c4afe27c652e93991bfb4cf6b660089f42c8e371dce57e99ffbbec553934bda3",
+    },
+    "empty_body": {
+        "input": dict(
+            method="POST",
+            url="https://api.privy.io/v1/wallets/abc/rpc",
+            app_id="cmnv54q5f03ex0cjley894xrp",
+            body={},
+        ),
+        "canon": (
+            '{"body":"","headers":{"privy-app-id":"cmnv54q5f03ex0cjley894xrp"},'
+            '"method":"POST","url":"https://api.privy.io/v1/wallets/abc/rpc","version":1}'
+        ),
+        "sha256": "5ddc3d9424a3fd3bd4168303c9417d6fae0b4946ee6f4153e7f9817d884a5c73",
+    },
+    "mixed": {
+        "input": dict(
+            method="POST",
+            url="https://api.privy.io/v1/x",
+            app_id="app1",
+            body={"note": "ascii-only", "n": 42, "arr": [3, 1, 2], "nested": {"z": 1, "a": 2}},
+        ),
+        "canon": (
+            '{"body":{"arr":[3,1,2],"n":42,"nested":{"a":2,"z":1},"note":"ascii-only"},'
+            '"headers":{"privy-app-id":"app1"},"method":"POST",'
+            '"url":"https://api.privy.io/v1/x","version":1}'
+        ),
+        "sha256": "514a899b5a9375893fed49e70a514cf15b1e2ba6da372d024b1d7097836d2164",
+    },
+}
+
+
+@pytest.mark.parametrize("label", list(_ORACLE.keys()))
+def test_canonicalize_matches_node_oracle(label: str) -> None:
+    """Python canonicalize が Node(JCS) と byte 一致 + SHA256 一致。"""
+    case = _ORACLE[label]
+    si = build_signing_input(**case["input"])
+    payload = canonical_payload(si)
+    assert payload == case["canon"].encode("utf-8"), f"{label}: canonicalize mismatch"
+    assert sha256(payload).hexdigest() == case["sha256"], f"{label}: sha256 mismatch"
+
+
+def test_empty_object_body_becomes_empty_string() -> None:
+    si = build_signing_input(method="POST", url="https://x/y", body={}, app_id="a")
+    assert si["body"] == ""
+
+
+def test_non_signable_method_rejected() -> None:
+    with pytest.raises(ValueError):
+        build_signing_input(method="GET", url="https://x/y", body={}, app_id="a")
+
+
+def _new_key_b64() -> tuple[str, ec.EllipticCurvePublicKey]:
+    """P-256 鍵を生成し PKCS8 DER base64（authorization_private_keys 形式）と公開鍵を返す。"""
+    key = ec.generate_private_key(ec.SECP256R1())
+    der = key.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
+    return base64.b64encode(der).decode("ascii"), key.public_key()
+
+
+def test_load_key_and_sign_verify_roundtrip() -> None:
+    """PKCS8 DER base64 をロードし、署名→公開鍵 verify が通る（DER/sha256）。"""
+    b64, pub = _new_key_b64()
+    loaded = load_authorization_private_key(b64)
+    assert isinstance(loaded, ec.EllipticCurvePrivateKey)
+
+    payload = canonical_payload(
+        build_signing_input(method="POST", url="https://x/y", body={"a": 1}, app_id="app")
+    )
+    sig_b64 = sign_payload(payload, loaded)
+    der_sig = base64.b64decode(sig_b64)
+    # 公開鍵で検証（例外なし=OK）
+    pub.verify(der_sig, payload, ec.ECDSA(hashes.SHA256()))
+
+
+def test_authorization_signature_header_multi_key() -> None:
+    """複数鍵はカンマ連結され、各署名が対応公開鍵で verify できる。"""
+    b1, pub1 = _new_key_b64()
+    b2, pub2 = _new_key_b64()
+    header = authorization_signature_header(
+        method="POST",
+        url="https://api.privy.io/v1/policies",
+        body={"name": "x"},
+        app_id="app",
+        authorization_private_keys=[b1, b2],
+    )
+    parts = header.split(",")
+    assert len(parts) == 2
+    payload = canonical_payload(
+        build_signing_input(
+            method="POST", url="https://api.privy.io/v1/policies", body={"name": "x"}, app_id="app"
+        )
+    )
+    pub1.verify(base64.b64decode(parts[0]), payload, ec.ECDSA(hashes.SHA256()))
+    pub2.verify(base64.b64decode(parts[1]), payload, ec.ECDSA(hashes.SHA256()))


### PR DESCRIPTION
## 概要

v4 Phase 2-D で Privy 委譲署名を **Python httpx REST 直叩き**で行う方針（Phase 1 spike で経路A GO確定・PR #822）の**技術基盤**。最もリスクの高い `privy-authorization-signature`(P-256) の生成を Python で実装し、Node SDK のオラクルで byte 一致検証した。

`@privy-io/node` の `formatRequestForAuthorizationSignature` + `generateAuthorizationSignature` を Python 再実装。

## 仕様（Node SDK `lib/authorization.js` と一致）
```
input = {version:1, method, url(末尾スラッシュなし), body(空objは""), headers:{privy-app-id,...}}
→ canonicalize(RFC 8785 JCS) → UTF-8 bytes
→ base64(DER(P256_ECDSA(sha256(payload))))
→ header: privy-authorization-signature = sig1,sig2,...
```

## 検証（最リスク部分の de-risk）
- **canonicalize byte 完全一致**: Node SDK が使う npm `canonicalize`(=RFC 8785 JCS) を dev VPS の harness で正解オラクル化し、Python の `json.dumps(sort_keys, compact, ensure_ascii=False)` が 3サンプル(policy作成 / 空body / 配列・ネスト混在型)で **byte 一致 + SHA256 一致**することをハードコード値で検証。
- PKCS8 DER base64 鍵のロード + sign→公開鍵 verify ラウンドトリップ。
- ASCII ペイロード前提（float/非ASCII を body に入れない）を docstring に明記。

## 範囲・安全性
- `backend/app/privy/auth_signature.py` は**純関数のみ**。外部 API 呼出・秘密鍵の常駐・I/O なし。
- 新規依存なし（cryptography 46.0.5 / 既存）。
- ✅ ruff / ruff format / mypy / pytest(7 tests) clean。
- まだ executor 等から未配線（基盤のみ）。

## 次（2-D-B.2）
httpx REST クライアント + 実 Privy app への **live 受理検証**（URL/body 構築の正確性確認）+ delegation grant → Privy policy 作成 → `privy_policy_id`/`privy_signer_id` 保存。

🤖 Generated with [Claude Code](https://claude.com/claude-code)