### PR TITLE
chore(prod): NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED を production ビルドに配線（dormant）

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -113,6 +113,9 @@ SLACK_WEBHOOK_URL=
 # フロントエンド（ビルド時埋め込み）
 # =============================================================================
 NEXT_PUBLIC_PRIVY_APP_ID=<privy-app-id — app.ultra-auto-trade.com をAllowed Originsに追加要>
+# v4 Phase 2-D-E: 委譲おまかせ consent フロー（ビルド時埋め込み・既定 false=dormant）。
+# staging-v4 検証後、本番 %キャップ段階(2-D-D)で true にして frontend 再ビルドで有効化。
+NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED=false
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=
 NEXT_PUBLIC_DEFAULT_CHAIN=base-mainnet
 NEXT_PUBLIC_DEFAULT_CHAIN_ID=8453

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -315,6 +315,9 @@ services:
         NEXT_PUBLIC_POSTHOG_KEY: ${NEXT_PUBLIC_POSTHOG_KEY:-}
         NEXT_PUBLIC_POSTHOG_HOST: ${NEXT_PUBLIC_POSTHOG_HOST:-https://us.i.posthog.com}
         NEXT_PUBLIC_APP_VERSION: ${NEXT_PUBLIC_APP_VERSION:-dev}
+        # v4 Phase 2-D-E: 委譲おまかせ consent フロー（ビルド時埋め込み・既定 false=dormant）。
+        # 本番 %キャップ段階(2-D-D)で true にして再ビルドすると有効化。staging-v4 で検証後。
+        NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED: ${NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED:-false}
         # Next.js ビルド OOM 対策 (CLAUDE.md §2026-05-19 GID 1214828243363427)
         NODE_BUILD_MAX_OLD_SPACE_SIZE: ${NODE_BUILD_MAX_OLD_SPACE_SIZE:-4096}
     environment:


### PR DESCRIPTION
## 概要
#836 で staging-v4 に配線した委譲 consent フラグの **production 版**。2-D-D 本番ロールアウト時に
**env だけで有効化**できるよう、`docker-compose.production.yml` の build args に追加する（既定 `false`=挙動不変）。
`frontend/Dockerfile` の ARG/ENV は #836 で追加済み（共有）のため compose 側のみ。

## 変更
- `docker-compose.production.yml`: build args に `NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED: ${...:-false}`
- `.env.production.example`: 文書化（staging-v4 検証後・%キャップ段階で true）

## dormant
**既定 `false` = 本番挙動不変**。実有効化は staging-v4 consent 検証（Asana 1215890808157196）完了 + L0(完了済) の後、2-D-D で env=true + frontend 再ビルド。

Tier S（production compose）変更だが inert（build-arg 追加のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)