### PR TITLE
feat(privy): per-user privy_wallet_id 取得（非カストディアル SCW 執行の前提配線）

### DIFF
--- a/backend/alembic/versions/pw20260705_add_privy_wallet_id.py
+++ b/backend/alembic/versions/pw20260705_add_privy_wallet_id.py
@@ -1,0 +1,44 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+"""add_privy_wallet_id
+
+users に privy_wallet_id (Privy 内部 wallet ID・アドレスではない) を追加する。
+委譲(SCW)執行の Privy wallet_sendCalls (POST /v1/wallets/{id}/rpc) が要求する識別子で、
+wallet-connect 時に frontend の Privy SDK から受領して保存する。
+
+非破壊・追加のみ。NULL = 未取得 (旧ユーザー / 非 Privy 経路)。unique 制約なし
+(内部識別子であり検索キーにしないため。将来必要なら別 migration で index 追加)。
+
+参照: app/proposals/router.py _resolve_privy_wallet_id / app/proposals/scw_executor.py
+      （既存コードは user.privy_wallet_id を優先し、無ければ PRIVY_DELEGATED_WALLET_ID にフォールバック）
+
+Revision ID: pw20260705
+Revises: pp20260624
+Create Date: 2026-07-05 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "pw20260705"
+down_revision: Union[str, Sequence[str], None] = "pp20260624"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add privy_wallet_id column to users table."""
+    op.add_column(
+        "users",
+        sa.Column("privy_wallet_id", sa.String(length=64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Remove privy_wallet_id column from users table."""
+    op.drop_column("users", "privy_wallet_id")

--- a/backend/app/auth/models.py
+++ b/backend/app/auth/models.py
@@ -278,9 +278,7 @@ class User(Base):
     # POST /v1/wallets/{id}/rpc で要求する識別子。wallet-connect 時に frontend の Privy SDK から
     # 受領して保存する。NULL = 未取得 (旧ユーザー / 非 Privy 経路)。
     # 参照: app/proposals/router.py _resolve_privy_wallet_id / app/proposals/scw_executor.py
-    privy_wallet_id: Mapped[Optional[str]] = mapped_column(
-        String(64), nullable=True, default=None
-    )
+    privy_wallet_id: Mapped[Optional[str]] = mapped_column(String(64), nullable=True, default=None)
     invited_by: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("users.id"), nullable=True, default=None
     )

--- a/backend/app/auth/models.py
+++ b/backend/app/auth/models.py
@@ -274,6 +274,13 @@ class User(Base):
     privy_did: Mapped[Optional[str]] = mapped_column(
         String(255), unique=True, nullable=True, index=True, default=None
     )
+    # Privy 内部 wallet ID (アドレスではない)。委譲(SCW)執行の Privy wallet_sendCalls が
+    # POST /v1/wallets/{id}/rpc で要求する識別子。wallet-connect 時に frontend の Privy SDK から
+    # 受領して保存する。NULL = 未取得 (旧ユーザー / 非 Privy 経路)。
+    # 参照: app/proposals/router.py _resolve_privy_wallet_id / app/proposals/scw_executor.py
+    privy_wallet_id: Mapped[Optional[str]] = mapped_column(
+        String(64), nullable=True, default=None
+    )
     invited_by: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("users.id"), nullable=True, default=None
     )

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -730,6 +730,21 @@ def wallet_connect(
                     detail="DID backfill failed",
                 ) from exc
 
+    # Privy 内部 wallet ID を保存 (委譲 SCW 執行用)。frontend の Privy SDK から受領。
+    # 執行にのみ使う識別子で login の必須要件ではないため、失敗しても login は止めない (best-effort)。
+    if request.privy_wallet_id and user.privy_wallet_id != request.privy_wallet_id:
+        try:
+            user.privy_wallet_id = request.privy_wallet_id
+            db.add(user)
+            db.commit()
+            db.refresh(user)
+        except Exception:  # noqa: BLE001
+            db.rollback()
+            logger.warning(
+                "privy_wallet_id store failed (non-fatal): wallet=%s...",
+                request.wallet_address[:10],
+            )
+
     token, expires_in = AuthService.create_access_token(
         user_id=user.id,
         email=user.email,

--- a/backend/app/auth/schemas.py
+++ b/backend/app/auth/schemas.py
@@ -296,6 +296,11 @@ class WalletConnectRequest(BaseModel):
         max_length=4096,
         description="Privy ID token (JWT). 提供時はサーバーで検証し sub == privy_did を確認する。",
     )
+    # Privy 内部 wallet ID (アドレスではない)。委譲(SCW)執行の wallet_sendCalls が要求する識別子。
+    # frontend の Privy SDK が保持する値を送る。非機密 (識別子のみ)。
+    privy_wallet_id: Optional[str] = Field(
+        None, max_length=64, description="Privy internal wallet ID (for delegated SCW execution)"
+    )
 
 
 class WalletConnectResponse(BaseModel):

--- a/backend/tests/auth/test_wallet_connect.py
+++ b/backend/tests/auth/test_wallet_connect.py
@@ -205,6 +205,45 @@ class TestWalletConnect:
         assert data["token_type"] == "bearer"
         assert data["is_new_user"] is True
 
+    def test_wallet_connect_stores_privy_wallet_id(self, client: TestClient, test_db) -> None:  # type: ignore[no-untyped-def]
+        """privy_wallet_id を送ると user に保存される (委譲 SCW 執行用)。"""
+        from sqlalchemy import select as _select
+
+        from app.auth.models import User as _User
+
+        _, engine = test_db
+        payload = self._make_valid_request()
+        payload["privy_wallet_id"] = "abc123privywalletid"
+        resp = client.post("/auth/wallet/connect", json=payload)
+        assert resp.status_code == 200, resp.text
+
+        with sessionmaker(bind=engine)() as s:
+            user = s.scalar(_select(_User).where(_User.privy_wallet_id == "abc123privywalletid"))
+        assert user is not None
+        assert user.privy_wallet_id == "abc123privywalletid"
+
+    def test_wallet_connect_backfills_privy_wallet_id_on_reconnect(
+        self, client: TestClient, test_db
+    ) -> None:  # type: ignore[no-untyped-def]
+        """既存ユーザーが後から privy_wallet_id 付きで再接続すると backfill される。"""
+        from sqlalchemy import select as _select
+
+        from app.auth.models import User as _User
+
+        _, engine = test_db
+        # 1回目: privy_wallet_id なし
+        client.post("/auth/wallet/connect", json=self._make_valid_request())
+        # 2回目: privy_wallet_id あり
+        payload = self._make_valid_request()
+        payload["privy_wallet_id"] = "wallet-id-backfilled"
+        resp = client.post("/auth/wallet/connect", json=payload)
+        assert resp.status_code == 200, resp.text
+
+        with sessionmaker(bind=engine)() as s:
+            user = s.scalar(_select(_User).where(_User.privy_wallet_id == "wallet-id-backfilled"))
+        assert user is not None
+        assert user.privy_wallet_id == "wallet-id-backfilled"
+
     def test_wallet_connect_new_user_needs_terms(self, client: TestClient):
         """新規ユーザーは needs_terms_acceptance = True になること。"""
         payload = self._make_valid_request()


### PR DESCRIPTION
## 概要

テスターの **非カストディアル SCW 執行**（本番同様フロー）を可能にするための前提配線。委譲(SCW)執行の Privy `wallet_sendCalls`（`POST /v1/wallets/{id}/rpc`）は **各ユーザーの Privy 内部 wallet ID** を要するが、`users` にその列が無く resolve できなかった。

`_resolve_privy_wallet_id` は `user.privy_wallet_id` を優先する作りだが、列が無いため常に `PRIVY_DELEGATED_WALLET_ID`（単一 spike wallet）へフォールバックしていた → マルチテスター執行不可。

## 変更内容

- `users.privy_wallet_id` 列追加（`String(64)` nullable、migration `pw20260705`、head=`pp20260624`）
- `WalletConnectRequest` に `privy_wallet_id` フィールド追加（frontend の Privy SDK が送る想定）
- `/auth/wallet/connect`: 新規/既存(backfill) 両方で **best-effort 保存**（失敗しても login は止めない=非致命）
- `test_wallet_connect.py` に保存/backfill テスト2件追加

`_resolve_privy_wallet_id` は `user.privy_wallet_id` を優先するため、**列が埋まれば自動でマルチユーザー SCW 執行に切り替わる**（執行コードの変更不要）。

## 検証

- `test_wallet_connect.py` **29 passed**（新規2件含む）
- ruff・mypy clean
- models.py 変更に対応する migration を追加済み → alembic 必須化チェック pass

## この配線の位置づけ（B→A の A トラック）

staging-v4 で確認済みの状態:
- ✅ 委譲署名基盤（`is_delegation_policy_enabled()=True`）
- ✅ gas sponsorship（App pays + Base Sepolia）
- ✅ 委譲 grant endpoint / SCW executor コード
- **本PR: per-user privy_wallet_id 取得（前提の最後のピース）**

## スコープ外（後続・要 live 検証）

- **frontend が privy_wallet_id を送る実装** — embedded EOA と SCW のどちらの wallet ID を `sendCalls` が要求するかは**実機 Privy で確認**が必要
- **実 Privy オンボーディングでの testnet 執行実証** — 現 staging-v4 のテストユーザーは `privy_did` 未設定（非 Privy）のため、実際の執行検証には実ログインが必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)