### PR TITLE
feat(staging): 新規テスターに自動でデモ資金を割当(Lido/Pendle提案の体験拡張)

### DIFF
--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -13,6 +13,7 @@ GET  /auth/me       - Retrieve current user information
 import logging
 import os
 from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
@@ -467,6 +468,57 @@ def get_terms_status(
     )
 
 
+def _auto_fund_tester_if_enabled(db: Session, user: User) -> None:
+    """staging-v4限定: 新規テスターにデモ資金を自動割当する(fail-open、production無効)。
+
+    二重ガード:
+      1. APP_ENV == "production" なら常に無効
+      2. AUTO_FUND_TESTER_ALLOCATION_USD / AUTO_FUND_PARTNER_ID が未設定/不正なら無効
+    既にactiveなfund_allocationを持つユーザーには何もしない(重複割当防止、
+    terms再同意のたびに増額されるのを防ぐ)。
+    """
+    if os.getenv("APP_ENV", "").strip().lower() == "production":
+        return
+    partner_id_str = os.getenv("AUTO_FUND_PARTNER_ID", "")
+    if not partner_id_str:
+        return
+    try:
+        amount = Decimal(os.getenv("AUTO_FUND_TESTER_ALLOCATION_USD", "0"))
+        partner_id = int(partner_id_str)
+    except (InvalidOperation, ValueError):
+        return
+    if amount <= Decimal("0"):
+        return
+
+    from app.partner.allocation_models import FundAllocation  # noqa: PLC0415
+
+    existing = (
+        db.query(FundAllocation)
+        .filter(FundAllocation.tester_user_id == user.id, FundAllocation.status == "active")
+        .first()
+    )
+    if existing is not None:
+        return
+
+    try:
+        from app.partner.allocation_schemas import AllocationCreateRequest  # noqa: PLC0415
+        from app.partner.allocation_service import create_allocation  # noqa: PLC0415
+
+        create_allocation(
+            db,
+            partner_id=partner_id,
+            request=AllocationCreateRequest(
+                tester_name=f"auto-demo:{user.email or user.id}",
+                tester_user_id=user.id,
+                allocated_amount_usd=amount,
+                notes="staging-v4 自動デモ資金割当(terms accept時、AUTO_FUND_TESTER_ALLOCATION_USD)",
+            ),
+        )
+        logger.info("Auto-funded tester user_id=%d with $%s (demo)", user.id, amount)
+    except Exception as exc:
+        logger.warning("Auto-fund tester failed (fail-open, ignored): %s", exc)
+
+
 @router.post(
     "/terms/accept",
     response_model=TermsStatusResponse,
@@ -482,6 +534,7 @@ def accept_terms(
     user.terms_version = request.version
     db.commit()
     db.refresh(user)
+    _auto_fund_tester_if_enabled(db, user)
     logger.info("User accepted terms v%s: %s", request.version, user.email)
     return TermsStatusResponse(
         accepted=True,

--- a/backend/tests/test_auth_auto_fund_tester.py
+++ b/backend/tests/test_auth_auto_fund_tester.py
@@ -1,0 +1,106 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/test_auth_auto_fund_tester.py
+"""staging-v4 テスター自動資金割当 (_auto_fund_tester_if_enabled) のテスト。"""
+
+import os
+import tempfile
+from typing import Generator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-auth-tests")
+
+from app.auth.models import User, UserRole
+from app.auth.router import _auto_fund_tester_if_enabled
+from app.database import Base
+from app.partner.allocation_models import FundAllocation
+
+
+@pytest.fixture()
+def db() -> Generator[Session, None, None]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    session = TestSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+        os.unlink(path)
+
+
+def _make_tester(db: Session, email: str = "tester@example.com") -> User:
+    user = User(
+        email=email,
+        username=email.split("@")[0],
+        hashed_password="x",
+        role=UserRole.VIEWER.value,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+class TestAutoFundTesterIfEnabled:
+    def test_noop_when_env_unset(self, db: Session, monkeypatch: pytest.MonkeyPatch) -> None:
+        """AUTO_FUND_PARTNER_ID/AMOUNT が未設定なら何も作らない。"""
+        monkeypatch.delenv("AUTO_FUND_PARTNER_ID", raising=False)
+        monkeypatch.delenv("AUTO_FUND_TESTER_ALLOCATION_USD", raising=False)
+        monkeypatch.delenv("APP_ENV", raising=False)
+        user = _make_tester(db)
+
+        _auto_fund_tester_if_enabled(db, user)
+
+        assert db.query(FundAllocation).count() == 0
+
+    def test_creates_allocation_when_enabled(
+        self, db: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """有効時は指定額の active FundAllocation が1件作られる。"""
+        monkeypatch.setenv("AUTO_FUND_PARTNER_ID", "9")
+        monkeypatch.setenv("AUTO_FUND_TESTER_ALLOCATION_USD", "150000")
+        monkeypatch.delenv("APP_ENV", raising=False)
+        user = _make_tester(db)
+
+        _auto_fund_tester_if_enabled(db, user)
+
+        allocations = db.query(FundAllocation).all()
+        assert len(allocations) == 1
+        assert allocations[0].tester_user_id == user.id
+        assert allocations[0].partner_id == 9
+        assert allocations[0].status == "active"
+        assert allocations[0].allocated_amount_usd == 150000
+
+    def test_no_duplicate_when_active_allocation_exists(
+        self, db: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """既にactiveなallocationがあれば重複作成しない(terms再同意対策)。"""
+        monkeypatch.setenv("AUTO_FUND_PARTNER_ID", "9")
+        monkeypatch.setenv("AUTO_FUND_TESTER_ALLOCATION_USD", "150000")
+        monkeypatch.delenv("APP_ENV", raising=False)
+        user = _make_tester(db)
+
+        _auto_fund_tester_if_enabled(db, user)
+        _auto_fund_tester_if_enabled(db, user)  # terms再同意を模した2回目呼び出し
+
+        assert db.query(FundAllocation).count() == 1
+
+    def test_disabled_in_production_even_if_configured(
+        self, db: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """APP_ENV=production なら金額設定済みでも常に無効。"""
+        monkeypatch.setenv("AUTO_FUND_PARTNER_ID", "9")
+        monkeypatch.setenv("AUTO_FUND_TESTER_ALLOCATION_USD", "150000")
+        monkeypatch.setenv("APP_ENV", "production")
+        user = _make_tester(db)
+
+        _auto_fund_tester_if_enabled(db, user)
+
+        assert db.query(FundAllocation).count() == 0


### PR DESCRIPTION
## Summary
- staging-v4のテスター体験は現状Aave SUPPLYしか提案されない。AI Optimizer(`StrategyComparator`)は投資額$6,000〜$8,000を境にAave→Pendle/Lidoへ推奨が切り替わる設計だが、テスターのfund_allocationが小さい(現状$50,000×10%ルール=$5,000)ためLido/Pendleが実際に選ばれたことは一度もなかった(`fund_allocations`8件全てAave)。
- `POST /auth/terms/accept`(オンボーディング完了ゲート)に`_auto_fund_tester_if_enabled()`を追加し、新規テスターに自動でデモ資金(`fund_allocations`)を割り当てるようにした。
- 二重ガードでproductionには一切影響しない: `APP_ENV=="production"`なら常に無効 / env var(`AUTO_FUND_TESTER_ALLOCATION_USD`, `AUTO_FUND_PARTNER_ID`)が未設定なら無効。既存の`create_allocation()`をそのまま再利用し新規CRUDロジックは書いていない。
- 既にactiveなfund_allocationを持つユーザーには何もしない(terms再同意のたびに重複作成されるのを防止)。

## staging-v4への追加設定(このPRのmerge後、別途デプロイ作業で実施)
```
AUTO_FUND_TESTER_ALLOCATION_USD=150000
AUTO_FUND_PARTNER_ID=9
PROPOSAL_AMOUNT_MAX_USD=20000
```

## Test plan
- [x] `backend/tests/test_auth_auto_fund_tester.py` 新規4ケース(未設定時no-op/有効時作成/重複防止/production無効)全通過
- [x] `ruff check` / `ruff format --check` / `mypy` 全通過
- [x] `./scripts/verify.sh` 全体(pytest coverage/tsc/frontend build含む)PASS (567s)
- [ ] staging-v4デプロイ後、実際にLido/Pendleの提案が生成されることを実機確認(次ステップ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUEgFqF7VE6jsggFVgfMj