### PR TITLE
fix(auth): LIFF terms-agree経路に自動デモ資金割当を配線

### DIFF
--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -13,7 +13,6 @@ GET  /auth/me       - Retrieve current user information
 import logging
 import os
 from datetime import datetime, timezone
-from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
@@ -24,6 +23,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.database import get_db
+from app.partner.allocation_service import auto_fund_tester_if_enabled
 from app.referral import service as referral_service
 from app.users.registration_webhook import send_registration_webhook
 
@@ -468,57 +468,6 @@ def get_terms_status(
     )
 
 
-def _auto_fund_tester_if_enabled(db: Session, user: User) -> None:
-    """staging-v4限定: 新規テスターにデモ資金を自動割当する(fail-open、production無効)。
-
-    二重ガード:
-      1. APP_ENV == "production" なら常に無効
-      2. AUTO_FUND_TESTER_ALLOCATION_USD / AUTO_FUND_PARTNER_ID が未設定/不正なら無効
-    既にactiveなfund_allocationを持つユーザーには何もしない(重複割当防止、
-    terms再同意のたびに増額されるのを防ぐ)。
-    """
-    if os.getenv("APP_ENV", "").strip().lower() == "production":
-        return
-    partner_id_str = os.getenv("AUTO_FUND_PARTNER_ID", "")
-    if not partner_id_str:
-        return
-    try:
-        amount = Decimal(os.getenv("AUTO_FUND_TESTER_ALLOCATION_USD", "0"))
-        partner_id = int(partner_id_str)
-    except (InvalidOperation, ValueError):
-        return
-    if amount <= Decimal("0"):
-        return
-
-    from app.partner.allocation_models import FundAllocation  # noqa: PLC0415
-
-    existing = (
-        db.query(FundAllocation)
-        .filter(FundAllocation.tester_user_id == user.id, FundAllocation.status == "active")
-        .first()
-    )
-    if existing is not None:
-        return
-
-    try:
-        from app.partner.allocation_schemas import AllocationCreateRequest  # noqa: PLC0415
-        from app.partner.allocation_service import create_allocation  # noqa: PLC0415
-
-        create_allocation(
-            db,
-            partner_id=partner_id,
-            request=AllocationCreateRequest(
-                tester_name=f"auto-demo:{user.email or user.id}",
-                tester_user_id=user.id,
-                allocated_amount_usd=amount,
-                notes="staging-v4 自動デモ資金割当(terms accept時、AUTO_FUND_TESTER_ALLOCATION_USD)",
-            ),
-        )
-        logger.info("Auto-funded tester user_id=%d with $%s (demo)", user.id, amount)
-    except Exception as exc:
-        logger.warning("Auto-fund tester failed (fail-open, ignored): %s", exc)
-
-
 @router.post(
     "/terms/accept",
     response_model=TermsStatusResponse,
@@ -534,7 +483,7 @@ def accept_terms(
     user.terms_version = request.version
     db.commit()
     db.refresh(user)
-    _auto_fund_tester_if_enabled(db, user)
+    auto_fund_tester_if_enabled(db, user)
     logger.info("User accepted terms v%s: %s", request.version, user.email)
     return TermsStatusResponse(
         accepted=True,

--- a/backend/app/partner/allocation_service.py
+++ b/backend/app/partner/allocation_service.py
@@ -11,7 +11,7 @@ CRUD 操作と Aave ポジションを使ったテスター別パフォーマン
 import logging
 import os
 from datetime import datetime, timezone
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Optional
 
 from sqlalchemy import func
@@ -66,6 +66,57 @@ def create_allocation(
     db.refresh(allocation)
     refresh_partner_tier(db, partner_id)
     return AllocationResponse.model_validate(allocation)
+
+
+def auto_fund_tester_if_enabled(db: Session, user: User) -> None:
+    """staging-v4限定: 新規テスターにデモ資金を自動割当する(fail-open、production無効)。
+
+    利用規約同意エンドポイント（app.auth.router の /terms/accept、
+    app.users.settings_router の /terms-agree の両方）から呼ばれる共通実装。
+    どちらか一方にしか配線しないと、実際に使われている方の経路でテスターが
+    デモ資金を受け取れない配線漏れが起きるため、両方から必ず呼ぶこと。
+
+    二重ガード:
+      1. APP_ENV == "production" なら常に無効
+      2. AUTO_FUND_TESTER_ALLOCATION_USD / AUTO_FUND_PARTNER_ID が未設定/不正なら無効
+    既にactiveなfund_allocationを持つユーザーには何もしない(重複割当防止、
+    terms再同意のたびに増額されるのを防ぐ)。
+    """
+    if os.getenv("APP_ENV", "").strip().lower() == "production":
+        return
+    partner_id_str = os.getenv("AUTO_FUND_PARTNER_ID", "")
+    if not partner_id_str:
+        return
+    try:
+        amount = Decimal(os.getenv("AUTO_FUND_TESTER_ALLOCATION_USD", "0"))
+        partner_id = int(partner_id_str)
+    except (InvalidOperation, ValueError):
+        return
+    if amount <= Decimal("0"):
+        return
+
+    existing = (
+        db.query(FundAllocation)
+        .filter(FundAllocation.tester_user_id == user.id, FundAllocation.status == "active")
+        .first()
+    )
+    if existing is not None:
+        return
+
+    try:
+        create_allocation(
+            db,
+            partner_id=partner_id,
+            request=AllocationCreateRequest(
+                tester_name=f"auto-demo:{user.email or user.id}",
+                tester_user_id=user.id,
+                allocated_amount_usd=amount,
+                notes="staging-v4 自動デモ資金割当(terms accept時、AUTO_FUND_TESTER_ALLOCATION_USD)",
+            ),
+        )
+        logger.info("Auto-funded tester user_id=%d with $%s (demo)", user.id, amount)
+    except Exception as exc:
+        logger.warning("Auto-fund tester failed (fail-open, ignored): %s", exc)
 
 
 def get_allocations(

--- a/backend/app/users/settings_router.py
+++ b/backend/app/users/settings_router.py
@@ -219,6 +219,7 @@ def agree_to_terms(
         current_user.email,
         now.isoformat(),
     )
+    allocation_service.auto_fund_tester_if_enabled(db, current_user)
     return {
         "terms_agreed_at": now.isoformat(),
         "already_agreed": False,

--- a/backend/tests/test_auth_auto_fund_tester.py
+++ b/backend/tests/test_auth_auto_fund_tester.py
@@ -1,7 +1,11 @@
 # Copyright (c) Ultra AutoTrade. All rights reserved.
 # Unauthorized copying or distribution is strictly prohibited.
 # backend/tests/test_auth_auto_fund_tester.py
-"""staging-v4 テスター自動資金割当 (_auto_fund_tester_if_enabled) のテスト。"""
+"""staging-v4 テスター自動資金割当 (auto_fund_tester_if_enabled) のテスト。
+
+app.auth.router の /terms/accept と app.users.settings_router の /terms-agree
+両方から呼ばれる共通実装 (app.partner.allocation_service) をテストする。
+"""
 
 import os
 import tempfile
@@ -14,9 +18,9 @@ from sqlalchemy.orm import Session, sessionmaker
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-auth-tests")
 
 from app.auth.models import User, UserRole
-from app.auth.router import _auto_fund_tester_if_enabled
 from app.database import Base
 from app.partner.allocation_models import FundAllocation
+from app.partner.allocation_service import auto_fund_tester_if_enabled
 
 
 @pytest.fixture()
@@ -56,7 +60,7 @@ class TestAutoFundTesterIfEnabled:
         monkeypatch.delenv("APP_ENV", raising=False)
         user = _make_tester(db)
 
-        _auto_fund_tester_if_enabled(db, user)
+        auto_fund_tester_if_enabled(db, user)
 
         assert db.query(FundAllocation).count() == 0
 
@@ -69,7 +73,7 @@ class TestAutoFundTesterIfEnabled:
         monkeypatch.delenv("APP_ENV", raising=False)
         user = _make_tester(db)
 
-        _auto_fund_tester_if_enabled(db, user)
+        auto_fund_tester_if_enabled(db, user)
 
         allocations = db.query(FundAllocation).all()
         assert len(allocations) == 1
@@ -87,8 +91,8 @@ class TestAutoFundTesterIfEnabled:
         monkeypatch.delenv("APP_ENV", raising=False)
         user = _make_tester(db)
 
-        _auto_fund_tester_if_enabled(db, user)
-        _auto_fund_tester_if_enabled(db, user)  # terms再同意を模した2回目呼び出し
+        auto_fund_tester_if_enabled(db, user)
+        auto_fund_tester_if_enabled(db, user)  # terms再同意を模した2回目呼び出し
 
         assert db.query(FundAllocation).count() == 1
 
@@ -101,6 +105,6 @@ class TestAutoFundTesterIfEnabled:
         monkeypatch.setenv("APP_ENV", "production")
         user = _make_tester(db)
 
-        _auto_fund_tester_if_enabled(db, user)
+        auto_fund_tester_if_enabled(db, user)
 
         assert db.query(FundAllocation).count() == 0

--- a/backend/tests/test_user_settings_api.py
+++ b/backend/tests/test_user_settings_api.py
@@ -16,6 +16,7 @@ os.environ.setdefault("INITIAL_ADMIN_EMAIL", "terms_admin@example.com")
 
 from app.database import Base, get_db  # noqa: E402
 from app.main import create_app  # noqa: E402
+from app.partner.allocation_models import FundAllocation  # noqa: E402
 
 
 @pytest.fixture()
@@ -354,6 +355,38 @@ class TestUserSettingsAPI:
         ts1 = r1.json()["terms_agreed_at"][:19]  # "YYYY-MM-DDTHH:MM:SS"
         ts2 = r2.json()["terms_agreed_at"][:19]
         assert ts1 == ts2
+
+    def test_terms_agree_triggers_auto_fund_when_enabled(
+        self, client: TestClient, test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """POST /api/user/terms-agree (LIFF経路) でも自動デモ資金割当が発火すること。
+
+        2026-07-08: auto_fund_tester_if_enabled が app.auth.router の /terms/accept
+        にしか配線されておらず、実際に使われる LIFF 経路 (/api/user/terms-agree) では
+        発火しない配線漏れがあった。両エンドポイントから共通実装
+        (app.partner.allocation_service) を呼ぶよう修正した回帰テスト。
+        """
+        monkeypatch.setenv("AUTO_FUND_PARTNER_ID", "9")
+        monkeypatch.setenv("AUTO_FUND_TESTER_ALLOCATION_USD", "150000")
+        monkeypatch.delenv("APP_ENV", raising=False)
+
+        token = register_and_login(client)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        r = client.post("/api/user/terms-agree", headers=headers)
+        assert r.status_code == 200
+
+        _override_get_db, engine = test_db
+        session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+        db = session_factory()
+        try:
+            allocations = db.query(FundAllocation).all()
+            assert len(allocations) == 1
+            assert allocations[0].partner_id == 9
+            assert allocations[0].allocated_amount_usd == 150000
+            assert allocations[0].status == "active"
+        finally:
+            db.close()
 
     def test_terms_agree_requires_auth(self, client: TestClient) -> None:
         """POST /api/user/terms-agree は認証必須であること。"""


### PR DESCRIPTION
## Summary
- staging-v4の新規テスターにデモ資金を自動割当する `auto_fund_tester_if_enabled` が `app.auth.router` の `/terms/accept` にしか配線されておらず、実際にフロントが使う LIFF 経路 (`app.users.settings_router` の `POST /api/user/terms-agree`) では発火しない配線漏れがあった。
- `hkobayashi@assistone.asia` での実機テストで、新規テスター(user 14)が規約に同意しても `fund_allocations` が作られないことが判明して発覚(`AUTO_FUND_PARTNER_ID=9` / `AUTO_FUND_TESTER_ALLOCATION_USD=150000` は設定済みだったにもかかわらず)。
- `auto_fund_tester_if_enabled` を `app.auth.router` から `app.partner.allocation_service` へ移設し、両エンドポイント(`/terms/accept`, `/terms-agree`)から呼ぶ共通実装にした。

## Test plan
- [x] `ruff check` / `ruff format --check` — PASS
- [x] `mypy app/ --config-file ../pyproject.toml` — PASS
- [x] `./scripts/verify.sh` フル実行 — All checks passed (780s)
- [x] 回帰テスト追加: `test_terms_agree_triggers_auto_fund_when_enabled` — `POST /api/user/terms-agree` 経由でも `FundAllocation` が作られることを検証
- [x] 既存 `test_auth_auto_fund_tester.py` は import 元を `app.partner.allocation_service` に更新（ロジック不変）、4ケース pass 継続
- [ ] staging-v4での実機確認(デプロイ後、既存user 14の遡及バックフィル含む)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUEgFqF7VE6jsggFVgfMj