### PR TITLE
test(billing): subscription テストの日付時限バグ修正（2026-06-30〜発火・全PR CI赤）

### DIFF
--- a/backend/tests/billing/test_subscription_billing.py
+++ b/backend/tests/billing/test_subscription_billing.py
@@ -83,9 +83,16 @@ def _add_user(
     user_id: int = 1,
     risk_mode: str = "balanced",
     tier: str = "LOWER",
-    created_days_ago: int = 60,
+    created_days_before_month: int = 60,
 ) -> User:
-    """テスト用アクティブユーザーを作成して返す。"""
+    """テスト用アクティブユーザーを作成して返す。
+
+    created_at は「計算対象月 (_MONTH) の N 日前」に固定する。
+    実時刻 (now) 基準にすると、now が _MONTH の created_days 日後に達した時点で
+    created_at が _MONTH 内に入り is_first_month=True に化け、初月サブスク=0 で
+    テストが日付依存に落ちる (2026-06-30 に created_days_ago=60 で発火した時限バグ)。
+    _MONTH 基準の固定にして「計算月より前に作成済み = 初月でない」を常に保証する。
+    """
     u = User(
         id=user_id,
         email=f"user{user_id}@test.com",
@@ -94,7 +101,8 @@ def _add_user(
         is_active=True,
         risk_mode=risk_mode,
         tier=tier,
-        created_at=datetime.now(timezone.utc) - timedelta(days=created_days_ago),
+        created_at=datetime(_MONTH.year, _MONTH.month, 1, tzinfo=timezone.utc)
+        - timedelta(days=created_days_before_month),
     )
     db.add(u)
     db.flush()


### PR DESCRIPTION
## 概要
`tests/billing/test_subscription_billing.py` の vendor課金系3件が **2026-06-30 から日付依存で fail** し、**全PRのCI（Test pytest）をブロック**していたのを修正。fee 本体ロジックは無変更（テストfixtureのみ）。

## 真因（時限バグ）
`_add_user` の `created_at` が **now 基準の相対日付**（`now - created_days_ago(=60)`）だった。

`is_first_month` 判定（`app/api/v1/fees.py:356`）:
```python
is_first_month = (month_start <= user_created_date < next_month)  # month=2026-05
```
初月は subscription rate=0（`calculator.py:289`）→ vendor課金されない。

- 〜2026-06-29: `now-60日 < 2026-05-01` → is_first_month=False → subscription>0 → **pass**
- 2026-06-30〜07-30: `now-60日 ∈ [2026-05-01, 2026-06-01)` → is_first_month=True → subscription=0 → `vendor_charges_attempted=0` → **fail**

→ #903 のCIは6/29に通り、6/30実行のPRから一斉に落ちていた（frontend-only PR含む）。

## 修正
`created_at` を **`_MONTH` 基準の固定**（計算月の N 日前）に変更し、実時刻に依存せず「計算月より前に作成済み＝初月でない」を常に保証。パラメータ名も `created_days_ago` → `created_days_before_month` に変更。

## 確認
- ✅ `pytest tests/billing/test_subscription_billing.py` → **15 passed**（落ちていた3件含む）
- ✅ `ruff check` / `ruff format --check` OK
- 影響: テストfixtureのみ。fee 計算ロジック・本番挙動に変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)