### PR TITLE
fix(liff): PWAモードでLINEアプリ前提のヒント文言が出る不具合を修正

### DIFF
--- a/frontend/app/(liff)/_components/BrowserLoginPrompt.tsx
+++ b/frontend/app/(liff)/_components/BrowserLoginPrompt.tsx
@@ -8,6 +8,7 @@
 import { Loader2, Wallet } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useLiffBrowserAuth } from "@/hooks/useLiffBrowserAuth";
+import { isLiffConfigured } from "@/lib/liff/init";
 
 interface BrowserLoginPromptProps {
   /** ログイン成功後の処理。未指定ならページをリロードして token を読み直す。 */
@@ -56,9 +57,11 @@ export function BrowserLoginPrompt({ onSuccess }: BrowserLoginPromptProps) {
 
       {error && <p className="text-red-600 text-xs mt-3 max-w-xs">{error}</p>}
 
-      <p className="ax-text-secondary opacity-70 text-xs mt-6 leading-relaxed">
-        {t("lineAppHint")}
-      </p>
+      {isLiffConfigured() && (
+        <p className="ax-text-secondary opacity-70 text-xs mt-6 leading-relaxed">
+          {t("lineAppHint")}
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- `BrowserLoginPrompt`(ブラウザPWAモード専用コンポーネント)が `isLiffConfigured()` 判定なしに `lineAppHint`("LINEアプリからご利用の場合は、メニューから開き直してください。")を無条件表示していた
- staging.ultra-auto-trade.com (`/liff-login`, PWAモード) で実機確認し発見
- `isLiffConfigured()` でガードし、`NEXT_PUBLIC_LIFF_ID` 未設定のPWAビルドでは非表示にする

## Test plan
- [x] staging.ultra-auto-trade.com の `/liff-login` で LINE 前提文言が消えることを確認予定（本PR merge後 staging に反映）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTCh94zRMsZtahURK99rHV