### PR TITLE
fix(liff-chat): 出金画面レイアウト崩れ修正 + Aave/Lido表記をUATに統一

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/SlideUpPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/SlideUpPanel.tsx
@@ -16,7 +16,7 @@ export function SlideUpPanel({
   onClose,
   title,
   children,
-  maxHeight = "90vh",
+  maxHeight = "90dvh",
 }: SlideUpPanelProps) {
   if (!open) return null
   return (

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -209,7 +209,7 @@
     "filterAll": "All",
     "dateFrom": "From",
     "dateTo": "To",
-    "aaveTab": "Aave Operations",
+    "aaveTab": "UAT Operations",
     "exchangeTab": "Exchange History (Coming Soon)",
     "loadMore": "Load More",
     "totalCount": "Total {total}",
@@ -242,9 +242,9 @@
     "loadingText": "Loading...",
     "totalCountExchange": "Total {total}",
     "pageCount": "Page {page} / {totalPages}",
-    "headerDesc": "Full history of Aave operations",
+    "headerDesc": "Full history of UAT operations",
     "csvTitle": "Tax CSV (Cryptact format)",
-    "csvDesc": "Export completed Aave operations in Cryptact free-tier format",
+    "csvDesc": "Export completed UAT operations in Cryptact free-tier format",
     "csvYearUnit": "{year}",
     "csvDownloading": "Downloading...",
     "csvDownload": "Download CSV",
@@ -388,7 +388,7 @@
     "featureAIDesc": "Claude Sonnet 4.6 + GPT-4o cross-validation",
     "featureSafe": "Safe Design",
     "featureSafeDesc": "Health Factor monitoring + Emergency Stop",
-    "featureAave": "Aave V3",
+    "featureAave": "UAT",
     "featureAaveDesc": "Auto trading on Base"
   },
   "Connect": {
@@ -815,7 +815,7 @@
         "depositAddressLabel": "Deposit address (Base Mainnet)",
         "depositAddressCopyBtn": "Copy address",
         "depositAddressCopied": "Copied",
-        "depositAddressNote": "Send USDC to this address. It will be automatically deposited into Aave once received.",
+        "depositAddressNote": "Send USDC to this address. It will be automatically deposited into UAT once received.",
         "depositNoWallet": "No wallet address registered",
         "depositBtn": "Deposit",
         "moonpayTitle": "Buy with card",
@@ -831,7 +831,7 @@
         "withdrawGuideNote1": "Important: the address must be on the {chain} network. Sending to a different network may result in loss of funds",
         "networkFeeLabel": "Network fee",
         "receiveAmountLabel": "You will receive",
-        "withdrawWarning": "Withdrawn assets leave Aave. No yield until re-deposited.",
+        "withdrawWarning": "Withdrawn assets leave UAT. No yield until re-deposited.",
         "withdrawBtn": "Withdraw",
         "confirmSheetTitle": "Confirm withdrawal",
         "confirmSheetWithdrawAmount": "Withdraw amount",
@@ -1198,15 +1198,15 @@
     "pageSubtitle": "Frequently asked questions about Ultra AutoTrade",
     "faqs": {
       "item1Question": "What is Health Factor (HF)?",
-      "item1Answer": "Health Factor is a safety metric for collateral in Aave. If it falls below 1.0, liquidation risk arises. Our system automatically manages it to stay at 1.6 or above.",
+      "item1Answer": "Health Factor is a safety metric for collateral in UAT. If it falls below 1.0, liquidation risk arises. Our system automatically manages it to stay at 1.6 or above.",
       "item2Question": "What happens if HF drops below 1.6?",
       "item2Answer": "The system switches to SAFE_MODE and halts new deposits. If necessary, positions are automatically reduced. If HF falls below 1.3, HARD_STOP (full withdrawal) is triggered.",
       "item3Question": "What should I do if an emergency stop is triggered?",
-      "item3Answer": "All automated trading stops. Your funds remain safely held in Aave. An administrator will review the situation and manually resume operations. No action is required from the user.",
+      "item3Answer": "All automated trading stops. Your funds remain safely held in UAT. An administrator will review the situation and manually resume operations. No action is required from the user.",
       "item4Question": "Why did the yield decrease?",
-      "item4Answer": "The USDC supply rate on Aave fluctuates based on market supply and demand. When borrowing demand decreases, the rate drops. The AI monitors market conditions and aims to operate at the optimal timing.",
+      "item4Answer": "The USDC supply rate on UAT fluctuates based on market supply and demand. When borrowing demand decreases, the rate drops. The AI monitors market conditions and aims to operate at the optimal timing.",
       "item5Question": "What should I do if I want to stop using the service?",
-      "item5Answer": "Please contact the administrator. They will handle the withdrawal from Aave. Your funds will be returned to your wallet.",
+      "item5Answer": "Please contact the administrator. They will handle the withdrawal from UAT. Your funds will be returned to your wallet.",
       "item6Question": "How often does the AI make decisions?",
       "item6Answer": "Market analysis and decisions are performed automatically every 4 hours. You can check the results on the dashboard.",
       "item7Question": "Is there a deadline for approving trades?",
@@ -1388,7 +1388,7 @@
     "abnormal": "Degraded",
     "active": "Active",
     "phase2Note": "Phase 2 upcoming:",
-    "phase2NoteText": "Lido stETH and Pendle PT/YT strategies are currently in development and will be available after official release.",
+    "phase2NoteText": "Staking-type and yield-optimization-type strategies are currently in development and will be available after official release.",
     "risk_low": "Low",
     "risk_medium": "Med",
     "risk_high": "High",
@@ -1396,16 +1396,16 @@
     "risk_medium_high": "Med-High",
     "aave": {
       "subtitle": "Lending Strategy",
-      "description": "Supply USDC to the Aave V3 protocol to earn stable lending interest. Safely managed with health factor monitoring and automatic rebalancing.",
+      "description": "Supply USDC to the stable-type plan to earn stable lending interest. Safely managed with health factor monitoring and automatic rebalancing.",
       "apyRange": "3–5%"
     },
     "lido": {
       "subtitle": "Liquid Staking",
-      "description": "Liquid-stake ETH via the Lido protocol and hold as stETH. Earn validator rewards while maintaining liquidity."
+      "description": "Liquid-stake ETH via the staking-type plan and hold as a liquid staking token. Earn validator rewards while maintaining liquidity."
     },
     "pendle": {
       "subtitle": "Yield Trading",
-      "description": "Buy and sell tokenized yields on the Pendle protocol. Advanced yield optimization using principal tokens (PT) and yield tokens (YT)."
+      "description": "Buy and sell tokenized yields via the yield-optimization-type plan. Advanced yield optimization using principal (PT) and yield (YT) portions."
     },
     "optimizer": {
       "title": "Optimize Allocation",
@@ -1427,11 +1427,11 @@
       "riskScoreLabel": "Risk score",
       "disclaimer": "This estimate is for reference only and does not guarantee actual returns.",
       "protocol": {
-        "aave": "Aave Lending",
-        "lido": "Lido stETH",
-        "lido_aave": "Lido + Aave Combined",
-        "pendle_pt": "Pendle PT",
-        "pendle_yt": "Pendle YT",
+        "aave": "Stable-type Lending",
+        "lido": "Staking-type",
+        "lido_aave": "Staking-type + Stable-type Combined",
+        "pendle_pt": "Yield-optimization-type (Principal)",
+        "pendle_yt": "Yield-optimization-type (Yield)",
         "idle": "Uninvested (cash)"
       }
     }
@@ -1516,7 +1516,7 @@
       },
       "howToStop": {
         "q": "How do I stop using the service?",
-        "a": "You can withdraw your assets from Aave at any time. Even after cancelling Ultra AutoTrade, your assets remain in your wallet. You only need gas fees to withdraw."
+        "a": "You can withdraw your assets from UAT at any time. Even after cancelling Ultra AutoTrade, your assets remain in your wallet. You only need gas fees to withdraw."
       }
     },
     "ctaBtn": "Connect Wallet to Get Started →"
@@ -3602,7 +3602,7 @@
   "ProposalsAllocationCards": {
     "conservativeName": "Conservative",
     "conservativeSubtitle": "Stable Supply Strategy",
-    "conservativeDescription": "Supply USDC to Base V3 (Aave) to earn stable lending interest. Operates without price volatility risk, under health factor monitoring.",
+    "conservativeDescription": "Supply USDC to UAT to earn stable lending interest. Operates without price volatility risk, under health factor monitoring.",
     "conservativeVenue": "Base V3 USDC supply",
     "standardName": "Standard",
     "aggressiveName": "Aggressive",
@@ -3781,7 +3781,7 @@
     "redirecting": "Redirecting..."
   },
   "RewardsCard": {
-    "title": "Aave Rewards",
+    "title": "UAT Rewards",
     "unclaimedTotal": "Unclaimed Total",
     "lastClaimedAt": "Last Claimed",
     "noData": "No reward data",
@@ -3832,7 +3832,7 @@
   "UnifiedPortfolioCard": {
     "title": "Unified Portfolio",
     "grandTotal": "Total Assets",
-    "sourceAave": "Aave Net",
+    "sourceAave": "UAT Net",
     "sourceWallet": "Wallet Balance",
     "sourceCex": "Exchange",
     "healthFactor": "Health Factor",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -209,7 +209,7 @@
     "filterAll": "すべて",
     "dateFrom": "開始日",
     "dateTo": "終了日",
-    "aaveTab": "Aave操作履歴",
+    "aaveTab": "UAT操作履歴",
     "exchangeTab": "取引所履歴（準備中）",
     "loadMore": "もっと見る",
     "totalCount": "全 {total} 件",
@@ -242,9 +242,9 @@
     "loadingText": "読み込み中...",
     "totalCountExchange": "全 {total} 件",
     "pageCount": "ページ {page} / {totalPages}",
-    "headerDesc": "Aave操作の全履歴を確認できます",
+    "headerDesc": "UAT操作の全履歴を確認できます",
     "csvTitle": "税務CSV (Cryptact形式)",
-    "csvDesc": "実行済みAave操作をCryptact無料版フォーマットでエクスポートします",
+    "csvDesc": "実行済みUAT操作をCryptact無料版フォーマットでエクスポートします",
     "csvYearUnit": "{year}年",
     "csvDownloading": "ダウンロード中...",
     "csvDownload": "CSVダウンロード",
@@ -388,7 +388,7 @@
     "featureAIDesc": "Claude Sonnet 4.6 + GPT-4o のクロス検証",
     "featureSafe": "安全設計",
     "featureSafeDesc": "ヘルスファクター監視 + 緊急停止",
-    "featureAave": "Aave V3",
+    "featureAave": "UAT",
     "featureAaveDesc": "Base で自動運用"
   },
   "Connect": {
@@ -815,7 +815,7 @@
         "depositAddressLabel": "入金用アドレス（Base Mainnet）",
         "depositAddressCopyBtn": "アドレスをコピー",
         "depositAddressCopied": "コピーしました",
-        "depositAddressNote": "このアドレスに USDC を送金してください。着金後、自動で Aave 運用に反映されます。",
+        "depositAddressNote": "このアドレスに USDC を送金してください。着金後、自動で UAT 運用に反映されます。",
         "depositNoWallet": "ウォレットアドレスが登録されていません",
         "depositBtn": "入金する",
         "moonpayTitle": "クレジットカードで購入",
@@ -831,7 +831,7 @@
         "withdrawGuideNote1": "【重要】必ず {chain} ネットワークのアドレスを指定してください。異なるネットワーク宛に送ると資金が失われる可能性があります",
         "networkFeeLabel": "ネットワーク手数料",
         "receiveAmountLabel": "受取予定額",
-        "withdrawWarning": "出金後の資産はAave運用から外れます。再入金まで利回りは発生しません。",
+        "withdrawWarning": "出金後の資産はUAT運用から外れます。再入金まで利回りは発生しません。",
         "withdrawBtn": "出金する",
         "confirmSheetTitle": "出金内容の確認",
         "confirmSheetWithdrawAmount": "出金額",
@@ -1198,15 +1198,15 @@
     "pageSubtitle": "Ultra AutoTradeの利用に関するFAQです",
     "faqs": {
       "item1Question": "Health Factor（HF）とは何ですか？",
-      "item1Answer": "Aaveにおける担保の安全度指標です。1.0を下回ると清算リスクが発生します。当システムでは1.6以上を維持するよう自動管理しています。",
+      "item1Answer": "UATにおける担保の安全度指標です。1.0を下回ると清算リスクが発生します。当システムでは1.6以上を維持するよう自動管理しています。",
       "item2Question": "HFが1.6を下回るとどうなりますか？",
       "item2Answer": "SAFE_MODEに移行し、新規供給を停止します。必要に応じて自動でポジション縮小を行います。HF < 1.3の場合はHARD_STOP（全引き出し）が発動します。",
       "item3Question": "緊急停止が発動したらどうすればいいですか？",
-      "item3Answer": "すべての自動取引が停止します。資金はAave上に安全に保管されたままです。管理者が状況を確認後、手動で再開します。特にユーザー側の操作は不要です。",
+      "item3Answer": "すべての自動取引が停止します。資金はUAT上に安全に保管されたままです。管理者が状況を確認後、手動で再開します。特にユーザー側の操作は不要です。",
       "item4Question": "利回りが下がったのはなぜですか？",
-      "item4Answer": "AaveのUSDC供給利率は市場の需給で変動します。借入需要が減ると利率が低下します。AIが市場状況を判断し、最適なタイミングでの運用を目指しています。",
+      "item4Answer": "UATのUSDC供給利率は市場の需給で変動します。借入需要が減ると利率が低下します。AIが市場状況を判断し、最適なタイミングでの運用を目指しています。",
       "item5Question": "運用をやめたい場合はどうすればいいですか？",
-      "item5Answer": "管理者にご連絡ください。Aaveからの引き出し手続きを行います。資金はお使いのウォレットに返却されます。",
+      "item5Answer": "管理者にご連絡ください。UATからの引き出し手続きを行います。資金はお使いのウォレットに返却されます。",
       "item6Question": "AIの判定はどのくらいの頻度で行われますか？",
       "item6Answer": "4時間ごとに自動で市場分析と判定を実施します。判定結果はダッシュボードで確認できます。",
       "item7Question": "取引の承認期限はありますか？",
@@ -1388,7 +1388,7 @@
     "abnormal": "異常",
     "active": "稼働中",
     "phase2Note": "Phase 2 予定:",
-    "phase2NoteText": "Lido stETH・Pendle PT/YT戦略は現在開発中です。正式リリース後に選択可能になります。",
+    "phase2NoteText": "ステーキング型・イールド最適化型戦略は現在開発中です。正式リリース後に選択可能になります。",
     "risk_low": "低",
     "risk_medium": "中",
     "risk_high": "高",
@@ -1396,16 +1396,16 @@
     "risk_medium_high": "中〜高",
     "aave": {
       "subtitle": "レンディング戦略",
-      "description": "USDCをAave V3プロトコルに供給し、安定した貸出利息を獲得します。ヘルスファクター監視と自動リバランスで安全に運用します。",
+      "description": "USDCを安定型プランに供給し、安定した貸出利息を獲得します。ヘルスファクター監視と自動リバランスで安全に運用します。",
       "apyRange": "3〜5%"
     },
     "lido": {
       "subtitle": "リキッドステーキング",
-      "description": "ETHをLidoプロトコルでリキッドステーキングし、stETHとして保有します。バリデーター報酬を受け取りながら流動性を維持できます。"
+      "description": "ETHをステーキング型プランでリキッドステーキングし、流動性のある保有トークンとして保有します。バリデーター報酬を受け取りながら流動性を維持できます。"
     },
     "pendle": {
       "subtitle": "イールドトレーディング",
-      "description": "Pendleプロトコルでトークン化された利回りを売買します。元本トークン（PT）と利回りトークン（YT）を活用した高度なイールド最適化戦略です。"
+      "description": "イールド最適化型プランでトークン化された利回りを売買します。元本部分（PT）と利回り部分（YT）を活用した高度なイールド最適化戦略です。"
     },
     "optimizer": {
       "title": "最適配分を試算",
@@ -1427,11 +1427,11 @@
       "riskScoreLabel": "リスクスコア",
       "disclaimer": "本試算は参考値です。実際の運用成果を保証するものではありません。",
       "protocol": {
-        "aave": "Aave レンディング",
-        "lido": "Lido stETH",
-        "lido_aave": "Lido + Aave 複合",
-        "pendle_pt": "Pendle PT",
-        "pendle_yt": "Pendle YT",
+        "aave": "安定型レンディング",
+        "lido": "ステーキング型",
+        "lido_aave": "ステーキング型 + 安定型 複合",
+        "pendle_pt": "イールド最適化型（元本）",
+        "pendle_yt": "イールド最適化型（利回り）",
         "idle": "未投資（現金）"
       }
     }
@@ -1516,7 +1516,7 @@
       },
       "howToStop": {
         "q": "やめたいときはどうすればいいですか？",
-        "a": "いつでも資産をAaveから引き出せます。Ultra AutoTradeを解除した後も、資産はあなたのウォレットに残ります。引き出しに必要なのはガス代のみです。"
+        "a": "いつでも資産をUATから引き出せます。Ultra AutoTradeを解除した後も、資産はあなたのウォレットに残ります。引き出しに必要なのはガス代のみです。"
       }
     },
     "ctaBtn": "ウォレットを接続して始める →"
@@ -3619,7 +3619,7 @@
   "ProposalsAllocationCards": {
     "conservativeName": "Conservative（保守）",
     "conservativeSubtitle": "安定供給戦略",
-    "conservativeDescription": "USDC を Base V3（Aave）に供給し、安定した貸出利息を獲得します。価格変動リスクを取らず、ヘルスファクター監視のもとで運用します。",
+    "conservativeDescription": "USDC を UAT に供給し、安定した貸出利息を獲得します。価格変動リスクを取らず、ヘルスファクター監視のもとで運用します。",
     "conservativeVenue": "Base V3 USDC supply",
     "standardName": "Standard（標準）",
     "aggressiveName": "Aggressive（積極）",
@@ -3798,7 +3798,7 @@
     "redirecting": "リダイレクト中..."
   },
   "RewardsCard": {
-    "title": "Aaveリワード",
+    "title": "UATリワード",
     "unclaimedTotal": "未請求合計",
     "lastClaimedAt": "最終Claim日時",
     "noData": "リワードデータがありません",
@@ -3849,7 +3849,7 @@
   "UnifiedPortfolioCard": {
     "title": "統合ポートフォリオ",
     "grandTotal": "合計資産",
-    "sourceAave": "Aave 純資産",
+    "sourceAave": "UAT 純資産",
     "sourceWallet": "ウォレット残高",
     "sourceCex": "取引所",
     "healthFactor": "ヘルスファクター",


### PR DESCRIPTION
## Summary
1. **レイアウト修正**: `SlideUpPanel`の`maxHeight`が`90vh`固定だったため、iOS Safariのツールバー収縮/展開でviewport高さが変動すると、sticky ヘッダー(タイトル)とコンテンツが重なって表示される不具合を修正。他のliff画面は既に`dvh`(動的viewport単位)に統一済みのため、`90dvh`に変更して揃えた。
2. **Aave/Lido/Pendle表記をUATに統一**: 出金画面の警告文に「Aave」が露出していた指摘を受け、消費者向け画面全体をスキャンして置換。
   - 入出金ガイド・FAQ・リワードカード等は単純にUATへ置換
   - 戦略選択画面(`/user/strategies`)はAave/Lido/Pendleが3種類の戦略の識別名として使われているため、単純に全てUATにすると区別不能になる。戦略タイプ名(安定型/ステーキング型/イールド最適化型)による区別に変更
   - 管理画面(Admin*/Partner*、AdminProtocols等)は運用監視に実プロトコル名が必要なため対象外(スコープは事前確認済み)

## Test plan
- [x] `npx tsc --noEmit` pass
- [x] `npm run build` pass
- [x] `node scripts/check-i18n-keys.mjs` — 新規欠落なし
- [x] Playwrightで実機確認: 出金タブに「Aave」の文言が一切残っていないこと、「UAT運用から外れます」等の新文言が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUEgFqF7VE6jsggFVgfMj