### PR TITLE
fix(ops): healthcheck FAIL通知の dedup/throttle でアラート疲労を解消

### DIFF
--- a/docs/ops/03_deploy_procedures.md
+++ b/docs/ops/03_deploy_procedures.md
@@ -420,3 +420,45 @@ docker inspect ultra-autotrade-postgres-production \
 3. `curl http://127.0.0.1:3000` でホスト→フロントエンドの疎通確認
 4. `docker logs ultra-autotrade-cloudflared-production` で `connection refused` 確認
 5. 多くは起動中の一時的状態（30秒待機で自然解消）
+
+### AI判定スケジューラが inactive color skip し続ける（2026-06-26 インシデント）
+
+**症状**: コンテナは healthy・nginx も疎通200・feeds も毎時更新されているのに、
+`ai_decisions` テーブルに新規行が増えず、AI由来 proposal が生成されない（実ユーザーに提案ゼロ）。
+
+**真因**: nginx upstream の実 active（`docker/nginx/upstream.production.conf` の `set $backend backend-XXX`）と
+`.env.production` の `ACTIVE_BACKEND_COLOR` が **drift**。`backend/app/main.py` の
+`_is_inactive_color_skip()`（BACKEND_COLOR ≠ ACTIVE_BACKEND_COLOR かつ両方set→True）により、
+実トラフィックを受けている唯一の生存コンテナが「自分は非アクティブ」と誤判定し、
+AI判定スケジューラを丸ごと skip する。feeds/HOWL は color ガード無しなので動き続けるため
+気づきにくい。2026-06-26 に本番で 22 日間（6/04〜）この状態が継続していた。
+
+**診断（read-only）**:
+```bash
+# 起動ログに skip が出ているか
+docker logs <active-backend> 2>&1 | grep -E "AI judgment scheduler started|inactive color: scheduler skip"
+# nginx 実 active と env の一致確認
+grep -E 'set \$backend' docker/nginx/upstream.production.conf      # 例: backend-blue
+docker exec <active-backend> printenv | grep -E "BACKEND_COLOR|ACTIVE_BACKEND_COLOR"
+# 死活: ai_decisions が最近書かれているか
+docker exec <postgres> psql -U ultra -d ultra_autotrade -c "SELECT MAX(created_at) FROM ai_decisions;"
+```
+
+**復旧**: `.env.production` の `ACTIVE_BACKEND_COLOR` を nginx 実 active（通常 blue）に揃え、
+当該 backend を **force-recreate**（env はコンテナ作成時固定のため `restart` では反映されない）。
+```bash
+ENV_FILE=.env.production
+TMP=$(mktemp "${ENV_FILE}.XXXXXX")
+awk '{if($0 ~ /^ACTIVE_BACKEND_COLOR=/){print "ACTIVE_BACKEND_COLOR=blue"}else{print}}' "$ENV_FILE" > "$TMP"
+cat "$TMP" > "$ENV_FILE" && rm -f "$TMP"        # inode 保持・sed -i 禁止
+docker compose -f docker-compose.production.yml --env-file .env.production \
+  up -d --no-deps --force-recreate backend-blue
+# 検証: 起動ログに "AI judgment scheduler started" が出ること
+```
+
+**再発防止**: deploy 後に nginx 実 active と `.env.production` の `ACTIVE_BACKEND_COLOR` の
+整合を `deploy_production.sh` がチェックする（drift で WARN）。また healthcheck L3
+（`ai_decisions_24h < 3 → FAIL`）はこの障害を検知できるが、**検知できていても気づけるとは限らない**
+（本件は L3 FAIL が 6099 回 Slack 送信されたが連発で埋没した＝アラート疲労）。
+FAIL 通知は dedup/throttle 済み（同一FAILは1h毎に再送・状態変化時のみ即送信、
+`scripts/healthcheck_l1_l6.sh`）。Twilio 電話エスカレーション（5連続FAIL）の credentials 設定も推奨。

--- a/scripts/healthcheck_l1_l6.sh
+++ b/scripts/healthcheck_l1_l6.sh
@@ -73,6 +73,15 @@ FAIL_COUNT_FILE="${TMPDIR:-/tmp}/.healthcheck_fail_count"
 TWILIO_LAST_CALL_FILE="${TMPDIR:-/tmp}/.healthcheck_twilio_last_call"
 PASS_COOLDOWN_SEC=3600  # 1時間
 
+# FAIL 通知の dedup/throttle (アラート疲労対策 / 2026-06-26)
+# 背景: FAIL 側は従来 throttle 無しで 5分毎に無条件送信していた。本番 P0(blue/green
+# color drift で AI判定停止)では L3=FAIL が 22日間・6099回連続で Slack に送られ続け、
+# 同一メッセージの洪水で #ultra-auto-project に埋没し人間が気づけなかった (検知も送信も
+# 正常だったが「鳴りすぎて無視された」)。対策: 同一 failed_layers が継続する間は
+# FAIL_RESEND_COOLDOWN_SEC に1回だけ再送し、状態変化(新規/解消/レイヤー変化)時は即送信。
+FAIL_SIG_FILE="${TMPDIR:-/tmp}/.healthcheck_fail_sig"
+FAIL_RESEND_COOLDOWN_SEC="${FAIL_RESEND_COOLDOWN_SEC:-3600}"  # 同一FAIL継続中の再送間隔 (既定1h)
+
 # ログ
 LOG_DIR="${LOG_DIR:-/var/log/ultra-autotrade}"
 mkdir -p "${LOG_DIR}" 2>/dev/null || true
@@ -445,6 +454,33 @@ should_send_pass_notification() {
 record_pass_time() {
   date +%s > "${LAST_PASS_FILE}" 2>/dev/null || true
   echo "0" > "${FAIL_COUNT_FILE}" 2>/dev/null || true
+  # 復旧したら FAIL シグネチャをクリアし、次の FAIL を「状態変化=即送信」扱いにする
+  rm -f "${FAIL_SIG_FILE}" 2>/dev/null || true
+}
+
+# FAIL 通知を送るべきか判定 (dedup/throttle)。
+# 引数: $1 = 現在の failed_layers シグネチャ (例 "L3 ")
+# 送信する条件: (a) 前回と異なるシグネチャ=状態変化/新規 (b) 前回送信から
+#   FAIL_RESEND_COOLDOWN_SEC 以上経過。いずれも該当しなければ抑止 (return 1)。
+# 送信決定時は新しいシグネチャ+時刻を記録する。
+should_send_fail_notification() {
+  local sig="$1"
+  local now prev_sig prev_ts elapsed
+  now=$(date +%s)
+  prev_sig=""
+  prev_ts=0
+  if [[ -f "${FAIL_SIG_FILE}" ]]; then
+    prev_sig=$(sed -n '1p' "${FAIL_SIG_FILE}" 2>/dev/null || echo "")
+    prev_ts=$(sed -n '2p' "${FAIL_SIG_FILE}" 2>/dev/null || echo "0")
+  fi
+  [[ "${prev_ts}" =~ ^[0-9]+$ ]] || prev_ts=0
+  elapsed=$(( now - prev_ts ))
+
+  if [[ "${sig}" != "${prev_sig}" ]] || (( elapsed >= FAIL_RESEND_COOLDOWN_SEC )); then
+    printf '%s\n%s\n' "${sig}" "${now}" > "${FAIL_SIG_FILE}" 2>/dev/null || true
+    return 0
+  fi
+  return 1
 }
 
 increment_fail_count() {
@@ -646,25 +682,34 @@ print(json.dumps(payload))
       log "PASS 通知スキップ (冷却期間中)"
     fi
   else
-    # FAIL: 即送信
+    # FAIL: dedup/throttle 付き送信 (アラート疲労対策)
     local fail_count
     fail_count=$(increment_fail_count)
-    log "FAIL 通知送信 (連続 ${fail_count} 回目)"
-    send_slack "${slack_json}"
 
-    # 5連続FAIL → Twilio 電話エスカレーション
+    # failed_layers シグネチャを先に算出 (throttle 判定と Twilio 双方で使う)
+    local failed_layers=""
+    [[ "${l1_status}" == "FAIL" ]] && failed_layers="${failed_layers}L1 "
+    [[ "${l2_status}" == "FAIL" ]] && failed_layers="${failed_layers}L2 "
+    [[ "${l3_status}" == "FAIL" ]] && failed_layers="${failed_layers}L3 "
+    [[ "${l4_status}" == "FAIL" ]] && failed_layers="${failed_layers}L4 "
+    [[ "${l5_status}" == "FAIL" ]] && failed_layers="${failed_layers}L5 "
+    [[ "${l7_status}" == "CRITICAL" ]] && failed_layers="${failed_layers}L7(disk) "
+    [[ "${l8_status}" == "FAIL" ]] && failed_layers="${failed_layers}L8(loki) "
+    [[ "${l9_status}" == "FAIL" ]] && failed_layers="${failed_layers}L9(proposal_rate) "
+    failed_layers="${failed_layers:-L1-L5}"
+
+    # 状態変化時は即送信 / 同一FAIL継続中は FAIL_RESEND_COOLDOWN_SEC に1回だけ再送
+    if should_send_fail_notification "${failed_layers}"; then
+      log "FAIL 通知送信 (連続 ${fail_count} 回目, layers=${failed_layers})"
+      send_slack "${slack_json}"
+    else
+      log "FAIL 通知抑止 (同一FAIL継続: ${failed_layers}, 連続 ${fail_count} 回目, 再送間隔 ${FAIL_RESEND_COOLDOWN_SEC}s 未満)"
+    fi
+
+    # 5連続FAIL → Twilio 電話エスカレーション (throttle とは独立に評価。
+    # 第2の砦なので埋没対策の対象外=連続FAILが続く限りレート制限内で発火させる)
     # L6 単独 FAIL は対象外 (overall_status が FAIL になるのは L1-L5 の FAIL のみ)
     if [[ "${fail_count}" -ge "${TWILIO_CONSECUTIVE_FAIL_THRESHOLD}" ]]; then
-      local failed_layers=""
-      [[ "${l1_status}" == "FAIL" ]] && failed_layers="${failed_layers}L1 "
-      [[ "${l2_status}" == "FAIL" ]] && failed_layers="${failed_layers}L2 "
-      [[ "${l3_status}" == "FAIL" ]] && failed_layers="${failed_layers}L3 "
-      [[ "${l4_status}" == "FAIL" ]] && failed_layers="${failed_layers}L4 "
-      [[ "${l5_status}" == "FAIL" ]] && failed_layers="${failed_layers}L5 "
-      [[ "${l7_status}" == "CRITICAL" ]] && failed_layers="${failed_layers}L7(disk) "
-      [[ "${l8_status}" == "FAIL" ]] && failed_layers="${failed_layers}L8(loki) "
-      [[ "${l9_status}" == "FAIL" ]] && failed_layers="${failed_layers}L9(proposal_rate) "
-      failed_layers="${failed_layers:-L1-L5}"
       log "5連続FAIL到達 (${fail_count}回) — Twilio 電話エスカレーション発動: ${failed_layers}"
       call_twilio_phone "${fail_count}" "${failed_layers}"
     fi


### PR DESCRIPTION
## 背景（本番 P0 postmortem 対策）

2026-06-26、本番 AI 判定スケジューラが **blue/green color drift** で 6/04 から22日間自己スキップし、`ai_decisions`/AI由来 proposal が生成されていなかった（実ユーザーに提案ゼロ）。P0 自体は env 修正(`ACTIVE_BACKEND_COLOR` green→blue + recreate)で復旧済み。

調査で判明した**再発防止の本丸**: healthcheck L3(`ai_decisions_24h < 3 → FAIL`)は22日間ずっと**正しく検知し Slack へ送信もしていた**（「FAIL 通知送信(連続6099回目)」）。しかし FAIL 側に throttle が無く 5分毎に同一メッセージを送り続けた結果、`#ultra-auto-project` に埋没して気づけなかった（**アラート疲労**）。curl 送信失敗は0件＝届いていたが無視された。Twilio エスカレーションは credentials 未設定で不発。

## 変更

- **`scripts/healthcheck_l1_l6.sh`**: FAIL 通知を dedup/throttle 化。
  - 状態変化（新規 FAIL / `failed_layers` の変化）時は**即送信**
  - 同一 FAIL 継続中は `FAIL_RESEND_COOLDOWN_SEC`（既定 3600s=1h）に**1回だけ再送**
  - PASS 復旧時にシグネチャをクリア（次の FAIL を状態変化として即送信）
  - Twilio 電話エスカレーション（5連続FAIL）は第2の砦なので throttle 対象外で従来通り評価
  - 効果: 同一障害の Slack を 288回/日 → 約24回/日 + 状態変化時に削減。重要シグナルは潰さない。
- **`docs/ops/03_deploy_procedures.md`**: 「AI判定スケジューラが inactive color skip し続ける」インシデント項目（症状/診断/復旧/再発防止）を追記。

## テスト

- throttle ロジック単体テスト 4ケース pass（新規→送信 / 同一直後→抑止 / レイヤー変化→送信 / cooldown超過→再送）
- `bash -n` 構文チェック pass

## 関連 / 残課題（別対応）

- deploy_production.sh に nginx 実 active と `.env.production` ACTIVE_BACKEND_COLOR の整合ガード追加（別PR・Tier S）
- Twilio credentials 設定（運用側）
- P1: Perplexity クォータ切れ(401)の新キー差し替え（本番/staging-v4 同一キー `pplx-...` のクォータ枯渇で macro 入力が空→AI が当面 HOLD）

🤖 Generated with [Claude Code](https://claude.com/claude-code)