### PR TITLE
fix(ai): AI判定理由の文言を日本語化（判定理由＋エラーメッセージ）

### DIFF
--- a/backend/app/ai/service.py
+++ b/backend/app/ai/service.py
@@ -263,7 +263,7 @@ class AIService:
                     provider=LLMProvider.RULE_BASED,
                     action=TradeAction.HOLD,
                     confidence=95,
-                    reason="COMPOUND RISK: Low HF + elevated geo risk. Forced HOLD by rule engine.",
+                    reason="複合リスク検知（Health Factor 低下＋地政学リスク上昇）のため、安全を優先して様子見（HOLD）としました。",
                     prompt_version=version,
                 )
                 return CrossValidationResult(
@@ -272,7 +272,7 @@ class AIService:
                     agreed=True,
                     final_action=TradeAction.HOLD,
                     final_confidence=95,
-                    final_reason="COMPOUND RISK detected. Rule engine forced HOLD before LLM call.",
+                    final_reason="複合リスクを検知したため、安全を優先して様子見（HOLD）としました。",
                 )
             # Guard 2: AND-condition for v4/v5 — SELL/BUY needs both Indicator AND Macro >=70%
             if version in ("v4", "v5") and not (
@@ -312,9 +312,8 @@ class AIService:
                 result.final_confidence,
             )
             _clamp_reason = (
-                f"AND-condition not met: LLM proposed {result.final_action.value} but "
-                "Indicator and Macro agents did not both agree >=70%. "
-                f"Original: {result.final_reason}"
+                "テクニカル指標とマクロ環境の両方が同方向（信頼度70%以上）で"
+                "揃わなかったため、安全を優先して様子見（HOLD）としました。"
             )
             _clamped = LLMDecision(
                 provider=LLMProvider.RULE_BASED,
@@ -351,9 +350,9 @@ class AIService:
                 _rule_ctx.indicator_signal.confidence,
             )
             _demo_reason = (
-                "STAGING DEMO RELAX: Indicator-only BULLISH>=70% でゲート緩和 "
-                "(macro 軸ドロップ・staging 限定)。"
-                f"Original: {result.final_reason}"
+                "テクニカル指標が強気シグナル"
+                f"（信頼度{_rule_ctx.indicator_signal.confidence}%）を示しているため、"
+                "買い（BUY）と判断しました。"
             )
             _demo_decision = LLMDecision(
                 provider=LLMProvider.RULE_BASED,
@@ -466,7 +465,7 @@ class AIService:
                 provider=LLMProvider.CLAUDE,
                 action=TradeAction.HOLD,
                 confidence=0,
-                reason="API key not configured",
+                reason="AI APIキーが未設定のため、安全を優先して様子見（HOLD）としました。",
                 prompt_version=version,
             )
 
@@ -538,7 +537,10 @@ class AIService:
                 provider=LLMProvider.CLAUDE_FALLBACK,
                 action=TradeAction.HOLD,
                 confidence=0,
-                reason=f"Opus error: {last_exc}; Fallback error: {exc}",
+                reason=(
+                    "AI判定に失敗したため、安全を優先して様子見（HOLD）としました。"
+                    f"（エラー: {last_exc} / フォールバックエラー: {exc}）"
+                ),
                 prompt_version=version,
             )
 
@@ -556,7 +558,7 @@ class AIService:
                 provider=LLMProvider.OPENAI,
                 action=TradeAction.HOLD,
                 confidence=0,
-                reason="API key not configured",
+                reason="AI APIキーが未設定のため、安全を優先して様子見（HOLD）としました。",
                 prompt_version=version,
             )
         try:
@@ -581,7 +583,7 @@ class AIService:
                 provider=LLMProvider.OPENAI,
                 action=TradeAction.HOLD,
                 confidence=0,
-                reason=f"API error: {exc}",
+                reason=f"AI判定でエラーが発生したため、安全を優先して様子見（HOLD）としました。（エラー: {exc}）",
                 prompt_version=version,
             )
 
@@ -615,7 +617,7 @@ class AIService:
                 provider=provider,
                 action=TradeAction.HOLD,
                 confidence=0,
-                reason=f"Parse error: {exc}",
+                reason=f"AI応答の解析に失敗したため、安全を優先して様子見（HOLD）としました。（エラー: {exc}）",
                 raw_response=raw,
             )
 
@@ -648,7 +650,7 @@ class AIService:
                 agreed=True,
                 final_action=primary.action,
                 final_confidence=avg_confidence,
-                final_reason=f"Both LLMs agree: {primary.reason}",
+                final_reason=f"2つのAIモデルの判定が一致しました。{primary.reason}",
                 prompt_version=primary.prompt_version,
             )
         else:
@@ -660,8 +662,8 @@ class AIService:
                 final_action=TradeAction.HOLD,
                 final_confidence=min(min_confidence, 30),
                 final_reason=(
-                    f"LLMs disagree ({primary.action.value} vs {secondary.action.value});"
-                    " defaulting to HOLD"
+                    f"2つのAIモデルの判定が分かれた（{primary.action.value} と "
+                    f"{secondary.action.value}）ため、安全を優先して様子見（HOLD）としました。"
                 ),
                 prompt_version=primary.prompt_version,
             )

--- a/backend/tests/test_ai_sell_and_condition.py
+++ b/backend/tests/test_ai_sell_and_condition.py
@@ -511,7 +511,7 @@ class TestJudgeWithRagAndConditionGuard:
         assert result.final_action == TradeAction.HOLD, (
             "SELL must be blocked when only Macro is BEARISH (AND-condition not met)"
         )
-        assert "AND-condition" in result.final_reason
+        assert "テクニカル指標とマクロ環境" in result.final_reason
 
     def test_sell_allowed_when_both_indicator_and_macro_bearish(self) -> None:
         """

--- a/backend/tests/test_security_review.py
+++ b/backend/tests/test_security_review.py
@@ -525,7 +525,7 @@ class TestLlmFailClosed:
 
         assert decision.action == TradeAction.HOLD
         assert decision.confidence == 0
-        assert "Parse error" in (decision.reason or "")
+        assert "解析に失敗" in (decision.reason or "")
 
     def test_parse_empty_string_returns_hold(self) -> None:
         """_parse_llm_response with empty string must return HOLD."""


### PR DESCRIPTION
## 概要
ユーザーに表示される AI 判定の `reason` 文言を英語から日本語へ統一しました。LINE 審査・本番ユーザー向けに、判定理由とフォールバック時のエラー文言が日本語で表示されるようになります。

## 変更内容（`backend/app/ai/service.py`）

### 判定ロジック由来の理由
- 複合リスク検知時の強制 HOLD 理由（Guard 1）
- AND 条件未成立時のクランプ理由
- staging デモ緩和時の BUY 理由
- 2モデル一致/不一致時の最終理由

### 技術的エラー由来（いずれも fail-closed で HOLD）
- APIキー未設定（Claude / OpenAI）
- Opus + フォールバック両失敗
- API エラー / 応答解析（Parse）失敗
- ※デバッグ用に例外詳細は括弧内で保持

## テスト追従
- `test_ai_sell_and_condition.py` — AND条件クランプ理由の assert を日本語文言に
- `test_security_review.py` — 解析失敗時の assert を `"解析に失敗"` に

## DoD
- ✅ `ruff check` / `ruff format --check`
- ✅ `mypy app/ai/service.py`
- ✅ `pytest`（test_ai_sell_and_condition / test_ai_judge / test_security_review = 138 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)