### PR TITLE
fix(privy): policy_mapper の Privy API スキーマ不一致 3 件を修正

### DIFF
--- a/backend/app/privy/delegation_service.py
+++ b/backend/app/privy/delegation_service.py
@@ -92,7 +92,6 @@ def prepare_delegation_policy(
         policy = build_delegation_policy(
             wallet_address=wallet_address,
             allowed_protocols=allowed_protocols,
-            expires_at=expires_at,
             chain_name=chain,
         )
     except PolicyMappingError as exc:

--- a/backend/app/privy/policy_mapper.py
+++ b/backend/app/privy/policy_mapper.py
@@ -10,41 +10,39 @@
 
     Privy policy(本モジュール / TEE enforce):
         - `to` allowlist  = 委譲対象プロトコルのコントラクト（Aave V3 Pool）に限定
-        - `current_unix_timestamp` lte = 委譲枠 expires_at（期限切れ署名を TEE が拒否）
-        - chain_type / 既定 DENY（allowlist 方式）
+        - chain_type（allowlist 方式）
     backend ゲート(2-D-A / risk_limiter / PolicyEngine Rule8):
         - 単一 ≤ 委譲枠% / 日次 ≤ 委譲枠% / HF floor（総資産 × % の絶対額クランプ）
         - allowed_assets の検証・出金経路の除外（proposal routing）
+        - 委譲枠 expires_at の期限チェック（Privy policy は field=current_unix_timestamp を
+          未サポートのため backend 側で enforce する）
 
 **% 上限を Privy policy の value cap に写像しない理由**: 委譲枠は **%** で持ち、絶対額は
 執行時の総資産に依存する（grant 時点では未確定）。よって絶対額クランプは backend
 risk_limiter（2-D-A 配線済）が担う。Privy policy は構造的エンベロープ（宛先 allowlist +
-期限 + chain）を TEE で enforce し、両者の積集合で被害上限を縛る。
+chain）を TEE で enforce し、両者の積集合で被害上限を縛る。
 
 **出金除外**: Phase 2-D の AUTO は SUPPLY 中心。出金（withdraw）は本人署名を維持する不変条件
 のため、委譲経路（scw_executor）が SUPPLY proposal のみを通す（routing で担保）。本 policy の
 `to` は Aave Pool だが、supply/withdraw の判別は Privy 静的条件では困難（calldata 動的参照は
 Privy 未サポート＝wallet_policy.py 注記）。よって出金除外は backend routing で enforce する。
 
-**Privy policy schema 出典**: `docs/ops/v4_phase1_session_signer_spike.md` §2
-（version 1.0 / chain_type=ethereum / rules[] / method=eth_signUserOperation・eth_sendTransaction /
-conditions: to・current_unix_timestamp）+ Privy API reference「Create policy」。
+**Privy policy schema 出典**: Privy API reference「Create policy」（実機検証 2026-06-23）。
+有効な condition field は `to | value | chain_id` のみ。`default_action` キーは未サポート。
 本 module は dormant（L1 で実 Privy に投げる前に live 受理検証する。rest_client と同じ運用）。
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Any
 
 from app.aave.chains import get_chain_config
 
-# Privy policy engine v1 定数（spike doc §2 / Privy API reference 準拠）
+# Privy policy engine v1 定数（Privy API reference / 実機検証 2026-06-23 準拠）
 _POLICY_VERSION = "1.0"
 _CHAIN_TYPE = "ethereum"
 _FIELD_SOURCE_TX = "ethereum_transaction"
 _ACTION_ALLOW = "ALLOW"
-_ACTION_DENY = "DENY"
 
 # 委譲経路が署名する method（UserOp 署名 = 経路A の本丸 / 直 tx も許容）
 _DELEGATED_METHODS = ("eth_signUserOperation", "eth_sendTransaction")
@@ -93,46 +91,33 @@ def _to_condition(contracts: list[str]) -> dict[str, Any]:
     return {**base, "operator": "in", "value": contracts}
 
 
-def _expiry_condition(expires_at: datetime) -> dict[str, Any]:
-    """期限条件（current_unix_timestamp <= expires_at の unix 秒）。"""
-    if expires_at.tzinfo is None:
-        expires_at = expires_at.replace(tzinfo=timezone.utc)
-    expires_unix = int(expires_at.timestamp())
-    return {
-        "field_source": _FIELD_SOURCE_TX,
-        "field": "current_unix_timestamp",
-        "operator": "lte",
-        "value": str(expires_unix),
-    }
-
-
 def build_delegation_policy(
     *,
     wallet_address: str,
     allowed_protocols: list[str],
-    expires_at: datetime,
     chain_name: str,
     policy_name: str | None = None,
 ) -> dict[str, Any]:
     """委譲枠 → Privy policy 作成 body（`PrivyRestClient.create_policy()` 入力）。
 
-    生成される policy は「許可コントラクト宛 かつ 期限内」の署名のみ ALLOW、それ以外は
-    既定 DENY。% 上限・allowed_assets・出金除外は backend ゲート側で enforce する（module
+    生成される policy は「許可コントラクト宛」の署名のみ ALLOW（宛先 allowlist）。
+    % 上限・allowed_assets・出金除外・期限 enforce は backend ゲート側で担う（module
     docstring 参照）。写像不能（未対応プロトコル / 不正チェーン）は PolicyMappingError。
 
     :param wallet_address: 委譲対象ウォレット（policy name の監査用識別子）
     :param allowed_protocols: 委譲枠の許可プロトコル（Phase 2-D は ["aave"] のみ解決可能）
-    :param expires_at: 委譲枠の失効時刻（naive は UTC 扱い）
     :param chain_name: 執行チェーン名（"base" 本番 / "base_sepolia" staging）
-    :param policy_name: 任意の policy 表示名（未指定なら wallet/chain から生成）
+    :param policy_name: 任意の policy 表示名（未指定なら wallet 短縮形/chain から生成、50文字以内）
     """
     if not wallet_address.strip():
         raise PolicyMappingError("wallet_address must not be empty")
 
     contracts = resolve_protocol_contracts(allowed_protocols, chain_name)
-    conditions = [_to_condition(contracts), _expiry_condition(expires_at)]
+    conditions = [_to_condition(contracts)]
 
-    name = policy_name or f"uata-delegation-{wallet_address.lower()}-{chain_name}"
+    # Privy policy name は 50 文字制限。wallet を先頭 6 + 末尾 4 文字に短縮して収める。
+    wallet_abbrev = f"{wallet_address[:6]}...{wallet_address[-4:]}".lower()
+    name = policy_name or f"uata-delegation-{wallet_abbrev}-{chain_name}"
     rules = [
         {
             "name": f"allow-{method}-within-scope",
@@ -147,5 +132,4 @@ def build_delegation_policy(
         "name": name,
         "chain_type": _CHAIN_TYPE,
         "rules": rules,
-        "default_action": _ACTION_DENY,
     }

--- a/backend/tests/test_privy_delegation_service.py
+++ b/backend/tests/test_privy_delegation_service.py
@@ -85,10 +85,10 @@ def test_prepare_success_returns_ids(enabled_env: None) -> None:
         )
     assert policy_id == "policy_abc"
     assert signer_id == "kq_server_1"
-    # create_policy に渡る body が Privy policy schema
+    # create_policy に渡る body が Privy policy schema（default_action は未サポート）
     sent = fake.create_policy.call_args.args[0]
     assert sent["version"] == "1.0"
-    assert sent["default_action"] == "DENY"
+    assert "default_action" not in sent
 
 
 def test_prepare_mapping_error_wrapped(enabled_env: None) -> None:

--- a/backend/tests/test_privy_policy_mapper.py
+++ b/backend/tests/test_privy_policy_mapper.py
@@ -2,14 +2,13 @@
 # backend/tests/test_privy_policy_mapper.py
 """policy_mapper の単体テスト（v4 Phase 2-D-B.2 / L1 写像）。
 
-委譲枠 → Privy policy(v1.0) の写像が schema どおり（version/chain_type/rules/conditions/
-default_action）であること、未対応プロトコル・不正入力で fail-closed すること、期限が
-unix 秒条件に正しく落ちることを検証する。実 Privy への投入（live 受理）は L1 で別途実施。
+委譲枠 → Privy policy(v1.0) の写像が Privy 実機受理スキーマどおり（version/chain_type/
+rules/conditions）であること、未対応プロトコル・不正入力で fail-closed すること、
+50 文字超 policy name・未サポートフィールドが生成されないことを検証する。
+実 Privy への投入（live 受理）は L1 で別途実施。
 """
 
 from __future__ import annotations
-
-from datetime import datetime, timezone
 
 import pytest
 
@@ -20,7 +19,6 @@ from app.privy.policy_mapper import (
     resolve_protocol_contracts,
 )
 
-_EXPIRES = datetime(2026, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
 _WALLET = "0x1234567890123456789012345678901234567890"
 
 
@@ -54,13 +52,16 @@ def test_build_policy_top_level_schema() -> None:
     policy = build_delegation_policy(
         wallet_address=_WALLET,
         allowed_protocols=["aave"],
-        expires_at=_EXPIRES,
         chain_name="base",
     )
     assert policy["version"] == "1.0"
     assert policy["chain_type"] == "ethereum"
-    assert policy["default_action"] == "DENY"
-    assert _WALLET.lower() in policy["name"]
+    # Privy schema に default_action は存在しない（Bug 3 修正）
+    assert "default_action" not in policy
+    # name は wallet 短縮形を含み 50 文字以内（Bug 1 修正）
+    assert _WALLET[:6].lower() in policy["name"]
+    assert _WALLET[-4:].lower() in policy["name"]
+    assert len(policy["name"]) <= 50
     # 委譲 method ごとに 1 ALLOW rule
     methods = {r["method"] for r in policy["rules"]}
     assert methods == {"eth_signUserOperation", "eth_sendTransaction"}
@@ -72,7 +73,6 @@ def test_build_policy_to_allowlist_condition() -> None:
     policy = build_delegation_policy(
         wallet_address=_WALLET,
         allowed_protocols=["aave"],
-        expires_at=_EXPIRES,
         chain_name="base",
     )
     rule = policy["rules"][0]
@@ -83,38 +83,33 @@ def test_build_policy_to_allowlist_condition() -> None:
     assert to_cond["field_source"] == "ethereum_transaction"
 
 
-def test_build_policy_expiry_condition_unix() -> None:
+def test_build_policy_no_expiry_condition() -> None:
+    """current_unix_timestamp は Privy policy で未サポート → 条件に含まれない（Bug 2 修正）。"""
     policy = build_delegation_policy(
         wallet_address=_WALLET,
         allowed_protocols=["aave"],
-        expires_at=_EXPIRES,
         chain_name="base",
     )
-    rule = policy["rules"][0]
-    exp_cond = next(c for c in rule["conditions"] if c["field"] == "current_unix_timestamp")
-    assert exp_cond["operator"] == "lte"
-    assert exp_cond["value"] == str(int(_EXPIRES.timestamp()))
+    for rule in policy["rules"]:
+        assert not any(c.get("field") == "current_unix_timestamp" for c in rule["conditions"]), (
+            "current_unix_timestamp は Privy 未サポートフィールド"
+        )
 
 
-def test_build_policy_naive_expiry_treated_as_utc() -> None:
-    naive = datetime(2026, 7, 1, 0, 0, 0)
+def test_build_policy_name_under_50_chars() -> None:
+    """最長チェーン名 base_sepolia でも 50 文字以内（Bug 1 修正）。"""
     policy = build_delegation_policy(
         wallet_address=_WALLET,
         allowed_protocols=["aave"],
-        expires_at=naive,
-        chain_name="base",
+        chain_name="base_sepolia",
     )
-    exp_cond = next(
-        c for c in policy["rules"][0]["conditions"] if c["field"] == "current_unix_timestamp"
-    )
-    assert exp_cond["value"] == str(int(_EXPIRES.timestamp()))
+    assert len(policy["name"]) <= 50
 
 
 def test_build_policy_custom_name() -> None:
     policy = build_delegation_policy(
         wallet_address=_WALLET,
         allowed_protocols=["aave"],
-        expires_at=_EXPIRES,
         chain_name="base",
         policy_name="my-policy",
     )
@@ -126,7 +121,6 @@ def test_build_policy_empty_wallet_raises() -> None:
         build_delegation_policy(
             wallet_address="  ",
             allowed_protocols=["aave"],
-            expires_at=_EXPIRES,
             chain_name="base",
         )
 
@@ -136,6 +130,5 @@ def test_build_policy_unsupported_protocol_raises() -> None:
         build_delegation_policy(
             wallet_address=_WALLET,
             allowed_protocols=["aave", "pendle"],
-            expires_at=_EXPIRES,
             chain_name="base",
         )


### PR DESCRIPTION
## Summary

staging-v4 実機検証（2026-06-23）で `POST /api/user/delegation/prepare` が Privy から 400 を返すことを発見。`policy_mapper.py` の Privy policy 生成ロジックにスキーマ不一致が 3 件あり修正。

- **Bug 1**: policy `name` が 50 文字超（`uata-delegation-{42char_wallet}-{chain}` = 71文字）→ wallet を先頭6+末尾4文字に短縮（42文字以内）
- **Bug 2**: `current_unix_timestamp` が Privy policy の `field` に未サポート（許容値: `to | value | chain_id` のみ）→ 条件を削除。期限 enforce は backend grant expiry check で担保
- **Bug 3**: `default_action` キーが Privy policy schema に存在しない → 削除

## Test plan

- [x] `test_build_policy_no_expiry_condition` 追加（Bug 2 リグレッション防止）
- [x] `test_build_policy_name_under_50_chars` 追加（Bug 1 リグレッション防止）
- [x] `test_build_policy_top_level_schema` を更新（`default_action not in policy` へ変更）
- [x] ruff / mypy 全 pass
- [x] pytest 4457 passed, 21 skipped
- [x] staging-v4 実機: `POST /api/user/delegation/prepare` → 200 + `privy_policy_id=uw6s2eu1xlc596y4k30cfh8c` / `privy_signer_id=awo18tp7hq3jxt4p0iy7ymuo`
- [x] Asana 1215890808157196 にコメント報告済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGdyDsfnbBVb32MSR9dr4E