### PR TITLE
fix(liff-chat): 入金パネルの「Base Mainnet」表記ハードコードを解消

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
@@ -11,6 +11,7 @@ import { base, baseSepolia } from "wagmi/chains"
 import { useWallet } from "@/hooks/useWallet"
 import { useUsdcBalance } from "@/hooks/useUsdcBalance"
 import { track, EV } from "@/lib/posthog"
+import { SUPPORTED_CHAIN_IDS, getChainDisplayName } from "@/lib/web3/config"
 
 // ---- 型定義 ---------------------------------------------------------------
 
@@ -256,7 +257,9 @@ export function DepositPanel() {
             <span className="text-sm font-normal text-[#736f7e] ml-2">USDC</span>
           </p>
         )}
-        <p className="text-xs text-[#736f7e] mt-1">{t("network")}</p>
+        <p className="text-xs text-[#736f7e] mt-1">
+          USDC · {getChainDisplayName(SUPPORTED_CHAIN_IDS[0])}
+        </p>
       </div>
 
       {/* 成功メッセージ */}


### PR DESCRIPTION
## 背景
liff-chatの実機テスト中（PR #918-922のstaging検証）に発見。`frontend/messages/{ja,en}.json`の`Liff.panels.deposit.network`キーが「USDC · Base Mainnet」に固定されており、staging（Base Sepolia、`NEXT_PUBLIC_DEFAULT_CHAIN_ID=84532`）でも常に「Base Mainnet」と表示されていた。

## 実害
Privyの実際の入金モーダル（`fundWallet`）は正しく「Receive funds on **Base Sepolia**」と表示しており機能的な実害はないが、**自前UIの残高カード表示だけが誤っていた**。テスターがこの誤表記を信じて実際にBase Mainnet上のUSDCを送金すると、staging側のアドレスはBase Sepolia用のため着金せず資金を失うリスクがあった。

## 修正
既存の`frontend/lib/web3/config.ts`の`getChainDisplayName()`/`SUPPORTED_CHAIN_IDS`（`NEXT_PUBLIC_DEFAULT_CHAIN_ID`駆動。`DepositPanel.tsx`の158行目でも同型のchainId判定を既に使用済み）を使い、i18nの固定文字列ではなく実行時の環境変数から動的にネットワーク名を組み立てるよう変更。

## Test
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [ ] staging実機再確認（マージ後デプロイして目視）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DB55vFp3HhQ3wFK9emzCpP
