### PR TITLE
fix(safety): detect_route_mismatch を執行後の整合チェックに結線（孤立安全装置）

### DIFF
--- a/.env.staging-v4.example
+++ b/.env.staging-v4.example
@@ -120,7 +120,25 @@ NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 # v4 Phase 2-D-E: 委譲おまかせ consent フロー（ビルド時埋め込み・既定 false=dormant）。
 # backend の L0 登録（PRIVY_SERVER_SIGNER_ID + DELEGATION_PRIVY_POLICY_ENABLED=1）完了後に
 # true にして frontend を再ビルドすると、OpModePanel の managed 選択で consent が走る。
+# 対になる backend 側 5 値は下の「Privy 委譲」セクション参照。
 NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED=false
+
+# =============================================================================
+# Privy 委譲 (Delegation / v4 Phase 2-D) — backend runtime 参照
+# is_delegation_policy_enabled() のゲート: DELEGATION_PRIVY_POLICY_ENABLED=true
+#   かつ PRIVY_SERVER_SIGNER_ID / PRIVY_APP_ID / PRIVY_APP_SECRET が揃うと有効化。
+#   いずれか欠けると /api/user/delegation/prepare は 503（dormant）＝本番 inert。
+# 実値は絶対にここに記載しない (§13)。staging-v4 では dev VPS の
+#   ~/.config/uata-privy-spike/.env と同値（spike = UAT app と同一 Privy app）から転記。
+# PRIVY_SERVER_SIGNER_ID は L0 (privy_register_key_quorum.py) で取得した key quorum id。
+# 検証手順は Asana 1215890808157196 / docs/ops/v4_phase2d_consent_flow_design.md。
+# 既定は dormant（フラグ未設定 = false）。有効化時のみ下 4 値を実値に置換し FLAG=true。
+# =============================================================================
+DELEGATION_PRIVY_POLICY_ENABLED=false
+PRIVY_SERVER_SIGNER_ID=
+PRIVY_APP_ID=
+PRIVY_APP_SECRET=
+PRIVY_AUTHORIZATION_PRIVATE_KEY=
 
 # =============================================================================
 # Fee Transfer (Non-Custodial / Operator Fee)

--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -357,7 +357,14 @@ def _execute_aave_for_proposal(proposal: Proposal, db: Session) -> None:
     from app.ai.schemas import TradeAction  # noqa: PLC0415
     from app.transactions.models import Transaction  # noqa: PLC0415
 
-    from .execution_route import ExecutionRoute, RouteMismatchError, assert_route
+    from .execution_route import (
+        DEFAULT_EXECUTION_ROUTE,
+        ExecutionRoute,
+        RouteMismatchError,
+        assert_route,
+        detect_route_mismatch,
+        notify_route_mismatch,
+    )
 
     # P0-2 誤執行ガード: Aave 自動実行は on-chain 経路専用。
     # CEX 選択 proposal がこの経路に入った場合は即時 EMERGENCY アラート + 例外で停止する
@@ -515,6 +522,26 @@ def _execute_aave_for_proposal(proposal: Proposal, db: Session) -> None:
         proposal.tx_hash = result.tx_hash
         proposal.status = "executed"
         proposal.executed_at = datetime.now(timezone.utc)
+
+        # 執行後の経路↔証跡整合チェック (§14a defense-in-depth)。
+        # assert_route は「執行前」ガードなのに対し、ここは「執行後」に
+        # 経路 (execution_route) と実際の証跡 (on-chain tx_hash / CEX order) の
+        # 食い違いを検出する。on-chain 経路の正常系 (tx あり / CEX order なし) では
+        # None を返し no-op。CEX order が誤って付くなど証跡破損 (誤執行の疑い) 時のみ
+        # EMERGENCY 通知を出して手動介入を促す (tx は確定済みのため status は変えない)。
+        _route = proposal.execution_route or DEFAULT_EXECUTION_ROUTE
+        _evidence_mismatch = detect_route_mismatch(
+            _route,
+            has_onchain_tx=bool(proposal.tx_hash),
+            has_cex_order=bool(proposal.cex_order_id),
+        )
+        if _evidence_mismatch:
+            notify_route_mismatch(proposal.id, _route, _evidence_mismatch)
+            logger.error(
+                "proposal %d: post-execution route mismatch — %s",
+                proposal.id,
+                _evidence_mismatch,
+            )
 
         # 取引履歴に記録
         tx_status = "completed" if result.tx_hash else "pending"

--- a/backend/tests/test_proposal_execution_route.py
+++ b/backend/tests/test_proposal_execution_route.py
@@ -297,3 +297,64 @@ def test_onchain_partners_not_mixed(db_session: Session) -> None:
     assert p2.tx_hash == "0x" + "22" * 32
     assert p1.user_id != p2.user_id
     assert p1.tx_hash != p2.tx_hash
+
+
+# ---------------------------------------------------------------------------
+# 執行後 (post-execution) の経路↔証跡整合チェック wiring
+# detect_route_mismatch が _execute_aave_for_proposal に結線されていることを担保する。
+# ---------------------------------------------------------------------------
+
+
+def test_onchain_execution_clean_evidence_no_mismatch_alert(db_session: Session) -> None:
+    """正常系: on-chain 経路 (tx あり / CEX order なし) では誤執行アラートを出さない。"""
+    from app.proposals.router import _execute_aave_for_proposal
+
+    _make_user_with_wallet(db_session, user_id=1, wallet_address="0x" + "ab" * 20)
+    p = _make_proposal(db_session, execution_route=ExecutionRoute.ONCHAIN_AAVE.value)
+    fake_result = MagicMock()
+    fake_result.tx_hash = "0x" + "cd" * 32
+    fake_result.status = "success"
+
+    with patch("app.proposals.execution_route.notify_route_mismatch") as mock_notify:
+        with patch.dict(os.environ, {"AAVE_ACTIVE_CHAINS": "base"}):
+            with patch("app.aave.service.MultiChainAaveService") as mock_svc:
+                mock_svc.return_value.execute_rebalance.return_value = fake_result
+                _execute_aave_for_proposal(p, db_session)
+
+    db_session.commit()
+    db_session.refresh(p)
+    assert p.status == "executed"
+    # 正常系では post-execution mismatch 通知は発火しない
+    mock_notify.assert_not_called()
+
+
+def test_onchain_execution_corrupted_cex_evidence_alerts(db_session: Session) -> None:
+    """証跡破損: on-chain proposal に CEX order が混入したら執行後に EMERGENCY 通知。
+
+    tx は確定済みのため status は executed のまま (手動介入を促す通知のみ)。
+    """
+    from app.proposals.router import _execute_aave_for_proposal
+
+    _make_user_with_wallet(db_session, user_id=1, wallet_address="0x" + "ab" * 20)
+    p = _make_proposal(db_session, execution_route=ExecutionRoute.ONCHAIN_AAVE.value)
+    # 誤執行の疑い: on-chain 経路なのに CEX order_id が付いている (証跡破損)
+    p.cex_order_id = "cex-order-should-not-exist"
+    db_session.commit()
+    fake_result = MagicMock()
+    fake_result.tx_hash = "0x" + "ef" * 32
+    fake_result.status = "success"
+
+    with patch("app.proposals.execution_route.notify_route_mismatch") as mock_notify:
+        with patch.dict(os.environ, {"AAVE_ACTIVE_CHAINS": "base"}):
+            with patch("app.aave.service.MultiChainAaveService") as mock_svc:
+                mock_svc.return_value.execute_rebalance.return_value = fake_result
+                _execute_aave_for_proposal(p, db_session)
+
+    db_session.commit()
+    db_session.refresh(p)
+    # tx は確定済み → status は executed のまま (誤執行は通知で人手介入を促す)
+    assert p.status == "executed"
+    assert p.tx_hash == "0x" + "ef" * 32
+    mock_notify.assert_called_once()
+    # 通知引数に当該 proposal_id が含まれる
+    assert mock_notify.call_args.args[0] == p.id


### PR DESCRIPTION
## 概要
`detect_route_mismatch`（`backend/app/proposals/execution_route.py`）は P0-2 / §14a の defense-in-depth として実装・unit test 済みだったが **呼出元ゼロの孤立安全装置** だった。`_execute_aave_for_proposal` の on-chain 執行成功直後に結線する。

## assert_route との違い
| | タイミング | 役割 |
|---|---|---|
| `assert_route`（既配線） | 執行**前** | 経路不一致 proposal を弾く（RouteMismatchError 送出） |
| `detect_route_mismatch`（本PRで配線） | 執行**後** | execution_route と実証跡（on-chain tx_hash / CEX order_id）の食い違いを検出 |

## 挙動
- on-chain 正常系（tx あり / CEX order なし）→ `None` 返却で **no-op（happy path 完全無影響）**。
- CEX order が誤って混入するなど証跡破損（誤執行の疑い）時のみ EMERGENCY 通知（`notify_route_mismatch`）+ error ログ。
- tx は確定済みのため **status は変えない**（通知で手動介入を促すのみ）。

## テスト
- 追加2件: 正常系で通知非発火 / 証跡破損で通知発火（status=executed 維持・proposal_id を通知へ渡すこと検証）。
- `test_proposal_execution_route` 19 pass / proposal+execution+scw 関連 **210 pass**・regression なし。ruff/mypy clean。

## スコープ外（誤検出だった分）
- `notify_route_mismatch` … `assert_route` 経由で既配線。
- `record_cex_execution` … CEX 執行経路が未実装のため配線は premature。

接続監査（2026-06-21）「安全装置の配線切れ」カテゴリの実対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)