### PR TITLE
feat(privy): 委譲(SCW)経路の実行コア（dormant / スライス2-D-C）

### DIFF
--- a/backend/app/proposals/scw_executor.py
+++ b/backend/app/proposals/scw_executor.py
@@ -1,0 +1,159 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/app/proposals/scw_executor.py
+"""委譲(SCW)経路の実行コア（v4 Phase 2-D-C）。
+
+ユーザーの非カストディアル Smart Wallet(SCW) を、サーバが session signer として委譲枠の
+範囲で駆動する実行層。Privy `wallet_sendCalls`(ERC-5792) 1 呼び出しで approve+supply を
+batch 送信する（spike probe3 で broadcast 到達を実証 = [[project_privy_signuserop_signonly]]）。
+従来の custodial EOA 直署名（`MultiChainAaveService.execute_rebalance`）の置換候補。
+
+**dormant（本番 inert）**: `execute_calls_via_scw` は `is_delegation_policy_enabled()`
+（DELEGATION_PRIVY_POLICY_ENABLED + L0 signer id + Privy creds）が揃わない限り
+`ScwNotEnabledError` を送出し Privy を一切叩かない。`PrivyRestClient` も creds 必須。
+
+**未配線（意図的）**: `_execute_aave_for_proposal`（proposals/router.py）への結線は別スライス
+（2-D-C.2）。理由 = Privy `send_calls` は **Privy 内部の wallet ID** を要するが、現状 users に
+`privy_wallet_id` 列が無い（`privy_did`/`smart_wallet_address` のみ）。実ユーザー結線には
+wallet ID 解決の配線が先に要る。本 module はその解決後に呼ばれる実行コアを提供する。
+
+安全分担（[[policy_mapper]] の二重ガード）: 本 module は「枠内に制約された送信」の実行のみ。
+HARD_STOP / risk_limiter %クランプ / Rule8（2-D-A）は **呼び出し元 router が執行直前に通す**
+（本 module はそれらを再実装しない）。出金は委譲対象外＝呼び出し元が SUPPLY のみ通す。
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from app.aave.chains import get_chain_config
+from app.privy.delegation_service import is_delegation_policy_enabled
+from app.privy.rest_client import PrivyRestClient, PrivyRestError
+
+logger = logging.getLogger(__name__)
+
+
+class ScwNotEnabledError(RuntimeError):
+    """委譲(SCW)実行が未有効化（dormant）。"""
+
+
+class ScwExecutionError(RuntimeError):
+    """委譲(SCW)実行が失敗した（Privy エラー等）。"""
+
+
+@dataclass(frozen=True)
+class ScwExecutionResult:
+    """委譲(SCW)送信の結果。"""
+
+    tx_hash: Optional[str]
+    """broadcast された tx hash（取れない場合は None・raw を参照）。"""
+
+    status: str
+    """"submitted"（送信受理）/ "unknown"（hash 不明）。"""
+
+    raw: dict[str, Any]
+    """Privy レスポンス原文（監査用・秘密は含まれない）。"""
+
+
+def caip2_for_chain(chain_name: str) -> str:
+    """チェーン名 → CAIP-2（``eip155:<chain_id>``）。本番 base=eip155:8453 / staging
+    base_sepolia=eip155:84532。"""
+    return f"eip155:{get_chain_config(chain_name).chain_id}"
+
+
+def build_supply_calls(deposit_txs: dict[str, Any]) -> list[dict[str, Any]]:
+    """`AaveClient.build_deposit_txs` の戻り（approve_tx / supply_tx）を ERC-5792 calls に変換。
+
+    approve → supply の順を保持して batch する（SCW が 1 UserOp で実行）。各 call は
+    ``{to, value, data}`` のみ（from/nonce/gas は SCW/bundler が決める）。
+    """
+    calls: list[dict[str, Any]] = []
+    for key in ("approve_tx", "supply_tx"):
+        tx = deposit_txs.get(key)
+        if not tx:
+            continue
+        calls.append(
+            {
+                "to": tx["to"],
+                "value": tx.get("value", "0x0"),
+                "data": tx["data"],
+            }
+        )
+    if not calls:
+        raise ScwExecutionError("no calls built from deposit_txs (missing approve_tx/supply_tx)")
+    return calls
+
+
+def _extract_tx_hash(resp: dict[str, Any]) -> Optional[str]:
+    """Privy wallet_sendCalls レスポンスから tx hash を best-effort で取り出す。"""
+    for key in ("transaction_hash", "hash", "transactionHash"):
+        val = resp.get(key)
+        if isinstance(val, str) and val:
+            return val
+    # ネストした result.* も見る
+    result = resp.get("result")
+    if isinstance(result, dict):
+        for key in ("transaction_hash", "hash", "transactionHash"):
+            val = result.get(key)
+            if isinstance(val, str) and val:
+                return val
+    return None
+
+
+def execute_calls_via_scw(
+    *,
+    privy_wallet_id: str,
+    chain_name: str,
+    calls: list[dict[str, Any]],
+    sponsor: bool = True,
+    idempotency_key: Optional[str] = None,
+    client: Optional[PrivyRestClient] = None,
+) -> ScwExecutionResult:
+    """委譲枠内の calls を SCW 経由で送信する（ERC-5792 wallet_sendCalls）。
+
+    :param privy_wallet_id: 委譲対象 EOA の **Privy 内部 wallet ID**（アドレスではない）
+    :param chain_name: 執行チェーン名（caip2 に変換）
+    :param calls: ``[{to, value, data}, ...]``（`build_supply_calls` の出力）
+    :param sponsor: paymaster sponsor（True=gasless）
+    :param client: テスト用 DI（未指定なら env から構築）
+    :raises ScwNotEnabledError: dormant（未有効化）時
+    :raises ScwExecutionError: 入力不正 / Privy 送信失敗
+    """
+    if not is_delegation_policy_enabled():
+        raise ScwNotEnabledError(
+            "SCW delegated execution is not enabled "
+            "(requires DELEGATION_PRIVY_POLICY_ENABLED + PRIVY_SERVER_SIGNER_ID after L0)"
+        )
+    if not privy_wallet_id:
+        raise ScwExecutionError("privy_wallet_id is required")
+    if not calls:
+        raise ScwExecutionError("calls must not be empty")
+
+    caip2 = caip2_for_chain(chain_name)
+    rest = client or PrivyRestClient()
+    try:
+        resp = rest.send_calls(
+            privy_wallet_id,
+            caip2=caip2,
+            calls=calls,
+            sponsor=sponsor,
+            idempotency_key=idempotency_key,
+        )
+    except PrivyRestError as exc:
+        # 秘密鍵・署名はログに出さない（status のみ）
+        logger.warning("SCW send_calls failed: status=%s", exc.status_code)
+        raise ScwExecutionError("Privy send_calls failed") from exc
+
+    tx_hash = _extract_tx_hash(resp)
+    logger.info(
+        "SCW execution submitted: chain=%s, wallet_id=%s, tx=%s",
+        chain_name,
+        privy_wallet_id[:6] + "...",
+        tx_hash or "(pending)",
+    )
+    return ScwExecutionResult(
+        tx_hash=tx_hash,
+        status="submitted" if tx_hash else "unknown",
+        raw=resp,
+    )

--- a/backend/tests/test_scw_executor.py
+++ b/backend/tests/test_scw_executor.py
@@ -1,0 +1,161 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_scw_executor.py
+"""scw_executor（委譲(SCW)経路の実行コア / 2-D-C）の単体テスト。
+
+dormant ゲート / caip2 変換 / build_deposit_txs→calls 変換 / send_calls 呼び出し形 /
+tx_hash 抽出 / エラー写像を検証する。Privy への live 送信は別途（staging-v4）。
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.aave.chains import get_chain_config
+from app.privy.rest_client import PrivyRestError
+from app.proposals.scw_executor import (
+    ScwExecutionError,
+    ScwNotEnabledError,
+    build_supply_calls,
+    caip2_for_chain,
+    execute_calls_via_scw,
+)
+
+_WALLET_ID = "sle3q76qzuvzwen06y64hfcj"
+_CALLS = [{"to": "0xpool", "value": "0x0", "data": "0xdeadbeef"}]
+
+
+@pytest.fixture()
+def enabled_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("DELEGATION_PRIVY_POLICY_ENABLED", "true")
+    monkeypatch.setenv("PRIVY_SERVER_SIGNER_ID", "kq_server_1")
+    monkeypatch.setenv("PRIVY_APP_ID", "app123")
+    monkeypatch.setenv("PRIVY_APP_SECRET", "secret123")
+    yield
+
+
+def _disable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DELEGATION_PRIVY_POLICY_ENABLED", raising=False)
+
+
+# ---- caip2 ----
+
+
+def test_caip2_base() -> None:
+    assert caip2_for_chain("base") == f"eip155:{get_chain_config('base').chain_id}"
+    assert caip2_for_chain("base") == "eip155:8453"
+
+
+def test_caip2_base_sepolia() -> None:
+    assert caip2_for_chain("base_sepolia") == "eip155:84532"
+
+
+# ---- build_supply_calls ----
+
+
+def test_build_supply_calls_order_and_shape() -> None:
+    deposit_txs = {
+        "approve_tx": {"to": "0xtoken", "data": "0xapprove", "value": "0x0", "from": "0xx"},
+        "supply_tx": {"to": "0xpool", "data": "0xsupply", "value": "0x0", "from": "0xx"},
+    }
+    calls = build_supply_calls(deposit_txs)
+    assert [c["to"] for c in calls] == ["0xtoken", "0xpool"]
+    assert calls[0] == {"to": "0xtoken", "value": "0x0", "data": "0xapprove"}
+    # from/nonce/gas は含めない
+    assert "from" not in calls[1]
+
+
+def test_build_supply_calls_supply_only() -> None:
+    calls = build_supply_calls({"supply_tx": {"to": "0xpool", "data": "0xs"}})
+    assert len(calls) == 1
+    assert calls[0]["value"] == "0x0"  # 既定 value
+
+
+def test_build_supply_calls_empty_raises() -> None:
+    with pytest.raises(ScwExecutionError):
+        build_supply_calls({})
+
+
+# ---- execute_calls_via_scw ----
+
+
+def test_execute_disabled_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    _disable(monkeypatch)
+    with pytest.raises(ScwNotEnabledError):
+        execute_calls_via_scw(
+            privy_wallet_id=_WALLET_ID, chain_name="base", calls=_CALLS, client=MagicMock()
+        )
+
+
+def test_execute_disabled_does_not_call_privy(monkeypatch: pytest.MonkeyPatch) -> None:
+    _disable(monkeypatch)
+    fake = MagicMock()
+    with pytest.raises(ScwNotEnabledError):
+        execute_calls_via_scw(
+            privy_wallet_id=_WALLET_ID, chain_name="base", calls=_CALLS, client=fake
+        )
+    fake.send_calls.assert_not_called()
+
+
+def test_execute_requires_wallet_id(enabled_env: None) -> None:
+    with pytest.raises(ScwExecutionError):
+        execute_calls_via_scw(
+            privy_wallet_id="", chain_name="base", calls=_CALLS, client=MagicMock()
+        )
+
+
+def test_execute_requires_calls(enabled_env: None) -> None:
+    with pytest.raises(ScwExecutionError):
+        execute_calls_via_scw(
+            privy_wallet_id=_WALLET_ID, chain_name="base", calls=[], client=MagicMock()
+        )
+
+
+def test_execute_success_request_shape(enabled_env: None) -> None:
+    fake = MagicMock()
+    fake.send_calls.return_value = {"transaction_hash": "0xfeed"}
+    result = execute_calls_via_scw(
+        privy_wallet_id=_WALLET_ID,
+        chain_name="base",
+        calls=_CALLS,
+        client=fake,
+    )
+    assert result.tx_hash == "0xfeed"
+    assert result.status == "submitted"
+    # send_calls に渡る引数（caip2 / calls / sponsor）
+    kwargs = fake.send_calls.call_args.kwargs
+    assert fake.send_calls.call_args.args[0] == _WALLET_ID
+    assert kwargs["caip2"] == "eip155:8453"
+    assert kwargs["calls"] == _CALLS
+    assert kwargs["sponsor"] is True
+
+
+def test_execute_tx_hash_nested_result(enabled_env: None) -> None:
+    fake = MagicMock()
+    fake.send_calls.return_value = {"result": {"hash": "0xabc"}}
+    result = execute_calls_via_scw(
+        privy_wallet_id=_WALLET_ID, chain_name="base", calls=_CALLS, client=fake
+    )
+    assert result.tx_hash == "0xabc"
+
+
+def test_execute_unknown_when_no_hash(enabled_env: None) -> None:
+    fake = MagicMock()
+    fake.send_calls.return_value = {"bundle_id": "xyz"}
+    result = execute_calls_via_scw(
+        privy_wallet_id=_WALLET_ID, chain_name="base", calls=_CALLS, client=fake
+    )
+    assert result.tx_hash is None
+    assert result.status == "unknown"
+    assert result.raw == {"bundle_id": "xyz"}
+
+
+def test_execute_privy_error_wrapped(enabled_env: None) -> None:
+    fake = MagicMock()
+    fake.send_calls.side_effect = PrivyRestError(500, "boom")
+    with pytest.raises(ScwExecutionError):
+        execute_calls_via_scw(
+            privy_wallet_id=_WALLET_ID, chain_name="base", calls=_CALLS, client=fake
+        )


### PR DESCRIPTION
## 概要
v4 Phase 2-D 委譲署名フローの **実行コア（2-D-C）**。委譲枠内の calls を Privy
`wallet_sendCalls`(ERC-5792) で **ユーザーの非カストディアル SCW を駆動**して送信する
`backend/app/proposals/scw_executor.py` を新設。spike probe3 で broadcast 到達を実証した
`sendCalls` 1 呼び出し方式（`#827` mapper / `#829` L0 / `#830` L1 に続く）。

## API
- `caip2_for_chain(chain_name)` → `eip155:8453`(base) / `eip155:84532`(base_sepolia)
- `build_supply_calls(deposit_txs)` — `AaveClient.build_deposit_txs` の `{approve_tx,supply_tx}` を ERC-5792 `[{to,value,data}]` に変換（approve→supply を 1 バッチ、from/nonce/gas は SCW/bundler に委ねる）
- `execute_calls_via_scw(...)` — `send_calls` 実行 + tx_hash 抽出 + エラー写像 → `ScwExecutionResult`

## dormant（本番 inert・runtime 挙動不変）
- `is_delegation_policy_enabled()`（`DELEGATION_PRIVY_POLICY_ENABLED` + L0 signer id + Privy creds）が揃わない限り `ScwNotEnabledError` で **Privy を一切叩かない**。
- `PrivyRestClient` も creds 必須。本番は現状いずれも未設定。

## 未配線（意図的）
`_execute_aave_for_proposal`（proposals/router.py）への結線は **2-D-C.2（別 PR）**。安全系本体（custodial 署名経路の置換）を触るため分離する。
- HARD_STOP / risk_limiter %クランプ / Rule8（2-D-A）は **呼び出し元 router が執行直前に通す**設計で、本 module は再実装しない。
- 出金除外も呼び出し元（SUPPLY のみ通す）。
- `wiring_lint` は router のみ対象＝本 module は孤立検出されない。テストから参照され、2-D-C.2 の呼び出し元を待つ実行コア。
- wallet ID 解決（dev/shadow は spike env の wallet id、将来はマルチユーザー per-user）は呼び出し元の責務（`execute_calls_via_scw` は `privy_wallet_id` を引数で受ける）。

## テスト / DoD
- `tests/test_scw_executor.py`（新規 13 件）: dormant ゲート / caip2 / calls 変換（順序・supply only・空）/ send_calls 呼び出し形 / tx_hash 抽出（直・ネスト・無）/ Privy エラー写像。
- `ruff`/`format`/`--select S`/`mypy` clean。

## 後続
- 2-D-C.2: router 配線（`build_deposit_txs`→`build_supply_calls`→`execute_calls_via_scw` の dormant SCW 分岐 + env ベース wallet id 解決）。
- L0 実登録（`#829` スクリプト・小林さん確認）+ フラグ ON で staging-v4 live 受理検証。
- 2-D-E frontend consent UI。

🤖 Generated with [Claude Code](https://claude.com/claude-code)