### PR TITLE
fix(pwa): apple-touch-iconの重複リンクタグを削除

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -50,7 +50,6 @@ export default async function RootLayout({
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <meta name="apple-mobile-web-app-title" content="Ultra AutoTrade" />
         <meta name="format-detection" content="telephone=no" />
-        <link rel="apple-touch-icon" href="/icons/icon-192.svg" />
       </head>
       <body className="bg-background text-foreground antialiased">
         <NextIntlClientProvider locale={locale} messages={messages}>


### PR DESCRIPTION
## Summary
`app/layout.tsx` の `<head>` に `apple-touch-icon` の `<link>` タグが2つ存在していた:
- Next.js `metadata.icons.apple` 経由で自動生成される正しい方(`apple-touch-icon.png`, 180x180 PNG)
- 手書きの余分な方(`icon-192.svg`) — **iOSはapple-touch-iconにSVGを認識しない**

複数の`apple-touch-icon`タグが存在するとiOS側のアイコン選択アルゴリズムが機種/バージョンによって不安定になり、ホーム画面追加時にロゴが正しく表示されない可能性があったため、無効な手書きの方を削除。

このPRは production/staging 共通の `app/layout.tsx`(全ルート共通レイアウト)を修正するもので、liff-chat固有の変更ではない。

## Test plan
- [x] `npx tsc --noEmit` pass
- [x] `npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUEgFqF7VE6jsggFVgfMj