### PR TITLE
feat(liff): 委譲おまかせ consent UI（dormant / スライス2-D-E）

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
@@ -4,19 +4,112 @@
 import { useEffect, useState } from "react"
 import { Bot, MousePointer2 } from "lucide-react"
 import { useTranslations } from "next-intl"
+import { useSigners, useWallets } from "@privy-io/react-auth"
 import { getAuthToken } from "@/lib/auth/token-key"
 import { liffFetch } from "@/lib/liff/liff-fetch"
 import { track, EV } from "@/lib/posthog"
+import {
+  DEFAULT_DELEGATION_PARAMS,
+  DelegationNotReadyError,
+  grantDelegation,
+  prepareDelegation,
+  revokeDelegation,
+} from "@/lib/api/delegation"
 
 type UserMode = "managed" | "active"
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ""
 
+// dormant フラグ: off（本番既定）のとき従来どおり user_mode の設定更新のみ（on-chain 委譲なし）。
+// on かつ backend L0 登録済みのときのみ、managed 選択で session signer の consent フローを走らせる。
+const CONSENT_ENABLED = process.env.NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED === "true"
+
 export function OpModePanel() {
   const t = useTranslations("Liff.panels.opMode")
   const [currentMode, setCurrentMode] = useState<UserMode | null>(null)
   const [loading, setLoading] = useState(true)
+  const [busy, setBusy] = useState(false)
   const [toast, setToast] = useState<string | null>(null)
+  const { addSigners, removeSigners } = useSigners()
+  const { wallets } = useWallets()
+
+  function showToast(msg: string) {
+    setToast(msg)
+    setTimeout(() => setToast(null), 2500)
+  }
+
+  function embeddedEoaAddress(): string | null {
+    // Privy embedded wallet (TEE) を委譲対象 EOA とする。外部 wallet は除外。
+    return wallets.find((w) => w.walletClientType === "privy")?.address ?? null
+  }
+
+  // managed への切替時: 委譲枠を作成（prepare）→ Privy で session signer を consent
+  // （addSigners）→ backend に grant 確定。失敗時は signer をロールバックする。
+  // 戻り値: consent + grant が成功したか。
+  async function runDelegationConsent(): Promise<boolean> {
+    let prep
+    try {
+      prep = await prepareDelegation(DEFAULT_DELEGATION_PARAMS)
+    } catch (e) {
+      if (e instanceof DelegationNotReadyError) {
+        showToast(t("consentNotReady"))
+        return false
+      }
+      showToast(t("consentFailed"))
+      return false
+    }
+
+    const eoa = embeddedEoaAddress()
+    if (!eoa) {
+      showToast(t("consentNoWallet"))
+      return false
+    }
+
+    try {
+      await addSigners({
+        address: eoa,
+        signers: [{ signerId: prep.privy_signer_id, policyIds: [prep.privy_policy_id] }],
+      })
+    } catch {
+      // ユーザーが consent をキャンセル / 失敗 → 何も確定しない
+      showToast(t("consentCancelled"))
+      return false
+    }
+
+    try {
+      await grantDelegation({
+        ...DEFAULT_DELEGATION_PARAMS,
+        privy_policy_id: prep.privy_policy_id,
+        privy_signer_id: prep.privy_signer_id,
+      })
+    } catch {
+      // grant 保存失敗 → 付与済み signer をロールバック（非カストディアル維持）
+      try {
+        await removeSigners({ address: eoa })
+      } catch {
+        // ロールバック失敗はログのみ（致命的でない）
+        console.warn("[opMode] signer rollback failed after grant error")
+      }
+      showToast(t("consentFailed"))
+      return false
+    }
+    return true
+  }
+
+  // managed から離脱時: session signer と grant を取消す（best-effort）。
+  async function revokeDelegationConsent(): Promise<void> {
+    const eoa = embeddedEoaAddress()
+    try {
+      if (eoa) await removeSigners({ address: eoa })
+    } catch {
+      console.warn("[opMode] removeSigners failed on revoke")
+    }
+    try {
+      await revokeDelegation()
+    } catch {
+      console.warn("[opMode] revokeDelegation failed")
+    }
+  }
 
   const MODES = [
     {
@@ -57,17 +150,29 @@ export function OpModePanel() {
       .finally(() => setLoading(false))
   }, [])
 
-  // モード切替（確認ステップ無しで即切替）
+  // モード切替。CONSENT_ENABLED off（本番既定）のときは従来どおり即切替（PUT のみ）。
+  // on のときは managed 選択で委譲 consent フロー、managed 離脱で revoke を挟む。
   async function handleSelect(newMode: UserMode) {
-    if (newMode === currentMode) return
+    if (newMode === currentMode || busy) return
     const token = getAuthToken()
     if (!token) {
-      setToast(t("toastAuthExpired"))
-      setTimeout(() => setToast(null), 2500)
+      showToast(t("toastAuthExpired"))
       return
     }
-    // 楽観的更新
     const prev = currentMode
+
+    // 委譲 consent（managed への切替・フラグ on のときのみ）
+    if (CONSENT_ENABLED && newMode === "managed") {
+      setBusy(true)
+      try {
+        const ok = await runDelegationConsent()
+        if (!ok) return // consent 未完了 → モード変更しない（toast は内部で表示済み）
+      } finally {
+        setBusy(false)
+      }
+    }
+
+    // 楽観的更新
     setCurrentMode(newMode)
     try {
       const res = await fetch(`${API_BASE}/api/user/settings`, {
@@ -80,13 +185,15 @@ export function OpModePanel() {
       })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       track(EV.OPMODE_CHANGE, { mode: newMode })
-      setToast(t("toastSwitched", { mode: MODE_LABEL[newMode] }))
-      setTimeout(() => setToast(null), 2500)
+      // managed から離脱したら委譲を取消す（フラグ on のみ）
+      if (CONSENT_ENABLED && prev === "managed" && newMode !== "managed") {
+        await revokeDelegationConsent()
+      }
+      showToast(t("toastSwitched", { mode: MODE_LABEL[newMode] }))
     } catch {
       // ロールバック
       setCurrentMode(prev)
-      setToast(t("toastSwitchFailed"))
-      setTimeout(() => setToast(null), 2500)
+      showToast(t("toastSwitchFailed"))
     }
   }
 
@@ -131,12 +238,14 @@ export function OpModePanel() {
               type="button"
               data-testid={`opmode-option-${mode.id}`}
               aria-pressed={isSelected}
+              disabled={busy}
               onClick={() => handleSelect(mode.id)}
               className={[
                 "w-full text-left rounded-2xl border-2 p-4 transition-all",
                 mode.bg,
                 mode.border,
                 isSelected ? "opacity-100" : "opacity-60",
+                busy ? "cursor-not-allowed" : "",
               ].join(" ")}
             >
               <div className="flex items-center gap-3">

--- a/frontend/lib/api/delegation.ts
+++ b/frontend/lib/api/delegation.ts
@@ -1,0 +1,116 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// frontend/lib/api/delegation.ts
+//
+// v4 Phase 2-D-E: 委譲（おまかせ運用）consent フローの API クライアント。
+// backend: /api/user/delegation/{prepare,grant,revoke} + GET /api/user/delegation。
+//
+// 非カストディアル: backend は policy 作成と grant 記録のみ。実際の session signer 付与は
+// frontend の Privy useSigners().addSigners が行う（秘密鍵はユーザー側 TEE に残る）。
+// prepare は backend が dormant（L0 未登録 / フラグ off）のとき 503 を返す
+// → DelegationNotReadyError として扱い、UI は「準備中」表示にフォールバックする。
+
+import { getAuthToken } from "@/lib/auth/token-key"
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ""
+
+export interface DelegationGrantParams {
+  max_single_trade_pct: string
+  max_daily_trade_pct: string
+  hf_floor: string
+  allowed_protocols: string[]
+  allowed_assets: string[]
+  expires_in_days: number
+}
+
+export interface DelegationPrepareResponse {
+  privy_policy_id: string
+  privy_signer_id: string
+  chain_name: string
+  expires_at: string
+}
+
+export interface DelegationGrantResponse {
+  id: number
+  status: string
+  wallet_address: string | null
+  max_single_trade_pct: string
+  max_daily_trade_pct: string
+  hf_floor: string
+  allowed_protocols: string[]
+  allowed_assets: string[]
+  consent_at: string
+  expires_at: string
+  revoked_at: string | null
+  privy_policy_id: string | null
+  privy_signer_id: string | null
+}
+
+/** backend が委譲 policy 作成を未有効化（dormant: L0 未登録 / フラグ off）= 503。 */
+export class DelegationNotReadyError extends Error {
+  constructor(message = "delegation policy preparation is not enabled") {
+    super(message)
+    this.name = "DelegationNotReadyError"
+  }
+}
+
+/** consent の既定枠。将来 UI から調整可能にする（現状は保守的な単一上限）。 */
+export const DEFAULT_DELEGATION_PARAMS: DelegationGrantParams = {
+  max_single_trade_pct: "10",
+  max_daily_trade_pct: "30",
+  hf_floor: "1.6",
+  allowed_protocols: ["aave"],
+  allowed_assets: ["USDC"],
+  expires_in_days: 90,
+}
+
+async function authedFetch(path: string, init?: RequestInit): Promise<Response> {
+  const token = getAuthToken()
+  if (!token) throw new Error("auth token missing")
+  return fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      ...init?.headers,
+    },
+  })
+}
+
+/** L1: 委譲枠から Privy policy を作成し signer/policy id を得る。dormant 時は 503 → throw。 */
+export async function prepareDelegation(
+  params: DelegationGrantParams
+): Promise<DelegationPrepareResponse> {
+  const res = await authedFetch("/api/user/delegation/prepare", {
+    method: "POST",
+    body: JSON.stringify(params),
+  })
+  if (res.status === 503) throw new DelegationNotReadyError()
+  if (!res.ok) throw new Error(`delegation prepare failed: HTTP ${res.status}`)
+  return res.json()
+}
+
+/** L3: consent 済みの枠 + Privy 識別子を保存して grant を確定する。 */
+export async function grantDelegation(
+  params: DelegationGrantParams & { privy_policy_id: string; privy_signer_id: string }
+): Promise<DelegationGrantResponse> {
+  const res = await authedFetch("/api/user/delegation/grant", {
+    method: "POST",
+    body: JSON.stringify(params),
+  })
+  if (!res.ok) throw new Error(`delegation grant failed: HTTP ${res.status}`)
+  return res.json()
+}
+
+/** 委譲枠を取消す（冪等）。 */
+export async function revokeDelegation(): Promise<DelegationGrantResponse | null> {
+  const res = await authedFetch("/api/user/delegation/revoke", { method: "POST" })
+  if (!res.ok) throw new Error(`delegation revoke failed: HTTP ${res.status}`)
+  return res.json()
+}
+
+/** 現在有効な委譲枠を返す（無ければ null）。 */
+export async function getDelegation(): Promise<DelegationGrantResponse | null> {
+  const res = await authedFetch("/api/user/delegation", { method: "GET" })
+  if (!res.ok) throw new Error(`delegation get failed: HTTP ${res.status}`)
+  return res.json()
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -880,7 +880,11 @@
         "activeDesc": "AI proposes. You approve before execution.",
         "toastSwitched": "Switched to \"{mode}\"",
         "toastAuthExpired": "Session expired. Please log in again.",
-        "toastSwitchFailed": "Failed to switch mode"
+        "toastSwitchFailed": "Failed to switch mode",
+        "consentNotReady": "Auto mode is being prepared. Please try again later.",
+        "consentNoWallet": "Wallet not found. Please log in again.",
+        "consentCancelled": "Auto mode authorization was cancelled.",
+        "consentFailed": "Failed to enable auto mode."
       },
       "txHistory": {
         "title": "Transaction History",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -880,7 +880,11 @@
         "activeDesc": "AIが提案。自分で承認してから実行。",
         "toastSwitched": "「{mode}」に切り替えました",
         "toastAuthExpired": "認証が切れています。再ログインしてください",
-        "toastSwitchFailed": "切り替えに失敗しました"
+        "toastSwitchFailed": "切り替えに失敗しました",
+        "consentNotReady": "おまかせ運用は現在準備中です。もう少しお待ちください",
+        "consentNoWallet": "ウォレットが見つかりません。再ログインしてください",
+        "consentCancelled": "おまかせ運用の許可がキャンセルされました",
+        "consentFailed": "おまかせ運用の設定に失敗しました"
       },
       "txHistory": {
         "title": "取引履歴",


### PR DESCRIPTION
## 概要
v4 Phase 2-D 委譲署名フローの **frontend（2-D-E）**。`OpModePanel` の「おまかせ(managed)」選択に
session signer の **consent ステップ**を追加し、backend（#827 mapper / #830 prepare / #831
scw_executor / #832 router 配線）と Privy `useSigners().addSigners` を接続する。これで
Phase 2-D が frontend↔backend で一通り揃う（全 dormant）。

## dormant（本番挙動不変・二重ゲート）
- **frontend**: `NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED`（既定 `off`）が off の間は**従来どおり
  `user_mode` の PUT のみ**（on-chain 委譲なし）。現行 managed UX はバイト等価。
- **backend**: フラグ on でも L0 未登録なら `prepare` が **503** → 「準備中」表示でモード変更せず。

## フロー（managed 選択・両ゲート on のとき）
```
prepareDelegation(枠)            // backend L1: Privy policy 作成 → {policy_id, signer_id}
→ embedded EOA 解決（walletClientType==='privy'）
→ addSigners({address, signers:[{signerId, policyIds:[policy_id]}]})  // Privy consent(L2)
→ grantDelegation(枠 + ids)      // backend L3: grant 保存
→ PUT user_mode=managed
```
- **ロールバック**: `grant` 失敗時は `removeSigners` で付与済み signer を取消（非カストディアル維持）。
- **revoke**: managed 離脱時に `removeSigners` + `revokeDelegation`。

## 変更
| ファイル | 内容 |
|---|---|
| `frontend/lib/api/delegation.ts`（新規） | `prepare/grant/revoke/get` + `DelegationNotReadyError`(503) + `DEFAULT_DELEGATION_PARAMS`（単一≤10/日次≤30/HF1.6/aave/USDC/90d） |
| `OpModePanel.tsx` | `useSigners`/`useWallets` 配線 + consent/revoke + `busy` ガード。**flag-off 経路は不変** |
| `messages/ja.json` / `en.json` | `consentNotReady`/`NoWallet`/`Cancelled`/`Failed`（parity 維持） |

Privy API: `@privy-io/react-auth` v3.30 の `useSigners().addSigners({address, signers})`
（`signers: Array<{signerId, policyIds?}>`）を型定義から確認。

## DoD
- `tsc --noEmit` clean（既存削除済 /trade の `.next` stale 型を除く・CI は fresh build）、`eslint` clean、i18n 欠落なし。
- 既存 `e2e/liff-chat-opmode.spec.ts`（flag-off 経路）は挙動不変で維持。
- consent フロー e2e は Privy mock が要るため flag/L0 有効化後（staging-v4）に追加。

## 後続
- L0 実登録（#829 スクリプト・小林さん確認）→ `PRIVY_SERVER_SIGNER_ID`。
- staging-v4 で両フラグ on → consent フロー実機検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)