### PR TITLE
feat(withdraw): P0 出金フロー配線完成（env gate / nav 導線 / liff整理 / test）

### DIFF
--- a/backend/tests/users/test_withdrawals_router.py
+++ b/backend/tests/users/test_withdrawals_router.py
@@ -1,0 +1,217 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/users/test_withdrawals_router.py
+"""POST/GET /api/users/withdrawals (non-custodial 出金記録) のテスト。
+
+対象: backend/app/users/withdrawals_router.py
+
+カバー範囲:
+- amount_usdc > WITHDRAWAL_MAX_USDC → 422 (pydantic validation)
+- amount_usdc <= 0 → 422 (Field gt=0)
+- 別ユーザーの tx_hash 上書き → 409
+- 同一ユーザー同一 tx_hash 再 POST → 200 (冪等)
+- network != "base" → 422
+- Decimal 精度保持 (文字列授受 → Decimal, float 不使用)
+- 未認証 → 401
+- ENABLE_WITHDRAWALS=false 時に route 未登録 → 404
+
+route 配線ガード (ENABLE_WITHDRAWALS) は create_app() 内で評価されるため、
+本テストでは flag on で app を生成する。flag off の網羅は
+backend/tests/test_withdrawals_flag.py と本ファイル末尾の 1 ケースで担保。
+
+認証: /auth/register は initial-admin 1 名のみ許可するため、複数ユーザーを
+扱うテスト (409 / list 分離) では require_active_user を fake user で override する
+(test_notification_settings_api.py と同じパターン)。401 ケースのみ override しない。
+
+★ #391 money gate を通すまで本番 .env で ENABLE_WITHDRAWALS=true にしないこと。
+"""
+
+import os
+import tempfile
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Generator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-withdrawals-router")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "withdraw_admin@example.com")
+
+from app.auth.dependencies import require_active_user  # noqa: E402
+from app.database import Base, get_db  # noqa: E402
+from app.main import create_app  # noqa: E402
+
+_WITHDRAW_PATH = "/api/users/withdrawals"
+_VALID_TX = "0x" + "a" * 64
+_VALID_TX_2 = "0x" + "b" * 64
+_VALID_TO = "0x" + "1" * 40
+
+
+@dataclass
+class _FakeUser:
+    """require_active_user の戻り値スタブ (router が参照する属性のみ)。"""
+
+    id: int
+    email: str
+    is_active: bool = True
+
+
+@pytest.fixture()
+def test_db() -> Generator[tuple[Any, Any], None, None]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db() -> Generator[Any, None, None]:
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    yield override_get_db, engine
+    Base.metadata.drop_all(bind=engine)
+    os.unlink(path)
+
+
+@pytest.fixture()
+def app(test_db: tuple[Any, Any], monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    # ENABLE_WITHDRAWALS=1 で route を登録 (create_app 評価前に設定必須)
+    monkeypatch.setenv("ENABLE_WITHDRAWALS", "1")
+    # 上限を明示 (default 100000 だが env で固定して assertion を安定させる)
+    monkeypatch.setenv("WITHDRAWAL_MAX_USDC", "100000")
+    # RPC verify は無効 (ネットワーク呼び出し回避)
+    monkeypatch.setenv("RPC_VERIFY", "false")
+    # in-memory rate limiter をリセット (他テストとの干渉防止)
+    from app.users import withdrawals_router as wr
+
+    wr._rate_limiter.reset()
+
+    override_get_db, _ = test_db
+    application = create_app()
+    application.dependency_overrides[get_db] = override_get_db
+    return application
+
+
+def _client_as(app: FastAPI, user: _FakeUser | None) -> TestClient:
+    """user を指定すると認証 override 付き、None で未認証クライアント。"""
+    if user is not None:
+        app.dependency_overrides[require_active_user] = lambda: user
+    else:
+        app.dependency_overrides.pop(require_active_user, None)
+    return TestClient(app)
+
+
+def _payload(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "tx_hash": _VALID_TX,
+        "to_address": _VALID_TO,
+        "amount_usdc": "100.5",
+        "network": "base",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestWithdrawalsRouter:
+    def test_requires_auth(self, app: FastAPI) -> None:
+        """未認証 → 401。"""
+        client = _client_as(app, None)
+        r = client.post(_WITHDRAW_PATH, json=_payload())
+        assert r.status_code == 401
+
+    def test_amount_exceeds_max_returns_422(self, app: FastAPI) -> None:
+        """amount_usdc > WITHDRAWAL_MAX_USDC → 422 (pydantic validation)。"""
+        client = _client_as(app, _FakeUser(id=1, email="over@example.com"))
+        r = client.post(_WITHDRAW_PATH, json=_payload(amount_usdc="100000.000001"))
+        assert r.status_code == 422
+
+    def test_amount_zero_returns_422(self, app: FastAPI) -> None:
+        """amount_usdc == 0 → 422 (Field gt=0)。"""
+        client = _client_as(app, _FakeUser(id=1, email="zero@example.com"))
+        r = client.post(_WITHDRAW_PATH, json=_payload(amount_usdc="0"))
+        assert r.status_code == 422
+
+    def test_amount_negative_returns_422(self, app: FastAPI) -> None:
+        """amount_usdc < 0 → 422 (Field gt=0)。"""
+        client = _client_as(app, _FakeUser(id=1, email="neg@example.com"))
+        r = client.post(_WITHDRAW_PATH, json=_payload(amount_usdc="-1"))
+        assert r.status_code == 422
+
+    def test_network_not_base_returns_422(self, app: FastAPI) -> None:
+        """network != "base" → 422。"""
+        client = _client_as(app, _FakeUser(id=1, email="net@example.com"))
+        r = client.post(_WITHDRAW_PATH, json=_payload(network="ethereum"))
+        assert r.status_code == 422
+
+    def test_create_returns_201_and_decimal_as_string(self, app: FastAPI) -> None:
+        """新規記録 → 201 + amount_usdc は文字列で返る (Decimal シリアライズ, float 不使用)。
+
+        CLAUDE.md Security: API レスポンスの Decimal は文字列で返却。
+        注: SQLite Numeric は float 格納のため高精度の round-trip は本テスト DB では
+        担保できない (本番 PostgreSQL Numeric は保持)。ここでは
+        (1) レスポンスが文字列であること (Decimal 経由) と
+        (2) 単純な値が等価で round-trip すること を検証する。
+        """
+        client = _client_as(app, _FakeUser(id=1, email="ok@example.com"))
+        amount = "100.5"
+        r = client.post(_WITHDRAW_PATH, json=_payload(amount_usdc=amount))
+        assert r.status_code == 201
+        body = r.json()
+        # Decimal は JSON 文字列で返る (数値型でない = float 誤差混入なし)
+        assert isinstance(body["amount_usdc"], str)
+        assert Decimal(body["amount_usdc"]) == Decimal(amount)
+        assert body["tx_hash"] == _VALID_TX
+        assert body["network"] == "base"
+        assert body["status"] == "completed"
+
+    def test_idempotent_same_user_same_tx_returns_200(self, app: FastAPI) -> None:
+        """同一ユーザー同一 tx_hash 再 POST → 200 (冪等)。"""
+        client = _client_as(app, _FakeUser(id=1, email="idem@example.com"))
+        first = client.post(_WITHDRAW_PATH, json=_payload())
+        assert first.status_code == 201
+        first_id = first.json()["id"]
+
+        second = client.post(_WITHDRAW_PATH, json=_payload())
+        assert second.status_code == 200
+        # 既存レコードがそのまま返る (新規作成されない)
+        assert second.json()["id"] == first_id
+
+    def test_other_user_tx_conflict_returns_409(self, app: FastAPI) -> None:
+        """別ユーザーが同一 tx_hash を上書きしようとする → 409。"""
+        client_a = _client_as(app, _FakeUser(id=1, email="usera@example.com"))
+        r1 = client_a.post(_WITHDRAW_PATH, json=_payload())
+        assert r1.status_code == 201
+
+        client_b = _client_as(app, _FakeUser(id=2, email="userb@example.com"))
+        r2 = client_b.post(_WITHDRAW_PATH, json=_payload())
+        assert r2.status_code == 409
+
+    def test_list_returns_only_own_withdrawals(self, app: FastAPI) -> None:
+        """GET は自分の出金のみ返す。"""
+        client_a = _client_as(app, _FakeUser(id=1, email="lista@example.com"))
+        client_a.post(_WITHDRAW_PATH, json=_payload(tx_hash=_VALID_TX))
+
+        client_b = _client_as(app, _FakeUser(id=2, email="listb@example.com"))
+        client_b.post(_WITHDRAW_PATH, json=_payload(tx_hash=_VALID_TX_2))
+
+        # user A の一覧には自分の 1 件のみ
+        client_a = _client_as(app, _FakeUser(id=1, email="lista@example.com"))
+        ra = client_a.get(_WITHDRAW_PATH)
+        assert ra.status_code == 200
+        items_a = ra.json()["items"]
+        assert len(items_a) == 1
+        assert items_a[0]["tx_hash"] == _VALID_TX
+
+
+def test_route_404_when_flag_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ENABLE_WITHDRAWALS 未設定 → route 未登録 → 404 (money gate 既定 off)。"""
+    monkeypatch.delenv("ENABLE_WITHDRAWALS", raising=False)
+    client = TestClient(create_app())
+    r = client.post(_WITHDRAW_PATH, json=_payload())
+    assert r.status_code == 404

--- a/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
@@ -202,29 +202,13 @@ export function DepositPanel() {
     { label: t("confirmSheetDest"), value: walletAddress ? `${walletAddress.slice(0, 6)}...${walletAddress.slice(-4)}` : t("withdrawDestDefault") },
   ]
 
+  // 出金は (user)/withdraw（Privy 本人署名 + 記録専用 /api/users/withdrawals）を正とする。
+  // 以前ここから呼んでいた POST /api/transactions/withdraw は backend に存在せず本番で 404 に
+  // なるため除去した。出金タブは disabled（準備中）で到達不能だが、誤 endpoint 呼び出しの
+  // 配線を物理的に断つため no-op 化する。出金 UI 有効化は (user)/withdraw 側 + #391 money gate。
   const handleWithdrawConfirm = useCallback(async () => {
-    setConfirmBusy(true)
-    setConfirmError(null)
-    try {
-      const res = await liffFetch("/api/transactions/withdraw", {
-        method: "POST",
-        body: JSON.stringify({ amount_usdc: withdrawNum }),
-      })
-      if (!res.ok) {
-        const detail = (await res.json().catch(() => null)) as { detail?: string } | null
-        throw new Error(detail?.detail ?? t("withdrawFailed"))
-      }
-      setConfirmOpen(false)
-      track(EV.WITHDRAW_SUBMIT)
-      setSuccessMsg(t("successMsg"))
-      setWithdrawAmount("")
-      refetchBalance()
-    } catch (e) {
-      setConfirmError(e instanceof Error ? e.message : t("withdrawFailed"))
-    } finally {
-      setConfirmBusy(false)
-    }
-  }, [withdrawNum, refetchBalance])
+    setConfirmError(t("withdrawComingSoon"))
+  }, [t])
 
   // ---- 残高ラベル（タブ依存） -----------------------------------------------
 

--- a/frontend/app/(user)/withdraw/page.tsx
+++ b/frontend/app/(user)/withdraw/page.tsx
@@ -39,6 +39,11 @@ const BASE_RPC_URL = process.env.NEXT_PUBLIC_BASE_RPC_URL || 'https://mainnet.ba
 // ETH price (USD) fallback; gas 表示の概算用。実値は estimateContractGas の結果に乗じる。
 const ETH_USD_FALLBACK = parseFloat(process.env.NEXT_PUBLIC_ETH_USD_FALLBACK || '3500')
 
+// 出金機能の env gate（money を動かす経路のため default-off）。
+// false のときは WithdrawPanel 本体を出さず「準備中」フォールバックを表示する。
+// (liff) DepositPanel と同じ env 名で統一。★ 有効化は #391 money gate 人間承認後。
+const WITHDRAW_ENABLED: boolean = process.env.NEXT_PUBLIC_WITHDRAW_ENABLED === 'true'
+
 // transfer(address,uint256) + balanceOf(address) ABI (minimal)
 const USDC_ABI = [
   {
@@ -744,7 +749,37 @@ function WithdrawPageInner() {
   )
 }
 
+function WithdrawComingSoon() {
+  const t = useTranslations('Withdraw')
+  return (
+    <div className="mx-auto max-w-md px-4 py-10">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">{t('comingSoonTitle')}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Alert>
+            <AlertTriangle className="h-4 w-4" />
+            <AlertDescription className="text-sm leading-relaxed">
+              {t('comingSoonBody')}
+            </AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
 export default function WithdrawPage() {
+  // env off（既定）では本体を出さず準備中表示にする。money gate (#391) 承認前に
+  // 実 UI を露出させないための物理ガード。
+  if (!WITHDRAW_ENABLED) {
+    return (
+      <AuthGuard>
+        <WithdrawComingSoon />
+      </AuthGuard>
+    )
+  }
   return (
     <AuthGuard>
       <WithdrawPageInner />

--- a/frontend/components/shared/BottomNav.tsx
+++ b/frontend/components/shared/BottomNav.tsx
@@ -4,10 +4,15 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Home, CheckCircle, Brain, Settings, HelpCircle, Users, ClipboardList, Gift } from 'lucide-react'
+import { Home, CheckCircle, Brain, Settings, HelpCircle, Users, ClipboardList, Gift, ArrowUpFromLine } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { cn } from '@/lib/utils'
 import { useAuth } from '@/lib/auth'
+
+// 出金導線の env gate（money を動かす経路のため default-off）。
+// (user)/withdraw ページ・UserHeader・(liff) DepositPanel と同じ env 名で統一。
+// ★ 有効化は #391 money gate 人間承認後。
+const WITHDRAW_ENABLED: boolean = process.env.NEXT_PUBLIC_WITHDRAW_ENABLED === 'true'
 
 export function BottomNav() {
   const pathname = usePathname()
@@ -18,6 +23,10 @@ export function BottomNav() {
     { href: '/user/dashboard', label: t('adminNav.home'), icon: Home },
     { href: '/user/approve', label: t('adminNav.approve'), icon: CheckCircle },
     { href: '/user/ai-feed', label: t('adminNav.aiDecisions'), icon: Brain },
+    // 出金は (user)/withdraw（URL: /withdraw, route group prefix なし）。env off のときは出さない。
+    ...(WITHDRAW_ENABLED
+      ? [{ href: '/withdraw', label: t('adminNav.withdraw'), icon: ArrowUpFromLine }]
+      : []),
     { href: '/user/settings', label: t('adminNav.settings'), icon: Settings },
   ]
 

--- a/frontend/components/user/UserHeader.tsx
+++ b/frontend/components/user/UserHeader.tsx
@@ -15,6 +15,11 @@ import { Badge } from '@/components/ui/badge'
 import { postJson } from '@/lib/api/http'
 import { useAutomationStatus } from '@/components/user/UserProviders'
 
+// 出金導線の env gate（money を動かす経路のため default-off）。
+// (user)/withdraw ページ・(liff) DepositPanel と同じ env 名で統一。
+// false のときは nav に出金リンクを出さない。★ 有効化は #391 money gate 人間承認後。
+const WITHDRAW_ENABLED: boolean = process.env.NEXT_PUBLIC_WITHDRAW_ENABLED === 'true'
+
 export function UserHeader() {
   const pathname = usePathname()
   const router = useRouter()
@@ -34,6 +39,11 @@ export function UserHeader() {
     { href: '/user/performance', label: t('adminNav.performance') },
     { href: '/user/simulation', label: t('adminNav.simulation') },
     { href: '/user/deposit', label: t('adminNav.deposit') },
+    // 出金は (user)/withdraw（URL: /withdraw, route group prefix なし）。
+    // env off のときは出さない。
+    ...(WITHDRAW_ENABLED
+      ? [{ href: '/withdraw', label: t('adminNav.withdraw') }]
+      : []),
     { href: '/user/settings', label: t('adminNav.settings') },
     { href: '/user/grid', label: t('adminNav.gridBot') },
     { href: '/user/copy-trading', label: t('adminNav.copyTrading') },

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1291,6 +1291,8 @@
   "Withdraw": {
     "pageTitle": "USDC Withdraw",
     "pageDesc": "Transfer USDC on Base network to a specified address.",
+    "comingSoonTitle": "Withdrawals coming soon",
+    "comingSoonBody": "USDC withdrawal is being prepared. Please check back once it becomes available.",
     "loading": "Loading...",
     "notConnected": "Wallet not connected",
     "notConnectedDesc": "Wallet is not connected. Please connect your wallet first.",
@@ -2505,6 +2507,7 @@
       "approve": "Approvals",
       "history": "History",
       "deposit": "Deposit",
+      "withdraw": "Withdraw",
       "settings": "Settings",
       "gridBot": "Grid Bot",
       "copyTrading": "Copy Trading",
@@ -2544,6 +2547,7 @@
       "home": "Home",
       "approve": "Approve",
       "aiDecisions": "AI",
+      "withdraw": "Withdraw",
       "settings": "Settings"
     },
     "partnerNav": {

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -1291,6 +1291,8 @@
   "Withdraw": {
     "pageTitle": "USDC 出金",
     "pageDesc": "Base ネットワーク上の USDC を指定アドレスへ送金します。",
+    "comingSoonTitle": "出金は準備中です",
+    "comingSoonBody": "USDC 出金機能は現在準備中です。提供開始までしばらくお待ちください。",
     "loading": "読み込み中...",
     "notConnected": "ウォレット未接続",
     "notConnectedDesc": "ウォレット未接続です。先にウォレットを接続してください。",
@@ -2522,6 +2524,7 @@
       "approve": "取引承認",
       "history": "取引履歴",
       "deposit": "入金",
+      "withdraw": "出金",
       "settings": "設定",
       "gridBot": "Grid Bot",
       "copyTrading": "Copy Trading",
@@ -2561,6 +2564,7 @@
       "home": "ホーム",
       "approve": "承認",
       "aiDecisions": "AI判定",
+      "withdraw": "出金",
       "settings": "設定"
     },
     "partnerNav": {


### PR DESCRIPTION
## 概要
P0 出金フローの**配線完成**。ゼロ実装ではなく、既存実装に未実装だった差分3点 + backend テストを追加。

### 既に存在していた実装（本PRでは作成不要だったもの）
- backend `backend/app/users/withdrawals_router.py`: `POST/GET /api/users/withdrawals`（記録専用・非カストディアル）。バリデーション / RBAC(`require_active_user`) / 冪等 / レート制限 完備。`main.py` に `ENABLE_WITHDRAWALS=true` gate 付きで配線済み。
- frontend `frontend/app/(user)/withdraw/page.tsx`: Privy `eth_sendTransaction` による USDC transfer 実送金、残高 / gas / receipt / エラー分類、i18n `Withdraw` namespace。
- 新規 router 作成・main.py 変更・`/api/wallet/withdraw` 作成は **なし**（正は既存 `/api/users/withdrawals`）。

### 未実装だった差分3点（本PRの実装）
1. **`(user)/withdraw/page.tsx` に env gate 追加** — `NEXT_PUBLIC_WITHDRAW_ENABLED !== 'true'` のとき WithdrawPanel 本体を出さず「準備中」フォールバック（`WithdrawComingSoon`）。`(liff)` DepositPanel と env 名を統一。文言は i18n `Withdraw.comingSoonTitle` / `comingSoonBody`（ja/en）。
2. **`/withdraw` への nav 導線** — `UserHeader`（desktop）と `BottomNav`（mobile）の admin nav に追加。`(user)/withdraw` の URL は `/withdraw`（route group prefix なし）。`WITHDRAW_ENABLED` env off のときは nav に出さない。ラベルは i18n（`UserHeader.adminNav.withdraw` / `SharedBottomNav.adminNav.withdraw`、ja/en）。
3. **`(liff)` DepositPanel の死んだ withdraw タブ整理** — 存在しない `POST /api/transactions/withdraw`（本番 404）を呼んでいた `handleWithdrawConfirm` を no-op 化。withdraw タブ自体は disabled（準備中）据え置き（方針(b)・スコープ最小）。`(user)/withdraw` を正とする。

### backend テスト新規
`backend/tests/users/test_withdrawals_router.py`（10 ケース）:
- amount > `WITHDRAWAL_MAX_USDC` → 422 / amount <= 0 → 422 / network != base → 422
- 別ユーザーの tx_hash 上書き → 409 / 同一ユーザー再 POST → 200（冪等）
- Decimal は JSON 文字列で返却（float 不使用）/ 未認証 → 401 / GET 自分のみ
- ENABLE_WITHDRAWALS 未設定で route 未登録 → 404

### 非カストディアル維持
backend は記録のみ（秘密鍵非保持）。残高チェックは frontend viem + チェーン revert で担保。USDC transfer に HF 概念なし。backend に独自オンチェーン残高取得 / HF チェックは追加していない。

### DoD 結果
- `./scripts/verify.sh` → `✅ All checks passed (1162s)`（ruff / format / mypy / pytest coverage 80%+ / security / build 全 PASS）
- `npx tsc --noEmit` → エラー 0
- `npm run build` → 成功（`/withdraw` route コンパイル確認）
- `node scripts/check-i18n-keys.mjs` → `✅ i18n: 新規の欠落なし`（ja/en parity 維持）

### WITHDRAW_ENABLED=false で /withdraw が準備中になるロジック
`WithdrawPage` default export 冒頭で `if (!WITHDRAW_ENABLED) return <AuthGuard><WithdrawComingSoon/></AuthGuard>`。env 未設定 / false で本体 UI を出さず準備中表示。

### env 有効化は人間ゲート
`ENABLE_WITHDRAWALS` / `NEXT_PUBLIC_WITHDRAW_ENABLED` はいずれも本PRで true にしていない。コードは env off 前提。有効化は **#391 money gate** 人間承認後。

Asana: 1215718095536272

🤖 Generated with [Claude Code](https://claude.com/claude-code)