### PR TITLE
fix(ui): 規約・特商法ページの見出しが arobix テーマで不可視になる問題を修正

### DIFF
--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -24,7 +24,9 @@ export default function TermsPage() {
           {t('back')}
         </Button>
 
-        <h1 className="text-2xl font-bold mb-2">{t('title')}</h1>
+        {/* arobix テーマ下では h1 が -webkit-text-fill-color を currentColor(薄色)で
+            継承し見出しがほぼ不可視になるため、暗色を明示する（--text-primary 相当）。 */}
+        <h1 className="text-2xl font-bold mb-2" style={{ color: '#1c1a27', WebkitTextFillColor: '#1c1a27' }}>{t('title')}</h1>
         <p className="text-sm text-zinc-500 mb-8">{t('lastUpdated')}</p>
 
         <div className="space-y-8 text-sm text-zinc-300 leading-relaxed">

--- a/frontend/app/tokushoho/page.tsx
+++ b/frontend/app/tokushoho/page.tsx
@@ -41,7 +41,9 @@ export default function TokushohoPage() {
           {t('back')}
         </Button>
 
-        <h1 className="text-2xl font-bold mb-2">{t('title')}</h1>
+        {/* arobix テーマ下では h1 が -webkit-text-fill-color を currentColor(薄色)で
+            継承し見出しがほぼ不可視になるため、暗色を明示する（--text-primary 相当）。 */}
+        <h1 className="text-2xl font-bold mb-2" style={{ color: '#1c1a27', WebkitTextFillColor: '#1c1a27' }}>{t('title')}</h1>
         <p className="text-sm text-zinc-500 mb-6">{t('lastUpdated')}</p>
         <p className="text-sm text-zinc-400 mb-8 leading-relaxed">{t('intro')}</p>
 


### PR DESCRIPTION
## 背景

staging-v4 の見えるUIテスト中に発見。**`/terms` と `/tokushoho` の h1 見出しが、明るい arobix 背景上でほぼ見えない**（審査担当者にはタイトルが消えて壊れて見える）。本文は読めるが見出しだけ薄色。

## 真因（staging-v4 実機の getComputedStyle で確定）

1. arobix `theme.css` は `.arobix-root` スコープのダーク系 Tailwind クラス（`text-zinc-*`）をライト配色へ `!important` 反転する。
2. ところがページのラッパー要素が **`arobix-root` と `text-zinc-100` を同一要素**に持つため、**子孫**セレクタ `.arobix-root .text-zinc-100` が自分自身には効かず、ラッパーの文字色が薄いまま。
3. 色クラスを持たない h1 がそのラッパーの薄色を継承。さらに **`-webkit-text-fill-color` が `currentColor`（薄色）を引き継ぎ、実際の描画色を支配**していた（`color` を上書きするため、color を変えても描画は薄いまま）。
4. 本文の `dt`/`dd` は自前の `text-zinc-200/400` を持つ子孫なので `.arobix-root .text-zinc-*` が効き、暗く描画される → 見出しだけ薄い、という非対称が発生。

## 修正

h1 に暗色を inline で明示：`style={{ color: '#1c1a27', WebkitTextFillColor: '#1c1a27' }}`（`#1c1a27` = arobix `--text-primary`）。`-webkit-text-fill-color` が実描画を支配するため、これを明示することで確実に暗色化する（`!important` 不要なことも実機確認済み）。

## 検証

- `tsc --noEmit`: 0 エラー
- staging-v4 実機で `h1.style.webkitTextFillColor = '#1c1a27'`（!important なし）→ 描画色 `rgb(28,26,39)` 暗色化を確認
- 差分: `/terms`・`/tokushoho` の h1 各1行のみ

反映には staging-v4 の再デプロイ（frontend 再ビルド）が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
