### PR TITLE
feat(liff-chat): AI判定+提案+ウォレット残高を1ボックスに統合

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/AwaitingFundsCard.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/AwaitingFundsCard.tsx
@@ -8,21 +8,22 @@
 import { useTranslations } from "next-intl"
 import { Loader2, Wallet } from "lucide-react"
 import type { ChatProposal } from "./ProposalSignSheet"
+import { DepositGuideInline } from "./DepositGuideInline"
 
 interface AwaitingFundsCardProps {
   proposal: ChatProposal
   balanceUsd: number | null
-  onDeposit: () => void
   onReject: () => void
   rejecting?: boolean
+  onDepositSettled?: () => void
 }
 
 export function AwaitingFundsCard({
   proposal,
   balanceUsd,
-  onDeposit,
   onReject,
   rejecting = false,
+  onDepositSettled,
 }: AwaitingFundsCardProps) {
   const t = useTranslations("Liff.awaitingFunds")
 
@@ -54,26 +55,18 @@ export function AwaitingFundsCard({
         <Row label={t("shortfall")} value={fmt(shortfall)} amber />
       </div>
 
-      <p className="text-[#736f7e] text-xs leading-relaxed mb-3">{t("guide")}</p>
-
       {/* actions */}
-      <div className="flex gap-3 mt-3">
-        <button
-          onClick={onReject}
-          disabled={rejecting}
-          className="flex-1 py-2.5 rounded-xl border border-[#1c1a27]/20 text-[#1c1a27]
-                     font-semibold disabled:opacity-40 transition-colors"
-        >
-          {t("reject")}
-        </button>
-        <button
-          onClick={onDeposit}
-          className="flex-1 py-2.5 rounded-xl bg-[#1D9E75] active:bg-[#178a64] text-white
-                     font-bold transition-colors"
-        >
-          {t("depositCta")}
-        </button>
-      </div>
+      <button
+        onClick={onReject}
+        disabled={rejecting}
+        className="w-full py-2.5 rounded-xl border border-[#1c1a27]/20 text-[#1c1a27]
+                   font-semibold disabled:opacity-40 transition-colors"
+      >
+        {t("reject")}
+      </button>
+
+      {/* 入金導線: 別パネルへ遷移せずボックス内で Privy fundWallet を直接起動する */}
+      <DepositGuideInline shortfallUsd={shortfall} onSettled={onDepositSettled} />
     </div>
   )
 }

--- a/frontend/app/(liff)/liff-chat/_components/DepositGuideInline.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/DepositGuideInline.tsx
@@ -1,0 +1,37 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// frontend/app/(liff)/liff-chat/_components/DepositGuideInline.tsx
+// 残高不足時にボックス内で完結させる入金導線。SBI VCトレード等の送金案内(Liff.awaitingFunds.guide
+// を流用)+ Privy fundWallet() の直接起動ボタン。別パネルへの画面遷移を挟まない
+// (ProposalActionCard の未承認・残高不足時、AwaitingFundsCard の入金待ち時の両方から使う)。
+"use client"
+
+import { useTranslations } from "next-intl"
+import { Loader2 } from "lucide-react"
+import { useDepositFundWallet } from "@/hooks/useDepositFundWallet"
+
+interface DepositGuideInlineProps {
+  /** 不足額(USD)。渡すと Privy fundWallet の初期入力額として使う。 */
+  shortfallUsd?: number
+  /** 入金後の残高再取得コールバック(呼び出し元の refetch)。 */
+  onSettled?: () => void
+}
+
+export function DepositGuideInline({ shortfallUsd, onSettled }: DepositGuideInlineProps) {
+  const t = useTranslations("Liff")
+  const { trigger, isFunding } = useDepositFundWallet({ onSettled })
+
+  return (
+    <div className="mt-3 rounded-xl bg-amber-50 border border-amber-200 p-3">
+      <p className="text-[#736f7e] text-xs leading-relaxed mb-3">{t("awaitingFunds.guide")}</p>
+      <button
+        onClick={() => { void trigger(shortfallUsd) }}
+        disabled={isFunding}
+        className="w-full flex items-center justify-center gap-2 py-2.5 rounded-lg bg-[#1D9E75]
+                   active:bg-[#178a64] text-white text-sm font-bold disabled:opacity-50 transition-colors"
+      >
+        {isFunding && <Loader2 className="w-4 h-4 animate-spin" />}
+        {t("exec.depositCta")}
+      </button>
+    </div>
+  )
+}

--- a/frontend/app/(liff)/liff-chat/_components/ProposalActionCard.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/ProposalActionCard.tsx
@@ -8,6 +8,7 @@ import { useTranslations } from "next-intl"
 import { ArrowUp, ArrowDown } from "lucide-react"
 import { liffFetch } from "@/lib/liff/liff-fetch"
 import type { ChatProposal } from "./ProposalSignSheet"
+import { DepositGuideInline } from "./DepositGuideInline"
 
 interface ProposalActionCardProps {
   proposal: ChatProposal
@@ -17,6 +18,12 @@ interface ProposalActionCardProps {
   // F4: wallet 残高 < 提案額のとき true。承認は有効のまま (押すと署名シートで入金導線を出す)
   // が、カードにヒントを表示して事前に気づけるようにする。
   insufficientBalance?: boolean
+  // 統合ボックス化: 汎用 AI 判定ボックスの代わりにこのカードが確信度・残高を表示する。
+  // confidence は proposal 自身の値ではなく直近の aiJudgment 由来（backend が
+  // ChatProposal.confidence を送信しないため）。UI上に注記を出して誤解を防ぐ。
+  confidence?: number
+  balanceUsd: number | null
+  onDepositSettled?: () => void
 }
 
 export function ProposalActionCard({
@@ -25,6 +32,9 @@ export function ProposalActionCard({
   onApprove,
   onReject,
   insufficientBalance = false,
+  confidence,
+  balanceUsd,
+  onDepositSettled,
 }: ProposalActionCardProps) {
   const t = useTranslations("Liff")
   const [expanded, setExpanded] = useState(false)
@@ -101,6 +111,24 @@ export function ProposalActionCard({
         </span>
       </div>
 
+      {/* 確信度（統合ボックス化: 直近の aiJudgment 由来。この提案固有の値ではない旨を注記） */}
+      {confidence != null && (
+        <p className="text-[#736f7e] text-xs mb-2">
+          {confidence}% {t("home.confidenceLabel")}
+          <span className="ml-1">({t("exec.confidenceNote")})</span>
+        </p>
+      )}
+
+      {/* ウォレット残高（統合ボックス化: page.tsx の KPI-E 行をここに集約） */}
+      <div className="flex items-center justify-between px-3 py-2 mb-3 rounded-lg bg-[#1c1a27]/5">
+        <span className="text-xs text-[#736f7e]">{t("kpi.walletBalance")}</span>
+        <span className="text-sm font-semibold text-[#1c1a27]">
+          {balanceUsd != null
+            ? `$${balanceUsd.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+            : "—"}
+        </span>
+      </div>
+
       {/* reason */}
       {reason && (
         <p className="text-[#736f7e] text-xs leading-relaxed mb-3 whitespace-pre-wrap">
@@ -116,9 +144,18 @@ export function ProposalActionCard({
         </p>
       )}
 
-      {/* F4: 残高不足ヒント (承認は有効・押すと署名シートで入金導線) */}
+      {/* F4: 残高不足ヒント (承認は有効・押すと awaiting_funds へ)。承認前から入金導線を
+          ボックス内に表示し、別パネルへ遷移せず Privy fundWallet を直接起動できるようにする。 */}
       {insufficientBalance && (
-        <p className="text-amber-700 text-xs mb-2">{t("exec.insufficientBalance")}</p>
+        <>
+          <p className="text-amber-700 text-xs mb-2">{t("exec.insufficientBalance")}</p>
+          <DepositGuideInline
+            shortfallUsd={
+              balanceUsd != null ? Number(proposal.amount_usd) - balanceUsd : undefined
+            }
+            onSettled={onDepositSettled}
+          />
+        </>
       )}
 
       {/* actions */}

--- a/frontend/app/(liff)/liff-chat/_components/ProposalSignSheet.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/ProposalSignSheet.tsx
@@ -13,6 +13,7 @@ import { ethers } from "ethers"
 import { Loader2, Lock, CheckCircle2 } from "lucide-react"
 import { buildPartnerTx, submitPartnerTx, type UnsignedTx } from "@/lib/api/admin-proposals"
 import { classifyTxError } from "@/lib/web3/classify-tx-error"
+import { DepositGuideInline } from "./DepositGuideInline"
 
 // build-tx の UnsignedTx を Smart Wallet UserOp の call 形式 (to/data/value) に変換する。
 // approve/supply/withdraw/buy_pt は 0 ETH value。STAKE_ETH (Lido submit) のみ value=添付 ETH。
@@ -54,8 +55,9 @@ interface ProposalSignSheetProps {
   onExecuted: (txHash: string) => void
   // F4: 入金系で wallet 残高 < 提案額のとき true。署名前ブロック + 入金導線に使う。
   insufficientBalance?: boolean
-  // F5: 残高不足時に入金パネルへ誘導するコールバック (page.tsx の setActivePanel("deposit"))。
-  onDeposit?: () => void
+  // 不足額計算・入金後の残高再取得用（DepositGuideInline に渡す）。
+  balanceUsd?: number | null
+  onDepositSettled?: () => void
 }
 
 export function ProposalSignSheet({
@@ -65,7 +67,8 @@ export function ProposalSignSheet({
   onClose,
   onExecuted,
   insufficientBalance = false,
-  onDeposit,
+  balanceUsd,
+  onDepositSettled,
 }: ProposalSignSheetProps) {
   const { login } = usePrivy()
   const { wallets } = useWallets()
@@ -320,19 +323,17 @@ export function ProposalSignSheet({
         {error && <p className="text-red-600 text-xs mb-3">{error}</p>}
 
         {/* F4/F5: 残高不足 — 署名前ブロック (insufficientBalance) または署名時検知 (showDepositCta)。
-            残高不足の案内 + 入金導線を出す。on-chain revert / 無駄ガスを未然に防ぐ。 */}
+            残高不足の案内 + 入金導線を出す。on-chain revert / 無駄ガスを未然に防ぐ。
+            別パネルへ遷移せず DepositGuideInline がボックス内で Privy fundWallet を直接起動する。 */}
         {(insufficientBalance || showDepositCta) && (
-          <div className="mb-3 rounded-xl bg-amber-50 border border-amber-200 p-3">
+          <div className="mb-3">
             <p className="text-amber-800 text-xs mb-2">{t("insufficientBalance")}</p>
-            {onDeposit && (
-              <button
-                onClick={onDeposit}
-                className="w-full py-2 rounded-lg bg-[#1D9E75] active:bg-[#178a64] text-white
-                           text-sm font-bold transition-colors"
-              >
-                {t("depositCta")}
-              </button>
-            )}
+            <DepositGuideInline
+              shortfallUsd={
+                balanceUsd != null ? Number(proposal.amount_usd) - balanceUsd : undefined
+              }
+              onSettled={onDepositSettled}
+            />
           </div>
         )}
 

--- a/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
@@ -6,12 +6,9 @@ import { AlertTriangle, Loader2 } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { useLanguage } from "@/lib/useLanguage"
 import { liffFetch } from "@/lib/liff/liff-fetch"
-import { useFundWallet } from "@privy-io/react-auth"
-import { base, baseSepolia } from "wagmi/chains"
-import { useWallet } from "@/hooks/useWallet"
 import { useUsdcBalance } from "@/hooks/useUsdcBalance"
 import { useEffectiveWalletAddress } from "@/hooks/useEffectiveWalletAddress"
-import { track, EV } from "@/lib/posthog"
+import { useDepositFundWallet } from "@/hooks/useDepositFundWallet"
 import { SUPPORTED_CHAIN_IDS, getChainDisplayName, DEPOSIT_GATE_USD } from "@/lib/web3/config"
 
 // ---- 型定義 ---------------------------------------------------------------
@@ -110,9 +107,6 @@ export function DepositPanel() {
       .catch(() => {})
   }, [])
 
-  // Privy ウォレット情報（chainId は署名/ネットワーク判定用。EOA。）
-  const { chainId } = useWallet()
-
   // 入金先/出金先/残高チェック対象アドレスは実効アドレス（smart_wallet_address 優先、
   // 未設定なら EOA）。Aave 実行の実体（backend submit_partner_tx の UserOp sender 検証）
   // と一致させるため、EOA 固定にしない（2026-07-04 資金迷子バグ修正）。
@@ -125,8 +119,6 @@ export function DepositPanel() {
 
   // 入金フォーム（金額は送金目安の表示用）
   const [depositAmount, setDepositAmount] = useState("")
-  // Privy fundWallet 処理中フラグ
-  const [isFunding, setIsFunding] = useState(false)
 
   // 出金フォーム
   const [withdrawAmount, setWithdrawAmount] = useState("")
@@ -139,43 +131,21 @@ export function DepositPanel() {
 
   // 残高はオンチェーン取得（useUsdcBalance が自動取得）。入金/出金後は refetchBalance() で更新する。
 
-  // ---- Privy fundWallet --------------------------------------------------
+  // ---- Privy fundWallet（共通hook。ProposalActionCard/AwaitingFundsCard/
+  // ProposalSignSheet のインライン入金導線と同じ実装を使う） -----------------------
 
-  const { fundWallet } = useFundWallet({
-    onUserExited: () => {
-      setIsFunding(false)
-      refetchBalance()
-    },
+  const { trigger: triggerFundWallet, isFunding } = useDepositFundWallet({
+    onSettled: refetchBalance,
   })
 
   const handleFundWallet = useCallback(async () => {
-    if (!address) return
-    track(EV.DEPOSIT_FUND)
-    setIsFunding(true)
-    try {
-      // 入力単位は言語で異なる: 英語=USD（USDC と 1:1）/ 日本語=¥（÷155 で USDC 換算）。
-      // Privy fundWallet の amount は USDC 建てのため、ここで USDC へ正規化する
-      // （旧実装は ¥ 値をそのまま USDC として渡していた不具合を修正）。
-      const num = parseFloat(depositAmount) || 0
-      const usdc = language === "en" ? num : num / jpyPerUsdc
-      await fundWallet({
-        address,
-        options: {
-          chain: chainId === 84532 ? baseSepolia : base,
-          amount: usdc > 0 ? usdc.toFixed(2) : "200",
-          asset: "USDC",
-        },
-      })
-    } catch (e) {
-      if (e instanceof Error && !e.message.toLowerCase().includes("exit")) {
-        // ユーザーキャンセル以外のエラーはコンソールに記録（UI は onUserExited で復旧）
-        console.error("[DepositPanel] fundWallet error:", e.message)
-      }
-    } finally {
-      setIsFunding(false)
-      refetchBalance()
-    }
-  }, [address, chainId, depositAmount, language, jpyPerUsdc, refetchBalance, fundWallet])
+    // 入力単位は言語で異なる: 英語=USD（USDC と 1:1）/ 日本語=¥（÷155 で USDC 換算）。
+    // Privy fundWallet の amount は USDC 建てのため、ここで USDC へ正規化する
+    // （旧実装は ¥ 値をそのまま USDC として渡していた不具合を修正）。
+    const num = parseFloat(depositAmount) || 0
+    const usdc = language === "en" ? num : num / jpyPerUsdc
+    await triggerFundWallet(usdc)
+  }, [depositAmount, language, jpyPerUsdc, triggerFundWallet])
 
   // ---- 出金可能額上限（全額ボタン用） ----------------------------------------
 

--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -495,103 +495,99 @@ export default function LiffChatPage() {
           <DividendChartWrapper data={dividends} />
         </div>
 
-        {/* AI 判定カード */}
-        <div
-          className={`rounded-2xl mx-4 mt-4 p-4 transition-all
-            ${isBuy
-              ? "ax-card-warm border-2 border-[#1D9E75] [animation:pulse_0.8s_ease-in-out_2]"
-              : isSell
-              ? "ax-card-warm border-2 border-red-500 [animation:pulse_0.8s_ease-in-out_2]"
-              : "ax-card-warm"
-            }`}
-        >
-          {/* ヘッダー行 */}
-          <div className="flex items-center gap-2 mb-2">
-            <div
-              className={`w-2 h-2 rounded-full ${
-                isBuy
-                  ? "bg-[#1D9E75] [animation:ping_0.5s_ease-in-out_4]"
-                  : isSell
-                  ? "bg-red-500"
-                  : "bg-[#736f7e]"
-              }`}
-            />
-            <span
-              className={`text-xs font-medium ${
-                isBuy ? "text-[#1D9E75]" : isSell ? "text-red-600" : "text-[#736f7e]"
-              }`}
-            >
-              {t("home.aiJudgment")}
-            </span>
-          </div>
-
-          {/* アクション表示 */}
+        {/* AI 判定カード（統合ボックス化: 保留中の提案がある間は下の統合カードに一本化し、
+            銘柄・金額のない汎用カードは表示しない） */}
+        {!pendingProposal && (
           <div
-            className={`font-bold text-2xl ${
-              isBuy ? "text-[#1D9E75]" : isSell ? "text-red-600" : "text-[#1c1a27]"
-            }`}
+            className={`rounded-2xl mx-4 mt-4 p-4 transition-all
+              ${isBuy
+                ? "ax-card-warm border-2 border-[#1D9E75] [animation:pulse_0.8s_ease-in-out_2]"
+                : isSell
+                ? "ax-card-warm border-2 border-red-500 [animation:pulse_0.8s_ease-in-out_2]"
+                : "ax-card-warm"
+              }`}
           >
-            {aiJudgment ? action : t("home.noSignal")}
-          </div>
-
-          {/* 確信度表示。HOLD は「シグナルが弱く様子見」と分かる文言、BUY/SELL は従来表記。 */}
-          {aiJudgment && (
-            <p className="mt-1 text-[#736f7e] text-xs" data-testid="confidence-label">
-              {action === "HOLD"
-                ? t("home.holdWeakSignalLabel", { confidence })
-                : `${confidence}% ${t("home.confidenceLabel")}`}
-            </p>
-          )}
-
-          {/* なぜ{action}？理由トグル（aiJudgment がある場合のみ表示） */}
-          {aiJudgment && (
-            <>
-              <button
-                onClick={() => { const next = !reasonOpen; setReasonOpen(next); track(EV.REASON_TOGGLE, { action, open: next }) }}
-                className="mt-2 text-[#736f7e] text-xs underline"
-                aria-expanded={reasonOpen}
+            {/* ヘッダー行 */}
+            <div className="flex items-center gap-2 mb-2">
+              <div
+                className={`w-2 h-2 rounded-full ${
+                  isBuy
+                    ? "bg-[#1D9E75] [animation:ping_0.5s_ease-in-out_4]"
+                    : isSell
+                    ? "bg-red-500"
+                    : "bg-[#736f7e]"
+                }`}
+              />
+              <span
+                className={`text-xs font-medium ${
+                  isBuy ? "text-[#1D9E75]" : isSell ? "text-red-600" : "text-[#736f7e]"
+                }`}
               >
-                {t("home.whyAction", { action })}
-              </button>
-              {reasonOpen && (
-                <p className="mt-2 text-[#736f7e] text-xs leading-relaxed whitespace-pre-wrap">
-                  {aiJudgment.reason ?? t("home.noReason")}
-                </p>
-              )}
-            </>
-          )}
-        </div>
-
-        {/* 保留中の提案（承認→自己署名→実行 / 見送り） */}
-        {pendingProposal && (
-          <>
-            {/* 提案カード上部のウォレット残高表示（KPI-E） */}
-            <div className="mx-4 mt-4 px-4 py-2.5 rounded-xl ax-card-warm flex items-center justify-between">
-              <span className="text-xs text-[#736f7e]">{t("kpi.walletBalance")}</span>
-              <span className="text-sm font-semibold text-[#1c1a27]">
-                {balanceUsd != null
-                  ? `$${balanceUsd.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
-                  : "—"}
+                {t("home.aiJudgment")}
               </span>
             </div>
-            {pendingProposal.status === "awaiting_funds" ? (
-              <AwaitingFundsCard
-                proposal={pendingProposal}
-                balanceUsd={balanceUsd}
-                rejecting={rejecting}
-                onDeposit={() => setActivePanel("deposit")}
-                onReject={handleRejectProposal}
-              />
-            ) : (
-              <ProposalActionCard
-                proposal={pendingProposal}
-                rejecting={rejecting}
-                onApprove={handleApproveProposal}
-                onReject={handleRejectProposal}
-                insufficientBalance={insufficientBalance}
-              />
+
+            {/* アクション表示 */}
+            <div
+              className={`font-bold text-2xl ${
+                isBuy ? "text-[#1D9E75]" : isSell ? "text-red-600" : "text-[#1c1a27]"
+              }`}
+            >
+              {aiJudgment ? action : t("home.noSignal")}
+            </div>
+
+            {/* 確信度表示。HOLD は「シグナルが弱く様子見」と分かる文言、BUY/SELL は従来表記。 */}
+            {aiJudgment && (
+              <p className="mt-1 text-[#736f7e] text-xs" data-testid="confidence-label">
+                {action === "HOLD"
+                  ? t("home.holdWeakSignalLabel", { confidence })
+                  : `${confidence}% ${t("home.confidenceLabel")}`}
+              </p>
             )}
-          </>
+
+            {/* なぜ{action}？理由トグル（aiJudgment がある場合のみ表示） */}
+            {aiJudgment && (
+              <>
+                <button
+                  onClick={() => { const next = !reasonOpen; setReasonOpen(next); track(EV.REASON_TOGGLE, { action, open: next }) }}
+                  className="mt-2 text-[#736f7e] text-xs underline"
+                  aria-expanded={reasonOpen}
+                >
+                  {t("home.whyAction", { action })}
+                </button>
+                {reasonOpen && (
+                  <p className="mt-2 text-[#736f7e] text-xs leading-relaxed whitespace-pre-wrap">
+                    {aiJudgment.reason ?? t("home.noReason")}
+                  </p>
+                )}
+              </>
+            )}
+          </div>
+        )}
+
+        {/* 保留中の提案（承認→自己署名→実行 / 見送り）。統合ボックス化により銘柄・金額・
+            確信度・ウォレット残高をカード内に集約する（KPI-E の別行表示は廃止）。 */}
+        {pendingProposal && (
+          pendingProposal.status === "awaiting_funds" ? (
+            <AwaitingFundsCard
+              proposal={pendingProposal}
+              balanceUsd={balanceUsd}
+              rejecting={rejecting}
+              onReject={handleRejectProposal}
+              onDepositSettled={refetchBalance}
+            />
+          ) : (
+            <ProposalActionCard
+              proposal={pendingProposal}
+              rejecting={rejecting}
+              onApprove={handleApproveProposal}
+              onReject={handleRejectProposal}
+              insufficientBalance={insufficientBalance}
+              confidence={aiJudgment?.confidence}
+              balanceUsd={balanceUsd}
+              onDepositSettled={refetchBalance}
+            />
+          )
         )}
 
         {/* 運用中コイン一覧 */}
@@ -751,7 +747,8 @@ export default function LiffChatPage() {
           onClose={() => setSignSheetOpen(false)}
           onExecuted={handleProposalExecuted}
           insufficientBalance={insufficientBalance}
-          onDeposit={() => { setSignSheetOpen(false); setActivePanel("deposit") }}
+          balanceUsd={balanceUsd}
+          onDepositSettled={refetchBalance}
         />
       )}
 

--- a/frontend/e2e/liff-chat-unified-proposal-card.spec.ts
+++ b/frontend/e2e/liff-chat-unified-proposal-card.spec.ts
@@ -1,0 +1,152 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+/**
+ * E2E tests for the unified AI judgment / proposal / wallet balance box on /liff-chat.
+ * (Asana 1216284377506806: AI判定+提案+ウォレット残高の統合ボックス)
+ *
+ * 検証対象:
+ *  1. 保留中の提案が無い(HOLD)場合は従来の汎用 AI 判定ボックスを表示する
+ *  2. 保留中の提案がある場合、汎用 AI 判定ボックスは非表示化され、統合ボックスに
+ *     銘柄・金額・確信度(直近AI判定由来の注記付き)・理由・ウォレット残高・承認/見送るボタンが集約される
+ *  3. 入金待ち(awaiting_funds)状態では必要額/現在残高/不足額+SBI VC送金案内+入金ボタンが
+ *     ボックス内にインライン表示される(別パネルへの画面遷移が前提でないこと)
+ *
+ * NOTE:
+ *  - /api/* は page.route() でモックするため、実バックエンド・実ウォレット接続は不要。
+ *  - Privy ウォレット未接続のためウォレット残高(useUsdcBalance)は常に null（"—"表示）。
+ *    残高不足プレ承認状態(オンチェーン残高が必要額を下回るケース)はウォレット接続のモックが
+ *    別途必要なためこのファイルではカバーしない(手動 / staging-v4 実機確認で担保)。
+ */
+
+import { test, expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+
+const AUTH_TOKEN = 'e2e-unified-card-token'
+
+interface ChatProposalMock {
+  id: number
+  operation: string
+  asset: string
+  amount: string
+  amount_usd: string
+  reason: string
+  protocol?: string
+  expected_hf_after: string | null
+  estimated_gas_usd: string | null
+  status: string
+  created_at: string
+}
+
+async function mockLiffChatApis(
+  page: Page,
+  opts: {
+    aiJudgment?: { action: string; confidence: number; reason?: string } | null
+    proposals?: ChatProposalMock[]
+  },
+) {
+  // terms_version は (liff)/layout.tsx の useLiffTermsGate が同意状態判定に使う。
+  // 省略すると "not-accepted" 扱いで /liff-confirm へリダイレクトされ children が描画されない。
+  await page.route('**/api/user/settings', (route) =>
+    route.fulfill({ json: { is_active: true, terms_version: 'liff-v4' } }),
+  )
+  await page.route('**/api/portfolio/current', (route) =>
+    route.fulfill({
+      json: { positions_json: [], has_data: false, total_value_usd: '0', weighted_avg_apy: '0' },
+    }),
+  )
+  await page.route('**/api/user/dividends', (route) =>
+    route.fulfill({ json: { dividends: [] } }),
+  )
+  await page.route('**/api/ai/decisions**', (route) =>
+    route.fulfill({ json: { items: opts.aiJudgment ? [opts.aiJudgment] : [] } }),
+  )
+  await page.route('**/api/proposals/pending', (route) =>
+    route.fulfill({ json: { items: opts.proposals ?? [] } }),
+  )
+}
+
+test.describe('[LIFF Chat] AI判定+提案+ウォレット残高の統合ボックス', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript((token) => {
+      window.localStorage.setItem('auth_token', token)
+    }, AUTH_TOKEN)
+  })
+
+  test('保留中の提案が無い(HOLD)場合は従来のAI判定ボックスを表示する', async ({ page }) => {
+    await mockLiffChatApis(page, {
+      aiJudgment: { action: 'HOLD', confidence: 42, reason: 'レンジ相場のため様子見' },
+      proposals: [],
+    })
+    await page.goto('/liff-chat', { waitUntil: 'domcontentloaded' })
+
+    await expect(page.getByText('AI JUDGMENT')).toBeVisible()
+    // 「なぜHOLD？」ボタンも部分一致するため exact: true で行動表示自体に絞る
+    await expect(page.getByText('HOLD', { exact: true })).toBeVisible()
+  })
+
+  test('保留中の提案(残高十分)は統合ボックスに銘柄・金額・確信度・残高・承認/見送るを表示する', async ({
+    page,
+  }) => {
+    await mockLiffChatApis(page, {
+      aiJudgment: { action: 'BUY', confidence: 78, reason: 'Aave 金利上昇' },
+      proposals: [
+        {
+          id: 1,
+          operation: 'SUPPLY',
+          asset: 'USDC',
+          amount: '1000',
+          amount_usd: '1000',
+          reason: 'テスト用の提案理由',
+          protocol: 'aave',
+          expected_hf_after: null,
+          estimated_gas_usd: null,
+          status: 'pending',
+          created_at: '2026-07-06T00:00:00Z',
+        },
+      ],
+    })
+    await page.goto('/liff-chat', { waitUntil: 'domcontentloaded' })
+
+    // 汎用 AI 判定ボックス(銘柄・金額なし)は統合ボックスに置き換わり非表示化される
+    await expect(page.getByText('AI JUDGMENT')).not.toBeVisible()
+
+    await expect(page.getByText('入金 (Supply)')).toBeVisible()
+    await expect(page.getByText('テスト用の提案理由')).toBeVisible()
+    await expect(page.getByText('信頼度')).toBeVisible()
+    await expect(page.getByText('直近のAI判定').first()).toBeVisible()
+    await expect(page.getByText('ウォレット残高')).toBeVisible()
+    await expect(page.getByRole('button', { name: '承認する' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '見送る' })).toBeVisible()
+  })
+
+  test('入金待ち(awaiting_funds)は必要額/残高/不足額+入金導線をボックス内にインライン表示する', async ({
+    page,
+  }) => {
+    await mockLiffChatApis(page, {
+      aiJudgment: { action: 'BUY', confidence: 80 },
+      proposals: [
+        {
+          id: 2,
+          operation: 'SUPPLY',
+          asset: 'USDC',
+          amount: '1000',
+          amount_usd: '1000',
+          reason: 'テスト理由2',
+          protocol: 'aave',
+          expected_hf_after: null,
+          estimated_gas_usd: null,
+          status: 'awaiting_funds',
+          created_at: '2026-07-06T00:00:00Z',
+        },
+      ],
+    })
+    await page.goto('/liff-chat', { waitUntil: 'domcontentloaded' })
+
+    await expect(page.getByText('入金待ち')).toBeVisible()
+    await expect(page.getByText('必要額')).toBeVisible()
+    await expect(page.getByText('不足額')).toBeVisible()
+    // Liff.awaitingFunds.guide の SBI VC 送金案内文がボックス内にインラインで出る
+    await expect(page.getByText('SBI VCトレード', { exact: false })).toBeVisible()
+    await expect(page.getByRole('button', { name: '入金する' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '見送る' })).toBeVisible()
+  })
+})

--- a/frontend/hooks/useDepositFundWallet.ts
+++ b/frontend/hooks/useDepositFundWallet.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Ultra AutoTrade. All rights reserved.
+'use client'
+
+import { useCallback, useState } from 'react'
+import { useFundWallet } from '@privy-io/react-auth'
+import { base, baseSepolia } from 'wagmi/chains'
+import { useWallet } from '@/hooks/useWallet'
+import { useEffectiveWalletAddress } from '@/hooks/useEffectiveWalletAddress'
+import { track, EV } from '@/lib/posthog'
+
+interface UseDepositFundWalletOptions {
+  /** fundWallet 終了時（成功・キャンセル問わず）に呼ぶ副作用。残高再取得等に使う。 */
+  onSettled?: () => void
+}
+
+// PrivyRootClient.tsx と同じ判定（build-time 定数のため条件付き hook 呼び出しでも
+// rules-of-hooks の実害は無い — useWallet.ts の PRIVY_CONFIGURED と同じ理屈）。
+// Privy App ID 未設定環境では PrivyRootClient が <PrivyProvider> 自体をツリーに
+// マウントしないため、ここで useFundWallet() を無条件に呼ぶと
+// "Cannot read properties of undefined (reading 'current')" で落ちる
+// （AwaitingFundsCard 等が pending 提案の到着だけで自動マウントするため、
+// DepositPanel の「ユーザーがボタンを押すまで遅延マウント」より露見しやすい）。
+const PRIVY_CONFIGURED = Boolean(
+  process.env.NEXT_PUBLIC_PRIVY_APP_ID &&
+    process.env.NEXT_PUBLIC_PRIVY_APP_ID !== 'clplaceholder000000000000000000000',
+)
+
+/**
+ * Privy fundWallet() の起動ロジックを一箇所に集約する。
+ * DepositPanel.tsx の入金タブ・提案カード内の残高不足インライン導線・署名シートの
+ * 入金導線のいずれからも同じ挙動（chain 判定・エラーハンドリング・PostHog計測）で呼べるようにする。
+ */
+export function useDepositFundWallet(options: UseDepositFundWalletOptions = {}) {
+  const { onSettled } = options
+  const { chainId } = useWallet()
+  const { address } = useEffectiveWalletAddress()
+  const [isFunding, setIsFunding] = useState(false)
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const fundWalletBridge = PRIVY_CONFIGURED
+    ? useFundWallet({
+        onUserExited: () => {
+          setIsFunding(false)
+          onSettled?.()
+        },
+      })
+    : null
+
+  const trigger = useCallback(
+    async (amountUsdcHint?: number) => {
+      if (!address || !fundWalletBridge) return
+      track(EV.DEPOSIT_FUND)
+      setIsFunding(true)
+      try {
+        await fundWalletBridge.fundWallet({
+          address,
+          options: {
+            chain: chainId === 84532 ? baseSepolia : base,
+            amount: amountUsdcHint && amountUsdcHint > 0 ? amountUsdcHint.toFixed(2) : '200',
+            asset: 'USDC',
+          },
+        })
+      } catch (e) {
+        if (e instanceof Error && !e.message.toLowerCase().includes('exit')) {
+          // ユーザーキャンセル以外のエラーはコンソールに記録（UI は onUserExited で復旧）
+          console.error('[useDepositFundWallet] fundWallet error:', e.message)
+        }
+      } finally {
+        setIsFunding(false)
+        onSettled?.()
+      }
+    },
+    [address, chainId, fundWalletBridge, onSettled],
+  )
+
+  return { trigger, isFunding, address }
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -673,6 +673,7 @@
       "signFailed": "Signing failed",
       "signCanceled": "Signature canceled",
       "insufficientBalance": "Your wallet USDC balance is below the proposed amount. Please deposit before signing.",
+      "confidenceNote": "latest AI judgment",
       "errInsufficientFunds": "Insufficient balance or gas. Please check your USDC balance and ETH (for gas).",
       "depositCta": "Deposit",
       "collapse": "Collapse",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -673,6 +673,7 @@
       "signFailed": "署名処理に失敗しました",
       "signCanceled": "署名がキャンセルされました",
       "insufficientBalance": "ウォレットの USDC 残高が提案額に足りません。入金してから署名してください。",
+      "confidenceNote": "直近のAI判定",
       "errInsufficientFunds": "残高またはガス代が不足しています。USDC 残高と ETH（ガス代）を確認してください。",
       "depositCta": "入金する",
       "collapse": "閉じる",


### PR DESCRIPTION
## Summary
- liff-chatホームの「AI判定カード」「保留中提案カード」「ウォレット残高表示」を1つの統合ボックスに集約。保留中の提案がある間は汎用AI判定ボックスを非表示化し、銘柄・金額・確信度(直近AI判定由来の注記付き)・理由・残高・承認/見送るを1ボックスにまとめる
- 残高不足時の入金導線を別パネルへの遷移なしにボックス内へインライン表示(SBI VC等の送金案内 + Privy fundWallet直接起動)。`ProposalActionCard`(未承認・残高不足)・`AwaitingFundsCard`(入金待ち)・`ProposalSignSheet`(署名時検知)の3箇所で共通コンポーネント`DepositGuideInline`を使用
- fundWallet起動ロジックを新規`useDepositFundWallet`フックに共通化(`DepositPanel.tsx`もリファクタして利用)。この過程でE2Eテストにより、Privy App ID未設定環境で`useFundWallet()`を無条件に呼ぶとクラッシュする既存の潜在バグ(旧`DepositPanel`は遅延マウントのため露見しなかったが、新規の`AwaitingFundsCard`はページ読み込み時に自動マウントするため顕在化しやすい)を検出し、build-time定数ガードで修正

要件定義: Asana [1216284377506806](https://app.asana.com/1/817733952351708/project/817733952351714/task/1216284377506806)

## Test plan
- [x] `cd frontend && npx tsc --noEmit` pass
- [x] `npm run build` pass
- [x] `node scripts/check-i18n-keys.mjs` — 新規欠落なし
- [x] `npm run lint` — 新規ファイルに新規warning/error無し
- [x] ローカル`next dev`+Playwright(モックAPI)で実機ブラウザ確認: HOLD/提案(残高十分)/入金待ち(awaiting_funds)の3状態を`frontend/e2e/liff-chat-unified-proposal-card.spec.ts`で検証しPASS
- [ ] 残高不足・未承認のプレ承認インライン導線(オンチェーン残高が実際に不足するケース)はウォレット接続のモックが必要なため未カバー。staging-v4実機での目視確認を推奨
- [ ] Codex Review推奨: confidenceデータソース(proposal自身でなくaiJudgment由来)の注記妥当性、SUPPLY限定スコープの妥当性

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUEgFqF7VE6jsggFVgfMj