### PR TITLE
fix(ai): AI判定の reason を日本語出力に（プロンプト V3〜V6 言語指定漏れ）

### DIFF
--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -104,7 +104,7 @@ Respond in JSON format ONLY:
 {{
     "action": "BUY" | "SELL" | "HOLD",
     "confidence": 0-100,
-    "reason": "Brief explanation referencing agent signals"
+    "reason": "判断根拠を必ず日本語で簡潔に記述する（どのエージェントのシグナルに基づくか言及。write the reason field in Japanese）"
 }}"""
 
 _V3_USER_TEMPLATE = """## Specialist Agent Reports:
@@ -150,7 +150,7 @@ Respond in JSON format ONLY:
 {{
     "action": "BUY" | "SELL" | "HOLD",
     "confidence": 0-100,
-    "reason": "Brief explanation referencing agent signals"
+    "reason": "判断根拠を必ず日本語で簡潔に記述する（どのエージェントのシグナルに基づくか言及。write the reason field in Japanese）"
 }}"""
 
 _V4_USER_TEMPLATE = """## Specialist Agent Reports:
@@ -201,7 +201,7 @@ Respond in JSON format ONLY:
 {{
     "action": "BUY" | "SELL" | "HOLD",
     "confidence": 0-100,
-    "reason": "Brief explanation referencing which agents agreed and their confidence"
+    "reason": "判断根拠を必ず日本語で簡潔に記述する（どのエージェントが一致したか・確信度に言及。write the reason field in Japanese）"
 }}"""
 
 _V5_USER_TEMPLATE = """## Specialist Agent Reports:
@@ -266,7 +266,7 @@ Respond in JSON format ONLY:
 {{
     "action": "BUY" | "SELL" | "HOLD",
     "confidence": 0-100,
-    "reason": "Brief explanation referencing the weighted score and which agents agreed"
+    "reason": "判断根拠を必ず日本語で簡潔に記述する（加重スコアとどのエージェントが一致したかに言及。write the reason field in Japanese）"
 }}"""
 
 _V6_USER_TEMPLATE = """## Specialist Agent Reports:

--- a/backend/tests/test_prompt_reason_language.py
+++ b/backend/tests/test_prompt_reason_language.py
@@ -1,0 +1,22 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+"""AI判定プロンプトの reason フィールドが日本語出力を指示しているかの回帰テスト。
+
+V3〜V6（英語システムプロンプト）は以前 reason の言語指定が無く LLM が英語で
+出力していた。日本語ユーザー向けに reason を日本語で出させるため、各版に
+「判断根拠を必ず日本語で」を明記した。本テストはその退行を防ぐ。
+"""
+
+import pytest
+
+from app.ai.prompts import PROMPT_REGISTRY
+
+
+@pytest.mark.parametrize("version", ["v3", "v4", "v5", "v6"])
+def test_reason_field_requires_japanese(version: str) -> None:
+    """V3〜V6 の system プロンプトが reason の日本語記述を指示している。"""
+    system = PROMPT_REGISTRY[version].system_prompt
+    assert "日本語" in system, f"{version}: reason の日本語指定が無い"
+    # 旧来の言語非指定ヒントが残っていないこと
+    assert "Brief explanation referencing" not in system, (
+        f"{version}: 言語非指定の旧 reason ヒントが残存している"
+    )

--- a/docs/64_line_review_demo_prep.md
+++ b/docs/64_line_review_demo_prep.md
@@ -20,9 +20,12 @@
 cd /opt/ultra-autotrade
 # .env.staging-v4 に追記（printf で改行保証 / sed -i 禁止）
 printf '\nSTAGING_REVIEW_DEMO_SEED=true\n' >> .env.staging-v4
-docker compose -p ultra-autotrade-staging-v4 -f docker-compose.staging-v4.yml \
-  up -d --no-deps --force-recreate backend
+# 【重要】--env-file 必須。これを抜くと ${POSTGRES_PASSWORD} 等が空展開され
+# backend が DB接続不能(fe_sendauth: no password supplied)になり全API 500 になる。
+docker compose --env-file .env.staging-v4 -p ultra-autotrade-staging-v4 \
+  -f docker-compose.staging-v4.yml up -d --no-deps --force-recreate backend
 # 検証: 新規LINEログイン → ホームに AI判定 + 保留中提案が出ること
+#       + docker logs ... | grep -i "no password" が空であること
 ```
 ※ 二重ガードで `APP_ENV=production` では仮に設定されても no-op。本番は無設定でよい。
 ※ 実行(on-chain tx)はサンプルのため発生しない。CURRENT ASSET(オンチェーン残高)は$0のまま


### PR DESCRIPTION
## 概要
ホームの AI判定カードの理由文が**英語**で表示される問題を解消。日本語ユーザー（LINE審査担当者含む）には日本語が適切。実機 staging-v4 で確認（"Agent shows 20 consecutive HOLDs..." 等が英語表示）。

## 原因
- 現行の英語システムプロンプト **V3〜V6** は `reason` フィールドに言語指定が無く、LLM が英語で出力していた。
- 旧 V1/V2 は `reason:（日本語、200文字以内）` と明記済みだった（V3 以降の移行で抜けた）。
- アクティブ版は `AI_PROMPT_VERSION` env 制御（staging-v4 は V5/V6）。

## 変更内容
- V3〜V6 の JSON 出力仕様の `reason` ヒントに「**判断根拠を必ず日本語で簡潔に記述する**」を明記。
- `action`/`confidence` は言語非依存のため変更なし → **判定ロジックは不変**（reason の言語のみ）。
- 回帰テスト追加。

## Gate
- ruff / format pass / 新規テスト **4 passed** / 既存 AI prompt・service **115 passed**（無リグレッション）

## 反映
- staging-v4 backend 再ビルド（**`--env-file .env.staging-v4` 必須**）+ 次の判定 tick（最大1h、または手動トリガ）で日本語 reason に切替。

🤖 Generated with [Claude Code](https://claude.com/claude-code)