### PR TITLE
fix(ai): 価格テクニカルシグナル取得を無認証の公開ccxt.bybit()に変更

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -774,12 +774,20 @@ def run_ai_judgment_job(db: Optional[Session] = None) -> dict[str, Any]:
         # 有効時のみスコアに反映）。独立した try/except に隔離し、失敗しても他の
         # market_ctx 構築には一切影響させない（fail-open。run_prefilter 自体も
         # 内部でOHLCV取得失敗をINSUFFICIENT_DATAとしてfail-open実装済み）。
+        #
+        # 取引用の BybitSandboxClient（testnet固定 + 取引APIキー要求）は使わない。
+        # OHLCVは公開市場データで認証不要のため、無認証の素の ccxt.bybit() で
+        # mainnetの実データを取得する（2026-07-06 staging-v4実機検証で判明:
+        # BybitSandboxClientはsandbox_mode(True)によりtestnetへ強制され、
+        # 本番用APIキーがtestnetでは無効なため fetch_ohlcv が全て失敗していた）。
         technical_signal: Optional[str] = None
         try:
-            from app.ai.prefilter import run_prefilter  # noqa: PLC0415
-            from app.exchange.client import BybitSandboxClient  # noqa: PLC0415
+            import ccxt  # noqa: PLC0415
 
-            prefilter_result = run_prefilter(BybitSandboxClient(), symbol="BTC/USDT")
+            from app.ai.prefilter import run_prefilter  # noqa: PLC0415
+
+            public_client = ccxt.bybit({"enableRateLimit": True})
+            prefilter_result = run_prefilter(public_client, symbol="BTC/USDT")
             technical_signal = prefilter_result.signal
         except Exception as exc:
             logger.warning(


### PR DESCRIPTION
## Summary
- PR #936 (Indicator Agent 価格モメンタムシグナル) をstaging-v4に実デプロイして実機検証したところ、`fetch_ohlcv`が全て失敗していた(`AuthenticationError: API key is invalid`)。
- 原因: `BybitSandboxClient`が`set_sandbox_mode(True)`でBybit testnetに固定されるが、`BYBIT_API_KEY`はmainnet用の実キー(production/staging-v4で共有・別件Task化済み)でtestnetでは認証エラーになる。
- OHLCV/tickerは認証不要の公開市場データ。無認証の`ccxt.bybit()`に変更し、mainnetの実データを直接取得するよう修正。
- fail-open設計により、この不具合があってもAI判定自体はクラッシュせずtechnical_signalが常にNoneになるだけだった(実害なし)。

## 実機検証 (staging-v4)
- 修正前: `Failed to fetch OHLCV for BTC/USDT: bybit does not have market symbol BTC/USDT`
- 修正後: 実データ取得成功 `RSI=80.56 MA_short=63080 MA_long=62883 → NEUTRAL (golden cross + overbought で相殺)`
- `AI_INDICATOR_MOMENTUM_ENABLED=true`にして`indicator_agent`のkey_dataに`technical_signal`が反映されることを確認
- `BUY_LEAN`を強制注入 → bias=BULLISH, confidence=60 (スコア設計通り)

## Test plan
- [x] ruff/mypy/pytest(172件、test_agents.py/test_ai_sell_and_condition.py/test_ai_prefilter.py/test_ai_judgment_scheduler.py)全通過
- [x] staging-v4実機で修正前後の挙動差を確認済み(上記)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUEgFqF7VE6jsggFVgfMj