### PR TITLE
feat(staging-demo): 審査用デモシード（新規LINEユーザーにサンプルAI提案）

### DIFF
--- a/backend/app/auth/line.py
+++ b/backend/app/auth/line.py
@@ -96,4 +96,10 @@ def get_or_create_line_user(db: Session, line_user_id: str, display_name: str) -
     db.commit()
     db.refresh(user)
     logger.info("Created new LINE user: user_id=%d", user.id)
+
+    # staging / 審査用デモシード（本番では no-op の二重ガード）。新規ユーザーのみ。
+    # 審査担当者が初回ログイン直後にホームで AI 提案を確認できるようにする。
+    from app.staging_demo import maybe_seed_review_demo  # noqa: PLC0415
+
+    maybe_seed_review_demo(db, user)
     return user

--- a/backend/app/staging_demo.py
+++ b/backend/app/staging_demo.py
@@ -1,0 +1,107 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/staging_demo.py
+
+"""staging / 審査用デモデータのシード（本番では絶対に無効）。
+
+LINE ミニアプリ審査担当者は毎回「自分の LINE アカウント」でログインするため、
+初期状態が「残高 $0・提案なし・データなし」になり、サービス内容をハンズオンで
+確認できない（crypto 系は実機確認されるため却下リスク）。
+
+本モジュールは **staging 限定**で、新規ユーザー作成時にサンプルの AI 判定と
+保留中提案を 1 件投入し、審査担当者がホームで「AI が運用提案を出す」挙動を
+即座に確認できるようにする。実行（on-chain tx）はサンプルのため発生しない。
+
+二重ガード（`ai.service._staging_demo_force_directional_enabled` と同方式で
+本番混入を防ぐ）:
+  1. APP_ENV=production なら常に無効（フラグ値に関わらず）
+  2. それ以外で STAGING_REVIEW_DEMO_SEED=true のときのみ有効（既定 false）
+
+失敗してもユーザー作成は壊さない（best-effort / 例外は握って rollback）。
+金融計算は Decimal のみ（CLAUDE.md [CRITICAL] 11）。
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def review_demo_seed_enabled() -> bool:
+    """審査用デモシードの有効判定（本番では常に False）。"""
+    if os.getenv("APP_ENV", "").strip().lower() == "production":
+        return False
+    return os.getenv("STAGING_REVIEW_DEMO_SEED", "false").strip().lower() == "true"
+
+
+def maybe_seed_review_demo(db, user) -> None:  # type: ignore[no-untyped-def]
+    """新規ユーザーに審査用デモの AI 判定 + 保留中提案を 1 件投入する。
+
+    - staging 限定（`review_demo_seed_enabled()` が False の本番では no-op）。
+    - 冪等: すでに提案を持つユーザーは skip。
+    - best-effort: 失敗してもユーザー作成フローを壊さない。
+
+    Args:
+        db: SQLAlchemy セッション。
+        user: 作成直後の User（id 確定済み）。
+    """
+    if not review_demo_seed_enabled():
+        return
+
+    from datetime import datetime, timedelta, timezone  # noqa: PLC0415
+    from decimal import Decimal  # noqa: PLC0415
+
+    from app.ai.models import AIDecision  # noqa: PLC0415
+    from app.proposals.models import Proposal  # noqa: PLC0415
+
+    try:
+        existing = db.query(Proposal).filter(Proposal.user_id == user.id).first()
+        if existing is not None:
+            return
+
+        now = datetime.now(timezone.utc)
+        decision = AIDecision(
+            user_id=user.id,
+            query="[審査デモ] USDC 相場分析",
+            action="BUY",
+            confidence=86,
+            reason=(
+                "（審査用サンプル）RSI と移動平均が上昇トレンドを示し、複数モデルが "
+                "BUY で一致したため買い判定。これは LINE 審査用に表示しているサンプルです。"
+            ),
+            primary_provider="claude",
+            primary_action="BUY",
+            primary_confidence=86,
+            secondary_provider="gpt-4o",
+            secondary_action="BUY",
+            secondary_confidence=82,
+            agreed=True,
+            prompt_version="demo",
+        )
+        db.add(decision)
+        db.flush()  # decision.id を確定
+
+        proposal = Proposal(
+            user_id=user.id,
+            ai_decision_id=decision.id,
+            operation="SUPPLY",
+            asset="USDC",
+            protocol="aave",
+            amount=Decimal("1000"),
+            amount_usd=Decimal("1000.00"),
+            reason=(
+                "（審査用サンプル）AI が USDC を Aave に供給する提案です。承認すると "
+                "ご自身のウォレットで実行されます（審査用サンプルのため実行はされません）。"
+            ),
+            status="pending",
+            expires_at=now + timedelta(hours=72),
+        )
+        db.add(proposal)
+        db.commit()
+        logger.info(
+            "[review-demo] seeded sample AI decision + pending proposal for user_id=%d",
+            user.id,
+        )
+    except Exception as exc:  # noqa: BLE001 — デモ失敗でユーザー作成を壊さない
+        db.rollback()
+        logger.warning("[review-demo] seed failed for user_id=%d: %s", user.id, exc)

--- a/backend/tests/test_staging_demo.py
+++ b/backend/tests/test_staging_demo.py
@@ -1,0 +1,62 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+"""staging_demo（審査用デモシード）の単体テスト。
+
+本番 no-op の二重ガード / 冪等 / best-effort を検証する。
+"""
+
+from unittest.mock import MagicMock
+
+from app.staging_demo import maybe_seed_review_demo, review_demo_seed_enabled
+
+
+def test_disabled_by_default(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """env 未設定なら無効。"""
+    monkeypatch.delenv("STAGING_REVIEW_DEMO_SEED", raising=False)
+    monkeypatch.delenv("APP_ENV", raising=False)
+    assert review_demo_seed_enabled() is False
+
+
+def test_production_always_disabled(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """APP_ENV=production ならフラグが true でも無効（二重ガード）。"""
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("STAGING_REVIEW_DEMO_SEED", "true")
+    assert review_demo_seed_enabled() is False
+
+
+def test_enabled_only_in_staging(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """非 production かつフラグ true のときのみ有効。"""
+    monkeypatch.setenv("APP_ENV", "staging")
+    monkeypatch.setenv("STAGING_REVIEW_DEMO_SEED", "true")
+    assert review_demo_seed_enabled() is True
+
+
+def test_seed_noop_when_disabled(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """無効時は DB に一切触れない。"""
+    monkeypatch.delenv("STAGING_REVIEW_DEMO_SEED", raising=False)
+    db = MagicMock()
+    maybe_seed_review_demo(db, MagicMock(id=11))
+    db.query.assert_not_called()
+    db.add.assert_not_called()
+    db.commit.assert_not_called()
+
+
+def test_seed_creates_decision_and_proposal(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """有効時、AI判定 + 保留中提案の 2 レコードを add して commit する。"""
+    monkeypatch.setenv("APP_ENV", "staging")
+    monkeypatch.setenv("STAGING_REVIEW_DEMO_SEED", "true")
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None  # 既存なし
+    maybe_seed_review_demo(db, MagicMock(id=11))
+    assert db.add.call_count == 2  # AIDecision + Proposal
+    db.commit.assert_called_once()
+
+
+def test_seed_idempotent_when_proposal_exists(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """既に提案を持つユーザーは skip（冪等）。"""
+    monkeypatch.setenv("APP_ENV", "staging")
+    monkeypatch.setenv("STAGING_REVIEW_DEMO_SEED", "true")
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = MagicMock()  # 既存あり
+    maybe_seed_review_demo(db, MagicMock(id=11))
+    db.add.assert_not_called()
+    db.commit.assert_not_called()

--- a/docs/64_line_review_demo_prep.md
+++ b/docs/64_line_review_demo_prep.md
@@ -1,0 +1,61 @@
+# LINE審査 デモ準備手順（審査担当者に「機能が動く」と見せる）
+
+> 背景: 実機調査(2026-06-29)で、LINE審査担当者が staging-v4 を触っても
+> **「残高$0・提案なし・データなし」の空画面**になることを確認。crypto系は
+> 実機ハンズオンで確認されるため、空画面＝「サービス内容が確認できない」で却下リスク大。
+>
+> 真因: 審査担当者は毎回「自分のLINEアカウント」でログイン＝毎回まっさらな新規ユーザー。
+> 新規ユーザーは fund_allocation 無し → 提案生成の対象外 → 提案ゼロ。提案取得は self-only
+> RBAC のため他人(user 3/10)の提案も見えない。
+
+## 対策（2本立て）
+
+### ① デモ自動シード（実機で見せる）— PR #901
+新規LINEユーザー作成時に **サンプルAI判定(BUY 86%)＋保留中提案(SUPPLY USDC 1000)** を
+自動投入。審査担当者が初回ログイン直後にホームで「AIが運用提案を出す」挙動を確認できる。
+
+**デプロイ手順（staging-v4・審査前）:**
+```bash
+# 本番VPS staging-v4 backend に env を追加して再作成（本番には設定しない）
+cd /opt/ultra-autotrade
+# .env.staging-v4 に追記（printf で改行保証 / sed -i 禁止）
+printf '\nSTAGING_REVIEW_DEMO_SEED=true\n' >> .env.staging-v4
+docker compose -p ultra-autotrade-staging-v4 -f docker-compose.staging-v4.yml \
+  up -d --no-deps --force-recreate backend
+# 検証: 新規LINEログイン → ホームに AI判定 + 保留中提案が出ること
+```
+※ 二重ガードで `APP_ENV=production` では仮に設定されても no-op。本番は無設定でよい。
+※ 実行(on-chain tx)はサンプルのため発生しない。CURRENT ASSET(オンチェーン残高)は$0のまま
+（入金導線は別途「入金してください」で見せる）。
+
+### ② 説明資料の添付（事前相談 / 審査に同梱）— フォームが明示的に許容
+実機が空でも「何ができるか」を示す資料。user 3/10（提案データ有り）or デモシード後の画面で撮影。
+
+**撮影する画面/フロー（スクショ + 任意で短い画面録画）:**
+1. LINEログイン → 6項目の同意ゲート（規約/リスク/非カストディアル/年齢18+）
+2. ホーム: AI判定カード（BUY/HOLD + 確信度 + 理由）
+3. ホーム: 保留中AI提案カード（SUPPLY USDC + 金額）
+4. 提案を「承認」→ 自己署名 → 実行（自分のウォレットで実行される非カストディアルの流れ）
+5. 入金パネル（Privy fundWallet）/ MyWallet（Non-Custodialバッジ・自分のアドレス）
+6. 規約・プライバシー・特定商取引法ページ
+
+各スクショに「AIは提案のみ・実行は利用者が都度承認・資産は利用者のウォレットに保持」を注記。
+
+## Perplexity 400（参考・後続改善）
+- Macro Agent が依存する Perplexity API が **一過性400**（200と6分おき交互。モデル名
+  `sonar-pro`/`sonar`は正しい・401クォータ切れではない）。retry 4回が全部一過性400を引くと
+  macro が空→60分HOLD固着。
+- 審査デモには **staging relax フラグ + デモシードで BUY/提案が出る**ので、Perplexity は
+  審査ブロッカーではない。本番ローンチ前に「標準A: fetch失敗時に前回成功キャッシュを保持
+  （空フォールバック回避）」で恒久対応推奨（`data_feeds/finance_feed.py`）。
+
+## 審査前チェックリスト
+- [ ] PR #901 main マージ → staging-v4 へデプロイ + `STAGING_REVIEW_DEMO_SEED=true`
+- [ ] 新規LINEログインでホームに AI判定+提案が出ることを実機確認
+- [ ] 説明資料（スクショ/録画）作成
+- [ ] PR #900（法務/リジェクト対策）main マージ → staging-v4 反映
+- [ ] 審査用LIFF(2010494865)で frontend 再ビルド（提出直前の最後の1手）
+- [ ] LINE事前相談フォーム提出（docs/63）
+
+> 関連: docs/63（事前相談フォーム記入）/ MEMORY `project_staging_v4_proposals_always_hold`,
+> `project_line_miniapp_review_readiness`


### PR DESCRIPTION
## 概要
LINEミニアプリ審査担当者が staging-v4 を実機で触ったとき「残高\$0・提案なし」の空画面になり、サービス内容を確認できず却下リスクが高い問題を解消する。実機調査で確認済み（新規LINEユーザー=fund_allocation無し→提案生成対象外→提案ゼロ）。

## 変更内容
- `app/staging_demo.py` 新設: 新規ユーザー作成時にサンプルの **AI判定(BUY 86%)** と **保留中提案(SUPPLY USDC 1000)** を1件投入。審査担当者が初回ログイン直後にホームで「AIが運用提案を出す」挙動を確認できる。実行(on-chain tx)はサンプルのため発生しない。
- **二重ガード**（`AI_STAGING_RELAX_MACRO_GATE` と同方式）: `APP_ENV=production` は常に no-op / 非productionかつ `STAGING_REVIEW_DEMO_SEED=true` のときのみ有効（既定 false）。
- 冪等（既存提案ありなら skip）/ best-effort（失敗してもユーザー作成を壊さない）/ Decimal型。
- `auth/line.py` `get_or_create_line_user` の新規ユーザー作成直後にフック。

## Gate
- ruff / format / mypy pass / 新規テスト **6 passed** / 既存 line・auth 系 **115 passed**（無リグレッション）

## デプロイ（審査前）
- staging-v4 backend env に `STAGING_REVIEW_DEMO_SEED=true` を設定して backend 再作成。
- **本番には設定しない**（二重ガードで仮に設定されても production は no-op）。

## 関連
- 実機調査: 審査担当者が触ってもAI提案が見えない問題（常時HOLD/$0）。説明資料添付と併用（docs/64）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)