### PR TITLE
feat(privy): AUTO 執行に委譲(SCW)経路を結線（dormant / スライス2-D-C.2）

### DIFF
--- a/backend/app/aave/service.py
+++ b/backend/app/aave/service.py
@@ -74,6 +74,11 @@ class AaveService:
         # 直近のトレード時刻を記録する（単純なリストで十分）
         self._recent_actions: List[datetime] = []
 
+    @property
+    def client(self) -> AaveClient:
+        """配下の AaveClient（委譲(SCW)経路の build_deposit_txs 等に使う read 用アクセサ）。"""
+        return self._client
+
     # ---- 内部ヘルパー -------------------------------------------------
 
     def _now(self) -> datetime:

--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -8,7 +8,7 @@ import logging
 import os
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from typing import Optional
+from typing import Any, Optional
 from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
@@ -25,6 +25,7 @@ from app.auth.models import User, UserRole
 from app.auth.models import User as UserModel
 from app.database import get_db
 from app.policy.engine import PolicyContext, get_policy_engine
+from app.users.models import DelegationGrant, get_active_grant
 
 from .models import Proposal
 from .schemas import (
@@ -272,6 +273,69 @@ def _daily_traded_usd_for_user(
     return Decimal(str(raw)) if raw is not None else Decimal("0")
 
 
+def _resolve_privy_wallet_id(user: Optional[UserModel]) -> str:
+    """委譲(SCW)送信に使う Privy **内部 wallet ID** を解決する（アドレスではない）。
+
+    dev/shadow フェーズは env ``PRIVY_DELEGATED_WALLET_ID`` の単一 wallet（spike の
+    ``SPIKE_SW_EOA_WALLET_ID`` を写す運用）。将来マルチユーザー本番化で per-user 列が入れば
+    そちらを優先する（現状 users に privy_wallet_id 列は無い）。
+    """
+    pid = getattr(user, "privy_wallet_id", None)
+    if pid:
+        return str(pid)
+    return os.getenv("PRIVY_DELEGATED_WALLET_ID", "")
+
+
+def _should_use_scw_route(proposal: Proposal, grant: Optional[DelegationGrant]) -> bool:
+    """委譲(SCW)経路で執行するか（dormant 既定 False）。
+
+    True 条件: delegation policy 有効（フラグ+L0 signer+creds）かつ 有効 grant に
+    privy_signer_id/privy_policy_id があり、operation が SUPPLY のとき。
+    出金(WITHDRAW)は委譲対象外＝常に custodial(本人署名)維持。
+    """
+    if proposal.operation != "SUPPLY":
+        return False
+    from app.privy.delegation_service import is_delegation_policy_enabled  # noqa: PLC0415
+
+    if not is_delegation_policy_enabled():
+        return False
+    if grant is None:
+        return False
+    return bool(grant.privy_signer_id and grant.privy_policy_id)
+
+
+def _execute_supply_via_scw(
+    proposal: Proposal, chain: str, grant: DelegationGrant, user: Optional[UserModel], db: Session
+) -> Any:
+    """委譲(SCW)経路で SUPPLY を執行し、custodial 互換の result(tx_hash/status) を返す。
+
+    HARD_STOP / risk_limiter / Rule8 は呼び出し元が執行直前に通過済み（本関数は通さない）。
+    amount は custodial 経路と同じく proposal.amount_usd を token 単位として渡す（既存挙動踏襲）。
+    """
+    from app.aave.service import MultiChainAaveService  # noqa: PLC0415
+    from app.proposals.scw_executor import (  # noqa: PLC0415
+        build_supply_calls,
+        execute_calls_via_scw,
+    )
+
+    scw_address = grant.wallet_address or (user.smart_wallet_address if user else None)
+    if not scw_address:
+        raise ValueError("SCW route requires a smart wallet address (grant/user)")
+    privy_wallet_id = _resolve_privy_wallet_id(user)
+
+    client = MultiChainAaveService().get_service(chain).client
+    deposit_txs = client.build_deposit_txs(
+        proposal.asset, Decimal(str(proposal.amount_usd)), wallet_address=scw_address
+    )
+    calls = build_supply_calls(deposit_txs)
+    return execute_calls_via_scw(
+        privy_wallet_id=privy_wallet_id,
+        chain_name=chain,
+        calls=calls,
+        idempotency_key=f"proposal-{proposal.id}",
+    )
+
+
 def _execute_aave_for_proposal(proposal: Proposal, db: Session) -> None:
     """
     承認された提案に対して Aave 操作を実行し、proposal を更新する。
@@ -426,15 +490,25 @@ def _execute_aave_for_proposal(proposal: Proposal, db: Session) -> None:
         return
 
     try:
-        multi_service = MultiChainAaveService()
-        result = multi_service.execute_rebalance(
-            chain_name=chain,
-            action=trade_action,
-            amount=Decimal(str(proposal.amount_usd)),
-            asset_symbol=proposal.asset,
-            dry_run=False,
-            wallet_address=_wallet_address,
-        )
+        # 委譲(SCW)経路（2-D-C.2・dormant）: delegation policy 有効 かつ 当該ユーザーに
+        # privy_signer_id/policy_id 付き有効 grant がある SUPPLY のみ SCW 経由で執行する。
+        # それ以外（本番現状＝フラグ未設定）は従来の custodial EOA 直署名経路で挙動不変。
+        _grant = get_active_grant(proposal.user_id, db)
+        if _grant is not None and _should_use_scw_route(proposal, _grant):
+            logger.info(
+                "proposal %d: routing via delegated SCW path (policy_id present)", proposal.id
+            )
+            result = _execute_supply_via_scw(proposal, chain, _grant, _user, db)
+        else:
+            multi_service = MultiChainAaveService()
+            result = multi_service.execute_rebalance(
+                chain_name=chain,
+                action=trade_action,
+                amount=Decimal(str(proposal.amount_usd)),
+                asset_symbol=proposal.asset,
+                dry_run=False,
+                wallet_address=_wallet_address,
+            )
 
         # 成功: attempt カウントも記録（診断用）
         proposal.execution_attempts += 1

--- a/backend/tests/test_proposal_scw_routing.py
+++ b/backend/tests/test_proposal_scw_routing.py
@@ -1,0 +1,138 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_proposal_scw_routing.py
+"""委譲(SCW)経路の routing 判定 + 執行ヘルパー（2-D-C.2）の単体テスト。
+
+dormant ゲート（_should_use_scw_route）・wallet id 解決・_execute_supply_via_scw の
+build→send 連結を mock で検証する。実 Privy への送信は別途（staging-v4 shadow）。
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.proposals.router import (
+    _execute_supply_via_scw,
+    _resolve_privy_wallet_id,
+    _should_use_scw_route,
+)
+from app.proposals.scw_executor import ScwExecutionResult
+
+
+@pytest.fixture()
+def enabled_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("DELEGATION_PRIVY_POLICY_ENABLED", "true")
+    monkeypatch.setenv("PRIVY_SERVER_SIGNER_ID", "kq_server_1")
+    monkeypatch.setenv("PRIVY_APP_ID", "app123")
+    monkeypatch.setenv("PRIVY_APP_SECRET", "secret123")
+    yield
+
+
+def _grant(**kw: object) -> SimpleNamespace:
+    base = {"wallet_address": "0xSCW", "privy_signer_id": "s1", "privy_policy_id": "p1"}
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _supply_proposal() -> SimpleNamespace:
+    return SimpleNamespace(id=7, asset="USDC", amount_usd=Decimal("5"), operation="SUPPLY")
+
+
+# ---- _resolve_privy_wallet_id ----
+
+
+def test_resolve_wallet_id_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRIVY_DELEGATED_WALLET_ID", "wid_env")
+    assert _resolve_privy_wallet_id(SimpleNamespace()) == "wid_env"
+
+
+def test_resolve_wallet_id_prefers_user_attr(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRIVY_DELEGATED_WALLET_ID", "wid_env")
+    user = SimpleNamespace(privy_wallet_id="wid_user")
+    assert _resolve_privy_wallet_id(user) == "wid_user"
+
+
+def test_resolve_wallet_id_empty_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PRIVY_DELEGATED_WALLET_ID", raising=False)
+    assert _resolve_privy_wallet_id(None) == ""
+
+
+# ---- _should_use_scw_route ----
+
+
+def test_route_false_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DELEGATION_PRIVY_POLICY_ENABLED", raising=False)
+    assert _should_use_scw_route(_supply_proposal(), _grant()) is False
+
+
+def test_route_true_when_enabled_supply_with_ids(enabled_env: None) -> None:
+    assert _should_use_scw_route(_supply_proposal(), _grant()) is True
+
+
+def test_route_false_for_withdraw(enabled_env: None) -> None:
+    p = SimpleNamespace(id=8, asset="USDC", amount_usd=Decimal("5"), operation="WITHDRAW")
+    assert _should_use_scw_route(p, _grant()) is False
+
+
+def test_route_false_when_no_grant(enabled_env: None) -> None:
+    assert _should_use_scw_route(_supply_proposal(), None) is False
+
+
+def test_route_false_when_grant_missing_ids(enabled_env: None) -> None:
+    assert _should_use_scw_route(_supply_proposal(), _grant(privy_signer_id=None)) is False
+    assert _should_use_scw_route(_supply_proposal(), _grant(privy_policy_id=None)) is False
+
+
+# ---- _execute_supply_via_scw ----
+
+
+def test_execute_supply_via_scw_builds_and_sends(
+    enabled_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PRIVY_DELEGATED_WALLET_ID", "wid_env")
+    # aave client build_deposit_txs を mock
+    fake_client = MagicMock()
+    fake_client.build_deposit_txs.return_value = {
+        "approve_tx": {"to": "0xtoken", "data": "0xapprove", "value": "0x0"},
+        "supply_tx": {"to": "0xpool", "data": "0xsupply", "value": "0x0"},
+    }
+    fake_service_obj = MagicMock()
+    fake_service_obj.get_service.return_value.client = fake_client
+    monkeypatch.setattr("app.aave.service.MultiChainAaveService", lambda: fake_service_obj)
+
+    captured: dict = {}
+
+    def fake_exec(**kw: object) -> ScwExecutionResult:
+        captured.update(kw)
+        return ScwExecutionResult(tx_hash="0xfeed", status="submitted", raw={})
+
+    monkeypatch.setattr("app.proposals.scw_executor.execute_calls_via_scw", fake_exec)
+
+    proposal = _supply_proposal()
+    user = SimpleNamespace(smart_wallet_address="0xSCW", privy_wallet_id=None)
+    result = _execute_supply_via_scw(proposal, "base", _grant(), user, MagicMock())
+
+    assert result.tx_hash == "0xfeed"
+    # build_deposit_txs に SCW アドレス / asset / amount(USD=token) が渡る
+    fake_client.build_deposit_txs.assert_called_once()
+    args, kwargs = fake_client.build_deposit_txs.call_args
+    assert args[0] == "USDC"
+    assert kwargs["wallet_address"] == "0xSCW"
+    # execute_calls_via_scw に env wallet id / chain / 2 calls(approve→supply) が渡る
+    assert captured["privy_wallet_id"] == "wid_env"
+    assert captured["chain_name"] == "base"
+    assert [c["to"] for c in captured["calls"]] == ["0xtoken", "0xpool"]
+    assert captured["idempotency_key"] == "proposal-7"
+
+
+def test_execute_supply_via_scw_requires_scw_address(
+    enabled_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    grant = _grant(wallet_address=None)
+    user = SimpleNamespace(smart_wallet_address=None, privy_wallet_id=None)
+    with pytest.raises(ValueError):
+        _execute_supply_via_scw(_supply_proposal(), "base", grant, user, MagicMock())


### PR DESCRIPTION
## 概要
v4 Phase 2-D **2-D-C.2**: `_execute_aave_for_proposal`（AUTO 執行本体）に **dormant な
委譲(SCW)分岐**を追加し、`scw_executor`(#831) を実際の執行経路に結線する。delegation policy
有効 かつ 当該ユーザーに `privy_signer_id`/`privy_policy_id` 付き有効 grant がある **SUPPLY のみ**、
Privy `sendCalls` 経由で SCW を駆動する。それ以外（**本番現状＝フラグ未設定**）は従来の
custodial EOA 直署名経路で **挙動完全不変**。

## 配線
```python
_grant = get_active_grant(proposal.user_id, db)
if _grant is not None and _should_use_scw_route(proposal, _grant):
    result = _execute_supply_via_scw(...)   # build_deposit_txs → build_supply_calls → execute_calls_via_scw
else:
    result = MultiChainAaveService().execute_rebalance(...)   # 従来 custodial（本番現状）
# 成功/失敗ハンドリングは両経路で共有（result.tx_hash/status 互換）
```

## 安全性（安全系本体の変更につき要点）
- **dormant**: `is_delegation_policy_enabled()` が False の本番では常に custodial → 挙動不変。
- **出金除外**: `operation != "SUPPLY"` は SCW 経路に入らない（withdraw は本人署名維持＝不変条件）。
- **amount 整合**: `build_deposit_txs` は custodial の `deposit()` と同じく amount を token 単位扱い（共に `amount_usd` を渡す既存の USDC 1:1 前提を踏襲）→ **新たな単位バグなし**。
- **安全ゲート不バイパス**: HARD_STOP / risk_limiter %クランプ / Rule8（2-D-A）は分岐の手前（執行直前）で通過済み。
- **回帰なし**: proposal/aave 系 **394 passed, 5 skipped**。

## 変更
| ファイル | 内容 |
|---|---|
| `app/proposals/router.py` | `_should_use_scw_route` / `_resolve_privy_wallet_id` / `_execute_supply_via_scw` + 執行 try 内に dormant 分岐 |
| `app/aave/service.py` | `AaveService.client` プロパティ（`build_deposit_txs` への read アクセサ） |

wallet ID は `PRIVY_DELEGATED_WALLET_ID` env で解決（dev/shadow は spike の `SPIKE_SW_EOA_WALLET_ID` を写す運用。将来マルチユーザー本番化で per-user 列が入れば優先）。

## テスト / DoD
- `tests/test_proposal_scw_routing.py`（新規 10 件）: routing 判定（SUPPLY/WITHDRAW/disabled/grant 無/ids 欠落）/ wallet id 解決（env/user 優先/空）/ `_execute_supply_via_scw` の build→send 連結 + SCW アドレス必須。
- `ruff`/`format`/`mypy` clean。

## これで 2-D-C 完成（実行コア #831 + 本 PR の配線）
コード上は **L0 実登録 + フラグ ON** で AUTO 委譲執行まで dormant で揃う。

## 後続（HUMAN-REVIEW-REQUIRED）
- L0 実登録（#829 スクリプト・小林さん確認）+ `PRIVY_SERVER_SIGNER_ID` / `PRIVY_DELEGATED_WALLET_ID` env。
- フラグ ON で staging-v4 shadow live 受理検証 → 本番（%キャップ段階・2-D-D）。
- 2-D-E frontend consent UI（`useSessionSigners`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)