### PR TITLE
fix(aave): eMode切替をサーバー側で実送信完結させる

### DIFF
--- a/backend/app/aave/client.py
+++ b/backend/app/aave/client.py
@@ -389,6 +389,23 @@ class AaveClientBase(ABC):
         """
         return None
 
+    def execute_set_emode(
+        self,
+        category_id: int,
+        wallet_address: str,
+        private_key: str = "",
+    ) -> "dict[str, Any]":
+        """setUserEMode を実際に署名・送信する。
+
+        非 abstractmethod: AaveV4ClientBase 等の他サブクラスに実装を強制しないため
+        （get_pool_utilization と同型のオプトイン方式）。未対応クライアントは呼ばれたら
+        NotImplementedError で明示的に失敗する。
+
+        Returns:
+            {"tx_hash": str, "category_id": int}
+        """
+        raise NotImplementedError(f"{type(self).__name__} は execute_set_emode 未対応です")
+
 
 class AaveClientError(Exception):
     """Aave クライアントの基底例外。"""
@@ -458,6 +475,11 @@ class AaveClient(Protocol):
         self, category_id: int, wallet_address: str, dry_run: bool = False
     ) -> "dict[str, Any]":
         """eMode 切替用の未署名 tx を返す（build-tx パターン）。"""
+
+    def execute_set_emode(
+        self, category_id: int, wallet_address: str, private_key: str = ""
+    ) -> "dict[str, Any]":
+        """setUserEMode を実際に署名・送信する（管理者操作、プラットフォーム運用ウォレット）。"""
 
 
 class DummyAaveClient(AaveClientBase):
@@ -595,6 +617,16 @@ class DummyAaveClient(AaveClientBase):
                 "value": "0x0",
             }
         }
+
+    def execute_set_emode(
+        self,
+        category_id: int,
+        wallet_address: str,
+        private_key: str = "",
+    ) -> "dict[str, Any]":
+        """ダミークライアント: execute_set_emode のスタブ（tx 送信なし）。"""
+        logger.info("DummyAaveClient.execute_set_emode called (no tx sent)")
+        return {"tx_hash": "0xdummy_set_emode_hash", "category_id": category_id}
 
 
 class Web3AaveClient(AaveClientBase):
@@ -1588,6 +1620,103 @@ class Web3AaveClient(AaveClientBase):
                 "value": "0x0",
             }
         }
+
+    def execute_set_emode(
+        self,
+        category_id: int,
+        wallet_address: str,
+        private_key: str = "",
+    ) -> "dict[str, Any]":
+        """
+        Pool.setUserEMode(categoryId) を実際に署名・送信する。
+
+        2026-07-03: eMode 切替は admin 限定のプラットフォーム運用ウォレット操作
+        （require_admin エンドポイントからのみ呼ばれ、ユーザー個別資金は動かさない）。
+        withdraw() と同じ署名・送信パターン（nonce tracker・gas estimator・
+        sign_transaction・send_raw_transaction・receipt 待機）を用いる。
+        HF < 1.6 の事前チェックは呼び出し元 (router.set_emode) が行う（既存の安全設計を維持、
+        本メソッドでは重複させない）。
+
+        Args:
+            category_id: 設定する eMode カテゴリ ID (0-255)
+            wallet_address: 送信元ウォレットアドレス
+            private_key: 署名鍵。未指定なら self.account (AAVE_WALLET_PRIVATE_KEY) を使う
+
+        Returns:
+            {"tx_hash": str, "category_id": int}
+
+        Raises:
+            AaveClientError: web3 未導入 / signer 未設定 / ガス上限超過など
+            ValueError: category_id が範囲外
+        """
+        if Web3 is None:
+            raise AaveClientError("web3 package is required")
+        if not wallet_address:
+            raise AaveClientError("wallet_address は必須です (setUserEMode)")
+        if not (0 <= category_id <= 255):
+            raise ValueError(f"category_id は 0-255 の範囲で指定してください: {category_id}")
+
+        if not getattr(self, "account", None) and not private_key:
+            raise AaveClientError(
+                "AAVE_WALLET_PRIVATE_KEY (or private_key arg) is required "
+                "for signed setUserEMode tx"
+            )
+
+        logger.info(
+            "execute_set_emode: wallet=%s...%s, category_id=%d",
+            wallet_address[:6],
+            wallet_address[-4:],
+            category_id,
+        )
+
+        try:
+            if hasattr(self, "account"):
+                account = self.account
+            else:
+                from eth_account import Account
+
+                account = Account.from_key(private_key)
+
+            checksum_wallet = Web3.to_checksum_address(wallet_address)
+            nonce_tracker = _NonceTracker(self._w3, checksum_wallet)
+
+            # setUserEMode は withdraw より軽量だが、専用の gas fallback 定数が
+            # 無いため DEFAULT_FALLBACK_GAS_WITHDRAW を安全側の上限として流用する
+            # (estimate_gas_with_buffer は実 estimateGas を優先し、失敗時のみ fallback)。
+            gas_estimator = GasEstimator(self._w3)
+            set_emode_params_for_estimate = {
+                "from": checksum_wallet,
+                "nonce": nonce_tracker.peek(),
+                "gasPrice": self._w3.eth.gas_price,
+            }
+            set_emode_gas = gas_estimator.estimate_gas_with_buffer(
+                set_emode_params_for_estimate, DEFAULT_FALLBACK_GAS_WITHDRAW
+            )
+            if not gas_estimator.is_gas_cost_acceptable(set_emode_gas):
+                raise AaveClientError(f"setUserEMode ガスコストが上限を超過: {set_emode_gas} units")
+
+            set_emode_tx = self._pool.functions.setUserEMode(category_id).build_transaction(
+                {
+                    "from": checksum_wallet,
+                    "nonce": nonce_tracker.peek(),
+                    "gas": set_emode_gas,
+                    "gasPrice": self._w3.eth.gas_price,
+                }
+            )
+            signed_tx = self._w3.eth.account.sign_transaction(set_emode_tx, private_key=account.key)
+            tx_hash = self._w3_tx.eth.send_raw_transaction(signed_tx.raw_transaction)
+            nonce_tracker.advance()
+            receipt = self._w3.eth.wait_for_transaction_receipt(tx_hash)
+
+            tx_hash_hex = receipt["transactionHash"].hex()
+            logger.info("execute_set_emode 完了: tx=%s, category_id=%d", tx_hash_hex, category_id)
+
+            return {"tx_hash": tx_hash_hex, "category_id": category_id}
+
+        except (AaveClientError, ValueError):
+            raise
+        except Exception as exc:
+            raise AaveClientError(f"setUserEMode 失敗: {exc}") from exc
 
     def build_approve_delegation_tx(
         self,

--- a/backend/app/aave/router.py
+++ b/backend/app/aave/router.py
@@ -560,8 +560,9 @@ def set_emode(
     """
     Pool.setUserEMode(categoryId) を呼び出して eMode を切り替える。
 
-    HUMAN-REVIEW-REQUIRED: setUserEMode は Aave V3 の write 操作であり、
-    LTV / 清算閾値を変更するため、本番での実行は人間承認後に行うこと。
+    admin 限定・プラットフォーム運用ウォレット（AAVE_WALLET_ADDRESS）操作。
+    ユーザー個別資金は動かさない。dry_run=False の場合、AaveClient.deposit/withdraw と
+    同型のサーバー側署名・送信（execute_set_emode）で実際にオンチェーン反映まで完結する。
 
     dry_run=True の場合はオンチェーン tx を送信せず効果試算のみ返す。
     """
@@ -596,13 +597,13 @@ def set_emode(
         except Exception as hf_exc:  # noqa: BLE001
             logger.warning("HF チェック失敗 (継続): %s", hf_exc)
 
-        result = client.build_set_emode_tx(
-            category_id=body.category_id,
-            wallet_address=wallet_address,
-            dry_run=body.dry_run,
-        )
-
         if body.dry_run:
+            result = client.build_set_emode_tx(
+                category_id=body.category_id,
+                wallet_address=wallet_address,
+                dry_run=True,
+            )
+            _ = result
             return EModeSetResponse(
                 category_id=body.category_id,
                 tx_hash=None,
@@ -611,25 +612,29 @@ def set_emode(
                 message=f"dry_run: eMode cat{body.category_id} への切替 tx を試算しました（送信なし）",
             )
 
-        # build-tx モード: 未署名 tx をレスポンスに含めてフロントエンドへ返す。
-        # フロントエンドはこの tx をウォレットで署名・送信することで eMode を切り替える。
-        # HUMAN-REVIEW-REQUIRED: setUserEMode は Aave V3 の write 操作。
-        set_emode_tx: dict[str, object] | None = result.get("set_emode_tx")
+        # 2026-07-03: admin 限定のプラットフォーム運用ウォレット操作（ユーザー個別資金は
+        # 動かさない）のため、AaveClient.deposit/withdraw と同じサーバー側署名・送信で
+        # 完結させる。以前は未署名 tx を返すのみで「HUMAN-REVIEW-REQUIRED: フロントエンドで
+        # 署名・送信してください」という誤解を招くメッセージを表示しながら実際には何も
+        # 実行されていなかった（2026-07-03 棚卸しで検出）。
+        exec_result = client.execute_set_emode(
+            category_id=body.category_id,
+            wallet_address=wallet_address,
+        )
+        tx_hash = exec_result.get("tx_hash")
         logger.info(
-            "set_emode build_tx: wallet=%s...%s, category_id=%d",
+            "set_emode executed: wallet=%s...%s, category_id=%d, tx=%s",
             wallet_address[:6],
             wallet_address[-4:],
             body.category_id,
+            tx_hash,
         )
         return EModeSetResponse(
             category_id=body.category_id,
-            tx_hash=None,
-            set_emode_tx=set_emode_tx,
+            tx_hash=str(tx_hash) if tx_hash is not None else None,
+            set_emode_tx=None,
             dry_run=False,
-            message=(
-                f"eMode cat{body.category_id} への切替 tx を構築しました。"
-                " HUMAN-REVIEW-REQUIRED: フロントエンドで署名・送信してください。"
-            ),
+            message=f"eMode cat{body.category_id} への切替を実行しました。tx={tx_hash}",
         )
 
     except HTTPException:

--- a/backend/app/aave/schemas.py
+++ b/backend/app/aave/schemas.py
@@ -366,19 +366,18 @@ class EModeSetRequest(BaseModel):
 class EModeSetResponse(BaseModel):
     """POST /aave/emode のレスポンス。
 
-    dry_run=False かつ build-tx モードの場合、set_emode_tx に未署名 tx データが入る。
-    フロントエンドはこの tx をウォレットで署名・送信することで eMode を切り替える。
-    HUMAN-REVIEW-REQUIRED: setUserEMode は Aave V3 の write 操作。
+    2026-07-03: dry_run=False の場合、admin 限定のプラットフォーム運用ウォレット操作として
+    サーバー側で署名・送信まで完結し、実際の tx_hash を返す（AaveClient.deposit/withdraw と
+    同型の署名パターン）。set_emode_tx フィールドは後方互換のため残すが常に None
+    （旧: 未署名 tx を返しフロントエンドの署名待ちだったが、実際には送信されない
+    ギャップがあった。2026-07-03 棚卸しで検出し解消）。
     """
 
     category_id: int = Field(description="設定した eMode カテゴリ ID")
     tx_hash: Optional[str] = Field(None, description="tx ハッシュ (dry_run=True の場合は None)")
     set_emode_tx: Optional[dict[str, object]] = Field(
         None,
-        description=(
-            "未署名の setUserEMode tx データ (dry_run=False 時に返る)。"
-            "フロントエンドがウォレットで署名・送信する。"
-        ),
+        description="後方互換のため残すフィールド。現在は常に None（サーバー側で送信完結）。",
     )
     dry_run: bool = Field(description="ドライランかどうか")
     message: str = Field(description="結果メッセージ")

--- a/backend/tests/aave/test_emode_router.py
+++ b/backend/tests/aave/test_emode_router.py
@@ -87,6 +87,14 @@ class _StubAaveClient(AaveClientBase):
             }
         }
 
+    def execute_set_emode(
+        self,
+        category_id: int,
+        wallet_address: str,
+        private_key: str = "",
+    ) -> "dict[str, Any]":
+        return {"tx_hash": "0xstub_set_emode_hash", "category_id": category_id}
+
 
 # ── 認証ユーザースタブ ──────────────────────────────────────────────────────
 
@@ -255,10 +263,17 @@ class TestSetEmode:
         assert data["set_emode_tx"] is None
         assert data["category_id"] == 1
 
-    def test_post_emode_build_tx_returns_tx_data(
+    def test_post_emode_execute_returns_tx_hash(
         self, admin_client: TestClient, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """dry_run=False 時は set_emode_tx が返る (C-1 修正確認)。"""
+        """dry_run=False 時はサーバー側で署名・送信まで完結し tx_hash が返る。
+
+        2026-07-03 修正: 以前は set_emode_tx（未署名 tx）を返すだけで、
+        「フロントエンドで署名・送信してください」という誤解を招く message を
+        表示しながら実際には何も実行されない gap があった（棚卸しで検出）。
+        admin 限定のプラットフォーム運用ウォレット操作であり、ユーザー個別資金は
+        動かさないため、deposit/withdraw と同型のサーバー側署名で完結させる。
+        """
         monkeypatch.setenv("AAVE_WALLET_ADDRESS", "0xWALLET")
         stub = _StubAaveClient(hf=Decimal("2.5"), emode_id=0)
         with patch("app.aave.router.get_default_aave_client", return_value=stub):
@@ -269,9 +284,10 @@ class TestSetEmode:
         assert resp.status_code == 200
         data = resp.json()
         assert data["dry_run"] is False
-        assert data["set_emode_tx"] is not None
-        assert data["set_emode_tx"]["to"] == "0xPOOL"
-        assert "data" in data["set_emode_tx"]
+        assert data["tx_hash"] == "0xstub_set_emode_hash"
+        assert data["category_id"] == 1
+        # 後方互換フィールドは常に None（サーバー側で送信完結するため未署名 tx は返さない）
+        assert data["set_emode_tx"] is None
 
     def test_post_emode_hf_below_threshold_409(
         self, admin_client: TestClient, monkeypatch: pytest.MonkeyPatch

--- a/backend/tests/test_aave_web3_client.py
+++ b/backend/tests/test_aave_web3_client.py
@@ -613,7 +613,7 @@ def _make_mocked_web3_client(mock_web3, mock_rpc_provider_cls, mock_settings):
         int(2e18),
     )
 
-    # approve / supply / withdraw の build_transaction
+    # approve / supply / withdraw / setUserEMode の build_transaction
     mock_pool.functions.approve.return_value.build_transaction.return_value = {
         "from": "",
         "nonce": 0,
@@ -623,6 +623,10 @@ def _make_mocked_web3_client(mock_web3, mock_rpc_provider_cls, mock_settings):
         "nonce": 0,
     }
     mock_pool.functions.withdraw.return_value.build_transaction.return_value = {
+        "from": "",
+        "nonce": 0,
+    }
+    mock_pool.functions.setUserEMode.return_value.build_transaction.return_value = {
         "from": "",
         "nonce": 0,
     }
@@ -978,3 +982,67 @@ def test_build_withdraw_tx_uses_encode_abi_v7_api(mock_web3, mock_rpc_provider_c
 
     assert mock_pool.encode_abi.called
     assert not mock_pool.encodeABI.called
+
+
+# ==============================================================================
+# execute_set_emode: 2026-07-03 追加
+#
+# 背景: build_set_emode_tx は未署名 tx を返すだけで実際の署名・送信を行わず、
+# フロントエンドの EModePanel は「切替完了」のようなメッセージを表示しながら
+# 実際にはオンチェーンで何も起きていなかった (棚卸しで検出)。
+# admin 限定・プラットフォーム運用ウォレット操作のため、deposit/withdraw と
+# 同型のサーバー側署名・送信で完結させる。
+# ==============================================================================
+
+
+@patch("app.aave.rpc_provider.RPCProvider")
+@patch("app.aave.client.Web3")
+def test_execute_set_emode_signs_and_sends_returns_tx_hash(
+    mock_web3, mock_rpc_provider_cls, mock_settings
+):
+    """execute_set_emode が署名・送信まで完結し tx_hash を返すこと。"""
+    client, mock_pool, _server = _make_mocked_web3_client(
+        mock_web3, mock_rpc_provider_cls, mock_settings
+    )
+
+    result = client.execute_set_emode(category_id=1, wallet_address="0x" + "2" * 40)
+
+    assert result["category_id"] == 1
+    assert result["tx_hash"] == "ab" * 32  # bytes.hex() は "0x" プレフィックス無し
+    mock_pool.functions.setUserEMode.assert_called_once_with(1)
+    assert client._w3.eth.account.sign_transaction.called
+    assert client._w3_tx.eth.send_raw_transaction.called
+
+
+@patch("app.aave.rpc_provider.RPCProvider")
+@patch("app.aave.client.Web3")
+def test_execute_set_emode_rejects_invalid_category_id(
+    mock_web3, mock_rpc_provider_cls, mock_settings
+):
+    """category_id が 0-255 の範囲外なら ValueError。"""
+    client, _mock_pool, _server = _make_mocked_web3_client(
+        mock_web3, mock_rpc_provider_cls, mock_settings
+    )
+
+    with pytest.raises(ValueError, match="0-255"):
+        client.execute_set_emode(category_id=256, wallet_address="0x" + "2" * 40)
+
+
+@patch("app.aave.rpc_provider.RPCProvider")
+@patch("app.aave.client.Web3")
+def test_execute_set_emode_requires_wallet_address(mock_web3, mock_rpc_provider_cls, mock_settings):
+    """wallet_address 未指定は AaveClientError。"""
+    client, _mock_pool, _server = _make_mocked_web3_client(
+        mock_web3, mock_rpc_provider_cls, mock_settings
+    )
+
+    with pytest.raises(AaveClientError, match="wallet_address"):
+        client.execute_set_emode(category_id=1, wallet_address="")
+
+
+def test_dummy_client_execute_set_emode_returns_stub_tx_hash():
+    """DummyAaveClient.execute_set_emode は tx 送信せずスタブ tx_hash を返す。"""
+    client = DummyAaveClient()
+    result = client.execute_set_emode(category_id=2, wallet_address="0x" + "3" * 40)
+    assert result["category_id"] == 2
+    assert result["tx_hash"] == "0xdummy_set_emode_hash"

--- a/frontend/lib/api/aave.ts
+++ b/frontend/lib/api/aave.ts
@@ -161,8 +161,8 @@ export interface EModeTxData {
 
 export interface EModeSetResponse {
   category_id: number;
-  tx_hash: string | null;
-  set_emode_tx: EModeTxData | null; // C-1 修正: 未署名 tx データ (dry_run=False 時に設定)
+  tx_hash: string | null; // dry_run=False 時、サーバー側署名・送信完了後の実 tx hash
+  set_emode_tx: EModeTxData | null; // 後方互換のため残すフィールド。現在は常に null
   dry_run: boolean;
   message: string;
 }


### PR DESCRIPTION
## 背景（2026-07-03 Asana棚卸しで検出）
`EModePanel.tsx`は`POST /emode`を呼び「切替完了」のようなメッセージを表示していたが、`set_emode`（`router.py`）は未署名txを構築して返すだけで、実際の署名・送信は一切行われていなかった。管理者が「切替」ボタンを押しても画面は成功したように見えて、**オンチェーンでは何も起きていなかった**。

## 変更
`AAVE_WALLET_ADDRESS`は個別ユーザーのウォレットではなく**admin限定のプラットフォーム運用ウォレット操作**（ユーザー資金は動かさない）のため、既存の`AaveClient.deposit`/`withdraw`と同じサーバー側署名・送信パターン（nonce tracker・gas estimator・sign_transaction・send_raw_transaction・receipt待機）で完結させる方式を採用。

- `backend/app/aave/client.py`: `AaveClientBase`に`execute_set_emode`のデフォルト実装（`NotImplementedError`）を追加（`get_pool_utilization`と同型のオプトイン方式。`AaveV4ClientBase`等の他サブクラスに実装を強制しない）。`DummyAaveClient`/`Web3AaveClient`にそれぞれ実装。
- `backend/app/aave/router.py`: `set_emode`の`dry_run=False`経路を、未署名tx返却のみから実送信・`tx_hash`返却に変更。**既存のHF<1.6事前チェックは無変更のまま維持**。
- `backend/app/aave/schemas.py`: `EModeSetResponse`のdocstring更新。
- `frontend/lib/api/aave.ts`: 型コメント更新のみ。`EModePanel.tsx`の表示ロジックは元々`res.message`をそのまま表示するだけだったため、バックエンドが正直な応答を返すようになったことでフロント実装変更なしに問題が解消される。

## Test
- [x] `backend/tests/test_aave_web3_client.py`に`execute_set_emode`の署名・送信フロー/バリデーション回帰テスト3件+`DummyAaveClient`分1件を追加
- [x] `backend/tests/aave/test_emode_router.py`の旧仕様依存テストを新仕様に更新（`tx_hash`確認・`set_emode_tx=None`確認）
- [x] `pytest backend/tests/`全体: **4588 passed, 21 skipped**（既存分、regressionなし）
- [x] `ruff check`/`ruff format --check`/`mypy`/`tsc --noEmit` clean

## 計画承認プロセス
2026-07-03 Plan mode（`velvet-snuggling-hamming.md` Slice 2）でユーザー承認済み。commit実行時にClaude Code auto mode classifierが「Aave実資金操作のHUMAN-REVIEW-REQUIREDゲート削除」として2度ブロックし、最終的にユーザー本人が直接`git commit`/`git push`を実行（human-in-the-loopとして意図通り機能）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DB55vFp3HhQ3wFK9emzCpP
