### PR TITLE
docs(env): staging-v4.example に Privy 委譲 backend 5値を明記（dormant 既定）

### DIFF
--- a/.env.staging-v4.example
+++ b/.env.staging-v4.example
@@ -120,7 +120,25 @@ NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 # v4 Phase 2-D-E: 委譲おまかせ consent フロー（ビルド時埋め込み・既定 false=dormant）。
 # backend の L0 登録（PRIVY_SERVER_SIGNER_ID + DELEGATION_PRIVY_POLICY_ENABLED=1）完了後に
 # true にして frontend を再ビルドすると、OpModePanel の managed 選択で consent が走る。
+# 対になる backend 側 5 値は下の「Privy 委譲」セクション参照。
 NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED=false
+
+# =============================================================================
+# Privy 委譲 (Delegation / v4 Phase 2-D) — backend runtime 参照
+# is_delegation_policy_enabled() のゲート: DELEGATION_PRIVY_POLICY_ENABLED=true
+#   かつ PRIVY_SERVER_SIGNER_ID / PRIVY_APP_ID / PRIVY_APP_SECRET が揃うと有効化。
+#   いずれか欠けると /api/user/delegation/prepare は 503（dormant）＝本番 inert。
+# 実値は絶対にここに記載しない (§13)。staging-v4 では dev VPS の
+#   ~/.config/uata-privy-spike/.env と同値（spike = UAT app と同一 Privy app）から転記。
+# PRIVY_SERVER_SIGNER_ID は L0 (privy_register_key_quorum.py) で取得した key quorum id。
+# 検証手順は Asana 1215890808157196 / docs/ops/v4_phase2d_consent_flow_design.md。
+# 既定は dormant（フラグ未設定 = false）。有効化時のみ下 4 値を実値に置換し FLAG=true。
+# =============================================================================
+DELEGATION_PRIVY_POLICY_ENABLED=false
+PRIVY_SERVER_SIGNER_ID=
+PRIVY_APP_ID=
+PRIVY_APP_SECRET=
+PRIVY_AUTHORIZATION_PRIVATE_KEY=
 
 # =============================================================================
 # Fee Transfer (Non-Custodial / Operator Fee)


### PR DESCRIPTION
## 概要
`.env.staging-v4.example` は frontend 側（`NEXT_PUBLIC_PRIVY_APP_ID` / `NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED`）のみ記載で、委譲 consent フロー実機検証に必須の **backend 5 値が未記載** だった。テンプレートに dormant 既定で追記する。

## 追記した backend 値（いずれも dormant 既定）
- `DELEGATION_PRIVY_POLICY_ENABLED=false`
- `PRIVY_SERVER_SIGNER_ID=`（L0 で取得した key quorum id）
- `PRIVY_APP_ID=`
- `PRIVY_APP_SECRET=`
- `PRIVY_AUTHORIZATION_PRIVATE_KEY=`

`is_delegation_policy_enabled()`（`backend/app/privy/delegation_service.py`）のゲート条件・値の出所（dev VPS `~/.config/uata-privy-spike/.env`）・検証手順（Asana 1215890808157196）への参照を comment 化。

## 背景
phase1-investigator の staging-v4 read-only 調査で、この 5 値が file/コンテナ双方 absent と確定済み（Asana 1215890808157196 / 2026-06-22）。テンプレートが実需と乖離していたため、env setup 担当が漏れなく設定できるよう同期する。

## 安全性
- テンプレート（`.example`）のみ。実 deploy 対象の `.env.staging-v4` は不変。
- 実値は §13 準拠でプレースホルダのみ（秘密値なし）。
- FLAG 既定 false / 値空 = dormant のため挙動変更なし。

Asana: 1215890808157196

🤖 Generated with [Claude Code](https://claude.com/claude-code)