### PR TITLE
fix(liff-chat): 出金タブがWITHDRAW_ENABLEDに関係なく常にdisabledだった不具合を修正

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/DepositPanel.tsx
@@ -194,7 +194,9 @@ export function DepositPanel() {
 
   return (
     <div className="pb-2">
-      {/* タブ（出金は準備中表示のみ・クリック不可） */}
+      {/* タブ（WITHDRAW_ENABLED=false の間は出金＝準備中表示のみ・クリック不可。
+          2026-07-07 修正: このタブボタン自体がフラグを見ずハードコードで disabled に
+          なっており、NEXT_PUBLIC_WITHDRAW_ENABLED=true にしても出金タブが開けなかった。 */}
       <div className="flex border-b border-[#1c1a27]/15 mb-4">
         <button
           onClick={() => handleTabChange("deposit")}
@@ -208,13 +210,23 @@ export function DepositPanel() {
           {t("tabDeposit")}
         </button>
         <button
-          disabled
-          className="flex-1 py-2 text-sm font-medium text-[#736f7e] opacity-40 cursor-not-allowed flex items-center justify-center gap-1"
+          onClick={WITHDRAW_ENABLED ? () => handleTabChange("withdraw") : undefined}
+          disabled={!WITHDRAW_ENABLED}
+          className={[
+            "flex-1 py-2 text-sm font-medium flex items-center justify-center gap-1 transition-colors",
+            !WITHDRAW_ENABLED
+              ? "text-[#736f7e] opacity-40 cursor-not-allowed"
+              : tab === "withdraw"
+                ? "border-b-2 border-[#1D9E75] text-[#1D9E75]"
+                : "text-[#736f7e]",
+          ].join(" ")}
         >
           {t("tabWithdraw")}
-          <span className="text-[10px] bg-[#736f7e]/20 rounded px-1 py-0.5 leading-none">
-            {t("withdrawComingSoon")}
-          </span>
+          {!WITHDRAW_ENABLED && (
+            <span className="text-[10px] bg-[#736f7e]/20 rounded px-1 py-0.5 leading-none">
+              {t("withdrawComingSoon")}
+            </span>
+          )}
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
PR #951(build-arg配線修正)の後も出金タブが「準備中」のままだった問題を調査。原因は別の場所にあった: タブボタン自体が`disabled`属性・「準備中」バッジを**フラグを見ずハードコード**していた(`WITHDRAW_ENABLED`は出金フォーム本体の表示条件にのみ使われ、タブの活性化には使われていなかった)。

`WITHDRAW_ENABLED`に応じてタブのdisabled/クリックハンドラ/準備中バッジを出し分けるよう修正。false(既定・staging/production)では従来通りdisabled+準備中バッジのまま、挙動は変わらない。

**注記**: タブは開けるようになるが、出金実行ボタン(`handleWithdrawConfirm`)は意図的にno-op(「準備中」表示)のまま。実出金は別途`(user)/withdraw`側の実装が必要(既存コメント参照)。今回はタブの表示バグ修正のみで、出金機能自体の実装ではない。

## Test plan
- [x] `npx tsc --noEmit` pass
- [x] `npm run build` pass
- [x] Playwrightで実機確認: `NEXT_PUBLIC_WITHDRAW_ENABLED=true`時にタブの`disabled`属性が`false`になること、クリックで出金フォーム(「出金可能残高」等)が実際に表示されることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUEgFqF7VE6jsggFVgfMj