### PR TITLE
fix(api): /api/user/resume の catch-22 を解消（pause後に再開不能だったバグ）

### DIFF
--- a/backend/app/users/settings_router.py
+++ b/backend/app/users/settings_router.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.auth.constants import ExecutionPolicy
-from app.auth.dependencies import require_active_user
+from app.auth.dependencies import get_current_user, require_active_user
 from app.auth.models import User, UserRole
 from app.database import get_db
 from app.partner import allocation_service
@@ -229,7 +229,11 @@ def pause_user(
 
 @router.post("/resume", summary="運用再開")
 def resume_user(
-    current_user: User = Depends(require_active_user),
+    # NOTE: require_active_user は使えない。pause で is_active=False にした後に resume を
+    # 呼ぶため、require_active_user だと 403 "User is inactive" で永久に再開不能になる
+    # (catch-22)。resume は「非アクティブな本人」が自分を再アクティブ化する操作なので
+    # 認証のみ (get_current_user) を要求する。
+    current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> dict[str, Any]:
     """運用を再開する（is_active=True）。"""

--- a/backend/tests/test_user_settings_api.py
+++ b/backend/tests/test_user_settings_api.py
@@ -185,6 +185,22 @@ class TestUserSettingsAPI:
         assert r.status_code == 200
         assert r.json()["is_active"] is True
 
+    def test_pause_then_resume_recovers(self, client: TestClient) -> None:
+        """pause で is_active=False にした後でも resume で再開できること (catch-22 回帰)。
+
+        resume が require_active_user 依存だと、pause 後 is_active=False のため 403
+        "User is inactive" で永久に再開不能になる。get_current_user に修正済。
+        """
+        headers = {"Authorization": f"Bearer {register_and_login(client)}"}
+        # pause → is_active=False
+        rp = client.post("/api/user/pause", headers=headers)
+        assert rp.status_code == 200
+        assert rp.json()["is_active"] is False
+        # 非アクティブ状態から resume → 再開できる (403 にならない)
+        rr = client.post("/api/user/resume", headers=headers)
+        assert rr.status_code == 200, f"resume が非アクティブ状態で失敗: {rr.status_code} {rr.text}"
+        assert rr.json()["is_active"] is True
+
     def test_automation_pause(self, client: TestClient) -> None:
         token = register_and_login(client)
         r = client.post("/api/automation/pause", headers={"Authorization": f"Bearer {token}"})


### PR DESCRIPTION
## 概要
v4 書き込み系フローの機能テスト中に staging-v4 で発見した**運用再開不能バグ**。

## 問題（catch-22）
`POST /api/user/resume` が `require_active_user` 依存だった。
- `pause` → `is_active=False`
- `resume` → `require_active_user` が `is_active=False` を見て **403 "User is inactive"**
- → **一度緊急停止すると二度と再開できない**

`require_active_user` は `if not user.is_active: raise 403` のため、resume には構造的に使えなかった。

## 修正
`resume_user` の依存を `require_active_user` → `get_current_user`（認証のみ・active不要）に変更。resume は「非アクティブな本人が自分を再アクティブ化する」操作なので妥当。

## 回帰テスト
既存 `test_resume_user` は**アクティブな新規ユーザー**で resume を呼ぶだけで、`pause→resume` サイクルを検証しておらず見逃していた。pause 後の非アクティブ状態から resume が成功することを検証する `test_pause_then_resume_recovers` を追加。

## 検証
- pause/resume テスト **5 pass** / ruff・format・mypy pass

## ⚠️ 関連 UX 課題（本PR対象外・要プロダクト判断）
`liff-chat` の緊急停止バーは paused 時「停止中」表示のみで **消費者向けの再開ボタンが無い**。本修正で `/resume` エンドポイントは機能するが、消費者が自分で再開できる UI が存在しない。安全設計として意図的（admin介入必須）か、再開ボタンを追加すべきか、プロダクト判断が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)