### PR TITLE
fix(deploy): .env 読み込みを値スペース耐性化（PRIVY_VERIFICATION_KEY PEM でデプロイ中断する不具合）

### DIFF
--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -481,8 +481,17 @@ log "git pull origin main"
 git pull origin main
 
 log ".env.production を読み込み（ビルド ARG 用）"
-# shellcheck disable=SC2046
-export $(grep -v '^#' "${ENV_FILE}" | grep '=' | xargs)
+# 値にスペース/特殊文字を含む行（例: PRIVY_VERIFICATION_KEY の PEM 公開鍵
+# "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----"）でも壊れないよう、
+# 1 行ずつ KEY=VALUE 全体を単一引数として export する。
+# 旧実装 `export $(grep ... | xargs)` は xargs の空白分割で
+# "BEGIN PUBLIC KEY" が複数トークンに割れ "not a valid identifier" で失敗していた。
+while IFS= read -r _envline || [[ -n "${_envline}" ]]; do
+  [[ -z "${_envline}" || "${_envline}" == \#* ]] && continue
+  [[ "${_envline}" != *=* ]] && continue
+  export "${_envline%%=*}=${_envline#*=}"
+done < "${ENV_FILE}"
+unset _envline
 
 # デプロイ版識別子: PostHog の app_version（全イベント super property）に git short SHA を埋め込む。
 # バージョンアップ前後の行動比較を可能にする。git 失敗時は dev フォールバック。

--- a/scripts/deploy_staging.sh
+++ b/scripts/deploy_staging.sh
@@ -324,8 +324,15 @@ log "git pull origin main"
 git pull origin main
 
 log "${ENV_FILE} を読み込み（ビルド ARG 用）"
-# shellcheck disable=SC2046
-export $(grep -v '^#' "${ENV_FILE}" | grep '=' | xargs)
+# 値にスペース/特殊文字を含む行（例: PRIVY_VERIFICATION_KEY の PEM 公開鍵）でも壊れないよう、
+# 1 行ずつ KEY=VALUE 全体を単一引数として export する。
+# 旧実装 `export $(grep ... | xargs)` は xargs の空白分割で失敗していた。
+while IFS= read -r _envline || [[ -n "${_envline}" ]]; do
+  [[ -z "${_envline}" || "${_envline}" == \#* ]] && continue
+  [[ "${_envline}" != *=* ]] && continue
+  export "${_envline%%=*}=${_envline#*=}"
+done < "${ENV_FILE}"
+unset _envline
 
 # デプロイ版識別子: PostHog の app_version（全イベント super property）に git short SHA を埋め込む。
 # バージョンアップ前後の行動比較を可能にする。git 失敗時は dev フォールバック。

--- a/scripts/deploy_staging_v4.sh
+++ b/scripts/deploy_staging_v4.sh
@@ -176,8 +176,15 @@ log "git pull origin main"
 git pull origin main
 
 log "${ENV_FILE} を読み込み（ビルド ARG 用）"
-# shellcheck disable=SC2046
-export $(grep -v '^#' "${ENV_FILE}" | grep '=' | xargs)
+# 値にスペース/特殊文字を含む行（例: PRIVY_VERIFICATION_KEY の PEM 公開鍵）でも壊れないよう、
+# 1 行ずつ KEY=VALUE 全体を単一引数として export する。
+# 旧実装 `export $(grep ... | xargs)` は xargs の空白分割で失敗していた。
+while IFS= read -r _envline || [[ -n "${_envline}" ]]; do
+  [[ -z "${_envline}" || "${_envline}" == \#* ]] && continue
+  [[ "${_envline}" != *=* ]] && continue
+  export "${_envline%%=*}=${_envline#*=}"
+done < "${ENV_FILE}"
+unset _envline
 
 # デプロイ版識別子: PostHog の app_version に git short SHA を埋め込む。
 export NEXT_PUBLIC_APP_VERSION="$(git rev-parse --short HEAD 2>/dev/null || echo dev)"


### PR DESCRIPTION
## 背景 / 症状

production の `--frontend-only` デプロイが、frontend ビルド開始前に以下で中断していた:

```
./scripts/deploy_production.sh: line 485: export: `KEY-----nMFkw...==n-----END': not a valid identifier
```

`app.ultra-auto-trade.com/liff-chat` の UI が staging より古いままだった直接原因。
production frontend image は 2026-06-16 ビルドのまま(BUILD_ID 相異・`Up 7 days`)で、
6/16 以降の liff-chat 変更が再デプロイできていなかった。

## 真因

`.env.production` に v4 Privy 委譲署名用の検証公開鍵が追加された:

```
PRIVY_VERIFICATION_KEY=-----BEGIN PUBLIC KEY-----\nMFkw...==\n-----END PUBLIC KEY-----
```

デプロイスクリプトの読み込みが `export $(grep -v '^#' "${ENV_FILE}" | grep '=' | xargs)` で、
`xargs` が値中の `BEGIN PUBLIC KEY` のスペースで分割 → `export KEY-----...` が
`not a valid identifier` で失敗 → `set -euo pipefail` でビルド前に停止していた。

## 修正

`.env.production` は**一切変更せず**、スクリプト側の読み込みを 1 行ずつ
`KEY=VALUE` 全体を単一引数として `export` する方式に置換。値にスペース/特殊文字が
入っても壊れない。

- `.env.production` を触らないため `env_file:` 経由で backend に渡る値はバイト単位で不変
  （docker-compose の env_file クォート処理のバージョン依存差を回避＝Privy 認証を壊さない）
- 同一の脆弱パターンを持つ `deploy_staging.sh` / `deploy_staging_v4.sh` も横展開で統一

## 検証

- `bash -n` 構文チェック: 3 本とも PASS
- 実 PEM 値を含むテスト env で挙動確認: `not a valid identifier` 消失、値が単一引数として保持、EXIT=0
- `.env.production` は無変更

## デプロイ

マージ後、本番 VPS で `git pull origin main` → `./scripts/deploy_production.sh --frontend-only`
で liff-chat が最新化される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)