### PR TITLE
chore(audit): lib/api の呼出元ゼロ dead export を削除（fe-09/fe-10）

### DIFF
--- a/frontend/lib/api/aave.ts
+++ b/frontend/lib/api/aave.ts
@@ -3,13 +3,14 @@
 // frontend/lib/api/aave.ts
 /**
  * Aave 関連 API クライアント
- * - getStressTest(): GET /api/aave/stress-test
  * - getPoolHealth(): GET /api/aave/pool-health
- * - getRewards(): GET /api/aave/rewards
  * - claimRewards(): POST /api/aave/rewards/claim
  * - getBorrowRates(): GET /api/aave/borrow-rates
  * - getEMode(): GET /api/aave/emode
  * - setEMode(): POST /api/aave/emode
+ *
+ * NOTE: getStressTest()/getRewards() は呼出元ゼロのため削除（2026-06-22 監査 fe-10）。
+ * 各 read は画面側 useAuthFetch がインラインで担当。型は保持。
  */
 
 import { getJson, postJson } from "./http";
@@ -32,10 +33,6 @@ export interface StressTestResult {
   liquidation_threshold: string | null; // Decimal 文字列 (例: "0.80")
   scenarios: StressTestScenario[];
   error: string | null;
-}
-
-export async function getStressTest(): Promise<StressTestResult> {
-  return getJson<StressTestResult>("/api/aave/stress-test");
 }
 
 // ---------------------------------------------------------------------------
@@ -86,13 +83,6 @@ export interface ClaimRewardsResponse {
   skip_reason: string | null;
   error: string | null;
   claimed_at: string | null;
-}
-
-/**
- * GET /aave/rewards — 未請求リワードを取得する（viewer 以上）
- */
-export async function getRewards(): Promise<RewardsResponse> {
-  return getJson<RewardsResponse>("/api/aave/rewards");
 }
 
 /**

--- a/frontend/lib/api/yield.ts
+++ b/frontend/lib/api/yield.ts
@@ -6,7 +6,7 @@
  * Privy Earn / Morpho Vaults アイドル資本自動運用エンドポイント。
  */
 
-import { getJson, postJson } from "./http";
+import { postJson } from "./http";
 
 // ---- Types ----
 
@@ -74,27 +74,8 @@ export interface WithdrawRequest {
 }
 
 // ---- API 関数 ----
-
-/**
- * GET /api/yield-optimizer/vaults — Vault 一覧取得 (viewer 以上)
- */
-export async function getVaults(): Promise<VaultListResponse> {
-  return getJson<VaultListResponse>("/api/yield-optimizer/vaults");
-}
-
-/**
- * GET /api/yield-optimizer/positions — ポジション一覧取得 (viewer 以上)
- */
-export async function getPositions(): Promise<PositionListResponse> {
-  return getJson<PositionListResponse>("/api/yield-optimizer/positions");
-}
-
-/**
- * GET /api/yield-optimizer/idle-report — アイドル資本レポート (viewer 以上)
- */
-export async function getIdleReport(): Promise<IdleCapitalReport> {
-  return getJson<IdleCapitalReport>("/api/yield-optimizer/idle-report");
-}
+// NOTE: getVaults/getPositions/getIdleReport は呼出元ゼロのため削除（2026-06-22 監査 fe-09）。
+// 各 read は画面側 useAuthFetch がインラインで担当。型は将来の UI 配線用に保持。
 
 /**
  * POST /api/yield-optimizer/deposit — Morpho Vault 入金 (admin 専用)


### PR DESCRIPTION
## 概要
2026-06-22 網羅監査で**呼出元ゼロ**と確定した未使用 export 関数を削除する。各 read は画面側 `useAuthFetch` がインラインで担当しており、これらは重複の死蔵だった。型は将来の UI 配線用に監査推奨どおり保持。

## 削除
- `lib/api/yield.ts`: `getVaults` / `getPositions` / `getIdleReport`（fe-09）。これら3つが唯一の `getJson` 利用だったため import を `postJson` のみに整理（`depositToVault`/`withdrawFromVault` は現役・維持）。
- `lib/api/aave.ts`: `getStressTest` / `getRewards`（fe-10）。`getPoolHealth`/`claimRewards`/`getBorrowRates`/`getEMode`/`setEMode` は現役のため import は維持。

## 確認
- 呼出元検証: `app`/`components`/`lib`/`hooks`/`e2e`/`tests` 全 grep で**ゼロ参照**（docstring 言及のみ）
- tsc：当該ファイル エラーなし / eslint clean
- 挙動変更なし（dead code 削除のみ・runtime 無影響）

## スコープ外
`portfolio.ts` の `getUnifiedPortfolio`（fe-11）は day-old の UnifiedPortfolioCard（PR #843）と対のため intent 確認を要するので本PR対象外。emergency/ITP 系の孤立 component 削除（fe-01/02/06）は e2e spec への cascade と fe-15 dead-layout の product 判断に依存するため別途（Asana 1215915078946951）。

Asana: 1215915078946951

🤖 Generated with [Claude Code](https://claude.com/claude-code)