### PR TITLE
fix(liff-chat): BUY/SELL強調+枠線光アニメーション+残高不足の赤警告

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/ProposalActionCard.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/ProposalActionCard.tsx
@@ -48,8 +48,9 @@ export function ProposalActionCard({
     WITHDRAW: { label: t("exec.withdraw"), color: "text-red-600", icon: ArrowDown },
     STAKE_ETH: { label: t("exec.stakeEth"), color: "text-[#1D9E75]", icon: ArrowUp },
     UNSTAKE_ETH: { label: t("exec.unstakeEth"), color: "text-red-600", icon: ArrowDown },
-    BUY_PT: { label: t("exec.buyPt"), color: "text-[#1D9E75]", icon: ArrowUp },
-    SELL_PT: { label: t("exec.sellPt"), color: "text-red-600", icon: ArrowDown },
+    // BUY_PT/SELL_PT は下の大表示 BUY/SELL が方向を示すため、ラベルは銘柄種別のみに短縮する。
+    BUY_PT: { label: t("exec.ptTokenLabel"), color: "text-[#1D9E75]", icon: ArrowUp },
+    SELL_PT: { label: t("exec.ptTokenLabel"), color: "text-red-600", icon: ArrowDown },
   }
   const config = operationConfig[proposal.operation] ?? operationConfig["SUPPLY"]
   const OperationIcon = config.icon
@@ -60,6 +61,10 @@ export function ProposalActionCard({
   // 判定する(マルチプロトコルで判定と提案がズレるリスクを避けるため確信度と同じ理由)。
   const isInflowOperation = ["SUPPLY", "STAKE_ETH", "BUY_PT"].includes(proposal.operation)
   const bigActionLabel = isInflowOperation ? "BUY" : "SELL"
+
+  // 残高不足の視覚的注意喚起（SUPPLY 限定の insufficientBalance/入金導線とは独立。
+  // Pendle/Lido 等でも残高が足りていなければ一目でわかるようにする）。
+  const isBalanceLow = balanceUsd != null && balanceUsd < Number(proposal.amount_usd)
 
   // MARKET-B: lido/pendle 提案のときのみ ETH/USD を取得してバッジ表示する。
   const isEthProposal = proposal.protocol === "lido" || proposal.protocol === "pendle"
@@ -85,8 +90,12 @@ export function ProposalActionCard({
   const isLong = reason.length > 120
   const displayReason = !isLong || expanded ? reason : reason.slice(0, 120) + "…"
 
+  const borderColor = isInflowOperation ? "border-[#1D9E75]/50" : "border-red-500/50"
+
   return (
-    <div className="ax-card-warm rounded-2xl mx-4 mt-4 p-4 border-2 border-[#1D9E75]/40">
+    <div
+      className={`ax-card-warm ax-shine-border rounded-2xl mx-4 mt-4 p-4 border-2 ${borderColor}`}
+    >
       {/* header */}
       <div className="flex items-center gap-2 mb-2">
         <span className={`flex items-center gap-1 text-sm font-bold ${config.color}`}>
@@ -110,8 +119,13 @@ export function ProposalActionCard({
         </div>
       </div>
 
-      {/* BUY/SELL 大表示（旧 AI 判定ボックスの action 表示を踏襲。一番目立たせる） */}
-      <div className={`font-bold text-2xl mb-1 ${config.color}`}>{bigActionLabel}</div>
+      {/* BUY/SELL 大表示（旧 AI 判定ボックスの action 表示を踏襲し、さらに強調。
+          白フチ(-webkit-text-stroke)で色覚・背景に依存せず視認性を確保する） */}
+      <div
+        className={`font-extrabold text-6xl text-center mb-1 tracking-wide leading-none ${config.color} [-webkit-text-stroke:2px_white] [paint-order:stroke_fill]`}
+      >
+        {bigActionLabel}
+      </div>
 
       {/* amount */}
       <div className="mb-2">
@@ -129,10 +143,23 @@ export function ProposalActionCard({
         </p>
       )}
 
-      {/* ウォレット残高（統合ボックス化: page.tsx の KPI-E 行をここに集約） */}
-      <div className="flex items-center justify-between px-3 py-2 mb-3 rounded-lg bg-[#1c1a27]/5">
-        <span className="text-xs text-[#736f7e]">{t("kpi.walletBalance")}</span>
-        <span className="text-sm font-semibold text-[#1c1a27]">
+      {/* ウォレット残高（統合ボックス化: page.tsx の KPI-E 行をここに集約）。
+          残高が提案額に満たない場合は operation 種別を問わず赤背景で警告する
+          （insufficientBalance の入金導線自体は SUPPLY 限定のままだが、視覚的な
+          注意喚起はどの operation でも出す）。 */}
+      <div
+        className={`flex items-center justify-between px-3 py-2 mb-3 rounded-lg ${
+          isBalanceLow
+            ? "bg-red-50 border border-red-300"
+            : "bg-[#1c1a27]/5"
+        }`}
+      >
+        <span className={`text-xs ${isBalanceLow ? "text-red-700" : "text-[#736f7e]"}`}>
+          {t("kpi.walletBalance")}
+        </span>
+        <span
+          className={`text-sm font-semibold ${isBalanceLow ? "text-red-700" : "text-[#1c1a27]"}`}
+        >
           {balanceUsd != null
             ? `$${balanceUsd.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
             : "—"}

--- a/frontend/app/arobix/theme.css
+++ b/frontend/app/arobix/theme.css
@@ -193,3 +193,46 @@
 .ax-safe-bottom {
   padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 0.75rem);
 }
+
+/* ================================================================
+ * AI提案ボックス: 枠線を光が一周するアニメーション（liff-chat 統合ボックス）
+ * conic-gradient を回転させ、mask-composite で枠線のリングだけ残す手法。
+ * 単純な左右スイープ(旧実装)は角にしか光が見えず控えめすぎたため、
+ * 枠線を一周する chase-light 表現に変更。
+ * @property 未対応の環境(旧Safari等)ではアニメーションなしの静止グラデーションに
+ * デグレードするだけで、枠線表示自体は壊れない。
+ * ================================================================ */
+@property --ax-shine-angle {
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
+}
+.ax-shine-border {
+  position: relative;
+  isolation: isolate;
+}
+.ax-shine-border::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 2.5px;
+  background: conic-gradient(
+    from var(--ax-shine-angle),
+    transparent 0deg,
+    transparent 300deg,
+    rgba(255, 255, 255, 0.95) 330deg,
+    white 345deg,
+    rgba(255, 255, 255, 0.95) 360deg
+  );
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  animation: ax-shine-rotate 2.4s linear infinite;
+  pointer-events: none;
+}
+@keyframes ax-shine-rotate {
+  to { --ax-shine-angle: 360deg; }
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -674,6 +674,7 @@
       "signCanceled": "Signature canceled",
       "insufficientBalance": "Your wallet USDC balance is below the proposed amount. Please deposit before signing.",
       "confidenceNote": "latest AI judgment",
+      "ptTokenLabel": "PT Token",
       "errInsufficientFunds": "Insufficient balance or gas. Please check your USDC balance and ETH (for gas).",
       "depositCta": "Deposit",
       "collapse": "Collapse",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -674,6 +674,7 @@
       "signCanceled": "署名がキャンセルされました",
       "insufficientBalance": "ウォレットの USDC 残高が提案額に足りません。入金してから署名してください。",
       "confidenceNote": "直近のAI判定",
+      "ptTokenLabel": "PT トークン",
       "errInsufficientFunds": "残高またはガス代が不足しています。USDC 残高と ETH（ガス代）を確認してください。",
       "depositCta": "入金する",
       "collapse": "閉じる",


### PR DESCRIPTION
## Summary
PR #940 の続き。山本さんフィードバックに対応:

1. **BUY/SELLをさらに強調**: `text-2xl` → `text-6xl`・中央寄せ・白フチ(`-webkit-text-stroke`)。「全然目立たない」というフィードバックに対応
2. **操作ラベル短縮**: `BUY_PT`/`SELL_PT` の表示を「PTトークン購入」「PTトークン売却」→「PTトークン」に短縮(方向は大表示のBUY/SELLが示すため冗長だった)
3. **枠線の光アニメーション追加**: カード枠線を BUY=緑/SELL=赤で動的化し、枠線を光が一周する演出(`ax-shine-border`、conic-gradient + mask-composite)を追加。「当初のUIで予定していたはず」という指摘に対応(統合ボックス化で欠落していたもの)
4. **ウォレット残高の赤警告**: 残高が提案額を下回る場合、operation種別を問わず残高欄を赤背景で警告(既存の`insufficientBalance`入金導線自体はSUPPLY限定のまま維持。視覚的な注意喚起のみ追加)

## Test plan
- [x] `npx tsc --noEmit` pass
- [x] `npm run build` pass
- [x] `node scripts/check-i18n-keys.mjs` — 新規欠落なし
- [x] 既存E2E `frontend/e2e/liff-chat-unified-proposal-card.spec.ts` 3件PASS(回帰なし)
- [x] ローカルモック(Pendle BUY_PT $15,000 / SELL_PT $500)でBUY緑・SELL赤・白フチ表示をスクリーンショット確認
- [x] Claude in Chromeで枠線アニメーションが実際に回転して見えることを実機確認(computed styleでanimation-name確認 + zoomスクリーンショット2枚で光の位置が移動していることを確認)
- [ ] 残高赤警告はPlaywrightモック環境(ウォレット未接続でbalanceUsd常にnull)では再現不可のため未スクリーンショット。ロジックは`balanceUsd != null && balanceUsd < Number(proposal.amount_usd)`で単純比較のみ、staging-v4実機で確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUEgFqF7VE6jsggFVgfMj