### PR TITLE
feat(proposal): 消費者の提案金額を wallet 残高 fallback で解決 (案C)

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -69,23 +69,84 @@ _PROPOSAL_ASSET = "USDC"
 _PROPOSAL_EXPIRES_HOURS = 72
 
 # 提案金額: fund_allocations.allocated_amount_usd × _PROPOSAL_RATIO で動的計算。
-# fund_allocations が未設定のユーザーへの提案は Decimal("0") → skip (安全側)。
+# fund_allocation 不在の非カストディアル消費者は本人 wallet の USDC 残高 × ratio に
+# fallback する (案C / docs/61)。いずれも sizing 不能なら Decimal("0") → skip (安全側)。
 # 環境変数で上書き可能。
 _PROPOSAL_RATIO = Decimal(os.getenv("PROPOSAL_AMOUNT_RATIO", "0.10"))  # 10%
 _PROPOSAL_AMOUNT_MIN_USD = Decimal(os.getenv("PROPOSAL_AMOUNT_MIN_USD", "50"))
 _PROPOSAL_AMOUNT_MAX_USD = Decimal(os.getenv("PROPOSAL_AMOUNT_MAX_USD", "2000"))
 
+# USDC は 6 decimals。ERC20 balanceOf の最小 ABI。
+_USDC_DECIMALS = 6
+_ERC20_BALANCE_OF_ABI: list[dict[str, Any]] = [
+    {
+        "constant": True,
+        "inputs": [{"name": "account", "type": "address"}],
+        "name": "balanceOf",
+        "outputs": [{"name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    }
+]
+
+
+def _read_wallet_usdc_balance(wallet_address: str) -> Optional[Decimal]:
+    """active chain 上の wallet USDC 残高 (USDC 単位) を返す。
+
+    AAVE_ACTIVE_CHAINS の先頭チェーン (production=base / staging=base_sepolia) の USDC
+    コントラクトに対し web3 で balanceOf する (web3.py の .call() は同期)。
+    web3 未導入 / RPC URL 未設定 / 不正アドレス / RPC 失敗時は **None** を返し、
+    呼び出し側で skip させる (安全側: 残高不明のまま提案金額を捏造しない)。
+
+    NOTE: チェーン別 USDC アドレス・RPC は app.aave.chains に集約済 (mainnet 直書きしない)。
+    """
+    try:
+        from web3 import Web3  # noqa: PLC0415
+
+        from app.aave.chains import (  # noqa: PLC0415
+            get_active_chains,
+            get_rpc_url_for_chain,
+        )
+
+        chain = get_active_chains()[0]
+        usdc_addr = chain.tokens.get("USDC")
+        if not usdc_addr:
+            logger.warning("[proposal_amount] USDC address missing for %s", chain.chain_name)
+            return None
+        rpc_url = get_rpc_url_for_chain(chain)
+        w3 = Web3(Web3.HTTPProvider(rpc_url))
+        contract = w3.eth.contract(
+            address=w3.to_checksum_address(usdc_addr),
+            abi=_ERC20_BALANCE_OF_ABI,
+        )
+        raw_balance = contract.functions.balanceOf(w3.to_checksum_address(wallet_address)).call()
+        return Decimal(raw_balance) / Decimal(10**_USDC_DECIMALS)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "[proposal_amount] wallet USDC balance read failed for %s: %s",
+            wallet_address,
+            exc,
+        )
+        return None
+
 
 def _resolve_proposal_amount(db: Session, user_id: int) -> Decimal:
-    """ユーザーの fund_allocations 合計 × _PROPOSAL_RATIO を提案金額として返す。
+    """提案金額を解決する (案C: fund_allocation 優先 + wallet 残高 fallback / docs/61)。
 
-    active な fund_allocations が存在しない場合は Decimal("0") を返し、
-    Slack 通知 (best-effort) を送る。$0 は下流の explicit check でスキップされる。
+    1. active fund_allocations 合計 × ratio (custodial パートナー/テスター枠)。
+       min/max にクランプ。**既存挙動を完全維持**。
+    2. allocation 不在 & wallet 設定済の非カストディアル消費者: 本人 wallet の
+       on-chain USDC 残高 × ratio。残高0 / 取得失敗 / min 未満は Decimal("0") で skip
+       (安全側: wallet 額を超える/極小の提案を作らない)。
+    3. allocation も wallet も無い: sizing 不能 → Slack 通知 + Decimal("0")
+       (パートナー/テスター登録漏れの検知を維持)。
 
-    新テスター追加後に fund_allocations INSERT を忘れると Slack 警告が飛ぶ設計。
+    $0 は呼び出し側 (_create_proposals_for_users) の explicit check でスキップされる。
+    金融計算は Decimal のみ (CLAUDE.md)。
     """
     from app.partner.allocation_models import FundAllocation  # noqa: PLC0415
 
+    # ── 1. fund_allocation 優先 (custodial 枠) ──
     raw = (
         db.query(func.sum(FundAllocation.allocated_amount_usd))
         .filter(
@@ -95,17 +156,44 @@ def _resolve_proposal_amount(db: Session, user_id: int) -> Decimal:
         .scalar()
     )
     allocated = Decimal(str(raw)) if raw else Decimal("0")
-    if allocated <= Decimal("0"):
-        logger.warning(
-            "fund_allocations empty for user_id=%d — proposal skipped. "
-            "ACTION REQUIRED: INSERT INTO fund_allocations (tester_user_id=%d, status='active').",
-            user_id,
-            user_id,
-        )
-        _notify_missing_allocation(user_id)
-        return Decimal("0")
-    amount = (allocated * _PROPOSAL_RATIO).quantize(Decimal("0.01"))
-    return max(_PROPOSAL_AMOUNT_MIN_USD, min(amount, _PROPOSAL_AMOUNT_MAX_USD))
+    if allocated > Decimal("0"):
+        amount = (allocated * _PROPOSAL_RATIO).quantize(Decimal("0.01"))
+        return max(_PROPOSAL_AMOUNT_MIN_USD, min(amount, _PROPOSAL_AMOUNT_MAX_USD))
+
+    # ── 2. fallback: 非カストディアル消費者の wallet USDC 残高 ──
+    user = db.get(User, user_id)
+    wallet = (user.smart_wallet_address or user.wallet_address) if user else None
+    if wallet:
+        balance = _read_wallet_usdc_balance(wallet)
+        if balance is None or balance <= Decimal("0"):
+            # 残高0 / RPC 取得失敗 → skip (安全側)
+            logger.debug(
+                "[proposal_amount] wallet USDC 0/unavailable for user_id=%d — skipped",
+                user_id,
+            )
+            return Decimal("0")
+        amount = (balance * _PROPOSAL_RATIO).quantize(Decimal("0.01"))
+        if amount < _PROPOSAL_AMOUNT_MIN_USD:
+            # 10% が gas viable な最小額未満 → skip。
+            # allocation 経路は min へ切り上げるが、消費者 wallet 経路では残高に対し
+            # 過大な supply を避けるため切り上げず skip する (意図的な非対称 / docs/61)。
+            logger.debug(
+                "[proposal_amount] wallet-based amount %s < min $%s for user_id=%d — skipped",
+                amount,
+                _PROPOSAL_AMOUNT_MIN_USD,
+                user_id,
+            )
+            return Decimal("0")
+        return min(amount, _PROPOSAL_AMOUNT_MAX_USD)
+
+    # ── 3. allocation も wallet も無い → sizing 不能 ──
+    logger.warning(
+        "no active fund_allocation and no wallet for user_id=%d — proposal skipped. "
+        "ACTION: register fund_allocations (tester) or ensure wallet is set (consumer).",
+        user_id,
+    )
+    _notify_missing_allocation(user_id)
+    return Decimal("0")
 
 
 def _notify_missing_allocation(user_id: int) -> None:

--- a/backend/tests/test_ai_judgment_scheduler.py
+++ b/backend/tests/test_ai_judgment_scheduler.py
@@ -1105,6 +1105,109 @@ def test_resolve_proposal_amount_multiple_allocations_summed(db_session):
     assert result == Decimal("500.00")
 
 
+# ---------------------------------------------------------------------------
+# _resolve_proposal_amount: wallet 残高 fallback (案C / docs/61)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_amount_wallet_fallback_uses_balance(db_session, monkeypatch):
+    """allocation 不在 + wallet 設定済 → wallet USDC 残高 × 10% を使う。
+
+    $1,000 残高 × 10% = $100。
+    """
+    import app.automation.ai_judgment_scheduler as sched  # noqa: PLC0415
+
+    user = _add_active_user(db_session, "wallet_consumer@example.com")
+    user.smart_wallet_address = "0x" + "a" * 40
+    db_session.commit()
+
+    monkeypatch.setattr(sched, "_read_wallet_usdc_balance", lambda _addr: Decimal("1000"))
+    result = sched._resolve_proposal_amount(db_session, user.id)
+    assert result == Decimal("100.00")
+
+
+def test_resolve_amount_wallet_below_min_is_skipped(db_session, monkeypatch):
+    """wallet 残高 × 10% が min ($50) 未満 → $0 で skip (切り上げない / 安全側)。
+
+    $400 残高 × 10% = $40 < $50 → $0。
+    """
+    import app.automation.ai_judgment_scheduler as sched  # noqa: PLC0415
+
+    user = _add_active_user(db_session, "wallet_small@example.com")
+    user.wallet_address = "0x" + "b" * 40
+    db_session.commit()
+
+    monkeypatch.setattr(sched, "_read_wallet_usdc_balance", lambda _addr: Decimal("400"))
+    result = sched._resolve_proposal_amount(db_session, user.id)
+    assert result == Decimal("0")
+
+
+def test_resolve_amount_wallet_clamps_to_max(db_session, monkeypatch):
+    """wallet 残高 × 10% が max ($2,000) 超 → $2,000 にクランプ。
+
+    $30,000 残高 × 10% = $3,000 → $2,000。
+    """
+    import app.automation.ai_judgment_scheduler as sched  # noqa: PLC0415
+
+    user = _add_active_user(db_session, "wallet_big@example.com")
+    user.smart_wallet_address = "0x" + "c" * 40
+    db_session.commit()
+
+    monkeypatch.setattr(sched, "_read_wallet_usdc_balance", lambda _addr: Decimal("30000"))
+    result = sched._resolve_proposal_amount(db_session, user.id)
+    assert result == Decimal("2000.00")
+
+
+def test_resolve_amount_wallet_balance_unavailable_is_skipped(db_session, monkeypatch):
+    """残高取得失敗 (None) / 残高0 → $0 で skip (誤った金額を捏造しない)。"""
+    import app.automation.ai_judgment_scheduler as sched  # noqa: PLC0415
+
+    user = _add_active_user(db_session, "wallet_rpcfail@example.com")
+    user.smart_wallet_address = "0x" + "d" * 40
+    db_session.commit()
+
+    monkeypatch.setattr(sched, "_read_wallet_usdc_balance", lambda _addr: None)
+    assert sched._resolve_proposal_amount(db_session, user.id) == Decimal("0")
+
+    monkeypatch.setattr(sched, "_read_wallet_usdc_balance", lambda _addr: Decimal("0"))
+    assert sched._resolve_proposal_amount(db_session, user.id) == Decimal("0")
+
+
+def test_resolve_amount_allocation_takes_priority_over_wallet(db_session, monkeypatch):
+    """allocation と wallet 双方ある場合は allocation を優先 (既存パートナー互換)。
+
+    allocation $10,000 → $1,000。wallet 残高は参照されない。
+    """
+    import app.automation.ai_judgment_scheduler as sched  # noqa: PLC0415
+
+    user = _add_active_user(db_session, "both@example.com")
+    user.smart_wallet_address = "0x" + "e" * 40
+    _add_fund_allocation(db_session, user, allocated_usd=Decimal("10000"))
+    db_session.commit()
+
+    def _should_not_be_called(_addr):
+        raise AssertionError("wallet balance must not be read when allocation exists")
+
+    monkeypatch.setattr(sched, "_read_wallet_usdc_balance", _should_not_be_called)
+    assert sched._resolve_proposal_amount(db_session, user.id) == Decimal("1000.00")
+
+
+def test_resolve_amount_no_allocation_no_wallet_notifies_and_zero(db_session, monkeypatch):
+    """allocation も wallet も無い → $0 + Slack 通知 (テスター登録漏れ検知を維持)。"""
+    import app.automation.ai_judgment_scheduler as sched  # noqa: PLC0415
+
+    user = _add_active_user(db_session, "nowallet@example.com")
+    db_session.commit()
+
+    called: dict[str, int] = {}
+    monkeypatch.setattr(
+        sched, "_notify_missing_allocation", lambda uid: called.__setitem__("uid", uid)
+    )
+    result = sched._resolve_proposal_amount(db_session, user.id)
+    assert result == Decimal("0")
+    assert called.get("uid") == user.id
+
+
 def test_create_proposals_db_error_one_user_does_not_stop_others(db_session):
     """_resolve_proposal_amount が DB 例外を投げたとき、他ユーザーの処理が継続すること。
 


### PR DESCRIPTION
## 概要

`docs/61` の設計提案(PR #875)を実装。v4 非カストディアル消費者(liff-chat)に **AI提案が生成されない**根本原因を解消する。

### 問題
`_resolve_proposal_amount` は `fund_allocations`(custodial パートナー枠)依存。liff-chat 消費者は枠が無く提案金額 $0 → 常に skip → **提案が一切生成されなかった**。

### 解決(案C: fund_allocation 優先 + wallet 残高 fallback)
`_resolve_proposal_amount` を 3 経路化:

1. **fund_allocation 優先**(custodial パートナー/テスター枠)— min/max クランプ・**既存挙動を完全維持**
2. **wallet 残高 fallback**(allocation 不在 + wallet 設定済の消費者)— 本人 wallet の on-chain USDC 残高 × ratio。残高0 / 取得失敗 / min 未満は `$0` で skip
3. **両方無い** — Slack 通知 + `$0`(テスター登録漏れ検知を維持)

## 安全設計

- **チェーン分離**: USDC アドレス・RPC は `app.aave.chains` に集約(mainnet 直書きせず、staging-v4 = `base_sepolia` でも正しく解決)
- **fail-safe**: `_read_wallet_usdc_balance` は web3 未導入 / RPC 失敗 / 不正アドレスを全て `None`=skip 化(残高不明のまま金額を捏造しない)
- **過大提案の回避**: 消費者 wallet 経路は min 未満を切り上げず skip(残高に対し過大な supply を回避。allocation 経路の切り上げとは**意図的に非対称**)
- **Decimal 厳守**(CLAUDE.md 金融計算ルール)

## テスト

- wallet fallback **6 ケース追加**: 残高あり($1000→$100) / min未満skip($400→$0) / maxクランプ($30k→$2000) / 取得失敗skip(None・0) / allocation優先 / no-wallet通知
- 既存 clamp 6 + scheduler 全 **51 pass** / ruff・format・mypy pass

## ⚠️ レビュー依頼
金融ロジック(提案サイジング→実トレード額)の変更につき **defi-aave-review / Codex adversarial review** を推奨。`_PROPOSAL_RATIO`(10%)・min($50)・max($2000)は env 上書き可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)