### PR TITLE
fix(liff): HOLD 時の確信度文言をユーザーに分かりやすく（Asana 1215849982919465）

### DIFF
--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -370,6 +370,14 @@ export default function LiffChatPage() {
             {aiJudgment ? action : t("home.noSignal")}
           </div>
 
+          {/* 確信度表示。HOLD は「シグナルが弱く様子見」と分かる文言、BUY/SELL は従来表記。 */}
+          {aiJudgment && (
+            <p className="mt-1 text-[#736f7e] text-xs" data-testid="confidence-label">
+              {action === "HOLD"
+                ? t("home.holdWeakSignalLabel", { confidence })
+                : `${confidence}% ${t("home.confidenceLabel")}`}
+            </p>
+          )}
 
           {/* なぜ{action}？理由トグル（aiJudgment がある場合のみ表示） */}
           {aiJudgment && (


### PR DESCRIPTION
## 概要
liff-chat の AI 判定カードで、HOLD 時の確信度表示がユーザーに誤読される問題を修正。
「{confidence}% 信頼度」だと「HOLD に自信がない→動いてよ」と読まれるため、HOLD のみ
**「売買シグナルが弱いため様子見中（確信度 {confidence}%）」** に変更。BUY/SELL は従来表記のまま。

## 実態
- i18n キー `Liff.home.holdWeakSignalLabel` / `confidenceLabel` は **ja/en 両方に既存**（準備済み）だったが、`page.tsx` から**未使用**で、確信度自体が表示されていなかった（`confidence` const も dead）。
- 本 PR で表示を配線し、DoD（HOLD は新文言 / BUY/SELL は従来）を満たす。

## 変更
- `app/(liff)/liff-chat/page.tsx`: AI 判定カードに `action === "HOLD"` 条件分岐の確信度行を追加。
  - HOLD → `t("home.holdWeakSignalLabel", { confidence })`
  - BUY/SELL → `{confidence}% {t("home.confidenceLabel")}`

## DoD
- i18n-check ✅（新規欠落なし・キーは既存）/ `tsc --noEmit` clean / `eslint` 0 error（既存の fetch warning のみ）。
- backend 変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)