### PR TITLE
feat(aave): Credit Delegation 安全枠計算（第1スライス / Asana 1215620587799245）

### DIFF
--- a/backend/app/aave/credit_delegation.py
+++ b/backend/app/aave/credit_delegation.py
@@ -1,0 +1,139 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/aave/credit_delegation.py
+"""Credit Delegation の安全枠計算（純関数）。
+
+Aave V3 Credit Delegation でユーザーが borrowing power を UATa 運用アドレスへ委譲する際の、
+**委譲枠上限と HF 影響の計算のみ**を提供する純関数群（Asana 1215620587799245 の第1スライス）。
+on-chain の approveDelegation / borrow_on_behalf・web3・秘密鍵・frontend は含まない
+（後続 HUMAN-REVIEW スライス）。
+
+Aave protocol は委譲額の法的上限を enforce しないため、**UATa 側で委譲枠上限ロジックを持つ**
+（タスク注意点）。本 module はその上限計算 = 「HF floor(1.6) を割らずに委譲先が借りられる最大額」+
+任意の絶対委譲上限の二重クランプを担う。
+
+借入後の Health Factor::
+
+    HF = collateral * liquidation_threshold / (existing_debt + borrow)
+
+を HF floor 以上に保つ最大 borrow を解く。金融計算は Decimal のみ（Rule 11）。副作用なし・dormant。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Optional
+
+# CLAUDE.md §Security Rule 2: HF < 1.6 → HARD_STOP。委譲借入もこの floor を割ってはならない。
+DEFAULT_HF_FLOOR = Decimal("1.6")
+
+
+class CreditDelegationError(ValueError):
+    """入力が委譲枠計算の前提を満たさない。"""
+
+
+@dataclass(frozen=True)
+class DelegationAssessment:
+    """委譲借入の安全枠評価（実行はしない）。"""
+
+    requested_usd: Decimal
+    """要求された委譲借入額（USD）。"""
+
+    approved_usd: Decimal
+    """承認可能な借入額（USD）= min(要求, HF floor 上限, 絶対委譲上限)。"""
+
+    max_borrow_usd: Decimal
+    """HF floor を割らない最大借入額（USD）。"""
+
+    projected_hf: Optional[Decimal]
+    """approved_usd 借入後の HF。借入後 debt=0 は None。"""
+
+    within_floor: bool
+    """approved_usd 借入後も HF が floor 以上か。"""
+
+    reason: str
+    """判定理由（監査・ログ用）。"""
+
+
+def compute_max_delegated_borrow(
+    *,
+    collateral_usd: Decimal,
+    existing_debt_usd: Decimal,
+    liquidation_threshold: Decimal,
+    hf_floor: Decimal = DEFAULT_HF_FLOOR,
+) -> Decimal:
+    """HF floor を割らずに追加で借りられる最大額（USD）。負にはならない（0 で下限）。
+
+    HF = collateral*lt/(debt+B) >= floor  ⇔  B <= collateral*lt/floor - debt。
+    """
+    if collateral_usd < 0 or existing_debt_usd < 0:
+        raise CreditDelegationError("collateral_usd / existing_debt_usd must be non-negative")
+    if liquidation_threshold <= 0 or liquidation_threshold > 1:
+        raise CreditDelegationError("liquidation_threshold must be in (0, 1]")
+    if hf_floor <= 0:
+        raise CreditDelegationError("hf_floor must be positive")
+
+    headroom = (collateral_usd * liquidation_threshold) / hf_floor - existing_debt_usd
+    return headroom if headroom > 0 else Decimal("0")
+
+
+def assess_delegated_borrow(
+    *,
+    collateral_usd: Decimal,
+    existing_debt_usd: Decimal,
+    requested_borrow_usd: Decimal,
+    liquidation_threshold: Decimal,
+    hf_floor: Decimal = DEFAULT_HF_FLOOR,
+    delegation_cap_usd: Optional[Decimal] = None,
+) -> DelegationAssessment:
+    """委譲借入の安全枠を評価する（計算のみ・実行しない）。
+
+    approved = min(requested, HF floor 上限, 絶対委譲上限) の二重クランプ。
+
+    :param delegation_cap_usd: UATa 側の絶対委譲上限（任意）。None なら HF floor 上限のみ。
+    :raises CreditDelegationError: 入力不正
+    """
+    if requested_borrow_usd < 0:
+        raise CreditDelegationError("requested_borrow_usd must be non-negative")
+    if delegation_cap_usd is not None and delegation_cap_usd < 0:
+        raise CreditDelegationError("delegation_cap_usd must be non-negative")
+
+    max_borrow = compute_max_delegated_borrow(
+        collateral_usd=collateral_usd,
+        existing_debt_usd=existing_debt_usd,
+        liquidation_threshold=liquidation_threshold,
+        hf_floor=hf_floor,
+    )
+
+    approved = min(requested_borrow_usd, max_borrow)
+    capped_by_delegation = False
+    if delegation_cap_usd is not None and approved > delegation_cap_usd:
+        approved = delegation_cap_usd
+        capped_by_delegation = True
+
+    total_debt = existing_debt_usd + approved
+    if total_debt <= 0:
+        projected_hf: Optional[Decimal] = None
+        within_floor = True
+    else:
+        projected_hf = (collateral_usd * liquidation_threshold) / total_debt
+        within_floor = projected_hf >= hf_floor
+
+    if approved <= 0:
+        reason = "no borrow headroom — HF floor already binding"
+    elif capped_by_delegation:
+        reason = "approved amount clamped by delegation cap"
+    elif approved < requested_borrow_usd:
+        reason = "approved amount clamped by HF floor"
+    else:
+        reason = "requested amount fully approved within HF floor"
+
+    return DelegationAssessment(
+        requested_usd=requested_borrow_usd,
+        approved_usd=approved,
+        max_borrow_usd=max_borrow,
+        projected_hf=projected_hf,
+        within_floor=within_floor,
+        reason=reason,
+    )

--- a/backend/tests/aave/test_credit_delegation.py
+++ b/backend/tests/aave/test_credit_delegation.py
@@ -1,0 +1,179 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/aave/test_credit_delegation.py
+"""Credit Delegation 安全枠計算の単体テスト（Asana 1215620587799245 第1スライス）。
+
+HF floor 上限・絶対委譲上限の二重クランプ、借入後 HF、fail-closed、入力検証を Decimal で検証。
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.aave.credit_delegation import (
+    DEFAULT_HF_FLOOR,
+    CreditDelegationError,
+    assess_delegated_borrow,
+    compute_max_delegated_borrow,
+)
+
+# ---- compute_max_delegated_borrow ----
+
+
+def test_max_borrow_basic() -> None:
+    # collateral*lt/floor - debt = 1000*0.8/1.6 - 0 = 500
+    m = compute_max_delegated_borrow(
+        collateral_usd=Decimal("1000"),
+        existing_debt_usd=Decimal("0"),
+        liquidation_threshold=Decimal("0.8"),
+    )
+    assert m == Decimal("500")
+
+
+def test_max_borrow_with_existing_debt() -> None:
+    # 1000*0.8/1.6 - 200 = 300
+    m = compute_max_delegated_borrow(
+        collateral_usd=Decimal("1000"),
+        existing_debt_usd=Decimal("200"),
+        liquidation_threshold=Decimal("0.8"),
+    )
+    assert m == Decimal("300")
+
+
+def test_max_borrow_floored_at_zero() -> None:
+    # 既に floor を割る水準 → 追加借入余地 0
+    m = compute_max_delegated_borrow(
+        collateral_usd=Decimal("1000"),
+        existing_debt_usd=Decimal("600"),
+        liquidation_threshold=Decimal("0.8"),
+    )
+    assert m == Decimal("0")
+
+
+# ---- assess_delegated_borrow ----
+
+
+def test_full_approval_within_floor() -> None:
+    a = assess_delegated_borrow(
+        collateral_usd=Decimal("1000"),
+        existing_debt_usd=Decimal("0"),
+        requested_borrow_usd=Decimal("400"),
+        liquidation_threshold=Decimal("0.8"),
+    )
+    assert a.approved_usd == Decimal("400")
+    assert a.max_borrow_usd == Decimal("500")
+    assert a.within_floor is True
+    assert a.projected_hf is not None and a.projected_hf >= DEFAULT_HF_FLOOR
+    assert "fully approved" in a.reason
+
+
+def test_clamped_by_hf_floor() -> None:
+    a = assess_delegated_borrow(
+        collateral_usd=Decimal("1000"),
+        existing_debt_usd=Decimal("0"),
+        requested_borrow_usd=Decimal("800"),  # > max 500
+        liquidation_threshold=Decimal("0.8"),
+    )
+    assert a.approved_usd == Decimal("500")
+    assert a.within_floor is True
+    # 借入後 HF はちょうど floor
+    assert a.projected_hf == DEFAULT_HF_FLOOR
+    assert "HF floor" in a.reason
+
+
+def test_clamped_by_delegation_cap() -> None:
+    a = assess_delegated_borrow(
+        collateral_usd=Decimal("1000"),
+        existing_debt_usd=Decimal("0"),
+        requested_borrow_usd=Decimal("400"),
+        liquidation_threshold=Decimal("0.8"),
+        delegation_cap_usd=Decimal("250"),  # 絶対上限が更に厳しい
+    )
+    assert a.approved_usd == Decimal("250")
+    assert "delegation cap" in a.reason
+    assert a.within_floor is True
+
+
+def test_no_headroom() -> None:
+    a = assess_delegated_borrow(
+        collateral_usd=Decimal("1000"),
+        existing_debt_usd=Decimal("600"),  # 既に floor 割れ水準
+        requested_borrow_usd=Decimal("100"),
+        liquidation_threshold=Decimal("0.8"),
+    )
+    assert a.approved_usd == Decimal("0")
+    assert a.max_borrow_usd == Decimal("0")
+    assert "no borrow headroom" in a.reason
+
+
+def test_zero_request_no_debt_hf_none() -> None:
+    a = assess_delegated_borrow(
+        collateral_usd=Decimal("1000"),
+        existing_debt_usd=Decimal("0"),
+        requested_borrow_usd=Decimal("0"),
+        liquidation_threshold=Decimal("0.8"),
+    )
+    assert a.approved_usd == Decimal("0")
+    assert a.projected_hf is None  # debt=0 → HF 無限大
+    assert a.within_floor is True
+
+
+def test_custom_hf_floor() -> None:
+    # floor 2.0: max = 1000*0.8/2.0 = 400
+    m = compute_max_delegated_borrow(
+        collateral_usd=Decimal("1000"),
+        existing_debt_usd=Decimal("0"),
+        liquidation_threshold=Decimal("0.8"),
+        hf_floor=Decimal("2.0"),
+    )
+    assert m == Decimal("400")
+
+
+# ---- input validation ----
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {
+            "collateral_usd": Decimal("-1"),
+            "existing_debt_usd": Decimal("0"),
+            "liquidation_threshold": Decimal("0.8"),
+        },
+        {
+            "collateral_usd": Decimal("1"),
+            "existing_debt_usd": Decimal("-1"),
+            "liquidation_threshold": Decimal("0.8"),
+        },
+        {
+            "collateral_usd": Decimal("1"),
+            "existing_debt_usd": Decimal("0"),
+            "liquidation_threshold": Decimal("0"),
+        },
+        {
+            "collateral_usd": Decimal("1"),
+            "existing_debt_usd": Decimal("0"),
+            "liquidation_threshold": Decimal("1.1"),
+        },
+        {
+            "collateral_usd": Decimal("1"),
+            "existing_debt_usd": Decimal("0"),
+            "liquidation_threshold": Decimal("0.8"),
+            "hf_floor": Decimal("0"),
+        },
+    ],
+)
+def test_invalid_inputs_raise(kwargs: dict) -> None:
+    with pytest.raises(CreditDelegationError):
+        compute_max_delegated_borrow(**kwargs)
+
+
+def test_negative_request_raises() -> None:
+    with pytest.raises(CreditDelegationError):
+        assess_delegated_borrow(
+            collateral_usd=Decimal("1000"),
+            existing_debt_usd=Decimal("0"),
+            requested_borrow_usd=Decimal("-1"),
+            liquidation_threshold=Decimal("0.8"),
+        )


### PR DESCRIPTION
## 概要
未着手だった **Credit Delegation**（Asana 1215620587799245 — ユーザーの borrowing power を
UATa 運用アドレスへ委譲する非カストディアル拡張）の **第1スライス＝委譲枠の純計算**。

セキュリティ重大（委譲先がユーザー担保に対し debt を作れる）かつ on-chain・HUMAN-REVIEW のため、
プロジェクトの scaffold-first 方針（self_liquidation・wallet_policy と同型）で安全な計算層のみ先行。

## 実装（`backend/app/aave/credit_delegation.py`・副作用なし）
- `compute_max_delegated_borrow()`: HF floor(1.6) を割らない最大借入額 = `collateral*lt/floor − debt`（0 下限）
- `assess_delegated_borrow()`: `approved = min(要求, HF floor 上限, 絶対委譲上限)` の**二重クランプ** + 借入後 HF + `within_floor` 判定
- **Aave protocol は委譲上限を enforce しない**ため、タスク注意点どおり **UATa 側で委譲枠上限ロジックを持つ** = 本 module がその安全枠を担う
- Decimal のみ（Rule 11）

## テスト / DoD
- `tests/aave/test_credit_delegation.py`（新規 15 件）: HF floor 上限 / 絶対委譲上限の二重クランプ / 借入後 HF==floor / headroom 無し / 入力検証。
- `ruff`/`format`/`--select S`/`mypy` clean、15 passed。

## 後続スライス（別 PR・HUMAN-REVIEW）
- web3 `approve_delegation` / `borrow_on_behalf`（実 debt 委譲・on-chain）
- `POST /aave/delegation/approve`（RBAC）+ `GET /aave/delegation/status`
- AccountPanel/settings の委譲状態・承認 UI + i18n

→ Asana タスクは本スライス後もオープン継続。

🤖 Generated with [Claude Code](https://claude.com/claude-code)