### PR TITLE
feat(privy): key quorum 登録サポート（L0 / スライス2-D-B.2-L0）

### DIFF
--- a/backend/app/privy/rest_client.py
+++ b/backend/app/privy/rest_client.py
@@ -156,3 +156,31 @@ class PrivyRestClient:
     def create_policy(self, policy: dict[str, Any]) -> dict[str, Any]:
         """POST /v1/policies（app-level / Basic auth のみ・委譲署名不要）。"""
         return self._post("/policies", policy, signed=False)
+
+    def create_key_quorum(
+        self,
+        *,
+        public_keys: list[str],
+        authorization_threshold: int = 1,
+        display_name: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """POST /v1/key_quorums（L0: サーバ authorization key を quorum 登録）。
+
+        app-level 操作で **Basic auth のみ**（委譲署名不要）。SDK の
+        `KeyQuorums.create` は `update`/`delete` と異なり authorization-signature を付けない
+        （`node_modules/@privy-io/node/resources/key-quorums.js` の create で確認）。
+
+        :param public_keys: P-256 公開鍵（SPKI DER の base64・PEM ヘッダなし）のリスト
+        :param authorization_threshold: 必要署名数（既定 1 = 単独サーバ signer）
+        :param display_name: 監査用表示名
+        :return: 作成された key quorum（``id`` が SERVER_SIGNER_ID = signerId）
+        """
+        if not public_keys:
+            raise ValueError("public_keys must not be empty")
+        body: dict[str, Any] = {
+            "public_keys": public_keys,
+            "authorization_threshold": authorization_threshold,
+        }
+        if display_name:
+            body["display_name"] = display_name
+        return self._post("/key_quorums", body, signed=False)

--- a/backend/app/privy/server_keys.py
+++ b/backend/app/privy/server_keys.py
@@ -1,0 +1,60 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/app/privy/server_keys.py
+"""サーバ authorization 鍵（P-256）の生成・公開鍵導出（v4 Phase 2-D-B.2 / L0）。
+
+Privy の key quorum 登録（L0）に使うサーバ署名鍵を、Privy が要求する形式で扱う純関数群::
+
+    秘密鍵 = PKCS8(DER, PEM ヘッダなし) の base64
+             → env PRIVY_AUTHORIZATION_PRIVATE_KEY / SDK の authorization_private_keys と同形式
+    公開鍵 = SPKI(DER) の base64
+             → key quorum 作成の public_keys と同形式
+
+spike で実証済の `openssl ecparam -name prime256v1` と同じ曲線（SECP256R1 = P-256）。
+秘密鍵は **絶対にログに出さない**（CLAUDE.md §Security 1/8）。本 module は生成・導出のみで、
+出力先（env / 標準出力）は呼び出し側が責任を持つ。
+"""
+
+from __future__ import annotations
+
+import base64
+
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+)
+
+from app.privy.auth_signature import load_authorization_private_key
+
+
+def _private_pkcs8_b64(key: ec.EllipticCurvePrivateKey) -> str:
+    der = key.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
+    return base64.b64encode(der).decode("ascii")
+
+
+def _public_spki_b64(key: ec.EllipticCurvePublicKey) -> str:
+    der = key.public_bytes(Encoding.DER, PublicFormat.SubjectPublicKeyInfo)
+    return base64.b64encode(der).decode("ascii")
+
+
+def generate_server_authorization_keypair() -> tuple[str, str]:
+    """新しい P-256 サーバ authorization 鍵を生成する。
+
+    :return: ``(private_key_b64_pkcs8_der, public_key_b64_spki_der)``
+        - private: env ``PRIVY_AUTHORIZATION_PRIVATE_KEY`` に格納（秘匿・非コミット）
+        - public:  key quorum 作成の ``public_keys`` に渡す
+    """
+    key = ec.generate_private_key(ec.SECP256R1())
+    return _private_pkcs8_b64(key), _public_spki_b64(key.public_key())
+
+
+def derive_public_key_spki_b64(private_key_b64_pkcs8: str) -> str:
+    """既存の base64 PKCS8 秘密鍵から SPKI(DER) base64 公開鍵を導出する。
+
+    spike で既に生成済の鍵（``~/.config/uata-privy-spike/.env`` 等）から、key quorum
+    登録に渡す公開鍵を再現するのに使う。秘密鍵は戻り値に含めない。
+    """
+    key = load_authorization_private_key(private_key_b64_pkcs8)
+    return _public_spki_b64(key.public_key())

--- a/backend/scripts/privy_register_key_quorum.py
+++ b/backend/scripts/privy_register_key_quorum.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/scripts/privy_register_key_quorum.py
+"""Privy key quorum 登録ツール（v4 Phase 2-D-B.2 / L0・1回実施）。
+
+サーバ authorization 鍵（P-256）を Privy アプリに **key quorum** として登録し、返る
+quorum ID（= ``SERVER_SIGNER_ID`` = signerId）を取得する。委譲署名フロー L0
+（`docs/ops/v4_phase2d_consent_flow_design.md`）の唯一の手作業をスクリプト化したもの。
+
+⚠️ これは Privy アプリ（"UAT" 等）への **設定変更**である。実施前に必ず小林さんに確認すること。
+
+前提環境変数（dev VPS の creds など）::
+
+    PRIVY_APP_ID                    必須
+    PRIVY_APP_SECRET                必須（Basic auth）
+    PRIVY_AUTHORIZATION_PRIVATE_KEY 任意（既存サーバ鍵 = PKCS8 DER の base64）
+
+使い方::
+
+    # 既存のサーバ鍵から公開鍵を導出して登録（推奨・spike 鍵を再利用）
+    PRIVY_APP_ID=... PRIVY_APP_SECRET=... PRIVY_AUTHORIZATION_PRIVATE_KEY=... \
+      python backend/scripts/privy_register_key_quorum.py --display-name "uata-server-signer"
+
+    # 新しいサーバ鍵を生成して登録（生成された秘密鍵を env に保存する運用）
+    PRIVY_APP_ID=... PRIVY_APP_SECRET=... \
+      python backend/scripts/privy_register_key_quorum.py --generate --display-name "uata-server-signer"
+
+    # 実際に投げる前に内容だけ確認
+    ... python backend/scripts/privy_register_key_quorum.py --dry-run
+
+秘密鍵は **標準出力にのみ** 1 度表示する（ログには出さない）。表示された秘密鍵は
+``PRIVY_AUTHORIZATION_PRIVATE_KEY`` に保存し、**絶対にコミットしない**（.env は gitignore 済）。
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+# backend/ を import パスに追加（リポジトリ直叩き実行に対応）
+_BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from app.privy.rest_client import PrivyRestClient, PrivyRestError  # noqa: E402
+from app.privy.server_keys import (  # noqa: E402
+    derive_public_key_spki_b64,
+    generate_server_authorization_keypair,
+)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Register a Privy key quorum (L0).")
+    p.add_argument(
+        "--generate",
+        action="store_true",
+        help="新しいサーバ鍵を生成する（既定は env の PRIVY_AUTHORIZATION_PRIVATE_KEY を使う）",
+    )
+    p.add_argument(
+        "--display-name",
+        default="uata-server-signer",
+        help="key quorum の表示名（監査用）",
+    )
+    p.add_argument(
+        "--threshold",
+        type=int,
+        default=1,
+        help="authorization_threshold（既定 1 = 単独サーバ signer）",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Privy に投げず、登録予定の公開鍵と body だけ表示する",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = _parse_args(argv)
+
+    app_id = os.getenv("PRIVY_APP_ID", "")
+    app_secret = os.getenv("PRIVY_APP_SECRET", "")
+    if not app_id or not app_secret:
+        print("ERROR: PRIVY_APP_ID / PRIVY_APP_SECRET が未設定です。", file=sys.stderr)
+        return 2
+
+    generated_private: str | None = None
+    if args.generate:
+        generated_private, public_key = generate_server_authorization_keypair()
+    else:
+        existing = os.getenv("PRIVY_AUTHORIZATION_PRIVATE_KEY", "")
+        if not existing:
+            print(
+                "ERROR: PRIVY_AUTHORIZATION_PRIVATE_KEY が未設定です。"
+                "（既存鍵を使わない場合は --generate を指定）",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            public_key = derive_public_key_spki_b64(existing)
+        except ValueError as exc:
+            print(f"ERROR: 秘密鍵をロードできません: {exc}", file=sys.stderr)
+            return 2
+
+    print("=== Privy key quorum 登録 (L0) ===")
+    print(f"display_name        : {args.display_name}")
+    print(f"authorization_threshold: {args.threshold}")
+    print(f"public_key (SPKI b64): {public_key}")
+
+    if args.dry_run:
+        print("\n[dry-run] Privy には投げていません。--dry-run を外すと実行します。")
+        if generated_private is not None:
+            _emit_generated_private(generated_private)
+        return 0
+
+    client = PrivyRestClient(app_id=app_id, app_secret=app_secret)
+    try:
+        result = client.create_key_quorum(
+            public_keys=[public_key],
+            authorization_threshold=args.threshold,
+            display_name=args.display_name,
+        )
+    except PrivyRestError as exc:
+        print(f"ERROR: key quorum 作成失敗: {exc}", file=sys.stderr)
+        return 1
+
+    signer_id = result.get("id", "")
+    print("\n✅ 登録成功")
+    print(f"SERVER_SIGNER_ID (=signerId): {signer_id}")
+    print("→ backend env に PRIVY_SERVER_SIGNER_ID として保存してください。")
+
+    if generated_private is not None:
+        _emit_generated_private(generated_private)
+    return 0
+
+
+def _emit_generated_private(private_key_b64: str) -> None:
+    """生成した秘密鍵を標準出力に 1 度だけ表示（ログ禁止・非コミット）。"""
+    print("\n--- 生成された秘密鍵（1 度のみ表示・env に保存し絶対にコミットしない）---")
+    print(f"PRIVY_AUTHORIZATION_PRIVATE_KEY={private_key_b64}")
+    print("--- ここまで ---")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/backend/tests/test_privy_rest_client.py
+++ b/backend/tests/test_privy_rest_client.py
@@ -147,6 +147,37 @@ def test_send_calls_request_shape() -> None:
     assert "privy-authorization-signature" in captured["headers"]
 
 
+def test_create_key_quorum_basic_auth_only() -> None:
+    """key quorum 作成は Basic auth のみ・authorization-signature を付けない（L0）。"""
+    captured: dict = {}
+    c = _client()
+    with _patch_httpx(captured, _FakeResp(200, {"id": "kq_123"})):
+        out = c.create_key_quorum(public_keys=["PUBKEY_SPKI_B64"], display_name="srv")
+    assert out == {"id": "kq_123"}
+    assert captured["url"] == "https://api.privy.io/v1/key_quorums"
+    assert captured["json"]["public_keys"] == ["PUBKEY_SPKI_B64"]
+    assert captured["json"]["authorization_threshold"] == 1
+    assert captured["json"]["display_name"] == "srv"
+    assert captured["auth"] == ("app123", "secret123")
+    assert "privy-authorization-signature" not in captured["headers"]
+    assert "privy-request-expiry" not in captured["headers"]
+
+
+def test_create_key_quorum_empty_keys_raises() -> None:
+    c = _client()
+    with pytest.raises(ValueError):
+        c.create_key_quorum(public_keys=[])
+
+
+def test_create_key_quorum_omits_display_name_when_absent() -> None:
+    captured: dict = {}
+    c = _client()
+    with _patch_httpx(captured, _FakeResp(200, {"id": "kq_1"})):
+        c.create_key_quorum(public_keys=["PK"], authorization_threshold=2)
+    assert "display_name" not in captured["json"]
+    assert captured["json"]["authorization_threshold"] == 2
+
+
 def test_non_2xx_raises_privy_rest_error() -> None:
     captured: dict = {}
     c = _client()

--- a/backend/tests/test_privy_server_keys.py
+++ b/backend/tests/test_privy_server_keys.py
@@ -1,0 +1,79 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_privy_server_keys.py
+"""server_keys（サーバ authorization 鍵の生成・公開鍵導出）の単体テスト（L0）。
+
+生成鍵が Privy の要求形式（PKCS8 DER base64 秘密 / SPKI DER base64 公開）であり、
+auth_signature の署名フローとラウンドトリップすることを検証する。
+"""
+
+from __future__ import annotations
+
+import base64
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import load_der_public_key
+
+from app.privy.auth_signature import (
+    canonical_payload,
+    load_authorization_private_key,
+    sign_payload,
+)
+from app.privy.server_keys import (
+    derive_public_key_spki_b64,
+    generate_server_authorization_keypair,
+)
+
+
+def test_generate_keypair_formats() -> None:
+    priv_b64, pub_b64 = generate_server_authorization_keypair()
+    # 秘密鍵は auth_signature がロードできる PKCS8 DER base64
+    key = load_authorization_private_key(priv_b64)
+    assert isinstance(key, ec.EllipticCurvePrivateKey)
+    assert isinstance(key.curve, ec.SECP256R1)
+    # 公開鍵は SPKI DER base64（load_der_public_key でロードできる）
+    pub = load_der_public_key(base64.b64decode(pub_b64))
+    assert isinstance(pub, ec.EllipticCurvePublicKey)
+
+
+def test_generated_public_matches_private() -> None:
+    priv_b64, pub_b64 = generate_server_authorization_keypair()
+    derived = derive_public_key_spki_b64(priv_b64)
+    assert derived == pub_b64
+
+
+def test_keypairs_are_unique() -> None:
+    p1, _ = generate_server_authorization_keypair()
+    p2, _ = generate_server_authorization_keypair()
+    assert p1 != p2
+
+
+def test_sign_verify_roundtrip() -> None:
+    """生成した秘密鍵で署名 → 導出した公開鍵で検証できる。"""
+    priv_b64, pub_b64 = generate_server_authorization_keypair()
+    key = load_authorization_private_key(priv_b64)
+    payload = canonical_payload(
+        {"version": 1, "method": "POST", "url": "https://x", "body": "", "headers": {}}
+    )
+    sig_b64 = sign_payload(payload, key)
+
+    pub = load_der_public_key(base64.b64decode(pub_b64))
+    assert isinstance(pub, ec.EllipticCurvePublicKey)
+    # 例外が出なければ検証成功
+    pub.verify(base64.b64decode(sig_b64), payload, ec.ECDSA(hashes.SHA256()))
+
+
+def test_derive_from_known_key() -> None:
+    """既存秘密鍵から公開鍵を導出（spike 鍵再利用シナリオ）。"""
+    key = ec.generate_private_key(ec.SECP256R1())
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        NoEncryption,
+        PrivateFormat,
+    )
+
+    priv_b64 = base64.b64encode(
+        key.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
+    ).decode("ascii")
+    derived = derive_public_key_spki_b64(priv_b64)
+    assert base64.b64decode(derived)  # 有効な base64 SPKI


### PR DESCRIPTION
## 概要
v4 完全おまかせ自動運用 Phase 2-D・委譲署名フロー **L0**（`docs/ops/v4_phase2d_consent_flow_design.md`）を
コード化する。L0 = サーバの P-256 authorization 鍵を Privy アプリに **key quorum** として登録し、返る
quorum ID（= `SERVER_SIGNER_ID` = signerId）を取得する一度きりの手作業。

⚠️ **実 Privy への登録自体は UAT アプリへの設定変更**であり、本 PR には含めない（実行は小林さん確認の上で別途）。本 PR は「登録するためのツール一式」をマージするだけで、**runtime 挙動は変えない（dormant）**。

## 変更
| ファイル | 内容 |
|---|---|
| `app/privy/rest_client.py` | `create_key_quorum()` 追加（`POST /v1/key_quorums`・**Basic auth のみ**） |
| `app/privy/server_keys.py`（新規） | サーバ P-256 鍵の生成（PKCS8 DER b64 秘密 / SPKI DER b64 公開）+ 既存秘密鍵からの公開鍵導出 |
| `scripts/privy_register_key_quorum.py`（新規） | L0 を 1 コマンド化（`--generate` / 既存鍵 / `--dry-run`） |

## wire 形の根拠（推測でなく SDK 由来）
dev VPS の `@privy-io/node` v0.22.0 から確定:
- `KeyQuorums.create` は基底クラスの素の `post('/v1/key_quorums', {body})` で、`update`/`delete` と違い **authorization-signature を付けない**（member 認可が不要な新規作成のため）→ `create_policy` と同じ Basic-auth 経路。
- body: `public_keys`(SPKI DER の base64 配列) / `authorization_threshold`(既定 1) / `display_name`。レスポンス `id` が SERVER_SIGNER_ID。

## セキュリティ
- 秘密鍵は **ログに出さない**（CLAUDE.md §Security 1/8）。スクリプトは生成秘密鍵を**標準出力に 1 度のみ**表示し、env 保存・非コミットを明示。
- 鍵形式は spike 実証済の `openssl prime256v1`（=P-256/SECP256R1）と同一。

## 使い方（L0 実施時・小林さん確認後）
```bash
# 既存 spike 鍵を再利用して登録
PRIVY_APP_ID=... PRIVY_APP_SECRET=... PRIVY_AUTHORIZATION_PRIVATE_KEY=... \
  python backend/scripts/privy_register_key_quorum.py --display-name uata-server-signer
# → SERVER_SIGNER_ID を backend env PRIVY_SERVER_SIGNER_ID に保存
```

## テスト / DoD
- `create_key_quorum` の Basic-auth wire（署名なし）/ 空鍵エラー / display_name 省略 3 件。
- `server_keys`: 鍵生成形式 / 公開鍵導出一致 / 一意性 / 署名検証ラウンドトリップ 5 件。
- privy スイート **33 passed**、`ruff`/`format`/`--select S`/`mypy` clean。スクリプト dry-run 動作確認済。

## 後続（HUMAN-REVIEW-REQUIRED）
- L0 実登録（小林さん確認 → `PRIVY_SERVER_SIGNER_ID` env 化）。
- L1 配線（`#827` の policy_mapper を `/delegation/grant` で実 Privy に投げる）。
- 2-D-C `scw_executor`（sendCalls で SCW 駆動）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)