### PR TITLE
fix(liff-account): おまかせ(Auto)無効時はアカウント画面の運用モード行を非表示

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
@@ -20,6 +20,7 @@ import { useLanguage } from "@/lib/useLanguage"
 import { getAuthToken, clearAuthToken } from "@/lib/auth/token-key"
 import { useWallet } from "@/hooks/useWallet"
 import { liffFetch } from "@/lib/liff/liff-fetch"
+import { isAutoModeEnabled } from "@/lib/flags"
 
 interface UserData {
   id?: number
@@ -539,11 +540,16 @@ export function AccountPanel() {
           <span className="text-[#1c1a27] text-sm">{getStartedAt()}</span>
         </div>
 
-        {/* 運用モード */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-[#1c1a27]/15">
-          <span className="text-[#736f7e] text-sm">{t("opMode")}</span>
-          <span className="text-[#1c1a27] text-sm">{getModeLabel()}</span>
-        </div>
+        {/* 運用モード（おまかせ/アクティブ）。
+            おまかせ(Auto)モード無効時はモードがアクティブ実態のみとなり、
+            「おまかせ」表記が実挙動(AI提案→都度承認のセミオート)と乖離するため、
+            ハンバーガーメニューの運用モード項目と同様にフラグで行ごと隠す。 */}
+        {isAutoModeEnabled() && (
+          <div className="flex items-center justify-between px-4 py-3 border-b border-[#1c1a27]/15">
+            <span className="text-[#736f7e] text-sm">{t("opMode")}</span>
+            <span className="text-[#1c1a27] text-sm">{getModeLabel()}</span>
+          </div>
+        )}
 
         {/* ウォレットアドレス */}
         <div className="flex items-center justify-between px-4 py-3">


### PR DESCRIPTION
## 概要
LINE審査向けスクショ点検で、アカウント画面に **「運用モード: おまかせ」** が常時表示されているのを検出。ハンバーガーメニューの運用モード項目は `isAutoModeEnabled()` で gate 済みだが、アカウントパネルだけ gating から漏れていた。

## 背景
- 森先生の法務判断（2026-06-26）で「おまかせ自動運用＝無登録投資運用業で日本提供不可」。審査スクショに「おまかせ」名が写るのは抵触領域
- おまかせ(Auto)無効ビルドでは運用は実態としてアクティブ（AI提案→**都度承認**のセミオート）のみで、「おまかせ」表記は実挙動と乖離

## 変更
- `AccountPanel.tsx` の運用モード行を `isAutoModeEnabled()` で行ごと条件表示にし、`HamburgerMenu` の運用モード項目と gating を整合

## 確認
- ✅ `tsc --noEmit` クリーン
- ✅ `eslint` クリーン
- 影響範囲: おまかせ(Auto)有効ビルドでは従来どおり表示。無効ビルド（審査用 staging-v4 等）でのみ行が消える

🤖 Generated with [Claude Code](https://claude.com/claude-code)