### PR TITLE
fix(privy): 実機検証で判明したPrivy署名2バグを修正 + operator fee検証完走

### DIFF
--- a/backend/app/fees/fee_transfer_service.py
+++ b/backend/app/fees/fee_transfer_service.py
@@ -437,12 +437,10 @@ class FeeTransferService:
             logger.warning("fee_transfer Privy send_transaction failed: status=%s", exc.status_code)
             raise
 
-        # Privy レスポンスから tx hash を取り出す (キー名の揺れに defensive)
-        tx_hash_hex = str(
-            resp.get("transaction_hash")
-            or resp.get("hash")
-            or (resp.get("data") or {}).get("transaction_hash", "")
-        ).strip()
+        # Privy レスポンスから tx hash を取り出す。eth_sendTransaction は
+        # ``{"method": ..., "data": {"hash": "0x..."}}`` の形（staging-v4 実機検証 2026-07-07）。
+        # top-level / data / result のいずれかに hash 系キーがある想定で defensive に探す。
+        tx_hash_hex = _extract_privy_tx_hash(resp)
         if not tx_hash_hex:
             raise RuntimeError(f"Privy returned no tx hash: keys={list(resp.keys())}")
         debug.append(f"privy_tx_hash={tx_hash_hex}")
@@ -564,6 +562,22 @@ class FeeTransferService:
 # ---------------------------------------------------------------------------
 # Helpers (module-level)
 # ---------------------------------------------------------------------------
+
+
+def _extract_privy_tx_hash(resp: dict[str, Any]) -> str:
+    """Privy wallet action レスポンスから tx hash を best-effort で取り出す。
+
+    eth_sendTransaction は ``{"method": ..., "data": {"hash": "0x..."}}`` を返す
+    (staging-v4 実機検証)。top-level / data / result のネストを順に探索する。
+    """
+    _keys = ("transaction_hash", "hash", "transactionHash")
+    for container in (resp, resp.get("data"), resp.get("result")):
+        if isinstance(container, dict):
+            for k in _keys:
+                v = container.get(k)
+                if isinstance(v, str) and v:
+                    return v.strip()
+    return ""
 
 
 def is_fee_transfer_enabled() -> bool:

--- a/backend/app/privy/auth_signature.py
+++ b/backend/app/privy/auth_signature.py
@@ -94,8 +94,16 @@ def load_authorization_private_key(b64_pkcs8: str) -> ec.EllipticCurvePrivateKey
 
     形式は Node SDK の `authorization_private_keys` と同一
     （`openssl pkcs8 -topk8 -nocrypt -outform DER | base64`）。
+
+    Privy dashboard が発行する authorization key は ``wallet-auth:<base64>`` の
+    プレフィックス付き形式のことがある（Node SDK も内部で strip する）。前後空白と
+    ``wallet-auth:`` prefix を除去してから base64 デコードする（2026-07-07 staging-v4
+    実機検証で prefix 付き値が "Incorrect padding" で落ちた不具合を修正）。
     """
-    der = base64.b64decode(b64_pkcs8)
+    cleaned = b64_pkcs8.strip()
+    if cleaned.startswith("wallet-auth:"):
+        cleaned = cleaned[len("wallet-auth:") :]
+    der = base64.b64decode(cleaned)
     key = load_der_private_key(der, password=None)
     if not isinstance(key, ec.EllipticCurvePrivateKey):
         raise ValueError("authorization key is not an EC (P-256) private key")

--- a/backend/app/privy/rest_client.py
+++ b/backend/app/privy/rest_client.py
@@ -186,12 +186,12 @@ class PrivyRestClient:
         """POST /v1/wallets（server wallet 作成・app-level / Basic auth のみ）。
 
         operator fee wallet を Privy Server Wallet として作成する 1 回限りセットアップ用。
-        body 例::
+        body 例（Privy API: POST /v1/wallets / @privy-io/api-types WalletCreateParams）::
 
             {
                 "chain_type": "ethereum",
+                "owner_id": "<server signer / key quorum id>",
                 "policy_ids": ["<operator fee policy id>"],
-                "authorization_key_ids": ["<server signer / key quorum id>"],
             }
 
         返り値の ``id`` が ``OPERATOR_FEE_PRIVY_WALLET_ID``、``address`` が

--- a/backend/scripts/setup_operator_fee_privy_wallet.py
+++ b/backend/scripts/setup_operator_fee_privy_wallet.py
@@ -125,11 +125,13 @@ def main(argv: list[str]) -> int:
         return 1
     print(f"\n✅ policy 作成成功: policy_id={policy_id}")
 
-    # 2) server wallet 作成（policy + signer を紐付け）
+    # 2) server wallet 作成（policy + owner(key quorum) を紐付け）。
+    # Privy API: POST /v1/wallets は owner_id(=key quorum id) を取る
+    # (@privy-io/api-types WalletCreateParams: chain_type / owner_id / policy_ids)。
     wallet_body = {
         "chain_type": "ethereum",
+        "owner_id": signer_id,
         "policy_ids": [policy_id],
-        "authorization_key_ids": [signer_id],
     }
     try:
         wallet_result = client.create_wallet(wallet_body)

--- a/backend/scripts/test_fee_transfer_staging.py
+++ b/backend/scripts/test_fee_transfer_staging.py
@@ -26,10 +26,18 @@
   # basescan で確認:
   # https://sepolia.basescan.org/tx/0x<tx_hash>
 
+署名モード (FEE_SIGNING_MODE, 既定 raw_key):
+  - raw_key: OPERATOR_FEE_WALLET_KEY(生鍵)でローカル署名 (従来)
+  - privy:   OPERATOR_FEE_PRIVY_WALLET_ID の Privy Server Wallet が TEE 内署名。
+             生鍵不要。追加で以下を設定:
+               export FEE_SIGNING_MODE="privy"
+               export OPERATOR_FEE_PRIVY_WALLET_ID="<setup スクリプトで作成した wallet id>"
+               export PRIVY_APP_ID / PRIVY_APP_SECRET / PRIVY_AUTHORIZATION_PRIVATE_KEY
+
 Non-custodial 設計確認ポイント:
   - from: TEST_USER_WALLET (ユーザーの aToken 保有者)
   - to:   OPERATOR_FEE_WALLET_ADDRESS (operator 受け取り先)
-  - 署名: OPERATOR_FEE_WALLET_KEY (operator 自身の鍵) が transferFrom を call
+  - 署名: raw_key=OPERATOR_FEE_WALLET_KEY / privy=Privy TEE が transferFrom を call
   - ユーザーの秘密鍵は allowance 付与にのみ使用 (本番では Privy 経由で browser 署名)
 """
 
@@ -114,17 +122,20 @@ def main() -> None:
     operator_key = os.getenv("OPERATOR_FEE_WALLET_KEY", "")
     user_wallet = os.getenv("TEST_USER_WALLET", "")
     user_key = os.getenv("TEST_USER_PRIVATE_KEY", "")
+    # 署名モード: raw_key(既定・生鍵) / privy(Privy Server Wallet・TEE 署名)。
+    signing_mode = os.getenv("FEE_SIGNING_MODE", "raw_key").strip().lower()
+    operator_privy_wallet_id = os.getenv("OPERATOR_FEE_PRIVY_WALLET_ID", "").strip()
 
-    missing = [
-        k
-        for k, v in [
-            ("ALCHEMY_RPC_URL_BASE_SEPOLIA", rpc_url),
-            ("OPERATOR_FEE_WALLET_ADDRESS", operator_addr),
-            ("OPERATOR_FEE_WALLET_KEY", operator_key),
-            ("TEST_USER_WALLET", user_wallet),
-        ]
-        if not v
+    required = [
+        ("ALCHEMY_RPC_URL_BASE_SEPOLIA", rpc_url),
+        ("OPERATOR_FEE_WALLET_ADDRESS", operator_addr),
+        ("TEST_USER_WALLET", user_wallet),
     ]
+    if signing_mode == "privy":
+        required.append(("OPERATOR_FEE_PRIVY_WALLET_ID", operator_privy_wallet_id))
+    else:
+        required.append(("OPERATOR_FEE_WALLET_KEY", operator_key))
+    missing = [k for k, v in required if not v]
     if missing:
         print(f"[ERROR] 環境変数未設定: {missing}")
         print("  設定方法は本スクリプト冒頭のコメントを参照してください。")
@@ -204,6 +215,7 @@ def main() -> None:
 
     from app.fees.fee_transfer_service import FeeTransferConfig, FeeTransferService  # noqa: PLC0415
 
+    print(f"  signing_mode: {signing_mode}")
     cfg = FeeTransferConfig(
         enabled=True,
         operator_wallet_address=operator_addr,
@@ -212,6 +224,9 @@ def main() -> None:
         data_provider_address=DATA_PROVIDER_ADDRESS,
         usdc_address=USDC_ADDRESS,
         chain_id=CHAIN_ID,
+        signing_mode=signing_mode,
+        operator_privy_wallet_id=operator_privy_wallet_id,
+        chain_name="base_sepolia",
     )
     svc = FeeTransferService(cfg)
     result = svc.transfer_fee(

--- a/backend/tests/test_privy_auth_signature.py
+++ b/backend/tests/test_privy_auth_signature.py
@@ -147,6 +147,17 @@ def test_load_key_and_sign_verify_roundtrip() -> None:
     pub.verify(der_sig, payload, ec.ECDSA(hashes.SHA256()))
 
 
+def test_load_key_strips_wallet_auth_prefix() -> None:
+    """Privy dashboard 形式 ``wallet-auth:<b64>`` の prefix / 前後空白を除去してロードできる。
+
+    2026-07-07 staging-v4 実機検証で prefix 付き値が "Incorrect padding" で落ちた回帰。
+    """
+    b64, _ = _new_key_b64()
+    for variant in (f"wallet-auth:{b64}", f"  wallet-auth:{b64}  ", f"  {b64}\n"):
+        loaded = load_authorization_private_key(variant)
+        assert isinstance(loaded, ec.EllipticCurvePrivateKey)
+
+
 def test_authorization_signature_header_multi_key() -> None:
     """複数鍵はカンマ連結され、各署名が対応公開鍵で verify できる。"""
     b1, pub1 = _new_key_b64()


### PR DESCRIPTION
## Summary
Track 1(operator wallet の Privy Server Wallet 署名化)を staging-v4(Base Sepolia)で **end-to-end 実機検証**し、実バグ2件を発見・修正した。最終的に **Privy TEE 署名の transferFrom が receipt status=1 で完走**(生鍵を env に置かず実 tx 成功)。

**検証 tx**: [0x40aa3c62...03fa75](https://sepolia.basescan.org/tx/0x40aa3c62b65ebbf62cb2f23dc68706709938f7e02b16b2fbe7c829f4ef03fa75) — 0.01 aUSDC がユーザー→operator に移動。operator の秘密鍵は一度も env に存在せず、Privy サーバーウォレット(TEE 内署名)で実行。

## 修正1: auth_signature が `wallet-auth:` prefix を扱えず署名不能
Privy 発行の authorization 鍵は `wallet-auth:<base64>` 形式のことがあるが、`load_authorization_private_key` が生 base64 を仮定し `base64decode` で **"Incorrect padding"** で落ちていた。prefix + 前後空白を除去してからデコードするよう修正。**委譲経路(scw_executor)も同じ署名基盤を使うため両方に影響する潜在バグ**(署名付き wallet action が今回初めてライブ実行されて発覚)。

## 修正2: `send_transaction` の tx hash 抽出漏れ
`eth_sendTransaction` の Privy レスポンスは `{method, data:{hash}}` 形式だが、`_submit_transferfrom_privy` が `data.hash` を見ておらず、**tx 成功済みでも "no tx hash" で failed 扱い**していた。`_extract_privy_tx_hash` を新設し top-level/data/result のネストを探索。

## 補助変更
- `rest_client.create_wallet` docstring の body 例を修正(`authorization_key_ids` → `owner_id`。Privy API `WalletCreateParams` 準拠。実機で 400 を確認して訂正)
- `setup_operator_fee_privy_wallet.py`: wallet 作成 body を `owner_id` 方式に修正
- `test_fee_transfer_staging.py`: `FEE_SIGNING_MODE` で raw_key/privy 両対応に

## ⚠️ 別途フォローアップ(本PR対象外・要対応)
staging-v4 の `PRIVY_AUTHORIZATION_PRIVATE_KEY`(env)と `PRIVY_SERVER_SIGNER_ID`(key quorum)の公開鍵が**不一致**で、そのままでは署名が 401 拒否される**設定不整合**があった(委譲経路も同様に影響)。検証では env 鍵に一致する新 quorum+wallet を作成して回避。**staging-v4 の env/quorum 整合は別途要修正**(委譲おまかせ実行を staging-v4 で使う前に必須)。

## Test plan
- [x] `ruff` / `ruff format --check` / `mypy app/` 全通過
- [x] `auth_signature` に `wallet-auth:` prefix 回帰テスト追加。**privy+fee 55 passed**
- [x] **staging-v4 実機**: Privy 署名 transferFrom が receipt status=1 で完走(basescan 確認済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUEgFqF7VE6jsggFVgfMj