### PR TITLE
fix(auth): root URLからLIFF/PWA消費者ユーザーを/liff-chatへ正しく誘導

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -6,6 +6,7 @@ import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import { AuthProvider, useAuth } from '@/lib/auth'
+import { getAuthToken } from '@/lib/auth/token-key'
 
 function getRoleDefaultPath(role: string | undefined): string {
   if (role === 'admin') return '/dashboard'
@@ -19,6 +20,14 @@ function RedirectGate() {
   const t = useTranslations('RootPage')
 
   useEffect(() => {
+    // LIFF/PWA 消費者アカウント(liff-login経由)は ultra_auth_expires を持たないため
+    // useAuth() の isAuthenticated では検出できず、root から /connect へ誤送されていた
+    // (実機: staging-v4 rootをそのまま開いたテスターが /liff-chat に着地できなかった不具合)。
+    // auth_token の有無を先に見て、あれば useAuth() の初期化完了を待たず /liff-chat へ送る。
+    if (getAuthToken()) {
+      router.replace('/liff-chat')
+      return
+    }
     if (isLoading) return
     if (isAuthenticated) {
       router.replace(getRoleDefaultPath(user?.role))


### PR DESCRIPTION
## Summary
`app/page.tsx` の `RedirectGate` は `useAuth()`(`lib/auth.ts`)の`isAuthenticated`のみで分岐していたが、この判定は `ultra_auth_expires` localStorage キーを要求する。`liff-login`経由のLIFF/PWA消費者アカウントはこのキーを設定しないため、有効な`auth_token`を持つユーザーでも`isAuthenticated=false`と判定され`/connect`へ誤送されていた。

**実機で発覚した不具合**: staging-v4のroot URL(`https://staging-v4.ultra-auto-trade.com`)をそのまま開いたテスターが`/liff-chat`に到達できず、別画面(`/user/dashboard`または`/connect`)が表示されていた。

## 修正内容
`getAuthToken()`(`token-key.ts`、JWT期限切れも判定済み)で`auth_token`の有無を先に確認し、あれば`useAuth()`の初期化を待たず`/liff-chat`へ直接リダイレクトする。既存のadmin/partner/legacy consumerフロー(`useAuth()`ベース)はfall-throughで変更なし。

## Test plan
- [x] `npx tsc --noEmit` pass
- [x] `npm run build` pass
- [x] Claude in Chromeでローカルdevサーバーに`auth_token`をセットしてroot(`/`)にアクセス → `/liff-chat`経由で`/liff-confirm`(未同意テストトークンのため)へ遷移することを実機確認(スクリーンショットで「重要事項の確認」画面着地を確認)。実際の同意済みユーザーはそのまま`/liff-chat`に着地する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUEgFqF7VE6jsggFVgfMj