### PR TITLE
fix(policy): build-tx（非カストディアル主経路）にPolicyEngine検査を配線

### DIFF
--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -1305,6 +1305,34 @@ def build_partner_tx(
             detail=f"Operation {proposal.operation} は partner 署名に非対応です",
         )
 
+    # PolicyEngine hard rule 検算（approve_proposal と同型）。Aave SUPPLY/WITHDRAW 限定
+    # （Lido/Pendle は STAKE_ETH/BUY_PT 等 PolicyEngine 既定 whitelist 対象外のため対象外。
+    # 本エンドポイントは approve_proposal を経由しない非カストディアル主経路のため、
+    # ここで通さないと HF floor / 単一取引上限 / velocity cap / cooldown / whitelist が
+    # 一切評価されないまま未署名 tx が発行されてしまう（2026-07-03 棚卸しで検出）。
+    # 本経路はパートナー本人が Privy で署名する手動フローであり AUTO 執行ではないため
+    # is_auto_execution=False 固定（Rule8 の delegation grant 要件は対象外）。
+    policy_ctx = PolicyContext(
+        user_id=proposal.user_id,
+        asset=proposal.asset,
+        operation=proposal.operation,
+        amount_usd=Decimal(str(proposal.amount_usd)),
+        expected_hf_after=Decimal(str(proposal.expected_hf_after))
+        if proposal.expected_hf_after is not None
+        else None,
+        proposal_id=proposal.id,
+        is_auto_execution=False,
+    )
+    policy_result = get_policy_engine().check(policy_ctx, db)
+    if policy_result.blocked:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "code": "POLICY_VIOLATION",
+                "violations": policy_result.violations,
+            },
+        )
+
     # B1: SUPPLY は USDC 残高不足を build-tx 前に検出し、無駄ガス・on-chain revert を防ぐ。
     # 残高取得失敗 (None) は fail-open（ガード skip）— submit-tx の revert→failed が安全網。
     # WITHDRAW は aToken 引出なので USDC 残高ガード対象外。

--- a/backend/tests/test_approve_policy_wiring.py
+++ b/backend/tests/test_approve_policy_wiring.py
@@ -75,6 +75,19 @@ def _create_pending_proposal(client: TestClient, token: str) -> int:
     return r.json()["id"]
 
 
+def _set_user_wallet(engine: object, user_id: int, wallet: str) -> None:
+    """build-tx はウォレット未設定だと PolicyEngine より前に 422 になるため設定する。"""
+    from sqlalchemy.orm import Session  # noqa: PLC0415
+
+    from app.auth.models import User  # noqa: PLC0415
+
+    with Session(engine) as db:  # type: ignore[arg-type]
+        u = db.get(User, user_id)
+        if u is not None:
+            u.wallet_address = wallet
+            db.commit()
+
+
 class TestApprovePolicyWiring:
     def test_policy_pass_approves_proposal(self, client: TestClient) -> None:
         """PolicyEngine が pass → 提案が approved になる。"""
@@ -168,3 +181,124 @@ class TestApprovePolicyWiring:
 
         assert r.status_code == 422
         assert "POLICY_VIOLATION" in r.json()["detail"]["code"]
+
+
+class TestBuildPartnerTxPolicyWiring:
+    """2026-07-03 棚卸しで検出: build-tx (Privy 非カストディアル主経路) が approve_proposal
+    を経由しないため PolicyEngine を一切通っていなかった問題の回帰テスト。"""
+
+    def test_policy_violation_blocks_build_tx(self, client: TestClient, test_db) -> None:
+        """PolicyEngine が blocked → build-tx も 422 POLICY_VIOLATION を返す。"""
+        _override, engine = test_db
+        token = _admin_token(client)
+        _set_user_wallet(engine, 1, "0x" + "b" * 40)
+        pid = _create_pending_proposal(client, token)
+
+        with patch("app.proposals.router.get_policy_engine") as mock_engine_factory:
+            mock_engine = mock_engine_factory.return_value
+            mock_engine.check.return_value = PolicyResult(
+                passed=False,
+                violations=["amount_usd 500 exceeds max_position 100"],
+            )
+
+            r = client.get(
+                f"/api/proposals/{pid}/build-tx",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert r.status_code == 422, r.text
+        body = r.json()
+        assert body["detail"]["code"] == "POLICY_VIOLATION"
+        mock_engine.check.assert_called_once()
+
+    def test_policy_pass_proceeds_past_policy_check(self, client: TestClient, test_db) -> None:
+        """PolicyEngine が pass → POLICY_VIOLATION では止まらず後段に進む
+        (build-tx 自体の成否は env/RPC 依存のため、ここでは
+        POLICY_VIOLATION が理由でないことのみを確認する)。"""
+        _override, engine = test_db
+        token = _admin_token(client)
+        _set_user_wallet(engine, 1, "0x" + "b" * 40)
+        pid = _create_pending_proposal(client, token)
+
+        with patch("app.proposals.router.get_policy_engine") as mock_engine_factory:
+            mock_engine = mock_engine_factory.return_value
+            mock_engine.check.return_value = PolicyResult(passed=True)
+
+            r = client.get(
+                f"/api/proposals/{pid}/build-tx",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        mock_engine.check.assert_called_once()
+        if r.status_code == 422:
+            detail = r.json()["detail"]
+            code = detail.get("code") if isinstance(detail, dict) else None
+            assert code != "POLICY_VIOLATION"
+
+    def test_policy_check_receives_correct_context(self, client: TestClient, test_db) -> None:
+        """PolicyContext が proposal のフィールド + is_auto_execution=False で
+        構築されることを検証（build-tx は手動 Privy 署名経路のため AUTO 扱いしない）。"""
+        _override, engine = test_db
+        token = _admin_token(client)
+        _set_user_wallet(engine, 1, "0x" + "b" * 40)
+        pid = _create_pending_proposal(client, token)
+
+        captured_ctx = []
+
+        def capture_check(ctx, db):  # type: ignore[no-untyped-def]
+            captured_ctx.append(ctx)
+            return PolicyResult(passed=True)
+
+        with patch("app.proposals.router.get_policy_engine") as mock_engine_factory:
+            mock_engine = mock_engine_factory.return_value
+            mock_engine.check.side_effect = capture_check
+
+            client.get(
+                f"/api/proposals/{pid}/build-tx",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert len(captured_ctx) == 1
+        ctx = captured_ctx[0]
+        assert ctx.asset == "USDC"
+        assert ctx.operation == "SUPPLY"
+        assert ctx.proposal_id == pid
+        assert ctx.is_auto_execution is False
+
+    def test_lido_partner_tx_not_blocked_by_aave_policy_check(
+        self, client: TestClient, test_db
+    ) -> None:
+        """Lido (STAKE_ETH) は Aave 専用の PolicyEngine 挿入箇所より前で分岐するため、
+        get_policy_engine が一切呼ばれないことを確認する
+        （既定 whitelist は USDC/SUPPLY/WITHDRAW のみで STAKE_ETH は対象外のため、
+        誤って同じ箇所を通すと必ずブロックされてしまう＝挿入位置の回帰テスト）。"""
+        _override, engine = test_db
+        token = _admin_token(client)
+        _set_user_wallet(engine, 1, "0x" + "b" * 40)
+
+        r = client.post(
+            "/api/proposals",
+            json={
+                "user_id": 1,
+                "operation": "STAKE_ETH",
+                "asset": "ETH",
+                "amount": "0.10",
+                "amount_usd": "300.00",
+                "protocol": "lido",
+                "reason": "lido policy bypass regression test",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 201, r.text
+        pid = r.json()["id"]
+
+        with patch("app.proposals.router.get_policy_engine") as mock_engine_factory:
+            mock_engine = mock_engine_factory.return_value
+            mock_engine.check.return_value = PolicyResult(passed=True)
+
+            client.get(
+                f"/api/proposals/{pid}/build-tx",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        mock_engine.check.assert_not_called()


### PR DESCRIPTION
## 背景（2026-07-03 Asana棚卸しで検出）
`PolicyEngine`（HF floor / 単一取引上限 / velocity cap / cooldown / whitelist）は `approve_proposal`（旧フロー）には配線済みだが、現行の主要非カストディアル実行経路（`build_partner_tx` → フロントでPrivy署名 → `submit_partner_tx`）は`approve_proposal`を経由しないため、**実際の本番取引がPolicyEngineの検査を一切受けていなかった**。

## 変更
`build_partner_tx`のAave SUPPLY/WITHDRAW専用パス（`op_map`検証後・Lido/Pendle分岐の後・USDC残高チェック前）に、`approve_proposal`（954-974行）と同型の`PolicyContext`構築 + `get_policy_engine().check()`を追加。`is_auto_execution=False`固定（本経路はパートナー本人によるPrivy手動署名でありAUTO執行ではないためRule8のdelegation grant要件対象外）。

**挿入位置に注意した点**: Lido/Pendle分岐より後ろに限定。Lido(`STAKE_ETH`)/Pendle(`BUY_PT`)はPolicyEngine既定whitelist(`USDC`/`SUPPLY`/`WITHDRAW`)の対象外のため、分岐前に置くと現在動いているLido/Pendleのbuild-txを誤ブロックしてしまうところだった（テストで実証済み: `test_lido_partner_tx_not_blocked_by_aave_policy_check`）。

## 変更しないもの
- `submit_partner_tx`のガード条件（build-tx側で通過を強制すれば十分）
- `AaveClient.withdraw`内の既存HF<1.6チェック（PolicyEngineのHF floorと二重防御になるだけで無害）
- `agents.py`/`service.py`等AI判定ロジックは無関係・無変更

## Test
- [x] `backend/tests/test_approve_policy_wiring.py::TestBuildPartnerTxPolicyWiring`（新規4件）: policy violation で422 / pass時は後段へ進む / PolicyContext構築内容検証（`is_auto_execution=False`確認）/ Lido分岐が`get_policy_engine`を一切呼ばないことの回帰テスト
- [x] `pytest backend/tests/` 全体: **4588 passed, 21 skipped**（既存分、regressionなし）
- [x] `ruff check` / `ruff format --check` / `mypy` clean
- [x] defi-aave-reviewスキルでチェックリスト確認（Decimal型のみ・HF既存ロジック無変更・float混入なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DB55vFp3HhQ3wFK9emzCpP