### PR TITLE
feat(proposals): custodial 自動執行に protocol 別 dispatch を追加（Phase D 土台 / Lido・Pendle は HUMAN-REVIEW 据置）

### DIFF
--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -599,6 +599,68 @@ def _execute_aave_for_proposal(proposal: Proposal, db: Session) -> None:
         _notify_aave_failure(proposal.id, error_message, failed_at)
 
 
+class ProtocolExecutionNotWiredError(Exception):
+    """custodial 自動執行がまだ配線されていない protocol を指す。
+
+    Lido/Pendle の on-chain 実行 (real ETH stake / PT swap の broadcast) は
+    HUMAN-REVIEW-REQUIRED かつ Opus による安全レビュー対象 (CLAUDE.md v4 鉄則10)。
+    本スライスでは dispatch 構造とテストのみ整備し、実 broadcast は意図的に未配線。
+    """
+
+
+def _execute_lido_for_proposal(proposal: Proposal, db: Session) -> None:
+    """[Phase D / HUMAN-REVIEW 未配線] Lido STAKE_ETH の custodial 実行。
+
+    実装方針 (HUMAN-REVIEW + Opus で配線すること):
+      1. LidoClient.stake_eth(amount_wei) で stETH をステーク (real ETH 送金 = 要レビュー)
+      2. receipt 確認 → proposal.status='executed' / tx_hash 保存
+      3. 失敗時は _execute_aave_for_proposal と同様に status='failed' + 通知
+
+    現状は実 broadcast を含まないため未配線として明示的に raise する。これにより
+    auto_execution_enabled=true でも Lido 提案が誤って Aave 経路で実行されることを防ぐ。
+    """
+    raise ProtocolExecutionNotWiredError(
+        f"Lido (proposal={proposal.id}, op={proposal.operation}) の custodial 自動執行は "
+        "未配線です (HUMAN-REVIEW-REQUIRED)。"
+    )
+
+
+def _execute_pendle_for_proposal(proposal: Proposal, db: Session) -> None:
+    """[Phase D / HUMAN-REVIEW 未配線] Pendle BUY_PT/SELL_PT の custodial 実行。
+
+    実装方針 (HUMAN-REVIEW + Opus で配線すること):
+      1. PendleService/RouterV4 で swap calldata 取得 (dry_run=True は安全・本番前確認用)
+      2. PENDLE_ENABLE_ONCHAIN_WRITE=true かつ dry_run=False で broadcast (要レビュー)
+      3. receipt 確認 → proposal.status='executed' / tx_hash 保存
+
+    現状は実 broadcast を含まないため未配線として明示的に raise する。
+    """
+    raise ProtocolExecutionNotWiredError(
+        f"Pendle (proposal={proposal.id}, op={proposal.operation}) の custodial 自動執行は "
+        "未配線です (HUMAN-REVIEW-REQUIRED)。"
+    )
+
+
+def _dispatch_custodial_execution(proposal: Proposal, db: Session) -> None:
+    """proposal.protocol で custodial 自動執行ハンドラを振り分ける。
+
+    protocol 無指定 / "aave" は従来どおり Aave 経路。"lido"/"pendle" は専用ハンドラ
+    (現状 HUMAN-REVIEW 未配線で raise)。protocol を見ずに常に Aave 実行していた
+    潜在的な誤執行 (Lido/Pendle 提案を Aave operation として実行) を防ぐ。
+    """
+    protocol = (proposal.protocol or "aave").lower()
+    if protocol in ("", "aave"):
+        _execute_aave_for_proposal(proposal, db)
+    elif protocol == "lido":
+        _execute_lido_for_proposal(proposal, db)
+    elif protocol == "pendle":
+        _execute_pendle_for_proposal(proposal, db)
+    else:
+        raise ProtocolExecutionNotWiredError(
+            f"未知の protocol '{protocol}' (proposal={proposal.id}) は自動執行非対応です。"
+        )
+
+
 @router.get(
     "/admin/all", response_model=AdminProposalListResponse, summary="全ユーザー提案一覧（管理者）"
 )
@@ -888,12 +950,23 @@ def approve_proposal(
         from .execution_route import RouteMismatchError  # noqa: PLC0415
 
         try:
-            _execute_aave_for_proposal(proposal, db)
+            # protocol (aave/lido/pendle) で執行ハンドラを振り分ける。
+            # Lido/Pendle は HUMAN-REVIEW 未配線のため ProtocolExecutionNotWiredError。
+            _dispatch_custodial_execution(proposal, db)
         except RouteMismatchError as exc:
             db.commit()  # status='failed' / error_message を永続化
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail=f"誤執行検出: {exc} (手動介入必須)",
+            ) from exc
+        except ProtocolExecutionNotWiredError as exc:
+            # Lido/Pendle の custodial 自動執行は未配線 (HUMAN-REVIEW)。
+            # approved のまま据置き、501 で明示する (Aave として誤実行しない)。
+            logger.warning("proposal %d: custodial execution 未配線: %s", proposal.id, exc)
+            db.commit()
+            raise HTTPException(
+                status_code=status.HTTP_501_NOT_IMPLEMENTED,
+                detail=str(exc),
             ) from exc
         db.commit()
         db.refresh(proposal)

--- a/backend/tests/test_proposal_protocol_dispatch.py
+++ b/backend/tests/test_proposal_protocol_dispatch.py
@@ -1,0 +1,78 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_proposal_protocol_dispatch.py
+"""custodial 自動執行の protocol 振り分け (_dispatch_custodial_execution) のテスト。
+
+[v4][Phase D] proposal.protocol で aave/lido/pendle を振り分ける。Lido/Pendle の
+on-chain 実行は HUMAN-REVIEW 未配線のため ProtocolExecutionNotWiredError を送出し、
+Aave 経路で誤実行しないことを保証する。
+"""
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-proposal-dispatch")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "admin@example.com")
+
+import app.proposals.router as router_mod  # noqa: E402
+from app.proposals.router import (  # noqa: E402
+    ProtocolExecutionNotWiredError,
+    _dispatch_custodial_execution,
+)
+
+
+def _mk_proposal(protocol: object) -> MagicMock:
+    p = MagicMock()
+    p.id = 1
+    p.protocol = protocol
+    p.operation = "SUPPLY"
+    return p
+
+
+def test_dispatch_aave_calls_aave_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: dict[str, bool] = {}
+    monkeypatch.setattr(
+        router_mod, "_execute_aave_for_proposal", lambda p, db: called.setdefault("aave", True)
+    )
+    _dispatch_custodial_execution(_mk_proposal("aave"), MagicMock())
+    assert called.get("aave") is True
+
+
+def test_dispatch_none_protocol_defaults_to_aave(monkeypatch: pytest.MonkeyPatch) -> None:
+    """protocol 無指定 (None) は従来どおり Aave 経路 (後方互換)。"""
+    called: dict[str, bool] = {}
+    monkeypatch.setattr(
+        router_mod, "_execute_aave_for_proposal", lambda p, db: called.setdefault("aave", True)
+    )
+    _dispatch_custodial_execution(_mk_proposal(None), MagicMock())
+    assert called.get("aave") is True
+
+
+def test_dispatch_lido_not_wired_and_does_not_call_aave(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lido は未配線で raise し、Aave 経路を呼ばない (誤実行防止)。"""
+
+    def _must_not_run(p: object, db: object) -> None:
+        raise AssertionError("Lido 提案で Aave 経路を実行してはならない")
+
+    monkeypatch.setattr(router_mod, "_execute_aave_for_proposal", _must_not_run)
+    with pytest.raises(ProtocolExecutionNotWiredError):
+        _dispatch_custodial_execution(_mk_proposal("lido"), MagicMock())
+
+
+def test_dispatch_pendle_not_wired_and_does_not_call_aave(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _must_not_run(p: object, db: object) -> None:
+        raise AssertionError("Pendle 提案で Aave 経路を実行してはならない")
+
+    monkeypatch.setattr(router_mod, "_execute_aave_for_proposal", _must_not_run)
+    with pytest.raises(ProtocolExecutionNotWiredError):
+        _dispatch_custodial_execution(_mk_proposal("pendle"), MagicMock())
+
+
+def test_dispatch_unknown_protocol_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _must_not_run(p: object, db: object) -> None:
+        raise AssertionError("未知 protocol で Aave 経路を実行してはならない")
+
+    monkeypatch.setattr(router_mod, "_execute_aave_for_proposal", _must_not_run)
+    with pytest.raises(ProtocolExecutionNotWiredError):
+        _dispatch_custodial_execution(_mk_proposal("compound"), MagicMock())


### PR DESCRIPTION
## 概要
Asana [v4][Phase D] の**安全な第1スライス**。on-chain 実 broadcast は含めず、protocol 別 dispatch の土台 + テストを整備する。

## 背景・修正
`/approve` の custodial 自動執行（`AUTO_EXECUTION_ENABLED=true` 時のみ・本番は default false で休眠）が `proposal.protocol` を見ずに常に `_execute_aave_for_proposal` を呼んでいた。→ **Lido/Pendle 提案が Aave operation として誤実行されうる潜在リスク**。protocol 別 dispatch で防ぐ。

## 変更
- `_dispatch_custodial_execution()`: `protocol` で aave/lido/pendle を振り分け
  - aave / 無指定 → 従来の `_execute_aave_for_proposal`（**不変**）
  - lido / pendle / 未知 → `ProtocolExecutionNotWiredError`
- `_execute_lido_for_proposal` / `_execute_pendle_for_proposal`: 実装方針 docstring 付きで raise（**実 broadcast は含まない**）
- `/approve`: `ProtocolExecutionNotWiredError` を **501** で返す（approved のまま据置・Aave 誤実行しない）

## 🔴 HUMAN-REVIEW-REQUIRED（本PR対象外・要 Opus + 安全レビュー）
- Lido `stake_eth()` の real ETH broadcast 配線
- Pendle RouterV4 swap の `dry_run=False` broadcast 配線
- **非カストディアル経路**にする場合: `LidoClient.build_stake_tx` 新設 + `PartnerUnsignedTxs` スキーマ拡張 + frontend `ProposalSignSheet` の STAKE_ETH/BUY_PT 対応が別途必要

## 調査所見（設計判断が必要）
Lido/Pendle クライアントは **server-side broadcast 設計**（Lido に未署名tx構築メソッドが無い）で、Aave の非カストディアル build-tx パターンとは別物。実行方式（非カストディアル Privy署名 vs custodial server-broadcast）は**アーキテクト設計判断**が先。

## 検証
- dispatch **5件** + 既存 proposals **44件** pass / ruff・format・mypy pass
- Aave SUPPLY/WITHDRAW の既存フローは不変

## Asana
[v4][Phase D] proposals/router.py に Lido/Pendle build-tx + 実行ルーティング追加（部分・土台）

🤖 Generated with [Claude Code](https://claude.com/claude-code)