### PR TITLE
fix(liff): PWA モードの LINE 誤表示とログアウト遷移を修正

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
@@ -20,6 +20,7 @@ import { useLanguage } from "@/lib/useLanguage"
 import { getAuthToken, clearAuthToken } from "@/lib/auth/token-key"
 import { useWallet } from "@/hooks/useWallet"
 import { liffFetch } from "@/lib/liff/liff-fetch"
+import { isLiffConfigured } from "@/lib/liff/init"
 import { isAutoModeEnabled } from "@/lib/flags"
 
 interface UserData {
@@ -53,6 +54,9 @@ export function AccountPanel() {
   const { language } = useLanguage()
   const router = useRouter()
   const { logout: privyLogout, authenticated } = usePrivy()
+  // ログイン経路の判定。LINE 未設定（PWA 本番形態）では Privy passwordless（メール）
+  // ログインとなるため、LINE 前提の表示・遷移を出し分ける。
+  const liffMode = isLiffConfigured()
   // ウォレット表示の単一情報源化: backend の wallet_address が未記録でも、
   // Privy embedded（または injected）ウォレットのアドレスを useWallet から拾って
   // 「未連携」誤表示を防ぐ（Asana 1215576087505209）。
@@ -366,8 +370,7 @@ export function AccountPanel() {
 
   // ログアウト
   const handleLogout = async () => {
-    const { getLiff, isLiffConfigured } = await import("@/lib/liff/init")
-    const liffMode = isLiffConfigured()
+    const { getLiff } = await import("@/lib/liff/init")
 
     // 1. Privy ログアウト
     try {
@@ -389,8 +392,10 @@ export function AccountPanel() {
     // 3. トークンクリア（正準キー + 旧キーの両方を消す）
     clearAuthToken()
 
-    // 4. リダイレクト（LIFF モードは /liff-login、ブラウザは /login）
-    router.replace(liffMode ? "/liff-login" : "/login")
+    // 4. リダイレクト。LIFF / PWA いずれも消費者は /liff-login へ送る
+    //    （PWA モードでは /liff-login が BrowserLoginPrompt=Privy を表示する）。
+    //    旧実装は PWA 時に /login（スタッフ用メール+パスワード画面）へ送っていた。
+    router.replace("/liff-login")
   }
 
   // アカウント削除申請
@@ -522,10 +527,11 @@ export function AccountPanel() {
                 {t("resetIcon")}
               </button>
             )}
-            {/* ログイン方法バッジ（LIFF = LINE ログイン） */}
+            {/* ログイン方法バッジ。LIFF モード=LINE ログイン / PWA モード=Privy
+                passwordless（メール）ログインのため出し分ける。 */}
             <div className="flex flex-wrap gap-1 mt-1">
               <span className="ax-card-warm text-[#1c1a27] text-xs px-2 py-0.5 rounded-full">
-                {t("lineLoginBadge")}
+                {liffMode ? t("lineLoginBadge") : t("browserLoginBadge")}
               </span>
             </div>
           </div>

--- a/frontend/app/(liff)/liff-chat/_components/panels/NotificationPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/NotificationPanel.tsx
@@ -6,6 +6,7 @@ import { MessageCircle, Bell, AlertTriangle, ShieldAlert, FileText, Info } from 
 import { useTranslations } from "next-intl"
 import { getAuthToken } from "@/lib/auth/token-key"
 import { liffFetch } from "@/lib/liff/liff-fetch"
+import { isLiffConfigured } from "@/lib/liff/init"
 
 // ---------------------------------------------------------------------------
 // 型定義
@@ -245,20 +246,24 @@ export function NotificationPanel() {
       {/* 通知チャネル */}
       <SectionHeader label={t("channelSection")} />
 
-      {/* LINE 通知 */}
-      <div className="flex items-center justify-between ax-card-warm rounded-xl px-4 py-3 mb-2">
-        <div className="flex items-center gap-3">
-          <MessageCircle className="w-5 h-5 text-[#1D9E75]" />
-          <div>
-            <div className="text-[#1c1a27] text-sm">{t("lineNotification")}</div>
-            <div className="text-[#1D9E75] text-xs">{t("lineConnected")}</div>
+      {/* LINE 通知。LIFF モード（LINE 連携）でのみ表示する。PWA 本番形態
+          （NEXT_PUBLIC_LIFF_ID 未設定）では LINE 未接続のため「接続済み」の
+          誤表示を避けて行ごと非表示にする。 */}
+      {isLiffConfigured() && (
+        <div className="flex items-center justify-between ax-card-warm rounded-xl px-4 py-3 mb-2">
+          <div className="flex items-center gap-3">
+            <MessageCircle className="w-5 h-5 text-[#1D9E75]" />
+            <div>
+              <div className="text-[#1c1a27] text-sm">{t("lineNotification")}</div>
+              <div className="text-[#1D9E75] text-xs">{t("lineConnected")}</div>
+            </div>
           </div>
+          <Toggle
+            checked={settings.line_enabled}
+            onChange={(v) => updateChannel("line_enabled", v)}
+          />
         </div>
-        <Toggle
-          checked={settings.line_enabled}
-          onChange={(v) => updateChannel("line_enabled", v)}
-        />
-      </div>
+      )}
 
       {/* PWA プッシュ通知 */}
       <div className="flex items-center justify-between ax-card-warm rounded-xl px-4 py-3 mb-2">

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -748,6 +748,7 @@
         "avatarAlt": "Avatar",
         "defaultUser": "User",
         "lineLoginBadge": "LINE",
+        "browserLoginBadge": "Email",
         "startedAt": "Started",
         "opMode": "Mode",
         "wallet": "Wallet",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -748,6 +748,7 @@
         "avatarAlt": "アバター",
         "defaultUser": "ユーザー",
         "lineLoginBadge": "LINE",
+        "browserLoginBadge": "メール",
         "startedAt": "運用開始日",
         "opMode": "運用モード",
         "wallet": "ウォレット",


### PR DESCRIPTION
## 背景
v3 本番の配布形態は **PWA + Privy passwordless**（`NEXT_PUBLIC_LIFF_ID` 空 → `isLiffConfigured()=false`）で、LINE は使用しない。しかし liff-chat に LINE 前提の表示・遷移が残っており、PWA ユーザーに事実と異なる UI が出ていた（実機調査で確認）。

## 修正内容（PWA 整合性 グループ1・2）

### グループ1: 虚偽・誤表示
- **NotificationPanel** (`liff-chat/_components/panels/NotificationPanel.tsx`)
  「LINE 通知 / **接続済み**」は接続状態に紐づかない**静的ラベル**で、PWA でも常に緑「接続済み」と表示していた。`isLiffConfigured()` で LINE 行ごと非表示にし、虚偽表示を解消（PWA は LINE 未接続で通知も飛ばない）。
- **AccountPanel** (`liff-chat/_components/panels/AccountPanel.tsx`)
  ログイン方法バッジが無条件で「**LINE**」だった。`isLiffConfigured()` で出し分け、PWA は「メール / Email」を表示（i18n `browserLoginBadge` を追加）。

### グループ2: 遷移の不整合（隣接事項）
- **AccountPanel** ログアウト後の遷移が PWA モードで `/login`（スタッフ用メール+パスワード画面）へ送っていた。`/liff-login`（PWA では BrowserLoginPrompt=Privy を表示）に統一。`(liff)` 配下の他 8 か所の認証リダイレクトと整合する（唯一の逸脱を解消）。

## 影響範囲
- 表示・遷移のみ。実資金・トレード・安全装置経路に影響なし。
- LIFF モード（将来 `NEXT_PUBLIC_LIFF_ID` 投入時）は従来どおり「LINE」表示 / LINE ログアウトを維持。

## Gate
- `tsc --noEmit`: エラー 0
- `eslint`（変更ファイル）: 0
- i18n key checker: 新規欠落なし（ja/en に `browserLoginBadge` 追加）

## 補足（本PR対象外）
同調査で挙げた グループ3（同意ゲート規約本文の「LINEアカウント」文言・法務確認要）/ グループ4（メニュー sub・紹介シェア・特商法等の文言）は別途対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)