### PR TITLE
feat(aave): Credit Delegation 第2スライス（approveDelegation 未署名tx構築 / dry_run）

### DIFF
--- a/backend/app/aave/client.py
+++ b/backend/app/aave/client.py
@@ -25,6 +25,7 @@ from decimal import Decimal
 from typing import Any, Optional, Protocol, cast
 
 from .config import AaveSettings, get_aave_settings
+from .credit_delegation import DelegationAssessment
 from .gas_estimator import (
     DEFAULT_FALLBACK_GAS_APPROVE,
     DEFAULT_FALLBACK_GAS_SUPPLY,
@@ -152,6 +153,40 @@ _ERC20_ABI_MINIMAL = [
         "name": "approve",
         "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
         "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "decimals",
+        "outputs": [{"internalType": "uint8", "name": "", "type": "uint8"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+]
+
+# Aave V3 variable debt token ABI（Credit Delegation — 最小限）
+# approveDelegation: delegator が delegatee に borrow allowance を委譲する write 操作。
+# borrowAllowance: 現在の委譲枠を読む view（テスト・監査用、本スライスでは未署名 tx のみ）。
+# decimals: amount→wei 変換用（underlying と同 decimals。USDC=6）。
+_DEBT_TOKEN_ABI_MINIMAL = [
+    {
+        "inputs": [
+            {"internalType": "address", "name": "delegatee", "type": "address"},
+            {"internalType": "uint256", "name": "amount", "type": "uint256"},
+        ],
+        "name": "approveDelegation",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "fromUser", "type": "address"},
+            {"internalType": "address", "name": "toUser", "type": "address"},
+        ],
+        "name": "borrowAllowance",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
         "type": "function",
     },
     {
@@ -1548,6 +1583,119 @@ class Web3AaveClient(AaveClientBase):
             "set_emode_tx": {
                 "to": str(self._pool.address),
                 "data": set_emode_data,
+                "from": checksum_wallet,
+                "chainId": chain_id,
+                "value": "0x0",
+            }
+        }
+
+    def build_approve_delegation_tx(
+        self,
+        *,
+        asset_symbol: str,
+        delegatee: str,
+        delegation_assessment: DelegationAssessment,
+        wallet_address: str,
+        dry_run: bool = False,
+    ) -> "dict[str, Any]":
+        """variableDebtToken.approveDelegation(delegatee, amount) の未署名 tx を構築する。
+
+        HUMAN-REVIEW-REQUIRED: on-chain broadcast は本スライス対象外（未署名 tx を返すのみ）。
+        署名・送信 (send_raw_transaction) は第3スライス（HUMAN-REVIEW）に隔離する。本メソッドは
+        Aave V3 Credit Delegation の approveDelegation calldata を組み立てるだけで、秘密鍵経路・
+        broadcast には一切触れない。
+
+        委譲額の上限は第1スライス（credit_delegation.assess_delegated_borrow）が算出した
+        ``delegation_assessment.approved_usd``（HF floor 1.6 と絶対委譲上限で二重クランプ済み）。
+        本メソッドは HF floor を読み取るだけで変更しない。
+
+        Args:
+            asset_symbol: 委譲対象資産シンボル（例: "USDC"）。variable debt token を解決する。
+            delegatee: borrow allowance を委譲する先（UATa 運用アドレス等）。
+            delegation_assessment: 第1スライスの安全枠評価。approved_usd を委譲額として使う。
+            wallet_address: 委譲元（delegator）ウォレットアドレス = tx の from。
+            dry_run: True なら calldata・tx を構築せず試算結果のみ返す。
+
+        Returns:
+            dry_run=True:  {"asset_symbol", "delegatee", "approved_usd", "dry_run": True}
+            dry_run=False: {"approve_delegation_tx": {to, data, from, chainId, value}}
+
+        Raises:
+            AaveClientError: web3 未導入 / アドレス未指定 / approved_usd<=0（安全枠超）/ 資産未解決時
+        """
+        if Web3 is None:
+            raise AaveClientError("web3 package is required")
+
+        if not wallet_address:
+            raise AaveClientError("wallet_address は必須です (approveDelegation)")
+        if not delegatee:
+            raise AaveClientError("delegatee は必須です (approveDelegation)")
+
+        approved_usd = delegation_assessment.approved_usd
+        if approved_usd <= 0:
+            # 安全枠（HF floor 1.6）超過 / headroom ゼロ → 委譲枠を作らせない
+            raise AaveClientError(
+                "approved_usd must be positive to approve delegation "
+                f"(assessment: {delegation_assessment.reason})"
+            )
+
+        checksum_wallet = Web3.to_checksum_address(wallet_address)
+        checksum_delegatee = Web3.to_checksum_address(delegatee)
+
+        logger.info(
+            "build_approve_delegation_tx: wallet=%s...%s, delegatee=%s...%s, "
+            "asset=%s, approved_usd=%s, dry_run=%s",
+            wallet_address[:6] if wallet_address else "N/A",
+            wallet_address[-4:] if wallet_address else "N/A",
+            delegatee[:6] if delegatee else "N/A",
+            delegatee[-4:] if delegatee else "N/A",
+            asset_symbol,
+            str(approved_usd),
+            dry_run,
+        )
+
+        if dry_run:
+            return {
+                "asset_symbol": asset_symbol,
+                "delegatee": checksum_delegatee,
+                "approved_usd": str(approved_usd),
+                "dry_run": True,
+            }
+
+        # asset_symbol → underlying address 解決
+        if not hasattr(self, "token_addresses"):
+            raise AaveClientError(f"Unknown asset: {asset_symbol}")
+        asset_address = self.token_addresses.get(asset_symbol)
+        if not asset_address:
+            raise AaveClientError(f"Unknown asset: {asset_symbol}")
+
+        # Pool.getReserveData(asset)[10] = variableDebtTokenAddress
+        reserve_data = self._pool.functions.getReserveData(
+            Web3.to_checksum_address(asset_address)
+        ).call()
+        vdebt_addr: str = reserve_data[10]
+        if not vdebt_addr or int(vdebt_addr, 16) == 0:
+            raise AaveClientError(f"variable debt token not found for asset: {asset_symbol}")
+
+        debt_token_contract = self._w3.eth.contract(
+            address=Web3.to_checksum_address(vdebt_addr),
+            abi=_DEBT_TOKEN_ABI_MINIMAL,
+        )
+        # decimals は underlying/debt token 共通（USDC=6）。Decimal のまま wei 化（float 化禁止）。
+        decimals = debt_token_contract.functions.decimals().call()
+        amount_wei = self._to_wei(approved_usd, decimals)
+        chain_id = self._w3.eth.chain_id
+
+        # web3.py v7: encode_abi（fn_name= → 位置引数）。send_raw_transaction は呼ばない。
+        approve_delegation_data = debt_token_contract.encode_abi(
+            "approveDelegation",
+            args=[checksum_delegatee, amount_wei],
+        )
+
+        return {
+            "approve_delegation_tx": {
+                "to": Web3.to_checksum_address(vdebt_addr),
+                "data": approve_delegation_data,
                 "from": checksum_wallet,
                 "chainId": chain_id,
                 "value": "0x0",

--- a/backend/tests/aave/test_credit_delegation_tx.py
+++ b/backend/tests/aave/test_credit_delegation_tx.py
@@ -1,0 +1,311 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/aave/test_credit_delegation_tx.py
+"""Web3AaveClient.build_approve_delegation_tx のユニットテスト（Credit Delegation 第2スライス）。
+
+第1スライス（assess_delegated_borrow）の安全枠（approved_usd）を上限に、Aave V3 variable debt
+token の approveDelegation 未署名 tx を構築する経路をカバーする。
+
+検証ポイント:
+- dry_run=True / dry_run=False いずれでも send_raw_transaction を一切呼ばない（broadcast 非実装）
+- 安全枠超（approved_usd<=0）は AaveClientError で拒否
+- requested>approved のとき amount_wei が approved ベースにクランプされる
+- Decimal→wei が途中 float 化なしで正確（USDC 6 decimals）
+- 空 delegatee / 空 wallet_address で fail-fast
+- encode_abi("approveDelegation", args=[...]) が呼ばれる
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("web3")
+
+from app.aave.client import AaveClientError, Web3AaveClient
+from app.aave.credit_delegation import DelegationAssessment, assess_delegated_borrow
+
+# テスト用アドレス（checksum 化可能な値）
+_WALLET = "0x52908400098527886E0F7030069857D2E4169EE7"
+_DELEGATEE = "0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe"
+_USDC_UNDERLYING = "0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8"
+_VDEBT_TOKEN = "0x8bAB6d1b75f19e9eD9fCe8b9BD338844fF79aE27"
+_CHAIN_ID = 84532  # Base Sepolia
+_USDC_DECIMALS = 6
+
+
+def _make_assessment(
+    *,
+    requested: str,
+    approved: str,
+) -> DelegationAssessment:
+    """approved_usd を任意指定した DelegationAssessment を組み立てる。"""
+    return DelegationAssessment(
+        requested_usd=Decimal(requested),
+        approved_usd=Decimal(approved),
+        max_borrow_usd=Decimal(approved),
+        projected_hf=Decimal("1.8"),
+        within_floor=True,
+        reason="test fixture",
+    )
+
+
+def _make_client(*, encoded_data: str = "0xdeadbeef") -> Web3AaveClient:
+    """__init__ を回避して _pool / _w3 / token_addresses を mock 注入した client。"""
+    client = object.__new__(Web3AaveClient)
+
+    # variable debt token contract (decimals / encode_abi / functions.* を持つ)
+    debt_contract = MagicMock()
+    debt_contract.functions.decimals.return_value.call.return_value = _USDC_DECIMALS
+    debt_contract.encode_abi.return_value = encoded_data
+
+    # _w3.eth.contract(...) は debt token contract を返す
+    w3 = MagicMock()
+    w3.eth.chain_id = _CHAIN_ID
+    w3.eth.contract.return_value = debt_contract
+
+    # _pool.functions.getReserveData(asset).call()[10] = variableDebtTokenAddress
+    reserve_data = [None] * 15
+    reserve_data[10] = _VDEBT_TOKEN
+    pool = MagicMock()
+    pool.functions.getReserveData.return_value.call.return_value = reserve_data
+
+    client._w3 = w3  # type: ignore[attr-defined]
+    client._pool = pool  # type: ignore[attr-defined]
+    client.token_addresses = {"USDC": _USDC_UNDERLYING}  # type: ignore[attr-defined]
+    # broadcast 経路の不在を検証するための spy
+    w3.eth.send_raw_transaction = MagicMock()
+
+    return client
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# dry_run=True
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_dry_run_returns_summary_without_tx() -> None:
+    """dry_run=True は試算 dict のみ返し、tx 構築・broadcast をしない。"""
+    client = _make_client()
+    assessment = _make_assessment(requested="100", approved="100")
+
+    result = client.build_approve_delegation_tx(
+        asset_symbol="USDC",
+        delegatee=_DELEGATEE,
+        delegation_assessment=assessment,
+        wallet_address=_WALLET,
+        dry_run=True,
+    )
+
+    assert result["dry_run"] is True
+    assert result["approved_usd"] == "100"
+    assert result["asset_symbol"] == "USDC"
+    # getReserveData / decimals / encode_abi / send_raw_transaction いずれも未呼出
+    client._pool.functions.getReserveData.assert_not_called()  # type: ignore[attr-defined]
+    client._w3.eth.contract.assert_not_called()  # type: ignore[attr-defined]
+    client._w3.eth.send_raw_transaction.assert_not_called()  # type: ignore[attr-defined]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# dry_run=False
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_real_run_builds_unsigned_tx_without_broadcast() -> None:
+    """dry_run=False は未署名 tx dict を返し、send_raw_transaction を呼ばない。"""
+    client = _make_client(encoded_data="0xabc123")
+    assessment = _make_assessment(requested="100", approved="100")
+
+    result = client.build_approve_delegation_tx(
+        asset_symbol="USDC",
+        delegatee=_DELEGATEE,
+        delegation_assessment=assessment,
+        wallet_address=_WALLET,
+        dry_run=False,
+    )
+
+    tx = result["approve_delegation_tx"]
+    from web3 import Web3
+
+    assert tx["to"] == Web3.to_checksum_address(_VDEBT_TOKEN)
+    assert tx["data"] == "0xabc123"
+    assert tx["from"] == Web3.to_checksum_address(_WALLET)
+    assert tx["chainId"] == _CHAIN_ID
+    assert tx["value"] == "0x0"
+    # broadcast 非実装の保証
+    client._w3.eth.send_raw_transaction.assert_not_called()  # type: ignore[attr-defined]
+
+
+def test_real_run_calls_encode_abi_approve_delegation() -> None:
+    """approveDelegation の encode_abi が checksum delegatee + wei amount で呼ばれる。"""
+    client = _make_client()
+    assessment = _make_assessment(requested="100", approved="100")
+
+    client.build_approve_delegation_tx(
+        asset_symbol="USDC",
+        delegatee=_DELEGATEE,
+        delegation_assessment=assessment,
+        wallet_address=_WALLET,
+        dry_run=False,
+    )
+
+    from web3 import Web3
+
+    debt_contract = client._w3.eth.contract.return_value  # type: ignore[attr-defined]
+    debt_contract.encode_abi.assert_called_once()
+    call = debt_contract.encode_abi.call_args
+    assert call.args[0] == "approveDelegation"
+    args = call.kwargs["args"]
+    assert args[0] == Web3.to_checksum_address(_DELEGATEE)
+    # 100 USDC × 10^6
+    assert args[1] == 100_000_000
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 安全枠超拒否
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_zero_approved_rejected() -> None:
+    """approved_usd=0（安全枠超 / headroom なし）は AaveClientError で拒否。"""
+    client = _make_client()
+    assessment = _make_assessment(requested="100", approved="0")
+
+    with pytest.raises(AaveClientError):
+        client.build_approve_delegation_tx(
+            asset_symbol="USDC",
+            delegatee=_DELEGATEE,
+            delegation_assessment=assessment,
+            wallet_address=_WALLET,
+            dry_run=False,
+        )
+
+    # 拒否時は tx 構築も broadcast もしない
+    client._pool.functions.getReserveData.assert_not_called()  # type: ignore[attr-defined]
+    client._w3.eth.send_raw_transaction.assert_not_called()  # type: ignore[attr-defined]
+
+
+def test_negative_approved_rejected() -> None:
+    """approved_usd<0 も AaveClientError で拒否。"""
+    client = _make_client()
+    assessment = _make_assessment(requested="100", approved="-5")
+
+    with pytest.raises(AaveClientError):
+        client.build_approve_delegation_tx(
+            asset_symbol="USDC",
+            delegatee=_DELEGATEE,
+            delegation_assessment=assessment,
+            wallet_address=_WALLET,
+            dry_run=False,
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 安全枠クランプ連携（第1スライスの assess_delegated_borrow と統合）
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_amount_wei_uses_approved_when_requested_exceeds() -> None:
+    """requested>approved のとき amount_wei は approved ベース（クランプ反映）。"""
+    # 安全枠を実際の assess_delegated_borrow で算出: collateral 1000, lt 0.8, floor 1.6
+    # max_borrow = 1000*0.8/1.6 - 0 = 500。requested=900 → approved=500 にクランプ。
+    assessment = assess_delegated_borrow(
+        collateral_usd=Decimal("1000"),
+        existing_debt_usd=Decimal("0"),
+        requested_borrow_usd=Decimal("900"),
+        liquidation_threshold=Decimal("0.8"),
+    )
+    assert assessment.requested_usd == Decimal("900")
+    assert assessment.approved_usd == Decimal("500")
+
+    client = _make_client()
+    client.build_approve_delegation_tx(
+        asset_symbol="USDC",
+        delegatee=_DELEGATEE,
+        delegation_assessment=assessment,
+        wallet_address=_WALLET,
+        dry_run=False,
+    )
+
+    debt_contract = client._w3.eth.contract.return_value  # type: ignore[attr-defined]
+    args = debt_contract.encode_abi.call_args.kwargs["args"]
+    # 500 USDC × 10^6（requested 900 ではない）
+    assert args[1] == 500_000_000
+
+
+def test_decimal_to_wei_no_float_drift() -> None:
+    """Decimal("100.123456") × 10^6 が float 誤差なく整数化される。"""
+    client = _make_client()
+    assessment = _make_assessment(requested="100.123456", approved="100.123456")
+
+    client.build_approve_delegation_tx(
+        asset_symbol="USDC",
+        delegatee=_DELEGATEE,
+        delegation_assessment=assessment,
+        wallet_address=_WALLET,
+        dry_run=False,
+    )
+
+    debt_contract = client._w3.eth.contract.return_value  # type: ignore[attr-defined]
+    args = debt_contract.encode_abi.call_args.kwargs["args"]
+    assert args[1] == 100_123_456
+    assert isinstance(args[1], int)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# fail-fast（空アドレス）
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_empty_delegatee_fails_fast() -> None:
+    """空 delegatee は AaveClientError で即時失敗。"""
+    client = _make_client()
+    assessment = _make_assessment(requested="100", approved="100")
+
+    with pytest.raises(AaveClientError):
+        client.build_approve_delegation_tx(
+            asset_symbol="USDC",
+            delegatee="",
+            delegation_assessment=assessment,
+            wallet_address=_WALLET,
+            dry_run=False,
+        )
+    client._w3.eth.send_raw_transaction.assert_not_called()  # type: ignore[attr-defined]
+
+
+def test_empty_wallet_fails_fast() -> None:
+    """空 wallet_address は AaveClientError で即時失敗。"""
+    client = _make_client()
+    assessment = _make_assessment(requested="100", approved="100")
+
+    with pytest.raises(AaveClientError):
+        client.build_approve_delegation_tx(
+            asset_symbol="USDC",
+            delegatee=_DELEGATEE,
+            delegation_assessment=assessment,
+            wallet_address="",
+            dry_run=False,
+        )
+    client._w3.eth.send_raw_transaction.assert_not_called()  # type: ignore[attr-defined]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 資産未解決
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_unknown_asset_rejected() -> None:
+    """token_addresses に無いシンボルは AaveClientError。"""
+    client = _make_client()
+    assessment = _make_assessment(requested="100", approved="100")
+
+    with pytest.raises(AaveClientError):
+        client.build_approve_delegation_tx(
+            asset_symbol="DAI",
+            delegatee=_DELEGATEE,
+            delegation_assessment=assessment,
+            wallet_address=_WALLET,
+            dry_run=False,
+        )


### PR DESCRIPTION
## 概要
Credit Delegation 第2スライス（Asana GID 1215620587799245）。第1スライス（PR #841, merged）の
安全枠計算 `assess_delegated_borrow` が算出した `approved_usd`（HF floor 1.6 と絶対委譲上限で
二重クランプ済み）を委譲額上限として、Aave V3 variable debt token の
`approveDelegation(delegatee, amount)` の **未署名 tx** を構築する。

## 安全枠連携
- 委譲額は `delegation_assessment.approved_usd`（第1スライス算出値）。`approved_usd <= 0`（安全枠超 /
  headroom なし）は `AaveClientError` で拒否し、委譲枠を作らせない。
- HF floor 1.6 は読み取りのみ・**不変更**。
- requested > approved のとき amount_wei は approved ベースにクランプされる（test で検証）。

## broadcast 非実装（第3スライスに隔離）
- `send_raw_transaction` / 署名 / 秘密鍵経路は**一切実装していない**（未署名 tx dict を返すのみ）。
- router エンドポイント（`POST /aave/delegation/approve` 等）も追加していない。
- **第3スライス（broadcast + router 公開）は HUMAN-REVIEW として残る。** Asana タスクはオープン継続。

## 実装詳細
- `_DEBT_TOKEN_ABI_MINIMAL` 追加（approveDelegation / borrowAllowance / decimals）。
- `Web3AaveClient.build_approve_delegation_tx(*, asset_symbol, delegatee, delegation_assessment,
  wallet_address, dry_run=False)` を `build_set_emode_tx` 直後に追加（既存メソッド非破壊）。
- variable debt token = `Pool.getReserveData(asset)[10]`。
- Decimal→wei は `_to_wei(approved_usd, decimals)`（途中 float 化なし）。
- web3 v7 `encode_abi("approveDelegation", args=[...])` 使用（encodeABI/fn_name=/buildTransaction/
  rawTransaction 不使用）。
- logger は wallet/delegatee を first6+last4 でマスク（Security Rule 8）。
- ABC/Protocol/DummyAaveClient への配線はしない（第3スライス）。

## 触ったファイル
- `backend/app/aave/client.py`（末尾追記 + ABI 定数 + import 1行）
- `backend/tests/aave/test_credit_delegation_tx.py`（新規 / 10 tests）

## DoD
- `ruff check` / `ruff format --check`: PASS（2 files）
- `mypy app/ --config-file ../pyproject.toml`: Success: no issues found in 311 source files
- `ruff check . --select S`: All checks passed!
- `pytest tests/ --cov=app --cov-fail-under=80`: **4507 passed, 21 skipped** /
  `Required test coverage of 80% reached. Total coverage: 84.79%`
- 新規 test 単体: 10 passed
- `git diff --stat`: client.py + 新規 test の 2 ファイルのみ
- web3 v7 API drift grep（encodeABI/buildTransaction/rawTransaction/fn_name=）: 新規分に混入なし
- `send_raw_transaction`: 新規コードに呼出なし（dry_run=True/False 両経路で test が `assert_not_called`）

## frontend gates
backend-only 変更のため tsc / npm build は N/A。

Asana: 1215620587799245（タスクはオープン継続 — 第3スライス HUMAN-REVIEW 残）