### PR TITLE
feat(privy): 委譲枠→Privy policy 写像（純関数・L1 / スライス2-D-B.2-L1）

### DIFF
--- a/backend/app/privy/policy_mapper.py
+++ b/backend/app/privy/policy_mapper.py
@@ -1,0 +1,151 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/app/privy/policy_mapper.py
+"""委譲枠（delegation_grants）→ Privy server policy 写像（v4 Phase 2-D-B.2 / L1）。
+
+ユーザーが consent した委譲枠を **Privy policy engine（TEE enforce）** の JSON に変換する
+純関数群。Privy API 呼び出し・秘密鍵・tx 送信は一切含まない（`rest_client.create_policy`
+に渡す body を組み立てるだけ）。生成した dict は `PrivyRestClient.create_policy()` へ渡す。
+
+二層ガードにおける enforcement の分担（[[consent flow design]] の「二重ガード維持」）::
+
+    Privy policy(本モジュール / TEE enforce):
+        - `to` allowlist  = 委譲対象プロトコルのコントラクト（Aave V3 Pool）に限定
+        - `current_unix_timestamp` lte = 委譲枠 expires_at（期限切れ署名を TEE が拒否）
+        - chain_type / 既定 DENY（allowlist 方式）
+    backend ゲート(2-D-A / risk_limiter / PolicyEngine Rule8):
+        - 単一 ≤ 委譲枠% / 日次 ≤ 委譲枠% / HF floor（総資産 × % の絶対額クランプ）
+        - allowed_assets の検証・出金経路の除外（proposal routing）
+
+**% 上限を Privy policy の value cap に写像しない理由**: 委譲枠は **%** で持ち、絶対額は
+執行時の総資産に依存する（grant 時点では未確定）。よって絶対額クランプは backend
+risk_limiter（2-D-A 配線済）が担う。Privy policy は構造的エンベロープ（宛先 allowlist +
+期限 + chain）を TEE で enforce し、両者の積集合で被害上限を縛る。
+
+**出金除外**: Phase 2-D の AUTO は SUPPLY 中心。出金（withdraw）は本人署名を維持する不変条件
+のため、委譲経路（scw_executor）が SUPPLY proposal のみを通す（routing で担保）。本 policy の
+`to` は Aave Pool だが、supply/withdraw の判別は Privy 静的条件では困難（calldata 動的参照は
+Privy 未サポート＝wallet_policy.py 注記）。よって出金除外は backend routing で enforce する。
+
+**Privy policy schema 出典**: `docs/ops/v4_phase1_session_signer_spike.md` §2
+（version 1.0 / chain_type=ethereum / rules[] / method=eth_signUserOperation・eth_sendTransaction /
+conditions: to・current_unix_timestamp）+ Privy API reference「Create policy」。
+本 module は dormant（L1 で実 Privy に投げる前に live 受理検証する。rest_client と同じ運用）。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from app.aave.chains import get_chain_config
+
+# Privy policy engine v1 定数（spike doc §2 / Privy API reference 準拠）
+_POLICY_VERSION = "1.0"
+_CHAIN_TYPE = "ethereum"
+_FIELD_SOURCE_TX = "ethereum_transaction"
+_ACTION_ALLOW = "ALLOW"
+_ACTION_DENY = "DENY"
+
+# 委譲経路が署名する method（UserOp 署名 = 経路A の本丸 / 直 tx も許容）
+_DELEGATED_METHODS = ("eth_signUserOperation", "eth_sendTransaction")
+
+# 委譲可能なプロトコル → コントラクト解決関数（Phase 2-D は Aave のみ）。
+# Lido / Pendle はコントラクトレジストリ未整備のため Phase 3（マルチプロトコル executor）で追加する。
+_SUPPORTED_PROTOCOLS: frozenset[str] = frozenset({"aave"})
+
+
+class PolicyMappingError(ValueError):
+    """委譲枠を Privy policy に写像できない（fail-closed で grant を拒否する）。"""
+
+
+def resolve_protocol_contracts(allowed_protocols: list[str], chain_name: str) -> list[str]:
+    """委譲対象プロトコル → 許可コントラクトアドレス（小文字・重複排除・安定順）。
+
+    解決できないプロトコルは PolicyMappingError（over-broad な policy を作らず fail-closed）。
+    """
+    if not allowed_protocols:
+        raise PolicyMappingError("allowed_protocols must not be empty")
+
+    contracts: list[str] = []
+    for raw in allowed_protocols:
+        protocol = raw.strip().lower()
+        if protocol not in _SUPPORTED_PROTOCOLS:
+            raise PolicyMappingError(
+                f"protocol {raw!r} is not delegatable in Phase 2-D "
+                f"(supported: {sorted(_SUPPORTED_PROTOCOLS)}; Lido/Pendle は Phase 3)"
+            )
+        if protocol == "aave":
+            try:
+                config = get_chain_config(chain_name)
+            except ValueError as exc:
+                raise PolicyMappingError(str(exc)) from exc
+            addr = config.pool_address.lower()
+            if addr not in contracts:
+                contracts.append(addr)
+    return contracts
+
+
+def _to_condition(contracts: list[str]) -> dict[str, Any]:
+    """宛先 allowlist 条件。1 件なら eq、複数なら in。"""
+    base = {"field_source": _FIELD_SOURCE_TX, "field": "to"}
+    if len(contracts) == 1:
+        return {**base, "operator": "eq", "value": contracts[0]}
+    return {**base, "operator": "in", "value": contracts}
+
+
+def _expiry_condition(expires_at: datetime) -> dict[str, Any]:
+    """期限条件（current_unix_timestamp <= expires_at の unix 秒）。"""
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    expires_unix = int(expires_at.timestamp())
+    return {
+        "field_source": _FIELD_SOURCE_TX,
+        "field": "current_unix_timestamp",
+        "operator": "lte",
+        "value": str(expires_unix),
+    }
+
+
+def build_delegation_policy(
+    *,
+    wallet_address: str,
+    allowed_protocols: list[str],
+    expires_at: datetime,
+    chain_name: str,
+    policy_name: str | None = None,
+) -> dict[str, Any]:
+    """委譲枠 → Privy policy 作成 body（`PrivyRestClient.create_policy()` 入力）。
+
+    生成される policy は「許可コントラクト宛 かつ 期限内」の署名のみ ALLOW、それ以外は
+    既定 DENY。% 上限・allowed_assets・出金除外は backend ゲート側で enforce する（module
+    docstring 参照）。写像不能（未対応プロトコル / 不正チェーン）は PolicyMappingError。
+
+    :param wallet_address: 委譲対象ウォレット（policy name の監査用識別子）
+    :param allowed_protocols: 委譲枠の許可プロトコル（Phase 2-D は ["aave"] のみ解決可能）
+    :param expires_at: 委譲枠の失効時刻（naive は UTC 扱い）
+    :param chain_name: 執行チェーン名（"base" 本番 / "base_sepolia" staging）
+    :param policy_name: 任意の policy 表示名（未指定なら wallet/chain から生成）
+    """
+    if not wallet_address.strip():
+        raise PolicyMappingError("wallet_address must not be empty")
+
+    contracts = resolve_protocol_contracts(allowed_protocols, chain_name)
+    conditions = [_to_condition(contracts), _expiry_condition(expires_at)]
+
+    name = policy_name or f"uata-delegation-{wallet_address.lower()}-{chain_name}"
+    rules = [
+        {
+            "name": f"allow-{method}-within-scope",
+            "method": method,
+            "conditions": conditions,
+            "action": _ACTION_ALLOW,
+        }
+        for method in _DELEGATED_METHODS
+    ]
+    return {
+        "version": _POLICY_VERSION,
+        "name": name,
+        "chain_type": _CHAIN_TYPE,
+        "rules": rules,
+        "default_action": _ACTION_DENY,
+    }

--- a/backend/tests/test_privy_policy_mapper.py
+++ b/backend/tests/test_privy_policy_mapper.py
@@ -1,0 +1,141 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_privy_policy_mapper.py
+"""policy_mapper の単体テスト（v4 Phase 2-D-B.2 / L1 写像）。
+
+委譲枠 → Privy policy(v1.0) の写像が schema どおり（version/chain_type/rules/conditions/
+default_action）であること、未対応プロトコル・不正入力で fail-closed すること、期限が
+unix 秒条件に正しく落ちることを検証する。実 Privy への投入（live 受理）は L1 で別途実施。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.aave.chains import get_chain_config
+from app.privy.policy_mapper import (
+    PolicyMappingError,
+    build_delegation_policy,
+    resolve_protocol_contracts,
+)
+
+_EXPIRES = datetime(2026, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
+_WALLET = "0x1234567890123456789012345678901234567890"
+
+
+def test_resolve_aave_contract_base() -> None:
+    contracts = resolve_protocol_contracts(["aave"], "base")
+    assert contracts == [get_chain_config("base").pool_address.lower()]
+
+
+def test_resolve_dedupes_and_lowercases() -> None:
+    contracts = resolve_protocol_contracts(["aave", "AAVE", " Aave "], "base_sepolia")
+    assert contracts == [get_chain_config("base_sepolia").pool_address.lower()]
+
+
+def test_resolve_empty_protocols_raises() -> None:
+    with pytest.raises(PolicyMappingError):
+        resolve_protocol_contracts([], "base")
+
+
+def test_resolve_unsupported_protocol_fails_closed() -> None:
+    with pytest.raises(PolicyMappingError) as ei:
+        resolve_protocol_contracts(["lido"], "base")
+    assert "lido" in str(ei.value)
+
+
+def test_resolve_bad_chain_raises() -> None:
+    with pytest.raises(PolicyMappingError):
+        resolve_protocol_contracts(["aave"], "no_such_chain")
+
+
+def test_build_policy_top_level_schema() -> None:
+    policy = build_delegation_policy(
+        wallet_address=_WALLET,
+        allowed_protocols=["aave"],
+        expires_at=_EXPIRES,
+        chain_name="base",
+    )
+    assert policy["version"] == "1.0"
+    assert policy["chain_type"] == "ethereum"
+    assert policy["default_action"] == "DENY"
+    assert _WALLET.lower() in policy["name"]
+    # 委譲 method ごとに 1 ALLOW rule
+    methods = {r["method"] for r in policy["rules"]}
+    assert methods == {"eth_signUserOperation", "eth_sendTransaction"}
+    assert all(r["action"] == "ALLOW" for r in policy["rules"])
+
+
+def test_build_policy_to_allowlist_condition() -> None:
+    pool = get_chain_config("base").pool_address.lower()
+    policy = build_delegation_policy(
+        wallet_address=_WALLET,
+        allowed_protocols=["aave"],
+        expires_at=_EXPIRES,
+        chain_name="base",
+    )
+    rule = policy["rules"][0]
+    to_cond = next(c for c in rule["conditions"] if c["field"] == "to")
+    # 単一コントラクトは eq
+    assert to_cond["operator"] == "eq"
+    assert to_cond["value"] == pool
+    assert to_cond["field_source"] == "ethereum_transaction"
+
+
+def test_build_policy_expiry_condition_unix() -> None:
+    policy = build_delegation_policy(
+        wallet_address=_WALLET,
+        allowed_protocols=["aave"],
+        expires_at=_EXPIRES,
+        chain_name="base",
+    )
+    rule = policy["rules"][0]
+    exp_cond = next(c for c in rule["conditions"] if c["field"] == "current_unix_timestamp")
+    assert exp_cond["operator"] == "lte"
+    assert exp_cond["value"] == str(int(_EXPIRES.timestamp()))
+
+
+def test_build_policy_naive_expiry_treated_as_utc() -> None:
+    naive = datetime(2026, 7, 1, 0, 0, 0)
+    policy = build_delegation_policy(
+        wallet_address=_WALLET,
+        allowed_protocols=["aave"],
+        expires_at=naive,
+        chain_name="base",
+    )
+    exp_cond = next(
+        c for c in policy["rules"][0]["conditions"] if c["field"] == "current_unix_timestamp"
+    )
+    assert exp_cond["value"] == str(int(_EXPIRES.timestamp()))
+
+
+def test_build_policy_custom_name() -> None:
+    policy = build_delegation_policy(
+        wallet_address=_WALLET,
+        allowed_protocols=["aave"],
+        expires_at=_EXPIRES,
+        chain_name="base",
+        policy_name="my-policy",
+    )
+    assert policy["name"] == "my-policy"
+
+
+def test_build_policy_empty_wallet_raises() -> None:
+    with pytest.raises(PolicyMappingError):
+        build_delegation_policy(
+            wallet_address="  ",
+            allowed_protocols=["aave"],
+            expires_at=_EXPIRES,
+            chain_name="base",
+        )
+
+
+def test_build_policy_unsupported_protocol_raises() -> None:
+    with pytest.raises(PolicyMappingError):
+        build_delegation_policy(
+            wallet_address=_WALLET,
+            allowed_protocols=["aave", "pendle"],
+            expires_at=_EXPIRES,
+            chain_name="base",
+        )


### PR DESCRIPTION
## 概要
v4 完全おまかせ自動運用 Phase 2-D（AUTO 執行配線）スライス **2-D-B.2 の L1 写像**。
委譲枠（`delegation_grants`）を **Privy server policy(v1.0)** の作成 body に変換する純関数
`backend/app/privy/policy_mapper.py` を新設する。`PrivyRestClient.create_policy()` に渡す dict を
組み立てるだけで、**API 呼出・秘密鍵・tx 送信・runtime 配線は一切含まない（dormant）**。

## 設計（二重ガードの分担）
| enforcement | 担当 | 内容 |
|---|---|---|
| **Privy policy (TEE)** | 本 module | `to` allowlist=Aave V3 Pool / `current_unix_timestamp` ≤ expires_at / 既定 DENY |
| **backend ゲート (2-D-A)** | risk_limiter / Rule8 | 単一≤% / 日次≤% / HF floor / allowed_assets / 出金除外(routing) |

- **% 上限を Privy value cap に写像しない**: 絶対額は執行時の総資産依存で grant 時点未確定。
  絶対額クランプは backend risk_limiter（2-D-A 配線済）が担う。Privy は構造エンベロープ
  （宛先 + 期限 + chain）を TEE enforce し、両者の積集合で被害上限を縛る。
- **出金除外**: AUTO は SUPPLY 中心。supply/withdraw の判別は Privy 静的条件では困難
  （calldata 動的参照 Privy 未サポート）→ 委譲経路(scw_executor)が SUPPLY proposal のみ通す
  routing で enforce（2-D-C）。
- **fail-closed**: 未対応プロトコル（Lido/Pendle=Phase 3）/ 不正チェーン / 空入力は
  `PolicyMappingError`（over-broad policy を作らない）。

Privy policy schema 出典: `docs/ops/v4_phase1_session_signer_spike.md` §2 + Privy API「Create policy」。

## 本 PR の範囲外（HUMAN-REVIEW-REQUIRED・後続）
- **L0**: サーバ P-256 公開鍵の key quorum 登録 → `PRIVY_SERVER_SIGNER_ID`（UAT アプリ設定変更・dashboard・1回・要小林さん確認）。
- **L1 配線**: `/delegation/grant`(or prepare) で `create_policy()` を**実 Privy に投げる**配線 + `privy_policy_id`/`privy_signer_id` 保存（runtime 挙動変更・L0 完了が前提）。
- 実 Privy への live 受理検証（dormant module のため未実施。rest_client と同じく投入前に検証）。

## テスト / DoD
- `tests/test_privy_policy_mapper.py` 新規 12 件（schema 写像 / allowlist eq / 期限 unix 秒 / naive=UTC / fail-closed）。
- privy スイート **25 passed**、`ruff check`/`ruff format`/`ruff --select S`/`mypy` clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)