### PR TITLE
fix(liff-chat): EOA/SmartWallet不一致による資金迷子バグを修正

### DIFF
--- a/backend/app/auth/schemas.py
+++ b/backend/app/auth/schemas.py
@@ -125,6 +125,8 @@ class UserResponse(BaseModel):
     invited_by: Optional[int] = None
     tier: InvestmentTier = InvestmentTier.LOWER
     execution_policy: str = "require_approval"
+    wallet_address: Optional[str] = None
+    smart_wallet_address: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/users/settings_router.py
+++ b/backend/app/users/settings_router.py
@@ -67,6 +67,8 @@ def _build_settings_response(user: User) -> UserSettingsResponse:
         terms_version=user.terms_version,
         corporate_fiscal_month=user.corporate_fiscal_month,
         role=user.role,
+        wallet_address=user.wallet_address,
+        smart_wallet_address=user.smart_wallet_address,
     )
 
 

--- a/backend/app/users/settings_schemas.py
+++ b/backend/app/users/settings_schemas.py
@@ -39,6 +39,11 @@ class UserSettingsResponse(BaseModel):
     corporate_fiscal_month: Optional[int] = None
     # ユーザーロール（admin / viewer / partner）。フロントエンドの権限分岐に使用する。
     role: str = "viewer"
+    # EOA ウォレットアドレス（Privy embedded wallet 等）。未設定なら None。
+    wallet_address: Optional[str] = None
+    # Smart Wallet (ERC-4337) アドレス。設定済みなら Aave 実行の実体はこちら
+    # (backend/app/proposals/router.py の smart_wallet_address 優先ロジックと対応)。
+    smart_wallet_address: Optional[str] = None
 
 
 class UserSettingsUpdate(BaseModel):

--- a/backend/tests/test_user_settings_api.py
+++ b/backend/tests/test_user_settings_api.py
@@ -78,6 +78,25 @@ class TestUserSettingsAPI:
         data = r.json()
         assert data["notification_frequency"] == "important"
         assert data["notification_email"] is None
+        assert data["wallet_address"] is None
+        assert data["smart_wallet_address"] is None
+
+    def test_get_settings_includes_smart_wallet_address_when_linked(
+        self, client: TestClient
+    ) -> None:
+        token = register_and_login(client)
+        headers = {"Authorization": f"Bearer {token}"}
+        addr = "0xb332b5fccf25c09cf5098f6363a18b1173158ce3"
+        link_res = client.post(
+            "/auth/wallet/smart-link",
+            json={"smart_wallet_address": addr},
+            headers=headers,
+        )
+        assert link_res.status_code == 200
+
+        r = client.get("/api/user/settings", headers=headers)
+        assert r.status_code == 200
+        assert r.json()["smart_wallet_address"] == addr.lower()
 
     def test_update_notification_email(self, client: TestClient) -> None:
         token = register_and_login(client)

--- a/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/AccountPanel.tsx
@@ -30,6 +30,7 @@ interface UserData {
   user_mode?: "managed" | "active" | "pro"
   created_at?: string
   wallet_address?: string
+  smart_wallet_address?: string
   avatar_url?: string
   // 法人決算月 (1-12)。backend /api/user/settings で永続化される。
   corporate_fiscal_month?: number | null
@@ -120,6 +121,7 @@ export function AccountPanel() {
             email?: string
             created_at?: string
             wallet_address?: string
+            smart_wallet_address?: string
           } | null,
         ) => {
           if (data) {
@@ -128,6 +130,9 @@ export function AccountPanel() {
               ...(data.email && { email: data.email }),
               ...(data.created_at && { created_at: data.created_at }),
               ...(data.wallet_address && { wallet_address: data.wallet_address }),
+              ...(data.smart_wallet_address && {
+                smart_wallet_address: data.smart_wallet_address,
+              }),
             }))
           }
         },
@@ -172,10 +177,12 @@ export function AccountPanel() {
     return t("defaultUser")
   }
 
-  // ウォレットアドレス短縮表示。backend の wallet_address を優先し、
-  // 未記録時は Privy/injected の実ウォレット（liveWalletAddress）にフォールバック。
+  // ウォレットアドレス短縮表示。実効アドレス（smart_wallet_address 優先、無ければ
+  // backend の wallet_address、未記録時は Privy/injected の実ウォレット）。
+  // Aave 実行の実体（backend submit_partner_tx の UserOp sender 検証）と一致させる
+  // ため EOA 固定にしない（2026-07-04 資金迷子バグ修正）。
   const getShortAddress = () => {
-    const addr = userData?.wallet_address ?? liveWalletAddress
+    const addr = userData?.smart_wallet_address ?? userData?.wallet_address ?? liveWalletAddress
     if (!addr) return null
     return `${addr.slice(0, 6)}…${addr.slice(-4)}`
   }
@@ -200,7 +207,7 @@ export function AccountPanel() {
 
   // ウォレットアドレスコピー（表示と同じ単一情報源を使う）
   const handleCopyWallet = async () => {
-    const addr = userData?.wallet_address ?? liveWalletAddress
+    const addr = userData?.smart_wallet_address ?? userData?.wallet_address ?? liveWalletAddress
     if (!addr) return
     try {
       await navigator.clipboard.writeText(addr)

--- a/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
@@ -10,6 +10,7 @@ import { useFundWallet } from "@privy-io/react-auth"
 import { base, baseSepolia } from "wagmi/chains"
 import { useWallet } from "@/hooks/useWallet"
 import { useUsdcBalance } from "@/hooks/useUsdcBalance"
+import { useEffectiveWalletAddress } from "@/hooks/useEffectiveWalletAddress"
 import { track, EV } from "@/lib/posthog"
 import { SUPPORTED_CHAIN_IDS, getChainDisplayName } from "@/lib/web3/config"
 
@@ -109,12 +110,16 @@ export function DepositPanel() {
       .catch(() => {})
   }, [])
 
-  // Privy ウォレット情報（useFundWallet 用）
-  const { address, chainId } = useWallet()
+  // Privy ウォレット情報（chainId は署名/ネットワーク判定用。EOA。）
+  const { chainId } = useWallet()
 
-  // 残高 = ユーザー自身のウォレットの USDC オンチェーン残高（非カストディアル）。
-  // 出金先/入金先アドレスも settings 依存をやめ useWallet の address を正とする。
-  const { balanceUsd, loading: balanceLoading, refetch: refetchBalance } = useUsdcBalance()
+  // 入金先/出金先/残高チェック対象アドレスは実効アドレス（smart_wallet_address 優先、
+  // 未設定なら EOA）。Aave 実行の実体（backend submit_partner_tx の UserOp sender 検証）
+  // と一致させるため、EOA 固定にしない（2026-07-04 資金迷子バグ修正）。
+  const { address } = useEffectiveWalletAddress()
+
+  // 残高 = 実効アドレスの USDC オンチェーン残高（非カストディアル）。
+  const { balanceUsd, loading: balanceLoading, refetch: refetchBalance } = useUsdcBalance(address)
   const balance = balanceUsd
   const walletAddress = address
 

--- a/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/MyWalletPanel.tsx
@@ -30,15 +30,18 @@ export function MyWalletPanel() {
   const t = useTranslations("Liff.panels.myWallet")
   const { ready: privyReady, login } = usePrivy()
 
-  // live wallet（injected / Privy embedded）は useWallet に集約済み。
+  // live wallet（injected / Privy embedded、EOA）は useWallet に集約済み。
   // settings 画面など他の消費者と同一の単一情報源を共有する。
   const { address: liveAddress } = useWallet()
 
-  // live wallet が取れないときだけ、バックエンド記録アドレスをフォールバック取得。
-  // （別デバイスで連携済み等。表示専用で署名はできない。）
-  const linked = useLinkedWalletAddress(privyReady && !liveAddress)
+  // smart_wallet_address 判定のため liveAddress の有無に関わらず常時取得する
+  // （live wallet が取れないときのフォールバック表示も兼ねる）。
+  const linked = useLinkedWalletAddress(privyReady)
 
-  const address = liveAddress ?? linked.address
+  // 表示・コピー・QRコード先は実効アドレス（smart_wallet_address 優先、無ければ EOA）。
+  // Aave 実行の実体（backend submit_partner_tx の UserOp sender 検証）と一致させるため
+  // EOA 固定にしない（2026-07-04 資金迷子バグ修正）。
+  const address = linked.smartWalletAddress ?? liveAddress ?? linked.address
 
   // 表示状態を派生。Privy 初期化前は loading を維持（永久固まり回避）。
   const fetchState: FetchState = !privyReady

--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -9,6 +9,7 @@ import { Menu, User } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { useLanguage } from "@/lib/useLanguage"
 import { useUsdcBalance } from "@/hooks/useUsdcBalance"
+import { useEffectiveWalletAddress } from "@/hooks/useEffectiveWalletAddress"
 import { track, EV } from "@/lib/posthog"
 import { HamburgerMenu } from "./_components/HamburgerMenu"
 import { SlideUpPanel } from "./_components/SlideUpPanel"
@@ -129,9 +130,12 @@ export default function LiffChatPage() {
   const t = useTranslations("Liff")
   const { language, setLanguage } = useLanguage()
 
-  // 現在資産 = ユーザー自身のウォレットの USDC オンチェーン残高（非カストディアル）。
-  // refetch は S2 の着金検知ポーリングで使う。
-  const { balanceUsd, refetch: refetchBalance } = useUsdcBalance()
+  // 現在資産 = 実効アドレス（smart_wallet_address 優先、無ければ EOA）の USDC
+  // オンチェーン残高（非カストディアル）。backend B1 の build-tx 残高ガード
+  // （smart_wallet_address 優先）とフロント表示を一致させる
+  // （2026-07-04 資金迷子バグ修正）。refetch は S2 の着金検知ポーリングで使う。
+  const { address: effectiveWalletAddress } = useEffectiveWalletAddress()
+  const { balanceUsd, refetch: refetchBalance } = useUsdcBalance(effectiveWalletAddress)
 
   // ── 既存 state（ハンバーガー）
   const [menuOpen, setMenuOpen] = useState(false)

--- a/frontend/hooks/useEffectiveWalletAddress.ts
+++ b/frontend/hooks/useEffectiveWalletAddress.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Ultra AutoTrade. All rights reserved.
+'use client'
+
+import { useWallet } from '@/hooks/useWallet'
+import { useLinkedWalletAddress } from '@/hooks/useLinkedWalletAddress'
+
+export interface EffectiveWalletAddress {
+  /** 残高・入金先・表示に使うべきアドレス。smart_wallet_address 優先、無ければ EOA。 */
+  address: string | null
+  /** true なら address は Smart Wallet (ERC-4337)。false なら EOA。 */
+  isSmartWallet: boolean
+  /** Privy embedded wallet 等の EOA アドレス（署名 provider の識別に使う場合用）。 */
+  eoaAddress: string | null
+  loading: boolean
+}
+
+/**
+ * Aave 実行の実体（backend/app/proposals/router.py の smart_wallet_address 優先ロジック、
+ * submit_partner_tx の UserOp sender==smart_wallet_address 検証）と一致する「実効アドレス」
+ * を解決する。署名は常に useWallet() の signer（EOA 鍵）で行うため signer は変更しない。
+ *
+ * smart_wallet_address 未設定（EOA のみのユーザー）の場合は useWallet().address にフォール
+ * バックし、従来どおり EOA を実効アドレスとして扱う。
+ */
+export function useEffectiveWalletAddress(): EffectiveWalletAddress {
+  const { address: eoaAddress } = useWallet()
+  const { smartWalletAddress, state } = useLinkedWalletAddress(true)
+
+  const isSmartWallet = Boolean(smartWalletAddress)
+  const address = smartWalletAddress ?? eoaAddress ?? null
+
+  return {
+    address,
+    isSmartWallet,
+    eoaAddress,
+    loading: state === 'loading',
+  }
+}

--- a/frontend/hooks/useLinkedWalletAddress.ts
+++ b/frontend/hooks/useLinkedWalletAddress.ts
@@ -16,6 +16,8 @@ export type LinkedAddressState = 'idle' | 'loading' | 'ready' | 'empty' | 'error
 
 export interface LinkedWalletAddress {
   address: string | null
+  /** Smart Wallet (ERC-4337) アドレス。未設定 (EOA ユーザー) なら null。 */
+  smartWalletAddress: string | null
   state: LinkedAddressState
   refetch: () => void
 }
@@ -38,6 +40,7 @@ export interface LinkedWalletAddress {
  */
 export function useLinkedWalletAddress(enabled = true): LinkedWalletAddress {
   const [address, setAddress] = useState<string | null>(null)
+  const [smartWalletAddress, setSmartWalletAddress] = useState<string | null>(null)
   const [state, setState] = useState<LinkedAddressState>('idle')
 
   const fetchAddress = useCallback(async () => {
@@ -50,6 +53,7 @@ export function useLinkedWalletAddress(enabled = true): LinkedWalletAddress {
     if (!token) {
       // 認証トークンが無い = 記録も引けない（空状態）
       setAddress(null)
+      setSmartWalletAddress(null)
       setState('empty')
       return
     }
@@ -64,13 +68,17 @@ export function useLinkedWalletAddress(enabled = true): LinkedWalletAddress {
         setState('error')
         return
       }
-      const data = (await res.json()) as { wallet_address?: string | null } | null
+      const data = (await res.json()) as {
+        wallet_address?: string | null
+        smart_wallet_address?: string | null
+      } | null
+      setSmartWalletAddress(data?.smart_wallet_address ?? null)
       if (data?.wallet_address) {
         setAddress(data.wallet_address)
         setState('ready')
       } else {
         setAddress(null)
-        setState('empty')
+        setState(data?.smart_wallet_address ? 'ready' : 'empty')
       }
     } catch {
       // ネットワーク失敗等は fail-visible（refetch 可能）
@@ -82,5 +90,5 @@ export function useLinkedWalletAddress(enabled = true): LinkedWalletAddress {
     void fetchAddress()
   }, [fetchAddress])
 
-  return { address, state, refetch: fetchAddress }
+  return { address, smartWalletAddress, state, refetch: fetchAddress }
 }

--- a/frontend/hooks/useUsdcBalance.ts
+++ b/frontend/hooks/useUsdcBalance.ts
@@ -27,9 +27,15 @@ const CHAINS = SUPPORTED_CHAINS as Record<string, { rpc?: string } | undefined>
  * 旧実装は /api/user/settings の `balance` を読んでいたが、当該フィールドはバックエンドに
  * 存在せず常に null（= 残高 $0 表示）だった。read-only provider 経由の balanceOf に置換する。
  * balanceOf は署名不要のため signer は使わない。
+ *
+ * @param addressOverride 残高を読む対象アドレス。省略時は useWallet().address（EOA）を使う
+ *   後方互換動作（v3 レガシーダッシュボード向け）。Smart Wallet ユーザーの実際の資金は
+ *   smart_wallet_address 側にあるため、liff-chat 等の呼び出し元は実効アドレス
+ *   （smart_wallet_address 優先）を明示的に渡すこと。
  */
-export function useUsdcBalance(): UsdcBalanceState {
-  const { address, chainId } = useWallet()
+export function useUsdcBalance(addressOverride?: string | null): UsdcBalanceState {
+  const { address: eoaAddress, chainId } = useWallet()
+  const address = addressOverride !== undefined ? addressOverride : eoaAddress
   const [balanceUsd, setBalanceUsd] = useState<number | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(false)


### PR DESCRIPTION
## 背景

stagingでliff-chatの入金〜提案承認フローを実機テストした結果、Aave実行の実体（`backend/app/proposals/router.py`の`submit_partner_tx`）はユーザーに`smart_wallet_address`（Coinbase Smart Wallet, ERC-4337）が設定されていればそちらを実行主体（UserOp sender）として扱う設計だが、フロントの残高表示・入金先アドレス・`insufficientBalance`事前チェックの複数箇所がPrivy embedded walletのEOAアドレスだけを見ていたことが判明した。

署名フロー自体（`ProposalSignSheet.tsx`/`ApproveConfirmSheet.tsx`）は`useSmartWallets()`でSCW優先に正しく分岐済みだったが、`DepositPanel.tsx`の「入金する」ボタン（Privy `fundWallet`）はEOA宛に入金させる設計になっており、**SCWユーザーが実際にAave実行で使う資金はそこに届かない**という実害のあるバグだった。

## 修正

### Backend（additive）
`UserSettingsResponse`/`UserResponse`に`wallet_address`・`smart_wallet_address`を追加。

### Frontend
- `useLinkedWalletAddress`拡張、新規`useEffectiveWalletAddress`フック追加（smart_wallet_address優先、無ければEOAフォールバック）
- `useUsdcBalance`はアドレスを明示的に渡せるようシグネチャ変更（省略時は既存どおりEOA、後方互換維持）
- `DepositPanel`/`MyWalletPanel`/`AccountPanel`/liff-chat `page.tsx`を実効アドレスベースに変更

### スコープ外
v3レガシーの直接EOA実行ダッシュボード（`user/deposit`, `user/dashboard`, `user/wallet`, `useAaveV3`）は署名フロー自体がEOA直接のため対象外（署名フロー再設計が必要な別プロジェクト規模）。

## Test
- [x] backend: pytest 33件全通過（新規2件） + ruff + mypy clean
- [x] frontend: tsc --noEmit clean / eslint エラー0 / check-i18n-keys.mjs 新規欠落なし
- [ ] staging実機再確認（マージ後デプロイして`wallet_efd141fd@wallet.local`ユーザーで確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DB55vFp3HhQ3wFK9emzCpP
