### PR TITLE
fix(chat): UAT AIチャットにユーザー実データのコンテキストを注入

### DIFF
--- a/backend/app/chat/router.py
+++ b/backend/app/chat/router.py
@@ -44,7 +44,7 @@ def post_chat(
     Returns:
         ChatResponse（response フィールドに AI 応答テキスト）
     """
-    return process_chat(db=db, user_id=user.id, message=body.message)
+    return process_chat(db=db, user=user, message=body.message)
 
 
 @router.get("/history", response_model=ChatHistoryResponse)

--- a/backend/app/chat/service.py
+++ b/backend/app/chat/service.py
@@ -5,16 +5,27 @@
 ユーザーメッセージの保存・Claude 応答生成・履歴取得を提供する。
 LLM 呼び出しは既存の app.ai.config パターンを流用し、新規依存を追加しない。
 fail-open 設計: API キー未設定 or API 例外時は 500 を返さず固定フォールバック文言を返す。
+
+チャット画面（frontend/app/(liff)/liff-chat/_components/ChatPanel.tsx）は
+8個の定型サジェストボタンのみで、自由入力欄は存在しない。ユーザーは AI の回答に対して
+自然文で聞き返す・追加情報を渡すことができない。そのため call_claude() には
+ユーザー本人の実データ（ポートフォリオ・AI判定・リスク設定）を build_context_block() で
+要約して渡し、AI が一回の回答で完結した内容を返せるようにする（system prompt 側でも
+「聞き返さない」ことを明示的に指示する）。
 """
 
 import logging
+from decimal import Decimal
 from typing import Optional
 
 from sqlalchemy.orm import Session
 
 from app.ai.config import get_ai_settings
+from app.ai.models import AIDecision
+from app.auth.models import User
 from app.chat.models import ChatMessage
 from app.chat.schemas import ChatHistoryResponse, ChatMessageOut, ChatResponse
+from app.portfolio.models import PortfolioHistory, PortfolioSnapshot
 
 logger = logging.getLogger(__name__)
 
@@ -23,15 +34,127 @@ _FALLBACK_RESPONSE = (
     "申し訳ありません、現在 AI アシスタントが利用できません。しばらくしてから再度お試しください。"
 )
 
+# 判定理由の最大文字数（context 肥大化 / token 浪費防止）
+_REASON_MAX_LEN = 300
+
 # チャット AI システムプロンプト
+#
+# UIがボタン選択のみ（自由入力なし）であることを前提に、
+# 「聞き返し禁止」「与えられたデータのみで一度に完結した回答」を明示する。
 _SYSTEM_PROMPT = (
-    "あなたは Ultra AutoTrade のサポートアシスタントです。"
-    "ユーザーの質問に対して、分かりやすく丁寧な日本語で回答してください。"
-    "投資に関する具体的なアドバイスは行わず、サービスの使い方や一般的な情報提供に留めてください。"
-    "回答は必ずプレーンテキストのみで書いてください。"
-    "見出し記号(#)、太字(**)、箇条書きの記号、区切り線(---)などのMarkdown記法は"
-    "一切使わないでください（チャット画面はMarkdownを表示できないプレーンテキスト表示のため）。"
+    "あなたは Ultra AutoTrade のサポートアシスタント「UAT AI」です。"
+    "ユーザーが使っているチャット画面には定型の質問ボタンしかなく、自由入力欄はありません。"
+    "そのためユーザーはあなたの回答に対して聞き返したり追加情報を伝えたりできません。"
+    "この前提を必ず守ってください:"
+    "1) ユーザーへ質問を返さない・「詳しく教えてください」「もう少し情報をいただけますか」"
+    "のような聞き返しは絶対にしない。"
+    "2) メッセージと一緒に渡される「現在の状況」データだけを根拠に、"
+    "質問に対する完結した回答を一度で返す。"
+    "3) 「現在の状況」に無いデータについては、無いという事実をそのまま伝える"
+    "（例:『まだ運用データがありません』）。存在しないデータを推測・創作しない。"
+    "4) 投資に関する具体的な売買アドバイス・数値目標は行わず、"
+    "サービスの状況説明や一般的な情報提供に留める。"
+    "5) 回答は2〜4文程度、分かりやすい日本語で簡潔に書く。"
+    "6) 見出し記号(#)、太字(**)、箇条書き記号、区切り線(---)などの"
+    "Markdown記法は一切使わない（チャット画面はプレーンテキスト表示のため）。"
 )
+
+
+def _fmt_usd(value: Optional[Decimal]) -> str:
+    """USD 金額をフォーマットする。None は「データなし」。"""
+    if value is None:
+        return "データなし"
+    return f"${value:,.2f}"
+
+
+def _fmt_pct(value: Optional[Decimal]) -> str:
+    """パーセンテージをフォーマットする。None は「データなし」。"""
+    if value is None:
+        return "データなし"
+    return f"{value:+.2f}%"
+
+
+def build_context_block(db: Session, user: User) -> str:
+    """チャット AI に渡す「現在の状況」コンテキストを組み立てる。
+
+    ユーザー本人のポートフォリオ・AI判定履歴・リスク設定を要約したテキストを返す。
+    データが存在しない項目は「データなし」と明示し、AI が推測で答えないようにする。
+    DB クエリ例外は fail-open（空コンテキストを返し、チャット自体は継続する）。
+
+    Args:
+        db: SQLAlchemy セッション
+        user: 認証済みユーザー
+
+    Returns:
+        Claude へのメッセージに埋め込むコンテキスト文字列
+    """
+    try:
+        lines: list[str] = [f"リスクモード: {user.risk_mode or 'データなし'}"]
+
+        snapshot = (
+            db.query(PortfolioSnapshot)
+            .filter(PortfolioSnapshot.user_id == user.id)
+            .order_by(PortfolioSnapshot.recorded_at.desc())
+            .first()
+        )
+        if snapshot is not None:
+            recorded = snapshot.recorded_at.strftime("%Y-%m-%d %H:%M UTC")
+            lines.append(
+                f"資産評価額: {_fmt_usd(snapshot.total_value_usd)}（記録日時: {recorded}）"
+            )
+            hf = snapshot.health_factor
+            lines.append(
+                f"Health Factor: {hf:.2f}" if hf is not None else "Health Factor: データなし"
+            )
+        else:
+            lines.append(
+                "ポートフォリオ: データなし（まだ資産スナップショットが記録されていません）"
+            )
+
+        monthly = (
+            db.query(PortfolioHistory)
+            .filter(
+                PortfolioHistory.user_id == user.id,
+                PortfolioHistory.period_type == "monthly",
+            )
+            .order_by(PortfolioHistory.period_start.desc())
+            .first()
+        )
+        if monthly is not None:
+            lines.append(f"今月の損益: {_fmt_usd(monthly.pnl_usd)}（{_fmt_pct(monthly.pnl_pct)}）")
+        else:
+            lines.append("今月の損益: データなし（月次集計がまだありません）")
+
+        # 本人宛の判定を優先し、無ければシステム判定（user_id IS NULL）にフォールバックする
+        decision = (
+            db.query(AIDecision)
+            .filter(AIDecision.user_id == user.id)
+            .order_by(AIDecision.created_at.desc())
+            .first()
+        )
+        if decision is None:
+            decision = (
+                db.query(AIDecision)
+                .filter(AIDecision.user_id.is_(None))
+                .order_by(AIDecision.created_at.desc())
+                .first()
+            )
+        if decision is not None:
+            judged_at = decision.created_at.strftime("%Y-%m-%d %H:%M UTC")
+            lines.append(
+                f"直近のAI判断: {decision.action}（確信度 {decision.confidence}%、判断時刻 {judged_at}）"
+            )
+            reason = (decision.reason or "").strip()
+            if len(reason) > _REASON_MAX_LEN:
+                reason = reason[:_REASON_MAX_LEN] + "…"
+            lines.append(f"判断理由: {reason or 'データなし'}")
+        else:
+            lines.append("直近のAI判断: データなし（まだAI判定が実行されていません）")
+
+        return "\n".join(lines)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("chat.service: build_context_block failed for user_id=%s: %s", user.id, exc)
+        return "現在の状況データを取得できませんでした。"
 
 
 def save_message(db: Session, user_id: int, role: str, content: str) -> ChatMessage:
@@ -53,7 +176,7 @@ def save_message(db: Session, user_id: int, role: str, content: str) -> ChatMess
     return msg
 
 
-def call_claude(message: str) -> str:
+def call_claude(message: str, context_block: str) -> str:
     """Claude API を呼び出してチャット応答を生成する。
 
     fail-open 設計:
@@ -61,7 +184,8 @@ def call_claude(message: str) -> str:
     - API 呼び出し例外 → フォールバック文言を返す（500 にしない）
 
     Args:
-        message: ユーザーメッセージ
+        message: ユーザーメッセージ（サジェストボタンの定型文言）
+        context_block: build_context_block() が組み立てたユーザー実データの要約
 
     Returns:
         Claude の応答テキスト、またはフォールバック文言
@@ -76,11 +200,12 @@ def call_claude(message: str) -> str:
         import anthropic
 
         client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+        user_content = f"[現在の状況]\n{context_block}\n\n[ユーザーの質問]\n{message}"
         resp = client.messages.create(
             model=settings.claude_model,
             max_tokens=1024,
             system=_SYSTEM_PROMPT,
-            messages=[{"role": "user", "content": message}],
+            messages=[{"role": "user", "content": user_content}],
         )
         raw_text = ""
         for block in resp.content:
@@ -93,33 +218,37 @@ def call_claude(message: str) -> str:
         return _FALLBACK_RESPONSE
 
 
-def process_chat(db: Session, user_id: int, message: str) -> ChatResponse:
+def process_chat(db: Session, user: User, message: str) -> ChatResponse:
     """チャットメッセージを処理する。
 
     処理順序:
     1. ユーザーメッセージを DB に INSERT（role='user'）
-    2. Claude API で応答を生成
-    3. AI 応答を DB に INSERT（role='ai'）
-    4. ChatResponse を返却
+    2. ユーザー実データ（ポートフォリオ・AI判定・リスク設定）からコンテキストを組み立て
+    3. Claude API で応答を生成（コンテキスト付き）
+    4. AI 応答を DB に INSERT（role='ai'）
+    5. ChatResponse を返却
 
     Args:
         db: SQLAlchemy セッション
-        user_id: 認証済みユーザー ID
+        user: 認証済みユーザー
         message: ユーザーメッセージ本文
 
     Returns:
         ChatResponse（response フィールドに AI 応答テキスト）
     """
     # ① ユーザーメッセージを保存
-    save_message(db=db, user_id=user_id, role="user", content=message)
+    save_message(db=db, user_id=user.id, role="user", content=message)
 
-    # ② Claude 呼び出し（fail-open）
-    ai_text = call_claude(message)
+    # ② ユーザー実データのコンテキストを組み立て
+    context_block = build_context_block(db, user)
 
-    # ③ AI 応答を保存
-    save_message(db=db, user_id=user_id, role="ai", content=ai_text)
+    # ③ Claude 呼び出し（fail-open）
+    ai_text = call_claude(message, context_block)
 
-    # ④ レスポンス返却
+    # ④ AI 応答を保存
+    save_message(db=db, user_id=user.id, role="ai", content=ai_text)
+
+    # ⑤ レスポンス返却
     return ChatResponse(response=ai_text)
 
 

--- a/backend/tests/chat/test_chat_context.py
+++ b/backend/tests/chat/test_chat_context.py
@@ -1,0 +1,238 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/chat/test_chat_context.py
+"""
+build_context_block() のテスト。
+
+チャット画面はサジェストボタンのみ（自由入力なし）のため、AI には
+ユーザー本人の実データ（ポートフォリオ・AI判定・リスク設定）を渡す必要がある。
+
+テストケース:
+① データなしユーザー → 各項目が「データなし」で明示される
+② ポートフォリオ・AI判定データありユーザー → 実データが文字列に含まれる
+③ 本人宛のAI判定が無い場合 → システム判定（user_id IS NULL）にフォールバック
+④ POST /api/chat が call_claude にコンテキストを渡している
+"""
+
+import os
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-chat-context-1234")
+os.environ.setdefault("JWT_ALGORITHM", "HS256")
+os.environ.setdefault("JWT_ACCESS_TOKEN_EXPIRE_MINUTES", "30")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "admin@example.com")
+
+from app.ai.models import AIDecision
+from app.auth.models import User, UserRole
+from app.auth.service import AuthService
+from app.chat.service import build_context_block
+from app.database import Base
+from app.main import create_app
+from app.portfolio.models import PortfolioHistory, PortfolioSnapshot
+
+TEST_DB_URL = "sqlite:///./test_chat_context.db"
+
+
+@pytest.fixture(scope="module")
+def engine():
+    eng = create_engine(TEST_DB_URL, connect_args={"check_same_thread": False})
+    Base.metadata.create_all(eng)
+    yield eng
+    eng.dispose()
+    import os as _os
+
+    try:
+        _os.remove("./test_chat_context.db")
+    except FileNotFoundError:
+        pass
+
+
+@pytest.fixture()
+def db(engine) -> Generator[Session, None, None]:
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+
+
+@pytest.fixture()
+def test_client(db: Session):
+    app = create_app()
+
+    def override_get_db():
+        try:
+            yield db
+        finally:
+            pass
+
+    from app.database import get_db  # noqa: F811
+
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def _create_user(db: Session, email: str, wallet: str, risk_mode: str = "balanced") -> User:
+    user = db.query(User).filter(User.email == email).first()
+    if user is None:
+        user = User(
+            email=email,
+            username=email.split("@")[0],
+            hashed_password="hashed_dummy",
+            wallet_address=wallet,
+            role=UserRole.VIEWER,
+            is_active=True,
+            risk_mode=risk_mode,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+    return user
+
+
+# ---------------------------------------------------------------------------
+# ① データなしユーザー
+# ---------------------------------------------------------------------------
+
+
+def test_build_context_block_no_data(db: Session) -> None:
+    """データなしユーザーは各項目で「データなし」が明示される（推測データを含まない）。"""
+    user = _create_user(db, email="ctx_nodata@example.com", wallet="0xCTX1")
+
+    context = build_context_block(db, user)
+
+    assert "リスクモード: balanced" in context
+    assert "データなし" in context
+    assert "まだ資産スナップショットが記録されていません" in context
+    assert "まだAI判定が実行されていません" in context
+
+
+# ---------------------------------------------------------------------------
+# ② 実データあり
+# ---------------------------------------------------------------------------
+
+
+def test_build_context_block_with_real_data(db: Session) -> None:
+    """ポートフォリオ・AI判定の実データが文字列に反映される。"""
+    user = _create_user(
+        db, email="ctx_withdata@example.com", wallet="0xCTX2", risk_mode="aggressive"
+    )
+
+    db.add(
+        PortfolioSnapshot(
+            user_id=user.id,
+            total_value_usd=Decimal("12345.67"),
+            total_supply_usd=Decimal("12345.67"),
+            total_borrow_usd=Decimal("0"),
+            health_factor=Decimal("2.5000"),
+            recorded_at=datetime.now(timezone.utc),
+        )
+    )
+    db.add(
+        PortfolioHistory(
+            user_id=user.id,
+            period_type="monthly",
+            period_start=datetime(2026, 6, 1, tzinfo=timezone.utc),
+            period_end=datetime(2026, 6, 30, tzinfo=timezone.utc),
+            open_value_usd=Decimal("10000.00"),
+            close_value_usd=Decimal("10500.00"),
+            high_value_usd=Decimal("10600.00"),
+            low_value_usd=Decimal("9900.00"),
+            pnl_usd=Decimal("500.00"),
+            pnl_pct=Decimal("5.00"),
+        )
+    )
+    db.add(
+        AIDecision(
+            user_id=user.id,
+            query="今の運用状況は？",
+            action="BUY",
+            confidence=78,
+            reason="Aaveプールの利用率が低下し供給APYが上昇したため。",
+            primary_provider="claude",
+            primary_action="BUY",
+            primary_confidence=78,
+            agreed=True,
+        )
+    )
+    db.commit()
+
+    context = build_context_block(db, user)
+
+    assert "リスクモード: aggressive" in context
+    assert "$12,345.67" in context
+    assert "2.50" in context  # Health Factor
+    assert "5.00%" in context  # 月次損益率
+    assert "BUY" in context
+    assert "Aaveプールの利用率が低下し供給APYが上昇したため" in context
+
+
+# ---------------------------------------------------------------------------
+# ③ システム判定へのフォールバック
+# ---------------------------------------------------------------------------
+
+
+def test_build_context_block_falls_back_to_system_decision(db: Session) -> None:
+    """本人宛のAI判定が無い場合、システム判定（user_id IS NULL）が使われる。"""
+    user = _create_user(db, email="ctx_fallback@example.com", wallet="0xCTX3")
+
+    db.add(
+        AIDecision(
+            user_id=None,
+            query="system tick",
+            action="HOLD",
+            confidence=55,
+            reason="市場のボラティリティが高いため様子見。",
+            primary_provider="claude",
+            primary_action="HOLD",
+            primary_confidence=55,
+            agreed=True,
+        )
+    )
+    db.commit()
+
+    context = build_context_block(db, user)
+
+    assert "HOLD" in context
+    assert "市場のボラティリティが高いため様子見" in context
+
+
+# ---------------------------------------------------------------------------
+# ④ POST /api/chat が call_claude にコンテキストを渡している
+# ---------------------------------------------------------------------------
+
+
+def test_post_chat_passes_context_to_call_claude(test_client: TestClient, db: Session) -> None:
+    """POST /api/chat が call_claude(message, context_block) の第2引数にユーザー実データを渡す。"""
+    user = _create_user(
+        db, email="ctx_apicheck@example.com", wallet="0xCTX4", risk_mode="conservative"
+    )
+
+    captured: dict[str, str] = {}
+
+    def _fake_call_claude(message: str, context_block: str) -> str:
+        captured["message"] = message
+        captured["context_block"] = context_block
+        return "テスト応答"
+
+    token, _ = AuthService.create_access_token(user.id, user.email, user.role)
+
+    with patch("app.chat.service.call_claude", side_effect=_fake_call_claude):
+        resp = test_client.post(
+            "/api/chat",
+            json={"message": "今の運用状況は？"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 200
+    assert captured["message"] == "今の運用状況は？"
+    assert "リスクモード: conservative" in captured["context_block"]


### PR DESCRIPTION
## Summary
- UAT AIチャット(liff-chat)は8個の定型サジェストボタンのみで自由入力欄がなく、ユーザーはAIの回答に聞き返せない。
- 従来の `call_claude()` はユーザーの質問文だけをClaudeに渡しており、実際のポートフォリオ・AI判定履歴・リスク設定を一切知らないまま一般論で回答するしかなかった。「今の運用状況は？」等を押しても実データに基づかない回答しか返らず、ユーザーには「テンプレしか返答しない」ように見えていた。
- `build_context_block()` を追加し、ユーザーのリスクモード・最新ポートフォリオ(資産評価額/Health Factor)・当月損益・直近AI判定(本人宛が無ければシステム判定にフォールバック)を要約してClaudeに渡すようにした。データが無い項目は「データなし」と明示し、AIが推測で答えないようにしている。
- system prompt を全面刷新し、「ユーザーは聞き返せない」前提を明示。聞き返し・追加情報の要求を禁止し、渡されたデータのみで一度に完結した回答を返すよう指示。PR #966 (Markdown禁止指示)の内容も包含する形で統合済み(#966とのマージコンフリクトを解消してrebase)。

## Test plan
- [x] `ruff check` / `ruff format --check` — PASS
- [x] `mypy app/ --config-file ../pyproject.toml` — PASS(316 files)
- [x] `./scripts/verify.sh` フル実行 — All checks passed (ruff/mypy/pytest coverage80%+/tsc/build)
- [x] 新規テスト `backend/tests/chat/test_chat_context.py`: データなしユーザー / 実データあり / システム判定フォールバック / POST /api/chatがcontext_blockをcall_claudeに渡すことを検証する統合テスト、計4ケース追加。chat配下は既存7 + 新規4 = 11 passed
- [ ] staging-v4での実チャット目視確認(デプロイ後)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUEgFqF7VE6jsggFVgfMj