### PR TITLE
fix(scripts): 実行時に影響する旧Hetzner IPハードコードを新VPSへ更新

### DIFF
--- a/.claude/hooks/send-lane-completion.sh
+++ b/.claude/hooks/send-lane-completion.sh
@@ -17,7 +17,7 @@
 # WEBHOOK 取得経路 (上から順に検索):
 #   1. 環境変数 SLACK_WEBHOOK_URL
 #   2. ローカル <git root>/.env.production の SLACK_WEBHOOK_URL=
-#   3. SSH ultra@77.42.46.155 で Hetzner 上の .env.production
+#   3. SSH root@5.223.88.14 で Hetzner (ASSIST ONE) 上の .env.production
 #
 # 終了コード: 200 OK → 0, それ以外 → 1
 
@@ -62,8 +62,8 @@ elif [[ -f "${HOME}/.claude-uata/secrets/slack.env" ]]; then
   WEBHOOK=$(grep "^SLACK_WEBHOOK_URL=" "${HOME}/.claude-uata/secrets/slack.env" | head -1 | cut -d= -f2-)
 elif GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) && [[ -f "${GIT_ROOT}/.env.production" ]]; then
   WEBHOOK=$(grep "^SLACK_WEBHOOK_URL=" "${GIT_ROOT}/.env.production" | head -1 | cut -d= -f2-)
-elif [[ -f "${HOME}/.ssh/hetzner_staging" ]]; then
-  WEBHOOK=$(ssh -i ~/.ssh/hetzner_staging ultra@77.42.46.155 \
+elif [[ -f "${HOME}/.ssh/hetzner_assistone_production" ]]; then
+  WEBHOOK=$(ssh -i ~/.ssh/hetzner_assistone_production root@5.223.88.14 \
     'grep SLACK_WEBHOOK_URL /opt/ultra-autotrade/.env.production | head -1 | cut -d= -f2-' 2>/dev/null || true)
 fi
 

--- a/scripts/chaos_test_3day_runner.sh
+++ b/scripts/chaos_test_3day_runner.sh
@@ -27,8 +27,8 @@
 #   STAGING_DB        staging DB 名 (default: ultra_autotrade_staging)
 #   STAGING_DB_USER   staging DB user (default: ultra)
 #
-# 実行場所: 本番 Hetzner VPS (77.42.46.155) — staging compose が同居している
-#   ssh -i ~/.ssh/hetzner_direct ultra@77.42.46.155 \
+# 実行場所: staging VPS (188.34.167.142, ASSIST ONE) — 2026-07-02移行後、staging専用VPS
+#   ssh -i ~/.ssh/hetzner_assistone_stagingdev root@188.34.167.142 \
 #     "bash /opt/ultra-autotrade/scripts/chaos_test_3day_runner.sh"
 #
 # 注意: production コンテナには絶対に触らない。chaos_test_staging.sh 側の

--- a/scripts/chaos_test_staging.sh
+++ b/scripts/chaos_test_staging.sh
@@ -8,7 +8,7 @@
 #   2026-06-11 実機確認)。root か sudo で実行すること (host PID への kill -9 が必要)。
 #
 # 対象: staging 環境のみ（production は絶対に触らない）
-# 実行場所: 本番 Hetzner VPS (77.42.46.155) または dev VPS
+# 実行場所: staging VPS (188.34.167.142, ASSIST ONE) 上で実行
 #
 # 使い方:
 #   bash scripts/chaos_test_staging.sh          # staging で全コンテナ検証
@@ -90,8 +90,8 @@ _safety_check() {
   local staging_count
   staging_count=$(docker ps --filter "name=staging" --format "{{.Names}}" | wc -l)
   if [[ "$staging_count" -eq 0 ]]; then
-    log_warn "staging コンテナが見つかりません。本番 VPS で実行してください。"
-    log_warn "または: ssh -i ~/.ssh/hetzner_direct ultra@77.42.46.155 'bash /opt/ultra-autotrade/scripts/chaos_test_staging.sh'"
+    log_warn "staging コンテナが見つかりません。staging VPS で実行してください。"
+    log_warn "または: ssh -i ~/.ssh/hetzner_assistone_stagingdev root@188.34.167.142 'bash /opt/ultra-autotrade/scripts/chaos_test_staging.sh'"
     exit 1
   fi
 

--- a/scripts/cloud-routine/db_schema_diff.sh
+++ b/scripts/cloud-routine/db_schema_diff.sh
@@ -18,7 +18,7 @@
 #   STAGING_DB_CONTAINER    staging postgres コンテナ名 (未指定時はスキップ)
 #   STAGING_DB_USER         staging postgres ユーザー名
 #   STAGING_DB_NAME         staging postgres DB 名
-#   HETZNER_SSH_HOST        SSH 経由で実行する場合のホスト (例: 77.42.46.155)
+#   HETZNER_SSH_HOST        SSH 経由で実行する場合のホスト (例: 5.223.88.14, ASSIST ONE production)
 #   HETZNER_SSH_USER        SSH ユーザー名 (default: root)
 #   HETZNER_SSH_KEY         SSH 鍵パス (default: ~/.ssh/id_ed25519)
 #   REPO_PATH               リポジトリパス (default: /opt/ultra-autotrade)
@@ -31,7 +31,7 @@
 #   SLACK_WEBHOOK_URL=https://... bash db_schema_diff.sh
 #
 # 実行例 (ローカル Mac から SSH 経由):
-#   HETZNER_SSH_HOST=77.42.46.155 HETZNER_SSH_USER=root \
+#   HETZNER_SSH_HOST=5.223.88.14 HETZNER_SSH_USER=root \
 #   SLACK_WEBHOOK_URL=... bash db_schema_diff.sh
 #
 # cron 設定例 (毎日 9:00 JST = 00:00 UTC、Hetzner cron):

--- a/scripts/cloud-routine/hf_monitor.sh
+++ b/scripts/cloud-routine/hf_monitor.sh
@@ -31,7 +31,7 @@
 #     bash scripts/cloud-routine/hf_monitor.sh >> /var/log/ultra/hf_monitor.log 2>&1
 #
 # Mac から cron でリモート実行する場合 (launchd 例は README.md 参照):
-#   */15 * * * * ssh -i ~/.ssh/hetzner_id_ed25519 user@77.42.46.155 \
+#   */15 * * * * ssh -i ~/.ssh/hetzner_assistone_production root@5.223.88.14 \
 #     'cd /opt/ultra-autotrade && env $(grep -v "^#" .env.production | xargs) \
 #     bash scripts/cloud-routine/hf_monitor.sh'
 

--- a/scripts/cloud-routine/yamamoto_24h_observer.sh
+++ b/scripts/cloud-routine/yamamoto_24h_observer.sh
@@ -6,9 +6,9 @@
 #
 # 環境変数:
 #   OBSERVATION_START_UTC  観察開始 UTC (デフォルト: 2026-05-01 02:50:00+00)
-#   HETZNER_HOST           Hetzner ホスト (デフォルト: 77.42.46.155)
-#   HETZNER_USER           SSH ユーザー   (デフォルト: ultra)
-#   HETZNER_SSH_KEY        SSH 鍵パス    (デフォルト: ~/.ssh/hetzner_staging)
+#   HETZNER_HOST           Hetzner ホスト (デフォルト: 5.223.88.14, ASSIST ONE production)
+#   HETZNER_USER           SSH ユーザー   (デフォルト: root)
+#   HETZNER_SSH_KEY        SSH 鍵パス    (デフォルト: ~/.ssh/hetzner_assistone_production)
 #   SLACK_WEBHOOK_URL      Slack Webhook URL (未設定時は通知スキップ)
 #
 # 実行頻度想定: 4 時間間隔
@@ -23,9 +23,9 @@ set -uo pipefail
 # 設定
 # -----------------------------------------------------------------------
 OBS_START="${OBSERVATION_START_UTC:-2026-05-01 02:50:00+00}"
-HETZNER_HOST="${HETZNER_HOST:-77.42.46.155}"
-HETZNER_USER="${HETZNER_USER:-ultra}"
-SSH_KEY="${HETZNER_SSH_KEY:-$HOME/.ssh/hetzner_staging}"
+HETZNER_HOST="${HETZNER_HOST:-5.223.88.14}"
+HETZNER_USER="${HETZNER_USER:-root}"
+SSH_KEY="${HETZNER_SSH_KEY:-$HOME/.ssh/hetzner_assistone_production}"
 POSTGRES_CTR="ultra-autotrade-postgres-production"
 BACKEND_CTR="ultra-autotrade-backend-blue-production"
 POSTGRES_USER="ultra"

--- a/scripts/e2e_emergency_stop.sh
+++ b/scripts/e2e_emergency_stop.sh
@@ -13,10 +13,10 @@
 # TC-4: HF < 1.6 閾値 → trading_paused=true + LINE 通知 (ロジック+状態検証)
 # TC-5: resume / 復元 総合確認
 #
-# 実行先: 本番 Hetzner VPS (77.42.46.155) 上 staging stack に対して実行。
-#         dev VPS からは構造上実行不可 (staging は本番 VPS に同居)。
+# 実行先: staging VPS (188.34.167.142, ASSIST ONE) 上の staging stack に対して実行。
+#         2026-07-02 移行後は staging は production と別 VPS に分離済み。
 #
-# SSH: ssh -i ~/.ssh/hetzner_direct ultra@77.42.46.155
+# SSH: ssh -i ~/.ssh/hetzner_assistone_stagingdev root@188.34.167.142
 #
 # 必須 env:
 #   ADMIN_EMAIL       staging admin ユーザーメール
@@ -173,11 +173,11 @@ _safety_check() {
     cat <<EOF
 
 [INFO] dev VPS (${hn}) では実行不可。
-       本スクリプトは本番 VPS (77.42.46.155) 上で staging stack に対して実行する設計です。
+       本スクリプトは staging VPS (188.34.167.142, ASSIST ONE) 上で staging stack に対して実行する設計です。
        実行手順:
          1) iMac で:
-              ssh -i ~/.ssh/hetzner_direct ultra@77.42.46.155
-         2) 本番 VPS で:
+              ssh -i ~/.ssh/hetzner_assistone_stagingdev root@188.34.167.142
+         2) staging VPS で:
               export ADMIN_EMAIL='<staging admin email>'
               export ADMIN_PASSWORD='<staging admin password>'
               cd /opt/ultra-autotrade

--- a/scripts/lane5_fee_null_backfill_check.sql
+++ b/scripts/lane5_fee_null_backfill_check.sql
@@ -1,5 +1,5 @@
 -- Lane 5: proposals.fee_rate / fee_amount NULL バックフィル判定用 診断 SQL
--- 実行: 本番 VPS (Hetzner 77.42.46.155) で hkobayashi が psql から実行する。
+-- 実行: 本番 VPS (Hetzner 5.223.88.14, ASSIST ONE) で hkobayashi が psql から実行する。
 --        dev VPS からは本番 DB へ到達不可のため、ここでは SQL のみ用意 (実行しない)。
 -- 目的: 2026-06-04 本番 proposal id=16 以外に fee_rate / fee_amount NULL の行が
 --        残っているかを把握し、バックフィルの要否・対象件数を判断する。

--- a/scripts/launch_gate/L0_schema.sh
+++ b/scripts/launch_gate/L0_schema.sh
@@ -43,14 +43,18 @@ fi
 # dev VPS からは prod DB に届かないので skip-with-instructions
 if is_dev_vps; then
   echo "[INFO] L0 schema: dev VPS のため DB に直接アクセスできません。"
-  echo "       prod VPS (77.42.46.155) で以下を実行し、exit 0 を確認してください:"
+  echo "       2026-07-02移行後、staging と production は別 VPS です。以下を実行し、exit 0 を確認してください:"
   echo ""
   for env in "${run_envs[@]}"; do
-    echo "         bash ${GAP_SCRIPT} --env=${env}"
+    case "${env}" in
+      production) echo "         ssh -i ~/.ssh/hetzner_assistone_production root@5.223.88.14 'cd /opt/ultra-autotrade && bash ${GAP_SCRIPT} --env=${env}'" ;;
+      staging)    echo "         ssh -i ~/.ssh/hetzner_assistone_stagingdev root@188.34.167.142 'cd /opt/ultra-autotrade && bash ${GAP_SCRIPT} --env=${env}'" ;;
+      *)          echo "         bash ${GAP_SCRIPT} --env=${env}" ;;
+    esac
   done
   echo ""
   echo "       0 でない場合は alembic head に gap あり → launch 不可。"
-  gate_record SKIP "${LABEL}" "dev VPS のため手動実行 (prod VPS で check_db_migration_gap.sh --env={${run_envs[*]}})"
+  gate_record SKIP "${LABEL}" "dev VPS のため手動実行 (production=5.223.88.14 / staging=188.34.167.142 で check_db_migration_gap.sh --env={${run_envs[*]}})"
   exit 0
 fi
 

--- a/scripts/launch_gate/L1_env.sh
+++ b/scripts/launch_gate/L1_env.sh
@@ -44,17 +44,21 @@ missing=()
 if [[ "${#missing[@]}" -gt 0 ]]; then
   cat <<EOF
 [INFO] L1 env: ${missing[*]} がこの worktree に存在しません。
-       prod VPS (77.42.46.155) 上で以下を実行し、結果を貼り付けてください:
+       2026-07-02移行後、staging と production は別 VPS です。それぞれ以下を実行し、結果を貼り付けてください:
 
-         bash ${SEP_SCRIPT}
-         grep -E '^(APP_ENV|AAVE_NETWORK|BYBIT_SANDBOX)=' ${PROD_ENV}
-         grep -E '^(APP_ENV|AAVE_NETWORK|BYBIT_SANDBOX)=' ${STAGING_ENV}
+         # production (5.223.88.14):
+         ssh -i ~/.ssh/hetzner_assistone_production root@5.223.88.14 \\
+           "cd /opt/ultra-autotrade && bash ${SEP_SCRIPT}; grep -E '^(APP_ENV|AAVE_NETWORK|BYBIT_SANDBOX)=' ${PROD_ENV}"
+
+         # staging (188.34.167.142):
+         ssh -i ~/.ssh/hetzner_assistone_stagingdev root@188.34.167.142 \\
+           "cd /opt/ultra-autotrade && grep -E '^(APP_ENV|AAVE_NETWORK|BYBIT_SANDBOX)=' ${STAGING_ENV}"
 
        期待値:
          .env.production: APP_ENV=production / AAVE_NETWORK=base / BYBIT_SANDBOX=false
          .env.staging:    APP_ENV=staging    / AAVE_NETWORK=base_sepolia / BYBIT_SANDBOX=true
 EOF
-  gate_record SKIP "${LABEL}" "${missing[*]} がこの host に無し (prod VPS で要手動確認)"
+  gate_record SKIP "${LABEL}" "${missing[*]} がこの host に無し (production=5.223.88.14 / staging=188.34.167.142 で要手動確認)"
   exit 0
 fi
 

--- a/scripts/launch_gate/L2_smoke.sh
+++ b/scripts/launch_gate/L2_smoke.sh
@@ -30,9 +30,9 @@
 #     その他 4xx (404 / 400 / 503 等以外)    -> FAIL (endpoint 消失 / 経路破損)
 #
 # 注意:
-#   staging は本番 Hetzner VPS (77.42.46.155) に同居しており dev VPS から
-#   到達不可。memory [[staging-lives-on-prod-vps]] / [[no-prod-vps-commands-from-dev]]
-#   に従い、dev VPS では skip-with-instructions モードに倒す。
+#   2026-07-02移行後、staging(188.34.167.142)は production(5.223.88.14)と
+#   別 VPS。いずれも dev VPS からは到達不可のため、dev VPS では
+#   skip-with-instructions モードに倒す。
 #
 # Usage:
 #   ENV_TARGET=staging    bash scripts/launch_gate/L2_smoke.sh
@@ -76,9 +76,14 @@ BASE_URL="${LAUNCH_GATE_BASE_URL:-${DEFAULT_BASE}}"
 # dev VPS では prod / staging に届かないため skip-with-instructions
 # ---------------------------------------------------------------------------
 if is_dev_vps; then
+  case "${ENV_TARGET}" in
+    production) TARGET_VPS_DESC="production VPS (ssh -i ~/.ssh/hetzner_assistone_production root@5.223.88.14)" ;;
+    staging)    TARGET_VPS_DESC="staging VPS (ssh -i ~/.ssh/hetzner_assistone_stagingdev root@188.34.167.142)" ;;
+    *)          TARGET_VPS_DESC="対象 VPS" ;;
+  esac
   cat <<EOF
-[INFO] L2 smoke: dev VPS のため prod VPS 同居の ${ENV_TARGET} に直接到達できません。
-       prod VPS (77.42.46.155) で以下のコマンドを実行し、結果を貼り付けてください:
+[INFO] L2 smoke: dev VPS のため ${ENV_TARGET} に直接到達できません。
+       ${TARGET_VPS_DESC} で以下のコマンドを実行し、結果を貼り付けてください:
 
          BASE=${BASE_URL}
          # /health は 2xx 必須

--- a/scripts/launch_gate/L4_kill_switch_e2e.sh
+++ b/scripts/launch_gate/L4_kill_switch_e2e.sh
@@ -14,8 +14,8 @@
 #   5) 発動・解除ログが Slack #ultra-auto-project に出る (backend ログから
 #      Slack post 試行を確認 / 直近 webhook 送信ログ 2 件以上)
 #
-# 実行先: iMac から `ssh -i ~/.ssh/hetzner_direct ultra@77.42.46.155` 後、
-#         本番 VPS 上で staging stack に対して実行する。
+# 実行先: iMac から `ssh -i ~/.ssh/hetzner_assistone_stagingdev root@188.34.167.142` 後、
+#         staging VPS (ASSIST ONE) 上で staging stack に対して実行する。
 #         本番 stack には絶対に触らない (staging endpoint / staging DB / staging
 #         backend container のみ操作)。
 #
@@ -72,16 +72,16 @@ trap 'rm -rf "${TMP_DIR}"' EXIT
 if is_dev_vps; then
   cat <<'EOF'
 [INFO] L4 kill switch e2e: dev VPS では実行不可。
-       本 script は本番 VPS (77.42.46.155) 上で staging stack に対して実行する設計です。
+       本 script は staging VPS (188.34.167.142, ASSIST ONE) 上で staging stack に対して実行する設計です。
        実行手順:
-         1) ローカル Mac で: ssh -i ~/.ssh/hetzner_direct ultra@77.42.46.155
-         2) 本番 VPS で:
+         1) ローカル Mac で: ssh -i ~/.ssh/hetzner_assistone_stagingdev root@188.34.167.142
+         2) staging VPS で:
               export ADMIN_EMAIL=...
               export ADMIN_PASSWORD=...
               cd /opt/ultra-autotrade
               bash scripts/launch_gate/L4_kill_switch_e2e.sh
 EOF
-  gate_record SKIP "L4-killswitch-e2e" "dev VPS のため SKIP (本番 VPS で実行する)"
+  gate_record SKIP "L4-killswitch-e2e" "dev VPS のため SKIP (staging VPS で実行する)"
   gate_summary
   exit 0
 fi

--- a/scripts/launch_gate/L4_killswitch.sh
+++ b/scripts/launch_gate/L4_killswitch.sh
@@ -35,9 +35,14 @@ BASE_URL="${LAUNCH_GATE_BASE_URL:-${DEFAULT_BASE}}"
 # dev VPS では prod / staging に届かないため skip-with-instructions
 # ---------------------------------------------------------------------------
 if is_dev_vps; then
+  case "${ENV_TARGET}" in
+    production) TARGET_VPS_DESC="production VPS (ssh -i ~/.ssh/hetzner_assistone_production root@5.223.88.14)" ;;
+    staging)    TARGET_VPS_DESC="staging VPS (ssh -i ~/.ssh/hetzner_assistone_stagingdev root@188.34.167.142)" ;;
+    *)          TARGET_VPS_DESC="対象 VPS" ;;
+  esac
   cat <<EOF
-[INFO] L4 kill switch: dev VPS のため prod VPS 同居の ${ENV_TARGET} に到達できません。
-       prod VPS (77.42.46.155) で以下を実行し、結果を貼り付けてください:
+[INFO] L4 kill switch: dev VPS のため ${ENV_TARGET} に到達できません。
+       ${TARGET_VPS_DESC} で以下を実行し、結果を貼り付けてください:
 
          BASE=${BASE_URL}
          # 1) 緊急停止

--- a/scripts/uata-morning-report.sh
+++ b/scripts/uata-morning-report.sh
@@ -72,10 +72,10 @@ FAILED_COUNT=$( [ -n "$FAILED" ] && printf '%s\n' "$FAILED" | grep -c '^' || ech
 # ─── 5. L1-L6 状態 ───
 # 本番ログ出力先: /opt/ultra-autotrade/logs/healthcheck_l1_l6.log (id=30 で修正)
 # fallback: SSH 取得失敗時は curl /health HTTP ステータスで代替 (PR #246 維持)
-SSH_OPTS=(-F /dev/null -i ~/.ssh/hetzner_staging -o IdentitiesOnly=yes
+SSH_OPTS=(-F /dev/null -i ~/.ssh/hetzner_assistone_production -o IdentitiesOnly=yes
           -o BatchMode=yes -o StrictHostKeyChecking=no -o ConnectTimeout=10)
 
-HEALTH_RAW=$(ssh "${SSH_OPTS[@]}" ultra@77.42.46.155 \
+HEALTH_RAW=$(ssh "${SSH_OPTS[@]}" root@5.223.88.14 \
     'tail -1 /opt/ultra-autotrade/logs/healthcheck_l1_l6.log 2>/dev/null' 2>/dev/null)
 if [ -n "$HEALTH_RAW" ]; then
     HEALTH="$HEALTH_RAW"
@@ -88,7 +88,7 @@ fi
 
 # ─── 6. 山本さん UAT 状況 (R3: 正ロール=ultra。heredoc で $$ 安全化) ───
 
-YAMAMOTO_STATUS=$(ssh "${SSH_OPTS[@]}" ultra@77.42.46.155 bash -s <<'ENDSSH' 2>/dev/null
+YAMAMOTO_STATUS=$(ssh "${SSH_OPTS[@]}" root@5.223.88.14 bash -s <<'ENDSSH' 2>/dev/null
 PG_CONTAINER=$(docker ps --filter 'name=postgres-production' --filter 'status=running' --format '{{.Names}}' | head -1)
 if [ -z "$PG_CONTAINER" ]; then
   echo "(postgres-production コンテナが見つかりません)"

--- a/scripts/uata-stuck-detector.sh
+++ b/scripts/uata-stuck-detector.sh
@@ -50,12 +50,12 @@ get_webhook() {
     grep "^SLACK_WEBHOOK_URL=" "${GIT_ROOT}/.env.production" | head -1 | cut -d= -f2-
     return
   fi
-  # 4. SSH fallback (Hetzner本番VPS — dev VPS からは接続不可の場合あり)
-  local ssh_key="${HOME}/.ssh/hetzner_direct"
+  # 4. SSH fallback (Hetzner本番VPS ASSIST ONE — dev VPS からは接続不可の場合あり)
+  local ssh_key="${HOME}/.ssh/hetzner_assistone_production"
   if [[ -f "$ssh_key" ]]; then
     ssh -i "$ssh_key" \
       -o ConnectTimeout=5 -o StrictHostKeyChecking=no -o BatchMode=yes \
-      ultra@77.42.46.155 \
+      root@5.223.88.14 \
       'grep SLACK_WEBHOOK_URL /opt/ultra-autotrade/.env.production | head -1 | cut -d= -f2-' \
       2>/dev/null || echo ""
   else


### PR DESCRIPTION
## Summary
- task #16(旧IPハードコード棚卸し)で判明した83ファイル中、**実行時に影響するカテゴリ**(自動トリガー系hook・cron・launch_gateスクリプト)15ファイルを新VPSのIPへ更新。
- production向け(Slack webhook取得/morning report/stuck-detector等): `ultra@77.42.46.155` → `root@5.223.88.14`(新VPSはroot専用ユーザー構成のため接続ユーザーも変更)
- staging向け(chaos test/e2e emergency stop等): `ultra@77.42.46.155` → `root@188.34.167.142`。移行後はstagingがproductionと別VPSになったため、「staging同居」前提だったコメント文も実態に合わせて修正。
- L0/L1/L2/L4 launch_gateスクリプト: staging/production両対象のdev VPS向け案内メッセージが、ENV_TARGETに関わらず単一の旧IPを表示していたため、正しいホストを動的に案内するよう修正。

ドキュメント(CLAUDE.md等)・過去のpostmortem/lessons記録は対象外(インベントリでカテゴリ分け済み、historical recordとして意図的に旧IPのまま残す)。

## Test plan
- [x] 修正15ファイル全てで旧IP(`77.42.46.155`/`77.42.79.75`)残存ゼロを確認
- [x] `bash -n` 構文チェック全PASS
- [x] `shellcheck -S error` エラーなし
- [ ] 実機でのSSH接続確認(次回morning-report/stuck-detector実行時に自然検証される想定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTCh94zRMsZtahURK99rHV