### PR TITLE
fix(deploy): ACTIVE_BACKEND_COLOR環境変数のcompose補間ズレを修正

### DIFF
--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -237,6 +237,13 @@ deploy_backend_zero_downtime() {
   rm -f "${_env_tmp}"
   log "ACTIVE_BACKEND_COLOR=${inactive_slot} → ${ENV_FILE} に書き込み完了"
 
+  # 2026-07-02: docker-compose.production.yml の environment: ACTIVE_BACKEND_COLOR は
+  # シェルにエクスポート済みの値を --env-file より優先して補間する(Compose の変数解決順序)。
+  # このシェルに古い ACTIVE_BACKEND_COLOR が残っていると、直前の書き込みが無視され
+  # 新コンテナが古い色で起動し scheduler color ガードが誤判定する(2026-07-02 移行時に発覚)。
+  # ここで明示的に再エクスポートし、常に書き込み直後の値と一致させる。
+  export ACTIVE_BACKEND_COLOR="${inactive_slot}"
+
   # 2. 新コンテナを起動 (--no-deps で他サービスに影響を与えない)
   log "backend-${inactive_slot} を起動..."
   ${DC} -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" up -d --no-deps "backend-${inactive_slot}"
@@ -638,6 +645,28 @@ else
   log "upstream.conf を blue に初期化..."
   write_upstream_conf "blue"
 
+  # 2026-07-02: .env.production に他環境由来の古い ACTIVE_BACKEND_COLOR が残っている場合
+  # (例: 別ホストからの .env 移行時)、フルデプロイで新規作成される backend-blue が
+  # 自身と異なる色を読み込み scheduler color ガードが誤判定する。フルデプロイは常に
+  # active=blue で始まるため、ここで blue に強制的に揃えてから export する。
+  log "ACTIVE_BACKEND_COLOR を blue に初期化 (${ENV_FILE})..."
+  _env_tmp_init=$(mktemp "${ENV_FILE}.XXXXXX")
+  if grep -q '^ACTIVE_BACKEND_COLOR=' "${ENV_FILE}"; then
+    awk '{
+      if ($0 ~ /^ACTIVE_BACKEND_COLOR=/) {
+        print "ACTIVE_BACKEND_COLOR=blue"
+      } else {
+        print
+      }
+    }' "${ENV_FILE}" > "${_env_tmp_init}"
+  else
+    awk '{print}' "${ENV_FILE}" > "${_env_tmp_init}"
+    printf '\nACTIVE_BACKEND_COLOR=blue\n' >> "${_env_tmp_init}"
+  fi
+  cat "${_env_tmp_init}" > "${ENV_FILE}"
+  rm -f "${_env_tmp_init}"
+  export ACTIVE_BACKEND_COLOR="blue"
+
   # ── 新イメージを down 前にビルド ──
   # 下記「down 前 migration」を新 migration 入りの使い捨てコンテナで先行実行するため、
   # 新イメージは down より前に確定している必要がある (旧コンテナは稼働継続のまま)。
@@ -915,8 +944,24 @@ check_active_color_consistency() {
     log "   → 生存 backend が inactive 判定で AI判定スケジューラを skip する恐れ（2026-06-26 P0 と同型）"
     log "   → 修正: .env.production の ACTIVE_BACKEND_COLOR を ${nginx_slot} に揃え backend-${nginx_slot} を force-recreate"
     slack_notify "🚨 [deploy_production.sh] active color drift 検出\nnginx active=${nginx_slot} / .env ACTIVE_BACKEND_COLOR=${env_color}\n生存 backend が AI判定スケジューラを skip する恐れ（2026-06-26 P0 と同型）。ACTIVE_BACKEND_COLOR を ${nginx_slot} に揃えて recreate してください。"
+    return
+  fi
+  log "✅ active color 整合 OK (nginx=${nginx_slot} = .env=${env_color})"
+
+  # 2026-07-02: 上記チェックは .env ファイルの値しか見ておらず、compose の
+  # environment: ACTIVE_BACKEND_COLOR: ${ACTIVE_BACKEND_COLOR:-} がシェルの古い
+  # エクスポート値で env_file を上書きするケース（ファイルは正しいがコンテナ内は古い値）
+  # を検出できない盲点があった（2026-07-02 移行時に発覚）。実コンテナの env も直接確認する。
+  local active_container container_color
+  active_container="ultra-autotrade-backend-${nginx_slot}-production"
+  container_color=$(docker exec "${active_container}" printenv ACTIVE_BACKEND_COLOR 2>/dev/null || echo "")
+  if [ "${container_color}" != "${nginx_slot}" ]; then
+    log "🚨 CRITICAL: コンテナ内 ACTIVE_BACKEND_COLOR drift 検出 — active=${nginx_slot} だがコンテナ内は「${container_color:-（未設定）}」"
+    log "   → .env ファイルは正しいが、compose の environment: 補間がシェルの古い値で上書きした疑い"
+    log "   → 修正: ACTIVE_BACKEND_COLOR=${nginx_slot} ${DC} -f ${COMPOSE_FILE} --env-file ${ENV_FILE} up -d --no-deps backend-${nginx_slot} で ${active_container} を再作成"
+    slack_notify "🚨 [deploy_production.sh] コンテナ内 ACTIVE_BACKEND_COLOR drift 検出\n.envファイルは${nginx_slot}で正しいが、稼働中コンテナ${active_container}の実環境変数は「${container_color:-未設定}」\nAI判定スケジューラがskipされている可能性大。手動で該当backendをACTIVE_BACKEND_COLOR明示指定して再作成してください。"
   else
-    log "✅ active color 整合 OK (nginx=${nginx_slot} = .env=${env_color})"
+    log "✅ コンテナ内 ACTIVE_BACKEND_COLOR 整合 OK (${active_container}: ${container_color})"
   fi
 }
 


### PR DESCRIPTION
## Summary
- `docker-compose.production.yml`の`environment: ACTIVE_BACKEND_COLOR: ${ACTIVE_BACKEND_COLOR:-}`が`env_file`を上書きし、かつシェルにエクスポート済みの古い値を優先して補間するため、Blue/Greenスワップ直後に新コンテナが古い色で起動しAI判定スケジューラをサイレントにskipする不具合を修正（過去の22日間停止事故と同型）。
- `deploy_backend_zero_downtime()`: `.env.production`書き込み直後にシェル変数を再exportして常に最新値を補間させる。
- フルデプロイ経路: 他環境由来の`.env`を使う場合に古い色が残っているケースに備え、blueへ強制初期化してexport。
- `check_active_color_consistency()`: 既存チェックは`.env`ファイルとnginxの比較のみで、コンテナ内の実env varとのズレ（今回の実バグパターン）を検出できない盲点があったため、稼働中コンテナの`ACTIVE_BACKEND_COLOR`も直接確認するチェックを追加。

2026-07-02のHetzner別アカウント(ASSIST ONE)移行時に発覚。手動で個別修正して本番復旧済み、本PRは再発防止の恒久修正。

## Test plan
- [x] `bash -n scripts/deploy_production.sh` 構文チェックPASS
- [x] `shellcheck` で新規警告なし（既存の無関係な警告のみ）
- [ ] staging環境で`--backend-only`実行し、Blue/Greenスワップ後に`scheduler:true`かつコンテナ内`ACTIVE_BACKEND_COLOR`が一致することを確認（本番適用前にstagingで検証推奨）
- [ ] フルデプロイ経路も同様に検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTCh94zRMsZtahURK99rHV