### PR TITLE
fix(privy): ログインモーダルのロゴを同一オリジン資産に固定（staging で画像切れ修正）

### DIFF
--- a/frontend/lib/wallet/PrivyRootClient.tsx
+++ b/frontend/lib/wallet/PrivyRootClient.tsx
@@ -43,6 +43,14 @@ export function PrivyRootClient({ children }: { children: ReactNode }) {
           // Privy モーダルの accentColor を Arobix purple に揃える。
           theme: 'dark',
           accentColor: '#6e56cf',
+          // ロゴは現在のオリジンの同一ドメイン資産を指す (public/icons/ に存在)。
+          // Privy ダッシュボード設定だと prod ドメイン (app.ultra-auto-trade.com) の URL が
+          // 入り、staging-v4 等では CSP img-src ('self' のみ) でブロックされ画像切れになる。
+          // window.location.origin を使い env を問わず同一オリジン = CSP 'self' で常に表示。
+          logo:
+            typeof window !== 'undefined'
+              ? `${window.location.origin}/icons/privy-logo-banner.png`
+              : '/icons/privy-logo-banner.png',
         },
         supportedChains: [base, baseSepolia],
         defaultChain,


### PR DESCRIPTION
## 概要
Privy ログインモーダルのロゴが staging-v4 で**画像切れ**（"UAT logo" の alt 表示）になっていた問題の修正。

## 原因
- ロゴ資産は `public/icons/privy-logo-banner.png` に実在（同一オリジン配信可）
- だが **Privy ダッシュボード設定のロゴ URL が prod ドメイン** `app.ultra-auto-trade.com/icons/...` を指定
- staging-v4 の CSP `img-src` は `'self' data: blob: https://auth.privy.io https://*.privy.io https://imagedelivery.net` のみ → **prod ドメインをブロック** → 画像切れ

## 修正
`appearance.logo` を `window.location.origin` ベースの**同一オリジン絶対 URL** に固定。env を問わず同一オリジン = CSP `'self'` で常に表示。ダッシュボード設定にも CSP 変更にも依存しない。

## 検証
- tsc 0 errors / eslint pass
- 表示確認は staging-v4 再デプロイ後に Privy ログインモーダルで（CLI からモーダルは描画できないため人間 or 再デプロイ後の実機確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)