### PR TITLE
feat(ai): staging 限定デモ用 macro ゲート緩和フラグ（本番は二重ガードで無効）

### DIFF
--- a/backend/app/ai/service.py
+++ b/backend/app/ai/service.py
@@ -13,10 +13,11 @@ Responsibilities:
 
 import json
 import logging
+import os
 from datetime import datetime, timezone
 from typing import Callable, Iterable, List, Optional
 
-from app.ai.agents import MultiAgentContext, run_all_agents
+from app.ai.agents import Bias, MultiAgentContext, run_all_agents
 from app.ai.judgment_log import CognitiveState
 from app.data_feeds.context import MarketContext
 from app.notion.schemas import NotionNewsItem
@@ -33,6 +34,26 @@ from .schemas import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Indicator-only confidence threshold for the staging demo relax (= directional
+# threshold used by the multi-agent AND-condition guard).
+_DEMO_DIRECTIONAL_THRESHOLD = 70
+
+
+def _staging_demo_force_directional_enabled() -> bool:
+    """staging 限定デモ用ゲート緩和の有効判定 (本番では絶対に無効)。
+
+    用途: 実 macro が directional でない (hawkish/neutral) ときでも、Indicator 単独
+    BULLISH>=70% で HOLD→BUY に格上げして提案生成パイプラインを実機検証するための
+    デモ専用フラグ。**二重ガード**で本番混入を防ぐ:
+      1. APP_ENV=production なら常に False (フラグ値に関わらず無効)
+      2. それ以外で AI_STAGING_RELAX_MACRO_GATE=true のときのみ True (既定 false)
+    HARD STOP / COMPOUND RISK は本メソッドより上流で return 済みなので、本緩和が
+    安全停止を上書きすることはない。
+    """
+    if os.getenv("APP_ENV", "").strip().lower() == "production":
+        return False
+    return os.getenv("AI_STAGING_RELAX_MACRO_GATE", "false").strip().lower() == "true"
 
 
 # LLM client type (expects a callable: NotionNewsItem -> AIAnalysisResult)
@@ -228,10 +249,13 @@ class AIService:
         version = ai_settings.prompt_version
         # AND-condition flag: set True if agents disagree and v4/v5 guard applies
         _and_condition_failed = False
+        # Rule-engine result kept for the staging demo relax (None if no market_context).
+        _rule_ctx: Optional[MultiAgentContext] = None
 
         # Rule engine: pre-LLM checks (deterministic, cannot be overridden by LLM)
         if market_context is not None:
             agent_ctx_check = run_all_agents(market_context)
+            _rule_ctx = agent_ctx_check
             # Guard 1: COMPOUND RISK → force HOLD
             if agent_ctx_check.has_compound_risk():
                 logger.warning("COMPOUND RISK detected by Risk Agent. Forcing HOLD.")
@@ -306,6 +330,45 @@ class AIService:
                 final_action=TradeAction.HOLD,
                 final_confidence=_clamped.confidence,
                 final_reason=_clamp_reason,
+                prompt_version=version,
+            )
+
+        # Staging-only demo relax (NEVER production / double-gated env flag):
+        # 実 macro が directional でない (hawkish/neutral) ときでも、Indicator 単独
+        # BULLISH>=70% で HOLD→BUY に格上げして提案生成パイプラインを実機検証する。
+        # COMPOUND RISK / HARD STOP は上流で return 済みなので安全停止は上書きしない。
+        if (
+            _staging_demo_force_directional_enabled()
+            and result.final_action == TradeAction.HOLD
+            and _rule_ctx is not None
+            and _rule_ctx.indicator_signal is not None
+            and _rule_ctx.indicator_signal.bias == Bias.BULLISH
+            and _rule_ctx.indicator_signal.confidence >= _DEMO_DIRECTIONAL_THRESHOLD
+        ):
+            logger.warning(
+                "STAGING DEMO RELAX: HOLD→BUY (Indicator-only BULLISH %s%%). "
+                "本番では無効 (AI_STAGING_RELAX_MACRO_GATE + non-production gate).",
+                _rule_ctx.indicator_signal.confidence,
+            )
+            _demo_reason = (
+                "STAGING DEMO RELAX: Indicator-only BULLISH>=70% でゲート緩和 "
+                "(macro 軸ドロップ・staging 限定)。"
+                f"Original: {result.final_reason}"
+            )
+            _demo_decision = LLMDecision(
+                provider=LLMProvider.RULE_BASED,
+                action=TradeAction.BUY,
+                confidence=_rule_ctx.indicator_signal.confidence,
+                reason=_demo_reason,
+                prompt_version=version,
+            )
+            result = CrossValidationResult(
+                primary=_demo_decision,
+                secondary=result.secondary,
+                agreed=result.agreed,
+                final_action=TradeAction.BUY,
+                final_confidence=_rule_ctx.indicator_signal.confidence,
+                final_reason=_demo_reason,
                 prompt_version=version,
             )
 

--- a/backend/tests/test_ai_sell_and_condition.py
+++ b/backend/tests/test_ai_sell_and_condition.py
@@ -14,6 +14,7 @@ Guard 2) and documented in the v4/v5 prompts.
 These tests are deterministic — no LLM calls are made.
 """
 
+import os
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
@@ -776,3 +777,110 @@ class TestPromptRegistry:
 
         versions = list_versions()
         assert "v5" in versions
+
+
+# ---------------------------------------------------------------------------
+# Tests: staging-only demo macro-gate relax (HOLD→BUY on Indicator-only BULLISH)
+# ---------------------------------------------------------------------------
+
+
+class TestStagingDemoMacroRelax:
+    """`AI_STAGING_RELAX_MACRO_GATE` のデモ用ゲート緩和。
+
+    実 macro が directional でない (hawkish/neutral) → LLM は HOLD を返すが、
+    フラグ有効 (かつ非 production) のときだけ Indicator 単独 BULLISH>=70% で
+    HOLD→BUY に格上げする。**本番では絶対に発火しない**ことを保証する。
+    """
+
+    def _make_service(self) -> AIService:
+        return AIService()
+
+    def _make_settings(self, version: str = "v5") -> MagicMock:
+        settings = MagicMock()
+        settings.prompt_version = version
+        settings.anthropic_api_key = "fake-key"
+        settings.openai_api_key = None
+        settings.cross_validation_enabled = False
+        settings.shadow_mode = False
+        settings.claude_model = "claude-opus-4-5"
+        return settings
+
+    def _indicator_bullish_hawkish_ctx(self):
+        """Indicator BULLISH (高HF/低util/高APY) だが macro は hawkish=非directional。
+
+        通常は LLM が HOLD → 緩和フラグ無しなら HOLD のまま。
+        """
+        fin = FinanceFeedResult(fed_stance="hawkish", stablecoin_risk="medium")
+        news = NewsFeedResult(sentiment="positive", summary="AAVE rallies")
+        return build_market_context(
+            health_factor=Decimal("2.8"),
+            aave_utilization_rate=Decimal("30"),
+            aave_supply_apy=Decimal("7.0"),
+            finance=fin,
+            news=news,
+        )
+
+    def _judge_hold(self, svc: AIService, settings: MagicMock):
+        with patch.object(
+            svc, "_call_claude", return_value=_make_cross_result(TradeAction.HOLD, 51).primary
+        ):
+            return svc.judge_with_rag(
+                query="market update",
+                rag_context=_make_rag_context(),
+                market_context=self._indicator_bullish_hawkish_ctx(),
+                settings=settings,
+            )
+
+    def test_flag_off_keeps_hold(self) -> None:
+        """既定 (フラグ未設定) では HOLD のまま (緩和は発火しない)。"""
+        svc = self._make_service()
+        settings = self._make_settings()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AI_STAGING_RELAX_MACRO_GATE", None)
+            result = self._judge_hold(svc, settings)
+        assert result.final_action == TradeAction.HOLD
+
+    def test_flag_on_non_production_upgrades_to_buy(self) -> None:
+        """フラグ有効 + 非 production + Indicator BULLISH>=70 → HOLD→BUY。"""
+        svc = self._make_service()
+        settings = self._make_settings()
+        with patch.dict(
+            os.environ,
+            {"AI_STAGING_RELAX_MACRO_GATE": "true", "APP_ENV": "staging"},
+        ):
+            result = self._judge_hold(svc, settings)
+        assert result.final_action == TradeAction.BUY
+
+    def test_flag_on_production_is_ignored(self) -> None:
+        """**本番安全**: APP_ENV=production ならフラグ有効でも HOLD のまま。"""
+        svc = self._make_service()
+        settings = self._make_settings()
+        with patch.dict(
+            os.environ,
+            {"AI_STAGING_RELAX_MACRO_GATE": "true", "APP_ENV": "production"},
+        ):
+            result = self._judge_hold(svc, settings)
+        assert result.final_action == TradeAction.HOLD
+
+    def test_flag_on_but_indicator_not_bullish_keeps_hold(self) -> None:
+        """Indicator が BULLISH>=70 でなければ緩和有効でも昇格しない。"""
+        svc = self._make_service()
+        settings = self._make_settings()
+        # 低HF → Indicator は BULLISH にならない
+        fin = FinanceFeedResult(fed_stance="hawkish")
+        news = NewsFeedResult(sentiment="negative", summary="risk-off")
+        ctx = build_market_context(health_factor=Decimal("1.45"), finance=fin, news=news)
+        with patch.dict(
+            os.environ,
+            {"AI_STAGING_RELAX_MACRO_GATE": "true", "APP_ENV": "staging"},
+        ):
+            with patch.object(
+                svc, "_call_claude", return_value=_make_cross_result(TradeAction.HOLD, 51).primary
+            ):
+                result = svc.judge_with_rag(
+                    query="market update",
+                    rag_context=_make_rag_context(),
+                    market_context=ctx,
+                    settings=settings,
+                )
+        assert result.final_action == TradeAction.HOLD


### PR DESCRIPTION
## 背景

本番 P0（blue/green color drift で AI判定22日停止）と P1（Perplexity クォータ切れ）を復旧後、staging-v4 で「AI が Aave/Lido 提案を生成する」実機検証を実施。**AI は完全に正常動作**していることを確認したが、**実 macro が hawkish（FED 3.50–3.75%）のため AI は正当に HOLD し続け**、提案生成（BUY経路）を実機で見せられなかった。

macro_agent: news positive(+15) + fed hawkish(−15) = score 50 → NEUTRAL/25 → BUY条件（Indicator かつ Macro 両方 BULLISH≥70%）未達 → HOLD。これは**バグではなく正しい保守判定**。

## 変更

staging-v4 でデモ／実機検証するための**ゲート緩和フラグ**を追加（`backend/app/ai/service.py`）：
- `AI_STAGING_RELAX_MACRO_GATE=true` かつ非 production のときのみ、LLM が HOLD でも **Indicator 単独 BULLISH≥70% で HOLD→BUY に格上げ**（macro 軸ドロップ）。

### 本番安全（二重ガード）
1. `APP_ENV=production` なら**常に無効**（フラグ値に関わらず）
2. それ以外で `AI_STAGING_RELAX_MACRO_GATE=true` のときのみ有効（**既定 false**）
- COMPOUND RISK / HARD STOP は本緩和より上流で return 済 → 安全停止は上書きしない。

## テスト（4ケース追加）

- `test_flag_off_keeps_hold`: 既定では HOLD 維持（緩和発火せず）
- `test_flag_on_non_production_upgrades_to_buy`: フラグ有効+非prod+Indicator BULLISH → BUY
- **`test_flag_on_production_is_ignored`**: APP_ENV=production ならフラグ有効でも HOLD（本番安全）
- `test_flag_on_but_indicator_not_bullish_keeps_hold`: Indicator非BULLISHなら昇格しない

`test_ai_sell_and_condition.py` 52 passed + 広域AI回帰（test_ai_service/judge/shadow_mode/judgment_scheduler）116 passed。ruff check / format clean。

## デプロイ（staging-v4 のみ）

main マージ後、本番ホストで `git pull origin main` → staging-v4 backend 再ビルド → `.env.staging-v4` に `AI_STAGING_RELAX_MACRO_GATE=true` 追加 → recreate。**本番（.env.production）には設定しない**（APP_ENV=production で二重に無効）。

## 関連

- 本番 P0 復旧: #884(merged)/#885 / P1 finance retry: #886(merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)