### PR TITLE
feat(fees): B-3 決済手段UIの導線化 + 料率/課金日の文脈提示

### DIFF
--- a/frontend/app/(liff)/liff-fee-approve/page.tsx
+++ b/frontend/app/(liff)/liff-fee-approve/page.tsx
@@ -9,6 +9,7 @@
 import { useTranslations } from 'next-intl'
 import { useLiff } from '@/hooks/useLiff'
 import { FeeApproveCard } from '@/components/user/FeeApproveCard'
+import FeePlanSection from '@/components/user/FeePlanSection'
 import { BrowserLoginPrompt } from '../_components/BrowserLoginPrompt'
 
 export default function LiffFeeApprovePage() {
@@ -61,6 +62,10 @@ export default function LiffFeeApprovePage() {
         <p className="text-sm text-zinc-400 mt-1">
           {t('description')}
         </p>
+      </div>
+      {/* B-3: 承認前に料率・課金日・「現在は徴収なし」を提示 */}
+      <div className="mb-4">
+        <FeePlanSection />
       </div>
       <FeeApproveCard />
     </div>

--- a/frontend/app/(user)/fee-approve/page.tsx
+++ b/frontend/app/(user)/fee-approve/page.tsx
@@ -7,6 +7,7 @@
 // aToken allowance 承認ページ (PWA / デスクトップ)
 
 import dynamic from 'next/dynamic'
+import FeePlanSection from '@/components/user/FeePlanSection'
 
 const FeeApproveCard = dynamic(
   () => import('@/components/user/FeeApproveCard').then((m) => ({ default: m.FeeApproveCard })),
@@ -22,6 +23,8 @@ export default function FeeApprovePage() {
           月次手数料の自動徴収を有効にするための承認を行います
         </p>
       </div>
+      {/* B-3: 承認前に料率・課金日・「現在は徴収なし」を提示（孤立していた本ページに文脈を付与） */}
+      <FeePlanSection />
       <FeeApproveCard />
     </main>
   )

--- a/frontend/app/(user)/fees/page.tsx
+++ b/frontend/app/(user)/fees/page.tsx
@@ -186,7 +186,8 @@ function FeesContent() {
 
       <div className="space-y-4 px-4 py-4 pb-24 max-w-4xl mx-auto">
         {/* B-1: 料金プラン / Tier別月額の事前提示（config は独自に取得・独立描画） */}
-        <FeePlanSection />
+        {/* B-3: 決済手段（自動引き落とし）設定への導線もここから提示 */}
+        <FeePlanSection showPaymentLink />
 
         {loading && (
           <div className="space-y-3">

--- a/frontend/components/user/FeePlanSection.tsx
+++ b/frontend/components/user/FeePlanSection.tsx
@@ -10,6 +10,7 @@
 // 「現在は無料」である旨を notActiveNote で明示する（規約第7条と整合）。
 
 import { useEffect, useState } from 'react'
+import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { apiFetch } from '@/lib/api/client'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -36,7 +37,7 @@ function jpy(v: number): string {
   return `¥${Math.round(v).toLocaleString()}`
 }
 
-export default function FeePlanSection() {
+export default function FeePlanSection({ showPaymentLink = false }: { showPaymentLink?: boolean }) {
   const t = useTranslations('FeePricing')
   const [config, setConfig] = useState<FeeConfig | null>(null)
   const [loading, setLoading] = useState(true)
@@ -139,6 +140,16 @@ export default function FeePlanSection() {
           <p className="text-xs text-zinc-400">{t('billingNote')}</p>
           <p className="text-xs text-amber-400/90">{t('notActiveNote')}</p>
         </div>
+
+        {/* 決済手段（自動引き落とし = operator allowance 承認）への導線。/fees からのみ表示。 */}
+        {showPaymentLink && (
+          <Link
+            href="/fee-approve"
+            className="block w-full text-center rounded-lg border border-zinc-700 bg-zinc-800/60 px-3 py-2.5 text-sm text-zinc-200 hover:bg-zinc-800 transition-colors"
+          >
+            {t('setupPaymentLink')}
+          </Link>
+        )}
       </CardContent>
     </Card>
   )

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2600,7 +2600,8 @@
     "depositRange": "Deposit {from} – {to}",
     "depositFrom": "Deposit {amount}+",
     "billingNote": "Charged after month-end finalization.",
-    "notActiveNote": "Monthly fees are not currently charged (free). Before we begin, we will notify you and apply them only with your consent."
+    "notActiveNote": "Monthly fees are not currently charged (free). Before we begin, we will notify you and apply them only with your consent.",
+    "setupPaymentLink": "Set up payment method (auto-debit)"
   },
   "SharedBottomNav": {
     "adminNav": {

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -2617,7 +2617,8 @@
     "depositRange": "預け入れ {from} 〜 {to}",
     "depositFrom": "預け入れ {amount} 以上",
     "billingNote": "課金は毎月末の確定後に行われます。",
-    "notActiveNote": "現在、月額利用料の徴収は行っておりません（無料）。開始時は事前に通知し、同意をいただいたうえで適用します。"
+    "notActiveNote": "現在、月額利用料の徴収は行っておりません（無料）。開始時は事前に通知し、同意をいただいたうえで適用します。",
+    "setupPaymentLink": "お支払い方法（自動引き落とし）を設定する"
   },
   "SharedBottomNav": {
     "adminNav": {


### PR DESCRIPTION
## 概要

孤立していた手数料承認ページ（`/fee-approve`・`/liff-fee-approve` = operator allowance 承認 = 非カストディアルな月額徴収の**決済手段**）に、料率・課金日・「現在は徴収なし」の文脈を付与し、料金プラン画面から導線を張る。Asana B-3。「全て実装（弁護士レビュー用）」シリーズの **PR 3/3**。

## 背景

探索マップで判明: `/fee-approve` / `/liff-fee-approve` は **どのナビからも到達不能**、かつ **料率・課金日を非表示**で承認だけ求める孤立ページだった。

## 変更内容

- **`FeePlanSection`**: `showPaymentLink` prop 追加。`true` の時のみ `/fee-approve` への導線を表示（自己リンク回避のため fee-approve 側では非表示）
- **`/fees`**: `FeePlanSection` を `showPaymentLink` 付きで表示 → 決済手段設定への導線
- **`/fee-approve`（PWA）・`/liff-fee-approve`（LIFF）**: `FeeApproveCard` の前に `FeePlanSection` を差し込み、承認前に **料率・課金日・「現在は徴収なし（無料）」** を明示
- **i18n**: `FeePricing.setupPaymentLink`（ja/en）

## 安全性

- 料率は `GET /api/v1/fees/config` 由来（#931 の `FeePlanSection` 再利用・**ハードコードなし**）
- 実際の徴収は依然 OFF（`FEE_TRANSFER_ENABLED=false`）。allowance 承認しても operator は引き落とさない
- **挙動変化なし**（導線と文脈の追加のみ）

## 検証

- `tsc --noEmit` clean / `eslint` 0 error / `check-i18n-keys` 新規欠落なし（parity維持）

## シリーズ全体（弁護士レビュー用「全て実装」）

- #931 料金プラン提示UX（merged）
- #932 料金の実額開示 + 月額同意ゲート（liff-v4・レビュー中）
- **本PR** 決済手段UIの導線化 + 料率/課金日提示

> 実際の資金徴収の有効化（B-2）はスコープ外（money movement・Tier S・operator鍵未設定 → OFF 継続）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)