### PR TITLE
fix(auth): LINE idToken 検証の client_id をチャネルIDに修正（審査用LIFFログイン不能を解消）

### DIFF
--- a/backend/app/auth/line.py
+++ b/backend/app/auth/line.py
@@ -38,10 +38,17 @@ async def verify_line_id_token(id_token: str) -> dict[str, Any]:
     if not liff_id:
         raise LineAuthError("LIFF_ID環境変数が設定されていません")
 
+    # LINE /oauth2/v2.1/verify の client_id は「チャネルID」を要求する。
+    # idToken の aud はチャネルID（数字）であり、LIFF ID 全体ではない。
+    # LIFF ID 形式 "1234567890-AbcdEfgh" はプレフィックスがチャネルIDなので、
+    # LIFF ID 全体を渡すと aud と不一致になり検証が 400/401 で失敗する。
+    # LINE_LOGIN_CHANNEL_ID が明示設定されていればそれを優先、なければ LIFF ID から導出する。
+    channel_id = os.getenv("LINE_LOGIN_CHANNEL_ID") or liff_id.split("-", 1)[0]
+
     async with httpx.AsyncClient(timeout=10.0) as client:
         response = await client.post(
             LINE_TOKEN_VERIFY_URL,
-            data={"id_token": id_token, "client_id": liff_id},
+            data={"id_token": id_token, "client_id": channel_id},
         )
 
     if response.status_code != 200:

--- a/backend/tests/test_line_auth.py
+++ b/backend/tests/test_line_auth.py
@@ -234,3 +234,91 @@ class TestLineAuth:
 
         assert response.status_code == 401
         assert "LIFF_ID" in response.json()["detail"]
+
+
+class TestVerifyLineIdTokenClientId:
+    """verify_line_id_token が LINE verify API に渡す client_id の検証。
+
+    LINE の /oauth2/v2.1/verify は client_id に「チャネルID」を要求する。
+    LIFF ID 全体（"<channelId>-<suffix>"）を渡すと idToken の aud（チャネルID）と
+    不一致になり 400/401 で失敗する（審査用 LIFF でログイン不能になる回帰）。
+    これらのテストは verify_line_id_token を丸ごとモックせず、実関数が
+    httpx に渡す data を捕捉して client_id を直接アサートする。
+    """
+
+    @staticmethod
+    def _capture_client_id(monkeypatch) -> dict:
+        """httpx.AsyncClient.post をモックし、渡された data を捕捉する。"""
+        import app.auth.line as line_module
+
+        captured: dict = {}
+
+        class _MockResponse:
+            status_code = 200
+
+            def json(self) -> dict:
+                return {"sub": "Uabcdef", "name": "Test"}
+
+        class _MockAsyncClient:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args) -> bool:
+                return False
+
+            async def post(self, url, data=None):
+                captured["url"] = url
+                captured["data"] = data
+                return _MockResponse()
+
+        monkeypatch.setattr(line_module.httpx, "AsyncClient", _MockAsyncClient)
+        return captured
+
+    def test_client_id_uses_channel_id_not_full_liff_id(self, monkeypatch):
+        """LIFF ID のプレフィックス（チャネルID）が client_id に渡ること。"""
+        import asyncio
+
+        import app.auth.line as line_module
+
+        monkeypatch.setenv("NEXT_PUBLIC_LIFF_ID", "2010494865-pto3eNh7")
+        monkeypatch.delenv("LINE_LOGIN_CHANNEL_ID", raising=False)
+        captured = self._capture_client_id(monkeypatch)
+
+        result = asyncio.run(line_module.verify_line_id_token("dummy-id-token"))
+
+        assert result["sub"] == "Uabcdef"
+        # 回帰防止: フルの LIFF ID ではなく数字のチャネルIDであること
+        assert captured["data"]["client_id"] == "2010494865"
+        assert captured["data"]["client_id"] != "2010494865-pto3eNh7"
+
+    def test_explicit_channel_id_env_takes_precedence(self, monkeypatch):
+        """LINE_LOGIN_CHANNEL_ID が設定されていればそれを優先すること。"""
+        import asyncio
+
+        import app.auth.line as line_module
+
+        monkeypatch.setenv("NEXT_PUBLIC_LIFF_ID", "2010494865-pto3eNh7")
+        monkeypatch.setenv("LINE_LOGIN_CHANNEL_ID", "9999999999")
+        captured = self._capture_client_id(monkeypatch)
+
+        asyncio.run(line_module.verify_line_id_token("dummy-id-token"))
+
+        assert captured["data"]["client_id"] == "9999999999"
+
+    def test_channel_id_when_liff_id_has_no_suffix(self, monkeypatch):
+        """LIFF_ID がサフィックスなし（チャネルIDのみ）でも壊れないこと。"""
+        import asyncio
+
+        import app.auth.line as line_module
+
+        monkeypatch.delenv("NEXT_PUBLIC_LIFF_ID", raising=False)
+        monkeypatch.setenv("LIFF_ID", "2010494865")
+        monkeypatch.delenv("LINE_LOGIN_CHANNEL_ID", raising=False)
+        captured = self._capture_client_id(monkeypatch)
+
+        asyncio.run(line_module.verify_line_id_token("dummy-id-token"))
+
+        assert captured["data"]["client_id"] == "2010494865"


### PR DESCRIPTION
## 背景

LINE ミニアプリの審査申請にあたり、審査用 LIFF (`2010494865-pto3eNh7` → `staging-v4.ultra-auto-trade.com/liff-chat`) で LINE ログインが通るか確認したところ、**バックエンドの idToken 検証が必ず失敗する**ことが判明した。

## 真因

`backend/app/auth/line.py` の `verify_line_id_token` が、LINE の `POST /oauth2/v2.1/verify` に **`client_id` として LIFF ID 全体**（例: `2010494865-pto3eNh7`）を渡していた。

LINE 公式仕様では `client_id` は **チャネルID**（= idToken の `aud`、数字のみ）でなければならない。LIFF ID 形式 `1234567890-AbcdEfgh` はプレフィックスがチャネルIDなので、サフィックス付きの全体を渡すと `aud` と不一致になり 400/401 → `LineAuthError` → `/auth/line` が 401。

結果、審査担当者が審査用 LIFF を開いてもログインできない＝**審査が確実に差し戻される状態**だった。

参考: [LINE Verify ID token](https://developers.line.biz/en/docs/line-login/verify-id-token/)（`client_id` = "Expected channel ID"、`aud` = "Channel ID"）

## 変更

- `client_id` に渡す値を `LINE_LOGIN_CHANNEL_ID`（明示 env、任意）優先 / なければ LIFF ID のプレフィックスから導出（`split("-", 1)[0]`）に修正。フロント `liff.init()` とバックが同じ `NEXT_PUBLIC_LIFF_ID` を読むため、どの stage に固定しても自己整合する。
- 既存テストは `verify_line_id_token` を**丸ごとモック**しており `client_id` 導出を検証していなかった（バグが長期間素通りした原因）。実関数が httpx に渡す `client_id` を捕捉し、チャネルIDであることをアサートする回帰防止テスト3件を追加。

## 検証

- `ruff check` / `ruff format --check`: pass
- `mypy app/auth/line.py`: Success
- `pytest tests/test_line_auth.py`: **11 passed**（既存8 + 新規3）。新規テストは旧コードでは必ず失敗する。

## ⚠️ このPRだけでは審査ログインは通らない（運用側の残作業）

本修正はコードのバグ修正のみ。審査申請前に **staging-v4** で以下が必要:

1. **`NEXT_PUBLIC_LIFF_ID` を審査用 `2010494865-pto3eNh7` にセットしてフロント再ビルド**（build-time 変数のため再デプロイ必須）
2. **実機の LINE アプリで審査用 LIFF URL を開き、`/liff-chat` にログイン状態で到達するか確認**
3. （任意）`LINE_LOGIN_CHANNEL_ID=2010494865` を明示設定するとより堅牢

別軸として `docs/36_line_miniapp_gap_analysis.md` に審査の非ログイン系ブロッカー（eKYC・年齢確認・セルフ退会・ログ保持等）あり。要別途確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)