### PR TITLE
fix(liff-chat): 入金方法注意書き・ウォレットパネルの「Base Mainnet」表記も動的化

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
@@ -318,7 +318,9 @@ export function DepositPanel() {
               {t("depositMethodDesc")}
             </p>
             <ul className="text-xs text-[#736f7e] leading-relaxed space-y-0.5 list-disc list-inside">
-              <li>{t("depositMethodNote1")}</li>
+              <li>
+                {t("depositMethodNote1", { chain: getChainDisplayName(SUPPORTED_CHAIN_IDS[0]) ?? "" })}
+              </li>
               <li>{t("depositMethodNote2")}</li>
               <li>{t("depositMethodNote3")}</li>
             </ul>

--- a/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
@@ -17,6 +17,7 @@ import { useTranslations } from "next-intl"
 import { usePrivy } from "@privy-io/react-auth"
 import { useWallet } from "@/hooks/useWallet"
 import { useLinkedWalletAddress } from "@/hooks/useLinkedWalletAddress"
+import { SUPPORTED_CHAIN_IDS, getChainDisplayName } from "@/lib/web3/config"
 
 // アドレス解決の状態。
 //  - loading : Privy 初期化中 / API 取得中
@@ -111,7 +112,9 @@ export function MyWalletPanel() {
           </div>
           <div className="flex items-center gap-1.5">
             <span className="w-2 h-2 rounded-full bg-[#1D9E75] inline-block" />
-            <span className="text-[#736f7e] text-xs">{t("baseMainnet")}</span>
+            <span className="text-[#736f7e] text-xs">
+              {getChainDisplayName(SUPPORTED_CHAIN_IDS[0])}
+            </span>
           </div>
         </div>
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -805,7 +805,7 @@
         "depositAmountPlaceholder": "Enter amount",
         "depositMethodTitle": "How to deposit",
         "depositMethodDesc": "Tap \"Deposit\" to reveal your deposit address. Send USDC from your exchange (e.g. SBI VC Trade) or wallet.",
-        "depositMethodNote1": "Important: Always send USDC on the Base (Base Mainnet) network. Funds sent on other networks (e.g. Ethereum) will NOT arrive",
+        "depositMethodNote1": "Important: Always send USDC on the {chain} network. Funds sent on other networks (e.g. Ethereum) will NOT arrive",
         "depositMethodNote2": "Very small amounts may not transfer (recommended minimum: ~$30)",
         "depositMethodNote3": "The amount entered is an estimate; set the actual transfer amount in your wallet",
         "depositAddressLabel": "Deposit address (Base Mainnet)",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -805,7 +805,7 @@
         "depositAmountPlaceholder": "金額を入力",
         "depositMethodTitle": "入金方法",
         "depositMethodDesc": "「入金する」を押すと入金用アドレスが表示されます。取引所（例: SBI VCトレード）やお持ちのウォレットから USDC を送金してください。",
-        "depositMethodNote1": "【重要】必ず Base（Base Mainnet）ネットワークで USDC を送金してください。Ethereum など他のネットワークで送ると着金しません",
+        "depositMethodNote1": "【重要】必ず {chain} ネットワークで USDC を送金してください。Ethereum など他のネットワークで送ると着金しません",
         "depositMethodNote2": "少額すぎると送金できない場合があります（目安: 数十ドル以上）",
         "depositMethodNote3": "入力した金額は送金額の目安です（実際の送金額はご自身で指定します）",
         "depositAddressLabel": "入金用アドレス（Base Mainnet）",


### PR DESCRIPTION
## 背景
PR #923をstagingにデプロイして実機再確認したところ、残高カード表示は正しく「USDC · Base Sepolia」になったが、同じ「Base Mainnet」ハードコードが以下2箇所に残っていた。

## 修正箇所
- `DepositPanel.tsx`「入金方法」注意書き（`depositMethodNote1`）
- `MyWalletPanel.tsx`ウォレットカード上部ネットワーク表示（`baseMainnet`キー）

PR #923と同じ根本原因（`frontend/messages/{ja,en}.json`に環境非依存の固定文字列としてハードコード）。`{chain}`プレースホルダー化し、`getChainDisplayName(SUPPORTED_CHAIN_IDS[0])`を渡すよう変更。

## Test
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [x] `node scripts/check-i18n-keys.mjs` 新規欠落なし
- [ ] staging実機再確認（マージ後デプロイして目視）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DB55vFp3HhQ3wFK9emzCpP
