### PR TITLE
feat(ai): Indicator Agentに価格モメンタムシグナルを追加(HOLD脱却A)

### DIFF
--- a/backend/app/ai/agents.py
+++ b/backend/app/ai/agents.py
@@ -19,6 +19,7 @@ No side effects, no state, easily testable.
 """
 
 import logging
+import os
 from decimal import ROUND_HALF_UP, Decimal
 from enum import Enum
 from typing import ClassVar, Optional
@@ -28,6 +29,7 @@ from pydantic import BaseModel, Field
 from app.ai.judgment_log import CognitiveState
 from app.ai.schemas import AgentContribution, DeterministicVerdict, TradeAction
 from app.data_feeds.context import MarketContext
+from app.data_feeds.mmt_feed import MMTCandle
 
 logger = logging.getLogger(__name__)
 
@@ -443,6 +445,38 @@ def resolve_llm_and_deterministic(
 # ============================================================
 # Specialist Agents (pure functions — no side effects)
 # ============================================================
+def _indicator_momentum_enabled() -> bool:
+    """価格モメンタムシグナルのkill switch(既定OFF)。
+
+    AI判定コアの新規シグナルのため、staging soak確認後に人間が明示的に
+    AI_INDICATOR_MOMENTUM_ENABLED=true を設定するまでは無効(既存動作と不変)。
+    異常発生時は env を戻すだけで即無効化できる(再デプロイ不要)。
+    """
+    return os.getenv("AI_INDICATOR_MOMENTUM_ENABLED", "false").strip().lower() == "true"
+
+
+def _compute_price_momentum(candles: dict[str, list[MMTCandle]]) -> Optional[Decimal]:
+    """MMT candles(1h足、直近24h)からシンボル横断の平均価格モメンタム(%)を計算する。
+
+    各シンボルごとに (最新close - 最古close) / 最古close * 100 を計算し、
+    有効なシンボルの単純平均を返す。close欠損・データ不足のシンボルはスキップし、
+    有効なシンボルが1つもなければ None を返す(呼び出し側で今までと同じ挙動=fail-open)。
+    """
+    symbol_momenta: list[Decimal] = []
+    for symbol_candles in candles.values():
+        if len(symbol_candles) < 2:
+            continue
+        oldest_close = symbol_candles[0].close
+        latest_close = symbol_candles[-1].close
+        if oldest_close is None or latest_close is None or oldest_close == 0:
+            continue
+        symbol_momenta.append((latest_close - oldest_close) / oldest_close * Decimal(100))
+
+    if not symbol_momenta:
+        return None
+    return sum(symbol_momenta) / Decimal(len(symbol_momenta))
+
+
 def indicator_agent(ctx: MarketContext) -> AgentSignal:
     """Analyze Aave on-chain indicators (utilization, APY, HF).
 
@@ -521,6 +555,23 @@ def indicator_agent(ctx: MarketContext) -> AgentSignal:
         elif apy_float < 1:
             score -= 6
             reasons.append(f"Supply APY at {supply_apy}% — yield compressed, weak demand")
+
+    if _indicator_momentum_enabled() and ctx.mmt_data is not None and ctx.mmt_data.candles:
+        momentum_pct = _compute_price_momentum(ctx.mmt_data.candles)
+        if momentum_pct is not None:
+            key_data["price_momentum_24h_pct"] = str(momentum_pct)
+            if momentum_pct >= 5:
+                score += 15
+                reasons.append(f"24h price momentum +{momentum_pct:.1f}% — strong upward move")
+            elif momentum_pct >= 2:
+                score += 8
+                reasons.append(f"24h price momentum +{momentum_pct:.1f}% — mild upward move")
+            elif momentum_pct <= -5:
+                score -= 15
+                reasons.append(f"24h price momentum {momentum_pct:.1f}% — strong downward move")
+            elif momentum_pct <= -2:
+                score -= 8
+                reasons.append(f"24h price momentum {momentum_pct:.1f}% — mild downward move")
 
     if score >= 65:
         bias = Bias.BULLISH

--- a/backend/app/ai/agents.py
+++ b/backend/app/ai/agents.py
@@ -29,7 +29,6 @@ from pydantic import BaseModel, Field
 from app.ai.judgment_log import CognitiveState
 from app.ai.schemas import AgentContribution, DeterministicVerdict, TradeAction
 from app.data_feeds.context import MarketContext
-from app.data_feeds.mmt_feed import MMTCandle
 
 logger = logging.getLogger(__name__)
 
@@ -446,35 +445,13 @@ def resolve_llm_and_deterministic(
 # Specialist Agents (pure functions — no side effects)
 # ============================================================
 def _indicator_momentum_enabled() -> bool:
-    """価格モメンタムシグナルのkill switch(既定OFF)。
+    """価格テクニカルシグナルのkill switch(既定OFF)。
 
     AI判定コアの新規シグナルのため、staging soak確認後に人間が明示的に
     AI_INDICATOR_MOMENTUM_ENABLED=true を設定するまでは無効(既存動作と不変)。
     異常発生時は env を戻すだけで即無効化できる(再デプロイ不要)。
     """
     return os.getenv("AI_INDICATOR_MOMENTUM_ENABLED", "false").strip().lower() == "true"
-
-
-def _compute_price_momentum(candles: dict[str, list[MMTCandle]]) -> Optional[Decimal]:
-    """MMT candles(1h足、直近24h)からシンボル横断の平均価格モメンタム(%)を計算する。
-
-    各シンボルごとに (最新close - 最古close) / 最古close * 100 を計算し、
-    有効なシンボルの単純平均を返す。close欠損・データ不足のシンボルはスキップし、
-    有効なシンボルが1つもなければ None を返す(呼び出し側で今までと同じ挙動=fail-open)。
-    """
-    symbol_momenta: list[Decimal] = []
-    for symbol_candles in candles.values():
-        if len(symbol_candles) < 2:
-            continue
-        oldest_close = symbol_candles[0].close
-        latest_close = symbol_candles[-1].close
-        if oldest_close is None or latest_close is None or oldest_close == 0:
-            continue
-        symbol_momenta.append((latest_close - oldest_close) / oldest_close * Decimal(100))
-
-    if not symbol_momenta:
-        return None
-    return sum(symbol_momenta) / Decimal(len(symbol_momenta))
 
 
 def indicator_agent(ctx: MarketContext) -> AgentSignal:
@@ -556,22 +533,14 @@ def indicator_agent(ctx: MarketContext) -> AgentSignal:
             score -= 6
             reasons.append(f"Supply APY at {supply_apy}% — yield compressed, weak demand")
 
-    if _indicator_momentum_enabled() and ctx.mmt_data is not None and ctx.mmt_data.candles:
-        momentum_pct = _compute_price_momentum(ctx.mmt_data.candles)
-        if momentum_pct is not None:
-            key_data["price_momentum_24h_pct"] = str(momentum_pct)
-            if momentum_pct >= 5:
-                score += 15
-                reasons.append(f"24h price momentum +{momentum_pct:.1f}% — strong upward move")
-            elif momentum_pct >= 2:
-                score += 8
-                reasons.append(f"24h price momentum +{momentum_pct:.1f}% — mild upward move")
-            elif momentum_pct <= -5:
-                score -= 15
-                reasons.append(f"24h price momentum {momentum_pct:.1f}% — strong downward move")
-            elif momentum_pct <= -2:
-                score -= 8
-                reasons.append(f"24h price momentum {momentum_pct:.1f}% — mild downward move")
+    if _indicator_momentum_enabled() and ctx.technical_signal is not None:
+        key_data["technical_signal"] = ctx.technical_signal
+        if ctx.technical_signal == "BUY_LEAN":
+            score += 15
+            reasons.append("Technical signal (RSI+MA cross): BUY_LEAN — momentum favors upside")
+        elif ctx.technical_signal == "SELL_LEAN":
+            score -= 15
+            reasons.append("Technical signal (RSI+MA cross): SELL_LEAN — momentum favors downside")
 
     if score >= 65:
         bias = Bias.BULLISH

--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -770,6 +770,23 @@ def run_ai_judgment_job(db: Optional[Session] = None) -> dict[str, Any]:
             logger.warning("GHO borrow signal fetch failed (fail-open, ignored): %s", exc)
             gho_signal = None
 
+        # 価格テクニカルシグナル（RSI+MAクロス、Indicator Agent の momentum kill switch
+        # 有効時のみスコアに反映）。独立した try/except に隔離し、失敗しても他の
+        # market_ctx 構築には一切影響させない（fail-open。run_prefilter 自体も
+        # 内部でOHLCV取得失敗をINSUFFICIENT_DATAとしてfail-open実装済み）。
+        technical_signal: Optional[str] = None
+        try:
+            from app.ai.prefilter import run_prefilter  # noqa: PLC0415
+            from app.exchange.client import BybitSandboxClient  # noqa: PLC0415
+
+            prefilter_result = run_prefilter(BybitSandboxClient(), symbol="BTC/USDT")
+            technical_signal = prefilter_result.signal
+        except Exception as exc:
+            logger.warning(
+                "Technical signal (prefilter) fetch failed (fail-open, ignored): %s", exc
+            )
+            technical_signal = None
+
         try:
             aave_data = fetch_aave_market_data_safe()
             cognitive_state = get_judgment_logger().get_cognitive_state()
@@ -780,6 +797,7 @@ def run_ai_judgment_job(db: Optional[Session] = None) -> dict[str, Any]:
                 health_factor=aave_data["health_factor"],
                 cognitive_state=cognitive_state,
                 gho_borrow_signal=gho_signal,
+                technical_signal=technical_signal,
             )
         except Exception as exc:
             context_degraded = True

--- a/backend/app/data_feeds/context.py
+++ b/backend/app/data_feeds/context.py
@@ -64,6 +64,12 @@ class MarketContext(BaseModel):
     # プロンプト注入は Phase 2（別PR、本番soak確認後）で追加する。
     gho_borrow_signal: Optional[str] = None
 
+    # 価格テクニカルシグナル（RSI+MAクロス、app.ai.prefilter.run_prefilter 由来）。
+    # "BUY_LEAN" | "SELL_LEAN" | "NEUTRAL" | "INSUFFICIENT_DATA" | None（未取得時、fail-open）。
+    # Indicator Agent の kill switch(AI_INDICATOR_MOMENTUM_ENABLED)が有効な場合のみ
+    # スコアに反映される（agents.py 参照）。
+    technical_signal: Optional[str] = None
+
     # Metadata
     collected_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
@@ -107,6 +113,9 @@ class MarketContext(BaseModel):
             mmt_section = self.mmt_data.to_prompt_section()
             if mmt_section:
                 parts.append(mmt_section)
+
+        if self.technical_signal is not None and self.technical_signal != "INSUFFICIENT_DATA":
+            parts.append(f"[Technical Signal] {self.technical_signal}")
 
         return "\n".join(parts)
 

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -4,6 +4,8 @@
 
 from decimal import Decimal
 
+import pytest
+
 from app.ai.agents import (
     AgentSignal,
     Bias,
@@ -18,7 +20,16 @@ from app.ai.judgment_log import CognitiveState
 from app.data_feeds.context import build_market_context
 from app.data_feeds.finance_feed import FinanceFeedResult
 from app.data_feeds.geopolitical import GeoRiskResult
+from app.data_feeds.mmt_feed import MMTCandle, MMTData
 from app.data_feeds.news_feed import NewsFeedResult
+
+
+def _candles(symbol: str, oldest_close: Decimal, latest_close: Decimal) -> list[MMTCandle]:
+    """2本のcandleでmomentum計算に必要な最小データを組み立てるテストヘルパー。"""
+    return [
+        MMTCandle(symbol=symbol, exchange="binancef", close=oldest_close, timestamp=1000),
+        MMTCandle(symbol=symbol, exchange="binancef", close=latest_close, timestamp=4600),
+    ]
 
 
 class TestIndicatorAgent:
@@ -171,6 +182,85 @@ class TestIndicatorAgent:
         assert sig_inf.bias == Bias.BULLISH, (
             f"inf シナリオは BULLISH になるべき (got {sig_inf.bias})"
         )
+
+    # ------------------------------------------------------------------
+    # Price momentum signal (2026-07-06 — HOLD脱却プロジェクト A)
+    # kill switch AI_INDICATOR_MOMENTUM_ENABLED は既定OFF。
+    # ------------------------------------------------------------------
+
+    def test_momentum_disabled_by_default_is_a_noop(self) -> None:
+        """flag未設定(既定false)なら candles があってもスコアは不変であること。"""
+        mmt_data = MMTData(candles={"btc/usd": _candles("btc/usd", Decimal(100), Decimal(105))})
+        ctx_with_momentum = build_market_context(
+            health_factor=Decimal("2.6"),
+            aave_utilization_rate=Decimal("75"),
+            mmt_data=mmt_data,
+        )
+        ctx_without_momentum = build_market_context(
+            health_factor=Decimal("2.6"),
+            aave_utilization_rate=Decimal("75"),
+        )
+        sig_with = indicator_agent(ctx_with_momentum)
+        sig_without = indicator_agent(ctx_without_momentum)
+        assert sig_with.confidence == sig_without.confidence
+        assert sig_with.bias == sig_without.bias
+        assert "price_momentum_24h_pct" not in sig_with.key_data
+
+    def test_momentum_disabled_when_mmt_data_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """flag ONでも mmt_data=None(フィード未取得)なら fail-open で不変であること。"""
+        monkeypatch.setenv("AI_INDICATOR_MOMENTUM_ENABLED", "true")
+        ctx = build_market_context(
+            health_factor=Decimal("2.6"), aave_utilization_rate=Decimal("75")
+        )
+        signal = indicator_agent(ctx)
+        assert "price_momentum_24h_pct" not in signal.key_data
+
+    def test_bullish_momentum_pushes_stuck_confidence_over_70(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """本番実測(HF=2.6/util=75→score68/conf66%)が+5%モメンタムで70超えを確認。
+
+        docs記載の「あと2ptでHOLD固着」ケースを再現し、momentum追加で
+        v4/v5 AND-conditionの閾値(confidence>=70)を実際に越えられることを検証する。
+        """
+        monkeypatch.setenv("AI_INDICATOR_MOMENTUM_ENABLED", "true")
+        mmt_data = MMTData(candles={"btc/usd": _candles("btc/usd", Decimal(100), Decimal(105))})
+        base_ctx = build_market_context(
+            health_factor=Decimal("2.6"), aave_utilization_rate=Decimal("75")
+        )
+        boosted_ctx = build_market_context(
+            health_factor=Decimal("2.6"),
+            aave_utilization_rate=Decimal("75"),
+            mmt_data=mmt_data,
+        )
+        base_signal = indicator_agent(base_ctx)
+        boosted_signal = indicator_agent(boosted_ctx)
+        assert base_signal.confidence < 70, (
+            f"前提が崩れている(momentum無しで既に70超え): {base_signal.confidence}"
+        )
+        assert boosted_signal.bias == Bias.BULLISH
+        assert boosted_signal.confidence >= 70
+        assert Decimal(boosted_signal.key_data["price_momentum_24h_pct"]) == Decimal("5")
+
+    def test_bearish_momentum_flips_neutral_to_bearish(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """NEUTRAL(score40)が-5%モメンタムでBEARISH/confidence>=70に転じることを確認。"""
+        monkeypatch.setenv("AI_INDICATOR_MOMENTUM_ENABLED", "true")
+        mmt_data = MMTData(candles={"eth/usd": _candles("eth/usd", Decimal(100), Decimal(95))})
+        base_ctx = build_market_context(
+            health_factor=Decimal("1.85"), aave_utilization_rate=Decimal("75")
+        )
+        boosted_ctx = build_market_context(
+            health_factor=Decimal("1.85"),
+            aave_utilization_rate=Decimal("75"),
+            mmt_data=mmt_data,
+        )
+        base_signal = indicator_agent(base_ctx)
+        boosted_signal = indicator_agent(boosted_ctx)
+        assert base_signal.bias == Bias.NEUTRAL
+        assert boosted_signal.bias == Bias.BEARISH
+        assert boosted_signal.confidence >= 70
 
 
 class TestPatternAgent:

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -20,16 +20,7 @@ from app.ai.judgment_log import CognitiveState
 from app.data_feeds.context import build_market_context
 from app.data_feeds.finance_feed import FinanceFeedResult
 from app.data_feeds.geopolitical import GeoRiskResult
-from app.data_feeds.mmt_feed import MMTCandle, MMTData
 from app.data_feeds.news_feed import NewsFeedResult
-
-
-def _candles(symbol: str, oldest_close: Decimal, latest_close: Decimal) -> list[MMTCandle]:
-    """2本のcandleでmomentum計算に必要な最小データを組み立てるテストヘルパー。"""
-    return [
-        MMTCandle(symbol=symbol, exchange="binancef", close=oldest_close, timestamp=1000),
-        MMTCandle(symbol=symbol, exchange="binancef", close=latest_close, timestamp=4600),
-    ]
 
 
 class TestIndicatorAgent:
@@ -184,83 +175,92 @@ class TestIndicatorAgent:
         )
 
     # ------------------------------------------------------------------
-    # Price momentum signal (2026-07-06 — HOLD脱却プロジェクト A)
+    # Technical (price momentum) signal (2026-07-06 — HOLD脱却プロジェクト A)
+    # RSI+MAクロス(app.ai.prefilter.run_prefilter)由来。
     # kill switch AI_INDICATOR_MOMENTUM_ENABLED は既定OFF。
     # ------------------------------------------------------------------
 
-    def test_momentum_disabled_by_default_is_a_noop(self) -> None:
-        """flag未設定(既定false)なら candles があってもスコアは不変であること。"""
-        mmt_data = MMTData(candles={"btc/usd": _candles("btc/usd", Decimal(100), Decimal(105))})
-        ctx_with_momentum = build_market_context(
+    def test_technical_signal_disabled_by_default_is_a_noop(self) -> None:
+        """flag未設定(既定false)なら technical_signal があってもスコアは不変であること。"""
+        ctx_with_signal = build_market_context(
             health_factor=Decimal("2.6"),
             aave_utilization_rate=Decimal("75"),
-            mmt_data=mmt_data,
+            technical_signal="BUY_LEAN",
         )
-        ctx_without_momentum = build_market_context(
+        ctx_without_signal = build_market_context(
             health_factor=Decimal("2.6"),
             aave_utilization_rate=Decimal("75"),
         )
-        sig_with = indicator_agent(ctx_with_momentum)
-        sig_without = indicator_agent(ctx_without_momentum)
+        sig_with = indicator_agent(ctx_with_signal)
+        sig_without = indicator_agent(ctx_without_signal)
         assert sig_with.confidence == sig_without.confidence
         assert sig_with.bias == sig_without.bias
-        assert "price_momentum_24h_pct" not in sig_with.key_data
+        assert "technical_signal" not in sig_with.key_data
 
-    def test_momentum_disabled_when_mmt_data_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """flag ONでも mmt_data=None(フィード未取得)なら fail-open で不変であること。"""
+    def test_technical_signal_noop_when_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """flag ONでも technical_signal=None(取得失敗)なら fail-open で不変であること。"""
         monkeypatch.setenv("AI_INDICATOR_MOMENTUM_ENABLED", "true")
         ctx = build_market_context(
             health_factor=Decimal("2.6"), aave_utilization_rate=Decimal("75")
         )
         signal = indicator_agent(ctx)
-        assert "price_momentum_24h_pct" not in signal.key_data
+        assert "technical_signal" not in signal.key_data
 
-    def test_bullish_momentum_pushes_stuck_confidence_over_70(
+    def test_buy_lean_pushes_stuck_confidence_over_70(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """本番実測(HF=2.6/util=75→score68/conf66%)が+5%モメンタムで70超えを確認。
+        """本番実測(HF=2.6/util=75→score68/conf66%)がBUY_LEANで70超えを確認。
 
-        docs記載の「あと2ptでHOLD固着」ケースを再現し、momentum追加で
+        docs記載の「あと2ptでHOLD固着」ケースを再現し、テクニカルシグナル追加で
         v4/v5 AND-conditionの閾値(confidence>=70)を実際に越えられることを検証する。
         """
         monkeypatch.setenv("AI_INDICATOR_MOMENTUM_ENABLED", "true")
-        mmt_data = MMTData(candles={"btc/usd": _candles("btc/usd", Decimal(100), Decimal(105))})
         base_ctx = build_market_context(
             health_factor=Decimal("2.6"), aave_utilization_rate=Decimal("75")
         )
         boosted_ctx = build_market_context(
             health_factor=Decimal("2.6"),
             aave_utilization_rate=Decimal("75"),
-            mmt_data=mmt_data,
+            technical_signal="BUY_LEAN",
         )
         base_signal = indicator_agent(base_ctx)
         boosted_signal = indicator_agent(boosted_ctx)
         assert base_signal.confidence < 70, (
-            f"前提が崩れている(momentum無しで既に70超え): {base_signal.confidence}"
+            f"前提が崩れている(シグナル無しで既に70超え): {base_signal.confidence}"
         )
         assert boosted_signal.bias == Bias.BULLISH
         assert boosted_signal.confidence >= 70
-        assert Decimal(boosted_signal.key_data["price_momentum_24h_pct"]) == Decimal("5")
+        assert boosted_signal.key_data["technical_signal"] == "BUY_LEAN"
 
-    def test_bearish_momentum_flips_neutral_to_bearish(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """NEUTRAL(score40)が-5%モメンタムでBEARISH/confidence>=70に転じることを確認。"""
+    def test_sell_lean_flips_neutral_to_bearish(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """NEUTRAL(score40)がSELL_LEANでBEARISH/confidence>=70に転じることを確認。"""
         monkeypatch.setenv("AI_INDICATOR_MOMENTUM_ENABLED", "true")
-        mmt_data = MMTData(candles={"eth/usd": _candles("eth/usd", Decimal(100), Decimal(95))})
         base_ctx = build_market_context(
             health_factor=Decimal("1.85"), aave_utilization_rate=Decimal("75")
         )
         boosted_ctx = build_market_context(
             health_factor=Decimal("1.85"),
             aave_utilization_rate=Decimal("75"),
-            mmt_data=mmt_data,
+            technical_signal="SELL_LEAN",
         )
         base_signal = indicator_agent(base_ctx)
         boosted_signal = indicator_agent(boosted_ctx)
         assert base_signal.bias == Bias.NEUTRAL
         assert boosted_signal.bias == Bias.BEARISH
         assert boosted_signal.confidence >= 70
+
+    def test_insufficient_data_signal_is_a_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """technical_signal="INSUFFICIENT_DATA"(prefilterのfail-open値)はスコア不変であること。"""
+        monkeypatch.setenv("AI_INDICATOR_MOMENTUM_ENABLED", "true")
+        base_ctx = build_market_context(
+            health_factor=Decimal("2.6"), aave_utilization_rate=Decimal("75")
+        )
+        ctx = build_market_context(
+            health_factor=Decimal("2.6"),
+            aave_utilization_rate=Decimal("75"),
+            technical_signal="INSUFFICIENT_DATA",
+        )
+        assert indicator_agent(ctx).confidence == indicator_agent(base_ctx).confidence
 
 
 class TestPatternAgent:


### PR DESCRIPTION
## Summary
- 本番AIのBUY/SELLを実質決めているv4/v5 AND-gate(`service.py:277-333`)は Indicator Agent 単独 confidence>=70% が最大のボトルネック。今週の本番実データ(7日/41件)でも Aave プール状態(HF/util/APY)のみのスコアではconfidence 43-51%(indicator単体では score68/conf66%相当)で終始HOLD・proposal生成ゼロが継続(Asana親 1216148382446630)。
- 当初はMMT(mmt.gg)の候補データ(`mmt_data`)を使う設計だったが、MMTは本番/staging-v4ともAPIキー未設定で、有効化にはBasicプランでも$199/moの新規契約が必要と判明。今回の用途(BTC/USDT24hモメンタム)には過剰なためユーザー判断で見送り。
- 代わりに **既存のBybit/ccxtクライアント**(`backend/app/exchange/client.py`)+ **既に実装・テスト済み(23件)だが呼び出し元がゼロだった`run_prefilter`**(RSI+MAクロス、`backend/app/ai/prefilter.py`)を配線。新規コスト・新規契約・新規APIクライアントは不要。
- `MarketContext.technical_signal`(BUY_LEAN/SELL_LEAN/NEUTRAL/INSUFFICIENT_DATA)を追加し、`ai_judgment_scheduler.py`で他のfail-openブロック(gho_signal等)と同型の独立try/exceptで取得。
- kill switch `AI_INDICATOR_MOMENTUM_ENABLED`(既定false)でstaging検証完了まで無効化。technical_signal取得失敗時もfail-openで既存動作と完全不変。

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy` 全通過
- [x] `pytest backend/tests/test_agents.py backend/tests/test_ai_sell_and_condition.py backend/tests/test_ai_prefilter.py backend/tests/test_ai_judgment_scheduler.py` 172 passed(新規5ケース含む、AND-gate/スケジューラー回帰なし)
- [x] `./scripts/verify.sh` 全体(pytest coverage/tsc/frontend build含む)PASS
- [ ] staging-v4で`AI_INDICATOR_MOMENTUM_ENABLED=true`にして実データでconfidence>=70到達を確認(次ステップ、別途デプロイ作業)
- [ ] production有効化はstaging soak確認後に人間レビューの上で判断(HUMAN-REVIEW-REQUIRED)

## Follow-up (別件・本PRスコープ外)
調査中に `BYBIT_API_KEY` が production と staging-v4 で同一値であることが判明。CLAUDE.md記載の既知ドリフトパターン(OPENAI_API_KEY環境共有と同種)に該当する可能性があり、別途調査・鍵分離を検討予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUEgFqF7VE6jsggFVgfMj