### PR TITLE
fix(alembic): env.py のモデル import 漏れを解消（autogenerate の DROP 誤生成防止）

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -13,10 +13,18 @@ from alembic import context
 # Add backend directory to sys.path so app modules can be imported
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-# Import all models so Alembic autogenerate can detect them
+# Import all models so Alembic autogenerate can detect them.
+# 【重要】__tablename__ を持つ全モデルモジュールをここで import すること。
+# import 漏れがあると Base.metadata がそのテーブルを認識せず、autogenerate が
+# 実在テーブルを「removed」と誤検出して DROP TABLE を生成する(本番スキーマ破壊リスク)。
+# 1 モジュールから 1 クラス import すれば、そのモジュール内の全テーブルが登録される。
+# 確認: grep -rl "__tablename__" app/ の全モジュールが下に揃っているか。
+from app.ai.feedback_models import AIFeedback  # noqa: F401, E402
 from app.ai.models import AIDecision  # noqa: F401, E402
 from app.auth.models import User  # noqa: F401, E402
+from app.chat.models import ChatMessage  # noqa: F401, E402
 from app.database import Base, get_database_url  # noqa: E402
+from app.fees.allowance_models import FeeAllowance  # noqa: F401, E402
 from app.fees.models import (  # noqa: F401, E402
     FeeConfigV10,
     FeeTransaction,
@@ -29,6 +37,8 @@ from app.knowledge.models import (  # noqa: F401, E402
     KnowledgeDocument,
     KnowledgeSource,
 )
+from app.notifications.models import NotificationLog  # noqa: F401, E402
+from app.partner.allocation_models import FundAllocation  # noqa: F401, E402
 from app.portfolio.models import PortfolioHistory, PortfolioSnapshot  # noqa: F401, E402
 from app.proposals.models import Proposal  # noqa: F401, E402
 from app.tos.models import ToSConsent, ToSUserAction  # noqa: F401, E402

--- a/backend/tests/test_alembic_env_completeness.py
+++ b/backend/tests/test_alembic_env_completeness.py
@@ -1,0 +1,75 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_alembic_env_completeness.py
+"""alembic/env.py のモデル import 完全性ガード。
+
+import 漏れがあると Base.metadata がそのテーブルを認識せず、autogenerate が
+実在テーブルを「removed」と誤検出して DROP TABLE を生成する(本番スキーマ破壊リスク)。
+新規モデルモジュール追加時に env.py への import 追加を強制する回帰テスト。
+2026-06-25: notification_logs / fund_allocations / chat_messages / fee_allowances /
+ai_feedbacks の 5 テーブルが env.py 未 import で alembic check WARNING を出していた事象の再発防止。
+"""
+
+import glob
+import re
+from pathlib import Path
+
+_BACKEND = Path(__file__).resolve().parent.parent
+
+
+def _module_path(file_path: str) -> str:
+    """app/x/y.py -> app.x.y"""
+    rel = Path(file_path).resolve().relative_to(_BACKEND)
+    return str(rel.with_suffix("")).replace("/", ".")
+
+
+def test_env_py_imports_every_model_module() -> None:
+    """__tablename__ を宣言する全モジュールが alembic/env.py で import されていること。"""
+    env_src = (_BACKEND / "alembic" / "env.py").read_text(encoding="utf-8")
+
+    model_modules: set[str] = set()
+    for f in glob.glob(str(_BACKEND / "app" / "**" / "*.py"), recursive=True):
+        if "test" in f:
+            continue
+        if "__tablename__" in Path(f).read_text(encoding="utf-8"):
+            model_modules.add(_module_path(f))
+
+    missing = sorted(m for m in model_modules if f"from {m} import" not in env_src)
+    assert not missing, (
+        "alembic/env.py が import していないモデルモジュール: "
+        f"{missing}。autogenerate が当該テーブルを DROP 誤生成する。env.py に import を追加すること。"
+    )
+
+
+def test_base_metadata_covers_all_declared_tables() -> None:
+    """env.py の import 集合で Base.metadata が全 __tablename__ を網羅すること(機能確認)。"""
+    # env.py が import する全モジュールを import (env.py と同一集合)
+    import app.ai.feedback_models  # noqa: F401
+    import app.ai.models  # noqa: F401
+    import app.auth.models  # noqa: F401
+    import app.chat.models  # noqa: F401
+    import app.fees.allowance_models  # noqa: F401
+    import app.fees.models  # noqa: F401
+    import app.invitations.models  # noqa: F401
+    import app.knowledge.models  # noqa: F401
+    import app.notifications.models  # noqa: F401
+    import app.partner.allocation_models  # noqa: F401
+    import app.portfolio.models  # noqa: F401
+    import app.proposals.models  # noqa: F401
+    import app.tos.models  # noqa: F401
+    import app.transactions.models  # noqa: F401
+    import app.users.models  # noqa: F401
+    from app.database import Base
+
+    registered = set(Base.metadata.tables.keys())
+
+    declared: set[str] = set()
+    for f in glob.glob(str(_BACKEND / "app" / "**" / "*.py"), recursive=True):
+        if "test" in f:
+            continue
+        for name in re.findall(
+            r"__tablename__\s*=\s*[\"']([a-z_]+)[\"']", Path(f).read_text(encoding="utf-8")
+        ):
+            declared.add(name)
+
+    missing = sorted(declared - registered)
+    assert not missing, f"Base.metadata に未登録のテーブル: {missing}"


### PR DESCRIPTION
## 概要
2026-06-25 本番デプロイの post-deploy チェックで出た `alembic check` WARNING の根本対応。

## 問題
`alembic/env.py` が `__tablename__` を持つ全モデルを import しておらず `Base.metadata` が不完全。その結果 `alembic check` / autogenerate が**実在テーブルを「removed」と誤検出**し、`alembic revision --autogenerate` 実行時に **DROP TABLE を誤生成**する状態だった（本番スキーマ破壊リスク）。DB スキーマ自体は正常で、アプリ稼働にも影響はないが、autogenerate が危険だった。

## 修正
未 import だった 5 モジュール（= 誤検出 5 テーブル）を env.py に追加:

| モジュール | テーブル |
|---|---|
| `app.ai.feedback_models` | ai_feedbacks |
| `app.chat.models` | chat_messages |
| `app.fees.allowance_models` | fee_allowances |
| `app.notifications.models` | notification_logs |
| `app.partner.allocation_models` | fund_allocations |

import 漏れ再発を CI で検出する回帰テスト（`test_alembic_env_completeness.py`）も追加。

## 検証
- `Base.metadata` が全 **27 テーブル**を網羅（修正前は 5 欠落）
- 修正版 env.py を staging-v4(本番相当 DB)で `alembic check` → **"No new upgrade operations detected"**（誤検出が消えて完全クリーン）
- 回帰テスト 2 件 pass / ruff・format pass

## 影響範囲
env.py の import 完全化のみ。**既存 migration・migration 生成ロジックに影響なし**。本番 DB スキーマも変更しない（元から正常）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)