### PR TITLE
feat(security): 顧客email収集経路をdormant実装(Track2 層1)

### DIFF
--- a/backend/app/auth/models.py
+++ b/backend/app/auth/models.py
@@ -279,6 +279,14 @@ class User(Base):
     privy_did: Mapped[Optional[str]] = mapped_column(
         String(255), unique=True, nullable=True, index=True, default=None
     )
+    # Track 2 / 層1: Privy linked_accounts から収集したアカウント email(実 PII)。
+    # notification_email(ユーザー任意入力・通知先)とは別で、ログイン時に自動収集する
+    # 連絡先。フィールドレベル暗号化(EncryptedString)で保存。収集は PII_EMAIL_COLLECTION_ENABLED
+    # フラグ ON 時のみ(既定 false・dormant)。利用目的明示・同意は層3(森先生判断・docs/13 §12.2)。
+    # ALTER TABLE users ADD COLUMN IF NOT EXISTS contact_email VARCHAR(512) NULL;
+    contact_email: Mapped[Optional[str]] = mapped_column(
+        EncryptedString(512), nullable=True, default=None
+    )
     # Privy 内部 wallet ID (アドレスではない)。委譲(SCW)執行の Privy wallet_sendCalls が
     # POST /v1/wallets/{id}/rpc で要求する識別子。wallet-connect 時に frontend の Privy SDK から
     # 受領して保存する。NULL = 未取得 (旧ユーザー / 非 Privy 経路)。

--- a/backend/app/auth/privy_verifier.py
+++ b/backend/app/auth/privy_verifier.py
@@ -28,11 +28,12 @@ Privy 公式仕様 (https://docs.privy.io/authentication/user-authentication/acc
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import threading
 import time
-from typing import Optional
+from typing import Any, Optional
 
 import httpx
 import jwt as pyjwt
@@ -52,6 +53,33 @@ PRIVY_ISSUER = "privy.io"
 PRIVY_ALGORITHM = "ES256"
 DEFAULT_JWKS_URL_TEMPLATE = "https://auth.privy.io/api/v1/apps/{app_id}/keys"
 JWKS_CACHE_TTL_SECONDS = 3600  # 1 hour
+
+
+def extract_email_from_claims(payload: "dict[str, Any]") -> Optional[str]:
+    """検証済み Privy claims の ``linked_accounts`` から email を抽出する（層1 / 収集）。
+
+    Privy ID Token は email ログイン時に ``linked_accounts`` を含む（JSON 文字列 or
+    既に list）。``type == "email"`` のエントリの ``address`` を返す。無ければ None。
+    parse 失敗は None（収集は best-effort・認証は止めない）。
+
+    ⚠️ **これは実 PII の取得**。呼び出し側は PII 収集フラグ ON 時のみ保存すること
+    （利用目的の明示・同意は層3 / 森先生判断。docs/13 §12.2）。
+    """
+    raw = payload.get("linked_accounts")
+    if raw is None:
+        return None
+    try:
+        accounts = json.loads(raw) if isinstance(raw, str) else raw
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(accounts, list):
+        return None
+    for acc in accounts:
+        if isinstance(acc, dict) and acc.get("type") == "email":
+            addr = acc.get("address")
+            if isinstance(addr, str) and addr.strip():
+                return addr.strip()
+    return None
 
 
 class PrivyVerifier:
@@ -76,8 +104,8 @@ class PrivyVerifier:
         self._jwks_cache_fetched_at: float = 0.0
         self._jwks_lock = threading.Lock()
 
-    def verify_id_token(self, token: str) -> str:
-        """ID Token を検証して sub claim (Privy DID) を返す。
+    def _verify_and_decode(self, token: str) -> "dict[str, Any]":
+        """ID Token を検証して verified payload(claims dict)を返す。
 
         失敗時は HTTPException(401) を raise する。JWKS 取得失敗のような
         外部依存系エラーは 503 で返す (クライアント原因と区別するため)。
@@ -89,7 +117,7 @@ class PrivyVerifier:
             )
         public_key = self._resolve_public_key(token)
         try:
-            payload = pyjwt.decode(
+            payload: dict[str, Any] = pyjwt.decode(
                 token,
                 public_key,
                 algorithms=[PRIVY_ALGORITHM],
@@ -121,7 +149,22 @@ class PrivyVerifier:
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid Privy ID token (missing sub)",
             )
-        return sub
+        return payload
+
+    def verify_id_token(self, token: str) -> str:
+        """ID Token を検証して sub claim (Privy DID) を返す。"""
+        return str(self._verify_and_decode(token)["sub"])
+
+    def verify_id_token_with_email(self, token: str) -> "tuple[str, Optional[str]]":
+        """ID Token を検証し ``(did, email)`` を返す。
+
+        email は Privy の ``linked_accounts`` claim(email ログイン時に含まれる)から
+        抽出する。追加 API 呼び出しは不要(検証済みトークン内から取得)。email が無い
+        (wallet 単独ログイン等)場合は ``None``。**PII 収集フラグが ON のときのみ
+        呼び出し側が保存する**(層1・dormant / docs/13 §12.2)。
+        """
+        payload = self._verify_and_decode(token)
+        return str(payload["sub"]), extract_email_from_claims(payload)
 
     # ── 公開鍵解決 ───────────────────────────────────────────
 

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -698,6 +698,13 @@ def wallet_connect(
     # 検証せずに drop する。本番環境では PRIVY_APP_ID + 公開鍵を必ず設定すること。
     verifier = get_privy_verifier()
     privy_did_to_store: str | None = None
+    # Track 2 / 層1(dormant): PII_EMAIL_COLLECTION_ENABLED=true のときのみ Privy
+    # linked_accounts から連絡先 email を収集して暗号化保存する。既定 false=収集しない。
+    # 有効化は利用目的明示・同意(層3・森先生判断)が前提(docs/13 §12.2)。
+    collect_email_enabled = (
+        os.getenv("PII_EMAIL_COLLECTION_ENABLED", "false").strip().lower() == "true"
+    )
+    collected_email: str | None = None
     if verifier is None:
         # 後方互換モード: PRIVY_APP_ID 未設定時は Privy フィールドを silent drop して通常認証へ継続
         if request.privy_id_token or request.privy_did:
@@ -708,8 +715,14 @@ def wallet_connect(
                 "<present>" if request.privy_did else None,
             )
     elif request.privy_id_token:
-        # 検証モード (PRIVY_APP_ID 設定済み): id_token を検証して DID を取得
-        verified_did = verifier.verify_id_token(request.privy_id_token)
+        # 検証モード (PRIVY_APP_ID 設定済み): id_token を検証して DID を取得。
+        # PII 収集フラグ ON 時のみ、同じ検証済みトークンから email も抽出する(追加 API 不要)。
+        if collect_email_enabled:
+            verified_did, collected_email = verifier.verify_id_token_with_email(
+                request.privy_id_token
+            )
+        else:
+            verified_did = verifier.verify_id_token(request.privy_id_token)
         if request.privy_did and request.privy_did != verified_did:
             logger.warning(
                 "Privy DID mismatch: request.privy_did=%s..., id_token.sub=%s...",
@@ -795,6 +808,23 @@ def wallet_connect(
             db.rollback()
             logger.warning(
                 "privy_wallet_id store failed (non-fatal): wallet=%s...",
+                request.wallet_address[:10],
+            )
+
+    # Track 2 / 層1(dormant): 収集フラグ ON かつ Privy から email が取れ、未保存なら
+    # contact_email に暗号化保存(EncryptedString が透過暗号化)。best-effort(login は止めない)。
+    # email 平文はログに出さない(CLAUDE.md §Security 8)。
+    if collect_email_enabled and collected_email and not user.contact_email:
+        try:
+            user.contact_email = collected_email
+            db.add(user)
+            db.commit()
+            db.refresh(user)
+            logger.info("contact_email collected for user_id=%d (Privy)", user.id)
+        except Exception:  # noqa: BLE001
+            db.rollback()
+            logger.warning(
+                "contact_email store failed (non-fatal): wallet=%s...",
                 request.wallet_address[:10],
             )
 

--- a/backend/tests/test_privy_email_collection.py
+++ b/backend/tests/test_privy_email_collection.py
@@ -1,0 +1,90 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_privy_email_collection.py
+"""Privy linked_accounts からの email 抽出（Track 2 層1 / dormant 収集）の単体テスト。
+
+`extract_email_from_claims`（純関数）と `verify_id_token_with_email`（_verify_and_decode を
+mock）を検証する。実 JWT / 実 Privy は使わない。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import patch
+
+from app.auth.privy_verifier import PrivyVerifier, extract_email_from_claims
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-privy-email")
+
+
+# ---------------------------------------------------------------------------
+# extract_email_from_claims
+# ---------------------------------------------------------------------------
+
+
+def test_extract_email_from_list():
+    payload = {
+        "sub": "did:privy:abc",
+        "linked_accounts": [
+            {"type": "wallet", "address": "0xabc"},
+            {"type": "email", "address": "user@example.com"},
+        ],
+    }
+    assert extract_email_from_claims(payload) == "user@example.com"
+
+
+def test_extract_email_from_json_string():
+    """linked_accounts が JSON 文字列でも抽出できる。"""
+    payload = {
+        "sub": "did:privy:abc",
+        "linked_accounts": json.dumps([{"type": "email", "address": "  Str@X.com "}]),
+    }
+    assert extract_email_from_claims(payload) == "Str@X.com"  # trim される
+
+
+def test_extract_email_none_when_no_linked_accounts():
+    assert extract_email_from_claims({"sub": "did:privy:abc"}) is None
+
+
+def test_extract_email_none_when_no_email_type():
+    payload = {"linked_accounts": [{"type": "wallet", "address": "0xabc"}]}
+    assert extract_email_from_claims(payload) is None
+
+
+def test_extract_email_malformed_returns_none():
+    assert extract_email_from_claims({"linked_accounts": "not-json{"}) is None
+    assert extract_email_from_claims({"linked_accounts": 123}) is None
+    assert extract_email_from_claims({"linked_accounts": [{"type": "email"}]}) is None
+
+
+# ---------------------------------------------------------------------------
+# verify_id_token_with_email
+# ---------------------------------------------------------------------------
+
+
+def test_verify_with_email_returns_did_and_email():
+    v = PrivyVerifier(app_id="app-123", verification_key="dummy")
+    payload = {
+        "sub": "did:privy:xyz",
+        "linked_accounts": [{"type": "email", "address": "a@b.com"}],
+    }
+    with patch.object(v, "_verify_and_decode", return_value=payload):
+        did, email = v.verify_id_token_with_email("tok")
+    assert did == "did:privy:xyz"
+    assert email == "a@b.com"
+
+
+def test_verify_with_email_none_when_wallet_only():
+    v = PrivyVerifier(app_id="app-123", verification_key="dummy")
+    payload = {"sub": "did:privy:xyz", "linked_accounts": [{"type": "wallet", "address": "0x1"}]}
+    with patch.object(v, "_verify_and_decode", return_value=payload):
+        did, email = v.verify_id_token_with_email("tok")
+    assert did == "did:privy:xyz"
+    assert email is None
+
+
+def test_verify_id_token_still_returns_sub():
+    """既存 verify_id_token は従来通り sub のみ返す(回帰)。"""
+    v = PrivyVerifier(app_id="app-123", verification_key="dummy")
+    with patch.object(v, "_verify_and_decode", return_value={"sub": "did:privy:z"}):
+        assert v.verify_id_token("tok") == "did:privy:z"

--- a/docs/13_security_design.md
+++ b/docs/13_security_design.md
@@ -429,7 +429,7 @@ Phase 2 以降: `AAVE_NETWORK=base`, `BYBIT_SANDBOX=false`, `APP_ENV=production`
 顧客メール収集を「障害通知/KYC（取引付随）」「キャンペーン/解析/第三者連携（要同意）」で使う場合、
 以下 3 層が必要。**本節（層2）は法務判断と独立に安全に作れる暗号化基盤**。
 
-1. 収集層（Privy 取得 / フォーム）— 未実装（森先生の法務判断後に配線）
+1. 収集層（Privy 取得 / フォーム）— **dormant 実装済み**（既定 OFF。§12.5 参照）
 2. **暗号化層（本節・実装済み）** — 保存時の AES-256-GCM 暗号化
 3. 同意・利用目的管理層 — 用途別オプトイン + プライバシーポリシー/特商法（**森先生判断必須**。
    特定電子メール法=マーケメール事前同意、個情法=第三者提供の個別同意）
@@ -461,6 +461,23 @@ Phase 2 以降: `AAVE_NETWORK=base`, `BYBIT_SANDBOX=false`, `APP_ENV=production`
 3. **鍵ローテ**: 新版 KEK を `PII_ENCRYPTION_KEK` に、旧版を `PII_ENCRYPTION_KEK_V<旧版>` に
    残し `PII_KEK_VERSION` をインクリメント。旧版暗号文は旧鍵で復号可能。
 4. KEK は `.gitignore` 済 `.env.*` のみ・ログ出力禁止（§1.1）。
+
+## 12.5 層1 収集（dormant 実装済み・2026-07-07）
+
+顧客の連絡先 email を Privy から収集する経路を **dormant（既定 OFF）** で実装済み。
+有効化は**利用目的の明示・同意（層3・森先生判断）が前提**。
+
+- **収集源**: Privy ID Token の `linked_accounts` claim（email ログイン時に含まれる）から
+  抽出する。**追加 API 呼び出し不要**（wallet-connect 時に検証する同じトークン内から取得）。
+  `app/auth/privy_verifier.py`: `extract_email_from_claims` / `verify_id_token_with_email`。
+- **保存先**: `users.contact_email`（`EncryptedString(512)`・§12.3 で暗号化）。ユーザーが
+  設定画面で任意入力する `notification_email` とは別（自動収集した連絡先）。
+- **フラグ**: `PII_EMAIL_COLLECTION_ENABLED`（既定 `false`）。OFF の間は `verify_id_token_with_email`
+  を呼ばず email を一切取得・保存しない（現行挙動不変）。`app/auth/router.py` wallet-connect。
+- **best-effort**: 収集・保存の失敗は login を止めない。email 平文はログに出さない（§1.1）。
+- **有効化前の必須**: ①列追加 `ALTER TABLE users ADD COLUMN IF NOT EXISTS contact_email
+  VARCHAR(512) NULL;` ②利用目的をプライバシーポリシー/規約に明示（個情法）③マーケ利用は
+  別途オプトイン（特定電子メール法）④第三者提供は個別同意（個情法）。①以外は森先生判断。
 
 ---
 


### PR DESCRIPTION
## Summary
セキュリティ設計 Track 2 の**層1(収集)**を **dormant(既定OFF)** で実装。Privy から顧客の連絡先emailを収集し、#956 の暗号化基盤で保存する経路を用意する。**有効化は利用目的明示・同意(層3・森先生判断)が前提**で、フラグOFFの間は挙動完全不変。

> ⚠️ **スタックPR**: #956(`feat/pii-field-level-encryption-foundation`)の上に積んでいます。base を #956 ブランチにしています。**#956 マージ後に base を main へ付け替え**てください。

## 変更
- `privy_verifier.py`: `extract_email_from_claims`(検証済みclaimsの`linked_accounts`からemail抽出・純関数)+ `verify_id_token_with_email`。**追加API不要**(wallet-connect時に検証する同じトークン内から取得)。`verify_id_token`(既存)はsubのみ返す挙動を維持
- `models.py`: `users.contact_email`(`EncryptedString(512)`)追加。ユーザー任意入力の`notification_email`とは別の自動収集連絡先。#956の透過暗号化で保存
- `router.py`: `PII_EMAIL_COLLECTION_ENABLED`(既定false)ON時のみemail抽出+`contact_email`に暗号化保存。best-effort(login止めない)・**email平文はログ非出力**
- `docs/13 §12.5`: 層1収集のdormant実装と有効化前の必須(列追加+法務判断)を追記

## dormant / スコープ
- フラグOFFの間は `verify_id_token_with_email` を呼ばず、emailを**一切取得・保存しない**(現行挙動不変)。
- 森先生に「収集できる状態」を見せて法務判断を仰ぐための土台。有効化には列追加SQL + 利用目的明示(個情法) + マーケはオプトイン(特定電子メール法) + 第三者提供は個別同意(個情法)が必要。

## Test plan
- [x] `ruff` / `ruff format --check` / `mypy app/` 全通過
- [x] pytest: extract 5ケース + verify_id_token_with_email 3ケース = **8 passed**
- [x] wallet_connect **29 passed** 回帰

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUEgFqF7VE6jsggFVgfMj