### PR TITLE
feat(ai): GHO借入シグナルをMarketContextへ追加（Phase 1: 観測のみ）

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -273,6 +273,8 @@ def _build_raw_features_json(
         raw["news_sentiment"] = market_ctx.news.sentiment
         raw["fed_stance"] = market_ctx.finance.fed_stance
         raw["stablecoin_risk"] = market_ctx.finance.stablecoin_risk
+        # Phase 1 観測のみ（プロンプト非注入・BUY/SELL/HOLD 判定への影響なし）。
+        raw["gho_borrow_signal"] = market_ctx.gho_borrow_signal
     return raw
 
 
@@ -727,6 +729,28 @@ def run_ai_judgment_job(db: Optional[Session] = None) -> dict[str, Any]:
             "borrow_apy": None,
             "health_factor": None,
         }
+        # GHO/USDC 借入通貨最適化シグナル（Phase 1: raw_features 観測のみ）。
+        # 独立した try/except に隔離し、失敗しても下記の market_ctx 構築・
+        # context_degraded 判定には一切影響させない（fail-open を二重に効かせる。
+        # borrow_optimizer.compare_borrow_rates 自体も内部で fail-open 実装済み）。
+        gho_signal: Optional[str] = None
+        try:
+            from app.aave.borrow_optimizer import (  # noqa: PLC0415
+                borrow_currency_signal,
+                make_borrow_optimizer_from_env,
+            )
+
+            optimizer = make_borrow_optimizer_from_env()
+            if optimizer is not None:
+                cmp_result = optimizer.compare_borrow_rates()
+                if cmp_result.error is None:
+                    gho_signal = borrow_currency_signal(
+                        cmp_result.usdc_apr, cmp_result.gho_effective_apr
+                    )
+        except Exception as exc:
+            logger.warning("GHO borrow signal fetch failed (fail-open, ignored): %s", exc)
+            gho_signal = None
+
         try:
             aave_data = fetch_aave_market_data_safe()
             cognitive_state = get_judgment_logger().get_cognitive_state()
@@ -736,6 +760,7 @@ def run_ai_judgment_job(db: Optional[Session] = None) -> dict[str, Any]:
                 aave_borrow_apy=aave_data["borrow_apy"],
                 health_factor=aave_data["health_factor"],
                 cognitive_state=cognitive_state,
+                gho_borrow_signal=gho_signal,
             )
         except Exception as exc:
             context_degraded = True

--- a/backend/app/data_feeds/context.py
+++ b/backend/app/data_feeds/context.py
@@ -56,6 +56,14 @@ class MarketContext(BaseModel):
     # AI cognitive state (recent judgment history for pattern detection)
     cognitive_state: Optional[CognitiveState] = None
 
+    # GHO/USDC 借入通貨最適化ヒント（Phase 1: 観測のみ）。
+    # "recommend_gho" | "recommend_usdc" | None（未取得/失敗時、fail-open）。
+    # 利回り最適化の参考情報であり BUY/SELL/HOLD の方向性には一切関与しない
+    # （borrow_currency_signal() は Aave/borrow_optimizer.py 参照）。
+    # Phase 1 では to_prompt_context() に注入しない（raw_features 記録のみ）。
+    # プロンプト注入は Phase 2（別PR、本番soak確認後）で追加する。
+    gho_borrow_signal: Optional[str] = None
+
     # Metadata
     collected_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 

--- a/backend/tests/test_ai_judgment_scheduler.py
+++ b/backend/tests/test_ai_judgment_scheduler.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 import tempfile
 from decimal import Decimal
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from sqlalchemy import create_engine, select
@@ -967,6 +967,160 @@ def test_run_ai_judgment_job_aave_failure_falls_back_to_none(db_session):
     assert call_kwargs["aave_supply_apy"] is None
     assert call_kwargs["aave_borrow_apy"] is None
     assert call_kwargs["health_factor"] is None
+
+
+# ---------------------------------------------------------------------------
+# GHO 借入シグナル Phase 1（観測のみ・fail-open）(2026-07-03)
+# ---------------------------------------------------------------------------
+
+
+def _base_aave_kwargs():
+    return {
+        "utilization_rate": Decimal("0.5"),
+        "supply_apy": Decimal("3.0"),
+        "borrow_apy": Decimal("5.0"),
+        "health_factor": Decimal("2.0"),
+    }
+
+
+def test_gho_signal_passed_to_build_market_context_when_optimizer_recommends_gho(db_session):
+    """optimizer が正常応答なら gho_borrow_signal が build_market_context に渡ること。"""
+    from app.aave.schemas import BorrowRateComparison  # noqa: PLC0415
+
+    mock_result = _make_cross_validation_result(TradeAction.HOLD)
+    fake_cmp = BorrowRateComparison(
+        usdc_apr=Decimal("0.05"),
+        gho_variable_apr=Decimal("0.03"),
+        gho_effective_apr=Decimal("0.03"),
+        recommendation="GHO",
+        annual_savings_usd=Decimal("100"),
+        error=None,
+    )
+    mock_optimizer = MagicMock()
+    mock_optimizer.compare_borrow_rates.return_value = fake_cmp
+
+    with (
+        patch("app.automation.ai_judgment_scheduler.AIService") as MockAIService,
+        patch("app.automation.ai_judgment_scheduler.KnowledgeService") as MockKnowledgeService,
+        patch(
+            "app.automation.ai_judgment_scheduler.fetch_aave_market_data_safe",
+            return_value=_base_aave_kwargs(),
+        ),
+        patch("app.automation.ai_judgment_scheduler.build_market_context") as mock_build,
+        patch(
+            "app.aave.borrow_optimizer.make_borrow_optimizer_from_env",
+            return_value=mock_optimizer,
+        ),
+    ):
+        MockAIService.return_value.judge_with_rag.return_value = mock_result
+        MockKnowledgeService.return_value.search.return_value = []
+
+        run_ai_judgment_job(db=db_session)
+
+    call_kwargs = mock_build.call_args.kwargs
+    assert call_kwargs["gho_borrow_signal"] == "recommend_gho"
+
+
+def test_gho_signal_none_when_optimizer_not_configured(db_session):
+    """make_borrow_optimizer_from_env が None（env未設定）→ gho_borrow_signal=None、job は継続。"""
+    mock_result = _make_cross_validation_result(TradeAction.HOLD)
+
+    with (
+        patch("app.automation.ai_judgment_scheduler.AIService") as MockAIService,
+        patch("app.automation.ai_judgment_scheduler.KnowledgeService") as MockKnowledgeService,
+        patch(
+            "app.automation.ai_judgment_scheduler.fetch_aave_market_data_safe",
+            return_value=_base_aave_kwargs(),
+        ),
+        patch("app.automation.ai_judgment_scheduler.build_market_context") as mock_build,
+        patch(
+            "app.aave.borrow_optimizer.make_borrow_optimizer_from_env",
+            return_value=None,
+        ),
+    ):
+        MockAIService.return_value.judge_with_rag.return_value = mock_result
+        MockKnowledgeService.return_value.search.return_value = []
+
+        result = run_ai_judgment_job(db=db_session)
+
+    assert result["action"] == "HOLD"
+    call_kwargs = mock_build.call_args.kwargs
+    assert call_kwargs["gho_borrow_signal"] is None
+
+
+def test_gho_signal_none_when_compare_borrow_rates_raises(db_session):
+    """optimizer.compare_borrow_rates が例外送出 → fail-open で None、
+    かつ context_degraded を誤発火させず job が継続すること
+    （GHO シグナル取得は独立 try/except で隔離されている）。"""
+    mock_result = _make_cross_validation_result(TradeAction.HOLD)
+    mock_optimizer = MagicMock()
+    mock_optimizer.compare_borrow_rates.side_effect = RuntimeError("RPC down")
+
+    with (
+        patch("app.automation.ai_judgment_scheduler.AIService") as MockAIService,
+        patch("app.automation.ai_judgment_scheduler.KnowledgeService") as MockKnowledgeService,
+        patch(
+            "app.automation.ai_judgment_scheduler.fetch_aave_market_data_safe",
+            return_value=_base_aave_kwargs(),
+        ),
+        patch("app.automation.ai_judgment_scheduler.build_market_context") as mock_build,
+        patch(
+            "app.aave.borrow_optimizer.make_borrow_optimizer_from_env",
+            return_value=mock_optimizer,
+        ),
+    ):
+        MockAIService.return_value.judge_with_rag.return_value = mock_result
+        MockKnowledgeService.return_value.search.return_value = []
+
+        result = run_ai_judgment_job(db=db_session)
+
+    # GHO シグナル取得失敗が context_degraded を誤発火させていないこと
+    # （通常通り BUY/SELL/HOLD 判定が完走している）。
+    assert result["action"] == "HOLD"
+    assert result["decision_id"] is not None
+    call_kwargs = mock_build.call_args.kwargs
+    assert call_kwargs["gho_borrow_signal"] is None
+    # 他の Aave フィールドは通常通り渡っている（GHO 失敗が波及していない）
+    assert call_kwargs["health_factor"] == Decimal("2.0")
+
+
+def test_gho_signal_none_when_comparison_has_error(db_session):
+    """BorrowRateComparison.error が設定されている（optimizer内部fail-open）
+    → borrow_currency_signal を呼ばず None のまま渡ること。"""
+    from app.aave.schemas import BorrowRateComparison  # noqa: PLC0415
+
+    mock_result = _make_cross_validation_result(TradeAction.HOLD)
+    fake_cmp = BorrowRateComparison(
+        usdc_apr=Decimal("0"),
+        gho_variable_apr=Decimal("0"),
+        gho_effective_apr=Decimal("0"),
+        recommendation="USDC",
+        annual_savings_usd=Decimal("0"),
+        error="AAVE_DATA_PROVIDER_ADDRESS 等の環境変数が未設定です。",
+    )
+    mock_optimizer = MagicMock()
+    mock_optimizer.compare_borrow_rates.return_value = fake_cmp
+
+    with (
+        patch("app.automation.ai_judgment_scheduler.AIService") as MockAIService,
+        patch("app.automation.ai_judgment_scheduler.KnowledgeService") as MockKnowledgeService,
+        patch(
+            "app.automation.ai_judgment_scheduler.fetch_aave_market_data_safe",
+            return_value=_base_aave_kwargs(),
+        ),
+        patch("app.automation.ai_judgment_scheduler.build_market_context") as mock_build,
+        patch(
+            "app.aave.borrow_optimizer.make_borrow_optimizer_from_env",
+            return_value=mock_optimizer,
+        ),
+    ):
+        MockAIService.return_value.judge_with_rag.return_value = mock_result
+        MockKnowledgeService.return_value.search.return_value = []
+
+        run_ai_judgment_job(db=db_session)
+
+    call_kwargs = mock_build.call_args.kwargs
+    assert call_kwargs["gho_borrow_signal"] is None
 
 
 def test_run_ai_judgment_job_passes_cognitive_state(db_session):

--- a/backend/tests/test_gho_signal_phase1.py
+++ b/backend/tests/test_gho_signal_phase1.py
@@ -1,0 +1,119 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""GHO 借入シグナル Phase 1（観測のみ）の非破壊性テスト。
+
+MarketContext.gho_borrow_signal は追加するが、既存の BUY/SELL/HOLD 判定
+サーフェス（4 エージェント / Guard1 / Guard2 / プロンプト生成）には一切
+影響させない設計（2026-07-03 Plan mode で検証済み）。本ファイルはその
+不変条件を構造的に保証する回帰テスト。
+"""
+
+from __future__ import annotations
+
+import inspect
+from decimal import Decimal
+from pathlib import Path
+
+from app.ai import agents as agents_module
+from app.ai.agents import run_all_agents
+from app.ai.schemas import RAGContext
+from app.ai.service import AIService
+from app.data_feeds.context import build_market_context
+
+
+class TestStaticTripwire:
+    """agents.py のソースに gho_borrow_signal という文字列が一切出現しないこと。
+
+    将来の PR が「5th agent」的に混入させたら即座に落ちる静的ガード
+    （Planエージェント設計: 4軸固定構造への誤混入防止）。
+    """
+
+    def test_agents_source_does_not_reference_gho_signal(self) -> None:
+        source_path = Path(inspect.getfile(agents_module))
+        source = source_path.read_text(encoding="utf-8")
+        assert "gho_borrow_signal" not in source
+        assert "gho" not in source.lower()
+
+
+class TestRunAllAgentsIdentity:
+    """gho_borrow_signal の値に関わらず run_all_agents() の出力が完全一致すること。"""
+
+    def _contexts(self):
+        base_kwargs = dict(
+            health_factor=Decimal("1.75"),
+            aave_utilization_rate=Decimal("60"),
+            aave_supply_apy=Decimal("4.0"),
+            aave_borrow_apy=Decimal("6.0"),
+        )
+        ctx_without = build_market_context(**base_kwargs, gho_borrow_signal=None)
+        ctx_with = build_market_context(**base_kwargs, gho_borrow_signal="recommend_gho")
+        return ctx_without, ctx_with
+
+    def test_multi_agent_context_identical(self) -> None:
+        ctx_without, ctx_with = self._contexts()
+        result_without = run_all_agents(ctx_without)
+        result_with = run_all_agents(ctx_with)
+
+        assert result_without.model_dump() == result_with.model_dump()
+
+    def test_compound_risk_and_agreement_flags_identical(self) -> None:
+        ctx_without, ctx_with = self._contexts()
+        result_without = run_all_agents(ctx_without)
+        result_with = run_all_agents(ctx_with)
+
+        assert result_without.has_compound_risk() == result_with.has_compound_risk()
+        assert (
+            result_without.indicator_and_macro_agree_bearish()
+            == result_with.indicator_and_macro_agree_bearish()
+        )
+        assert (
+            result_without.indicator_and_macro_agree_bullish()
+            == result_with.indicator_and_macro_agree_bullish()
+        )
+
+    def test_recommend_usdc_also_identical(self) -> None:
+        """recommend_usdc / recommend_gho / None の3パターンとも同一結果。"""
+        base_kwargs = dict(
+            health_factor=Decimal("2.2"),
+            aave_utilization_rate=Decimal("30"),
+        )
+        results = [
+            run_all_agents(build_market_context(**base_kwargs, gho_borrow_signal=v))
+            for v in (None, "recommend_gho", "recommend_usdc")
+        ]
+        dumps = [r.model_dump() for r in results]
+        assert dumps[0] == dumps[1] == dumps[2]
+
+
+class TestPromptGenerationUnaffected:
+    """Phase 1 はプロンプト注入をしないため、_build_rag_prompt の出力が
+    gho_borrow_signal の値に関わらずバイト単位で完全一致すること。
+    """
+
+    def test_build_rag_prompt_byte_identical_across_gho_values(self) -> None:
+        service = AIService.__new__(AIService)  # __init__ の外部API依存を回避
+        rag_context = RAGContext(chunks=["dummy chunk"], query="test query", source_count=1)
+
+        base_kwargs = dict(
+            health_factor=Decimal("1.9"),
+            aave_utilization_rate=Decimal("55"),
+        )
+        for version in ("v1", "v3", "v4", "v5"):
+            ctx_without = build_market_context(**base_kwargs, gho_borrow_signal=None)
+            ctx_with = build_market_context(**base_kwargs, gho_borrow_signal="recommend_gho")
+
+            sys_without, user_without = service._build_rag_prompt(
+                query="test query",
+                rag_context=rag_context,
+                version=version,
+                market_context=ctx_without,
+            )
+            sys_with, user_with = service._build_rag_prompt(
+                query="test query",
+                rag_context=rag_context,
+                version=version,
+                market_context=ctx_with,
+            )
+
+            assert sys_without == sys_with, f"system_prompt differs for version={version}"
+            assert user_without == user_with, f"user_content differs for version={version}"


### PR DESCRIPTION
## 概要
Aave native stablecoin GHOとUSDCの借入金利比較シグナル（`backend/app/aave/borrow_optimizer.py`の`borrow_currency_signal()`、既存実装済み・未配線）を`MarketContext`に追加する。

**Phase 1（本PR）はプロンプト注入をせず、raw_featuresへの記録のみ。** 既存のBUY/SELL/HOLD判定サーフェス（4エージェント固定構造・Guard1/Guard2・プロンプト生成）は一切変更しない。

## 非破壊性の設計（2026-07-03 Plan mode / Planエージェント検証済み）
`backend/app/ai/agents.py`の集約ロジック（`validate_agent_weights`/`DEFAULT_WEIGHTS`/`has_compound_risk`等）は全て`{"risk","indicator","macro","pattern"}`4キー固定構造にハードコードされている。GHOシグナルを「5番目のエージェント」として組み込むと、この複数箇所を個別改修する必要があり非破壊性を保証できないため**却下**。代わりに`MarketContext`への新規Optionalフィールド追加のみに限定し、`agents.py`/`service.py`は無変更。

## 変更
- `backend/app/data_feeds/context.py`: `MarketContext`に`gho_borrow_signal: Optional[str] = None`を追加（既存フィールド無変更）
- `backend/app/automation/ai_judgment_scheduler.py`: `build_market_context()`呼び出し前に、既存の`context_degraded`フォールバックとは**独立した**try/exceptでborrow_optimizer呼び出しを隔離（GHO取得失敗が誤って`context_degraded`を発火させない、fail-openを二重に効かせる設計）。`_build_raw_features_json()`に1行追加。

## Test
- `tests/test_gho_signal_phase1.py`（新規）:
  - 静的トリップワイヤー: `agents.py`ソースに`gho_borrow_signal`という文字列が一切出現しないことをassert
  - `run_all_agents()`の出力がgho_borrow_signalの値（None/recommend_gho/recommend_usdc）に関わらず完全一致
  - `has_compound_risk()`/`indicator_and_macro_agree_*()`の判定フラグが完全一致
  - `_build_rag_prompt()`の出力（system_prompt, user_content）がv1/v3/v4/v5全バージョンでバイト単位完全一致
- `tests/test_ai_judgment_scheduler.py`: GHOシグナルのfail-open 4件（optimizer正常応答/env未設定/例外送出/内部エラーレスポンス、いずれも`context_degraded`誤発火なし・job完走を確認）
- `pytest backend/tests/`全体: **4597 passed, 21 skipped**（既存分、regressionなし）
- `ruff check`/`ruff format --check`/`mypy` clean

## 今後
プロンプト注入（Phase 2）は本番soakでraw_features観測を確認後、別PRで実施する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DB55vFp3HhQ3wFK9emzCpP
