### PR TITLE
feat(liff-chat): 保留中の提案がある間PWAアイコンにバッジ表示

### DIFF
--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -317,6 +317,24 @@ export default function LiffChatPage() {
     return () => ws.close()
   }, [])
 
+  // ── アプリアイコンバッジ（Badging API）: 保留中の提案がある間、ホーム画面に
+  // 追加済みPWAのアイコンにネイティブアプリ同様の丸バッジを表示する。
+  // ブラウザタブ表示時や未対応環境（iOS 16.3以下等）では navigator.setAppBadge
+  // 自体が存在しないため何もしない（フォアグラウンドで開いている間のみ更新される。
+  // バックグラウンドでの自動更新には Web Push 連携が別途必要）。
+  useEffect(() => {
+    const nav = navigator as Navigator & {
+      setAppBadge?: (contents?: number) => Promise<void>
+      clearAppBadge?: () => Promise<void>
+    }
+    if (!nav.setAppBadge || !nav.clearAppBadge) return
+    if (pendingProposal) {
+      nav.setAppBadge(1).catch(() => {})
+    } else {
+      nav.clearAppBadge().catch(() => {})
+    }
+  }, [pendingProposal])
+
 
   // ── 緊急停止: POST /api/user/pause（require_active_user / consumer 可）
   // backend の OR ロジック安全装置は変更せず、ユーザーの is_active フラグを落とすだけ。


### PR DESCRIPTION
## Summary
Badging API (`navigator.setAppBadge`/`clearAppBadge`) を使い、ホーム画面に追加済みのPWAアイコンにネイティブアプリ同様の丸バッジを表示する。`pendingProposal`の有無に応じてセット/クリア。

## 制約(既知の限界)
- ホーム画面追加(standalone)済み環境のみ。ブラウザタブ表示では出ない
- Android Chrome / iOS Safari 16.4+ で対応。それ以外は`setAppBadge`自体が存在しないため何もしない(fail-open、undefined環境でクラッシュしない)
- フォアグラウンドでliff-chatを開いている間のみ更新される。バックグラウンドでの自動更新には別途Web Push連携が必要

## 調査結果(参考)
Web Push通知については別途調査済み: フロント(`PushNotificationToggle.tsx`)・バックエンド(VAPID送信ロジック`push.py`)とも実装はあるが、(1)UIがどこにも配線されていない孤立コンポーネント、(2)AI提案作成時の自動送信フックが無く手動テスト送信のみ、(3)購読情報がDB永続化されずメモリ保存のみ、(4)staging-v4にVAPIDキー未設定、という状態。実際に機能させるには別途まとまった作業が必要なため、今回はスコープ外(バッジのみ)とした。

## Test plan
- [x] `npx tsc --noEmit` pass
- [x] `npm run build` pass
- [x] `node scripts/check-i18n-keys.mjs` — 変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUEgFqF7VE6jsggFVgfMj