### PR TITLE
feat(liff-chat): 承認するボタンを3秒間隔でゆっくり点滅

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/ProposalActionCard.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/ProposalActionCard.tsx
@@ -208,8 +208,10 @@ export function ProposalActionCard({
         <button
           onClick={onApprove}
           disabled={rejecting}
-          className="flex-1 py-2.5 rounded-xl bg-[#1D9E75] active:bg-[#178a64] text-white
-                     font-bold disabled:opacity-50 transition-colors"
+          className={`flex-1 py-2.5 rounded-xl bg-[#1D9E75] active:bg-[#178a64] text-white
+                     font-bold disabled:opacity-50 transition-colors ${
+                       rejecting ? "" : "ax-approve-pulse"
+                     }`}
         >
           {t("home.approve")}
         </button>

--- a/frontend/app/arobix/theme.css
+++ b/frontend/app/arobix/theme.css
@@ -236,3 +236,14 @@
 @keyframes ax-shine-rotate {
   to { --ax-shine-angle: 360deg; }
 }
+
+/* ================================================================
+ * 「承認する」ボタン: ゆっくり点滅（3秒間隔）で行動を促す。
+ * ================================================================ */
+.ax-approve-pulse {
+  animation: ax-approve-pulse 3s ease-in-out infinite;
+}
+@keyframes ax-approve-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}


### PR DESCRIPTION
## Summary
- 「承認する」ボタンに opacity 1→0.55→1 を3秒周期(ease-in-out)で繰り返す `ax-approve-pulse` を適用し、行動を促す
- 見送り処理中(rejecting=true、承認ボタン自体disabled)は点滅を止める

## Test plan
- [x] `npx tsc --noEmit` pass
- [x] `node scripts/check-i18n-keys.mjs` — 変更なし(新規キーなし)
- [ ] ローカルdevサーバーがコンパイルで詰まったため実機ブラウザ確認は未実施(単純なCSS opacityアニメーション追加のみ、低リスク判断)。staging-v4デプロイ後に実機確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUEgFqF7VE6jsggFVgfMj