### PR TITLE
feat(audit): 招待コード事前検証 GET /api/invitations/{code} を新設（G4）

### DIFF
--- a/backend/app/invitations/router.py
+++ b/backend/app/invitations/router.py
@@ -1,0 +1,47 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/invitations/router.py
+"""招待コード API ルーター。
+
+公開（認証不要）の事前検証エンドポイントを提供する。register 画面が URL の
+招待コードを送信前に検証し「有効/無効」を表示するために使う（2026-06-22 監査 G4）。
+
+登録本体の検証は POST /auth/register 内の validate_code が担保しており、本 GET は
+あくまで UX 用の事前チェック。enumeration 対策として、無効コードには valid=False のみ
+返し、有効コードにのみ付随情報（保有者は既にコードを知っている）を返す。
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+
+from .schemas import InvitationValidateResponse
+from .service import validate_code
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/invitations", tags=["invitations"])
+
+
+@router.get("/{code}", response_model=InvitationValidateResponse)
+def validate_invitation_code(
+    code: str,
+    db: Session = Depends(get_db),
+) -> InvitationValidateResponse:
+    """招待コードを事前検証する（認証不要）。
+
+    有効なら valid=True と付随情報、無効/期限切れ/使用超過なら valid=False のみ返す。
+    """
+    invitation = validate_code(db, code)
+    if invitation is None:
+        return InvitationValidateResponse(valid=False)
+    return InvitationValidateResponse(
+        valid=True,
+        type=invitation.type,
+        partner_id=invitation.partner_id,
+        expires_at=invitation.expires_at,
+        uses_remaining=invitation.max_uses - invitation.used_count,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -63,6 +63,7 @@ from app.error_handlers import register_error_handlers
 from app.exchange.router import router as exchange_router
 from app.health.detail_router import router as health_detail_router
 from app.hooks.router import router as hooks_router
+from app.invitations.router import router as invitations_router
 from app.knowledge.router import router as knowledge_router
 from app.notifications.models import (
     NotificationLog,  # noqa: F401 — ensure table registered with Base.metadata
@@ -242,6 +243,7 @@ def create_app() -> FastAPI:
 
     # --- Router registration ---
     app.include_router(auth_router)  # Auth (Phase12)
+    app.include_router(invitations_router)  # 招待コード事前検証 (監査 G4)
     app.include_router(partner_router)  # Partner stats (Wave 2)
     app.include_router(
         allocation_router, prefix="/api/partner", tags=["partner-allocations"]

--- a/backend/tests/test_invitations.py
+++ b/backend/tests/test_invitations.py
@@ -438,3 +438,51 @@ class TestRegistrationWithInvitation:
             },
         )
         assert resp.status_code == 403
+
+
+# ────────────────────────────────────────────────────────────────
+# GET /api/invitations/{code} 事前検証エンドポイント（監査 G4）
+# ────────────────────────────────────────────────────────────────
+
+
+class TestInvitationValidateEndpoint:
+    """公開（認証不要）の招待コード事前検証 GET エンドポイント。"""
+
+    def test_valid_code_returns_valid_true(self, client: TestClient, test_db) -> None:
+        """有効コードは valid=True と付随情報を返す（認証不要）。"""
+        override_get_db, _ = test_db
+        db: Session = next(override_get_db())
+        try:
+            inv = invitation_service.create_invitation(db, partner_id=7, expires_at=_future())
+            code = inv.code
+        finally:
+            db.close()
+
+        resp = client.get(f"/api/invitations/{code}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["valid"] is True
+        assert body["partner_id"] == 7
+        assert body["uses_remaining"] == 1
+
+    def test_unknown_code_returns_valid_false(self, client: TestClient) -> None:
+        """存在しないコードは 200 + valid=False（enumeration 対策で付随情報なし）。"""
+        resp = client.get("/api/invitations/NONEXISTENTCODE0")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["valid"] is False
+        assert body["partner_id"] is None
+
+    def test_expired_code_returns_valid_false(self, client: TestClient, test_db) -> None:
+        """期限切れコードは 200 + valid=False。"""
+        override_get_db, _ = test_db
+        db: Session = next(override_get_db())
+        try:
+            inv = invitation_service.create_invitation(db, partner_id=1, expires_at=_past())
+            code = inv.code
+        finally:
+            db.close()
+
+        resp = client.get(f"/api/invitations/{code}")
+        assert resp.status_code == 200
+        assert resp.json()["valid"] is False


### PR DESCRIPTION
## 概要
2026-06-22 網羅監査 **G4**。register ページ（`app/register/page.tsx:60`）が `GET /api/invitations/{code}` を叩くが backend に router が存在せず（`app/invitations/` は models/schemas/service のみ・`InvitationValidateResponse` は定義済みだが handler 不在＝作りかけ）、proxy も無いため**有効な招待 URL でも常に 404 → 「無効」誤表示**だった。

## 修正
- `backend/app/invitations/router.py` を新設：`GET /api/invitations/{code}`（認証不要・公開）で既存 `validate_code` を呼び `InvitationValidateResponse` を返す。
- `main.py` に `include_router(invitations_router)` 登録（import は I001 整合済み・line 66）。
- enumeration 対策: 無効/期限切れ/使用超過は `valid=False` のみ、有効コードにのみ付随情報（保有者は既にコードを知っている）。

登録本体の検証は従来通り `POST /auth/register` 内 `validate_code` が担保＝本 GET は UX 用の事前チェックのみ。挙動変更は frontend の事前表示が正しくなるだけで、登録フロー・権限には影響なし。

## 確認
- test 3件追加（有効=valid true+付随情報 / 不明=valid false / 期限切れ=valid false・全て認証なしで 200）→ PASS
- ruff / mypy / format clean
- `create_app()` boot + `/api/invitations/{code}` 登録 smoke pass
- 公開エンドポイント: グローバル auth middleware 無し（CORS + server header のみ）＝Depends(require_*) 無しで公開、pre-registration 用途に整合

Asana: 1215915078947239

🤖 Generated with [Claude Code](https://claude.com/claude-code)