### PR TITLE
fix(frontend): Aave管理パネルにAuthorizationヘッダーを付与（本番401バグ）

### DIFF
--- a/frontend/lib/api/aave.ts
+++ b/frontend/lib/api/aave.ts
@@ -10,10 +10,23 @@
  * - setEMode(): POST /api/aave/emode
  *
  * NOTE: getStressTest()/getRewards() は呼出元ゼロのため削除（2026-06-22 監査 fe-10）。
- * 各 read は画面側 useAuthFetch がインラインで担当。型は保持。
+ *
+ * 2026-07-03 修正: 本ファイルの全関数が Authorization ヘッダーを一切付与しておらず、
+ * NEXT_PUBLIC_API_URL 設定時（production 含む全環境）は require_admin/require_viewer
+ * エンドポイントに対し常に 401 になっていた（ブラウザ実機確認で検出）。getJson/postJson
+ * は credentials: "include" のみで、backend 側に cookie 発行機構が存在しないため、
+ * Authorization ヘッダーの明示付与が唯一の認証手段。lib/api/wallet_balance.ts 等と
+ * 同型の authHeaders() パターンを、呼出元シグネチャを変えずに内部で getAuthToken() を
+ * 読む形で適用する。
  */
 
+import { getAuthToken } from "../auth/token-key";
 import { getJson, postJson } from "./http";
+
+function authHeaders(): HeadersInit {
+  const token = getAuthToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
 
 // ---------------------------------------------------------------------------
 // ストレステスト
@@ -54,7 +67,7 @@ export interface PoolHealthResult {
 }
 
 export async function getPoolHealth(): Promise<PoolHealthResult> {
-  return getJson<PoolHealthResult>("/api/aave/pool-health");
+  return getJson<PoolHealthResult>("/api/aave/pool-health", { headers: authHeaders() });
 }
 
 // ---------------------------------------------------------------------------
@@ -89,7 +102,7 @@ export interface ClaimRewardsResponse {
  * POST /aave/rewards/claim — リワードを手動 Claim する（admin のみ）
  */
 export async function claimRewards(): Promise<ClaimRewardsResponse> {
-  return postJson<ClaimRewardsResponse>("/api/aave/rewards/claim", {});
+  return postJson<ClaimRewardsResponse>("/api/aave/rewards/claim", {}, { headers: authHeaders() });
 }
 
 // ---------------------------------------------------------------------------
@@ -115,7 +128,7 @@ export interface BorrowRateComparison {
  * GET /aave/borrow-rates — GHO / USDC 借入金利比較と最適借入通貨推奨を取得する（viewer 以上）
  */
 export async function getBorrowRates(): Promise<BorrowRateComparison> {
-  return getJson<BorrowRateComparison>("/api/aave/borrow-rates");
+  return getJson<BorrowRateComparison>("/api/aave/borrow-rates", { headers: authHeaders() });
 }
 
 // ---------------------------------------------------------------------------
@@ -171,12 +184,12 @@ export interface EModeSetResponse {
  * GET /aave/emode — 現在の eMode 設定と最適化推奨を取得する（viewer 以上）
  */
 export async function getEMode(): Promise<EModeGetResponse> {
-  return getJson<EModeGetResponse>("/api/aave/emode");
+  return getJson<EModeGetResponse>("/api/aave/emode", { headers: authHeaders() });
 }
 
 /**
  * POST /aave/emode — eMode カテゴリを切り替える（admin のみ）
  */
 export async function setEMode(req: EModeSetRequest): Promise<EModeSetResponse> {
-  return postJson<EModeSetResponse>("/api/aave/emode", req);
+  return postJson<EModeSetResponse>("/api/aave/emode", req, { headers: authHeaders() });
 }

--- a/frontend/lib/api/protocols.ts
+++ b/frontend/lib/api/protocols.ts
@@ -1,6 +1,15 @@
 // Copyright (c) Ultra AutoTrade. All rights reserved.
 // Unauthorized copying or distribution is strictly prohibited.
+import { getAuthToken } from "../auth/token-key";
 import { getJson } from "./http";
+
+// 2026-07-03 修正: fetchOracleStatus は require_viewer 保護下だが Authorization
+// ヘッダーが付与されておらず、production を含む全環境で 401 になっていた
+// （ブラウザ実機確認で検出。lib/api/aave.ts と同種のバグ）。
+function authHeaders(): HeadersInit {
+  const token = getAuthToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
 
 export type RiskLevel = "low" | "medium" | "high" | "critical";
 
@@ -50,7 +59,7 @@ export async function fetchProtocolsHealth(): Promise<ProtocolHealth[]> {
 }
 
 export async function fetchOracleStatus(): Promise<OracleStatusResponse> {
-  return getJson<OracleStatusResponse>("/api/aave/oracle-status");
+  return getJson<OracleStatusResponse>("/api/aave/oracle-status", { headers: authHeaders() });
 }
 
 export async function fetchPendleMarkets(): Promise<PendleMarketInfo[]> {


### PR DESCRIPTION
## 発見の経緯
PR #920（eMode server-side signing）のレビュー中、ユーザーから「フロントとバックがつながっているかテストしたか」と問われ、pytestとtsc型チェックのみで実際にブラウザ・実サーバーでの確認をしていなかったことに気づいた。ローカルでbackend（`AAVE_CLIENT_TYPE=dummy`）+ frontendを実際に起動し、admin管理者としてブラウザで`/protocols`ページを操作したところ、eMode/GHO/Pool Health/Oracleの4パネルが全て401で機能していないことを発見。

## 根本原因
`frontend/lib/api/aave.ts`（`getPoolHealth`/`claimRewards`/`getBorrowRates`/`getEMode`/`setEMode`）と`frontend/lib/api/protocols.ts`（`fetchOracleStatus`）が、Authorizationヘッダーを一切付与せず`getJson`/`postJson`（`credentials: "include"`のみ）を呼んでいた。backend側にはcookie発行機構が存在せず（`require_admin`/`require_viewer`はAuthorizationヘッダーのみを見る）、grep確認済み。

## 本番への影響
`docker-compose.production.yml`で`NEXT_PUBLIC_API_URL`が本番でもデフォルト設定される（`https://api.ultra-auto-trade.com`）ため、**この6エンドポイントは本番でも常に401**だったはず。管理者ダッシュボードの`/protocols`ページ下部4パネルが本番で機能していなかった可能性が高い。

## 修正
`lib/auth/token-key.ts`の`getAuthToken()`（他の`lib/api/*.ts`と同じ正準トークン読み出しヘルパー）を使い、`Authorization: Bearer`ヘッダーを内部で付与するよう変更。呼出元コンポーネント（EModePanel/BorrowRatesPanel/PoolHealthPanel/OracleStatusPanel）のシグネチャ・呼び出し方は無変更（関数内部で完結）。

**対象外**: `fetchProtocolsHealth`（`/api/protocols/health`）はbackend側に認証依存が無い意図的な公開エンドポイントのため対象外（grep確認済み）。

## Test（実機確認・エンドツーエンド）
- [x] ローカルでPostgres(Docker)+backend(uvicorn, `AAVE_CLIENT_TYPE=dummy`)+frontend(`npm run dev`)を実起動
- [x] ブラウザで管理者ログイン→`/protocols`ページ操作
- [x] 修正前: `GET /api/aave/{oracle-status,pool-health,borrow-rates,emode}` 全て401（Network タブで確認）
- [x] 修正後: 上記全て200、パネルが実データで正常表示
- [x] `AAVE_COLLATERAL_ASSETS=USDC,USDT`設定で推奨eModeとの差分を作り、「eModeを切替」ボタンを実クリック→確認ダイアログ→実行→**実際にtx_hashを含む成功メッセージ表示**を確認（`POST /api/aave/emode` 200、レスポンスに`tx_hash`）
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DB55vFp3HhQ3wFK9emzCpP
