### PR TITLE
fix(liff): PWA で残存する LINE 前提の文言・導線を一般化（グループ4）

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/ReferralPanel.tsx
@@ -8,6 +8,7 @@ import { getReferralInfo, createReferralCode, type ReferralInfo } from "@/lib/ap
 
 type TFn = ReturnType<typeof useTranslations>
 import { getAuthToken } from "@/lib/auth/token-key"
+import { isLiffConfigured } from "@/lib/liff/init"
 
 // SIGNUP URL: 専用の env/定数が無いため、sibling パネル (TermsPanel 等) と同じ
 // app.ultra-auto-trade.com 系ドメインへハードコードでフォールバックする。
@@ -109,7 +110,7 @@ export function ReferralPanel() {
     if (!code) return
     const shareText = buildShareText(code, t("shareTextBody"))
     try {
-      const { getLiff, isLiffConfigured } = await import("@/lib/liff/init")
+      const { getLiff } = await import("@/lib/liff/init")
       // ブラウザ PWA モード（LIFF 未設定）は SDK を触らずクリップボードへ degrade。
       const liff = isLiffConfigured() ? await getLiff() : null
       if (liff && liff.isApiAvailable("shareTargetPicker")) {
@@ -130,7 +131,7 @@ export function ReferralPanel() {
     const body = encodeURIComponent(buildShareText(code, t("shareTextBody")))
     const mailtoUrl = `mailto:?subject=${subject}&body=${body}`
     try {
-      const { getLiff, isLiffConfigured } = await import("@/lib/liff/init")
+      const { getLiff } = await import("@/lib/liff/init")
       const liff = isLiffConfigured() ? await getLiff() : null
       if (liff) {
         // LIFF webview では openWindow(external=true) でOS のメールアプリを起動する。
@@ -251,16 +252,21 @@ export function ReferralPanel() {
         <div className="space-y-2">
           <p className="text-[#736f7e] text-xs font-medium px-1">{t("shareSectionLabel")}</p>
           <div className="space-y-2">
-            <button
-              onClick={handleLineShare}
-              className="w-full flex items-center gap-3 bg-[#06C755] hover:bg-[#05a848]
-                         text-white font-semibold py-3 px-4 rounded-xl
-                         transition-colors"
-            >
-              <Share2 className="w-5 h-5" />
-              <span className="flex-1 text-left">{t("lineShareBtn")}</span>
-              <ChevronRight className="w-4 h-4 opacity-60" />
-            </button>
+            {/* LINE 共有は LIFF モード（LINE 連携）でのみ表示。PWA 本番形態では
+                LINE shareTargetPicker が使えずクリップボードへ degrade するだけで
+                「LINEで送る」表記が実態と食い違うため、メール共有＋リンクコピーに委ねる。 */}
+            {isLiffConfigured() && (
+              <button
+                onClick={handleLineShare}
+                className="w-full flex items-center gap-3 bg-[#06C755] hover:bg-[#05a848]
+                           text-white font-semibold py-3 px-4 rounded-xl
+                           transition-colors"
+              >
+                <Share2 className="w-5 h-5" />
+                <span className="flex-1 text-left">{t("lineShareBtn")}</span>
+                <ChevronRight className="w-4 h-4 opacity-60" />
+              </button>
+            )}
 
             <button
               onClick={handleMailShare}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1010,7 +1010,7 @@
       "taxLabel": "TAX & REPORTS",
       "taxSub": "Tax reports & CSV export",
       "notificationLabel": "Notifications",
-      "notificationSub": "LINE & push notification settings",
+      "notificationSub": "Notification settings",
       "accountLabel": "Account",
       "accountSub": "Profile & log out",
       "termsLabel": "Terms",
@@ -1169,7 +1169,7 @@
       "badge": "Recommended",
       "bullet1": "AI manages your assets fully automatically after deposit",
       "bullet2": "Assets are protected automatically in case of risk",
-      "bullet3": "Results are notified via LINE"
+      "bullet3": "Results delivered via notifications"
     },
     "active": {
       "title": "Active Mode",
@@ -1646,7 +1646,7 @@
     "cancelLabel": "Returns, Cancellation and Termination",
     "cancelValue": "Due to the nature of digital services, refunds after the service has begun are generally not accepted. Users may delete their account (stop using the service) at any time from \"Account > Delete Account\" within the app (Terms of Service Article 10).",
     "envLabel": "System Requirements",
-    "envValue": "LINE Mini App, or the latest modern browser."
+    "envValue": "The latest modern browser, or the LINE Mini App."
   },
   "PartnerDashboard": {
     "title": "Partner Dashboard",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -1010,7 +1010,7 @@
       "taxLabel": "TAX & REPORTS",
       "taxSub": "税務レポート・CSV出力",
       "notificationLabel": "通知設定",
-      "notificationSub": "LINE・プッシュ通知の設定",
+      "notificationSub": "通知の設定",
       "accountLabel": "アカウント",
       "accountSub": "プロフィール・ログアウト",
       "termsLabel": "利用規約",
@@ -1169,7 +1169,7 @@
       "badge": "おすすめ",
       "bullet1": "入金したらAIが全自動で運用します",
       "bullet2": "危険時は自動で資産を守ります",
-      "bullet3": "結果はLINEでお知らせ"
+      "bullet3": "結果は通知でお知らせ"
     },
     "active": {
       "title": "アクティブモード",
@@ -1646,7 +1646,7 @@
     "cancelLabel": "返品・キャンセル・解約",
     "cancelValue": "デジタルサービスの性質上、提供開始後の返金は原則として承っておりません。利用者は、アプリ内「アカウント > アカウント削除」より、いつでも退会（利用停止）できます（利用規約 第10条）。",
     "envLabel": "動作環境",
-    "envValue": "LINEミニアプリ、または最新のモダンブラウザ。"
+    "envValue": "最新のモダンブラウザ、またはLINEミニアプリ。"
   },
   "PartnerDashboard": {
     "title": "パートナーダッシュボード",


### PR DESCRIPTION
## 背景
v3 本番は PWA（LINE 不使用 / `NEXT_PUBLIC_LIFF_ID` 空）。PWA 整合性調査の **グループ4** = 細かな LINE 前提の文言・導線を一般化する。

## 修正内容

### 文言（i18n / ja・en）
| キー | 旧 | 新 |
|---|---|---|
| `Liff.menu.notificationSub` | 「LINE・プッシュ通知の設定」 | 「通知の設定」 |
| `Onboarding.managed.bullet3` | 「結果はLINEでお知らせ」 | 「結果は通知でお知らせ」 |
| `tokushoho.envValue` | 「LINEミニアプリ、または最新のモダンブラウザ」 | 「最新のモダンブラウザ、またはLINEミニアプリ」（ブラウザ先頭・LINE は v4 用に残す） |

### ロジック（ReferralPanel）
- LINE 共有ボタンを `isLiffConfigured()` で **LIFF モード限定表示**に。PWA では `shareTargetPicker` が使えずクリップボード degrade するだけで「LINEで送る」表記が実態と食い違うため、**メール共有＋リンクコピー**に委ねる（両ボタンは PWA でも従来どおり表示）。
- 共有ハンドラの動的 import を整理（`isLiffConfigured` を静的 import、`getLiff` のみ動的）。

> 紹介機能自体は審査リスクのため `isReferralEnabled()` フラグで非表示。本変更は有効化時の PWA 整合を先回りで担保するもの。

## 影響範囲
- 文言＋紹介シェアボタンの表示条件のみ。実資金・安全装置経路に影響なし。
- LIFF モード（将来 `NEXT_PUBLIC_LIFF_ID` 投入時）は LINE 共有ボタン・LINE 表記を従来どおり維持。

## Gate
- `tsc --noEmit`: 0
- `eslint`: 0 errors（既存 warning 2件のみ・本変更と無関係）
- i18n key checker: 新規欠落なし / ja・en JSON 妥当

## 関連（PWA 整合性 一括対応）
- グループ1・2（虚偽表示・ログアウト遷移） = PR #906
- グループ3（同意ゲート規約文言・法務確認要） = PR #907
- グループ4（本PR）でひととおり完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)