### PR TITLE
feat(v4): Round 3 — Phase-C1 / Phase-C2 / Phase-C3 / MARKET-B

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/ProposalActionCard.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/ProposalActionCard.tsx
@@ -3,9 +3,10 @@
 // 保留中の AI 提案を arobix カードで表示し、承認 (→署名シート) / 見送り を提供する。
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { useTranslations } from "next-intl"
 import { ArrowUp, ArrowDown } from "lucide-react"
+import { liffFetch } from "@/lib/liff/liff-fetch"
 import type { ChatProposal } from "./ProposalSignSheet"
 
 interface ProposalActionCardProps {
@@ -24,8 +25,32 @@ export function ProposalActionCard({
   const t = useTranslations("Liff")
   const [expanded, setExpanded] = useState(false)
 
-  const isSupply = proposal.operation === "SUPPLY"
-  const OperationIcon = isSupply ? ArrowUp : ArrowDown
+  // operation 種別ごとの表示設定（マルチプロトコル対応 / Phase-C2）。
+  const operationConfig: Record<
+    string,
+    { label: string; color: string; icon: typeof ArrowUp }
+  > = {
+    SUPPLY: { label: t("exec.supply"), color: "text-[#1D9E75]", icon: ArrowUp },
+    WITHDRAW: { label: t("exec.withdraw"), color: "text-red-600", icon: ArrowDown },
+    STAKE_ETH: { label: t("exec.stakeEth"), color: "text-[#1D9E75]", icon: ArrowUp },
+    UNSTAKE_ETH: { label: t("exec.unstakeEth"), color: "text-red-600", icon: ArrowDown },
+    BUY_PT: { label: t("exec.buyPt"), color: "text-[#1D9E75]", icon: ArrowUp },
+    SELL_PT: { label: t("exec.sellPt"), color: "text-red-600", icon: ArrowDown },
+  }
+  const config = operationConfig[proposal.operation] ?? operationConfig["SUPPLY"]
+  const OperationIcon = config.icon
+
+  // MARKET-B: lido/pendle 提案のときのみ ETH/USD を取得してバッジ表示する。
+  const isEthProposal = proposal.protocol === "lido" || proposal.protocol === "pendle"
+  const [ethUsd, setEthUsd] = useState<string | null>(null)
+  useEffect(() => {
+    if (!isEthProposal) return
+    liffFetch("/api/market/prices")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => setEthUsd(d?.eth_usd ?? null))
+      .catch(() => {})
+  }, [isEthProposal])
+
   const amountUsd = Number(proposal.amount_usd).toLocaleString("ja-JP", {
     style: "currency",
     currency: "USD",
@@ -43,15 +68,25 @@ export function ProposalActionCard({
     <div className="ax-card-warm rounded-2xl mx-4 mt-4 p-4 border-2 border-[#1D9E75]/40">
       {/* header */}
       <div className="flex items-center gap-2 mb-2">
-        <span
-          className={`flex items-center gap-1 text-sm font-bold ${
-            isSupply ? "text-[#1D9E75]" : "text-red-600"
-          }`}
-        >
+        <span className={`flex items-center gap-1 text-sm font-bold ${config.color}`}>
           <OperationIcon className="w-4 h-4" />
-          {isSupply ? t("exec.supply") : t("exec.withdraw")}
+          {config.label}
         </span>
         <span className="text-[#1c1a27] text-sm font-semibold">{proposal.asset}</span>
+        <div className="ml-auto flex items-center gap-1.5">
+          {/* MARKET-B: ETH 価格バッジ（lido/pendle 提案時のみ / API 失敗時はサイレントスキップ） */}
+          {isEthProposal && ethUsd && (
+            <span className="text-xs text-[#736f7e] bg-[#1c1a27]/5 px-2 py-0.5 rounded-full">
+              1 ETH ≈ ${Number(ethUsd).toLocaleString("en-US", { maximumFractionDigits: 0 })}
+            </span>
+          )}
+          {/* Phase-C2: protocol バッジ（aave 以外のとき表示） */}
+          {proposal.protocol && proposal.protocol !== "aave" && (
+            <span className="text-xs bg-[#1c1a27]/10 px-2 py-0.5 rounded-full text-[#736f7e]">
+              {proposal.protocol}
+            </span>
+          )}
+        </div>
       </div>
 
       {/* amount */}

--- a/frontend/app/(liff)/liff-chat/_components/ProposalSignSheet.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/ProposalSignSheet.tsx
@@ -28,11 +28,12 @@ function toCall(tx: UnsignedTx): { to: `0x${string}`; data: `0x${string}`; value
 // confidence は ai_decision 由来で ProposalResponse には含まれないため optional。
 export interface ChatProposal {
   id: number
-  operation: "SUPPLY" | "WITHDRAW"
+  operation: "SUPPLY" | "WITHDRAW" | "STAKE_ETH" | "UNSTAKE_ETH" | "BUY_PT" | "SELL_PT"
   asset: string
   amount: string
   amount_usd: string
   reason: string
+  protocol?: string // "aave" | "lido" | "pendle"
   expected_hf_after: string | null
   estimated_gas_usd: string | null
   confidence?: number
@@ -186,6 +187,19 @@ export function ProposalSignSheet({
   const isBusy = signingStatus === "signing" || signingStatus === "confirming"
   const isSupply = proposal.operation === "SUPPLY"
 
+  // operation 種別ごとの表示ラベル（マルチプロトコル対応 / Phase-C3）。
+  const operationLabel: Record<string, string> = {
+    SUPPLY: t("supply"),
+    WITHDRAW: t("withdraw"),
+    STAKE_ETH: t("stakeEth"),
+    UNSTAKE_ETH: t("unstakeEth"),
+    BUY_PT: t("buyPt"),
+    SELL_PT: t("sellPt"),
+  }
+  const operationDisplayLabel = operationLabel[proposal.operation] ?? proposal.operation
+  // 入金系（資金投入）= 緑 / 出金系（引き出し）= 赤
+  const isInflowOperation = ["SUPPLY", "STAKE_ETH", "BUY_PT"].includes(proposal.operation)
+
   return (
     <div className="fixed inset-0 z-50 flex items-end justify-center">
       <div
@@ -201,8 +215,14 @@ export function ProposalSignSheet({
         {/* detail rows */}
         <div className="space-y-3 mb-4">
           <DetailRow label={t("operation")}>
-            <span className={isSupply ? "text-[#1D9E75] font-semibold" : "text-red-600 font-semibold"}>
-              {isSupply ? t("supply") : t("withdraw")}
+            <span
+              className={
+                isInflowOperation
+                  ? "text-[#1D9E75] font-semibold"
+                  : "text-red-600 font-semibold"
+              }
+            >
+              {operationDisplayLabel}
             </span>
           </DetailRow>
           <DetailRow label={t("amount")}>
@@ -222,6 +242,11 @@ export function ProposalSignSheet({
             </DetailRow>
           )}
         </div>
+
+        {/* protocol 別の注意書き（Phase-C3） */}
+        {proposal.protocol === "lido" && (
+          <p className="text-xs text-[#736f7e] mt-2">{t("lidoStakeNote")}</p>
+        )}
 
         {/* signing status */}
         {(signingStatus === "signing" || signingStatus === "confirming") && (

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -677,7 +677,12 @@
       "rejecting": "Dismissing...",
       "rejected": "Proposal dismissed",
       "rejectFailed": "Failed to dismiss. Please try again later.",
-      "executeSuccess": "Proposal executed"
+      "executeSuccess": "Proposal executed",
+      "stakeEth": "Stake ETH",
+      "unstakeEth": "Unstake ETH",
+      "buyPt": "Buy PT Token",
+      "sellPt": "Sell PT Token",
+      "lidoStakeNote": "* ETH staking will be executed after approval"
     },
     "header": {
       "menuAriaLabel": "Open menu",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -677,7 +677,12 @@
       "rejecting": "見送り中...",
       "rejected": "提案を見送りました",
       "rejectFailed": "見送りに失敗しました。時間をおいて再度お試しください",
-      "executeSuccess": "提案を実行しました"
+      "executeSuccess": "提案を実行しました",
+      "stakeEth": "ETH ステーキング",
+      "unstakeEth": "ETH 引き出し",
+      "buyPt": "PT トークン購入",
+      "sellPt": "PT トークン売却",
+      "lidoStakeNote": "※ ETH ステーキングは承認後に実行されます"
     },
     "header": {
       "menuAriaLabel": "メニューを開く",


### PR DESCRIPTION
## v4 Round 3 (Round 2 の対応タスク完了後に解禁)

⚠️ **Stacked PR**: base は `feat/v4-round2`（PR #867）。#867 マージ後に main へ retarget が必要。

| タスク | 内容 |
|---|---|
| **Phase-C1** | i18n exec に Lido/Pendle 操作ラベル追加（stakeEth/unstakeEth/buyPt/sellPt、ja/en） |
| **Phase-C2** | ProposalActionCard を operationConfig マップでマルチプロトコル対応（SUPPLY/WITHDRAW/STAKE_ETH/UNSTAKE_ETH/BUY_PT/SELL_PT）。ChatProposal 型に operation union + `protocol?` 追加。aave 以外で protocol バッジ表示 |
| **Phase-C3** | ProposalSignSheet の操作行を operation ラベルマップ化 + 入金/出金で色分け。protocol=lido のとき注意書き（exec.lidoStakeNote）表示 |
| **MARKET-B** | ProposalActionCard に ETH 価格バッジ（lido/pendle 提案時のみ、liffFetch で /api/market/prices 取得、API失敗時サイレントスキップ） |

## 品質ゲート
- `npx tsc --noEmit` エラー 0 / i18n checker pass / 既存 SUPPLY/WITHDRAW カード非崩壊
- exec に stakeEth/unstakeEth/buyPt/sellPt/lidoStakeNote 追加（ja/en 両方一致）
- `./scripts/verify.sh` 実行中（結果は完了後追記）

## マージ順序（重要）
1. #867 (Round 2) を main にマージ
2. #868 を main へ retarget → マージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)