### PR TITLE
fix(liff): 規約/プライバシーの「戻る」を /connect でなく /liff-chat に戻す

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/TermsPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TermsPanel.tsx
@@ -3,31 +3,37 @@
 
 import { ExternalLink, FileText, Shield } from "lucide-react"
 import { useTranslations } from "next-intl"
+import { useRouter } from "next/navigation"
 
-// 利用規約/プライバシーポリシーは外部ブラウザ (新コンテキスト) で開く。
-// LIFF webview 内で SPA を置換すると liff-chat の履歴が汚れ「戻る」で
-// /liff-approve (パートナートップ) に戻ってしまうため、target=_blank の
-// 素の <a> ではなく liff.openWindow({external:true}) を優先して使用する。
-// liff が無い (通常ブラウザ等) 場合は window.open へフォールバック。
+// 法的文書ページから liff-chat に戻すための return パラメータ。
+// 各文書ページの useSmartBack がこれを最優先で読み「戻る」で /liff-chat へ戻す。
+const RETURN_TO = "/liff-chat"
+
+// 利用規約/プライバシーポリシーへの遷移。
+// - LINE (LIFF webview): 外部ブラウザで開く。LIFF webview 内で SPA を置換すると
+//   liff-chat の履歴が汚れ「戻る」で /liff-approve に飛ぶため liff.openWindow({external:true})。
+// - PWA / 通常ブラウザ: 同一タブで router.push する。新規タブ (window.open) は
+//   認証セッション・履歴を引き継げず「戻る」が fallback `/` → 未認証で /connect に
+//   飛ぶ不具合があったため、同一タブ遷移に変更し ?return=/liff-chat で戻り先を明示する。
 //
-// path は同一オリジン相対 ("/terms" 等) で保持し、openExternal で
-// window.location.origin を前置して絶対 URL 化する。prod ドメインを
-// ハードコードすると staging で開いても本番 (app.ultra-auto-trade.com) に
-// 飛んでしまうため (環境跨ぎバグ)、必ず現在のオリジン基準で解決する。
-function openExternal(path: string) {
-  const url = typeof window !== "undefined" ? `${window.location.origin}${path}` : path
-  if (
-    typeof window !== "undefined" &&
-    (window as Window & { liff?: { openWindow: (opts: { url: string; external: boolean }) => void } }).liff
-  ) {
-    (window as Window & { liff?: { openWindow: (opts: { url: string; external: boolean }) => void } }).liff?.openWindow({ url, external: true })
+// path は同一オリジン相対 ("/terms" 等) で保持。LINE 経路のみ window.location.origin を
+// 前置して絶対 URL 化する (prod ドメインのハードコードは環境跨ぎバグの元なので避ける)。
+function openDoc(router: ReturnType<typeof useRouter>, path: string) {
+  const href = `${path}?return=${encodeURIComponent(RETURN_TO)}`
+  const liff =
+    typeof window !== "undefined"
+      ? (window as Window & { liff?: { openWindow: (opts: { url: string; external: boolean }) => void } }).liff
+      : undefined
+  if (liff) {
+    liff.openWindow({ url: `${window.location.origin}${href}`, external: true })
   } else {
-    window.open(url, "_blank", "noopener,noreferrer")
+    router.push(href)
   }
 }
 
 export function TermsPanel() {
   const t = useTranslations("Liff.panels.terms")
+  const router = useRouter()
 
   const links = [
     {
@@ -51,7 +57,7 @@ export function TermsPanel() {
         <button
           key={href}
           type="button"
-          onClick={() => openExternal(href)}
+          onClick={() => openDoc(router, href)}
           className="flex items-center gap-3 w-full ax-card-warm hover:bg-black/5 px-4 py-4 rounded-xl transition-colors text-left"
         >
           <Icon className="w-5 h-5 text-[#1D9E75] flex-shrink-0" />

--- a/frontend/hooks/useSmartBack.ts
+++ b/frontend/hooks/useSmartBack.ts
@@ -11,22 +11,32 @@ import { useRouter } from 'next/navigation'
  * 設定画面・LIFF webview 等）からリンクされる法的文書ページで使う。
  *
  * 挙動:
- * - ブラウザ履歴がある場合（同一タブ遷移）は `router.back()` で「来訪元」に戻す。
- *   これにより /signup から開いて戻ると /signup に、/connect から開いて戻ると
- *   /connect に戻る（従来は遷移先が /connect 固定で、/signup 等から開くと
- *   無関係なウォレット接続画面に飛ばされていた）。
- * - 履歴が無い場合（`target="_blank"` で別タブが開かれた、ブックマーク等で直接
- *   URL を開いた）は戻り先が存在しないため、安全な `fallback`（既定はトップ `/`）へ。
+ * 挙動（優先順）:
+ * 1. URL に `?return=<path>` がある場合はそこへ `router.push`（最優先）。
+ *    liff-chat 等から新規タブ／新規履歴で開かれると router.back() が来訪元に戻れず
+ *    （history.length=1 → fallback `/` → 未認証だと /connect に飛ぶ）問題になるため、
+ *    呼び出し側が戻り先を明示できるようにする。open-redirect 防止のため同一オリジンの
+ *    相対パス（`/` 始まり・`//` 除外）のみ許可する。
+ * 2. ブラウザ履歴がある場合（同一タブ遷移）は `router.back()` で「来訪元」に戻す。
+ *    これにより /signup から開いて戻ると /signup に、/connect から開いて戻ると /connect に戻る。
+ * 3. 履歴が無い場合（別タブ・ブックマーク直開き等）は安全な `fallback`（既定はトップ `/`）へ。
  *
- * @param fallback 履歴が無いときの遷移先（既定 `/`）
+ * @param fallback 履歴も `?return` も無いときの遷移先（既定 `/`）
  */
 export function useSmartBack(fallback = '/') {
   const router = useRouter()
   return useCallback(() => {
-    if (typeof window !== 'undefined' && window.history.length > 1) {
-      router.back()
-    } else {
-      router.push(fallback)
+    if (typeof window !== 'undefined') {
+      const ret = new URLSearchParams(window.location.search).get('return')
+      if (ret && ret.startsWith('/') && !ret.startsWith('//')) {
+        router.push(ret)
+        return
+      }
+      if (window.history.length > 1) {
+        router.back()
+        return
+      }
     }
+    router.push(fallback)
   }, [router, fallback])
 }


### PR DESCRIPTION
## 症状
production(PWA)の liff-chat で「利用規約」「プライバシーポリシー」を開き「戻る」を押すと
`/liff-chat` ではなく `/connect`(ウォレット接続画面)に飛んでしまう。

## 真因
`TermsPanel` が PWA でも `window.open(url, "_blank")` で**新規タブ**を開いていた。

1. 新規タブは履歴(`history.length=1`)も認証セッションも引き継げない
2. `useSmartBack` は履歴が無いと fallback `/` へ
3. ルート `app/page.tsx` は未認証だと `router.replace('/connect')`

→ 「戻る」が `/connect` に着地。

## 修正
- **`TermsPanel`**: PWA/通常ブラウザでは**同一タブ遷移**(`router.push`)に変更し認証・履歴を保持。URL に `?return=/liff-chat` を付与。LINE(LIFF webview)は従来の `liff.openWindow({external:true})`(liff-chat 履歴汚染回避)を維持しつつ return を付与。
- **`useSmartBack`**: クリック時に `?return=<path>` があれば最優先で `router.push`。open-redirect 防止のため**同一オリジン相対パス**(`/` 始まり・`//` 除外)のみ許可。無ければ従来の `back()`/fallback。

→ liff-chat → 規約/プライバシー → 戻る → **/liff-chat** に戻る。

## 影響範囲
- `useSmartBack` は terms / privacy-policy / risk-disclosure の3ページで使用。`?return` が無ければ挙動は完全に従来通りなので、`/connect`・`/signup` 等からの既存導線は無変更。

## 検証
- `npm run build` 成功(全ルート出力・postbuild 完走)
- 変更ファイルの型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)