### PR TITLE
feat(aave): 自己清算保護のデレバレッジ純計算（第1スライス / Asana 1215620828227794）

### DIFF
--- a/backend/app/aave/self_liquidation.py
+++ b/backend/app/aave/self_liquidation.py
@@ -1,0 +1,193 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/aave/self_liquidation.py
+"""自己清算保護（Flash Loan デレバレッジ）の純計算層。
+
+HF が危険域に近づいたとき、外部清算業者に清算されてペナルティ（5-10%）を払う前に、
+Flash Loan で自力デレバレッジ（debt の一部を返済して HF を回復）する戦略の**計算のみ**を
+提供する純関数群。Solidity コントラクト・on-chain 実行・web3・秘密鍵は一切含まない
+（Asana 1215620828227794 の第1スライス）。
+
+デレバレッジの原子的フロー（実行は後続 HUMAN-REVIEW スライス）::
+
+    1. USDC を Flash Loan で借りる（amount = 返済する debt 額）
+    2. その USDC で Aave の debt を `amount` だけ返済
+    3. 担保を `amount * (1 + fee)` 相当だけ引き出す
+    4. Flash Loan を `amount * (1 + fee)` で返済（手数料込み）
+
+返済後の Health Factor::
+
+    HF = (collateral - amount*(1+fee)) * liquidation_threshold / (debt - amount)
+
+を目標 HF に一致させる返済額 `amount` を解析的に解く。金融計算は Decimal のみ（Rule 11）。
+
+**dormant**: 本 module は計算だけで副作用なし。実行（flash_loan_service / SelfLiquidator.sol）・
+workflow 統合・frontend は別スライス（Tier S / HUMAN-REVIEW）。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Optional
+
+# Aave V3 の Flash Loan 手数料（flashLoanSimple は 0.05%）。
+DEFAULT_FLASH_LOAN_FEE_RATE = Decimal("0.0005")
+
+# 既定の発動トリガー（current_hf がこの値未満で自己清算保護を検討）。HARD_STOP(1.6) より手前。
+DEFAULT_TRIGGER_HF = Decimal("1.3")
+
+# デレバレッジ後に回復させる目標 HF（HARD_STOP 1.6 に十分なマージンを足す）。
+DEFAULT_TARGET_HF = Decimal("1.8")
+
+
+class SelfLiquidationError(ValueError):
+    """入力が自己清算計算の前提を満たさない。"""
+
+
+@dataclass(frozen=True)
+class DeleverageQuote:
+    """自己清算デレバレッジの見積り（実行はしない）。"""
+
+    feasible: bool
+    """この入力で目標 HF まで回復可能か。"""
+
+    repay_debt_usd: Decimal
+    """返済する debt 額（USD）= Flash Loan で借りる USDC 額。"""
+
+    flash_loan_fee_usd: Decimal
+    """Flash Loan 手数料（USD）= repay_debt_usd * fee_rate。"""
+
+    collateral_withdraw_usd: Decimal
+    """引き出す担保額（USD）= repay_debt_usd + 手数料（Flash Loan 返済に充てる）。"""
+
+    projected_hf: Optional[Decimal]
+    """デレバレッジ後の HF。全 debt 返済（debt=0）になる場合は None（実質無限大）。"""
+
+    reason: str
+    """判定理由（監査・ログ用）。"""
+
+
+def compute_health_factor(
+    collateral_usd: Decimal, debt_usd: Decimal, liquidation_threshold: Decimal
+) -> Optional[Decimal]:
+    """HF = collateral * liquidation_threshold / debt。debt=0 は None（無限大）。"""
+    if debt_usd <= 0:
+        return None
+    return (collateral_usd * liquidation_threshold) / debt_usd
+
+
+def should_protect(current_hf: Optional[Decimal], trigger_hf: Decimal = DEFAULT_TRIGGER_HF) -> bool:
+    """自己清算保護を発動検討すべきか（current_hf が trigger 未満）。
+
+    debt 無し（current_hf=None）は対象外（清算リスクなし）。
+    """
+    if current_hf is None:
+        return False
+    return current_hf < trigger_hf
+
+
+def compute_deleverage_quote(
+    *,
+    collateral_usd: Decimal,
+    debt_usd: Decimal,
+    liquidation_threshold: Decimal,
+    target_hf: Decimal = DEFAULT_TARGET_HF,
+    flash_loan_fee_rate: Decimal = DEFAULT_FLASH_LOAN_FEE_RATE,
+) -> DeleverageQuote:
+    """目標 HF まで回復するデレバレッジ見積りを返す（計算のみ・実行しない）。
+
+    :raises SelfLiquidationError: 入力が不正（負値 / liquidation_threshold が範囲外 / target<=0）
+    """
+    if collateral_usd < 0 or debt_usd < 0:
+        raise SelfLiquidationError("collateral_usd / debt_usd must be non-negative")
+    if liquidation_threshold <= 0 or liquidation_threshold > 1:
+        raise SelfLiquidationError("liquidation_threshold must be in (0, 1]")
+    if target_hf <= 0:
+        raise SelfLiquidationError("target_hf must be positive")
+    if flash_loan_fee_rate < 0:
+        raise SelfLiquidationError("flash_loan_fee_rate must be non-negative")
+
+    zero = Decimal("0")
+
+    # debt が無ければ清算リスクなし＝デレバレッジ不要。
+    if debt_usd <= 0:
+        return DeleverageQuote(
+            feasible=False,
+            repay_debt_usd=zero,
+            flash_loan_fee_usd=zero,
+            collateral_withdraw_usd=zero,
+            projected_hf=None,
+            reason="no debt — deleverage not needed",
+        )
+
+    current_hf = (collateral_usd * liquidation_threshold) / debt_usd
+    if current_hf >= target_hf:
+        return DeleverageQuote(
+            feasible=False,
+            repay_debt_usd=zero,
+            flash_loan_fee_usd=zero,
+            collateral_withdraw_usd=zero,
+            projected_hf=current_hf,
+            reason="HF already at or above target — no action needed",
+        )
+
+    one_plus_fee = Decimal("1") + flash_loan_fee_rate
+    # amount = (target*debt - collateral*lt) / (target - (1+fee)*lt)
+    numerator = target_hf * debt_usd - collateral_usd * liquidation_threshold
+    denominator = target_hf - one_plus_fee * liquidation_threshold
+    if denominator <= 0:
+        # target_hf <= (1+fee)*lt の病的ケース（担保引き出しで HF が上がらない）。
+        return DeleverageQuote(
+            feasible=False,
+            repay_debt_usd=zero,
+            flash_loan_fee_usd=zero,
+            collateral_withdraw_usd=zero,
+            projected_hf=current_hf,
+            reason="target_hf is not reachable for this liquidation_threshold/fee",
+        )
+
+    amount = numerator / denominator
+    if amount <= 0:
+        return DeleverageQuote(
+            feasible=False,
+            repay_debt_usd=zero,
+            flash_loan_fee_usd=zero,
+            collateral_withdraw_usd=zero,
+            projected_hf=current_hf,
+            reason="no positive repayment restores target HF",
+        )
+
+    # debt 全額を超える返済は不要（全返済で HF は無限大）。
+    full_repayment = amount >= debt_usd
+    repay = debt_usd if full_repayment else amount
+    fee = repay * flash_loan_fee_rate
+    withdraw = repay + fee
+
+    # 引き出す担保が現在の担保を超えるなら自己清算では回復不能（fail-closed）。
+    if withdraw > collateral_usd:
+        return DeleverageQuote(
+            feasible=False,
+            repay_debt_usd=zero,
+            flash_loan_fee_usd=zero,
+            collateral_withdraw_usd=zero,
+            projected_hf=current_hf,
+            reason="insufficient collateral to withdraw for repayment + fee",
+        )
+
+    remaining_debt = debt_usd - repay
+    if remaining_debt <= 0:
+        projected = None
+    else:
+        projected = ((collateral_usd - withdraw) * liquidation_threshold) / remaining_debt
+
+    return DeleverageQuote(
+        feasible=True,
+        repay_debt_usd=repay,
+        flash_loan_fee_usd=fee,
+        collateral_withdraw_usd=withdraw,
+        projected_hf=projected,
+        reason="full debt repayment restores safety"
+        if full_repayment
+        else "partial deleverage restores target HF",
+    )

--- a/backend/tests/aave/test_self_liquidation.py
+++ b/backend/tests/aave/test_self_liquidation.py
@@ -1,0 +1,183 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/aave/test_self_liquidation.py
+"""自己清算保護（Flash Loan デレバレッジ）純計算の単体テスト（Asana 1215620828227794 第1スライス）。
+
+返済額の解析解が目標 HF を正しく回復すること、各種 fail-closed 分岐、HF 計算・発動判定を検証。
+金融計算はすべて Decimal。
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.aave.self_liquidation import (
+    DEFAULT_TARGET_HF,
+    DeleverageQuote,
+    SelfLiquidationError,
+    compute_deleverage_quote,
+    compute_health_factor,
+    should_protect,
+)
+
+# ---- compute_health_factor ----
+
+
+def test_hf_basic() -> None:
+    hf = compute_health_factor(Decimal("1000"), Decimal("500"), Decimal("0.8"))
+    assert hf == Decimal("1.6")
+
+
+def test_hf_no_debt_is_none() -> None:
+    assert compute_health_factor(Decimal("1000"), Decimal("0"), Decimal("0.8")) is None
+
+
+# ---- should_protect ----
+
+
+def test_should_protect_below_trigger() -> None:
+    assert should_protect(Decimal("1.2")) is True
+
+
+def test_should_protect_at_or_above_trigger() -> None:
+    assert should_protect(Decimal("1.3")) is False
+    assert should_protect(Decimal("1.6")) is False
+
+
+def test_should_protect_no_debt() -> None:
+    assert should_protect(None) is False
+
+
+def test_should_protect_custom_trigger() -> None:
+    assert should_protect(Decimal("1.55"), trigger_hf=Decimal("1.6")) is True
+
+
+# ---- compute_deleverage_quote: feasible ----
+
+
+def test_partial_deleverage_restores_target_hf() -> None:
+    """部分返済で projected_hf が目標 HF に一致する（解析解の検算）。"""
+    q = compute_deleverage_quote(
+        collateral_usd=Decimal("1000"),
+        debt_usd=Decimal("900"),
+        liquidation_threshold=Decimal("0.8"),
+    )
+    assert q.feasible is True
+    assert q.repay_debt_usd < Decimal("900")  # 部分返済
+    assert q.flash_loan_fee_usd == q.repay_debt_usd * Decimal("0.0005")
+    assert q.collateral_withdraw_usd == q.repay_debt_usd + q.flash_loan_fee_usd
+    assert q.projected_hf is not None
+    # 目標 1.8 にほぼ一致
+    assert abs(q.projected_hf - DEFAULT_TARGET_HF) < Decimal("0.001")
+
+
+def test_custom_target_hf() -> None:
+    q = compute_deleverage_quote(
+        collateral_usd=Decimal("1000"),
+        debt_usd=Decimal("900"),
+        liquidation_threshold=Decimal("0.8"),
+        target_hf=Decimal("2.0"),
+    )
+    assert q.feasible is True
+    assert q.projected_hf is not None
+    assert abs(q.projected_hf - Decimal("2.0")) < Decimal("0.001")
+
+
+# ---- compute_deleverage_quote: not feasible ----
+
+
+def test_no_debt_not_feasible() -> None:
+    q = compute_deleverage_quote(
+        collateral_usd=Decimal("1000"),
+        debt_usd=Decimal("0"),
+        liquidation_threshold=Decimal("0.8"),
+    )
+    assert q.feasible is False
+    assert q.repay_debt_usd == Decimal("0")
+    assert "no debt" in q.reason
+
+
+def test_hf_already_safe_not_feasible() -> None:
+    q = compute_deleverage_quote(
+        collateral_usd=Decimal("10000"),
+        debt_usd=Decimal("1000"),
+        liquidation_threshold=Decimal("0.8"),
+    )
+    assert q.feasible is False
+    assert q.projected_hf == Decimal("8")  # HF=8 ≥ target
+    assert "already" in q.reason
+
+
+def test_insufficient_collateral_not_feasible() -> None:
+    """深く水没（collateral < 必要引出額）だと自己清算では救えず fail-closed。"""
+    q = compute_deleverage_quote(
+        collateral_usd=Decimal("500"),
+        debt_usd=Decimal("600"),
+        liquidation_threshold=Decimal("0.8"),
+    )
+    assert q.feasible is False
+    assert q.repay_debt_usd == Decimal("0")
+    assert "insufficient collateral" in q.reason
+
+
+def test_target_unreachable_for_threshold() -> None:
+    """target_hf <= (1+fee)*lt の病的ケースは到達不能。"""
+    q = compute_deleverage_quote(
+        collateral_usd=Decimal("400"),
+        debt_usd=Decimal("1000"),
+        liquidation_threshold=Decimal("0.8"),
+        target_hf=Decimal("0.5"),
+    )
+    assert q.feasible is False
+    assert "not reachable" in q.reason
+
+
+# ---- input validation ----
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {
+            "collateral_usd": Decimal("-1"),
+            "debt_usd": Decimal("1"),
+            "liquidation_threshold": Decimal("0.8"),
+        },
+        {
+            "collateral_usd": Decimal("1"),
+            "debt_usd": Decimal("-1"),
+            "liquidation_threshold": Decimal("0.8"),
+        },
+        {
+            "collateral_usd": Decimal("1"),
+            "debt_usd": Decimal("1"),
+            "liquidation_threshold": Decimal("0"),
+        },
+        {
+            "collateral_usd": Decimal("1"),
+            "debt_usd": Decimal("1"),
+            "liquidation_threshold": Decimal("1.5"),
+        },
+        {
+            "collateral_usd": Decimal("1"),
+            "debt_usd": Decimal("1"),
+            "liquidation_threshold": Decimal("0.8"),
+            "target_hf": Decimal("0"),
+        },
+    ],
+)
+def test_invalid_inputs_raise(kwargs: dict) -> None:
+    with pytest.raises(SelfLiquidationError):
+        compute_deleverage_quote(**kwargs)
+
+
+def test_quote_is_frozen() -> None:
+    q = compute_deleverage_quote(
+        collateral_usd=Decimal("1000"),
+        debt_usd=Decimal("900"),
+        liquidation_threshold=Decimal("0.8"),
+    )
+    assert isinstance(q, DeleverageQuote)
+    with pytest.raises(Exception):
+        q.feasible = False  # type: ignore[misc]


### PR DESCRIPTION
## 概要
未着手だった **Flash Loan 自己清算保護**（Asana 1215620828227794 — HF 危機時に外部清算ペナルティ
5-10% を払う前に、Flash Loan 手数料 0.05% で自力デレバレッジする出口戦略）の **第1スライス＝純計算層**。

プロジェクトの scaffold-first / dormant 方針（wallet_policy.py・liquidation_sentinel と同型）に倣い、
**Solidity コントラクト・on-chain 実行・web3・秘密鍵・frontend は含めない**（後続 HUMAN-REVIEW/Tier S）。

## 実装（`backend/app/aave/self_liquidation.py`・副作用なし）
- `compute_health_factor()` / `should_protect()`（発動 trigger 既定 1.3 = HARD_STOP 1.6 の手前）
- `compute_deleverage_quote()`: Flash Loan 返済額の**解析解**
  ```
  amount = (target_hf*debt − collateral*lt) / (target_hf − (1+fee)*lt)
  ```
  で目標 HF（既定 1.8）を回復する返済額を求め、手数料（0.05%）・引出担保・回復後 HF を見積る。
  **fail-closed**: debt 無し / HF 既に安全 / 担保不足（深い水没で自己清算不能） / target 到達不能 → `feasible=False`。
- 金融計算は **Decimal のみ**（Rule 11）。

## なぜ純計算から
- デレバレッジ後の HF は `(collateral − amount*(1+fee)) * lt / (debt − amount)`。これを目標に解く**返済額の正確な計算**が機能の心臓部で、ここを純関数で固めてから実行層（contract/flash loan）を載せるのが安全。
- コントラクトデプロイ（gas・Base Sepolia）と実行は DeFi 安全系で HUMAN-REVIEW 必須のため本 PR から分離。

## テスト / DoD
- `tests/aave/test_self_liquidation.py`（新規 18 件）: 解析解の検算（`projected_hf == target`）/ 全 fail-closed 分岐 / HF 計算 / 発動判定 / 入力検証。
- `ruff`/`format`/`--select S`/`mypy` clean、18 passed。

## 後続スライス（別 PR・別タスク化推奨）
1. `contracts/SelfLiquidator.sol`（IFlashLoanSimpleReceiver）+ Base Sepolia デプロイ
2. `flash_loan_service.execute_self_liquidation()`（実行前 HF<1.3 ガード）
3. dashboard 発動履歴カード + admin 有効/無効・閾値トグル + i18n
4. workflow.py 統合（Tier S）

→ Asana タスクは本スライス完了後もオープン継続（上記が残）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)