### PR TITLE
chore(ops): VPS 運用 CLI-prep — stale-env 検知CI + cron/journald runbook

### DIFF
--- a/.github/workflows/env-separation-check.yml
+++ b/.github/workflows/env-separation-check.yml
@@ -34,6 +34,9 @@ jobs:
             exit 1
           fi
           echo "✅ docker-compose に .env.staging 参照なし"
+      - name: Check no real .env files committed
+        # 旧 env ファイル含む実 .env が tracked に混入していないか検証 (Asana 1214696986457078)。
+        run: bash scripts/check_no_committed_env_files.sh
       - name: Shellcheck
         uses: ludeeus/action-shellcheck@master
         with:

--- a/docs/ops/vps_ops_runbook_2026_06.md
+++ b/docs/ops/vps_ops_runbook_2026_06.md
@@ -1,0 +1,129 @@
+# VPS 運用セットアップ runbook（2026-06）
+
+本番 VPS（Hetzner `77.42.46.155` / user `ultra`）で実施する運用ジョブ登録の手順書。
+リポジトリ側のスクリプト・CI は実装済み。本書の作業は **VPS 実行（3段プロトコル）** が前提。
+
+> **[CRITICAL] パス**: 本番 VPS の repo root は `/opt/ultra-autotrade/`（`main/` サブディレクトリなし）。
+> SSH ログイン後に必ず `pwd && ls` で確認してから実行すること。
+> 接続は3段プロトコル（@phase1-investigator → @phase2-implementer → @phase3-deployer）経由。
+
+対象 Asana:
+- 1214954820902281（ディスク監視 + Docker 自動 cleanup）
+- 1214702770084840（DB 週次バックアップ自動化・5/2 以降停止の再開）
+- 1214988731707550（journald 永続上限 SystemMaxUse=1G）
+- 1214696986457078（.env 旧ファイル削除 ／ 検知 CI は実装済み）
+
+---
+
+## 0. 事前準備（ログ出力先）
+
+cron が書き込むログディレクトリを作成しておく（未作成だと cron が無言で失敗する）。
+
+```bash
+sudo mkdir -p /var/log/ultra-autotrade
+sudo chown ultra:ultra /var/log/ultra-autotrade
+```
+
+---
+
+## 1. Docker 積極 cleanup（週次）
+
+スクリプト: `scripts/periodic_docker_cleanup.sh`（builder cache 全削除 + dangling image +
+journal vacuum 1G。WARN=80% / CRITICAL=90% で Slack 通知）。
+
+`crontab -e`（user `ultra`）に追記:
+
+```cron
+# 毎週日曜 04:00 — Docker 積極 cleanup（ディスク逼迫対策）
+0 4 * * 0 /opt/ultra-autotrade/scripts/periodic_docker_cleanup.sh >> /var/log/ultra-autotrade/periodic_cleanup.log 2>&1
+```
+
+検証:
+```bash
+crontab -l | grep periodic_docker_cleanup        # 登録確認
+/opt/ultra-autotrade/scripts/periodic_docker_cleanup.sh   # 手動 1 回実行（ログ確認）
+df -h / && docker system df                       # 効果確認
+```
+
+> 禁止: `docker system prune -af`（使用中 image 削除リスク・CLAUDE.md 明記）。本スクリプトは使わない。
+
+---
+
+## 2. PostgreSQL バックアップ（週次・5/2 以降停止の再開）
+
+スクリプト: `scripts/backup_db.sh`（バックアップ後に gzip 整合性を自己検証、失敗時 Slack 通知 + exit 1）。
+
+`crontab -e`（user `ultra`）に追記:
+
+```cron
+# 毎週日曜 02:00 — production DB バックアップ（cleanup と時間をずらす）
+0 2 * * 0 ENVIRONMENT=production /opt/ultra-autotrade/scripts/backup_db.sh >> /var/log/ultra-autotrade/backup.log 2>&1
+```
+
+> 日次にする場合は `0 3 * * *`（スクリプト header の推奨値）。タスクは「週次」のため上記を既定とする。
+
+検証:
+```bash
+crontab -l | grep backup_db                                   # 登録確認
+ENVIRONMENT=production /opt/ultra-autotrade/scripts/backup_db.sh   # 手動 1 回実行
+ls -lh <バックアップ出力先>                                    # ファイル生成 + サイズ確認
+bash /opt/ultra-autotrade/scripts/restore_test.sh             # リストア検証（任意・推奨）
+```
+
+---
+
+## 3. journald 永続上限（SystemMaxUse=1G）
+
+systemd journal が無制限に肥大化してディスクを圧迫するのを防ぐ。root（sudo）作業。
+
+```bash
+# /etc/systemd/journald.conf を編集（sed -i は使わず確実に）
+sudo cp /etc/systemd/journald.conf /etc/systemd/journald.conf.bak.$(date +%Y%m%d)
+# [Journal] セクションの SystemMaxUse を 1G に設定（行が無ければ追記）
+sudo sed -n 's/^#\?SystemMaxUse=.*/SystemMaxUse=1G/p' /etc/systemd/journald.conf  # まず現状確認
+```
+
+`SystemMaxUse=1G` を `[Journal]` セクションに設定（コメントアウト `#SystemMaxUse=` を有効化、
+または無ければ追記）。エディタ作業のため手動編集が確実。設定後:
+
+```bash
+sudo systemctl restart systemd-journald
+journalctl --disk-usage           # 反映確認（1.0G 以下に収束していく）
+sudo journalctl --vacuum-size=1G  # 即時に 1G まで縮小（任意）
+```
+
+---
+
+## 4. 旧 .env ファイルの物理削除（VPS / ローカル）
+
+非推奨の旧 env ファイル（R1: 単独名 `.env.staging` 等）が VPS / ローカルに残っている場合に削除する。
+正式名は `.env.staging-new`（v3 staging）/ `.env.staging-v4`（v4 staging）/ `.env.production`。
+
+> **削除前に必ず中身を確認**し、正式ファイルが別に存在することを確かめてから消すこと。
+
+```bash
+cd /opt/ultra-autotrade
+ls -la .env*                       # 現状の env ファイル一覧
+# 例: 旧 .env.staging（単独名・R1 非推奨）が .env.staging-new と別に残っていれば削除
+#     diff .env.staging .env.staging-new で差分確認 → 不要なら:
+# rm .env.staging
+```
+
+> 自動削除はしない（誤削除防止）。差分確認のうえ手動で。CI 側は committed な実 env ファイルの
+> 混入を `scripts/check_no_committed_env_files.sh`（env-separation-check）で検出する。
+
+---
+
+## 5. 完了確認チェックリスト
+
+- [ ] `/var/log/ultra-autotrade/` 作成済み（chown ultra）
+- [ ] `crontab -l` に `periodic_docker_cleanup`（日曜 04:00）登録
+- [ ] `crontab -l` に `backup_db`（日曜 02:00 / ENVIRONMENT=production）登録
+- [ ] 各スクリプトを手動 1 回実行してログ・出力を確認
+- [ ] `journalctl --disk-usage` が 1G 近辺に収束
+- [ ] 旧 `.env.staging`（単独名）が VPS に残っていれば差分確認のうえ削除
+- [ ] CI: env-separation-check の "Check no real .env files committed" が green
+
+---
+
+*リポジトリ側（スクリプト + 検知 CI）は実装済み。本書は VPS 実行手順のみ。*

--- a/scripts/check_no_committed_env_files.sh
+++ b/scripts/check_no_committed_env_files.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# check_no_committed_env_files.sh — 実 .env ファイルが git に commit されていないか検証する。
+#
+# 許可: .env.*.example テンプレートのみ commit 可。
+# 禁止: 実 env ファイル (.env / .env.production / .env.staging / .env.staging-new /
+#        .env.*.bak / .env.*.backup.* 等) は .gitignore 対象で commit 禁止
+#        (Security Rule 1 = secrets を commit しない / 環境分離)。
+#
+# 旧 env ファイル (例: 非推奨の .env.staging 単独名) が誤って tracked になった場合も
+# 本チェックで検出される。CI (env-separation-check) から呼ばれ、ローカルでも実行可能。
+#
+# Asana 1214696986457078 (.env 旧ファイル削除 + 検知 CI)
+
+set -euo pipefail
+
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# git 管理下の実 .env ファイル (.example テンプレートを除く) を列挙。
+# パターン: パス末尾の構成要素が .env もしくは .env<.|->... で終わり、.example で終わらないもの。
+mapfile -t tracked < <(
+  git ls-files \
+    | grep -E '(^|/)\.env([.-][^/]*)?$' \
+    | grep -vE '\.example$' \
+    || true
+)
+
+if [ "${#tracked[@]}" -gt 0 ]; then
+  echo "::error::実 .env ファイルが git に commit されています (.gitignore / Security Rule 1 違反):"
+  printf '  - %s\n' "${tracked[@]}"
+  echo "実 env ファイルは commit 禁止です。.env.*.example テンプレートのみ commit 可。"
+  echo "対処: git rm --cached <file> で追跡解除し、.gitignore を確認してください。"
+  exit 1
+fi
+
+echo "✅ 実 .env ファイルの commit なし (.env.*.example テンプレートのみ tracked)"


### PR DESCRIPTION
## 概要
VPS 運用 4件のうち **CLI 側で書ける分**を実装。スクリプトは既に揃っており、残りは VPS 実行（cron 登録 / journald / 物理削除 = 3段プロトコル）。「CLI-prep を全部書く」方針に基づく。

## 1. stale-env 検知 CI（Asana 1214696986457078）
- `scripts/check_no_committed_env_files.sh`: 実 env ファイル（旧ファイル含む）が git に commit されていないか検証（`.env.*.example` テンプレートのみ許可）。Security Rule 1 + 環境分離の CI ゲート。ローカル実行可・shellcheck clean。
- `env-separation-check.yml` に `Check no real .env files committed` ステップ追加（既存の docker-compose 旧 staging env 参照チェックと並ぶ）。
- 現状 commit 済み実 env ファイルは **0 件**（CI green）。

## 2. VPS 実行 runbook（`docs/ops/vps_ops_runbook_2026_06.md`）
あなたの 3段プロトコル実行用に copy-paste + 検証コマンドをまとめた:
- Docker 積極 cleanup 週次 cron（`periodic_docker_cleanup.sh`・日曜 04:00）
- DB 週次バックアップ cron（`backup_db.sh`・日曜 02:00・5/2 以降停止の再開）
- journald `SystemMaxUse=1G` 設定手順
- 旧 staging env 物理削除手順（差分確認のうえ手動）
- 本番 VPS パス（`/opt/ultra-autotrade/`・`main/` なし）明記

## スコープ
リポジトリ側（検知 CI + runbook）のみ。実際の cron 登録 / journald 設定 / 物理削除は VPS 実行（あなた・3段プロトコル）。

Asana: 1214696986457078 / 1214954820902281 / 1214702770084840 / 1214988731707550

🤖 Generated with [Claude Code](https://claude.com/claude-code)
