### PR TITLE
feat(fees): operator fee wallet をPrivy Server Wallet署名に置換可能化(Track1)

### DIFF
--- a/backend/app/fees/fee_transfer_service.py
+++ b/backend/app/fees/fee_transfer_service.py
@@ -91,7 +91,15 @@ _DATA_PROVIDER_ABI_MINIMAL: list[dict[str, object]] = [
 
 @dataclass(frozen=True)
 class FeeTransferConfig:
-    """on-chain fee transfer の設定。環境変数から組み立て。"""
+    """on-chain fee transfer の設定。環境変数から組み立て。
+
+    signing_mode:
+      - ``"raw_key"``(既定・後方互換): operator_wallet_key(生鍵)を使い
+        `w3.eth.account.sign_transaction` で署名・送信する旧式。
+      - ``"privy"``: operator wallet を Privy Server Wallet 化し、生鍵を env に
+        置かず Privy REST(`eth_sendTransaction`, TEE 内署名)で送信する。env に残る
+        秘密は P-256 authorization 鍵のみ(= ブロックチェーン鍵ではない・policy 制約下)。
+    """
 
     enabled: bool
     operator_wallet_address: str
@@ -100,6 +108,9 @@ class FeeTransferConfig:
     data_provider_address: str
     usdc_address: str
     chain_id: int
+    signing_mode: str = "raw_key"
+    operator_privy_wallet_id: str = ""
+    chain_name: str = "base_sepolia"
 
     @classmethod
     def from_env(cls, chain_name: str = "base_sepolia") -> "FeeTransferConfig":
@@ -112,6 +123,11 @@ class FeeTransferConfig:
         enabled = os.getenv("FEE_TRANSFER_ENABLED", "false").lower() == "true"
         op_address = os.getenv("OPERATOR_FEE_WALLET_ADDRESS", "")
         op_key = os.getenv("OPERATOR_FEE_WALLET_KEY", "")
+        # 署名モード: 既定 raw_key(後方互換)。privy 指定時は Privy Server Wallet 経路。
+        signing_mode = os.getenv("FEE_SIGNING_MODE", "raw_key").strip().lower()
+        if signing_mode not in ("raw_key", "privy"):
+            signing_mode = "raw_key"
+        operator_privy_wallet_id = os.getenv("OPERATOR_FEE_PRIVY_WALLET_ID", "").strip()
         active_chain = os.getenv("AAVE_ACTIVE_CHAINS", chain_name).split(",")[0].strip()
         chain_cfg = get_chain_config(active_chain)
         rpc_url = os.getenv(chain_cfg.rpc_url_env_var, "") if chain_cfg.rpc_url_env_var else ""
@@ -123,6 +139,9 @@ class FeeTransferConfig:
             data_provider_address=chain_cfg.data_provider_address or "",
             usdc_address=chain_cfg.tokens.get("USDC", ""),
             chain_id=chain_cfg.chain_id,
+            signing_mode=signing_mode,
+            operator_privy_wallet_id=operator_privy_wallet_id,
+            chain_name=active_chain,
         )
 
 
@@ -198,9 +217,37 @@ class FeeTransferService:
                 debug_log=debug,
             )
 
-        # Gate 2: operator wallet 設定
-        if not self.config.operator_wallet_address or not self.config.operator_wallet_key:
-            msg = "OPERATOR_FEE_WALLET_ADDRESS or OPERATOR_FEE_WALLET_KEY not configured"
+        # Gate 2: operator wallet 設定 (署名モード別)
+        #   raw_key: address + key(生鍵) が必要
+        #   privy:   address(allowance 確認 + transferFrom 宛先) + Privy wallet ID が必要
+        #            (生鍵 operator_wallet_key は不要・env に置かない)
+        if not self.config.operator_wallet_address:
+            msg = "OPERATOR_FEE_WALLET_ADDRESS not configured"
+            logger.error("fee_transfer user_id=%d: %s", user_id, msg)
+            return FeeTransferResult(
+                user_id=user_id,
+                user_wallet=user_wallet,
+                fee_usd=Decimal("0"),
+                atoken_units=0,
+                status="failed",
+                error=msg,
+                debug_log=debug,
+            )
+        if self.config.signing_mode == "privy":
+            if not self.config.operator_privy_wallet_id:
+                msg = "FEE_SIGNING_MODE=privy but OPERATOR_FEE_PRIVY_WALLET_ID not configured"
+                logger.error("fee_transfer user_id=%d: %s", user_id, msg)
+                return FeeTransferResult(
+                    user_id=user_id,
+                    user_wallet=user_wallet,
+                    fee_usd=Decimal("0"),
+                    atoken_units=0,
+                    status="failed",
+                    error=msg,
+                    debug_log=debug,
+                )
+        elif not self.config.operator_wallet_key:
+            msg = "OPERATOR_FEE_WALLET_KEY not configured (raw_key mode)"
             logger.error("fee_transfer user_id=%d: %s", user_id, msg)
             return FeeTransferResult(
                 user_id=user_id,
@@ -319,6 +366,89 @@ class FeeTransferService:
             logger.error("_get_atoken_address error: %s", exc)
             return None
 
+    def _submit_transferfrom_raw_key(
+        self,
+        w3: Any,
+        atoken_contract: Any,
+        user_addr_cs: str,
+        op_addr_cs: str,
+        atoken_units: int,
+    ) -> tuple[str, int]:
+        """raw_key モード: 生鍵で transferFrom を署名・送信し (tx_hash_hex, status) を返す。
+
+        旧式(後方互換)。operator_wallet_key を使い web3 でローカル署名する。
+        """
+        account = w3.eth.account.from_key(self.config.operator_wallet_key)
+        nonce = w3.eth.get_transaction_count(account.address, "pending")
+        tx = atoken_contract.functions.transferFrom(
+            user_addr_cs,
+            op_addr_cs,
+            atoken_units,
+        ).build_transaction(
+            {
+                "from": account.address,
+                "nonce": nonce,
+                "chainId": self.config.chain_id,
+                "gas": 100000,
+                "gasPrice": w3.eth.gas_price,
+            }
+        )
+        signed = w3.eth.account.sign_transaction(tx, private_key=self.config.operator_wallet_key)
+        tx_hash = w3.eth.send_raw_transaction(signed.raw_transaction)
+        receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=120)
+        return tx_hash.hex(), int(receipt.status)
+
+    def _submit_transferfrom_privy(
+        self,
+        w3: Any,
+        atoken_contract: Any,
+        atoken_addr: str,
+        user_addr_cs: str,
+        op_addr_cs: str,
+        atoken_units: int,
+        debug: list[str],
+    ) -> tuple[str, int]:
+        """privy モード: Privy Server Wallet(TEE 内署名)で transferFrom を送信する。
+
+        生鍵を env に置かず、Privy REST `eth_sendTransaction` に calldata を渡す。
+        gas/nonce は Privy 側が補完。返却 tx_hash を web3 で receipt 待ちして status を確認。
+        """
+        from app.privy.rest_client import PrivyRestClient, PrivyRestError  # noqa: PLC0415
+        from app.proposals.scw_executor import caip2_for_chain  # noqa: PLC0415
+
+        # transferFrom calldata を encode (web3.py v7: encode_abi 位置引数)
+        data = atoken_contract.encode_abi(
+            "transferFrom", args=[user_addr_cs, op_addr_cs, atoken_units]
+        )
+        caip2 = caip2_for_chain(self.config.chain_name)
+        transaction = {
+            "to": w3.to_checksum_address(atoken_addr),
+            "data": data,
+            "value": "0x0",
+        }
+        try:
+            resp = PrivyRestClient().send_transaction(
+                self.config.operator_privy_wallet_id,
+                caip2=caip2,
+                transaction=transaction,
+            )
+        except PrivyRestError as exc:
+            # 秘密鍵・署名はログに出さない (status のみ)
+            logger.warning("fee_transfer Privy send_transaction failed: status=%s", exc.status_code)
+            raise
+
+        # Privy レスポンスから tx hash を取り出す (キー名の揺れに defensive)
+        tx_hash_hex = str(
+            resp.get("transaction_hash")
+            or resp.get("hash")
+            or (resp.get("data") or {}).get("transaction_hash", "")
+        ).strip()
+        if not tx_hash_hex:
+            raise RuntimeError(f"Privy returned no tx hash: keys={list(resp.keys())}")
+        debug.append(f"privy_tx_hash={tx_hash_hex}")
+        receipt = w3.eth.wait_for_transaction_receipt(tx_hash_hex, timeout=120)
+        return tx_hash_hex, int(receipt.status)
+
     def _execute_transfer(
         self,
         user_id: int,
@@ -372,32 +502,19 @@ class FeeTransferService:
                     debug_log=debug,
                 )
 
-            # Nonce 取得
-            account = w3.eth.account.from_key(self.config.operator_wallet_key)
-            nonce = w3.eth.get_transaction_count(account.address, "pending")
+            # 署名モード別に transferFrom を送信し (tx_hash_hex, receipt_status) を得る。
+            #   raw_key: 生鍵で sign_transaction → send_raw_transaction (旧式)
+            #   privy:   Privy REST(eth_sendTransaction, TEE 内署名) で送信 (生鍵不要)
+            if self.config.signing_mode == "privy":
+                tx_hash_hex, receipt_status = self._submit_transferfrom_privy(
+                    w3, atoken_contract, atoken_addr, user_addr_cs, op_addr_cs, atoken_units, debug
+                )
+            else:
+                tx_hash_hex, receipt_status = self._submit_transferfrom_raw_key(
+                    w3, atoken_contract, user_addr_cs, op_addr_cs, atoken_units
+                )
 
-            # transferFrom tx 構築
-            tx = atoken_contract.functions.transferFrom(
-                user_addr_cs,
-                op_addr_cs,
-                atoken_units,
-            ).build_transaction(
-                {
-                    "from": account.address,
-                    "nonce": nonce,
-                    "chainId": self.config.chain_id,
-                    "gas": 100000,
-                    "gasPrice": w3.eth.gas_price,
-                }
-            )
-            signed = w3.eth.account.sign_transaction(
-                tx, private_key=self.config.operator_wallet_key
-            )
-            tx_hash = w3.eth.send_raw_transaction(signed.raw_transaction)
-            receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=120)
-
-            tx_hash_hex = tx_hash.hex()
-            if receipt.status != 1:
+            if receipt_status != 1:
                 msg = f"tx reverted: {tx_hash_hex}"
                 logger.error("fee_transfer user_id=%d: %s", user_id, msg)
                 return FeeTransferResult(

--- a/backend/app/privy/policy_mapper.py
+++ b/backend/app/privy/policy_mapper.py
@@ -133,3 +133,49 @@ def build_delegation_policy(
         "chain_type": _CHAIN_TYPE,
         "rules": rules,
     }
+
+
+def build_operator_fee_policy(
+    *,
+    atoken_address: str,
+    chain_name: str,
+    policy_name: str | None = None,
+) -> dict[str, Any]:
+    """operator fee wallet 用 Privy policy（手数料徴収の transferFrom を宛先で縛る）。
+
+    operator wallet を Privy Server Wallet 化する際の TEE 側ガード。手数料徴収は
+    aToken コントラクトへの `eth_sendTransaction`（`transferFrom`）のみ。宛先 allowlist を
+    aToken アドレス 1 件に限定する（委譲経路の宛先 allowlist と同型）。
+
+    **静的制約の限界**（[[policy_mapper]] docstring と同じ）: Privy policy は calldata を
+    動的参照できないため「transferFrom の第2引数=operator address」までは TEE で縛れない。
+    その enforcement は backend `_execute_transfer` の allowance チェック + transferFrom の
+    宛先固定（op_addr_cs）で担う。Privy policy は「aToken 宛の tx のみ」の構造エンベロープを
+    TEE で enforce し、両者の積集合で被害上限を縛る。
+
+    :param atoken_address: 手数料徴収対象の aToken（aUSDC）コントラクトアドレス
+    :param chain_name: 執行チェーン名（監査用の policy name に含める）
+    :param policy_name: 任意の表示名（未指定なら atoken 短縮形/chain から生成・50文字以内）
+    """
+    addr = atoken_address.strip().lower()
+    if not addr:
+        raise PolicyMappingError("atoken_address must not be empty")
+
+    conditions = [_to_condition([addr])]
+    atoken_abbrev = f"{addr[:6]}...{addr[-4:]}"
+    name = policy_name or f"uata-operator-fee-{atoken_abbrev}-{chain_name}"
+    # operator は自身の EOA から直 tx を送る（eth_sendTransaction のみ）。
+    rules = [
+        {
+            "name": "allow-fee-transferfrom-to-atoken",
+            "method": "eth_sendTransaction",
+            "conditions": conditions,
+            "action": _ACTION_ALLOW,
+        }
+    ]
+    return {
+        "version": _POLICY_VERSION,
+        "name": name,
+        "chain_type": _CHAIN_TYPE,
+        "rules": rules,
+    }

--- a/backend/app/privy/rest_client.py
+++ b/backend/app/privy/rest_client.py
@@ -153,9 +153,52 @@ class PrivyRestClient:
         }
         return self.wallet_rpc(wallet_id, body, idempotency_key=idempotency_key)
 
+    def send_transaction(
+        self,
+        wallet_id: str,
+        *,
+        caip2: str,
+        transaction: dict[str, Any],
+        idempotency_key: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """eth_sendTransaction（EOA server wallet が自身の tx を TEE 内署名して送信）。
+
+        smart wallet の `send_calls`(ERC-5792) と異なり、operator 自身の EOA wallet が
+        単一 tx を署名・broadcast する経路。手数料徴収 (aToken.transferFrom) の
+        Privy 化に使う。生鍵 (`OPERATOR_FEE_WALLET_KEY`) 経路の置換。
+
+        :param wallet_id: operator の **Privy 内部 wallet ID**（アドレスではない）
+        :param caip2: 執行チェーン（``eip155:<chain_id>``・`scw_executor.caip2_for_chain`）
+        :param transaction: ``{to, data, value}``（nonce/gas は Privy が補完）
+        """
+        body: dict[str, Any] = {
+            "method": "eth_sendTransaction",
+            "caip2": caip2,
+            "params": {"transaction": transaction},
+        }
+        return self.wallet_rpc(wallet_id, body, idempotency_key=idempotency_key)
+
     def create_policy(self, policy: dict[str, Any]) -> dict[str, Any]:
         """POST /v1/policies（app-level / Basic auth のみ・委譲署名不要）。"""
         return self._post("/policies", policy, signed=False)
+
+    def create_wallet(self, body: dict[str, Any]) -> dict[str, Any]:
+        """POST /v1/wallets（server wallet 作成・app-level / Basic auth のみ）。
+
+        operator fee wallet を Privy Server Wallet として作成する 1 回限りセットアップ用。
+        body 例::
+
+            {
+                "chain_type": "ethereum",
+                "policy_ids": ["<operator fee policy id>"],
+                "authorization_key_ids": ["<server signer / key quorum id>"],
+            }
+
+        返り値の ``id`` が ``OPERATOR_FEE_PRIVY_WALLET_ID``、``address`` が
+        ``OPERATOR_FEE_WALLET_ADDRESS`` になる。実 body 形状は Privy API reference に従い
+        セットアップスクリプト側で組む（本メソッドは薄い POST ラッパ）。
+        """
+        return self._post("/wallets", body, signed=False)
 
     def create_key_quorum(
         self,

--- a/backend/scripts/setup_operator_fee_privy_wallet.py
+++ b/backend/scripts/setup_operator_fee_privy_wallet.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/scripts/setup_operator_fee_privy_wallet.py
+"""operator fee wallet を Privy Server Wallet 化するセットアップツール（1回実施）。
+
+生鍵 ``OPERATOR_FEE_WALLET_KEY`` を env から排除し、手数料徴収 wallet を Privy Server
+Wallet 化するための policy 作成 + server wallet 作成を行う。作成後に得られる wallet ID /
+address を env（``OPERATOR_FEE_PRIVY_WALLET_ID`` / ``OPERATOR_FEE_WALLET_ADDRESS``）へ
+保存し、``FEE_SIGNING_MODE=privy`` に切り替えることで生鍵経路を置換する。
+
+⚠️ これは Privy アプリへの **設定変更**である。実施前に必ず小林さんに確認すること。
+既定は ``--dry-run``（Privy に投げず body を表示するのみ）。実行は ``--apply`` を明示。
+
+前提:
+  - key quorum(L0) 登録済み → ``PRIVY_SERVER_SIGNER_ID``（未登録なら
+    ``privy_register_key_quorum.py`` を先に実施）
+  - ``PRIVY_APP_ID`` / ``PRIVY_APP_SECRET``（Basic auth）
+  - aToken(aUSDC) アドレスは Aave data provider から解決（``--atoken`` で明示も可）
+
+使い方::
+
+    # 1) policy body を確認（Privy に投げない）
+    PRIVY_APP_ID=... PRIVY_APP_SECRET=... \
+      python backend/scripts/setup_operator_fee_privy_wallet.py --chain base_sepolia --atoken 0x...
+
+    # 2) 実際に policy + wallet を作成
+    PRIVY_APP_ID=... PRIVY_APP_SECRET=... PRIVY_SERVER_SIGNER_ID=... \
+      python backend/scripts/setup_operator_fee_privy_wallet.py \
+        --chain base_sepolia --atoken 0x... --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+# backend/ を import パスに追加（リポジトリ直叩き実行に対応）
+_BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from app.privy.policy_mapper import PolicyMappingError, build_operator_fee_policy  # noqa: E402
+from app.privy.rest_client import PrivyRestClient, PrivyRestError  # noqa: E402
+
+
+def _resolve_atoken(chain_name: str) -> str:
+    """Aave data provider から aUSDC の aToken アドレスを解決する（--atoken 省略時）。"""
+    from app.fees.fee_transfer_service import FeeTransferConfig, FeeTransferService  # noqa: PLC0415
+
+    cfg = FeeTransferConfig.from_env(chain_name)
+    svc = FeeTransferService(cfg)
+    w3 = svc._get_w3()  # noqa: SLF001 — セットアップ用途で内部 helper を利用
+    atoken = svc._get_atoken_address(w3)  # noqa: SLF001
+    if not atoken:
+        raise RuntimeError(
+            "aToken アドレスを解決できません（RPC / data_provider / usdc の env を確認）。"
+            "--atoken で明示指定してください。"
+        )
+    return atoken
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Set up operator fee Privy server wallet.")
+    p.add_argument("--chain", default="base_sepolia", help="執行チェーン名（base / base_sepolia）")
+    p.add_argument("--atoken", default="", help="aUSDC の aToken アドレス（省略時は RPC で解決）")
+    p.add_argument("--apply", action="store_true", help="実際に Privy へ作成する（既定は dry-run）")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = _parse_args(argv)
+
+    app_id = os.getenv("PRIVY_APP_ID", "")
+    app_secret = os.getenv("PRIVY_APP_SECRET", "")
+    if not app_id or not app_secret:
+        print("ERROR: PRIVY_APP_ID / PRIVY_APP_SECRET が未設定です。", file=sys.stderr)
+        return 2
+
+    atoken = args.atoken.strip()
+    if not atoken:
+        try:
+            atoken = _resolve_atoken(args.chain)
+        except Exception as exc:  # noqa: BLE001
+            print(f"ERROR: aToken 解決失敗: {exc}", file=sys.stderr)
+            return 2
+
+    try:
+        policy = build_operator_fee_policy(atoken_address=atoken, chain_name=args.chain)
+    except PolicyMappingError as exc:
+        print(f"ERROR: policy 写像失敗: {exc}", file=sys.stderr)
+        return 2
+
+    print("=== operator fee wallet Privy 化セットアップ ===")
+    print(f"chain           : {args.chain}")
+    print(f"aToken(aUSDC)   : {atoken}")
+    print("policy body     :")
+    print(json.dumps(policy, indent=2, ensure_ascii=False))
+
+    if not args.apply:
+        print("\n[dry-run] Privy には投げていません。--apply で policy + wallet を作成します。")
+        return 0
+
+    signer_id = os.getenv("PRIVY_SERVER_SIGNER_ID", "").strip()
+    if not signer_id:
+        print(
+            "ERROR: PRIVY_SERVER_SIGNER_ID が未設定です。"
+            "（先に privy_register_key_quorum.py で L0 登録）",
+            file=sys.stderr,
+        )
+        return 2
+
+    client = PrivyRestClient(app_id=app_id, app_secret=app_secret)
+
+    # 1) policy 作成
+    try:
+        policy_result = client.create_policy(policy)
+    except PrivyRestError as exc:
+        print(f"ERROR: policy 作成失敗: {exc}", file=sys.stderr)
+        return 1
+    policy_id = str(policy_result.get("id", "")).strip()
+    if not policy_id:
+        print("ERROR: Privy が policy id を返しませんでした。", file=sys.stderr)
+        return 1
+    print(f"\n✅ policy 作成成功: policy_id={policy_id}")
+
+    # 2) server wallet 作成（policy + signer を紐付け）
+    wallet_body = {
+        "chain_type": "ethereum",
+        "policy_ids": [policy_id],
+        "authorization_key_ids": [signer_id],
+    }
+    try:
+        wallet_result = client.create_wallet(wallet_body)
+    except PrivyRestError as exc:
+        print(f"ERROR: server wallet 作成失敗: {exc}", file=sys.stderr)
+        return 1
+    wallet_id = str(wallet_result.get("id", "")).strip()
+    wallet_address = str(wallet_result.get("address", "")).strip()
+    print("\n✅ server wallet 作成成功")
+    print(f"OPERATOR_FEE_PRIVY_WALLET_ID={wallet_id}")
+    print(f"OPERATOR_FEE_WALLET_ADDRESS={wallet_address}")
+    print(
+        "\n→ backend env に上記 2 値 + FEE_SIGNING_MODE=privy を保存してください。\n"
+        "  旧 OPERATOR_FEE_WALLET_KEY(生鍵) は Privy 経路確立の検証後に env から削除する。\n"
+        "  ⚠️ ユーザーの aToken allowance は新 operator address 宛に再承認が必要な点に注意。"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/backend/tests/test_fee_transfer_service.py
+++ b/backend/tests/test_fee_transfer_service.py
@@ -56,6 +56,20 @@ DISABLED_CFG = FeeTransferConfig(
 
 USER_WALLET = "0xUserWallet00000000000000000000000000000001"
 
+# privy 署名モード config (生鍵 operator_wallet_key は空)。
+PRIVY_CFG = FeeTransferConfig(
+    enabled=True,
+    operator_wallet_address="0xOperator000000000000000000000000000000001",
+    operator_wallet_key="",  # privy モードでは生鍵不要
+    rpc_url="https://base-sepolia.example.com",
+    data_provider_address="0xBc9f5b7E248451CdD7cA54e717a2BFe1F32b566b",
+    usdc_address="0xba50cd2a20f6da35d788639e581bca8d0b5d4d5f",
+    chain_id=84532,
+    signing_mode="privy",
+    operator_privy_wallet_id="privy-wallet-abc123",
+    chain_name="base_sepolia",
+)
+
 
 # ---------------------------------------------------------------------------
 # is_fee_transfer_enabled
@@ -233,6 +247,9 @@ def _make_w3_mock(
         "gasPrice": 1000000000,
     }
 
+    # privy モード用: encode_abi(transferFrom calldata)
+    atoken_contract.encode_abi.return_value = "0xa9059cbb" + "00" * 64
+
     return w3
 
 
@@ -314,6 +331,143 @@ def test_transfer_fee_web3_exception():
 
     assert result.status == "failed"
     assert result.tx_hash is None
+
+
+# ---------------------------------------------------------------------------
+# transfer_fee: privy 署名モード (operator wallet = Privy Server Wallet)
+# ---------------------------------------------------------------------------
+
+
+def test_transfer_fee_privy_mode_sent_success():
+    """privy モード: Privy REST send_transaction 成功 + receipt status=1 → sent。生鍵不使用。"""
+    svc = FeeTransferService(PRIVY_CFG)
+    mock_w3 = _make_w3_mock(allowance=100_000_000)
+    privy_tx = "0xprivy" + "00" * 30
+
+    privy_client = MagicMock()
+    privy_client.send_transaction.return_value = {"transaction_hash": privy_tx}
+
+    with (
+        patch.object(svc, "_get_w3", return_value=mock_w3),
+        patch("app.privy.rest_client.PrivyRestClient", return_value=privy_client),
+    ):
+        result = svc.transfer_fee(
+            user_id=30,
+            user_wallet=USER_WALLET,
+            fee_amount_jpy=Decimal("1500"),
+            subscription_amount_jpy=Decimal("0"),
+            yield_excess_jpy=Decimal("0"),
+            usd_jpy_rate=Decimal("150"),
+        )
+
+    assert result.status == "sent"
+    assert result.tx_hash == privy_tx
+    # privy モードでは生鍵署名 (from_key / sign_transaction) を呼ばない
+    mock_w3.eth.account.from_key.assert_not_called()
+    mock_w3.eth.account.sign_transaction.assert_not_called()
+    # Privy REST が呼ばれ、正しい wallet_id が渡っている
+    privy_client.send_transaction.assert_called_once()
+    assert privy_client.send_transaction.call_args.args[0] == "privy-wallet-abc123"
+
+
+def test_transfer_fee_privy_mode_no_wallet_id_returns_failed():
+    """privy モードだが OPERATOR_FEE_PRIVY_WALLET_ID 未設定 → failed。"""
+    cfg = FeeTransferConfig(
+        enabled=True,
+        operator_wallet_address="0xOperator000000000000000000000000000000001",
+        operator_wallet_key="",
+        rpc_url="https://rpc",
+        data_provider_address="0xDP",
+        usdc_address="0xUSDC",
+        chain_id=84532,
+        signing_mode="privy",
+        operator_privy_wallet_id="",  # 未設定
+        chain_name="base_sepolia",
+    )
+    svc = FeeTransferService(cfg)
+    result = svc.transfer_fee(
+        user_id=31,
+        user_wallet=USER_WALLET,
+        fee_amount_jpy=Decimal("1500"),
+        subscription_amount_jpy=Decimal("0"),
+        yield_excess_jpy=Decimal("0"),
+        usd_jpy_rate=Decimal("150"),
+    )
+    assert result.status == "failed"
+    assert "OPERATOR_FEE_PRIVY_WALLET_ID" in (result.error or "")
+
+
+def test_transfer_fee_privy_mode_rest_error_returns_failed():
+    """privy モード: Privy REST が例外 → status='failed' (外側 except が捕捉)。"""
+    from app.privy.rest_client import PrivyRestError
+
+    svc = FeeTransferService(PRIVY_CFG)
+    mock_w3 = _make_w3_mock(allowance=100_000_000)
+
+    privy_client = MagicMock()
+    privy_client.send_transaction.side_effect = PrivyRestError(500, "server error")
+
+    with (
+        patch.object(svc, "_get_w3", return_value=mock_w3),
+        patch("app.privy.rest_client.PrivyRestClient", return_value=privy_client),
+    ):
+        result = svc.transfer_fee(
+            user_id=32,
+            user_wallet=USER_WALLET,
+            fee_amount_jpy=Decimal("1500"),
+            subscription_amount_jpy=Decimal("0"),
+            yield_excess_jpy=Decimal("0"),
+            usd_jpy_rate=Decimal("150"),
+        )
+
+    assert result.status == "failed"
+
+
+def test_transfer_fee_privy_mode_no_tx_hash_returns_failed():
+    """privy モード: Privy レスポンスに tx hash が無い → status='failed'。"""
+    svc = FeeTransferService(PRIVY_CFG)
+    mock_w3 = _make_w3_mock(allowance=100_000_000)
+
+    privy_client = MagicMock()
+    privy_client.send_transaction.return_value = {"unexpected": "shape"}
+
+    with (
+        patch.object(svc, "_get_w3", return_value=mock_w3),
+        patch("app.privy.rest_client.PrivyRestClient", return_value=privy_client),
+    ):
+        result = svc.transfer_fee(
+            user_id=33,
+            user_wallet=USER_WALLET,
+            fee_amount_jpy=Decimal("1500"),
+            subscription_amount_jpy=Decimal("0"),
+            yield_excess_jpy=Decimal("0"),
+            usd_jpy_rate=Decimal("150"),
+        )
+
+    assert result.status == "failed"
+
+
+def test_transfer_fee_privy_mode_still_checks_allowance():
+    """privy モードでも allowance 不足なら送信せず no_allowance (安全ゲート共通)。"""
+    svc = FeeTransferService(PRIVY_CFG)
+    mock_w3 = _make_w3_mock(allowance=0)
+
+    privy_client = MagicMock()
+    with (
+        patch.object(svc, "_get_w3", return_value=mock_w3),
+        patch("app.privy.rest_client.PrivyRestClient", return_value=privy_client),
+    ):
+        result = svc.transfer_fee(
+            user_id=34,
+            user_wallet=USER_WALLET,
+            fee_amount_jpy=Decimal("1500"),
+            subscription_amount_jpy=Decimal("0"),
+            yield_excess_jpy=Decimal("0"),
+            usd_jpy_rate=Decimal("150"),
+        )
+
+    assert result.status == "no_allowance"
+    privy_client.send_transaction.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_privy_policy_mapper.py
+++ b/backend/tests/test_privy_policy_mapper.py
@@ -16,10 +16,12 @@ from app.aave.chains import get_chain_config
 from app.privy.policy_mapper import (
     PolicyMappingError,
     build_delegation_policy,
+    build_operator_fee_policy,
     resolve_protocol_contracts,
 )
 
 _WALLET = "0x1234567890123456789012345678901234567890"
+_ATOKEN = "0xABCdef0000000000000000000000000000000001"
 
 
 def test_resolve_aave_contract_base() -> None:
@@ -132,3 +134,41 @@ def test_build_policy_unsupported_protocol_raises() -> None:
             allowed_protocols=["aave", "pendle"],
             chain_name="base",
         )
+
+
+# ---------------------------------------------------------------------------
+# operator fee policy（手数料徴収 wallet の Privy 化）
+# ---------------------------------------------------------------------------
+
+
+def test_build_operator_fee_policy_structure() -> None:
+    """operator fee policy: eth_sendTransaction を aToken 宛のみ ALLOW。"""
+    policy = build_operator_fee_policy(atoken_address=_ATOKEN, chain_name="base_sepolia")
+    assert policy["version"] == "1.0"
+    assert policy["chain_type"] == "ethereum"
+    assert len(policy["rules"]) == 1
+    rule = policy["rules"][0]
+    assert rule["method"] == "eth_sendTransaction"
+    assert rule["action"] == "ALLOW"
+    cond = rule["conditions"][0]
+    assert cond["field"] == "to"
+    assert cond["operator"] == "eq"
+    # 宛先は小文字化された aToken 1 件
+    assert cond["value"] == _ATOKEN.lower()
+
+
+def test_build_operator_fee_policy_name_under_50_chars() -> None:
+    policy = build_operator_fee_policy(atoken_address=_ATOKEN, chain_name="base_sepolia")
+    assert len(policy["name"]) <= 50
+
+
+def test_build_operator_fee_policy_empty_atoken_raises() -> None:
+    with pytest.raises(PolicyMappingError):
+        build_operator_fee_policy(atoken_address="  ", chain_name="base")
+
+
+def test_build_operator_fee_policy_custom_name() -> None:
+    policy = build_operator_fee_policy(
+        atoken_address=_ATOKEN, chain_name="base", policy_name="op-fee"
+    )
+    assert policy["name"] == "op-fee"

--- a/docs/13_security_design.md
+++ b/docs/13_security_design.md
@@ -115,6 +115,34 @@ UAT ユーザー向けのウォレット接続は以下の2方式を採用する
 - `backend/app/auth/service.py:verify_wallet_signature()` で実装
 - 本番 Base Mainnet 接続時は Cloudflare Tunnel 経由のみ許可
 
+## 2.5 operator fee wallet の Privy Server Wallet 化（2026-07-07）
+
+手数料徴収用 operator wallet の署名方式を、**生の秘密鍵を env に置く旧式**から
+**Privy Server Wallet（TEE 内署名）** に置換可能にした（`FEE_SIGNING_MODE` で切替）。
+
+| モード | 秘密鍵の所在 | 署名 | env に残る秘密 |
+|---|---|---|---|
+| `raw_key`（既定・後方互換） | `.env` の `OPERATOR_FEE_WALLET_KEY`（生鍵） | `w3.eth.account.sign_transaction`（ローカル） | ブロックチェーン秘密鍵そのもの |
+| `privy` | Privy TEE（2-of-2 分割・署名時のみ再構成・即破棄） | `PrivyRestClient.send_transaction`（`eth_sendTransaction`） | P-256 authorization 鍵のみ（=ブロックチェーン鍵ではない） |
+
+- **設計原則（2.1 節）との整合**: `privy` モードでは「秘密鍵をコード・env・ログに書かない」を
+  完全に満たす。env に残る P-256 authorization 鍵は「Privy に対してこの操作を承認する」鍵であり、
+  Privy policy（`build_operator_fee_policy`: aToken 宛の `eth_sendTransaction` のみ ALLOW）の
+  外は動かせない。漏洩しても生鍵のように全資産を持ち出せない。
+- **二重ガード**: Privy policy（TEE・宛先 allowlist）+ backend（`_execute_transfer` の allowance
+  チェック + transferFrom 宛先を operator address に固定）。calldata 動的参照は Privy 未サポートの
+  ため、transferFrom の引数制約は backend 側で enforce する。
+- **実装**: `backend/app/fees/fee_transfer_service.py`（`FEE_SIGNING_MODE` / `_submit_transferfrom_privy`）、
+  `backend/app/privy/rest_client.py`（`send_transaction` / `create_wallet`）、
+  `backend/app/privy/policy_mapper.py`（`build_operator_fee_policy`）。
+- **セットアップ**: `backend/scripts/setup_operator_fee_privy_wallet.py`（policy + server wallet 作成、
+  既定 dry-run）。key quorum(L0) は委譲経路と共用（`privy_register_key_quorum.py`）。
+- **移行手順**: ①L0 登録 → ②setup スクリプトで policy+wallet 作成 → ③新 operator address へ
+  ユーザー allowance 再承認 → ④`FEE_SIGNING_MODE=privy` + `OPERATOR_FEE_PRIVY_WALLET_ID` 設定 →
+  ⑤staging-v4 で小額 transferFrom 検証 → ⑥検証後に旧 `OPERATOR_FEE_WALLET_KEY`（生鍵）を env から削除。
+- **安全弁**: `FEE_TRANSFER_ENABLED=false` の間はモードに関わらず一切送金しない（DB 記録のみ）。
+  本番の有効化は別途人間判断（実資金移動）。
+
 ---
 
 # 3. 操作額制限（スマートコントラクト保護）


### PR DESCRIPTION
## Summary
セキュリティ設計 Track 1。手数料徴収用 operator wallet の署名方式を、**生の秘密鍵を env に平文で置く旧式**から **Privy Server Wallet(TEE内署名)** に切り替え可能にする。`FEE_SIGNING_MODE` で `raw_key`(既定・後方互換) / `privy` を選択。dormant-first で既存挙動は完全不変。

グローバル調査(2026業界標準)の結論: 秘密鍵は MPC/TEEベースのサーバーウォレット(生鍵をアプリが持たない)が標準。このプロジェクトには既に Privy サーバー署名基盤(`rest_client`/`auth_signature`/`server_keys`/`scw_executor`)が実装済み・休眠中だったため、これを再利用。

## 変更
- `rest_client.py`: `send_transaction`(eth_sendTransaction) + `create_wallet` を追加
- `fee_transfer_service.py`: `FeeTransferConfig` に `signing_mode` / `operator_privy_wallet_id` を追加。`_execute_transfer` を署名モードで分岐。allowance チェック等の安全ゲートは両モード共通
- `policy_mapper.py`: `build_operator_fee_policy`(aToken宛の`eth_sendTransaction`のみALLOWする operator用 Privy policy)を追加
- `setup_operator_fee_privy_wallet.py`: policy + server wallet 作成の1回限りセットアップスクリプト(既定 dry-run)
- `docs/13_security_design.md §2.5`: operator wallet Privy化の設計・移行手順を追記

## 安全設計
- `privy` モードでは env に残る秘密は **P-256 authorization 鍵のみ**(=ブロックチェーン鍵ではない・Privy policy 制約下でしか動けない・単体で資金移動不可)
- **二重ガード**: Privy policy(TEE・aToken宛allowlist) + backend(allowance確認 + transferFrom宛先をoperator addressに固定)
- `FEE_TRANSFER_ENABLED=false` の間はモードに関わらず一切送金しない(現行維持)

## スコープ / 注意
- 本 PR は **経路の追加のみ**。本番は `FEE_TRANSFER_ENABLED=false` かつ `FEE_SIGNING_MODE` 未設定(=raw_key)のまま挙動不変。
- 実際の Privy 移行(server wallet 作成・allowance 再承認・`FEE_SIGNING_MODE=privy` 化)は別途セットアップ + staging-v4 実機検証 + 人間判断が必要(docs §2.5 移行手順参照)。

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy app/`(3ファイル) 全通過
- [x] `ruff check --select S`(セキュリティ) 全通過
- [x] pytest: privyモード5ケース(成功/wallet_id未設定/RESTエラー/tx_hash欠落/allowance共通ゲート) + operator policy 4ケース追加。raw_keyモード既存17ケースは回帰。**fees+privy 47 passed**
- [ ] (後続) staging-v4 実 Privy server wallet で小額 transferFrom を実送信し receipt status=1 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUEgFqF7VE6jsggFVgfMj