### PR TITLE
fix(proposal): 提案フロー可視化 + protocol露出 + 消費者金額の設計提案

### DIFF
--- a/backend/app/proposals/schemas.py
+++ b/backend/app/proposals/schemas.py
@@ -35,6 +35,10 @@ class ProposalResponse(BaseModel):
     ai_decision_id: Optional[int]
     operation: str
     asset: str
+    # 提案元プロトコル ("aave" / "lido" / "pendle")。model/DB には存在するが
+    # 従来 response schema 未露出のため、フロントの protocol バッジ・lido 注記・
+    # operation 別表示が機能しなかった (NULL=従来 Aave 既定フロー)。
+    protocol: Optional[str] = None
     amount: Decimal
     amount_usd: Decimal
     reason: str

--- a/docs/61_consumer_proposal_amount_design.md
+++ b/docs/61_consumer_proposal_amount_design.md
@@ -1,0 +1,49 @@
+# 設計提案: v4 非カストディアル消費者の提案金額解決
+
+> 2026-06-25 / status: **提案 (要アーキテクト判断)** / 関連: `backend/app/automation/ai_judgment_scheduler.py:_resolve_proposal_amount`
+
+## 背景 / 問題
+
+liff-chat の AI 提案フロー(表示→承認→Privy 自己署名→submit-tx)は配線・RBAC とも揃っているが、**提案金額の決まり方が v4 消費者に未対応**で、消費者には提案が一切生成されない。
+
+`_resolve_proposal_amount(db, user_id)` は `fund_allocations`(パートナー→テスターのカストディアル枠)の active 合計 × `PROPOSAL_AMOUNT_RATIO(=0.10)` を金額とする。active 行が無いと `Decimal("0")` を返し提案をスキップ(Slack 警告のみ)。
+
+```
+fund_allocations(tester_user_id=U, status='active') が無い
+  → 提案金額 $0 → _create_proposals_for_users で skip → 消費者に提案が出ない
+```
+
+liff-chat 消費者(role=VIEWER・自己オンボーディング)に `fund_allocations` を登録する経路はコード上存在しない。`fund_allocations` は「パートナーが手動 INSERT」前提の custodial 概念であり、**非カストディアル消費者(自分の wallet で運用)には意味的に合わない**。
+
+## 選択肢
+
+### 案A: 消費者にも fund_allocations を登録(運用のみ・コード変更なし)
+- onboarding 完了時 or 入金検知時に `fund_allocations` 行を INSERT する ops/バッチ。
+- 長所: コード変更最小。既存ロジックそのまま。
+- 短所: 非カストディアル消費者に custodial テーブルを流用する設計負債。金額が実 wallet 残高と乖離(枠を別管理)。スケールで手運用 or 別バッチが必要。
+
+### 案B: wallet 残高ベースの金額解決(推奨・要実装)
+- 消費者(fund_allocation 不在)は **本人 wallet の USDC 残高 × ratio** を提案金額にする。
+- 既存資産: `backend/app/partner/wallet_balance_service.py::fetch(wallet_address)` が on-chain USDC/ETH 残高を取得(60s cache・RPC 失敗時 0 フォールバック)。
+- `User.smart_wallet_address` / `User.wallet_address` で対象アドレス取得可。
+- 長所: 非カストディアルの実態に一致。手運用不要。残高 0 なら自然に $0 skip(安全側)。
+- 実装上の論点(要設計):
+  1. **async/sync 橋渡し**: `_resolve_proposal_amount` / `_create_proposals_for_users` は sync。`wallet_balance_service.fetch` は async。ループ内で `asyncio.run` は非効率 → 事前に対象 wallet を集めて一括 await、もしくは同期版 RPC ヘルパーを用意。
+  2. **チェーン分離**: `wallet_balance_service` は Base **mainnet** 固定(USDC コントラクト・Chainlink)。staging-v4 は Base **Sepolia**。env で token/feed/RPC を環境別に解決する必要(`AAVE_NETWORK` 連動)。
+  3. **min/max・ratio**: 既存 `_PROPOSAL_AMOUNT_MIN_USD(50)` / `_MAX(2000)` / `_RATIO(0.10)` を踏襲。残高 < min のとき提案を出すか skip するか要決定(初期は skip 安全側)。
+  4. **fail 時挙動**: RPC 失敗 = 残高 0 = skip(誤った大口提案を出さない安全側)。
+  5. **Decimal 厳守**(CLAUDE.md 金融計算ルール)。
+
+### 案C: ハイブリッド
+- `fund_allocation` があればそれを優先(既存パートナー/テスター互換)、無ければ wallet 残高(消費者)。
+- 案B の実装に「fund_allocation 優先 → fallback wallet 残高」の分岐を足すだけ。**後方互換を保ちつつ消費者対応**。**実質これが最有力**。
+
+## 推奨
+
+**案C(fund_allocation 優先 + wallet 残高 fallback)** を、案B の実装論点(async/sync・チェーン分離・fail-safe）を解いた上で実装する。金融計算の経路変更のため Plan モード + Codex/defi-review ゲート + 単体テスト(残高あり/0/RPC失敗/min境界)必須。
+
+## 本セッションで実施済(別 PR)
+- `/api/proposals/pending` 500 修正(proposals.protocol カラム追加・staging-v4)＋ alembic baseline 確立。
+- `ProposalResponse` に `protocol` 露出(マルチプロトコル バッジ/注記の有効化)。
+- liff-chat の silent fetch catch を可視化(PostHog `liff_data_fetch_error` + console.warn)。
+- 実機 E2E: テスト proposal INSERT → liff-chat で ProposalActionCard 表示確認。

--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -95,6 +95,30 @@ function mapPositionsToHoldings(
     .filter((c) => c.asset !== "" && Number.isFinite(c.amount_usd))
 }
 
+// fetch 失敗 (非2xx レスポンス / 例外) を観測可能化する。
+// 従来は `.catch(() => {})` と `r.ok ? json : null` で 500 等が無言で握りつぶされ、
+// 提案カードや AI 判定が「出ない」障害が長期間表面化しなかった
+// (例: /api/proposals/pending の 500 = protocol カラム欠落)。
+// 消費者 UX は変えず (データ無し表示は従来通り)、console.warn + PostHog で早期検知する。
+function reportFetchError(endpoint: string, detail: unknown): null {
+  console.warn(`[liff-chat] ${endpoint} の取得に失敗`, detail)
+  try {
+    track(EV.DATA_FETCH_ERROR, {
+      endpoint,
+      detail: detail instanceof Error ? detail.message : String(detail),
+    })
+  } catch {
+    // posthog 未初期化でも握りつぶさない (console.warn は出ている)
+  }
+  return null
+}
+
+// レスポンスを JSON 化する。非2xx は reportFetchError で記録して null を返す。
+async function jsonOrReport(endpoint: string, r: Response): Promise<unknown> {
+  if (!r.ok) return reportFetchError(endpoint, `HTTP ${r.status}`)
+  return r.json()
+}
+
 // ────────────────────────────────────────────
 // ページ本体
 // ────────────────────────────────────────────
@@ -152,37 +176,40 @@ export default function LiffChatPage() {
     // 運用停止状態（is_active=false）を読んで緊急停止バーの初期状態に反映する。
     // 現在資産はオンチェーン残高（useUsdcBalance）で取得するため、ここでは balance を読まない。
     fetch(`${API_BASE}/api/user/settings`, { headers })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((d: { is_active?: boolean } | null) => {
-        if (d?.is_active === false) setPaused(true)
+      .then((r) => jsonOrReport("user/settings", r))
+      .then((d) => {
+        const s = d as { is_active?: boolean } | null
+        if (s?.is_active === false) setPaused(true)
       })
-      .catch(() => {})
+      .catch((e) => reportFetchError("user/settings", e))
 
     // AI 判定（最新 1 件）
     fetch(`${API_BASE}/api/ai/decisions?limit=1`, { headers })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((d: { items?: AiJudgment[] } | null) => {
-        if (d?.items?.[0]) setAiJudgment(d.items[0])
+      .then((r) => jsonOrReport("ai/decisions", r))
+      .then((d) => {
+        const j = d as { items?: AiJudgment[] } | null
+        if (j?.items?.[0]) setAiJudgment(j.items[0])
       })
-      .catch(() => {})
+      .catch((e) => reportFetchError("ai/decisions", e))
 
     // 運用中コイン: 最新ポートフォリオ snapshot の positions_json を表示する。
     // /api/user/holdings は不在のため /api/portfolio/current を使う (Asana 1215723024139228)。
     // v3 (shadow mode) は positions_json が空 → 「運用中のコインがありません」が正。
     fetch(`${API_BASE}/api/portfolio/current`, { headers })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((d: PortfolioCurrentResponse | null) => {
-        setCoins(mapPositionsToHoldings(d?.positions_json))
+      .then((r) => jsonOrReport("portfolio/current", r))
+      .then((d) => {
+        setCoins(mapPositionsToHoldings((d as PortfolioCurrentResponse | null)?.positions_json))
       })
-      .catch(() => {})
+      .catch((e) => reportFetchError("portfolio/current", e))
 
     // 保留中の提案（最新 1 件）。あれば承認/見送りの実行導線を表示する。
     fetch(`${API_BASE}/api/proposals/pending`, { headers })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((d: { items?: ChatProposal[] } | null) => {
-        if (d?.items?.[0]) setPendingProposal(d.items[0])
+      .then((r) => jsonOrReport("proposals/pending", r))
+      .then((d) => {
+        const p = d as { items?: ChatProposal[] } | null
+        if (p?.items?.[0]) setPendingProposal(p.items[0])
       })
-      .catch(() => {})
+      .catch((e) => reportFetchError("proposals/pending", e))
   }, [])
 
   // ── KPI-C: 運用残高 + 加重平均APY を 30秒ポーリングで取得
@@ -194,11 +221,11 @@ export default function LiffChatPage() {
     const headers = { Authorization: `Bearer ${token}` }
     const fetchPortfolio = () => {
       fetch(`${API_BASE}/api/portfolio/current`, { headers })
-        .then((r) => (r.ok ? r.json() : null))
-        .then((d: PortfolioCurrentResponse | null) => {
-          if (d) setPortfolio(d)
+        .then((r) => jsonOrReport("portfolio/current", r))
+        .then((d) => {
+          if (d) setPortfolio(d as PortfolioCurrentResponse)
         })
-        .catch(() => {})
+        .catch((e) => reportFetchError("portfolio/current", e))
     }
     fetchPortfolio()
     const id = setInterval(fetchPortfolio, 30_000)
@@ -213,8 +240,9 @@ export default function LiffChatPage() {
     if (!token) return
     const headers = { Authorization: `Bearer ${token}` }
     fetch(`${API_BASE}/api/user/dividends`, { headers })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((d: { dividends?: { month: string; user_takehome_jpy: string }[] } | null) => {
+      .then((r) => jsonOrReport("user/dividends", r))
+      .then((raw) => {
+        const d = raw as { dividends?: { month: string; user_takehome_jpy: string }[] } | null
         if (!d?.dividends) return
         setDividends(
           d.dividends
@@ -225,7 +253,7 @@ export default function LiffChatPage() {
             .reverse(),
         )
       })
-      .catch(() => {})
+      .catch((e) => reportFetchError("user/dividends", e))
   }, [])
 
   // ── WebSocket: AI 判定リアルタイム受信
@@ -249,7 +277,10 @@ export default function LiffChatPage() {
         // parse 失敗は無視
       }
     }
-    ws.onerror = () => ws.close()
+    ws.onerror = (ev) => {
+      reportFetchError("ai/ws/decisions", ev)
+      ws.close()
+    }
     return () => ws.close()
   }, [])
 

--- a/frontend/lib/posthog.ts
+++ b/frontend/lib/posthog.ts
@@ -38,6 +38,9 @@ export const EV = {
   OPMODE_CHANGE:       "liff_opmode_change",
   DEPOSIT_FUND:        "liff_deposit_fund",
   WITHDRAW_SUBMIT:     "liff_withdraw_submit",
+  // データ取得失敗 (非2xx / 例外)。silent な握りつぶしを観測可能化し、
+  // 提案・AI判定・残高などが「出ない」障害を早期検知する。
+  DATA_FETCH_ERROR:    "liff_data_fetch_error",
 } as const
 
 export type EventName = typeof EV[keyof typeof EV]


### PR DESCRIPTION
## 概要

v4 LINE消費者(liff-chat)の **AI提案フロー**を調査。フロント動線(表示→承認→Privy自己署名→submit-tx)は完全実装・RBAC健全だが、提案が「出ない」原因を実機で特定し対応した。

## 実機で特定した問題と対応

### 1. `/api/proposals/pending` が 500(staging-v4 / 別途 DB 修正済)
`proposals.protocol` カラム欠落で `column does not exist` → 提案カードが永久に出ない。フロントが `.catch(()=>{})` で無言。
- staging-v4 に `ALTER TABLE proposals ADD COLUMN IF NOT EXISTS protocol VARCHAR(50)` 適用 → 500→200(本PRのコード変更外・DB操作)
- staging-v4 は `alembic_version` 不在だったため `alembic stamp heads` で baseline 確立(head=pp20260624)
- **本番は古いモデルで protocol 非SELECT=整合・500せず**

### 2. フロント: silent fetch catch の可視化 〔本PR〕
各 fetch の `.catch(()=>{})` / `r.ok?json:null` が 500 を握りつぶし、上記バグが長期間隠れた。`reportFetchError` で非2xx/例外を `console.warn` + PostHog(`liff_data_fetch_error`)に記録。**消費者UXは不変**。

### 3. backend: `ProposalResponse` に `protocol` 露出 〔本PR〕
protocol は model/DB にあるが response schema 未露出 → フロントの protocol バッジ・lido注記が機能せず。`Optional[str]` で後方互換に追加。

### 4. 設計提案: 消費者の提案金額解決 〔本PR / docs/61〕
提案金額が `fund_allocations`(custodialパートナー枠)依存で、非カストディアル消費者は枠不在→ $0 skip →提案が一切生成されない。**案C(fund_allocation優先 + wallet残高fallback)** を推奨し、async/sync・チェーン分離・fail-safe の論点を整理。金融ロジックのため別途 Plan モードで実装。

## 検証

- tsc 0 errors / frontend build **85/85 pass** / backend ruff・format・mypy pass / proposals tests **59 pass**
- **実機 E2E(staging-v4)**: protocol列追加で `/api/proposals/pending` 500→200 → テスト proposal INSERT → liff-chat で **ProposalActionCard(入金 Supply USDC \$100 + 承認する)表示を確認**

## 補足
- staging-v4 にテスト用 proposal(id=1, user 8)を INSERT 済。不要なら `DELETE FROM proposals WHERE id=1;`
- 本番に v4 backend をデプロイする際は protocol migration を**先に**当てること(alembic先行)

🤖 Generated with [Claude Code](https://claude.com/claude-code)