### PR TITLE
fix(i18n): terms/privacy が日本語ユーザーに英語で表示されるバグを修正

### DIFF
--- a/frontend/e2e/partner-proposals-i18n.spec.ts
+++ b/frontend/e2e/partner-proposals-i18n.spec.ts
@@ -8,7 +8,7 @@
  *   TC2: /partner/proposals に JP pageTitle "AI提案管理" が存在する
  *        認証ゲートで到達できない場合は gracefully skip
  *   TC3: /partner/proposals に EN pageTitle "AI Proposal Management" が存在する
- *        （accept-language: en ヘッダー付きリクエスト / 認証ゲートで到達不能なら skip）
+ *        （NEXT_LOCALE=en cookie 設定 / 認証ゲートで到達不能なら skip）
  *   TC4: NextIntlClientProvider が runtime エラーを起こさず DOM が構築される
  *        （runtime error overlay または uncaught IntlError が存在しないことを確認）
  *
@@ -46,14 +46,17 @@ test.describe('[partner-proposals-i18n] /partner/proposals i18n smoke', () => {
     await expect(jpTitle).toBeVisible()
   })
 
-  test('TC3: EN Accept-Language - "AI Proposal Management" が DOM に存在する', async ({
+  test('TC3: NEXT_LOCALE=en cookie - "AI Proposal Management" が DOM に存在する', async ({
     browser,
   }) => {
-    // EN ロケールを accept-language で指定して新しいコンテキストを作成
-    const context = await browser.newContext({
-      locale: 'en-US',
-      extraHTTPHeaders: { 'Accept-Language': 'en-US,en;q=0.9' },
-    })
+    // middleware は NEXT_LOCALE cookie のみで locale を決定する（Accept-Language は不使用）。
+    // liff.openWindow({external:true}) で開いた外部ブラウザが LINE WebView の cookie を
+    // 引き継がず、Accept-Language 依存で日本語ユーザーに英語が表示されるバグの修正に伴い変更。
+    const COOKIE_DOMAIN = new URL(process.env.STAGING_URL || 'https://app.ultra-auto-trade.com').hostname
+    const context = await browser.newContext()
+    await context.addCookies([
+      { name: 'NEXT_LOCALE', value: 'en', domain: COOKIE_DOMAIN, path: '/' },
+    ])
     const page = await context.newPage()
 
     const res = await page.goto(PROPOSALS_URL, { waitUntil: 'domcontentloaded' })

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -3,16 +3,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 export function middleware(request: NextRequest) {
-  // Check cookie first (user explicit choice), then Accept-Language header
+  // Locale source: explicit NEXT_LOCALE cookie only (user's in-app choice via useLanguage).
+  // Accept-Language is intentionally NOT used: this is a Japan-primary app, and when
+  // liff.openWindow({external:true}) opens /terms or /privacy-policy in the device's
+  // default browser, that browser does not share cookies with LINE's WebView.
+  // Relying on Accept-Language showed English to Japanese users whose external browser
+  // is English-primary. Default is 'ja' unless user explicitly toggled via setLanguage().
   const cookieLocale = request.cookies.get('NEXT_LOCALE')?.value
-  let locale = 'ja' // default
-
-  if (cookieLocale === 'en' || cookieLocale === 'ja') {
-    locale = cookieLocale
-  } else {
-    const acceptLang = request.headers.get('accept-language') || ''
-    locale = acceptLang.toLowerCase().startsWith('en') ? 'en' : 'ja'
-  }
+  const locale = (cookieLocale === 'en' || cookieLocale === 'ja') ? cookieLocale : 'ja'
 
   const response = NextResponse.next()
   response.headers.set('x-locale', locale)


### PR DESCRIPTION
## 問題

v3 liff-chat で「利用規約」「プライバシーポリシー」ボタンをタップすると英語ページが表示される。

## 根本原因

`TermsPanel.tsx` は `liff.openWindow({external:true})` で `/terms` `/privacy-policy` を **外部ブラウザ**（Safari/Chrome）で開く。この外部ブラウザは LINE WebView のセッションとは別コンテキストのため、`useLanguage.tsx` が LINE WebView 側に書き込んだ `NEXT_LOCALE` cookie を引き継がない。

`middleware.ts` は cookie が無い場合に `Accept-Language` ヘッダーで locale を判定していたため、iOS を英語で設定している日本ユーザーの Safari が `en-US,...` を送ると middleware が `en` を返し、英語コンテンツが表示されていた。

```
LINE WebView (NEXT_LOCALE=ja) → liff.openWindow → Safari (cookie なし)
                                                   → Accept-Language: en-US
                                                   → middleware: locale=en
                                                   → 英語の利用規約表示 ❌
```

## 修正

**`frontend/middleware.ts`**: `Accept-Language` 自動検出を廃止。日本語優先市場向けアプリとして、locale は `NEXT_LOCALE` cookie の明示的なユーザー選択のみで決定する。cookie 無し = デフォルト `ja`。

```ts
// Before: Accept-Language が 'en' で始まれば自動で英語
const acceptLang = request.headers.get('accept-language') || ''
locale = acceptLang.toLowerCase().startsWith('en') ? 'en' : 'ja'

// After: NEXT_LOCALE cookie のみ、デフォルト ja
const locale = (cookieLocale === 'en' || cookieLocale === 'ja') ? cookieLocale : 'ja'
```

英語切り替えは `setLanguage('en')` → `NEXT_LOCALE=en` cookie で引き続き動作。

**`e2e/partner-proposals-i18n.spec.ts` TC3**: Accept-Language ヘッダー依存から `NEXT_LOCALE=en` cookie 方式に変更（middleware の変更に合わせて同期）。

## 影響範囲

| ケース | Before | After |
|---|---|---|
| 日本語ブラウザ (ja Accept-Language) | ja ✅ | ja ✅ |
| 英語優先ブラウザ (en Accept-Language、cookie なし) | en ❌ 今回の不具合 | ja ✅ 修正 |
| 英語切り替え済み (NEXT_LOCALE=en cookie) | en ✅ | en ✅ |
| 外部ブラウザ (cookie なし、LINE WebView から開く) | en ❌ | ja ✅ 修正 |

## テスト計画

- [ ] staging-v4 で liff-chat → 利用規約 → 外部ブラウザで日本語テキスト「Ultra AutoTrade 利用規約」を確認
- [ ] NEXT_LOCALE=en cookie を設定した状態で /terms アクセス → 英語テキスト "Ultra AutoTrade Terms of Service" を確認
- [ ] E2E `partner-proposals-i18n.spec.ts` TC3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGdyDsfnbBVb32MSR9dr4E