### PR TITLE
fix(auth): PRIVY_VERIFICATION_KEY の \n リテラルを実改行へ正規化（静的鍵設定で Privy ログインが全件 500 になる不具合）

### DIFF
--- a/backend/app/auth/privy_verifier.py
+++ b/backend/app/auth/privy_verifier.py
@@ -245,6 +245,15 @@ def get_privy_verifier() -> Optional[PrivyVerifier]:
         if not app_id:
             return None
         verification_key = os.getenv("PRIVY_VERIFICATION_KEY") or None
+        if verification_key:
+            # .env では PEM を 1 行で持つため改行を "\n" リテラルでエスケープしている
+            # (例: "-----BEGIN PUBLIC KEY-----\nMFkw...\n-----END PUBLIC KEY-----")。
+            # pyjwt/cryptography の PEM パーサは実改行を要求し、リテラル "\n" のままだと
+            # `ValueError: Unable to load PEM file` を raise する。これは verify_id_token の
+            # except 節 (InvalidTokenError 系) で捕捉されず HTTP 500 になり、かつ
+            # verification_key が真値のため JWKS フォールバックにも入らない。
+            # ここで実改行へ正規化する (実改行で渡された値には影響しない)。
+            verification_key = verification_key.replace("\\n", "\n")
         jwks_url = os.getenv("PRIVY_JWKS_URL") or None
         _default_verifier = PrivyVerifier(
             app_id=app_id,

--- a/backend/tests/auth/test_wallet_connect.py
+++ b/backend/tests/auth/test_wallet_connect.py
@@ -790,3 +790,49 @@ class TestErrorHandlingFixes:
                 AuthService.create_wallet_user(s2, wallet2, privy_did=did)
             assert exc_info.value.status_code == 409
             assert "did" in str(exc_info.value.detail).lower()
+
+
+class TestPrivyVerificationKeyNewlineNormalization:
+    """PRIVY_VERIFICATION_KEY に "\\n" リテラルが含まれる場合の正規化テスト。
+
+    .env では PEM を 1 行で持つため改行を "\\n" エスケープで格納する。
+    正規化漏れがあると pyjwt が `ValueError: Unable to load PEM file` を
+    raise し、verify_id_token の except 節で捕捉されず HTTP 500 になる
+    (かつ verification_key が真値のため JWKS フォールバックにも入らない)。
+    """
+
+    def test_literal_backslash_n_key_is_normalized_and_verifies(
+        self, privy_keypair: Tuple[bytes, bytes]
+    ) -> None:
+        from app.auth.privy_verifier import get_privy_verifier
+
+        private_pem, public_pem = privy_keypair
+        # 実改行 PEM を 1 行 "\\n" エスケープ形式へ（.env.production と同じ表現）
+        escaped = public_pem.decode("ascii").replace("\n", "\\n")
+        assert "\\n" in escaped and "\n" not in escaped  # リテラルであることを保証
+
+        prev_app_id = os.environ.get("PRIVY_APP_ID")
+        prev_key = os.environ.get("PRIVY_VERIFICATION_KEY")
+        os.environ["PRIVY_APP_ID"] = PRIVY_TEST_APP_ID
+        os.environ["PRIVY_VERIFICATION_KEY"] = escaped
+        reset_privy_verifier()
+        try:
+            verifier = get_privy_verifier()
+            assert verifier is not None
+            # 正規化されて実改行になっていること
+            assert "\n" in verifier.verification_key
+            assert "\\n" not in verifier.verification_key
+
+            token = _make_id_token(private_pem, sub="did:privy:newline-test")
+            # 500 ではなく正常に sub を返せること（PEM パース成功）
+            assert verifier.verify_id_token(token) == "did:privy:newline-test"
+        finally:
+            if prev_app_id is None:
+                os.environ.pop("PRIVY_APP_ID", None)
+            else:
+                os.environ["PRIVY_APP_ID"] = prev_app_id
+            if prev_key is None:
+                os.environ.pop("PRIVY_VERIFICATION_KEY", None)
+            else:
+                os.environ["PRIVY_VERIFICATION_KEY"] = prev_key
+            reset_privy_verifier()


### PR DESCRIPTION
## 背景

PR #862 の調査中に判明した別件。`.env.production` に v4 Privy 委譲署名用の検証公開鍵が
1 行・`\n` エスケープ形式で追加されている:

```
PRIVY_VERIFICATION_KEY=-----BEGIN PUBLIC KEY-----\nMFkw...==\n-----END PUBLIC KEY-----
```

## 真因（実証済み）

`get_privy_verifier()` はこの値を正規化せず `pyjwt.decode` に渡していた。
pyjwt/cryptography の PEM パーサは**実改行を要求**し、リテラル `\n` のままだと
`ValueError: Unable to load PEM file` を raise する。

ローカル実証（pyjwt 2.12.1 / cryptography 46.0.5）:

| 鍵の形式 | prepare_key |
|---|---|
| literal `\n`（.env 現状） | **FAIL — ValueError: Unable to load PEM file** |
| 実改行（正） | OK |

この `ValueError` は `InvalidTokenError` のサブクラスでは**ない**ため、
`verify_id_token` の except 節（401/503 を返す）で捕捉されず **HTTP 500** になる。
さらに `_resolve_public_key` は `verification_key` が真値だと JWKS フォールバックに
入らないため、**静的鍵を設定した瞬間に Privy ログイン検証が全件 500** になる。

> ⚠️ production への影響: backend コンテナは `env_file` を起動時に読む。現在の
> production backend は 2026-06-16 起動のまま（PR #862 参照）なので、この鍵が
> 追加されたのが 6/16 以降なら**まだ顕在化しておらず、次の backend 再起動で発火する潜在地雷**。
> backend 再デプロイ前にこの PR を入れること。

## 修正

env 読込直後に `verification_key.replace("\\n", "\n")` で実改行へ正規化（GCP/Firebase の
鍵-in-env と同じ定石）。実改行で渡された値には影響しない。`.env.production` 側は変更不要。

## 検証

- 新規回帰テスト `TestPrivyVerificationKeyNewlineNormalization`: literal `\n` 鍵が
  正規化されて `verify_id_token` が sub を返すことを確認（修正前は 500 相当の ValueError）
- `pytest tests/auth/test_wallet_connect.py`: **27 passed**
- `ruff check` / `ruff format --check` / `mypy`（privy_verifier.py）: all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)