### PR TITLE
feat(aave): Flash Loan 自己清算保護 第2スライス（executor サービス層 / dry_run）

### DIFF
--- a/backend/app/aave/flash_loan_service.py
+++ b/backend/app/aave/flash_loan_service.py
@@ -1,0 +1,162 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/aave/flash_loan_service.py
+"""自己清算保護（Flash Loan デレバレッジ）の executor サービス層（第2スライス）。
+
+第1スライスの純計算層（``self_liquidation``）の上に、ライブの Aave アカウントデータ
+（HF / 担保 / 債務 / liquidation_threshold）を**読み取り**、保護発動の要否を判定して
+デレバレッジ見積りを算出する **orchestration** を提供する。
+
+本スライスは ``dry_run=True`` のみ実装する。on-chain での Flash Loan ブロードキャスト
+（USDC borrow → repay → withdraw → flash loan repay の実 tx 署名・送信）は、秘密鍵と
+write 経路を伴うため別の HUMAN-REVIEW スライスに隔離する（``dry_run=False`` は
+``NotImplementedError``）。
+
+副作用は一切なし: ``get_account_data``（read-only）のみ呼び出し、deposit/withdraw/borrow/
+repay 等の write 系メソッドは呼ばない。金融計算は Decimal のみ（Rule 11）。HF / 緊急停止
+フラグ / HARD_STOP(1.6) は読み取りのみで変更しない（Asana 1215620828227794 第2スライス）。
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Optional
+
+from app.aave.client import AaveClientBase, AccountData
+from app.aave.self_liquidation import (
+    DEFAULT_TARGET_HF,
+    DEFAULT_TRIGGER_HF,
+    DeleverageQuote,
+    compute_deleverage_quote,
+    should_protect,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SelfLiquidationExecution:
+    """自己清算保護の実行（または dry-run シミュレーション）結果。"""
+
+    executed: bool
+    """保護アクション（dry-run 含む）が実行されたか。発動不要・実行不能なら False。"""
+
+    dry_run: bool
+    """True の場合は tx を送信していない（シミュレーションのみ）。"""
+
+    tx_hash: Optional[str]
+    """送信した tx のハッシュ。dry-run / 未実行の場合は None。"""
+
+    quote: Optional[DeleverageQuote]
+    """算出したデレバレッジ見積り。算出前に終了した場合は None。"""
+
+    before_health_factor: Optional[Decimal]
+    """実行判定時点の HF（監査・ログ用）。"""
+
+    reason: str
+    """判定理由（監査・ログ用）。"""
+
+
+class FlashLoanSelfLiquidator:
+    """ライブ Aave アカウントを読み取り、自己清算デレバレッジを orchestration する。
+
+    read-only な ``get_account_data`` のみを呼び出し、計算は第1スライスの純関数に委譲する。
+    """
+
+    def __init__(
+        self,
+        client: AaveClientBase,
+        *,
+        trigger_hf: Decimal = DEFAULT_TRIGGER_HF,
+        target_hf: Decimal = DEFAULT_TARGET_HF,
+    ) -> None:
+        self._client = client
+        self._trigger_hf = trigger_hf
+        self._target_hf = target_hf
+
+    def execute_self_liquidation(
+        self, wallet_address: str, *, dry_run: bool = True
+    ) -> SelfLiquidationExecution:
+        """HF を読み取り、必要なら自己清算デレバレッジを実行（dry-run）する。
+
+        :param wallet_address: 対象ウォレットアドレス。
+        :param dry_run: True（既定）の場合は tx を送信せずシミュレーションのみ。
+        :raises NotImplementedError: ``dry_run=False``（on-chain 実行は別 HUMAN-REVIEW スライス）。
+        """
+        acct: AccountData = self._client.get_account_data(wallet_address)
+
+        # fail-closed: liquidation_threshold が無いと安全な見積りができない。
+        if acct.liquidation_threshold is None:
+            return SelfLiquidationExecution(
+                executed=False,
+                dry_run=dry_run,
+                tx_hash=None,
+                quote=None,
+                before_health_factor=acct.health_factor,
+                reason="liquidation_threshold unavailable",
+            )
+
+        # fail-closed: HF が読めない場合も判定不能。
+        if acct.health_factor is None:
+            return SelfLiquidationExecution(
+                executed=False,
+                dry_run=dry_run,
+                tx_hash=None,
+                quote=None,
+                before_health_factor=None,
+                reason="health_factor unavailable",
+            )
+
+        if not should_protect(acct.health_factor, self._trigger_hf):
+            return SelfLiquidationExecution(
+                executed=False,
+                dry_run=dry_run,
+                tx_hash=None,
+                quote=None,
+                before_health_factor=acct.health_factor,
+                reason="HF above trigger — no protection needed",
+            )
+
+        quote = compute_deleverage_quote(
+            collateral_usd=acct.total_collateral_usd,
+            debt_usd=acct.total_debt_usd,
+            liquidation_threshold=acct.liquidation_threshold,
+            target_hf=self._target_hf,
+        )
+
+        if not quote.feasible:
+            return SelfLiquidationExecution(
+                executed=False,
+                dry_run=dry_run,
+                tx_hash=None,
+                quote=quote,
+                before_health_factor=acct.health_factor,
+                reason=quote.reason,
+            )
+
+        if dry_run:
+            logger.info(
+                "FlashLoanSelfLiquidator dry-run: wallet=%s before_hf=%s "
+                "repay_debt_usd=%s flash_loan_fee_usd=%s collateral_withdraw_usd=%s "
+                "projected_hf=%s",
+                wallet_address,
+                str(acct.health_factor),
+                str(quote.repay_debt_usd),
+                str(quote.flash_loan_fee_usd),
+                str(quote.collateral_withdraw_usd),
+                str(quote.projected_hf),
+            )
+            return SelfLiquidationExecution(
+                executed=True,
+                dry_run=True,
+                tx_hash=None,
+                quote=quote,
+                before_health_factor=acct.health_factor,
+                reason="dry-run: flash loan deleverage simulated",
+            )
+
+        raise NotImplementedError(
+            "on-chain flash loan execution is a separate HUMAN-REVIEW slice. dry_run=True only."
+        )

--- a/backend/tests/aave/test_flash_loan_service.py
+++ b/backend/tests/aave/test_flash_loan_service.py
@@ -1,0 +1,197 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/aave/test_flash_loan_service.py
+"""FlashLoanSelfLiquidator（executor サービス層）の単体テスト（Asana 1215620828227794 第2スライス）。
+
+dry_run=True のみが実装されていること、HF 読み取りに副作用がない（write 系メソッド未呼び出し）こと、
+fail-closed 経路、Decimal 型保持、trigger_hf 注入による発動境界を検証する。
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Optional
+
+import pytest
+
+from app.aave.client import AaveClientBase, AccountData, DummyAaveClient
+from app.aave.flash_loan_service import FlashLoanSelfLiquidator
+
+
+class _StubAaveClient(AaveClientBase):
+    """get_account_data だけを差し替えるテスト用 stub。
+
+    write 系メソッド（deposit/withdraw/borrow/repay 相当）が呼ばれたら即座に失敗させ、
+    HF 読み取りに副作用がないことを保証する。
+    """
+
+    def __init__(self, account: AccountData) -> None:
+        self._account = account
+        self.write_calls: list[str] = []
+
+    def get_account_data(self, wallet_address: str) -> AccountData:
+        return self._account
+
+    # --- read-only: HF だけは別経路でも提供する（呼ばれても副作用なし） ---
+    def get_health_factor(self, wallet_address: str = "") -> Decimal:
+        return self._account.health_factor
+
+    def get_user_emode(self, wallet_address: str) -> int:
+        return 0
+
+    # --- write 系: 呼ばれてはならない ---
+    def deposit(
+        self,
+        asset_address: str,
+        amount: Decimal,
+        wallet_address: str,
+        private_key: str,
+        dry_run: bool = False,
+    ) -> dict:
+        self.write_calls.append("deposit")
+        raise AssertionError("deposit must not be called by self-liquidation read path")
+
+    def withdraw(
+        self,
+        asset_address: str,
+        amount: Decimal,
+        wallet_address: str,
+        private_key: str,
+        dry_run: bool = False,
+    ) -> dict:
+        self.write_calls.append("withdraw")
+        raise AssertionError("withdraw must not be called by self-liquidation read path")
+
+    def build_set_emode_tx(
+        self, category_id: int, wallet_address: str, dry_run: bool = False
+    ) -> dict:
+        self.write_calls.append("build_set_emode_tx")
+        raise AssertionError("build_set_emode_tx must not be called")
+
+
+def _account(
+    *,
+    collateral: str,
+    debt: str,
+    hf: str,
+    lt: Optional[str] = "0.80",
+) -> AccountData:
+    return AccountData(
+        total_collateral_usd=Decimal(collateral),
+        total_debt_usd=Decimal(debt),
+        available_borrows_usd=Decimal("0"),
+        health_factor=Decimal(hf),
+        liquidation_threshold=Decimal(lt) if lt is not None else None,
+    )
+
+
+_WALLET = "0xWALLET"
+
+
+def test_dry_run_low_hf_executes_simulation() -> None:
+    """HF=1.1 → dry_run=True で executed=True / tx_hash None / quote.feasible。"""
+    # collateral=10000, debt=7273, lt=0.80 → HF ≈ 1.1
+    client = _StubAaveClient(_account(collateral="10000", debt="7273", hf="1.1"))
+    sut = FlashLoanSelfLiquidator(client)
+
+    result = sut.execute_self_liquidation(_WALLET, dry_run=True)
+
+    assert result.executed is True
+    assert result.dry_run is True
+    assert result.tx_hash is None
+    assert result.quote is not None
+    assert result.quote.feasible is True
+    assert result.reason == "dry-run: flash loan deleverage simulated"
+    assert client.write_calls == []
+
+
+def test_safe_hf_no_protection_needed() -> None:
+    """DummyAaveClient（HF=2.5）→ executed=False / "no protection needed" / write 未呼び出し。"""
+    client = DummyAaveClient()
+    sut = FlashLoanSelfLiquidator(client)
+
+    result = sut.execute_self_liquidation(_WALLET, dry_run=True)
+
+    assert result.executed is False
+    assert result.tx_hash is None
+    assert result.quote is None
+    assert "no protection needed" in result.reason
+    assert result.before_health_factor == Decimal("2.5")
+
+
+def test_dry_run_false_raises_not_implemented() -> None:
+    """dry_run=False は on-chain 実行スライス未実装のため NotImplementedError。"""
+    client = _StubAaveClient(_account(collateral="10000", debt="7273", hf="1.1"))
+    sut = FlashLoanSelfLiquidator(client)
+
+    with pytest.raises(NotImplementedError, match="HUMAN-REVIEW"):
+        sut.execute_self_liquidation(_WALLET, dry_run=False)
+
+    assert client.write_calls == []
+
+
+def test_infeasible_quote_propagates_reason() -> None:
+    """担保不足で quote.feasible=False → executed=False / quote の reason を継承。"""
+    # 担保が債務をほぼ上回らない極端なケース（lt 高・HF 危険域）→ 返済+手数料分の担保を
+    # 引き出せず target HF を回復できない（fail-closed）。HF=1.00 < trigger(1.3) で発動経路に入る。
+    client = _StubAaveClient(_account(collateral="100", debt="99.99", hf="1.00", lt="0.9999"))
+    sut = FlashLoanSelfLiquidator(client)
+
+    result = sut.execute_self_liquidation(_WALLET, dry_run=True)
+
+    assert result.executed is False
+    assert result.quote is not None
+    assert result.quote.feasible is False
+    assert result.reason == result.quote.reason
+    assert "insufficient collateral" in result.reason
+    assert client.write_calls == []
+
+
+def test_missing_liquidation_threshold_fails_closed() -> None:
+    """liquidation_threshold=None → fail-closed で executed=False。"""
+    client = _StubAaveClient(_account(collateral="10000", debt="7273", hf="1.1", lt=None))
+    sut = FlashLoanSelfLiquidator(client)
+
+    result = sut.execute_self_liquidation(_WALLET, dry_run=True)
+
+    assert result.executed is False
+    assert result.quote is None
+    assert result.reason == "liquidation_threshold unavailable"
+    assert client.write_calls == []
+
+
+def test_decimal_types_preserved() -> None:
+    """quote.repay_debt_usd / before_health_factor が Decimal 型で保持される。"""
+    client = _StubAaveClient(_account(collateral="10000", debt="7273", hf="1.1"))
+    sut = FlashLoanSelfLiquidator(client)
+
+    result = sut.execute_self_liquidation(_WALLET, dry_run=True)
+
+    assert result.quote is not None
+    assert isinstance(result.quote.repay_debt_usd, Decimal)
+    assert isinstance(result.before_health_factor, Decimal)
+
+
+def test_no_write_side_effects_on_read_path() -> None:
+    """発動経路でも write 系（deposit/withdraw/build_set_emode_tx）が呼ばれない。"""
+    client = _StubAaveClient(_account(collateral="10000", debt="7273", hf="1.1"))
+    sut = FlashLoanSelfLiquidator(client)
+
+    sut.execute_self_liquidation(_WALLET, dry_run=True)
+
+    assert client.write_calls == []
+
+
+def test_custom_trigger_hf_boundary() -> None:
+    """trigger_hf=1.2 注入: HF=1.15 → 発動 / HF=1.25 → 不発火。"""
+    # collateral/debt/lt は固定で HF だけ AccountData に明示。
+    triggering = _StubAaveClient(_account(collateral="10000", debt="6957", hf="1.15"))
+    sut_trigger = FlashLoanSelfLiquidator(triggering, trigger_hf=Decimal("1.2"))
+    result_trigger = sut_trigger.execute_self_liquidation(_WALLET, dry_run=True)
+    assert result_trigger.executed is True
+    assert result_trigger.dry_run is True
+
+    not_triggering = _StubAaveClient(_account(collateral="10000", debt="6400", hf="1.25"))
+    sut_safe = FlashLoanSelfLiquidator(not_triggering, trigger_hf=Decimal("1.2"))
+    result_safe = sut_safe.execute_self_liquidation(_WALLET, dry_run=True)
+    assert result_safe.executed is False
+    assert "no protection needed" in result_safe.reason


### PR DESCRIPTION
## 概要

第1スライス #839（純計算層 \`self_liquidation.py\`）の上に **executor サービス層** を追加。
ライブ Aave アカウントデータ（HF / 担保 / 債務 / liquidation_threshold）を **read-only** で読み取り、
保護発動要否を判定してデレバレッジ見積りを算出する orchestration を提供する。

## dry_run 隔離（重要）

- **本スライスは \`dry_run=True\` のみ実装**。tx は一切送信しない（シミュレーションのみ）。
- \`dry_run=False\` は \`NotImplementedError("on-chain flash loan execution is a separate HUMAN-REVIEW slice. dry_run=True only.")\` を raise。
- on-chain ブロードキャスト（USDC borrow → repay → withdraw → flash loan repay の実 tx 署名・送信）は秘密鍵・write 経路を伴うため **後続 HUMAN-REVIEW スライスに隔離**。
- 副作用なし: \`get_account_data\`（read-only）のみ呼び出し。deposit/withdraw/borrow/repay/build_set_emode_tx 等の write 系は一切呼ばない（テストで未呼び出しをアサート）。
- HF / 緊急停止フラグ / HARD_STOP(1.6) は読み取りのみで **不変更**。金融計算は Decimal のみ（Rule 11）。

## 触ったファイル（新規2のみ）

\`\`\`
 backend/app/aave/flash_loan_service.py           | 174 +++++++++
 backend/tests/aave/test_flash_loan_service.py    | 185 +++++++++
 2 files changed, 359 insertions(+)
\`\`\`

既存ファイル（self_liquidation.py / service.py / client.py / schemas.py / state_manager.py / automation/* / main.py / router.py）への diff は **ゼロ**。

## DoD 結果

- \`ruff check\` — All checks passed
- \`ruff format --check\` — 2 files already formatted
- \`mypy app/aave/flash_loan_service.py\` — Success: no issues found in 1 source file
- \`pytest tests/aave/test_flash_loan_service.py\` — **8 passed**
- \`verify.sh\` 最終行（backend）: \`4505 passed, 21 skipped ... coverage 84.80%\` → \`✅ pytest passed (coverage >= 80%)\` / \`✅ security check passed\`
  - Gate 6 (tsc) はこの worktree に frontend \`node_modules\` が無いため failed。本 PR は **backend-only でフロント変更ゼロ** のため非該当。

## dry_run 実機証跡

\`\`\`
executed= True | dry_run= True | tx_hash= None
before_hf= 1.1 | reason= dry-run: flash loan deleverage simulated
quote.feasible= True | repay_debt_usd= 5093.437374949979991996798719
\`\`\`

## 後続作業（HUMAN-REVIEW で残る）

- on-chain Flash Loan 実行スライス（dry_run=False 経路 / SelfLiquidator.sol / web3 署名・送信） — Tier S / HUMAN-REVIEW
- workflow / scheduled_tasks への配線、frontend 表示 — 別スライス

## Asana

GID 1215620828227794（タスクはオープン継続）