### PR TITLE
fix(csp): AI判定 WebSocket (wss) を connect-src に許可

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -5,11 +5,20 @@
 // (scripts/cf-pages-prebuild.js) which runs before next build.
 const isCFPages = process.env.CF_PAGES === '1';
 const backendUrl = process.env.NEXT_PUBLIC_API_URL || '';
+// AI 判定のリアルタイム配信は wss://<api-host>/api/ai/ws/decisions に接続する
+// (liff-chat/page.tsx の WebSocket)。connect-src に wss 版が無いと CSP がブロックし、
+// AI判定カードがリアルタイム更新されない (初期 fetch にフォールバックするため一見動くが
+// realtime push が静かに死ぬ)。https の API ホストと同一オリジンの wss を明示的に許可する。
+// NOTE: connect-src の "https:" ワイルドカードは wss スキームを許可しない。
+const wssBackendUrl = backendUrl ? backendUrl.replace(/^https?:\/\//, 'wss://') : '';
 const cspConnectSrc = [
   "'self'",
   backendUrl,
+  wssBackendUrl,
   "https://api.ultra-auto-trade.com",
+  "wss://api.ultra-auto-trade.com",
   "https://api-staging.ultra-auto-trade.com",
+  "wss://api-staging.ultra-auto-trade.com",
   "https://*.infura.io",
   "https://*.alchemy.com",
   "wss://*.walletconnect.org",


### PR DESCRIPTION
## 概要
v4 全パネル UI スイープ中に発見。**AI判定のリアルタイム WebSocket が CSP でブロック**されていた(全環境・本番含む)。

## 問題
liff-chat は `wss://<api-host>/api/ai/ws/decisions` に接続して AI判定をリアルタイム受信するが、CSP `connect-src` に **wss 版の API ホストが無い**ため、ブラウザがブロックしていた。本番 `app.ultra-auto-trade.com` の実 CSP ヘッダーでも `wss://api...` 不在を確認(walletconnect の wss のみ存在)。

**影響**: AI判定カードがリアルタイム更新されない。初期 fetch にフォールバックするためページ読込時は判定が表示されるが、**WebSocket push が静かに死んでいた**(`"https:"` ワイルドカードは wss スキームを許可しない)。

## 修正
`backendUrl` から導出した env 別 wss URL + 本番/staging の wss API ホストを `connect-src` に追加。

## 検証
- prod build の**実 CSP ヘッダー**に `wss://api-staging-v4...` / `wss://api.ultra-auto-trade.com` / `wss://api-staging...` が出力されることを確認
- tsc 0 errors

## 関連: v4 全パネルスイープ結果 (2026-06-25 / staging-v4)
- ✅ 全9パネル + home + chat: **i18n 生キー 0 / JSクラッシュ 0 / MISSING_MESSAGE 0**
- ✅ consumer GET endpoint 全て **200(500なし)**
- 🔴 本PR: CSP が AI WebSocket をブロック → 修正
- ⚠️ 軽微(別途): MY WALLET の "Base Mainnet" ラベルがハードコード(staging-v4=Sepolia で不一致・本番は正)/ Privy バナー画像が img-src でブロック(cosmetic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)