### PR TITLE
feat(security): 顧客PIIフィールドレベル暗号化の基盤を追加(Track2 層2)

### DIFF
--- a/backend/app/auth/models.py
+++ b/backend/app/auth/models.py
@@ -65,6 +65,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from app.auth.constants import ExecutionPolicy
 from app.database import Base
+from app.security.sqlalchemy_types import EncryptedString
 
 logger = logging.getLogger(__name__)
 
@@ -244,8 +245,12 @@ class User(Base):
     risk_mode: Mapped[Optional[str]] = mapped_column(
         String(20), nullable=True, default="conservative"
     )
+    # Track 2 / 層2: 実 PII のためフィールドレベル暗号化(AES-256-GCM)。
+    # DB には enc:v<ver>:<b64> の暗号文が入る。暗号文は base64 で平文より長いため列幅を拡張。
+    # ALTER TABLE users ALTER COLUMN notification_email TYPE VARCHAR(512);
+    # KEK 未設定環境では平文パススルー(後方互換)。既存平文は enc: prefix 無しで読める。
     notification_email: Mapped[Optional[str]] = mapped_column(
-        String(255), nullable=True, default=None
+        EncryptedString(512), nullable=True, default=None
     )
     notification_frequency: Mapped[str] = mapped_column(
         String(20), nullable=False, default="important"

--- a/backend/app/security/__init__.py
+++ b/backend/app/security/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.

--- a/backend/app/security/field_crypto.py
+++ b/backend/app/security/field_crypto.py
@@ -1,0 +1,150 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/app/security/field_crypto.py
+"""顧客PII のフィールドレベル暗号化（Track 2 / 層2 暗号化基盤）。
+
+保存時に PII（メールアドレス等）を AES-256-GCM で暗号化し、DB 漏洩時も平文が出ないように
+する。検索が必要な列は `blind_index`（HMAC-SHA256・決定的）で等価検索・unique を維持する。
+
+**鍵管理（env KEK + バージョン・ローテ対応）**:
+  - ``PII_ENCRYPTION_KEK``       現行 KEK（base64 の 32byte）。暗号化に使う。
+  - ``PII_KEK_VERSION``          現行 KEK の版番号（整数・既定 1）。暗号文に埋める。
+  - ``PII_ENCRYPTION_KEK_V<n>``  旧版 KEK（ローテ中の復号用・任意）。
+  - ``PII_BLIND_INDEX_KEY``      blind index 用 HMAC 鍵（base64・検索列がある場合のみ必須）。
+  self-hosted VPS の現実解として env に置く。将来 KMS 移行の余地を残すため版番号を暗号文に
+  埋め、旧版鍵での復号を可能にする（HMAC 鍵ローテは blind index 全再計算が必要）。
+
+**暗号文フォーマット**: ``enc:v<version>:<base64(nonce(12B) || ciphertext || tag)>``
+  - ``enc:`` prefix が無い値は「未暗号化の平文（レガシー / 未移行）」とみなし、復号側は
+    そのまま返す（後方互換・段階移行を可能にする）。
+
+秘密鍵・KEK・平文は**絶対にログに出さない**（CLAUDE.md §Security 1/8）。
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+from typing import Optional
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+_ENC_PREFIX = "enc:"
+_NONCE_BYTES = 12  # AES-GCM 推奨 nonce 長
+_KEK_BYTES = 32  # AES-256
+
+
+class FieldCryptoError(RuntimeError):
+    """PII 暗号化/復号の構成不備・処理失敗（KEK 未設定・不正フォーマット等）。"""
+
+
+def _current_version() -> int:
+    raw = os.getenv("PII_KEK_VERSION", "1").strip()
+    try:
+        return int(raw)
+    except ValueError:
+        return 1
+
+
+def _load_kek(version: int) -> Optional[bytes]:
+    """指定版の KEK（32byte）を env から読む。無ければ None。
+
+    現行版は ``PII_ENCRYPTION_KEK``、旧版は ``PII_ENCRYPTION_KEK_V<n>`` を見る。
+    現行版番号が n のとき ``PII_ENCRYPTION_KEK_V<n>`` が無ければ ``PII_ENCRYPTION_KEK``
+    にフォールバックする。
+    """
+    candidates = []
+    if version == _current_version():
+        candidates.append("PII_ENCRYPTION_KEK")
+    candidates.append(f"PII_ENCRYPTION_KEK_V{version}")
+    if version == _current_version():
+        candidates.append("PII_ENCRYPTION_KEK")  # 明示旧版名が無い場合の保険
+    for env_name in candidates:
+        raw = os.getenv(env_name, "").strip()
+        if raw:
+            try:
+                key = base64.b64decode(raw)
+            except Exception as exc:  # noqa: BLE001
+                raise FieldCryptoError(f"{env_name} is not valid base64") from exc
+            if len(key) != _KEK_BYTES:
+                raise FieldCryptoError(
+                    f"{env_name} must decode to {_KEK_BYTES} bytes (got {len(key)})"
+                )
+            return key
+    return None
+
+
+def is_encryption_configured() -> bool:
+    """現行 KEK が設定済みか（未設定なら暗号化せず平文パススルー）。"""
+    return _load_kek(_current_version()) is not None
+
+
+def encrypt_pii(plaintext: Optional[str]) -> Optional[str]:
+    """平文 → ``enc:v<ver>:<b64>``。KEK 未設定時は平文をそのまま返す（未移行扱い）。
+
+    None は None のまま返す。既に ``enc:`` 済みの値は二重暗号化しない。
+    """
+    if plaintext is None:
+        return None
+    if plaintext.startswith(_ENC_PREFIX):
+        return plaintext  # 二重暗号化防止（冪等）
+    version = _current_version()
+    kek = _load_kek(version)
+    if kek is None:
+        return plaintext  # KEK 未設定 = 平文パススルー（dev / 未構成）
+    nonce = os.urandom(_NONCE_BYTES)
+    ct = AESGCM(kek).encrypt(nonce, plaintext.encode("utf-8"), None)
+    blob = base64.b64encode(nonce + ct).decode("ascii")
+    return f"{_ENC_PREFIX}v{version}:{blob}"
+
+
+def decrypt_pii(stored: Optional[str]) -> Optional[str]:
+    """``enc:v<ver>:<b64>`` → 平文。``enc:`` prefix 無しは平文とみなしそのまま返す。
+
+    None は None。版に対応する KEK が無い / 改ざん時は FieldCryptoError。
+    """
+    if stored is None:
+        return None
+    if not stored.startswith(_ENC_PREFIX):
+        return stored  # レガシー平文（未移行）
+    try:
+        _, ver_part, blob = stored.split(":", 2)
+        version = int(ver_part.lstrip("v"))
+    except (ValueError, AttributeError) as exc:
+        raise FieldCryptoError("malformed ciphertext header") from exc
+    kek = _load_kek(version)
+    if kek is None:
+        raise FieldCryptoError(f"no KEK available for version {version}")
+    try:
+        raw = base64.b64decode(blob)
+        nonce, ct = raw[:_NONCE_BYTES], raw[_NONCE_BYTES:]
+        return AESGCM(kek).decrypt(nonce, ct, None).decode("utf-8")
+    except Exception as exc:  # noqa: BLE001
+        # 復号失敗（鍵不一致 / 改ざん）。平文・鍵はログに出さない。
+        raise FieldCryptoError("PII decryption failed") from exc
+
+
+def _blind_index_key() -> Optional[bytes]:
+    raw = os.getenv("PII_BLIND_INDEX_KEY", "").strip()
+    if not raw:
+        return None
+    try:
+        return base64.b64decode(raw)
+    except Exception as exc:  # noqa: BLE001
+        raise FieldCryptoError("PII_BLIND_INDEX_KEY is not valid base64") from exc
+
+
+def blind_index(value: Optional[str]) -> Optional[str]:
+    """正規化(小文字化・trim)後の HMAC-SHA256 hex。等価検索・unique 用の決定的インデックス。
+
+    None は None。鍵未設定時は FieldCryptoError（検索列を作るなら鍵は必須）。
+    メール等の大文字小文字・前後空白の揺れを吸収して同一値に一致させる。
+    """
+    if value is None:
+        return None
+    key = _blind_index_key()
+    if key is None:
+        raise FieldCryptoError("PII_BLIND_INDEX_KEY is required for blind_index")
+    normalized = value.strip().lower().encode("utf-8")
+    return hmac.new(key, normalized, hashlib.sha256).hexdigest()

--- a/backend/app/security/sqlalchemy_types.py
+++ b/backend/app/security/sqlalchemy_types.py
@@ -1,0 +1,40 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/app/security/sqlalchemy_types.py
+"""PII フィールド暗号化用の SQLAlchemy TypeDecorator（Track 2 / 層2）。
+
+`EncryptedString` を列型に使うと、ORM の write 時に `encrypt_pii`、read 時に `decrypt_pii`
+が透過的に走る。呼び出し側（router / service）は平文を扱うだけで、DB には暗号文が入る。
+各読み書き箇所を個別に触らないため、暗号化漏れ（= 平文がそのまま保存される事故）を防ぐ。
+
+後方互換: `enc:` prefix の無い既存平文はそのまま読める（段階移行を許容）。KEK 未設定の
+環境（dev / 未構成）では平文パススルー（`field_crypto` 参照）。
+
+DB カラム長: 暗号文は base64 で平文より長い。列は十分な長さ（例: String(512) / Text）で
+定義すること。
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import String
+from sqlalchemy.types import TypeDecorator
+
+from app.security.field_crypto import decrypt_pii, encrypt_pii
+
+
+class EncryptedString(TypeDecorator[str]):
+    """保存時に暗号化・取得時に復号する文字列型（AES-256-GCM / `field_crypto`）。
+
+    検索（WHERE 等価）が不要な PII 列に使う。等価検索が要る列は別途 blind index 列を
+    併設すること（`field_crypto.blind_index`）。
+    """
+
+    impl = String
+    cache_ok = True
+
+    def process_bind_param(self, value: Optional[str], dialect: object) -> Optional[str]:
+        return encrypt_pii(value)
+
+    def process_result_value(self, value: Optional[str], dialect: object) -> Optional[str]:
+        return decrypt_pii(value)

--- a/backend/app/users/models.py
+++ b/backend/app/users/models.py
@@ -32,6 +32,7 @@ from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, Numeric, St
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
+from app.security.sqlalchemy_types import EncryptedString
 
 
 class UserSettings(Base):
@@ -66,8 +67,10 @@ class UserSettings(Base):
         unique=True,
         index=True,
     )
+    # Track 2 / 層2: 実 PII のためフィールドレベル暗号化(AES-256-GCM)。
+    # ALTER TABLE user_settings ALTER COLUMN notification_email TYPE VARCHAR(512);
     notification_email: Mapped[Optional[str]] = mapped_column(
-        String(255), nullable=True, default=None
+        EncryptedString(512), nullable=True, default=None
     )
     notification_frequency: Mapped[str] = mapped_column(
         String(20), nullable=False, default="important"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,6 +21,7 @@ aiohttp<3.14
 sqlalchemy>=2.0.0
 bcrypt>=4.1.0
 PyJWT[crypto]>=2.9.0    # [crypto] extra で cryptography (RS256/ES256 等) を有効化 — Privy ID Token 検証に必要
+cryptography>=42.0.0    # PII フィールドレベル暗号化 (AES-256-GCM / app/security/field_crypto)。PyJWT[crypto] 経由の推移依存を明示化。
 pydantic[email]>=2.0.0
 
 # PostgreSQL + pgvector (PoC Pivot)

--- a/backend/tests/test_encrypted_string_type.py
+++ b/backend/tests/test_encrypted_string_type.py
@@ -1,0 +1,54 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_encrypted_string_type.py
+"""EncryptedString TypeDecorator（Track 2 層2）の単体テスト。
+
+ORM bind（write）で暗号化、result（read）で復号が透過的に走ることを、TypeDecorator の
+process_bind_param / process_result_value を直接呼んで検証する（DB 不要）。
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from unittest.mock import patch
+
+from app.security.sqlalchemy_types import EncryptedString
+
+_KEK = base64.b64encode(b"\x03" * 32).decode()
+
+
+def _env(**kw: str) -> dict[str, str]:
+    base = {"PII_ENCRYPTION_KEK": "", "PII_KEK_VERSION": ""}
+    base.update(kw)
+    return base
+
+
+def test_bind_encrypts_result_decrypts_roundtrip():
+    t = EncryptedString(512)
+    with patch.dict(os.environ, _env(PII_ENCRYPTION_KEK=_KEK, PII_KEK_VERSION="1")):
+        stored = t.process_bind_param("secret@example.com", None)
+        assert stored is not None
+        assert stored.startswith("enc:v1:")
+        assert "secret@example.com" not in stored
+        assert t.process_result_value(stored, None) == "secret@example.com"
+
+
+def test_bind_none_stays_none():
+    t = EncryptedString(512)
+    with patch.dict(os.environ, _env(PII_ENCRYPTION_KEK=_KEK)):
+        assert t.process_bind_param(None, None) is None
+        assert t.process_result_value(None, None) is None
+
+
+def test_legacy_plaintext_read_passthrough():
+    """DB に既にある平文（enc: 無し）は復号側でそのまま返る（段階移行）。"""
+    t = EncryptedString(512)
+    with patch.dict(os.environ, _env(PII_ENCRYPTION_KEK=_KEK)):
+        assert t.process_result_value("old-plain@x.com", None) == "old-plain@x.com"
+
+
+def test_no_kek_passthrough():
+    """KEK 未設定なら平文のまま保存（dev / 未構成・後方互換）。"""
+    t = EncryptedString(512)
+    with patch.dict(os.environ, _env()):
+        assert t.process_bind_param("plain@x.com", None) == "plain@x.com"

--- a/backend/tests/test_field_crypto.py
+++ b/backend/tests/test_field_crypto.py
@@ -1,0 +1,160 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_field_crypto.py
+"""field_crypto（PII フィールドレベル暗号化 / Track 2 層2）の単体テスト。
+
+AES-256-GCM 暗号化/復号のラウンドトリップ、バージョン埋め込み、KEK 未設定時の平文
+パススルー(後方互換)、レガシー平文の透過復号、blind index の決定性・正規化を検証する。
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from unittest.mock import patch
+
+import pytest
+
+from app.security.field_crypto import (
+    FieldCryptoError,
+    blind_index,
+    decrypt_pii,
+    encrypt_pii,
+    is_encryption_configured,
+)
+
+_KEK_V1 = base64.b64encode(b"\x01" * 32).decode()
+_KEK_V2 = base64.b64encode(b"\x02" * 32).decode()
+_BIDX_KEY = base64.b64encode(b"\x09" * 32).decode()
+
+
+def _env(**kw: str) -> dict[str, str]:
+    """PII 系 env をクリアしてから指定値をセットする patch.dict 用 dict を返す。"""
+    base = {
+        "PII_ENCRYPTION_KEK": "",
+        "PII_KEK_VERSION": "",
+        "PII_ENCRYPTION_KEK_V1": "",
+        "PII_ENCRYPTION_KEK_V2": "",
+        "PII_BLIND_INDEX_KEY": "",
+    }
+    base.update(kw)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# encrypt/decrypt round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_roundtrip_with_kek():
+    with patch.dict(os.environ, _env(PII_ENCRYPTION_KEK=_KEK_V1, PII_KEK_VERSION="1")):
+        ct = encrypt_pii("user@example.com")
+        assert ct is not None
+        assert ct.startswith("enc:v1:")
+        assert "user@example.com" not in ct  # 平文が暗号文に露出しない
+        assert decrypt_pii(ct) == "user@example.com"
+
+
+def test_encrypt_none_returns_none():
+    with patch.dict(os.environ, _env(PII_ENCRYPTION_KEK=_KEK_V1)):
+        assert encrypt_pii(None) is None
+        assert decrypt_pii(None) is None
+
+
+def test_encrypt_is_idempotent_on_ciphertext():
+    """既に enc: 済みの値は二重暗号化しない。"""
+    with patch.dict(os.environ, _env(PII_ENCRYPTION_KEK=_KEK_V1)):
+        ct = encrypt_pii("a@b.com")
+        assert encrypt_pii(ct) == ct
+
+
+def test_encrypt_uses_random_nonce():
+    """同一平文でも nonce により暗号文は毎回変わる(決定的でない)。"""
+    with patch.dict(os.environ, _env(PII_ENCRYPTION_KEK=_KEK_V1)):
+        assert encrypt_pii("same@x.com") != encrypt_pii("same@x.com")
+
+
+# ---------------------------------------------------------------------------
+# KEK 未設定 = 平文パススルー(後方互換)
+# ---------------------------------------------------------------------------
+
+
+def test_no_kek_passthrough():
+    with patch.dict(os.environ, _env()):
+        assert is_encryption_configured() is False
+        assert encrypt_pii("plain@x.com") == "plain@x.com"
+        assert decrypt_pii("plain@x.com") == "plain@x.com"
+
+
+def test_legacy_plaintext_read_with_kek():
+    """KEK 設定後も enc: prefix 無しの既存平文はそのまま読める(段階移行)。"""
+    with patch.dict(os.environ, _env(PII_ENCRYPTION_KEK=_KEK_V1)):
+        assert decrypt_pii("legacy-plain@x.com") == "legacy-plain@x.com"
+
+
+# ---------------------------------------------------------------------------
+# 鍵ローテ(版番号)
+# ---------------------------------------------------------------------------
+
+
+def test_decrypt_old_version_after_rotation():
+    """v1 で暗号化 → v2 にローテ後も、旧版 KEK があれば v1 暗号文を復号できる。"""
+    with patch.dict(os.environ, _env(PII_ENCRYPTION_KEK=_KEK_V1, PII_KEK_VERSION="1")):
+        ct_v1 = encrypt_pii("rotate@x.com")
+    # ローテ: 現行を v2 に、旧 v1 鍵を PII_ENCRYPTION_KEK_V1 に保持
+    with patch.dict(
+        os.environ,
+        _env(PII_ENCRYPTION_KEK=_KEK_V2, PII_KEK_VERSION="2", PII_ENCRYPTION_KEK_V1=_KEK_V1),
+    ):
+        assert decrypt_pii(ct_v1) == "rotate@x.com"
+        # 新規暗号化は v2
+        assert encrypt_pii("new@x.com").startswith("enc:v2:")
+
+
+def test_decrypt_missing_version_key_raises():
+    """版に対応する KEK が無ければ FieldCryptoError。"""
+    with patch.dict(os.environ, _env(PII_ENCRYPTION_KEK=_KEK_V1, PII_KEK_VERSION="1")):
+        ct_v1 = encrypt_pii("x@x.com")
+    with patch.dict(os.environ, _env(PII_ENCRYPTION_KEK=_KEK_V2, PII_KEK_VERSION="2")):
+        with pytest.raises(FieldCryptoError):
+            decrypt_pii(ct_v1)
+
+
+def test_tampered_ciphertext_raises():
+    with patch.dict(os.environ, _env(PII_ENCRYPTION_KEK=_KEK_V1)):
+        ct = encrypt_pii("tamper@x.com")
+        # base64 本体を 1 文字改ざん
+        head, blob = ct.rsplit(":", 1)
+        bad = f"{head}:{'A' if blob[0] != 'A' else 'B'}{blob[1:]}"
+        with pytest.raises(FieldCryptoError):
+            decrypt_pii(bad)
+
+
+def test_invalid_kek_length_raises():
+    short = base64.b64encode(b"\x01" * 16).decode()
+    with patch.dict(os.environ, _env(PII_ENCRYPTION_KEK=short)):
+        with pytest.raises(FieldCryptoError):
+            encrypt_pii("x@x.com")
+
+
+# ---------------------------------------------------------------------------
+# blind_index
+# ---------------------------------------------------------------------------
+
+
+def test_blind_index_deterministic_and_normalized():
+    with patch.dict(os.environ, _env(PII_BLIND_INDEX_KEY=_BIDX_KEY)):
+        a = blind_index("  User@Example.COM ")
+        b = blind_index("user@example.com")
+        assert a == b  # 大文字小文字・前後空白を正規化して一致
+        assert len(a) == 64  # SHA-256 hex
+
+
+def test_blind_index_none_returns_none():
+    with patch.dict(os.environ, _env(PII_BLIND_INDEX_KEY=_BIDX_KEY)):
+        assert blind_index(None) is None
+
+
+def test_blind_index_no_key_raises():
+    with patch.dict(os.environ, _env()):
+        with pytest.raises(FieldCryptoError):
+            blind_index("x@x.com")

--- a/docs/13_security_design.md
+++ b/docs/13_security_design.md
@@ -412,7 +412,59 @@ Phase 2 以降: `AAVE_NETWORK=base`, `BYBIT_SANDBOX=false`, `APP_ENV=production`
 
 ---
 
-最終更新: 2026-04-19
+# 12. 顧客PIIのフィールドレベル暗号化（Track 2 / 2026-07-07）
+
+## 12.1 前提と現状
+
+- **消費者の実メールは DB に保存していない**: Privy/LINE ログインの消費者ユーザーの `email`
+  列は合成ID（`wallet_<slug>@wallet.local` / `line_<id>@line.local`）。Privy verifier は
+  ID Token の `sub`（`did:privy:xxxx`）のみ取得し、実メールは Privy 側に保管される
+  （データ最小化＝漏洩リスク低減。`app/auth/privy_verifier.py`）。
+- DB に入る実 PII は、社内アカウント（admin/partner の実メール）と、ユーザーが任意入力する
+  `notification_email` のみ。将来 UAT が顧客メールを収集（Privy `linked_accounts` 取得 or
+  フォーム入力）する場合に実 PII が増える。
+
+## 12.2 層構成（3層）
+
+顧客メール収集を「障害通知/KYC（取引付随）」「キャンペーン/解析/第三者連携（要同意）」で使う場合、
+以下 3 層が必要。**本節（層2）は法務判断と独立に安全に作れる暗号化基盤**。
+
+1. 収集層（Privy 取得 / フォーム）— 未実装（森先生の法務判断後に配線）
+2. **暗号化層（本節・実装済み）** — 保存時の AES-256-GCM 暗号化
+3. 同意・利用目的管理層 — 用途別オプトイン + プライバシーポリシー/特商法（**森先生判断必須**。
+   特定電子メール法=マーケメール事前同意、個情法=第三者提供の個別同意）
+
+## 12.3 層2 暗号化基盤（実装済み）
+
+- `app/security/field_crypto.py`:
+  - `encrypt_pii` / `decrypt_pii`: AES-256-GCM。暗号文 = `enc:v<版>:<base64(nonce||ct||tag)>`。
+  - `blind_index`: HMAC-SHA256（正規化=小文字化+trim）。等価検索・unique が要る列用（決定的）。
+  - 鍵は env KEK + 版番号でローテ対応（`PII_ENCRYPTION_KEK` / `PII_KEK_VERSION` /
+    旧版 `PII_ENCRYPTION_KEK_V<n>` / `PII_BLIND_INDEX_KEY`）。self-hosted 現実解、将来 KMS 移行余地。
+- `app/security/sqlalchemy_types.py` `EncryptedString`: ORM 列型。write で暗号化・read で復号を
+  透過処理し、各読み書き箇所を触らず暗号化漏れを防ぐ。**適用済み列**: `users.notification_email`
+  / `user_settings.notification_email`。
+- **後方互換**: `enc:` prefix 無しの既存平文はそのまま読める（段階移行）。KEK 未設定環境
+  （dev / 現状の staging・本番）は平文パススルー（挙動不変）。
+
+## 12.4 有効化手順（KEK 設定時の必須オペレーション）
+
+1. **先に列幅拡張**: 暗号文は base64 で平文より長い（255文字メール → 約 390 文字）。KEK を
+   設定する前に必ず実行:
+   ```sql
+   ALTER TABLE users         ALTER COLUMN notification_email TYPE VARCHAR(512);
+   ALTER TABLE user_settings ALTER COLUMN notification_email TYPE VARCHAR(512);
+   ```
+2. `PII_ENCRYPTION_KEK`（base64 32byte）+ `PII_KEK_VERSION=1` を env に設定 → 再デプロイ。
+   以降の write は暗号化される。既存平文行は次回 write 時に暗号化される（backfill する場合は
+   全行 read→write の冪等バッチ）。
+3. **鍵ローテ**: 新版 KEK を `PII_ENCRYPTION_KEK` に、旧版を `PII_ENCRYPTION_KEK_V<旧版>` に
+   残し `PII_KEK_VERSION` をインクリメント。旧版暗号文は旧鍵で復号可能。
+4. KEK は `.gitignore` 済 `.env.*` のみ・ログ出力禁止（§1.1）。
+
+---
+
+最終更新: 2026-07-07
 主要変更:
 - OctoBot 依存の全記述を削除（アーキテクチャは Knowledge Hub → AI → Bybit/Aave に）
 - Privy / MetaMask ウォレット方式（2.4 節）を追加
@@ -420,3 +472,5 @@ Phase 2 以降: `AAVE_NETWORK=base`, `BYBIT_SANDBOX=false`, `APP_ENV=production`
 - OR ロジック緊急停止（6.2 節）を追加（docs/33 整合）
 - Phase 1 期間中の意図的 .env 乖離（1.4 節）を追加
 - パートナー管理画面の権限分離 方式 B（11 節）を追加
+- operator fee wallet の Privy Server Wallet 化（2.5 節・2026-07-07）を追加
+- 顧客PIIのフィールドレベル暗号化（12 節・2026-07-07）を追加


### PR DESCRIPTION
## Summary
セキュリティ設計 Track 2 の**層2(暗号化基盤)**。顧客メール等の実PIIを保存時に AES-256-GCM で暗号化する土台を追加。用途別の収集層(層1)・同意管理層(層3・**要森先生法務判断**)とは独立に安全に作れる部分のみを実装。

### 調査で判明した重要事実
消費者(Privy/LINE)の**実メールはDBに保存されていない**。`email`列は合成ID(`wallet_xxx@wallet.local`/`line_xxx@line.local`)、Privy verifier は `sub`(DID)のみ取得し、実メールはPrivy側保管(=データ最小化・既に良い設計)。DBの実PIIは社内アカウントとユーザー任意入力の`notification_email`のみ。

## 変更
- `app/security/field_crypto.py`: `encrypt_pii`/`decrypt_pii`(AES-256-GCM・版番号埋め込みで鍵ローテ対応)+ `blind_index`(HMAC-SHA256・検索/unique列用)。env KEK 管理
- `app/security/sqlalchemy_types.py`: `EncryptedString` TypeDecorator。ORM write時暗号化・read時復号を透過処理し、各読み書き箇所を触らず暗号化漏れを防ぐ
- `notification_email`(users / user_settings)に `EncryptedString` 適用
- `requirements.txt`: `cryptography` を明示化(PyJWT[crypto]の推移依存だった)
- `docs/13 §12`: PII暗号化の設計・有効化手順を追記

## スコープ / 安全性
- **後方互換・挙動不変**: `enc:` prefix無しの既存平文はそのまま読める(段階移行)。KEK未設定環境(dev/現状staging・本番)は**平文パススルーで完全に挙動不変**。
- 実際の暗号化有効化は「列幅拡張 `ALTER TABLE ... TYPE VARCHAR(512)` + KEK設定 + 再デプロイ」の別ステップ(docs §12.4)。本PRは基盤追加のみで何も暗号化を開始しない。
- 収集層(層1)・同意管理層(層3)、特にマーケ/第三者提供は**森先生の法務判断が必要**なため本PRでは配線しない。

## Test plan
- [x] `ruff check` / `ruff format --check` / `ruff check --select S`(セキュリティ) 全通過
- [x] `mypy app/`(5ファイル) 全通過
- [x] pytest: field_crypto 13ケース(ラウンドトリップ/None/冪等/ランダムnonce/KEK未設定パススルー/レガシー平文/鍵ローテ/改ざん検知/blind index正規化) + EncryptedString 4ケース = **17 passed**
- [x] 既存 settings/user系 **230 passed** 回帰(モデルimport健全性)
- [x] `import app.main` smoke OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUEgFqF7VE6jsggFVgfMj