### PR TITLE
fix(hooks): guard-env-files R5 を新production VPS対応(移行取り残し)

### DIFF
--- a/.claude/hooks/guard-env-files.sh
+++ b/.claude/hooks/guard-env-files.sh
@@ -94,12 +94,16 @@ check_cmd() {
   fi
 
   # R5: production への直接書込(production_operation_checklist.md 違反)
+  # 対象ホスト: 旧 production 77.42.46.155 + 新 production(ASSIST ONE) 5.223.88.14
+  #   (2026-07-02 移行後、新ホストは root@5.223.88.14。旧ルールは ultra@77.42.46.155 の
+  #    ハードコードで新ホストの .env.production 書込を素通ししていた = 本ゲートの取り残し。
+  #    IP で照合し user を問わない形に一般化して両ホストを covered にする)
   # 誤発火対策 (2026-05-19 GID 1214761976014146):
   #   `2>&1 ./build.sh --env-file .env.production` のような ">" + 任意文字 + .env.production を
   #   誤検知しないよう、各パターンを厳密化。
   #   - redirect: `>[[:space:]]*\.env\.production` (> の直後が .env.production のみ BLOCK)
   #   - tee: tee の直後引数が .env.production の場合のみ BLOCK
-  if [[ "$cmd" =~ ssh.*ultra@77\.42\.46\.155 ]] \
+  if [[ "$cmd" =~ ssh.*(77\.42\.46\.155|5\.223\.88\.14) ]] \
      && [[ "$cmd" =~ \.env\.production ]] \
      && { [[ "$cmd" =~ sed[[:space:]]+-i ]] \
           || [[ "$cmd" =~ tee[[:space:]]+\.env\.production ]] \
@@ -109,7 +113,7 @@ check_cmd() {
       log_block "R5" \
         "ssh production への .env.production 直接書込 (production_operation_checklist.md ゲート 3 違反)" \
         "$cmd" \
-        "ローカルで編集 → scp → 必ずバックアップ + Phase 3 承認後"
+        "3段プロトコル(phase3-deployer)の承認済み手順で・必ずバックアップ後。意図的実行は UATA_HOOK_BYPASS_R5=1"
       return 2
     fi
   fi
@@ -136,6 +140,13 @@ self_test() {
     'PASS||ssh ultra@77.42.46.155 "bash deploy.sh 2>&1 --env-file .env.production"'
     'PASS||ssh ultra@77.42.46.155 "docker compose --env-file .env.production build 2>&1 | tee /tmp/build.log"'
     'PASS||ssh ultra@77.42.46.155 "cat .env.production"'
+    'BLOCK|R5|ssh -i ~/.ssh/hetzner_assistone_production root@5.223.88.14 "printf FOO=bar >> /opt/ultra-autotrade/.env.production"'
+    'BLOCK|R5|ssh -i ~/.ssh/hetzner_assistone_production root@5.223.88.14 "sed -i s/old/new/ /opt/ultra-autotrade/.env.production"'
+    'BLOCK|R5|ssh root@5.223.88.14 "tee .env.production"'
+    'BLOCK|R5|ssh root@5.223.88.14 "cp /tmp/new.env .env.production"'
+    'PASS||ssh -i ~/.ssh/hetzner_assistone_production root@5.223.88.14 "cat /opt/ultra-autotrade/.env.production | grep API_KEY"'
+    'PASS||ssh root@5.223.88.14 "grep NEXT_PUBLIC_AUTO_MODE_ENABLED /opt/ultra-autotrade/.env.production"'
+    'BYPASS_R5|PASS|ssh root@5.223.88.14 "printf FOO=bar >> /opt/ultra-autotrade/.env.production"'
     "PASS||ls -la /opt/ultra-autotrade/"
     "BYPASS_R1|PASS|cat /opt/ultra-autotrade/.env.staging"
   )
@@ -145,8 +156,14 @@ self_test() {
     IFS='|' read -r expected rule_id cmd <<< "$t"
     local actual_exit=0
 
-    if [[ "$expected" == "BYPASS_R1" ]]; then
-      UATA_HOOK_BYPASS_R1=1 check_cmd "$cmd" >/dev/null 2>&1 || actual_exit=$?
+    if [[ "$expected" =~ ^BYPASS_(R[0-9]+)$ ]]; then
+      # BYPASS_R<N>: 該当ルールを個別 bypass した上で PASS(exit 0) を期待。
+      # bash の動的スコープで、ここで local 宣言した変数は check_cmd→is_bypassed の
+      # `${!var:-0}` 間接展開から参照できる。
+      local bypass_var="UATA_HOOK_BYPASS_${BASH_REMATCH[1]}"
+      local "$bypass_var=1"
+      check_cmd "$cmd" >/dev/null 2>&1 || actual_exit=$?
+      unset "$bypass_var"
       expected="PASS"
     else
       check_cmd "$cmd" >/dev/null 2>&1 || actual_exit=$?


### PR DESCRIPTION
## 背景
ASSIST ONE 移行（2026-07-02）後、`guard-env-files.sh` の **R5**（本番 env ファイルへの直接書込を「バックアップ＋Phase 3 承認」に強制する安全ゲート）が旧ホスト（`ultra@77.42.46.155`）のハードコードのままだった。新 production VPS は `root@5.223.88.14`（user も IP も変化）のため、**新ホストへの本番 env 書込が R5 を素通り**していた（移行時の安全フック更新漏れ）。

Autoモード本番反映（2026-07-03）の Phase 3 実行時に、この取り残しを検出。

## 変更
- R5 のホスト照合を **IP 単位**（`77.42.46.155` | `5.223.88.14`）に一般化。user を問わず両 production ホストを covered に。
- self-test に新ホストの BLOCK 4件（追記リダイレクト / インプレース編集 / tee / cp）+ read-only PASS 2件 + `BYPASS_R5` 1件を追加。
- self-test ハーネスを `BYPASS_R<N>` 汎用対応に拡張（従来は `BYPASS_R1` のみハードコード）。bash 動的スコープで local 宣言した bypass 変数を `is_bypassed` の間接展開が参照。

## 挙動への影響
- 今後 phase3-deployer 等が新 production VPS で本番 env を書き込む際、R5 が発火 → 意図的実行は `UATA_HOOK_BYPASS_R5=1`（設計通りの「STOP して意識的に bypass」ゲート）。
- read-only（cat/grep）や `--env-file` 付き deploy は従来通り PASS（誤発火対策は維持）。

## 既知の限界（本PRでは対象外）
R5 は Bash コマンド文字列の正規表現照合のため、**本番ホスト IP と env ファイル名と書込動詞を同時に含む「文章」**（例: 本PRの説明文を含む `gh pr create`）も誤検知し得る。回避は body-file 化または `UATA_HOOK_BYPASS_R5=1`。恒久対策（実 ssh コマンドと散文の区別）は別途。

## Test
- [x] `bash .claude/hooks/guard-env-files.sh --self-test` → **25 PASS / 0 FAIL**

## Tier
`.claude/hooks/*.sh` = Tier B。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DB55vFp3HhQ3wFK9emzCpP
