### PR TITLE
fix(i18n): ネスト provider の messages 部分指定で生キー表示されるバグを修正

### DIFF
--- a/frontend/components/providers/AdminProviders.tsx
+++ b/frontend/components/providers/AdminProviders.tsx
@@ -37,8 +37,11 @@ function AdminGuardInner({ children }: { children: React.ReactNode }) {
 }
 
 function AdminGuard({ children }: { children: React.ReactNode }) {
+  // 完全な messages を渡す。部分指定だとこの provider が子孫 (AppShell / TermsModal 等) の
+  // i18n context を覆い隠し、MISSING_MESSAGE → 生キー表示になる。
+  // next-intl のネスト provider は messages をマージせず置換するため全量必須。
   return (
-    <NextIntlClientProvider locale="ja" messages={{ ProvidersAdmin: jaMessages.ProvidersAdmin }}>
+    <NextIntlClientProvider locale="ja" messages={jaMessages}>
       <AdminGuardInner>{children}</AdminGuardInner>
     </NextIntlClientProvider>
   )

--- a/frontend/components/providers/PartnerProviders.tsx
+++ b/frontend/components/providers/PartnerProviders.tsx
@@ -40,8 +40,11 @@ function PartnerGuardInner({ children }: { children: React.ReactNode }) {
 }
 
 function PartnerGuard({ children }: { children: React.ReactNode }) {
+  // 完全な messages を渡す。部分指定だとこの provider が子孫 (AppShell / EmergencyStopFloat 等) の
+  // i18n context を覆い隠し、MISSING_MESSAGE → 生キー表示になる。
+  // next-intl のネスト provider は messages をマージせず置換するため全量必須。
   return (
-    <NextIntlClientProvider locale="ja" messages={{ ProvidersPartner: jaMessages.ProvidersPartner }}>
+    <NextIntlClientProvider locale="ja" messages={jaMessages}>
       <PartnerGuardInner>{children}</PartnerGuardInner>
     </NextIntlClientProvider>
   )

--- a/frontend/components/user/UserProviders.tsx
+++ b/frontend/components/user/UserProviders.tsx
@@ -70,8 +70,12 @@ function UserGuardInner({ children }: { children: React.ReactNode }) {
 }
 
 function UserGuard({ children }: { children: React.ReactNode }) {
+  // 完全な messages を渡す。部分指定 ({ ProvidersUser, SharedSessionExpiry } のみ) だと
+  // この provider が子孫 (UserHeader / BottomNav / EmergencyStopFloat 等) の i18n context を
+  // 覆い隠し、UserHeader 等の namespace が解決できず MISSING_MESSAGE → 生キー表示になる。
+  // next-intl のネスト provider は messages をマージせず置換するため、ここは全量必須。
   return (
-    <NextIntlClientProvider locale="ja" messages={{ ProvidersUser: jaMessages.ProvidersUser, SharedSessionExpiry: jaMessages.SharedSessionExpiry }}>
+    <NextIntlClientProvider locale="ja" messages={jaMessages}>
       <UserGuardInner>{children}</UserGuardInner>
     </NextIntlClientProvider>
   )

--- a/frontend/e2e/i18n-provider-regression.spec.ts
+++ b/frontend/e2e/i18n-provider-regression.spec.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+//
+// 回帰テスト: ネスト NextIntlClientProvider の messages 部分指定による
+// MISSING_MESSAGE → i18n 生キー表示バグ (2026-06-25)。
+//
+// 背景: UserProviders / AdminProviders / PartnerProviders の Guard が
+// `messages={{ ProvidersX }}` のように部分 messages で子孫を包むと、next-intl の
+// ネスト provider は messages をマージせず置換するため、UserHeader / AppShell /
+// TermsModal 等の namespace が解決できず生キー (例 "UserHeader.viewerNav.dashboard")
+// が表示される。本テストは公開ページ /connect で生キー非表示を保証する。
+
+import { test, expect } from '@playwright/test'
+
+test.describe('i18n provider 回帰 — ネスト provider の messages 欠落検出', () => {
+  test('/connect に i18n 生キーが表示されない', async ({ page }) => {
+    const missingMessageErrors: string[] = []
+    page.on('console', (m) => {
+      if (m.type() === 'error' && m.text().includes('MISSING_MESSAGE')) {
+        missingMessageErrors.push(m.text().split('\n')[0])
+      }
+    })
+
+    await page.goto('/connect')
+    await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {})
+    await page.waitForTimeout(1500)
+
+    const bodyText = await page.locator('body').innerText()
+    // "Namespace.path.to.key" 形式の未解決 i18n キー (UserHeader.viewerNav.dashboard 等)
+    const rawKeys = bodyText.match(/[A-Z][a-zA-Z]+\.[a-zA-Z]+\.[a-zA-Z.]+/g) || []
+
+    expect(
+      rawKeys,
+      `i18n 生キーが描画されています (ネスト provider の messages 欠落): ${JSON.stringify(rawKeys.slice(0, 8))}`,
+    ).toHaveLength(0)
+    expect(
+      missingMessageErrors,
+      `MISSING_MESSAGE エラー: ${JSON.stringify(missingMessageErrors.slice(0, 8))}`,
+    ).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## 概要

v4 staging-v4 の UI テスト中に発見した **i18n 生キー表示バグ** の修正。`/connect` のナビや管理ダッシュボードに `UserHeader.viewerNav.dashboard` / `AppShell.adminNav.automation` / `TermsModal.title` 等の**未翻訳の生キー**が表示されていた(production にも存在)。

## 根本原因

`UserProviders` / `AdminProviders` / `PartnerProviders` の Guard が `messages={{ ProvidersX }}` のように**部分 messages** で子孫を包んでいた。next-intl のネスト `NextIntlClientProvider` は messages を**マージせず置換**するため、この部分 provider が `UserHeader` / `SharedBottomNav` / `AppShell` / `TermsModal` / `SharedEmergencyStopFloat` 等の namespace を覆い隠し、`MISSING_MESSAGE` → 生キー描画になっていた。

- SSR は正しく日本語をレンダリングするが、クライアント再ハイドレーション時に部分 provider にバインドされて生キー化
- デスクトップ nav は `hidden md:flex`(モバイル非表示)のため、LINE/PWA モバイル主体の運用で長期間気づかれなかった
- `/liff-chat`(v4 LINE 消費者の入口)は独自の全量 provider を持つため**無傷**

## 修正

| ファイル | 変更 |
|---|---|
| `UserProviders.tsx` | `UserGuard` の messages を全量 `jaMessages` に |
| `AdminProviders.tsx` | `AdminGuard` の messages を全量 `jaMessages` に |
| `PartnerProviders.tsx` | `PartnerGuard` の messages を全量 `jaMessages` に |
| `e2e/i18n-provider-regression.spec.ts` | `/connect` 生キー非表示の回帰テスト追加 |

`locale="ja"` 固定は従来通り(これらの画面は元々 ja 固定 = 回帰なし)。`jaMessages` は既に import 済みで bundle コスト増なし。`SharedSessionExpiry` のみの狭い provider は正しくスコープされているため変更なし。

## 検証

- **dev mode**: バグ再現(`UserHeader`/`SharedBottomNav`/`SharedEmergencyStopFloat` の MISSING_MESSAGE)→ 修正後 **0 件**
- **prod build** (`next build && next start`): `/connect`(user群)・`/dashboard`(admin群)とも **raw keys 0 / MISSING_MESSAGE 0** を確認
- `tsc --noEmit` pass / 回帰テスト pass

## デプロイ後の確認

staging-v4 デプロイ後、`/connect` ナビと運用ダッシュボードが日本語表示になることを確認すること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)