### PR TITLE
feat(staging): v4ローンチ相当フィーチャーフラグのbuild-arg配線をstagingに追加

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -302,6 +302,13 @@ services:
         NEXT_PUBLIC_POSTHOG_KEY: ${NEXT_PUBLIC_POSTHOG_KEY:-}
         NEXT_PUBLIC_POSTHOG_HOST: ${NEXT_PUBLIC_POSTHOG_HOST:-https://us.i.posthog.com}
         NEXT_PUBLIC_APP_VERSION: ${NEXT_PUBLIC_APP_VERSION:-dev}
+        # v4 Phase 2-D-E: 委譲おまかせ consent フロー（ビルド時埋め込み・既定 false=dormant）。
+        NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED: ${NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED:-false}
+        # PWA 配布向けフィーチャーフラグ（lib/flags.ts・build-time 埋め込み）。
+        # 本番 PR #917 と同型配線。.env.staging-new で true 設定 + frontend 再ビルドで有効化。
+        NEXT_PUBLIC_AUTO_MODE_ENABLED: ${NEXT_PUBLIC_AUTO_MODE_ENABLED:-false}
+        NEXT_PUBLIC_PUBLIC_REGISTRATION_ENABLED: ${NEXT_PUBLIC_PUBLIC_REGISTRATION_ENABLED:-false}
+        NEXT_PUBLIC_REFERRAL_ENABLED: ${NEXT_PUBLIC_REFERRAL_ENABLED:-false}
         # Next.js ビルド OOM 対策 (CLAUDE.md §2026-05-19 GID 1214828243363427)
         # staging-new は 7.6GB RAM / swap なし → 4096MB が安全下限。
         # 実ビルドログでピーク確認後に値を調整すること。


### PR DESCRIPTION
## 背景
staging（PWAモード）でv4ローンチ相当の機能（Auto mode / 公開登録 / 紹介機能）を実コイン以外でUIテストしたいという要望を受けて、本番PR #917（`cf8583e4`）で追加されたフィーチャーフラグのbuild-arg配線がstagingには一切通っていないことが判明した。

## 修正
`docker-compose.staging.yml`のfrontend build.argsに、本番PR #917と同型で以下を追加:
- `NEXT_PUBLIC_AUTO_MODE_ENABLED`
- `NEXT_PUBLIC_PUBLIC_REGISTRATION_ENABLED`
- `NEXT_PUBLIC_REFERRAL_ENABLED`
- `NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED`（既に本番/staging-v4には配線済みだったがstagingには無かった）

`frontend/Dockerfile`側のARG/ENVは全環境共通のため既に配線済み。既定値はfalse=dormantのため、本PRマージだけでは挙動不変。

## Test
- 既存のdocker-compose設定への追記のみ、既定値変更なし（false継続）
- マージ後、`.env.staging-new`でtrue設定 + frontend再ビルドで有効化予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DB55vFp3HhQ3wFK9emzCpP
