### PR TITLE
fix(audit): デプロイ前監査の修正（register_open 同意整合性 + テストフレーク + コメント）

### DIFF
--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -318,7 +318,12 @@ def register_open(
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
 
-    user.terms_version = _LIFF_TERMS_VERSION
+    # 一般登録の terms_consent は「一般利用規約 (CURRENT_TERMS_VERSION=2.0)」への同意。
+    # LIFF 固有の同意 (_LIFF_TERMS_VERSION=liff-v4, 月額利用料 monthly_fee 項目を含む) を
+    # ここでセットすると、LIFF 導線に入ったユーザーが /liff-confirm の項目別同意を一度も
+    # 見ないまま「liff-v4 同意済み」と記録されてしまう (同意整合性の欠落)。
+    # 一般規約版を記録し、LIFF 利用時は frontend terms gate (liff-v4 要求) が /liff-confirm へ誘導する。
+    user.terms_version = CURRENT_TERMS_VERSION
     user.terms_accepted_at = datetime.now(timezone.utc)
     db.add(user)
     db.commit()

--- a/backend/tests/test_deposit_gate_enforcement.py
+++ b/backend/tests/test_deposit_gate_enforcement.py
@@ -68,19 +68,27 @@ def client(test_db) -> TestClient:  # type: ignore[no-untyped-def]
     return TestClient(app)
 
 
-# 登録は INITIAL_ADMIN_EMAIL に一致する email のみ許可される (initial admin, first user)。
-# conftest が先に setdefault するため、実際に有効な値を runtime で読む。
-_ADMIN_EMAIL = os.environ.get("INITIAL_ADMIN_EMAIL", "gate_admin@example.com")
 _ADMIN_PASSWORD = "GateTestPass123!"
+
+
+def _admin_email() -> str:
+    """登録は「initial admin (first user) かつ email == 現在の INITIAL_ADMIN_EMAIL」のみ許可。
+
+    他テスト (例: test_api_v1_fees) が INITIAL_ADMIN_EMAIL を os.environ に上書きするため、
+    module import 時にキャプチャすると実行順序で register 403→login 401 になる。
+    必ず呼び出し時 (runtime) に現在値を読むこと。
+    """
+    return os.environ.get("INITIAL_ADMIN_EMAIL", "gate_admin@example.com")
 
 
 def _login(client: TestClient) -> str:
     """INITIAL_ADMIN_EMAIL ユーザー（admin ロール）を登録してトークン取得。"""
+    email = _admin_email()
     client.post(
         "/auth/register",
-        json={"email": _ADMIN_EMAIL, "username": "gate_admin", "password": _ADMIN_PASSWORD},
+        json={"email": email, "username": "gate_admin", "password": _ADMIN_PASSWORD},
     )
-    r = client.post("/auth/login", json={"email": _ADMIN_EMAIL, "password": _ADMIN_PASSWORD})
+    r = client.post("/auth/login", json={"email": email, "password": _ADMIN_PASSWORD})
     assert r.status_code == 200, f"login failed: {r.status_code} {r.text}"
     return str(r.json()["access_token"])
 
@@ -179,7 +187,7 @@ class TestApprovalDepositGate:
         """残高 $150 (<$200) で承認は 422 DEPOSIT_BELOW_MINIMUM（執行前に遮断）。"""
         _, engine = test_db
         token = _login(client)
-        uid = _user_id(engine, _ADMIN_EMAIL)
+        uid = _user_id(engine, _admin_email())
         pid = _create_pending_proposal(client, token, uid)
         with patch(_RESOLVER, return_value=Decimal("150")):
             r = client.post(f"/api/proposals/{pid}/approve", headers=_auth(token))
@@ -190,7 +198,7 @@ class TestApprovalDepositGate:
         """境界: $199.99 は承認 block。"""
         _, engine = test_db
         token = _login(client)
-        uid = _user_id(engine, _ADMIN_EMAIL)
+        uid = _user_id(engine, _admin_email())
         pid = _create_pending_proposal(client, token, uid)
         with patch(_RESOLVER, return_value=Decimal("199.99")):
             r = client.post(f"/api/proposals/{pid}/approve", headers=_auth(token))

--- a/backend/tests/test_open_registration.py
+++ b/backend/tests/test_open_registration.py
@@ -143,6 +143,29 @@ class TestOpenRegistrationAPI:
         assert data["role"] == "viewer"
         assert "access_token" in data
 
+    def test_register_open_records_general_terms_not_liff(self, client: TestClient) -> None:
+        """register-open は一般規約版 (CURRENT_TERMS_VERSION=2.0) を記録し LIFF 版を付与しない。
+
+        liff-v4 を付与すると、LIFF 導線に入ったユーザーが /liff-confirm の月額利用料
+        (monthly_fee) 項目別同意を一度も見ないまま「liff-v4 同意済み」と記録されてしまう
+        （同意整合性の欠落）。一般規約版なら LIFF terms gate が /liff-confirm へ誘導する。
+        """
+        resp = client.post(
+            "/auth/register-open",
+            json={
+                "email": "generalterms@example.com",
+                "username": "genterms",
+                "password": "Password123",
+                "terms_consent": True,
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        token = resp.json()["access_token"]
+        settings = client.get("/api/user/settings", headers={"Authorization": f"Bearer {token}"})
+        assert settings.status_code == 200
+        assert settings.json()["terms_version"] == "2.0"
+        assert settings.json()["terms_version"] != "liff-v4"
+
     def test_register_open_creates_audit_invitation(self, client: TestClient, test_db) -> None:
         """open 登録後に type='open' の監査レコードが invitations テーブルに作られる。"""
         _, engine = test_db

--- a/frontend/app/(liff)/layout.tsx
+++ b/frontend/app/(liff)/layout.tsx
@@ -69,7 +69,7 @@ const LiffInitError = withLiffLayoutIntl(LiffLayoutInitError)
 // - liff-sign-poc: 署名診断ページ (ログイン状態を意図的に表示する)
 const AUTH_GUARD_EXEMPT = ['/liff-login', '/liff-sign-poc']
 
-// 重要事項同意 (terms_version="liff-v3") を入口非依存で強制する BtoC 消費者ページ。
+// 重要事項同意 (terms_version="liff-v4") を入口非依存で強制する BtoC 消費者ページ。
 // リッチメニュー / ブックマーク等で直接アクセスされても、未同意なら /liff-confirm へ
 // 誘導する (法的同意の 1 経路依存を解消; Asana 1215360586206558)。
 // パートナー承認系 (liff-approve / liff-fee-approve 等) は別系統のため対象外。
@@ -85,7 +85,7 @@ export default function LiffLayout({ children }: { children: React.ReactNode }) 
   const reauth = useLiffAutoReAuth()
 
   // ── 重要事項同意ガード (入口非依存) ──
-  // token を持つ消費者が TERMS_GATE_PATHS に直接来た場合に、liff-v3 未同意なら
+  // token を持つ消費者が TERMS_GATE_PATHS に直接来た場合に、liff-v4 未同意なら
   // /liff-confirm へ送る。token が無い場合は下の auth guard 側に委ねる。
   const token = getAuthToken()
   const needsTermsGate =

--- a/frontend/hooks/useLiffTermsGate.ts
+++ b/frontend/hooks/useLiffTermsGate.ts
@@ -2,7 +2,7 @@
 // Unauthorized copying or distribution is strictly prohibited.
 // frontend/hooks/useLiffTermsGate.ts
 //
-// LIFF (BtoC 消費者) の重要事項同意 (terms_version="liff-v3") を入口非依存で
+// LIFF (BtoC 消費者) の重要事項同意 (terms_version="liff-v4") を入口非依存で
 // 強制するためのゲート判定フック。
 //
 // 背景 (Asana 1215360586206558):
@@ -47,8 +47,8 @@ export type LiffTermsGateState = "loading" | "accepted" | "not-accepted"
  * @param enabled          false の間はゲートを無効化し常に "accepted" を返す
  *                         (除外ページ / 未認証時に呼び出し側が無効化する)。
  * @param acceptedVersions 「同意済み」とみなすバージョン一覧。
- *                         デフォルト ['liff-v3'] — 既存 LIFF 呼び出しは引数省略で後方互換。
- *                         ブラウザ経路では ['liff-v3', '2.0'] を渡す。
+ *                         デフォルト ['liff-v4'] — 既存 LIFF 呼び出しは引数省略で後方互換。
+ *                         ブラウザ経路では ['liff-v3', 'liff-v4', '2.0'] を渡す。
  */
 export function useLiffTermsGate(
   enabled: boolean,


### PR DESCRIPTION
## 概要

デプロイ前の**網羅監査**（front↔back 契約 / 孤立コード / DB / 管理画面 / UI で見えない論理を read-only 監査エージェント4本 + 実機テストで検証）で検出した問題を修正。

**監査結論: ブロッキングな配線漏れ・孤立コード・DB 乖離・本番破壊リスクはゼロ。** 対応は以下2件（+コメント整合）のみ。

## 1. register_open の同意整合性ギャップ 🔴

`POST /auth/register-open` が新規ユーザーに `_LIFF_TERMS_VERSION`（`liff-v4`、月額利用料 `monthly_fee` 項目を含む）を自動付与していた。→ LIFF 導線に入ったユーザーが `/liff-confirm` の**項目別同意を一度も見ないまま「liff-v4 同意済み」と記録**される恐れ（#932 の法的目的を毀損）。

**修正**: 一般規約版 `CURRENT_TERMS_VERSION`（`2.0`）を記録。LIFF 利用時は frontend terms gate（`liff-v4` 要求）が `/liff-confirm` へ誘導する。回帰テスト `test_register_open_records_general_terms_not_liff` 追加。

> ※ `register_open` は `ENABLE_OPEN_REGISTRATION` 既定 off で通常到達不可だが、有効化時の同意整合性のため防御的に修正。

## 2. test_deposit_gate_enforcement.py の順序依存フレーク（CI 潜在フレーク）🟡

`INITIAL_ADMIN_EMAIL` を **module import 時にキャプチャ**していたため、他テスト（`test_api_v1_fees` が `os.environ` を上書き）の後に走ると register 403 → login 401 で **7件 fail**（単独実行では pass だったため #930 の CI をすり抜けていた）。

**修正**: 呼び出し時 runtime に読む。フルスイート（`-k fee/tier/terms/deposit/...`）が **7 failed → 0 failed（914 passed）**。

## 3. 陳腐化コメント整合

`useLiffTermsGate.ts` / `(liff)/layout.tsx` の `"liff-v3"` 記述を実挙動 `liff-v4` に整合（機能影響なし）。

## 検証

- backend ruff・mypy clean
- **フルスイート（fee/tier/terms/deposit/proposal/settings/billing/subscription/registration）: 914 passed / 8 skipped / 0 failed**（監査前は 7 failed）
- frontend tsc clean・eslint 0 error
- ゲート/徴収の**実挙動は不変**

## 監査で ✅ 確認できた主要項目（参考）

- front↔back API 契約 11/11 MATCH（パス・認証・レスポンスフィールド・Decimal ラップ）
- Design B 削除の dangling import ゼロ / tier 配線 / $200ゲート3経路 / 月額UI/同意 全配線済み
- DB スキーマ整合、**CHECK 制約 tier IN ('LOWER','MIDDLE','UPPER') が models と一致**（過去の LOW/MIDDLE/HIGH 乖離は再発なし）、`users.tier` に CHECK なし → MIDDLE/UPPER 書戻しで IntegrityError 出ない
- 徴収 OFF が二重ゲート（`FEE_TRANSFER_ENABLED=false` + `ENABLE_MONTHLY_FEE_BATCH=0`）、allowance 承認先行でも引き落とし不可
- 管理画面 fee-management は `require_admin` + フロント接続あり、viewer に admin 書込 UI 露出なし
- i18n 全キー ja/en 存在（MISSING_MESSAGE リスクなし）、pct(0)→"0%"（0-to-dash バグ不在）、RBAC 不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)