### PR TITLE
feat(fees): B-1 料金プラン/Tier別月額の事前提示UX（第1弾: 料金ページ + 導線）

### DIFF
--- a/frontend/app/(user)/fees/page.tsx
+++ b/frontend/app/(user)/fees/page.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect } from 'react'
 import { apiFetch } from '@/lib/api/client'
 import { useAuth } from '@/lib/auth'
 import AuthGuard from '@/components/AuthGuard'
+import FeePlanSection from '@/components/user/FeePlanSection'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 
@@ -184,6 +185,9 @@ function FeesContent() {
       </div>
 
       <div className="space-y-4 px-4 py-4 pb-24 max-w-4xl mx-auto">
+        {/* B-1: 料金プラン / Tier別月額の事前提示（config は独自に取得・独立描画） */}
+        <FeePlanSection />
+
         {loading && (
           <div className="space-y-3">
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">

--- a/frontend/components/shared/BottomNav.tsx
+++ b/frontend/components/shared/BottomNav.tsx
@@ -4,7 +4,7 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Home, CheckCircle, Brain, Settings, HelpCircle, Users, ClipboardList, Gift, ArrowUpFromLine } from 'lucide-react'
+import { Home, CheckCircle, Brain, Settings, HelpCircle, Users, ClipboardList, Gift, ArrowUpFromLine, Receipt } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { cn } from '@/lib/utils'
 import { useAuth } from '@/lib/auth'
@@ -44,6 +44,8 @@ export function BottomNav() {
   const viewerNavItems = [
     { href: '/user/dashboard', label: t('viewerNav.home'), icon: Home },
     { href: '/user/ai-feed', label: t('viewerNav.aiDecisions'), icon: Brain },
+    // B-1: 料金プラン / Tier別月額の事前提示ページ（URL: /fees, route group prefix なし）。
+    { href: '/fees', label: t('viewerNav.fees'), icon: Receipt },
     { href: '/user/help', label: t('viewerNav.help'), icon: HelpCircle },
   ]
 

--- a/frontend/components/user/FeePlanSection.tsx
+++ b/frontend/components/user/FeePlanSection.tsx
@@ -1,0 +1,145 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+'use client'
+
+// B-1: 料金プラン / Tier別月額 の事前提示 UX。
+// 料率は GET /api/v1/fees/config から取得（ハードコード禁止）。
+// 文言はすべて i18n (FeePricing namespace) 経由で、月利/月額表記は B-5 法務の
+// 結論を後から差し替え可能な構造にしている。
+// 徴収は現在停止中 (ENABLE_MONTHLY_FEE_BATCH=0 / FEE_TRANSFER_ENABLED=false) のため、
+// 「現在は無料」である旨を notActiveNote で明示する（規約第7条と整合）。
+
+import { useEffect, useState } from 'react'
+import { useTranslations } from 'next-intl'
+import { apiFetch } from '@/lib/api/client'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+
+interface FeeConfig {
+  tier_thresholds_jpy: number[]
+  tier_fee_rates: number[]
+  subscription_rates: Record<string, number>
+}
+
+// tier_fee_rates / tier_thresholds_jpy のインデックス順（LOWER / MIDDLE / UPPER）。
+const TIER_KEYS = ['lower', 'middle', 'upper'] as const
+// subscription_rates のキー（RiskMode 内部値）。
+const RISK_KEYS = ['conservative', 'balanced', 'aggressive'] as const
+
+function pct(rate: number): string {
+  // 0.003 → "0.3", 0.3 → "30"。金額計算ではなく表示用なので通常の丸めで良い。
+  return String(Number((rate * 100).toFixed(2)))
+}
+
+function jpy(v: number): string {
+  // ロケール非依存の表示（¥1,000,000）。i18n テンプレは前後の語だけを担う。
+  return `¥${Math.round(v).toLocaleString()}`
+}
+
+export default function FeePlanSection() {
+  const t = useTranslations('FeePricing')
+  const [config, setConfig] = useState<FeeConfig | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [failed, setFailed] = useState(false)
+
+  useEffect(() => {
+    let alive = true
+    apiFetch<FeeConfig>('/api/v1/fees/config')
+      .then((c) => {
+        if (alive) setConfig(c)
+      })
+      .catch(() => {
+        if (alive) setFailed(true)
+      })
+      .finally(() => {
+        if (alive) setLoading(false)
+      })
+    return () => {
+      alive = false
+    }
+  }, [])
+
+  if (loading) {
+    return <Skeleton className="h-56 rounded-xl bg-zinc-800" />
+  }
+
+  // fail-open: 料率が取れない場合はハードコードで代替せず、セクションごと非表示にする。
+  if (failed || !config) {
+    return null
+  }
+
+  return (
+    <Card className="bg-zinc-900 border-zinc-800">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base text-zinc-100">{t('title')}</CardTitle>
+        <p className="text-xs text-zinc-500 mt-1">{t('subtitle')}</p>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {/* 月額利用料（サブスク）: risk mode 別 */}
+        <section>
+          <h3 className="text-sm font-semibold text-zinc-200 mb-2">{t('subscriptionTitle')}</h3>
+          <div className="grid grid-cols-3 gap-2">
+            {RISK_KEYS.map((rk) => {
+              const rate = config.subscription_rates?.[rk]
+              return (
+                <div
+                  key={rk}
+                  className="rounded-lg border border-zinc-800 bg-zinc-950/40 px-3 py-2.5 text-center"
+                >
+                  <p className="text-xs text-zinc-500 mb-1">{t(`risk.${rk}`)}</p>
+                  <p className="text-sm font-semibold text-zinc-100">
+                    {rate == null ? '—' : `${pct(rate)}%`}
+                  </p>
+                  <p className="text-[10px] text-zinc-600 mt-0.5">{t('perMonthOfDeposit')}</p>
+                </div>
+              )
+            })}
+          </div>
+          <p className="text-xs text-zinc-500 mt-2">{t('subscriptionNote')}</p>
+        </section>
+
+        {/* 成功報酬: tier（預け入れ規模）別 */}
+        <section>
+          <h3 className="text-sm font-semibold text-zinc-200 mb-2">{t('performanceTitle')}</h3>
+          <div className="space-y-1.5">
+            {TIER_KEYS.map((tk, i) => {
+              const rate = config.tier_fee_rates?.[i]
+              const lowerBound = i === 0 ? 0 : config.tier_thresholds_jpy?.[i - 1]
+              const upperBound = config.tier_thresholds_jpy?.[i]
+              const range =
+                i === TIER_KEYS.length - 1
+                  ? t('depositFrom', { amount: jpy(lowerBound ?? 0) })
+                  : lowerBound === 0
+                    ? t('depositUpTo', { amount: jpy(upperBound ?? 0) })
+                    : t('depositRange', {
+                        from: jpy(lowerBound ?? 0),
+                        to: jpy(upperBound ?? 0),
+                      })
+              return (
+                <div
+                  key={tk}
+                  className="flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-950/40 px-3 py-2"
+                >
+                  <div>
+                    <p className="text-sm text-zinc-200">{t(`tier.${tk}`)}</p>
+                    <p className="text-[10px] text-zinc-600">{range}</p>
+                  </div>
+                  <p className="text-sm font-semibold text-zinc-100">
+                    {rate == null ? '—' : `${pct(rate)}%`}
+                  </p>
+                </div>
+              )
+            })}
+          </div>
+          <p className="text-xs text-zinc-500 mt-2">{t('performanceNote')}</p>
+        </section>
+
+        {/* 課金タイミング + 現在無料の明示 */}
+        <div className="rounded-lg border border-zinc-800 bg-zinc-950/40 px-3 py-2.5 space-y-1">
+          <p className="text-xs text-zinc-400">{t('billingNote')}</p>
+          <p className="text-xs text-amber-400/90">{t('notActiveNote')}</p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2578,6 +2578,30 @@
     "resumeWarning": "Note: If automated conditions (e.g., Health Factor) are not resolved, trading may stop again after resuming.",
     "resumeButton": "Resume"
   },
+  "FeePricing": {
+    "title": "Pricing",
+    "subtitle": "Breakdown of fees for managed operation.",
+    "subscriptionTitle": "Monthly fee (by operation mode)",
+    "subscriptionNote": "Calculated at month-end on your deposited amount at the rates above. The first month is free.",
+    "perMonthOfDeposit": "of deposit / month",
+    "risk": {
+      "conservative": "Conservative",
+      "balanced": "Balanced",
+      "aggressive": "Aggressive"
+    },
+    "performanceTitle": "Performance fee (on profit)",
+    "performanceNote": "Charged only when your operation is profitable, at a rate based on your deposit size.",
+    "tier": {
+      "lower": "Standard",
+      "middle": "Premium",
+      "upper": "Ultimate"
+    },
+    "depositUpTo": "Deposit up to {amount}",
+    "depositRange": "Deposit {from} – {to}",
+    "depositFrom": "Deposit {amount}+",
+    "billingNote": "Charged after month-end finalization.",
+    "notActiveNote": "Monthly fees are not currently charged (free). Before we begin, we will notify you and apply them only with your consent."
+  },
   "SharedBottomNav": {
     "adminNav": {
       "home": "Home",
@@ -2597,6 +2621,7 @@
     "viewerNav": {
       "home": "Home",
       "aiDecisions": "AI",
+      "fees": "Pricing",
       "help": "Help"
     }
   },

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -2595,6 +2595,30 @@
     "resumeWarning": "注意: Health Factor など自動条件が未改善の場合、再開後に再停止される可能性があります。",
     "resumeButton": "再開する"
   },
+  "FeePricing": {
+    "title": "料金プラン",
+    "subtitle": "運用にかかる費用の内訳です。",
+    "subscriptionTitle": "月額利用料（運用モード別）",
+    "subscriptionNote": "毎月末に、預け入れ額に対して上記の料率で計算されます。初月は無料です。",
+    "perMonthOfDeposit": "預け入れ額 / 月",
+    "risk": {
+      "conservative": "保守的",
+      "balanced": "バランス",
+      "aggressive": "積極的"
+    },
+    "performanceTitle": "成功報酬（運用益に対して）",
+    "performanceNote": "運用益（利益）が出た場合のみ、預け入れ規模に応じた料率がかかります。",
+    "tier": {
+      "lower": "スタンダード",
+      "middle": "プレミアム",
+      "upper": "アルティメット"
+    },
+    "depositUpTo": "預け入れ {amount} まで",
+    "depositRange": "預け入れ {from} 〜 {to}",
+    "depositFrom": "預け入れ {amount} 以上",
+    "billingNote": "課金は毎月末の確定後に行われます。",
+    "notActiveNote": "現在、月額利用料の徴収は行っておりません（無料）。開始時は事前に通知し、同意をいただいたうえで適用します。"
+  },
   "SharedBottomNav": {
     "adminNav": {
       "home": "ホーム",
@@ -2614,6 +2638,7 @@
     "viewerNav": {
       "home": "ホーム",
       "aiDecisions": "AI判定",
+      "fees": "料金",
       "help": "ヘルプ"
     }
   },


### PR DESCRIPTION
## 概要

消費者(VIEWER)向けに **「月額がいくら・成功報酬がいくら・いつ引かれるか」を事前に把握できる料金提示** を追加する。Asana B-1 のうち、安全な追加分（料金ページ + ナビ導線 + i18n）を先行実装し、リスクのある onboarding 同意ゲート統合と規約の法定文言化は後続 PR に分離した。

## 背景（探索で確定した現状）

- 料金データは `GET /api/v1/fees/config`（consumer-accessible）で取れるが、**消費者向けフロントラッパが未実装**だった。
- `/fees` ページ（`(user)` group）は事後表示（累計・履歴）のみで料金プランの事前提示が無く、**どのナビからも到達不能**だった。

## 変更内容

- **`components/user/FeePlanSection.tsx`（新設）**
  - 料率は `GET /api/v1/fees/config` から取得（**ハードコード禁止**）
  - 月額利用料（サブスク・運用モード別 0% / 0.3% / 1%）+ 成功報酬（Tier別 30% / 25% / 20% + 預け入れ規模レンジ）を表示
  - config 取得失敗時は **fail-open で当該セクション非表示**（ダミー値を出さない）
  - 徴収は現在停止中（`ENABLE_MONTHLY_FEE_BATCH=0`）のため「**現在は無料**」を明示（規約第7条と整合）
  - 文言はすべて i18n 経由で、**月利/月額表記は B-5 法務の結論を後差し替え可能**な構造
- **`(user)/fees/page.tsx`（URL `/fees`）** 冒頭に `FeePlanSection` を差し込み（既存の事後表示履歴は温存）
- **`BottomNav`** 消費者タブに「料金」→ `/fees` 導線を追加
- **i18n**: `FeePricing` namespace（ja/en 各18キー・parity一致）+ `SharedBottomNav.viewerNav.fees`

## 検証

- `tsc --noEmit` clean / `eslint` clean / `check-i18n-keys.mjs` 新規欠落なし
- **front↔back 契約を実機確認**: SQLite で `fee_config` を seed → register/login → `GET /api/v1/fees/config` が 200 で以下を返却、component の変換（`0.003`→`0.3%` 等）が正値を生成することを確認:
  ```
  tier_thresholds_jpy: [1000000, 10000000]
  tier_fee_rates:      [0.3, 0.25, 0.2]
  subscription_rates:  {conservative: 0.0, balanced: 0.003, aggressive: 0.01}
  ```
- ピクセル単位の見た目確認は staging（seed済 config + ログイン）推奨

## スコープ外（後続 PR）

- **onboarding/liff-confirm への月額同意ゲート統合** — クリティカルパス変更 + lockout リスク（$200ゲート #929 と同種）のため、慎重な fail-open 設計 + B-5 法務の文言確定を待って別 PR
- **規約第7条「現在無料」→ 実額の法定文言化** — B-5 規制トラック

🤖 Generated with [Claude Code](https://claude.com/claude-code)