### PR TITLE
fix(liff-chat): 統合ボックスでBUY/SELLを大きく目立たせる

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/ProposalActionCard.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/ProposalActionCard.tsx
@@ -54,6 +54,13 @@ export function ProposalActionCard({
   const config = operationConfig[proposal.operation] ?? operationConfig["SUPPLY"]
   const OperationIcon = config.icon
 
+  // 統合ボックス化で汎用 AI 判定ボックス(BUY/SELLを text-2xl で大きく表示)が非表示に
+  // なったため、代わりにこのカード自身で BUY/SELL を一番目立つ位置に大きく出す。
+  // aiJudgment.action(直近の別ティック判定)ではなく、この提案自身の operation から
+  // 判定する(マルチプロトコルで判定と提案がズレるリスクを避けるため確信度と同じ理由)。
+  const isInflowOperation = ["SUPPLY", "STAKE_ETH", "BUY_PT"].includes(proposal.operation)
+  const bigActionLabel = isInflowOperation ? "BUY" : "SELL"
+
   // MARKET-B: lido/pendle 提案のときのみ ETH/USD を取得してバッジ表示する。
   const isEthProposal = proposal.protocol === "lido" || proposal.protocol === "pendle"
   const [ethUsd, setEthUsd] = useState<string | null>(null)
@@ -102,6 +109,9 @@ export function ProposalActionCard({
           )}
         </div>
       </div>
+
+      {/* BUY/SELL 大表示（旧 AI 判定ボックスの action 表示を踏襲。一番目立たせる） */}
+      <div className={`font-bold text-2xl mb-1 ${config.color}`}>{bigActionLabel}</div>
 
       {/* amount */}
       <div className="mb-2">


### PR DESCRIPTION
## Summary
- PR #939 の統合ボックス化により汎用AI判定ボックス(BUY/SELLをtext-2xlで大きく表示)が非表示になった結果、統合後の提案カードでは操作ラベル(「PTトークン購入」等)が小さいテキストのみで、BUY/SELLの判定が一目で分からなくなっていた
- staging-v4での実機テスト中に山本さんから「BUYが消えた?」というフィードバックがあり判明
- 提案自身の`operation`からBUY/SELLを判定し、旧AI判定ボックスと同じ`text-2xl`太字・色付きで一番目立つ位置に表示するよう修正
- `aiJudgment.action`(直近の別ティックの汎用判定)ではなく`proposal.operation`から判定することで、マルチプロトコル環境で判定と提案がズレるリスクも回避(確信度表示と同じ設計判断)

## Test plan
- [x] `npx tsc --noEmit` pass
- [x] 既存E2E `frontend/e2e/liff-chat-unified-proposal-card.spec.ts` 3件PASS(回帰なし)
- [x] ローカルモックでPendle BUY_PT提案($15,000 / 残高$5 / confidence100%)をスクリーンショット確認、BUYが緑・大きく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUEgFqF7VE6jsggFVgfMj