### PR TITLE
feat(auth): 新規ユーザー登録完了後に ScrapingForce Webhook 送信

### DIFF
--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -15,7 +15,7 @@ import os
 from datetime import datetime, timezone
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
 from pydantic import BaseModel
 from slowapi import Limiter
 from slowapi.util import get_remote_address
@@ -24,6 +24,7 @@ from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.referral import service as referral_service
+from app.users.registration_webhook import send_registration_webhook
 
 from .dependencies import require_active_user, require_admin
 from .models import (
@@ -80,6 +81,7 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 )
 def register(
     request: RegisterRequest,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
 ) -> RegisterResponse:
     """
@@ -110,6 +112,13 @@ def register(
             "User registered via invitation: %s (partner_id=%d)", user.email, invitation.partner_id
         )
         token, expires_in = AuthService.create_access_token(user.id, user.email, user.role)
+        background_tasks.add_task(
+            send_registration_webhook,
+            user.email,
+            user.id,
+            None,
+            user.created_at.isoformat(),
+        )
         return RegisterResponse(
             **UserResponse.model_validate(user).model_dump(),
             access_token=token,
@@ -143,6 +152,13 @@ def register(
         )
         logger.info("Initial admin registered: %s", user.email)
         token, expires_in = AuthService.create_access_token(user.id, user.email, user.role)
+        background_tasks.add_task(
+            send_registration_webhook,
+            user.email,
+            user.id,
+            None,
+            user.created_at.isoformat(),
+        )
         return RegisterResponse(
             **UserResponse.model_validate(user).model_dump(),
             access_token=token,
@@ -165,6 +181,7 @@ def register(
 def register_with_referral(
     request: Request,
     body: RegisterWithReferralRequest,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
 ) -> RegisterResponse:
     """
@@ -223,6 +240,13 @@ def register_with_referral(
 
     # Step 7: JWT
     token, expires_in = AuthService.create_access_token(user.id, user.email, user.role)
+    background_tasks.add_task(
+        send_registration_webhook,
+        user.email,
+        user.id,
+        body.referral_code,
+        user.created_at.isoformat(),
+    )
     return RegisterResponse(
         **UserResponse.model_validate(user).model_dump(),
         access_token=token,
@@ -240,6 +264,7 @@ def register_with_referral(
 def register_open(
     request: Request,
     body: OpenRegisterRequest,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
 ) -> RegisterResponse:
     """
@@ -303,6 +328,13 @@ def register_open(
 
     logger.info("User registered via open registration: %s", user.email)
     token, expires_in = AuthService.create_access_token(user.id, user.email, user.role)
+    background_tasks.add_task(
+        send_registration_webhook,
+        user.email,
+        user.id,
+        None,
+        user.created_at.isoformat(),
+    )
     return RegisterResponse(
         **UserResponse.model_validate(user).model_dump(),
         access_token=token,

--- a/backend/app/users/registration_webhook.py
+++ b/backend/app/users/registration_webhook.py
@@ -1,0 +1,61 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/users/registration_webhook.py
+"""
+新規ユーザー登録完了後に ScrapingForce へ Webhook を非同期送信するモジュール。
+
+fire-and-forget: 送信失敗してもユーザー登録レスポンスには影響しない。
+"""
+
+import logging
+import os
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_WEBHOOK_URL = "https://sf.ultra-auto-trade.com/api/webhooks/uat-registration"
+_TIMEOUT = 10.0
+
+
+async def send_registration_webhook(
+    email: str,
+    uat_user_id: int,
+    referral_code: str | None,
+    registered_at: str,
+) -> None:
+    """登録完了 Webhook を ScrapingForce へ非同期送信する（fire-and-forget）。
+
+    UAT_WEBHOOK_SECRET 未設定時は警告ログのみで送信をスキップする。
+    送信失敗時も例外を握りつぶし、呼び出し元には影響を与えない。
+    """
+    secret = os.getenv("UAT_WEBHOOK_SECRET")
+    if not secret:
+        logger.warning("UAT_WEBHOOK_SECRET not set, skipping registration webhook")
+        return
+
+    payload = {
+        "email": email,
+        "uat_user_id": uat_user_id,
+        "referral_code": referral_code,
+        "registered_at": registered_at,
+    }
+    headers = {"x-uat-webhook-secret": secret}
+
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.post(_WEBHOOK_URL, json=payload, headers=headers)
+        if resp.status_code >= 400:
+            logger.warning(
+                "Registration webhook returned %d for user_id=%d",
+                resp.status_code,
+                uat_user_id,
+            )
+        else:
+            logger.info("Registration webhook sent for user_id=%d", uat_user_id)
+    except Exception:
+        logger.warning(
+            "Registration webhook failed for user_id=%d",
+            uat_user_id,
+            exc_info=True,
+        )

--- a/backend/tests/test_registration_webhook.py
+++ b/backend/tests/test_registration_webhook.py
@@ -1,0 +1,124 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/test_registration_webhook.py
+"""send_registration_webhook のユニットテスト。"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.users.registration_webhook import send_registration_webhook
+
+
+@pytest.mark.asyncio
+async def test_send_webhook_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """正常: httpx.AsyncClient.post が呼ばれ、200 レスポンスで成功ログが出る。"""
+    monkeypatch.setenv("UAT_WEBHOOK_SECRET", "test-secret")
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=mock_resp)
+
+    with patch("app.users.registration_webhook.httpx.AsyncClient", return_value=mock_client):
+        await send_registration_webhook(
+            email="test@example.com",
+            uat_user_id=42,
+            referral_code="ABCD1234",
+            registered_at="2026-06-24T10:00:00+00:00",
+        )
+
+    mock_client.post.assert_awaited_once()
+    call_kwargs = mock_client.post.call_args
+    assert call_kwargs.kwargs["json"]["email"] == "test@example.com"
+    assert call_kwargs.kwargs["json"]["uat_user_id"] == 42
+    assert call_kwargs.kwargs["json"]["referral_code"] == "ABCD1234"
+    assert call_kwargs.kwargs["headers"]["x-uat-webhook-secret"] == "test-secret"
+
+
+@pytest.mark.asyncio
+async def test_send_webhook_no_referral_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    """referral_code が null の場合も正常送信できること。"""
+    monkeypatch.setenv("UAT_WEBHOOK_SECRET", "test-secret")
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 201
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=mock_resp)
+
+    with patch("app.users.registration_webhook.httpx.AsyncClient", return_value=mock_client):
+        await send_registration_webhook(
+            email="admin@example.com",
+            uat_user_id=1,
+            referral_code=None,
+            registered_at="2026-06-24T10:00:00+00:00",
+        )
+
+    payload = mock_client.post.call_args.kwargs["json"]
+    assert payload["referral_code"] is None
+
+
+@pytest.mark.asyncio
+async def test_send_webhook_secret_not_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """UAT_WEBHOOK_SECRET 未設定時は httpx を呼ばずに静かにスキップすること。"""
+    monkeypatch.delenv("UAT_WEBHOOK_SECRET", raising=False)
+
+    with patch("app.users.registration_webhook.httpx.AsyncClient") as mock_cls:
+        await send_registration_webhook(
+            email="user@example.com",
+            uat_user_id=99,
+            referral_code=None,
+            registered_at="2026-06-24T10:00:00+00:00",
+        )
+
+    mock_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_webhook_http_error_does_not_raise(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Webhook 送信が例外を投げても呼び出し元に伝播しないこと（fire-and-forget）。"""
+    monkeypatch.setenv("UAT_WEBHOOK_SECRET", "test-secret")
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(side_effect=Exception("network error"))
+
+    with patch("app.users.registration_webhook.httpx.AsyncClient", return_value=mock_client):
+        # 例外が伝播しないことを確認（raise しなければ OK）
+        await send_registration_webhook(
+            email="user@example.com",
+            uat_user_id=5,
+            referral_code=None,
+            registered_at="2026-06-24T10:00:00+00:00",
+        )
+
+
+@pytest.mark.asyncio
+async def test_send_webhook_non_2xx_logs_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    """4xx レスポンスでも例外を投げず警告ログに記録すること。"""
+    monkeypatch.setenv("UAT_WEBHOOK_SECRET", "test-secret")
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 500
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=mock_resp)
+
+    with patch("app.users.registration_webhook.httpx.AsyncClient", return_value=mock_client):
+        await send_registration_webhook(
+            email="user@example.com",
+            uat_user_id=7,
+            referral_code=None,
+            registered_at="2026-06-24T10:00:00+00:00",
+        )
+
+    mock_client.post.assert_awaited_once()

--- a/backend/tests/test_registration_webhook.py
+++ b/backend/tests/test_registration_webhook.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest


### PR DESCRIPTION
## Summary

- `backend/app/users/registration_webhook.py` 新設: `httpx.AsyncClient` による非同期 fire-and-forget Webhook 送信
- `POST /auth/register` / `register-with-referral` / `register-open` の3エンドポイントに `BackgroundTasks` で hook
- `UAT_WEBHOOK_SECRET` 未設定でも起動エラーなし（警告ログのみ）

## 変更詳細

| ファイル | 変更 |
|---|---|
| `backend/app/users/registration_webhook.py` | 新規: `send_registration_webhook()` async 関数 |
| `backend/app/auth/router.py` | `BackgroundTasks` 追加・3エンドポイントに webhook hook |
| `backend/tests/test_registration_webhook.py` | 新規: 5テストケース |

## Payload

```json
{ "email": str, "uat_user_id": int, "referral_code": str|null, "registered_at": ISO8601 }
```

Header: `x-uat-webhook-secret: {UAT_WEBHOOK_SECRET}`

## Test plan

- [x] `pytest tests/test_registration_webhook.py` — 5/5 PASS
- [x] `pytest tests/test_auth.py tests/test_auth_register_with_referral.py tests/test_open_registration.py` — 50/50 PASS（既存テスト影響なし）
- [x] `ruff check` + `ruff format --check` — エラー 0
- [x] `mypy app/users/registration_webhook.py` — 型エラー 0
- [x] `UAT_WEBHOOK_SECRET` 未設定時の動作: 警告ログのみ、送信スキップ確認済み
- [x] Webhook 失敗時: 例外握りつぶし、ユーザー登録レスポンス継続確認済み

Asana GID: 1215958588011875

🤖 Generated with [Claude Code](https://claude.com/claude-code)