### PR TITLE
feat(proposals): awaiting_funds 入金待ちフロー + 着金検知（S2）

### DIFF
--- a/backend/app/automation/scheduled_tasks.py
+++ b/backend/app/automation/scheduled_tasks.py
@@ -838,6 +838,124 @@ async def proposal_timeout_loop(
             await asyncio.sleep(600)
 
 
+def run_funding_detection_once() -> int:
+    """awaiting_funds proposal を1回スキャンし、状態遷移した件数を返す (S2・同期)。
+
+    funding_detection_loop が asyncio.to_thread 経由で呼ぶ本体。テスト容易化のため
+    モジュールレベルに分離。残高 >= amount_usd → approved+通知 / expires_at<now → expired。
+    残高取得失敗(None)は skip(次サイクル再試行・安全側)。
+    """
+    from datetime import datetime, timezone  # noqa: PLC0415
+    from decimal import Decimal  # noqa: PLC0415
+
+    from app.aave.balance import read_wallet_usdc_balance  # noqa: PLC0415
+    from app.database import SessionLocal  # noqa: PLC0415
+
+    db = SessionLocal()
+    try:
+        from app.auth.models import User  # noqa: PLC0415
+        from app.proposals.models import Proposal  # noqa: PLC0415
+
+        now = datetime.now(timezone.utc)
+        waiting = db.query(Proposal).filter(Proposal.status == "awaiting_funds").all()
+        changed = 0
+        for proposal in waiting:
+            try:
+                # funding window 切れ → expired
+                if proposal.expires_at is not None and proposal.expires_at < now:
+                    proposal.status = "expired"
+                    db.flush()
+                    changed += 1
+                    logger.info("awaiting_funds proposal %d expired (funding window)", proposal.id)
+                    continue
+                user = db.get(User, proposal.user_id)
+                wallet = (user.smart_wallet_address or user.wallet_address) if user else None
+                if not wallet:
+                    continue
+                balance = read_wallet_usdc_balance(wallet)
+                if balance is None:
+                    continue  # RPC 失敗は次サイクル再試行 (安全側)
+                if balance >= Decimal(str(proposal.amount_usd)):
+                    proposal.status = "approved"
+                    proposal.approved_at = now
+                    db.flush()
+                    changed += 1
+                    logger.info(
+                        "Funding detected for proposal %d (balance=%s >= %s)",
+                        proposal.id,
+                        balance,
+                        proposal.amount_usd,
+                    )
+                    try:
+                        from app.notifications.factory import (  # noqa: PLC0415
+                            get_notification_service,
+                        )
+                        from app.notifications.templates import (  # noqa: PLC0415
+                            funding_detected_notification,
+                        )
+
+                        payload = funding_detected_notification(
+                            operation=proposal.operation,
+                            asset=proposal.asset,
+                            required_usd=proposal.amount_usd,
+                        )
+                        m = payload.notification_message.model_copy(
+                            update={"user_id": proposal.user_id}
+                        )
+                        get_notification_service().send(m)
+                    except Exception as _n_exc:
+                        logger.debug("funding_detected notify failed: %s", _n_exc)
+            except Exception as _item_exc:
+                logger.warning("Funding check failed for proposal %d: %s", proposal.id, _item_exc)
+        if changed:
+            db.commit()
+        return changed
+    except Exception as _db_exc:
+        db.rollback()
+        logger.warning("Funding detection DB error: %s", _db_exc)
+        return 0
+    finally:
+        db.close()
+
+
+async def funding_detection_loop(
+    *,
+    interval_seconds: int = 60,
+    on_error: Optional[Callable[[Exception], None]] = None,
+) -> None:
+    """awaiting_funds(入金待ち) proposal の着金を検知して approved 化する定期ループ (S2)。
+
+    interval ごとに status=awaiting_funds を検索し、本人 wallet の USDC 残高 >= amount_usd
+    なら approved に遷移して「署名できます」通知を送る。funding window(expires_at)を過ぎたら
+    expired に倒す(docs/62 §11.2 案A)。非カストディアル: 残高検知のみで秘密鍵に触れない。
+    残高取得失敗(None)は次サイクルで再試行(安全側)。
+
+    Args:
+        interval_seconds: チェック間隔（秒）。デフォルト 60 秒。
+        on_error: エラー発生時のコールバック。
+    """
+    logger.info("Starting funding detection loop (interval: %ds)", interval_seconds)
+
+    while True:
+        try:
+            await asyncio.sleep(interval_seconds)
+            await asyncio.to_thread(run_funding_detection_once)
+
+        except asyncio.CancelledError:
+            logger.info("Funding detection loop cancelled - shutting down")
+            raise
+
+        except Exception as exc:
+            logger.error("Error in funding detection loop: %s", exc)
+            if on_error:
+                try:
+                    on_error(exc)
+                except Exception as callback_exc:
+                    logger.error("Error in on_error callback: %s", callback_exc)
+
+            await asyncio.sleep(600)
+
+
 async def proposal_expiry_reminder_loop(
     *,
     interval_seconds: int = 300,
@@ -1789,6 +1907,7 @@ class ScheduledTaskManager:
         self._health_check_task: Optional[asyncio.Task[None]] = None
         self._latency_monitor_task: Optional[asyncio.Task[None]] = None
         self._proposal_timeout_task: Optional[asyncio.Task[None]] = None
+        self._funding_detection_task: Optional[asyncio.Task[None]] = None
         self._learning_task: Optional[asyncio.Task[None]] = None
         self._outcome_labeling_task: Optional[asyncio.Task[None]] = None
         self._compound_risk_task: Optional[asyncio.Task[None]] = None
@@ -1848,6 +1967,11 @@ class ScheduledTaskManager:
     def is_proposal_timeout_running(self) -> bool:
         """期限切れProposalチェックタスクが動作中かどうか。"""
         return self._proposal_timeout_task is not None and not self._proposal_timeout_task.done()
+
+    @property
+    def is_funding_detection_running(self) -> bool:
+        """着金検知タスク (S2) が動作中かどうか。"""
+        return self._funding_detection_task is not None and not self._funding_detection_task.done()
 
     @property
     def is_learning_running(self) -> bool:
@@ -2394,6 +2518,48 @@ class ScheduledTaskManager:
 
         self._proposal_timeout_task = None
         logger.info("Proposal timeout task stopped")
+
+    async def start_funding_detection(
+        self,
+        *,
+        interval_seconds: int = 60,
+        on_error: Optional[Callable[[Exception], None]] = None,
+    ) -> None:
+        """着金検知タスク (S2) を開始する。
+
+        Raises:
+            RuntimeError: 既に開始されている場合
+        """
+        if self.is_funding_detection_running:
+            raise RuntimeError("Funding detection already running")
+
+        logger.info("Starting funding detection task")
+        self._funding_detection_task = asyncio.create_task(
+            funding_detection_loop(interval_seconds=interval_seconds, on_error=on_error)
+        )
+        logger.info("Funding detection task started")
+
+    async def stop_funding_detection(self, timeout: float = 5.0) -> None:
+        """着金検知タスク (S2) を停止する。"""
+        if not self.is_funding_detection_running:
+            logger.debug("Funding detection not running - nothing to stop")
+            return
+
+        logger.info("Stopping funding detection task")
+        assert self._funding_detection_task is not None  # noqa: S101
+        self._funding_detection_task.cancel()
+
+        try:
+            await asyncio.wait_for(self._funding_detection_task, timeout=timeout)
+        except asyncio.CancelledError:
+            logger.info("Funding detection task cancelled successfully")
+        except asyncio.TimeoutError:
+            logger.warning("Funding detection task did not stop within %.1fs timeout", timeout)
+        except Exception as exc:
+            logger.error("Error while stopping funding detection task: %s", exc)
+
+        self._funding_detection_task = None
+        logger.info("Funding detection task stopped")
 
     async def start_latency_monitor(
         self,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -686,6 +686,19 @@ def create_app() -> FastAPI:
             except BaseException as exc:
                 logger.error("Failed to start expiry reminder: %s", exc)
 
+        # --- 着金検知 (S2 / opt-in: ENABLE_FUNDING_DETECTION=1) ---
+        # awaiting_funds 提案の残高を監視し、着金したら approved 化して署名可能にする。
+        # 既定 off → 本番/staging で明示有効化するまで無影響。
+        if os.getenv("ENABLE_FUNDING_DETECTION", "0") == "1":
+            try:
+                await scheduled_manager.start_funding_detection(
+                    interval_seconds=int(os.getenv("FUNDING_DETECTION_INTERVAL_SECONDS", "60")),
+                    on_error=_make_scheduler_error_handler("funding_detection_loop"),
+                )
+                logger.info("Funding detection scheduled (S2)")
+            except BaseException as exc:
+                logger.error("Failed to start funding detection: %s", exc)
+
     @app.on_event("startup")
     async def startup_health_probes() -> None:
         """Start background probes for /health/detail (OpenAI / Perplexity / Aave safety)."""

--- a/backend/app/notifications/templates.py
+++ b/backend/app/notifications/templates.py
@@ -152,6 +152,33 @@ def trade_executed_notification(
     return _build_payload(title, body, "info")
 
 
+def funding_requested_notification(
+    operation: str,
+    asset: str,
+    required_usd: Decimal,
+) -> NotificationPayload:
+    """入金待ち化通知 (S2): 残高不足で承認したので「あと $X 入金してください」。"""
+    op_label = _ACTION_LABEL_JA.get(operation, operation)
+    title = "💰 入金待ち"
+    body = (
+        f"{op_label}（{asset}）の提案を入金待ちにしました。"
+        f"必要額 ${required_usd} 分の USDC を Base ウォレットに入金すると署名できます。"
+    )
+    return _build_payload(title, body, "info")
+
+
+def funding_detected_notification(
+    operation: str,
+    asset: str,
+    required_usd: Decimal,
+) -> NotificationPayload:
+    """着金検知通知 (S2): 残高が必要額に到達したので署名可能になった。"""
+    op_label = _ACTION_LABEL_JA.get(operation, operation)
+    title = "✅ 入金を確認しました"
+    body = f"{op_label}（{asset}・${required_usd}）の入金を確認しました。署名して実行できます。"
+    return _build_payload(title, body, "info")
+
+
 def trade_failed_notification(
     operation: str,
     asset: str,

--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -50,6 +50,10 @@ router = APIRouter(prefix="/api/proposals", tags=["proposals"])
 # 恒久エラー (ValueError/KeyError 等の設定起因) は 1回目で即 failed。
 MAX_EXECUTION_ATTEMPTS = 3
 
+# S2: awaiting_funds(入金待ち)の funding window(日)。承認=投資意図キャプチャ時に
+# expires_at を now+この日数に書き換え、市場期限(72h)と分離する(docs/62 §11.2 案A)。
+_FUNDING_WINDOW_DAYS = int(os.getenv("FUNDING_WINDOW_DAYS", "7"))
+
 # 恒久エラー (RPC 設定未完成 / チェーン未設定 等): 再試行しても無意味なので即 failed。
 _PERMANENT_EXCEPTION_TYPES = (ValueError, KeyError)
 
@@ -873,13 +877,18 @@ def list_pending_proposals(
     current_user: User = Depends(require_viewer),
     db: Session = Depends(get_db),
 ) -> ProposalListResponse:
-    """自分の保留中（pending）提案リストを返す。"""
+    """自分の保留中（pending）+ 入金待ち（awaiting_funds）提案リストを返す。
+
+    S2: awaiting_funds も含めることで、フロントが入金待ちカードを表示し残高ポーリングで
+    着金検知できる。`_expire_old_proposals` は pending のみ対象なので awaiting_funds の
+    期限切れには影響しない（funding window の expire は funding_detection_loop が担当）。
+    """
     _expire_old_proposals(db, current_user.id)
     stmt = (
         select(Proposal)
         .where(
             Proposal.user_id == current_user.id,
-            Proposal.status == "pending",
+            Proposal.status.in_(["pending", "awaiting_funds"]),
         )
         .order_by(Proposal.created_at.desc())
     )
@@ -1040,6 +1049,65 @@ def reject_proposal(
     db.commit()
     db.refresh(proposal)
     return ProposalResponse.model_validate(proposal)
+
+
+@router.post(
+    "/{proposal_id}/await-funds",
+    response_model=ProposalResponse,
+    summary="入金待ち化（残高不足時の投資意図キャプチャ）",
+)
+def await_funds_proposal(
+    proposal_id: int,
+    current_user: User = Depends(require_active_user),
+    db: Session = Depends(get_db),
+) -> ProposalResponse:
+    """残高不足の SUPPLY 提案を `awaiting_funds`(入金待ち)に遷移させる (S2 / docs/62)。
+
+    「承認＝投資意図のキャプチャ」。署名はまだ行わず、入金期限(funding window)内に
+    着金すれば funding_detection_loop が approved 化して署名可能になる。
+    市場期限(72h)とは分離するため expires_at を now+_FUNDING_WINDOW_DAYS に書き換える(案A)。
+    VIEWER は自分の提案のみ。admin/partner は代行可。reject と同じ認可・遷移パターン。
+    """
+    stmt = select(Proposal).where(Proposal.id == proposal_id)
+    proposal = db.scalars(stmt).first()
+    if proposal is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Proposal not found")
+    _is_privileged = current_user.role in (UserRole.ADMIN.value, UserRole.PARTNER.value)
+    if not _is_privileged and proposal.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to access this proposal",
+        )
+    if proposal.status != "pending":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Cannot await-funds proposal with status '{proposal.status}'",
+        )
+    now = datetime.now(timezone.utc)
+    proposal.status = "awaiting_funds"
+    # funding window: 市場期限と分離。入金待ち中は expires_at をこちらで上書き。
+    proposal.expires_at = now + timedelta(days=_FUNDING_WINDOW_DAYS)
+    db.commit()
+    db.refresh(proposal)
+    _notify_funding_requested(proposal)
+    return ProposalResponse.model_validate(proposal)
+
+
+def _notify_funding_requested(proposal: Proposal) -> None:
+    """入金待ち化を「あと $X 入金してください」とユーザー通知する (best-effort)。"""
+    try:
+        from app.notifications.factory import get_notification_service  # noqa: PLC0415
+        from app.notifications.templates import funding_requested_notification  # noqa: PLC0415
+
+        payload = funding_requested_notification(
+            operation=proposal.operation,
+            asset=proposal.asset,
+            required_usd=proposal.amount_usd,
+        )
+        msg = payload.notification_message.model_copy(update={"user_id": proposal.user_id})
+        get_notification_service().send(msg)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("_notify_funding_requested failed for proposal %d: %s", proposal.id, exc)
 
 
 def _resolve_onchain_token_amount(proposal: Proposal) -> Decimal:

--- a/backend/tests/automation/test_funding_detection.py
+++ b/backend/tests/automation/test_funding_detection.py
@@ -1,0 +1,116 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/automation/test_funding_detection.py
+"""run_funding_detection_once (S2 着金検知) のユニットテスト。
+
+- 残高 >= amount_usd → approved + approved_at + 着金通知1件
+- 残高 < amount_usd → awaiting_funds のまま・通知なし
+- 残高取得失敗(None) → skip (awaiting_funds のまま)
+- funding window 切れ(expires_at < now) → expired (残高に関わらず)
+ScheduledTaskManager.start/stop_funding_detection の二重起動 guard も検証。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Any, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.automation.scheduled_tasks import (
+    ScheduledTaskManager,
+    run_funding_detection_once,
+)
+
+
+def _make_awaiting_proposal(
+    id_: int = 1,
+    amount_usd: Decimal = Decimal("1000"),
+    minutes_until_expiry: int = 60,
+    user_id: int = 42,
+) -> MagicMock:
+    now = datetime.now(timezone.utc)
+    p = MagicMock()
+    p.id = id_
+    p.status = "awaiting_funds"
+    p.amount_usd = amount_usd
+    p.expires_at = now + timedelta(minutes=minutes_until_expiry)
+    p.user_id = user_id
+    p.operation = "SUPPLY"
+    p.asset = "USDC"
+    p.approved_at = None
+    return p
+
+
+def _run_once(
+    proposals: list[Any],
+    balance: Optional[Decimal],
+    wallet: str = "0xabc0000000000000000000000000000000000000",
+) -> tuple[int, list[Any], MagicMock]:
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.all.return_value = proposals
+    mock_user = MagicMock()
+    mock_user.smart_wallet_address = wallet
+    mock_user.wallet_address = None
+    mock_db.get.return_value = mock_user
+    sent: list[Any] = []
+    with (
+        patch("app.database.SessionLocal", return_value=mock_db),
+        patch("app.aave.balance.read_wallet_usdc_balance", return_value=balance),
+        patch("app.notifications.factory.get_notification_service") as mock_get_svc,
+    ):
+        mock_get_svc.return_value.send.side_effect = lambda m: sent.append(m)
+        changed = run_funding_detection_once()
+    return changed, sent, mock_db
+
+
+class TestRunFundingDetectionOnce:
+    def test_approves_when_balance_sufficient(self) -> None:
+        p = _make_awaiting_proposal(amount_usd=Decimal("1000"))
+        changed, sent, db = _run_once([p], balance=Decimal("1500"))
+        assert p.status == "approved"
+        assert p.approved_at is not None
+        assert changed == 1
+        assert len(sent) == 1  # 着金通知
+        db.commit.assert_called()
+
+    def test_approves_at_exact_amount(self) -> None:
+        p = _make_awaiting_proposal(amount_usd=Decimal("1000"))
+        changed, _sent, _db = _run_once([p], balance=Decimal("1000"))
+        assert p.status == "approved"  # >= なので一致でも承認
+        assert changed == 1
+
+    def test_stays_awaiting_when_insufficient(self) -> None:
+        p = _make_awaiting_proposal(amount_usd=Decimal("1000"))
+        changed, sent, _db = _run_once([p], balance=Decimal("999.99"))
+        assert p.status == "awaiting_funds"
+        assert changed == 0
+        assert len(sent) == 0
+
+    def test_skips_when_balance_none(self) -> None:
+        p = _make_awaiting_proposal()
+        changed, sent, _db = _run_once([p], balance=None)
+        assert p.status == "awaiting_funds"
+        assert changed == 0
+        assert len(sent) == 0
+
+    def test_expires_when_funding_window_passed(self) -> None:
+        # expires_at が過去 → 残高十分でも expired(残高チェック前に倒れる)
+        p = _make_awaiting_proposal(minutes_until_expiry=-10)
+        changed, _sent, _db = _run_once([p], balance=Decimal("9999"))
+        assert p.status == "expired"
+        assert changed == 1
+
+
+class TestFundingDetectionManager:
+    @pytest.mark.asyncio
+    async def test_start_stop(self) -> None:
+        mgr = ScheduledTaskManager()
+        assert not mgr.is_funding_detection_running
+        await mgr.start_funding_detection(interval_seconds=3600)
+        assert mgr.is_funding_detection_running
+        with pytest.raises(RuntimeError):
+            await mgr.start_funding_detection(interval_seconds=3600)  # 二重起動 guard
+        await mgr.stop_funding_detection()
+        assert not mgr.is_funding_detection_running

--- a/backend/tests/test_non_custodial_f1f2.py
+++ b/backend/tests/test_non_custodial_f1f2.py
@@ -591,3 +591,43 @@ class TestBuildTxBalanceGuard:
 
         # None は skip。残高不足 422 にはしない (build 自体は env 依存で別結果になりうる)。
         assert "残高不足" not in r.text
+
+
+class TestAwaitFunds:
+    """S2: POST /{id}/await-funds (pending→awaiting_funds + funding window 書換)。"""
+
+    def test_await_funds_transitions_pending_to_awaiting(self, client: TestClient) -> None:
+        token = get_admin_token(client)
+        proposal_id = create_proposal(client, token)  # SUPPLY pending
+        r = client.post(
+            f"/api/proposals/{proposal_id}/await-funds",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        assert r.json()["status"] == "awaiting_funds"
+
+    def test_await_funds_appears_in_pending(self, client: TestClient) -> None:
+        """awaiting_funds 提案は /pending に含まれる (フロント入金待ちカード用)。"""
+        token = get_admin_token(client)
+        proposal_id = create_proposal(client, token)
+        client.post(
+            f"/api/proposals/{proposal_id}/await-funds",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        r = client.get("/api/proposals/pending", headers={"Authorization": f"Bearer {token}"})
+        assert r.status_code == 200
+        statuses = {it["status"] for it in r.json()["items"]}
+        assert "awaiting_funds" in statuses
+
+    def test_await_funds_non_pending_returns_400(self, client: TestClient) -> None:
+        token = get_admin_token(client)
+        proposal_id = create_proposal(client, token)
+        client.post(
+            f"/api/proposals/{proposal_id}/reject",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        r = client.post(
+            f"/api/proposals/{proposal_id}/await-funds",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 400

--- a/docs/integration/backend_deps.md
+++ b/docs/integration/backend_deps.md
@@ -5,6 +5,23 @@
 
 ---
 
+## PR #891 (S2 入金待ち): funding_detection loop の opt-in 起動配線 (2026-06-26)
+
+### 変更: startup_scheduled_tasks に funding detection の opt-in 起動を追加
+- **対象凍結ファイル**: `backend/app/main.py`
+- **変更内容**:
+  - `startup_scheduled_tasks` 内、期限切れリマインダー(`ENABLE_EXPIRY_REMINDER`)の直後に
+    `if os.getenv("ENABLE_FUNDING_DETECTION","0")=="1":` ブロックを追加し
+    `scheduled_manager.start_funding_detection(interval_seconds=..., on_error=...)` を呼ぶ。
+- **理由**: S2(docs/62) の awaiting_funds 着金検知 loop を起動するため。残高が必要額に
+  到達したら proposal を approved 化して署名可能にする。
+- **影響範囲**: **既定 off**（`ENABLE_FUNDING_DETECTION` 未設定で起動しない）。既存の起動
+  シーケンス・他 loop・エンドポイントへの影響なし。明示有効化した環境でのみ 60秒間隔で
+  awaiting_funds 提案の残高を read-only に監視する（秘密鍵に触れない非カストディアル）。
+- **承認**: feat/s2-awaiting-funds → main の通常フロー経由（PR #891）
+
+---
+
 ## PR #775 (AI判定 WebSocket): ai_decisions_ws_router 配線 (2026-06-17)
 
 ### 変更: ai_decisions_ws_router を main.py に include_router

--- a/frontend/app/(liff)/liff-chat/_components/AwaitingFundsCard.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/AwaitingFundsCard.tsx
@@ -1,0 +1,108 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// frontend/app/(liff)/liff-chat/_components/AwaitingFundsCard.tsx
+// S2: 入金待ち(awaiting_funds)提案カード。残高不足で承認した提案を保持し、必要額/不足額/
+// 入金導線を表示。バックグラウンドで残高ポーリングし、着金検知で approved 化すると
+// page.tsx が自動で署名フロー(ProposalActionCard/ProposalSignSheet)へ遷移する。
+"use client"
+
+import { useTranslations } from "next-intl"
+import { Loader2, Wallet } from "lucide-react"
+import type { ChatProposal } from "./ProposalSignSheet"
+
+interface AwaitingFundsCardProps {
+  proposal: ChatProposal
+  balanceUsd: number | null
+  onDeposit: () => void
+  onReject: () => void
+  rejecting?: boolean
+}
+
+export function AwaitingFundsCard({
+  proposal,
+  balanceUsd,
+  onDeposit,
+  onReject,
+  rejecting = false,
+}: AwaitingFundsCardProps) {
+  const t = useTranslations("Liff.awaitingFunds")
+
+  const required = Number(proposal.amount_usd)
+  const current = balanceUsd ?? 0
+  const shortfall = Math.max(0, required - current)
+  const fmt = (n: number) =>
+    n.toLocaleString("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 2 })
+
+  return (
+    <div
+      role="status"
+      className="ax-card-warm rounded-2xl mx-4 mt-4 p-4 border-2 border-amber-300/60"
+    >
+      {/* header */}
+      <div className="flex items-center gap-2 mb-3">
+        <Wallet className="w-4 h-4 text-amber-600" />
+        <span className="text-sm font-bold text-amber-700">{t("title")}</span>
+        <span className="ml-auto flex items-center gap-1.5 text-xs text-[#736f7e]">
+          <Loader2 className="w-3.5 h-3.5 animate-spin text-amber-500" />
+          {t("detecting")}
+        </span>
+      </div>
+
+      {/* amounts */}
+      <div className="space-y-1.5 mb-3">
+        <Row label={t("requiredAmount")} value={fmt(required)} strong />
+        <Row label={t("currentBalance")} value={balanceUsd != null ? fmt(current) : "—"} />
+        <Row label={t("shortfall")} value={fmt(shortfall)} amber />
+      </div>
+
+      <p className="text-[#736f7e] text-xs leading-relaxed mb-3">{t("guide")}</p>
+
+      {/* actions */}
+      <div className="flex gap-3 mt-3">
+        <button
+          onClick={onReject}
+          disabled={rejecting}
+          className="flex-1 py-2.5 rounded-xl border border-[#1c1a27]/20 text-[#1c1a27]
+                     font-semibold disabled:opacity-40 transition-colors"
+        >
+          {t("reject")}
+        </button>
+        <button
+          onClick={onDeposit}
+          className="flex-1 py-2.5 rounded-xl bg-[#1D9E75] active:bg-[#178a64] text-white
+                     font-bold transition-colors"
+        >
+          {t("depositCta")}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function Row({
+  label,
+  value,
+  strong,
+  amber,
+}: {
+  label: string
+  value: string
+  strong?: boolean
+  amber?: boolean
+}) {
+  return (
+    <div className="flex justify-between items-baseline gap-2">
+      <span className="text-xs text-[#736f7e]">{label}</span>
+      <span
+        className={
+          amber
+            ? "text-sm font-semibold text-amber-700"
+            : strong
+              ? "text-sm font-bold text-[#1c1a27]"
+              : "text-sm text-[#1c1a27]"
+        }
+      >
+        {value}
+      </span>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/ProposalSignSheet.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/ProposalSignSheet.tsx
@@ -40,6 +40,8 @@ export interface ChatProposal {
   confidence?: number
   status: string
   created_at: string
+  // S2: awaiting_funds の funding window 期限 (案A で expires_at を funding deadline に流用)。
+  expires_at?: string
 }
 
 type SigningStatus = "idle" | "signing" | "confirming" | "success" | "error"

--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -23,7 +23,9 @@ import { AccountPanel } from "./_components/panels/AccountPanel"
 import { TermsPanel } from "./_components/panels/TermsPanel"
 import { ChatPanel } from "./_components/ChatPanel"
 import { ProposalActionCard } from "./_components/ProposalActionCard"
+import { AwaitingFundsCard } from "./_components/AwaitingFundsCard"
 import { ProposalSignSheet, type ChatProposal } from "./_components/ProposalSignSheet"
+import { awaitFundsProposal } from "@/lib/api/admin-proposals"
 import { DividendChartWrapper } from "./_components/DividendChartWrapper"
 
 // recharts は SSR クラッシュ防止のため dynamic import
@@ -128,7 +130,8 @@ export default function LiffChatPage() {
   const { language, setLanguage } = useLanguage()
 
   // 現在資産 = ユーザー自身のウォレットの USDC オンチェーン残高（非カストディアル）。
-  const { balanceUsd } = useUsdcBalance()
+  // refetch は S2 の着金検知ポーリングで使う。
+  const { balanceUsd, refetch: refetchBalance } = useUsdcBalance()
 
   // ── 既存 state（ハンバーガー）
   const [menuOpen, setMenuOpen] = useState(false)
@@ -232,6 +235,32 @@ export default function LiffChatPage() {
     return () => clearInterval(id)
   }, [])
 
+  // ── S2: awaiting_funds(入金待ち)の間だけ残高+提案状態を 30秒ポーリングして着金検知。
+  // 残高 ≥ 必要額になると backend(funding_detection_loop)が approved 化 → ここで検知して
+  // setPendingProposal で署名フロー(ProposalActionCard/ProposalSignSheet)へ自動遷移する。
+  useEffect(() => {
+    const p = pendingProposal
+    if (p?.status !== "awaiting_funds") return
+    const token =
+      typeof window !== "undefined" ? (localStorage.getItem("auth_token") ?? "") : ""
+    const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ""
+    if (!token) return
+    const headers = { Authorization: `Bearer ${token}` }
+    const poll = () => {
+      refetchBalance()
+      fetch(`${API_BASE}/api/proposals/pending`, { headers })
+        .then((r) => jsonOrReport("proposals/pending", r))
+        .then((d) => {
+          const items = (d as { items?: ChatProposal[] } | null)?.items
+          const same = items?.find((it) => it.id === p.id)
+          if (same && same.status !== p.status) setPendingProposal(same)
+        })
+        .catch((e) => reportFetchError("proposals/pending", e))
+    }
+    const id = setInterval(poll, 30_000)
+    return () => clearInterval(id)
+  }, [pendingProposal, refetchBalance])
+
   // ── KPI-D: 月次手取り（配当）を取得（月次データのため初回のみ）
   useEffect(() => {
     const token =
@@ -332,6 +361,23 @@ export default function LiffChatPage() {
       setRejecting(false)
       setTimeout(() => setToast(null), 2800)
     }
+  }
+
+  // ── 提案 承認: 残高十分なら署名シート、残高不足なら入金待ち(awaiting_funds)化(S2)。
+  // 「承認＝投資意図のキャプチャ」。await-funds で保持し、着金検知で署名可能になる。
+  async function handleApproveProposal() {
+    if (!pendingProposal || !authToken) return
+    if (insufficientBalance) {
+      try {
+        await awaitFundsProposal(pendingProposal.id, authToken)
+        setPendingProposal({ ...pendingProposal, status: "awaiting_funds" })
+      } catch {
+        setToast(t("exec.signFailed"))
+        setTimeout(() => setToast(null), 2800)
+      }
+      return
+    }
+    setSignSheetOpen(true)
   }
 
   // ── 提案 実行完了（署名シートからの成功コールバック）
@@ -524,13 +570,23 @@ export default function LiffChatPage() {
                   : "—"}
               </span>
             </div>
-            <ProposalActionCard
-              proposal={pendingProposal}
-              rejecting={rejecting}
-              onApprove={() => setSignSheetOpen(true)}
-              onReject={handleRejectProposal}
-              insufficientBalance={insufficientBalance}
-            />
+            {pendingProposal.status === "awaiting_funds" ? (
+              <AwaitingFundsCard
+                proposal={pendingProposal}
+                balanceUsd={balanceUsd}
+                rejecting={rejecting}
+                onDeposit={() => setActivePanel("deposit")}
+                onReject={handleRejectProposal}
+              />
+            ) : (
+              <ProposalActionCard
+                proposal={pendingProposal}
+                rejecting={rejecting}
+                onApprove={handleApproveProposal}
+                onReject={handleRejectProposal}
+                insufficientBalance={insufficientBalance}
+              />
+            )}
           </>
         )}
 

--- a/frontend/lib/api/admin-proposals.ts
+++ b/frontend/lib/api/admin-proposals.ts
@@ -107,6 +107,18 @@ export async function rejectProposal(
   );
 }
 
+// S2: 残高不足の SUPPLY 提案を awaiting_funds(入金待ち)に遷移させる(投資意図キャプチャ)。
+export async function awaitFundsProposal(
+  id: number,
+  token: string
+): Promise<AdminProposal> {
+  return await postJson<AdminProposal>(
+    `/api/proposals/${id}/await-funds`,
+    {},
+    { headers: authHeaders(token) }
+  );
+}
+
 // --- 方式2: パートナー本人署名 (Privy) ---
 
 export interface UnsignedTx {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -693,6 +693,16 @@
       "accountAriaLabel": "Account",
       "langToggleAriaLabel": "Switch language"
     },
+    "awaitingFunds": {
+      "title": "Awaiting deposit",
+      "detecting": "Checking for your deposit…",
+      "requiredAmount": "Required",
+      "currentBalance": "Current balance",
+      "shortfall": "Shortfall",
+      "guide": "Deposit USDC on the Base network to your wallet. Domestic exchanges (e.g. SBI VC Trade) withdraw USDC on Ethereum, so bridge it to Base via Circle CCTP before sending (this can take tens of minutes). Once your deposit is confirmed, you'll be able to sign automatically.",
+      "depositCta": "Deposit",
+      "reject": "Dismiss"
+    },
     "home": {
       "currentAsset": "CURRENT ASSET",
       "lastMonthComparison": "vs last month",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -693,6 +693,16 @@
       "accountAriaLabel": "アカウント",
       "langToggleAriaLabel": "言語切替"
     },
+    "awaitingFunds": {
+      "title": "入金待ち",
+      "detecting": "着金を確認中…",
+      "requiredAmount": "必要額",
+      "currentBalance": "現在残高",
+      "shortfall": "不足額",
+      "guide": "Base ネットワークの USDC をウォレットに入金してください。国内取引所(SBI VCトレード等)は USDC を Ethereum で出庫するため、Circle CCTP で Base へブリッジしてから送金します（数十分かかる場合があります）。入金を確認すると自動で署名できるようになります。",
+      "depositCta": "入金する",
+      "reject": "見送る"
+    },
     "home": {
       "currentAsset": "CURRENT ASSET",
       "lastMonthComparison": "先月比",


### PR DESCRIPTION
## 概要

設計 `docs/62`（#888）の本体。S1（#889）で「残高不足は署名前に 422 ブロック＋入金導線」を塞いだのに続き、**「承認＝投資意図のキャプチャ → `awaiting_funds` で保持 → 着金を検知して自動で署名可能化」**の非同期フローを実装。SBI→Ethereum→CCTP→Base の着金ラグ（数十分〜数時間）を吸収する。

決定済み（docs/62）: **§8 金額＝案a 提案額固定** / **§11.2 期限＝案A funding window 分離**。

## Backend
- **`POST /{id}/await-funds`**: `pending→awaiting_funds` ＋ `expires_at` を funding window（`FUNDING_WINDOW_DAYS` 既定7）に書換＝市場期限と分離。reject 対称・**migration 不要**（status は CHECK なし）。`funding_requested_notification` 送信。
- **`funding_detection_loop` / `run_funding_detection_once`**（scheduled_tasks.py）: `awaiting_funds` を SELECT→`read_wallet_usdc_balance`（S1 共有）→残高 ≥ `amount_usd` で `approved`+`approved_at`+`funding_detected_notification`、`expires_at<now` で `expired`。Manager `start/stop_funding_detection` ＋ main.py **opt-in**（`ENABLE_FUNDING_DETECTION=1`・既定 off で無影響）。
- **`/pending`** を `status.in_(["pending","awaiting_funds"])` に拡張（入金待ちカード取得用）。
- `templates.py`: `funding_requested_notification` / `funding_detected_notification` 追加。
- **Tier S 注意**: `scheduled_tasks.py`・`main.py` を変更（計画的単一 PR）。

## Frontend
- **`AwaitingFundsCard`**（新規）: 必要額／現在残高／不足額／着金検知中スピナー／入金導線（DepositPanel）／見送り。
- `page.tsx`: `status==="awaiting_funds"` で AwaitingFundsCard に分岐。承認時 `insufficientBalance`（S1）なら `awaitFundsProposal` 呼出→awaiting_funds 化。**awaiting_funds の間だけ 30s ポーリング**（残高 refetch ＋ `/pending` 再取得）し `approved` 化で署名フローへ自動遷移。
- `ChatProposal.expires_at` 追加 / `admin-proposals.ts` に `awaitFundsProposal`。
- i18n: `Liff.awaitingFunds`（ja/en）。**CCTP ガイドは PR #788 教訓厳守**（「自動変換/即時着金」禁止・SBI=Ethereum 限定→CCTP ブリッジを明記）。

## テスト
- backend: 着金検知 **7件**（残高≥→approved+通知 / <→awaiting 維持 / None skip / 期限→expired / Manager start/stop 二重起動 guard）＋ await-funds **3件**（遷移 / `/pending` 露出 / 非pending 400）→ f1f2+funding **28 passed**。回帰（proposals_api / expiry_reminder / e2e_approve）**45 passed**。`ruff`/`format` pass。
- frontend: **`tsc --noEmit` exit 0** / **i18n parity（新規欠落なし）** / **production build 85/85 成功**（初回 run）。
  - ⚠️ 後続 rebuild は**共有ローカル node_modules の `next` を別プロセスが除去した環境要因**で失敗（コード起因でない）。CI のクリーン環境で確認。
- Playwright 入金待ちカード可視 E2E は staging-v4 実機検証で確認予定（S1 同様）。

## スコープ外（S3）
署名直前の再見積もり（APY/HF/gas）、CCTP アプリ内蔵、funding window のリマインド強化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)