### PR TITLE
feat(dashboard): 統合ポートフォリオ カード（frontend / Asana 1215698091414471）

### DIFF
--- a/frontend/app/user/dashboard/page.tsx
+++ b/frontend/app/user/dashboard/page.tsx
@@ -19,6 +19,7 @@ import { useAuthFetch } from '@/hooks/useAuthFetch'
 import { RewardsCard } from '@/components/dashboard/RewardsCard'
 import { IdleYieldCard } from '@/components/dashboard/IdleYieldCard'
 import { StressTestCard } from '@/components/dashboard/StressTestCard'
+import { UnifiedPortfolioCard } from '@/components/dashboard/UnifiedPortfolioCard'
 
 // Note: PortfolioSummary, SafetyScore, AiAccuracyCard are used by ActiveDashboard only
 
@@ -223,6 +224,11 @@ function ManagedDashboard({ isAdmin }: { isAdmin: boolean }) {
   const t = useTranslations('Dashboard')
   return (
     <div className="px-4 py-6 max-w-4xl mx-auto space-y-6">
+      {/* 統合ポートフォリオ（自分の Aave 純資産 + Privy Wallet 残高） */}
+      <section>
+        <UnifiedPortfolioCard />
+      </section>
+
       {/* 資金割り振り — メインコンテンツ */}
       <section>
         <AllocationCard />
@@ -266,6 +272,11 @@ function ActiveDashboard({ isAdmin }: { isAdmin: boolean }) {
       <div className="flex items-center gap-2">
         <RiskModeBadge />
       </div>
+
+      {/* 統合ポートフォリオ（自分の Aave 純資産 + Privy Wallet 残高） */}
+      <section>
+        <UnifiedPortfolioCard />
+      </section>
 
       <section>
         <PortfolioSummary />

--- a/frontend/components/dashboard/UnifiedPortfolioCard.tsx
+++ b/frontend/components/dashboard/UnifiedPortfolioCard.tsx
@@ -1,0 +1,101 @@
+'use client'
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+// frontend/components/dashboard/UnifiedPortfolioCard.tsx
+//
+// 統合ポートフォリオ（消費者個人）表示カード。GET /api/portfolio/unified の grand_total +
+// ソース別配分（Aave 純資産 / Privy Wallet）を表示。fail-open（degraded 警告）対応。
+
+import { useTranslations } from 'next-intl'
+import { Layers, Loader2, RefreshCw, AlertTriangle } from 'lucide-react'
+import { useAuthFetch } from '@/hooks/useAuthFetch'
+import type { UnifiedPortfolioView } from '@/lib/api/portfolio'
+
+const SOURCE_LABEL_KEY: Record<string, string> = {
+  aave: 'sourceAave',
+  wallet: 'sourceWallet',
+  cex: 'sourceCex',
+}
+
+function fmtUsd(value: string | null | undefined): string {
+  if (value == null) return '—'
+  const n = Number(value)
+  if (Number.isNaN(n)) return '—'
+  return n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+export function UnifiedPortfolioCard() {
+  const t = useTranslations('UnifiedPortfolioCard')
+  const { data, loading, error, refetch } = useAuthFetch<UnifiedPortfolioView>(
+    '/api/portfolio/unified',
+    { refreshInterval: 300000 }, // 5分ごと
+  )
+
+  return (
+    <div className="rounded-2xl border border-zinc-800 bg-zinc-900 p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Layers className="h-4 w-4 text-violet-400" />
+          <h2 className="text-sm font-semibold text-zinc-400">{t('title')}</h2>
+        </div>
+        <button
+          onClick={() => void refetch()}
+          aria-label={t('refresh')}
+          className="p-1 rounded hover:bg-zinc-800 transition-colors"
+        >
+          <RefreshCw className="h-3 w-3 text-zinc-500" />
+        </button>
+      </div>
+
+      {loading && (
+        <div className="flex items-center gap-2 py-2">
+          <Loader2 className="h-4 w-4 animate-spin text-zinc-500" />
+          <span className="text-xs text-zinc-500">{t('loading')}</span>
+        </div>
+      )}
+
+      {!loading && error && <p className="text-xs text-red-400 py-2">{t('fetchError')}</p>}
+
+      {!loading && !error && data && (
+        <>
+          {/* 合計 */}
+          <div className="space-y-1">
+            <p className="text-xs text-zinc-500">{t('grandTotal')}</p>
+            <p className="text-xl font-bold text-zinc-100">${fmtUsd(data.grand_total_usd)}</p>
+          </div>
+
+          {/* ソース別配分（available のみ） */}
+          <ul className="space-y-1.5" data-testid="unified-allocations">
+            {data.allocations
+              .filter((a) => a.available && a.source !== 'cex')
+              .map((a) => (
+                <li key={a.source} className="flex items-center justify-between text-xs">
+                  <span className="text-zinc-400">{t(SOURCE_LABEL_KEY[a.source] ?? 'sourceWallet')}</span>
+                  <span className="text-zinc-300">
+                    ${fmtUsd(a.total_usd)}{' '}
+                    <span className="text-zinc-500">({Number(a.allocation_pct).toFixed(1)}%)</span>
+                  </span>
+                </li>
+              ))}
+          </ul>
+
+          {/* Health Factor（Aave available 時のみ） */}
+          {data.health_factor != null && (
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-zinc-400">{t('healthFactor')}</span>
+              <span className="text-zinc-300">{Number(data.health_factor).toFixed(2)}</span>
+            </div>
+          )}
+
+          {/* fail-open: 一部ソース取得失敗時の警告 */}
+          {data.degraded && (
+            <div className="flex items-center gap-1.5 text-[10px] text-amber-500">
+              <AlertTriangle className="h-3 w-3" />
+              <span>{t('degraded', { available: data.sources_available, total: data.sources_total })}</span>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/lib/api/portfolio.ts
+++ b/frontend/lib/api/portfolio.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// frontend/lib/api/portfolio.ts
+//
+// 統合ポートフォリオ API クライアント（消費者個人スコープ）。
+// backend: GET /api/portfolio/unified（aave 純資産 + Privy wallet 残高 / CEX なし / fail-open）。
+
+import { getJson } from "./http"
+
+export interface SourceAllocation {
+  source: string // "aave" | "wallet" | "cex"
+  total_usd: string // Decimal 文字列
+  allocation_pct: string // Decimal 文字列 (0-100)
+  available: boolean
+}
+
+export interface UnifiedPortfolioView {
+  grand_total_usd: string
+  aave_net_usd: string
+  wallet_usd: string
+  cex_usd: string
+  health_factor: string | null
+  allocations: SourceAllocation[]
+  sources_available: number
+  sources_total: number
+  degraded: boolean
+}
+
+export async function getUnifiedPortfolio(): Promise<UnifiedPortfolioView> {
+  return getJson<UnifiedPortfolioView>("/api/portfolio/unified")
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -3707,6 +3707,18 @@
     "refresh": "Refresh",
     "note": "Estimated health factor if collateral price drops (liquidation at 1.0)."
   },
+  "UnifiedPortfolioCard": {
+    "title": "Unified Portfolio",
+    "grandTotal": "Total Assets",
+    "sourceAave": "Aave Net",
+    "sourceWallet": "Wallet Balance",
+    "sourceCex": "Exchange",
+    "healthFactor": "Health Factor",
+    "loading": "Loading...",
+    "fetchError": "Unable to fetch data",
+    "refresh": "Refresh",
+    "degraded": "Some data could not be fetched ({available}/{total} sources)"
+  },
   "BorrowRatesPanel": {
     "title": "GHO / USDC Borrow Rate Comparison",
     "description": "Displays the optimal borrowing currency considering stkAAVE discounts in real time (auto-refreshed every 60s)",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -3723,5 +3723,17 @@
     "fetchError": "データを取得できません",
     "refresh": "更新",
     "note": "担保価格が下落した場合のヘルスファクター試算です（1.0 で清算）。"
+  },
+  "UnifiedPortfolioCard": {
+    "title": "統合ポートフォリオ",
+    "grandTotal": "合計資産",
+    "sourceAave": "Aave 純資産",
+    "sourceWallet": "ウォレット残高",
+    "sourceCex": "取引所",
+    "healthFactor": "ヘルスファクター",
+    "loading": "読み込み中...",
+    "fetchError": "データを取得できません",
+    "refresh": "更新",
+    "degraded": "一部のデータを取得できませんでした（{available}/{total} ソース）"
   }
 }


### PR DESCRIPTION
## 概要
**統合ポートフォリオダッシュボード**（Asana 1215698091414471）の frontend スライス。#842 の消費者向け
`GET /api/portfolio/unified` を表示するダッシュボードカードを追加。これで本機能の user-facing 価値が揃う
（純集約 #751 + endpoint #842 + 本 PR）。

## 変更
| ファイル | 内容 |
|---|---|
| `lib/api/portfolio.ts`（新規） | `getUnifiedPortfolio()` + `UnifiedPortfolioView` 型 |
| `components/dashboard/UnifiedPortfolioCard.tsx`（新規） | 合計資産 + ソース別配分（Aave 純資産 / Wallet・%）+ HF + **degraded 警告**（fail-open）。`useAuthFetch`（5分更新） |
| `app/user/dashboard/page.tsx` | managed / active 両ダッシュボードの先頭付近に組込 |
| `messages/ja.json` / `en.json` | `UnifiedPortfolioCard` 名前空間（parity 維持） |

- CEX 行は消費者スコープのため非表示（`source !== 'cex'` + available フィルタ）。
- 一部ソース取得失敗時は `degraded` 警告（{available}/{total}）で他ソースの表示を継続。

## DoD
- `check-i18n-keys` ✅ / `tsc --noEmit` clean / `eslint` 0 error。
- backend は #842（別 PR）。本 PR はパス文字列で呼ぶため独立。

→ これで Asana 1215698091414471 はクローズ可能（純集約 + endpoint + frontend が揃う）。admin/operator 向け 3 ソースビューは任意の別 endpoint。

🤖 Generated with [Claude Code](https://claude.com/claude-code)