### PR TITLE
docs(flags): Autoモード有効化に関する事業判断を記録

### DIFF
--- a/frontend/lib/flags.ts
+++ b/frontend/lib/flags.ts
@@ -13,6 +13,13 @@
  * 揃ってからフラグを true にして再ビルドする（code-ready-behind-flag）。
  * backend POST /auth/register-open 自体は常時実装済だが、フロント側の到達経路を
  * このフラグで gate する。
+ *
+ * 2026-07-03: hkobayashi が法務(non-custodial S-5)・KYC ベンダー判断は既に揃って
+ * いると確認し、PWA 配布（LINE 審査を経由しない経路）側では true にすることを決定。
+ * LINE 審査を経由する配布（staging-v4 / LINE production 版）は審査通過まで false を
+ * 維持する（審査中に見せる内容を審査終了前に変えるとレビュー撹乱になるため）。
+ * env var は PWA 系(.env.staging-new / PWA 用 .env.production)にのみ設定し、
+ * LINE 系(.env.staging-v4)には設定しないこと。
  */
 export function isPublicRegistrationEnabled(): boolean {
   return process.env.NEXT_PUBLIC_PUBLIC_REGISTRATION_ENABLED === 'true'
@@ -44,6 +51,12 @@ export function isAutoModeEnabled(): boolean {
  * 利益連動の金銭リワードは、LINE ミニアプリ審査でマルチ商法的訴求と見なされる
  * リスクがあるため、審査期間中はフラグで非表示にする。審査通過後に文言を
  * 利益非連動の設計へ整備したうえで true にして再ビルドする（code-ready-behind-flag）。
+ *
+ * 2026-07-03: この理由は LINE 審査リスクのみ（法務ブロッカーとは無関係）と確認済み。
+ * hkobayashi の決定により、PWA 配布（LINE 審査を経由しない経路）側では true にする。
+ * LINE 審査を経由する配布（staging-v4 / LINE production 版）は審査通過まで false を
+ * 維持する。env var は PWA 系(.env.staging-new / PWA 用 .env.production)にのみ設定し、
+ * LINE 系(.env.staging-v4)には設定しないこと。
  */
 export function isReferralEnabled(): boolean {
   return process.env.NEXT_PUBLIC_REFERRAL_ENABLED === 'true'

--- a/frontend/lib/flags.ts
+++ b/frontend/lib/flags.ts
@@ -21,16 +21,17 @@ export function isPublicRegistrationEnabled(): boolean {
 /**
  * 「おまかせ（Auto / managed）」運用モードを UI に表示するか。
  *
- * 既定 false（非表示）。おまかせは AI が事前条件の範囲内で売買を自動執行する
- * 一任運用に該当し、日本では投資運用業（金商法）の登録なしに提供できない
- * （森先生 法務判断 2026-06-26）。
+ * 背景: おまかせは AI が事前条件の範囲内で売買を自動執行する一任運用に該当し、
+ * 日本では投資運用業（金商法）の登録なしに提供すると無登録営業（刑事罰対象）
+ * になり得る（森先生 法務判断 2026-06-26）。登録取得・設計変更による法務クリア
+ * のいずれも満たさないまま有効化することは非推奨。
  *
- * このフラグを true にしてよいのは「時間が経過したから」ではなく、次のいずれかが
- * 満たされたときのみ:
- *   1. 投資運用業の登録を取得した、または
- *   2. 一任に当たらない設計へ作り変え、法務（森先生）が明示的にクリアした。
- * 上記なしに true にすると無登録投資運用業（刑事罰対象）になるため、安易に
- * フラグを反転しないこと。backend の user_mode 自体は実装済（code-ready-behind-flag）。
+ * 2026-07-03: hkobayashi が上記リスクを認識した上で「Auto モードも含め全ユーザーに
+ * 今すぐ全機能を開放する」と明示決定（法務再クリアを待たない事業判断）。
+ * このフラグの既定値をリポジトリ側で true に変更することはしない
+ * （production への反映は .env.production 側で NEXT_PUBLIC_AUTO_MODE_ENABLED=true
+ * を設定 + frontend 再ビルドで行う。3段プロトコル / 本番デプロイ手順に従うこと）。
+ * 詳細: memory `project_jp_auto_mode_open_decision_2026_07_03`。
  */
 export function isAutoModeEnabled(): boolean {
   return process.env.NEXT_PUBLIC_AUTO_MODE_ENABLED === 'true'


### PR DESCRIPTION
## Summary
- 2026-07-03 hkobayashi が森先生の法務判断(Auto モード=無登録投資運用業リスク、刑事罰対象)を認識した上で、Auto モードを含む全機能を今すぐ全ユーザーに開放する事業判断を明示。
- `frontend/lib/flags.ts` の `isAutoModeEnabled()` コメントに経緯を記録（既定値 false は変更せず、production 側 env var で制御する方針を維持）。

## 実際の有効化について
- コード変更はコメントのみ。実際に production で Auto モードを表示するには `.env.production` に `NEXT_PUBLIC_AUTO_MODE_ENABLED=true` を設定し、frontend 再ビルド+デプロイが必要（本 PR merge 後、別途 3段プロトコル/本番デプロイ手順で実施）。

## Test plan
- [x] コメントのみの変更のため lint/build 影響なし
- [ ] production env 反映後、Auto モード選択 UI (OpModePanel/HamburgerMenu/AccountPanel/onboarding/connect/OperationModeSelector) の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTCh94zRMsZtahURK99rHV