### PR TITLE
docs: dev VPS(ASSIST ONE)構築完了をホスト判定表・runbookに反映

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,13 +16,13 @@ hostname && pwd && echo "branch: $(git branch --show-current 2>/dev/null || echo
 
 | hostname / IP | 環境 | git repo root | 許可 | 禁止 |
 |---|---|---|---|---|
-| `95.216.167.198` | **dev VPS**（ASSIST ONE、2026-07-02時点未構築） | `/opt/ultra-autotrade/main/`（構築後） | git commit / push / merge / Claude Code 実行 | production DB 直接操作 |
+| `95.216.167.198` | **dev VPS**（ASSIST ONE、2026-07-03構築完了） | `/opt/ultra-autotrade/main/` | git commit / push / merge / Claude Code 実行 | production DB 直接操作 |
 | `188.34.167.142` | **staging VPS**（ASSIST ONE、staging+staging-v4同居） | `/opt/ultra-autotrade/` ※`main/`なし | git pull / docker compose up / deploy_staging.sh | git commit / git merge / nano 直接編集 |
 | `5.223.88.14` | **production VPS**（ASSIST ONE、専用Project分離） | `/opt/ultra-autotrade/` ※`main/`なし | git pull / docker compose up / deploy_production.sh | git commit / git merge / nano 直接編集 |
 | `77.42.46.155` | **旧production/staging VPS**（保険期間中、解約予定） | `/opt/ultra-autotrade/` | 参照のみ（automation停止済み） | 新規操作全般（Phase 10保険期間終了後解約） |
 | Mac (`hostname` = 個人 Mac) | **ローカル** | — | 全開発作業 / Agent View 起動 | production VPS 直接接続（3段プロトコル経由のみ、alias自体を作らない） |
 
-> **パス構造差**: dev VPS は worktree 構造で `main/` サブディレクトリが存在する（構築後）。staging/production VPS は repo root が直接 `/opt/ultra-autotrade/`。
+> **パス構造差**: dev VPS は worktree 構造で `main/` サブディレクトリが存在する。staging/production VPS は repo root が直接 `/opt/ultra-autotrade/`。
 > SSH 後は必ず `pwd && ls` で確認してから操作すること。`/opt/ultra-autotrade/main/` を staging/production VPS で使うと `No such file or directory`。
 
 ### production VPS での禁止操作 (ABSOLUTE)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -538,7 +538,7 @@ tmux attach -t phase-<X>
 
 | 層 | ホスト | IP | OS user | 作業ディレクトリ | 用途 |
 |----|--------|----|---------|------------------|------|
-| **dev** | ASSIST ONE dev VPS（Helsinki） | `95.216.167.198` | `root` | `/opt/ultra-autotrade/main`（main worktree、予定）+ `/opt/ultra-autotrade-worktrees/<branch>` | Claude Code CLI による実装・並列レーン開発。実資金・実トレードなし。**2026-07-02時点でVPS provisioningのみ完了、repo clone等のアプリ環境構築は未実施**（`/opt/ultra-autotrade` 自体が未作成） |
+| **dev** | ASSIST ONE dev VPS（Helsinki） | `95.216.167.198` | `root` | `/opt/ultra-autotrade/main`（main worktree）+ `/opt/ultra-autotrade-worktrees/<branch>` | Claude Code CLI による実装・並列レーン開発。実資金・実トレードなし。**2026-07-03構築完了**（repo clone / backend venv / frontend node_modules / Docker+Compose / Claude Code CLI 導入済み。HEAD は origin/main 追従） |
 | **staging** | ASSIST ONE staging VPS（Falkenstein） | `188.34.167.142` | `root` | `/opt/ultra-autotrade`（staging compose stack） | Shadow Mode 専用（Base Sepolia）、port 3001/8082(nginx)/5433（旧8001廃止） |
 | **staging-v4** | ASSIST ONE staging VPS（Falkenstein、staging と同居） | `188.34.167.142` | `root` | `/opt/ultra-autotrade`（staging-v4 compose stack） | v4 開発用 staging（Base Sepolia）、port 3002/8083(nginx)/8030(backend)/5434。v3 staging-new と独立 |
 | **production** | ASSIST ONE production VPS（Singapore、専用 Hetzner Project で分離） | `5.223.88.14` | `root` | `/opt/ultra-autotrade`（production compose stack） | 実資金・実トレード（Base Mainnet）、port 3000/8000/5432 |
@@ -547,11 +547,11 @@ tmux attach -t phase-<X>
 >
 > | VPS | git repo root | `backend/` の絶対パス |
 > |---|---|---|
-> | **dev VPS**（構築後） | `/opt/ultra-autotrade/main/` | `/opt/ultra-autotrade/main/backend/` |
+> | **dev VPS** (`95.216.167.198`) | `/opt/ultra-autotrade/main/` | `/opt/ultra-autotrade/main/backend/` |
 > | **staging VPS** (`188.34.167.142`) | `/opt/ultra-autotrade/` | `/opt/ultra-autotrade/backend/` |
 > | **production VPS** (`5.223.88.14`) | `/opt/ultra-autotrade/` | `/opt/ultra-autotrade/backend/` |
 >
-> dev VPS の `/main/` サブディレクトリは git worktree 構造に由来する（構築後の想定。2026-07-02時点で未構築）。staging/production 両VPSには `main/` サブディレクトリは**存在しない**。
+> dev VPS の `/main/` サブディレクトリは git worktree 構造に由来する（2026-07-03 構築済み）。staging/production 両VPSには `main/` サブディレクトリは**存在しない**。
 > 手順書・Lane プロンプト・curl パスに `/opt/ultra-autotrade/main/` を書いた場合、staging/production VPS で `No such file or directory` になる。
 > SSH ログイン直後に必ず `pwd && ls` で確認してから操作を開始すること。
 
@@ -567,20 +567,24 @@ tmux attach -t phase-<X>
 | 主体 | 稼働場所 | 責務 |
 |------|----------|------|
 | **claude.ai** | ブラウザ | PM / アーキテクト / Asana 管理 / Phase 計画 / 4 軸確認（コード実装はしない） |
-| **Claude Code CLI** | dev VPS (`root@95.216.167.198`、構築後) | 実装・テスト・並列レーン（worktree 分離）・PR 作成 |
+| **Claude Code CLI** | dev VPS (`root@95.216.167.198`) | 実装・テスト・並列レーン（worktree 分離）・PR 作成 |
 | **Mac（ローカル）** | 開発者端末 | GitHub への push 起点 / ローカル merge / レビュー。production VPS は **pull only**（CLAUDE.md ABSOLUTE） |
 
 - 正規フロー: dev VPS で実装 → PR → ローカル Mac で merge → GitHub push → production VPS で `git pull origin main` → `deploy_production.sh`
 - production VPS 上で直接 `git merge` / `git commit` / エディタ編集をしない（「本番デプロイフロー」セクション準拠）
 
-### dev VPS 構築状況（2026-07-02時点）
+### dev VPS 構築状況（2026-07-03時点）
 
-> **未構築。** ASSIST ONE 上に dev VPS（95.216.167.198）は provisioning 済みだが、
-> `/opt/ultra-autotrade` 自体が存在せず、repo clone / venv / node_modules いずれも未実施
-> （2026-07-02 read-only 確認: `ls /opt/ultra-autotrade/` → No such file or directory）。
-> 旧 `uata-dev-01`（77.42.79.75）は廃止対象。dev VPS 実装環境の構築は
-> `docs/ops/host_migration_runbook.md`「Dev VPS 構築」セクション参照、
-> production/staging のデータ移行フェーズとは独立して別途実施が必要。
+> **構築完了。** ASSIST ONE dev VPS（95.216.167.198）で以下を実施・確認済み（read-only 実機確認 + セットアップ実行）:
+> - repo clone（`/opt/ultra-autotrade/main/`、worktree構造）、`git pull origin main` で HEAD = origin/main 最新
+> - backend `.venv` 依存インストール済み（`pip install -r requirements.txt` 差分なし）
+> - frontend `node_modules` インストール済み（`npm install --legacy-peer-deps` up to date）
+> - Docker / Docker Compose 新規インストール（`docker.io` 29.1.3 + `docker-compose-v2` 2.40.3、Ubuntu 26.04 標準リポジトリ。`hello-world` 疎通確認済み）
+> - Claude Code CLI 導入済み（v2.1.197）
+> - `/opt/ultra-autotrade-worktrees/` 新規作成（並列レーン用）
+>
+> 旧 `uata-dev-01`（77.42.79.75）は廃止対象のまま。手順は `docs/ops/host_migration_runbook.md`「Dev VPS 構築」セクション参照。
+> 未実施: `.env.*` 実ファイルの配置（`.example` のみ）、VSCode Remote SSH 接続確認（小林さん側手動確認項目）。
 
 ---
 

--- a/docs/ops/host_migration_runbook.md
+++ b/docs/ops/host_migration_runbook.md
@@ -452,11 +452,14 @@ cd ../frontend && npm install --legacy-peer-deps
 sudo fallocate -l 4G /swapfile && sudo chmod 600 /swapfile && sudo mkswap /swapfile && sudo swapon /swapfile
 ```
 
-- [ ] repo clone（worktree構造 `/opt/ultra-autotrade/main/`）
-- [ ] backend venv 構築・依存インストール
-- [ ] frontend node_modules 構築
-- [ ] VSCode Remote SSH で接続確認（`~/.ssh/config` の dev alias 経由）
-- [ ] CLAUDE.md / .claude/CLAUDE.md のホスト判定表を新IPに合わせて更新（別PR）
+- [x] repo clone（worktree構造 `/opt/ultra-autotrade/main/`）— 2026-07-03完了、HEAD = origin/main 追従
+- [x] backend venv 構築・依存インストール — 2026-07-03完了
+- [x] frontend node_modules 構築 — 2026-07-03完了
+- [x] Docker / Docker Compose 導入（`docker.io` + `docker-compose-v2`、Ubuntu 26.04標準リポジトリ）— 2026-07-03完了（本チェックリストになかったが並列レーン運用に必要なため追加実施）
+- [x] `/opt/ultra-autotrade-worktrees/` 作成（並列レーン用）— 2026-07-03完了
+- [ ] VSCode Remote SSH で接続確認（`~/.ssh/config` の dev alias 経由）— 小林さん側手動確認待ち
+- [x] CLAUDE.md / .claude/CLAUDE.md のホスト判定表を新IPに合わせて更新（本PR）
+- [ ] `.env.*` 実ファイルの配置（現状 `.example` のみ。secrets配布は別途判断）
 
 ---
 


### PR DESCRIPTION
## Summary
- dev VPS (95.216.167.198) の構築作業を実施(repo clone/git pull/backend venv/frontend node_modules/Docker+Compose導入/`/opt/ultra-autotrade-worktrees/`作成/Claude Code CLI確認)、実機で確認済み
- CLAUDE.md / .claude/CLAUDE.md のホスト判定表・dev VPS構築状況セクションを「未構築」から実態に更新
- docs/ops/host_migration_runbook.md のDev VPS構築チェックリストを完了項目にマーク、Docker追加実施分を追記

## Test plan
- [x] dev VPSにssh uata-assistone-devで接続し `git log -1` でHEAD=origin/main一致を確認
- [x] `docker --version` / `docker compose version` / `docker run --rm hello-world` で疎通確認
- [x] backend venv / frontend node_modules ともに追加インストールなし(既に最新)を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DB55vFp3HhQ3wFK9emzCpP