### PR TITLE
fix(liff-chat): 運用元プロトコル名(Aave/Pendle等)をUIから非表示に

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/ProposalActionCard.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/ProposalActionCard.tsx
@@ -110,12 +110,6 @@ export function ProposalActionCard({
               1 ETH ≈ ${Number(ethUsd).toLocaleString("en-US", { maximumFractionDigits: 0 })}
             </span>
           )}
-          {/* Phase-C2: protocol バッジ（aave 以外のとき表示） */}
-          {proposal.protocol && proposal.protocol !== "aave" && (
-            <span className="text-xs bg-[#1c1a27]/10 px-2 py-0.5 rounded-full text-[#736f7e]">
-              {proposal.protocol}
-            </span>
-          )}
         </div>
       </div>
 

--- a/frontend/app/(liff)/liff-chat/_components/panels/TxHistoryPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TxHistoryPanel.tsx
@@ -107,7 +107,6 @@ function TxDetailPanel({ tx, onClose }: TxDetailPanelProps) {
     { label: t("detailDate"), value: formatDate(tx.created_at) },
     { label: t("detailStatus"), value: statusLabel(tx.status) },
   ]
-  if (tx.protocol) detailRows.push({ label: t("detailProtocol"), value: tx.protocol })
   if (tx.apy) detailRows.push({ label: t("detailApy"), value: `${tx.apy}%` })
   if (tx.gas_fee_usd) detailRows.push({ label: t("detailGas"), value: `$${Number(tx.gas_fee_usd).toFixed(4)}` })
   if (tx.wallet_address) detailRows.push({ label: t("detailWallet"), value: `${tx.wallet_address.slice(0, 6)}...${tx.wallet_address.slice(-4)}` })

--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -608,7 +608,6 @@ export default function LiffChatPage() {
                 </div>
                 <div className="flex-1 text-left">
                   <div className="text-[#1c1a27] text-sm font-medium">{coin.asset}</div>
-                  <div className="text-[#736f7e] text-xs">{coin.protocol}</div>
                 </div>
                 <div className="text-right">
                   <div className="text-[#1c1a27] text-sm">${coin.amount_usd.toLocaleString()}</div>


### PR DESCRIPTION
## Summary
方針: 消費者向けliff-chatでは運用元サービス名(Aave/Pendle/Lido等)を表示しない。以下3箇所を削除(データフィールド自体は保持、表示のみ抑制):

- `page.tsx`: 運用中コイン一覧のprotocol行(例: 「Aave V3」)
- `ProposalActionCard.tsx`: 提案カードのprotocolバッジ(例: 「pendle」)
- `TxHistoryPanel.tsx`: 取引履歴詳細のprotocol行

ETH価格バッジ表示に使う`isEthProposal`判定(`protocol==="lido"/"pendle"`)やLido向け注意書き分岐など、内部ロジックとしてのprotocol参照はそのまま維持(ユーザーには見えない)。

スコープ: liff-chat(消費者向け)配下のみ。admin/partner側のprotocol表示は対象外(運用者は把握が必要なため)。

## Test plan
- [x] `npx tsc --noEmit` pass
- [x] `npm run build` pass
- [x] `node scripts/check-i18n-keys.mjs` — 新規欠落なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUEgFqF7VE6jsggFVgfMj