### PR TITLE
fix(data_feeds): Perplexity Finance のリトライ回数を 2→4（一過性400で macro が空になる対策）

### DIFF
--- a/backend/app/data_feeds/finance_feed.py
+++ b/backend/app/data_feeds/finance_feed.py
@@ -34,8 +34,13 @@ _VALID_STABLECOIN_RISKS = ("low", "medium", "high")
 
 # 2026-05-28: staging soak で sonar-pro が 200/400 交互。
 # 1) 非2xx 時に response body をログ (DoD: 真因特定)。
-# 2) 4xx/5xx/timeout を一過性とみなし最大 1 回 retry (DoD: 200 安定化)。
-_PERPLEXITY_MAX_ATTEMPTS = 2
+# 2) 4xx/5xx/timeout を一過性とみなし retry (DoD: 200 安定化)。
+# 2026-06-26: クォータ復旧後の実機検証で、起動時 fetch が一過性 400 に当たると
+# 次の 60min tick まで macro が fed=unknown のまま空になり、AI 判定が常時 HOLD に
+# 張り付くことを確認 (手動 curl では同 payload が 200 を返すため真に一過性)。
+# attempts を 2→4 に増やし、空振り (fed=unknown フォールバック) の頻度を下げる。
+# 背景タスク (60min 間隔) なので最悪 +6s 程度の追加レイテンシは許容範囲。
+_PERPLEXITY_MAX_ATTEMPTS = 4
 _PERPLEXITY_RETRY_BACKOFF_SECONDS = 2.0
 # auth 系は retry 不要 (key が違うだけ無駄打ち) なので除外。
 _PERPLEXITY_NON_RETRIABLE_STATUSES = frozenset({401, 403})


### PR DESCRIPTION
## 背景

本番 P0（AI判定停止）復旧後、Perplexity クォータ切れ(401)を新キーで解消。その実機検証で**別の問題**が表面化：

`finance_feed` の `sonar-pro` 呼び出しは既知の「200/400 交互」一過性エラー（コメント `finance_feed.py:35`、2026-05-28 staging soak）があり、**起動時 fetch がこの 400 に当たると、次の 60min tick まで macro が `fed=unknown` のまま空**になる。macro が空だと AI 判定の BUY 条件（Indicator かつ Macro 両方 BULLISH ≥70%）が成立せず**常時 HOLD に張り付く**＝提案が出ない。

同一 payload を手動 curl すると **200 OK**（実 macro JSON）を返すため、キー/モデル/payload はすべて正常で、真に一過性のエラーと確定。

## 変更

- `backend/app/data_feeds/finance_feed.py`: `_PERPLEXITY_MAX_ATTEMPTS` を **2→4** に増やし、一過性 400/timeout での空振り（`fed=unknown` フォールバック）頻度を下げる。
- `backoff`(2.0s)・非retry対象(401/403 auth)は変更なし。背景タスク（60min間隔）なので最悪 +6s 程度の追加レイテンシは許容範囲。

## テスト

- 既存 finance feed テスト **20 件 pass**（retry 成功パスは2回目成功で return するため `call_count==2` assertion は不変／401非retry `==1` も不変）。

## 関連

- 本番 P0（blue/green color drift）復旧 + 再発防止: #884（merged）, #885
- P1 の root cause（Perplexity クォータ切れ）は新キー差替で解消済み。本PRは復旧後に残る一過性400の堅牢化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)