### PR TITLE
fix(auth): LINE idToken 検証失敗時に LINE のエラー本文をログ出力（原因切り分け）

### DIFF
--- a/backend/app/auth/line.py
+++ b/backend/app/auth/line.py
@@ -52,7 +52,15 @@ async def verify_line_id_token(id_token: str) -> dict[str, Any]:
         )
 
     if response.status_code != 200:
-        logger.warning("LINE token verify failed: status=%d", response.status_code)
+        # LINE の検証失敗は client_id(チャネルID)不一致 / idToken 期限切れ / scope 不足 等、
+        # 原因が status だけでは切り分けられない。LINE が返す error_description を
+        # ログに残して原因を特定できるようにする（本文は LINE のエラー説明で idToken は含まれない）。
+        logger.warning(
+            "LINE token verify failed: status=%d client_id=%s body=%s",
+            response.status_code,
+            channel_id,
+            response.text[:300],
+        )
         raise LineAuthError("LINE idTokenの検証に失敗しました")
 
     payload = response.json()


### PR DESCRIPTION
実機 LINE で /auth/line が verify 400→401。チャネルID は LIFF ID プレフィックスと一致確認済（#890 の導出は正しい）なので 400 の真因は idToken 側（期限切れ/scope/形式）の可能性が高い。LINE が返す error_description をログに出して特定する。body は LINE のエラー説明で idToken は含まない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)