### PR TITLE
fix(liff): 期限切れ JWT による再ログイン不能のソフトロックを解消

### DIFF
--- a/frontend/app/(liff)/liff-confirm/page.tsx
+++ b/frontend/app/(liff)/liff-confirm/page.tsx
@@ -7,7 +7,7 @@ import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { CheckCircle, ChevronDown, ExternalLink } from "lucide-react"
-import { getAuthToken } from "@/lib/auth/token-key"
+import { getAuthToken, clearAuthToken } from "@/lib/auth/token-key"
 import { TERMS_JUST_ACCEPTED_KEY } from "@/hooks/useLiffTermsGate"
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ""
@@ -84,7 +84,9 @@ export default function LiffConfirmPage() {
         sessionStorage.setItem(TERMS_JUST_ACCEPTED_KEY, "liff-v3")
         router.replace("/liff-chat")
       } else if (res.status === 401) {
-        // セッション切れ — 再ログインへ誘導
+        // セッション切れ — 失効トークンを消してから再ログインへ誘導。
+        // 消さないと /liff-login が残存トークンで /liff-chat へ押し戻すループになる。
+        clearAuthToken()
         router.replace("/liff-login")
       } else {
         // それ以外の失敗は黙らせず明示（沈黙の失敗を防ぐ）

--- a/frontend/lib/auth/token-key.ts
+++ b/frontend/lib/auth/token-key.ts
@@ -54,12 +54,42 @@ function safeRemove(key: string): void {
 }
 
 /**
+ * JWT の exp(秒) を見て期限切れかを判定する。
+ * decode 不能 / exp 不在時は false を返す (fail-open: 解釈できないトークンは壊さない)。
+ * 最終的な失効判定は backend (401) が真実源で、本判定はクライアント側の早期検知用。
+ */
+function isJwtExpired(token: string): boolean {
+  try {
+    const part = token.split(".")[1];
+    if (!part) return false;
+    // base64url → base64
+    const base64 = part.replace(/-/g, "+").replace(/_/g, "/");
+    const payload = JSON.parse(atob(base64)) as { exp?: number };
+    if (typeof payload.exp !== "number") return false;
+    return payload.exp * 1000 <= Date.now();
+  } catch {
+    return false;
+  }
+}
+
+/**
  * 保存済み auth token を取得する。
  * 正準キー (AUTH_TOKEN_KEY) を優先し、無ければ旧キー (LEGACY_AUTH_TOKEN_KEY) を
  * フォールバックで読む移行シム。SSR / localStorage アクセス不可時は null。
+ *
+ * 期限切れ JWT は localStorage に残っていても無効として扱い、消して null を返す。
+ * 残置すると /liff-login が「ログイン済み」と誤認して /liff-chat へ押し戻し、
+ * terms gate が 401 → /liff-confirm → /liff-login の無限ループ (再ログイン不能の
+ * ソフトロック) を起こすため (調査: 期限切れ token で smart-link/terms-agree が 401)。
  */
 export function getAuthToken(): string | null {
-  return safeGet(AUTH_TOKEN_KEY) ?? safeGet(LEGACY_AUTH_TOKEN_KEY);
+  const token = safeGet(AUTH_TOKEN_KEY) ?? safeGet(LEGACY_AUTH_TOKEN_KEY);
+  if (token === null) return null;
+  if (isJwtExpired(token)) {
+    clearAuthToken();
+    return null;
+  }
+  return token;
 }
 
 /**

--- a/frontend/lib/liff/liff-fetch.ts
+++ b/frontend/lib/liff/liff-fetch.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 // liffFetch: LIFF パネル用の fetch ラッパー。
 // 401 レスポンス時に /liff-login へリダイレクトし、サイレント無視を防ぐ。
-import { getAuthToken } from "@/lib/auth/token-key"
+import { getAuthToken, clearAuthToken } from "@/lib/auth/token-key"
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ""
 
@@ -19,6 +19,9 @@ export async function liffFetch(
     },
   })
   if (res.status === 401 && typeof window !== "undefined") {
+    // 失効/無効トークンは消してから再ログインへ送る。消さないと /liff-login が
+    // 残存トークンで「ログイン済み」と誤認し /liff-chat へ押し戻すループになる。
+    clearAuthToken()
     window.location.href = "/liff-login"
   }
   return res


### PR DESCRIPTION
## 調査結果（先日の smart-link 401 の真因）
本番 liff-chat で「同意ゲート完了→ウォレット生成が 401 で失敗しホーム未到達」を調査。実ブラウザの JWT を decode した結果、**localStorage の `auth_token` が約6日前に期限切れ**（テストセッションの残存トークン）と確定。happy-path のバグではないが、**期限切れトークンが引き起こす潜在的ソフトロック**を露呈した。

### ループの構造（期限切れトークンが残っている場合）
1. `/liff-login` は `getAuthToken()` がトークンを返すと（期限切れでも）`/liff-chat` へ送る
2. `/liff-chat` terms gate の API が 401 → `/liff-confirm`
3. `/liff-confirm` はトークン存在のためゲート表示（ログインへ飛ばさない）
4. 6/6 完了 → submit → `/api/user/terms-agree` 401 → `/liff-login`
5. → **1 に戻る無限ループ**（再ログイン手段なし）
6. 背後で `SmartWalletRegistrar` が `/auth/wallet/smart-link` を 401 で延々リトライ

**真因**: 401 ハンドラ（liffFetch / liff-confirm）が `/liff-login` へ送るのみで **`clearAuthToken()` を呼ばない**。失効トークンが消えないため入口で押し戻される。

## 修正
- **`token-key.ts`（中央修正）**: `getAuthToken()` を期限切れ対応に。JWT の `exp` を見て失効していれば `clearAuthToken()` して `null` を返す。これ一つで liff-login / liff-confirm / layout / liffFetch / SmartWalletRegistrar **全経路**が失効トークンを「未ログイン」として扱い、`/liff-login` が `BrowserLoginPrompt`（Privy 再ログイン）を表示する。decode 不能 / exp 不在は **fail-open**（解釈できないトークンは壊さない）。最終的な失効判定は backend(401) が真実源で、本判定は早期検知用。
- **`liff-fetch.ts`**: 401 時に `clearAuthToken()` してから `/liff-login`（防御。revoke / user 削除など server 側 401 にも対応）。
- **`liff-confirm/page.tsx`**: submit の 401 分岐で `clearAuthToken()` を追加（防御）。

## 検証
- 実ブラウザの期限切れトークン（exp 約6日超過）に対し、新 `isJwtExpired()` が `true` を返すことを確認 → 新 `getAuthToken()` は clear + null を返す。
- `tsc --noEmit`: 0 / `eslint`: 0 errors（既存 warning のみ）

## 影響範囲
- フロントのみ。実資金・安全装置経路に影響なし。
- 正常な（未失効）トークンの挙動は不変。失効トークンのみ確実にログアウト＝再ログインに誘導。

🤖 Generated with [Claude Code](https://claude.com/claude-code)