### PR TITLE
fix(risk): probe失敗を避難トリガーにしない (Lido複合リスク避難の誤検知修正)

### DIFF
--- a/CLAUDE.lessons.md
+++ b/CLAUDE.lessons.md
@@ -1198,3 +1198,18 @@ deploy_staging.sh)が稼働中だった。ps の ELAPSED は MM:SS 表記、誤�
 - backend 側に積み上がった差分は `git log <前回反映HEAD>..origin/main -- backend/` で都度可視化し、`docs/ops/03_deploy_procedures.md` の該当セクションに申し送りとして記録する (次回 backend/full デプロイ時、Tier S 1日1PR原則に照らした分割/一括判断の材料にする)。
 - デプロイ後 WARNING (alembic drift / 401連発等) は「今回のデプロイで新規発生したか」「デプロイ前から継続していたか」を時系列ログで切り分けてから対応要否を判断する (無条件に blocker 扱いしない、無条件に無視もしない)。
 - 詳細手順は `docs/ops/03_deploy_procedures.md`「`--frontend-only` デプロイ時の backend drift 注意」セクション参照 (PR #948)。
+
+## 2026-07-08 probe 失敗を fail-CLOSED (CRITICAL) にすると安全装置がオオカミ少年化する (Lido 複合リスク避難の誤検知)
+
+**何が起きたか**: 本番で「複合リスク避難 成立 lido」の緊急 Slack アラートが 48h で 286 回発火 (2026-06-28 起票 `project_lido_compound_risk_false_positive.md`)。真因は `protocol_monitor.py` の `check_aave/lido/pendle_health` が、RPC/API probe 失敗の except 節で **`risk_level=RiskLevel.CRITICAL` (fail-CLOSED)** を返していたこと。本番の実 LidoClient が Holesky RPC 403 で `get_steth_eth_ratio`/`get_staking_apr` 例外 → CRITICAL → `compound_risk.assess()` が `any(p.risk_level==CRITICAL)` で `should_evacuate=True` → 10分ごとに Slack EMERGENCY。実資金は Lido に $0 で避難は dry_run stub のため無害だが、監視信頼性を毀損。
+
+**根本原因の言語化**: **「probe 失敗 (監視できていない)」と「プロトコルが危険 (CRITICAL)」は別事象**。前者を後者にマッピングすると、外部依存が一時的に落ちるたびに安全装置が資産の有無に関係なく発火する。probe 失敗は監視不能 = `is_operational=False` で可視化するのが正しく、避難トリガー (CRITICAL) にしてはならない。本当の危険 (HF<1.6 等) は client 正常応答時の分岐で CRITICAL 判定されるパスなので、except 節を LOW にしても危険検知能力は落ちない。
+
+**修正 (PR #970, Tier S・安全装置系)**:
+- 一次防御: `protocol_monitor.py` の 3 つの except 節を `CRITICAL → LOW` + `is_operational=False` 維持。`logger.exception → logger.warning` (監視不能は想定内の degraded)。alerts は固定文言に統一 (旧 lido/pendle は `f"...: {exc}"` で例外を外部露出 = 無認証 GET /api/protocols/health 経由で Security Rule 8 違反だった)。
+- 二次防御 (二重防御): `compound_risk.py` の `assess()` 避難判定と `calculate_risk_score()` の has_critical を `CRITICAL and p.is_operational` に。万一 CRITICAL + 監視不能が来ても避難根拠から除外。
+
+**教訓 (再発防止)**:
+- 安全装置の except 節を書くときは「fail-open / fail-closed のどちらが安全か」を必ず明示的に判断する。**外部 probe の失敗は原則 fail-open (監視不能フラグで可視化)**、実データが「危険」を示したときのみ避難トリガーにする。
+- 外部例外を alerts / API レスポンスにそのまま載せない (RPC URL に API キーが埋まる = Security Rule 8)。固定文言 + サーバーログ限定。
+- 安全装置は「発火しないこと」ではなく「正しい条件でのみ発火すること」でテストする。エラー経路テストは CRITICAL 期待ではなく LOW + is_operational=False を期待値にし、compound 側で「CRITICAL だが監視不能 → 避難しない」「CRITICAL かつ稼働中 → 避難する (退行防止)」を両方カバーする。

--- a/backend/app/protocols/risk/compound_risk.py
+++ b/backend/app/protocols/risk/compound_risk.py
@@ -95,11 +95,16 @@ class CompoundRiskAssessor:
         should_evacuate = False
         evacuation_reason: Optional[str] = None
 
-        if any(p.risk_level == RiskLevel.CRITICAL for p in protocol_risks):
+        # [二重防御] is_operational=False のプロトコル (= probe 失敗で監視不能) は避難根拠に
+        # しない。protocol_monitor 側が probe 失敗を LOW にするのが一次防御だが、万一
+        # CRITICAL + 監視不能が来ても、監視できていないだけのプロトコルで避難アラートを
+        # 出さない (2026-06-28 Lido 誤検知の再発防止)。
+        operational_critical = [
+            p for p in protocol_risks if p.risk_level == RiskLevel.CRITICAL and p.is_operational
+        ]
+        if operational_critical:
             should_evacuate = True
-            critical_protocols = [
-                p.protocol for p in protocol_risks if p.risk_level == RiskLevel.CRITICAL
-            ]
+            critical_protocols = [p.protocol for p in operational_critical]
             evacuation_reason = (
                 f"プロトコルで緊急リスクが検知されました: {', '.join(critical_protocols)}"
             )
@@ -183,9 +188,11 @@ class CompoundRiskAssessor:
 
         total = protocol_score + peg_score + maturity_score
 
-        # CRITICAL 検知時は最低 80 に切り上げ
+        # CRITICAL 検知時は最低 80 に切り上げ。
+        # プロトコル CRITICAL は is_operational=True のもののみ算入する (監視不能プロトコルを
+        # 危険域スコアに数えない。避難判定と同じ二重防御 / 2026-06-28 Lido 誤検知対策)。
         has_critical = (
-            any(p.risk_level == RiskLevel.CRITICAL for p in protocol_risks)
+            any(p.risk_level == RiskLevel.CRITICAL and p.is_operational for p in protocol_risks)
             or (peg_status is not None and peg_status.risk_level == RiskLevel.CRITICAL)
             or any(a.risk_level == RiskLevel.CRITICAL for a in maturity_alerts)
         )

--- a/backend/app/protocols/risk/protocol_monitor.py
+++ b/backend/app/protocols/risk/protocol_monitor.py
@@ -74,9 +74,12 @@ class ProtocolMonitor:
         is_operational は MonitoringService.is_trading_allowed()（緊急停止
         フラグの OR ロジック）を反映する。
 
-        fail-open: 依存サービスの例外時は raise せず CRITICAL /
-        tvl_usd=Decimal("0") / is_operational=False / 日本語アラートで返す
-        （check_lido_health のエラーハンドリングと同型）。
+        fail-open: 依存サービスの例外 (RPC 落ち等) 時は raise せず、監視不能として
+        risk_level=LOW / tvl_usd=Decimal("0") / is_operational=False / 日本語アラートで返す。
+        probe 失敗は「監視できていない」だけで「プロトコルが危険」ではないため、避難
+        トリガー (CRITICAL) にはしない (2026-06-28 Lido 誤検知インシデント対策)。本当の
+        危険 (HF<1.6) は client 正常応答時に下の分岐で CRITICAL 判定される。
+        （check_lido_health / check_pendle_health のエラーハンドリングと同型）。
         """
         logger.info("check_aave_health: Aave ヘルスチェック実行")
         alerts: list[str] = []
@@ -117,16 +120,23 @@ class ProtocolMonitor:
         except Exception:
             # 例外詳細 (AaveClientError 等) は RPC URL (APIキー埋め込み形式) を内包し得る。
             # alerts は無認証 GET /api/protocols/health で外部露出されるため (Security Rule 8)、
-            # 固定文言のみを返し、詳細はサーバーログ (logger.exception) に限定する。
-            logger.exception("Aave ヘルスチェック失敗")
+            # 固定文言のみを返し、詳細はサーバーログに限定する。
+            #
+            # [fail-open] probe 失敗は「監視不能」であって「プロトコルが危険」ではない。
+            # CRITICAL を返すと compound_risk が should_evacuate=True にし、実資金の有無に
+            # 関係なく避難アラートを乱発する (2026-06-28 Lido 誤検知)。監視不能は
+            # risk_level=LOW (避難トリガーにしない) + is_operational=False (可視化) で表す。
+            logger.warning("Aave ヘルスチェック失敗（監視不能・避難トリガーにしない）")
             return ProtocolHealth(
                 protocol="aave",
-                risk_level=RiskLevel.CRITICAL,
+                risk_level=RiskLevel.LOW,
                 tvl_usd=Decimal("0"),
                 tvl_change_24h_pct=Decimal("0"),
                 is_operational=False,
                 last_checked=datetime.now(tz=timezone.utc),
-                alerts=["Aave ヘルスチェックエラー（詳細はログ参照）"],
+                alerts=[
+                    "Aave の稼働状況を一時的に確認できませんでした（監視のみ・資産への影響なし）"
+                ],
             )
 
         return ProtocolHealth(
@@ -154,16 +164,22 @@ class ProtocolMonitor:
         try:
             apr = await self._lido_client.get_staking_apr()
             ratio = await self._lido_client.get_steth_eth_ratio()
-        except Exception as exc:
-            logger.exception("Lido クライアント呼び出し失敗")
+        except Exception:
+            # [fail-open] probe 失敗 (stETH/ETH レート・APR 取得の RPC/API エラー) は
+            # 監視不能であって危険ではない。CRITICAL を返すと should_evacuate=True で
+            # 避難アラートを乱発する (2026-06-28 誤検知)。監視不能は LOW + is_operational=False。
+            # 例外詳細は RPC URL を内包し得るため alerts に露出せず固定文言のみ (Security Rule 8)。
+            logger.warning("Lido クライアント呼び出し失敗（監視不能・避難トリガーにしない）")
             return ProtocolHealth(
                 protocol="lido",
-                risk_level=RiskLevel.CRITICAL,
+                risk_level=RiskLevel.LOW,
                 tvl_usd=Decimal("0"),
                 tvl_change_24h_pct=Decimal("0"),
                 is_operational=False,
                 last_checked=datetime.now(tz=timezone.utc),
-                alerts=[f"Lido クライアントエラー: {exc}"],
+                alerts=[
+                    "Lido の稼働状況を一時的に確認できませんでした（監視のみ・資産への影響なし）"
+                ],
             )
 
         # APR チェック
@@ -207,16 +223,22 @@ class ProtocolMonitor:
 
         try:
             market_info = await self._pendle_client.get_market_info(market_address)
-        except Exception as exc:
-            logger.exception("Pendle クライアント呼び出し失敗")
+        except Exception:
+            # [fail-open] probe 失敗 (market 情報取得の API エラー) は監視不能であって
+            # 危険ではない。CRITICAL を返すと should_evacuate=True で避難アラートを乱発する
+            # (2026-06-28 誤検知)。監視不能は LOW + is_operational=False。
+            # 例外詳細は endpoint 情報を内包し得るため alerts に露出せず固定文言のみ (Security Rule 8)。
+            logger.warning("Pendle クライアント呼び出し失敗（監視不能・避難トリガーにしない）")
             return ProtocolHealth(
                 protocol="pendle",
-                risk_level=RiskLevel.CRITICAL,
+                risk_level=RiskLevel.LOW,
                 tvl_usd=Decimal("0"),
                 tvl_change_24h_pct=Decimal("0"),
                 is_operational=False,
                 last_checked=datetime.now(tz=timezone.utc),
-                alerts=[f"Pendle クライアントエラー: {exc}"],
+                alerts=[
+                    "Pendle の稼働状況を一時的に確認できませんでした（監視のみ・資産への影響なし）"
+                ],
             )
 
         tvl = market_info.tvl_usd

--- a/backend/tests/protocols/test_risk/test_compound_risk.py
+++ b/backend/tests/protocols/test_risk/test_compound_risk.py
@@ -20,15 +20,17 @@ from app.protocols.risk.schemas import (
 _FORBIDDEN_JARGON = ["APY", "yield", "protocol", "peg", "maturity", "TVL", "HF"]
 
 
-def _make_protocol_health(risk_level: RiskLevel) -> ProtocolHealth:
+def _make_protocol_health(
+    risk_level: RiskLevel, *, is_operational: bool = True, protocol: str = "test"
+) -> ProtocolHealth:
     from datetime import datetime, timezone
 
     return ProtocolHealth(
-        protocol="test",
+        protocol=protocol,
         risk_level=risk_level,
         tvl_usd=Decimal("1000000"),
         tvl_change_24h_pct=Decimal("0"),
-        is_operational=True,
+        is_operational=is_operational,
         last_checked=datetime.now(tz=timezone.utc),
         alerts=[],
     )
@@ -145,6 +147,76 @@ class TestAssess:
                 )
 
 
+class TestEvacuationOperationalGuard:
+    """probe 失敗 (is_operational=False) のプロトコルを避難根拠から除外する二重防御。
+
+    2026-06-28 Lido 誤検知の再発防止。protocol_monitor が probe 失敗を LOW にするのが
+    一次防御だが、万一 CRITICAL + 監視不能が来ても避難アラートを出さないことを保証する。
+    """
+
+    def _build_assessor(self, protocol_risks: list[ProtocolHealth]) -> CompoundRiskAssessor:
+        """protocol_risks を返す mock を注入した assessor を組み立てる。
+
+        peg / maturity は避難条件に触れない (LOW / 空) 状態にして、プロトコル判定のみを検証する。
+        """
+        protocol_monitor = AsyncMock()
+        protocol_monitor.check_all.return_value = protocol_risks
+        peg_monitor = AsyncMock()
+        peg_monitor.get_peg_status.return_value = _make_peg_status(RiskLevel.LOW)
+        maturity_manager = AsyncMock()
+        maturity_manager.check_maturities.return_value = []
+        return CompoundRiskAssessor(
+            protocol_monitor=protocol_monitor,
+            peg_monitor=peg_monitor,
+            maturity_manager=maturity_manager,
+        )
+
+    @pytest.mark.asyncio
+    async def test_critical_but_not_operational_does_not_evacuate(self) -> None:
+        """CRITICAL でも is_operational=False (監視不能) なら should_evacuate=False。"""
+        assessor = self._build_assessor(
+            [
+                _make_protocol_health(RiskLevel.CRITICAL, is_operational=False, protocol="lido"),
+                _make_protocol_health(RiskLevel.LOW, protocol="aave"),
+                _make_protocol_health(RiskLevel.LOW, protocol="pendle"),
+            ]
+        )
+        result = await assessor.assess()
+        assert result.should_evacuate is False
+        assert result.evacuation_reason is None
+
+    @pytest.mark.asyncio
+    async def test_critical_and_operational_still_evacuates(self) -> None:
+        """CRITICAL かつ is_operational=True なら従来通り should_evacuate=True（退行防止）。"""
+        assessor = self._build_assessor(
+            [
+                _make_protocol_health(RiskLevel.CRITICAL, is_operational=True, protocol="lido"),
+                _make_protocol_health(RiskLevel.LOW, protocol="aave"),
+                _make_protocol_health(RiskLevel.LOW, protocol="pendle"),
+            ]
+        )
+        result = await assessor.assess()
+        assert result.should_evacuate is True
+        assert result.evacuation_reason is not None
+        assert "lido" in result.evacuation_reason
+
+    @pytest.mark.asyncio
+    async def test_operational_critical_only_names_operational_protocol(self) -> None:
+        """避難理由には is_operational=True の CRITICAL プロトコルのみ列挙する。"""
+        assessor = self._build_assessor(
+            [
+                _make_protocol_health(RiskLevel.CRITICAL, is_operational=False, protocol="lido"),
+                _make_protocol_health(RiskLevel.CRITICAL, is_operational=True, protocol="aave"),
+                _make_protocol_health(RiskLevel.LOW, protocol="pendle"),
+            ]
+        )
+        result = await assessor.assess()
+        assert result.should_evacuate is True
+        assert result.evacuation_reason is not None
+        assert "aave" in result.evacuation_reason
+        assert "lido" not in result.evacuation_reason
+
+
 class TestCalculateRiskScore:
     def test_score_0_to_20_is_low(self) -> None:
         assessor = CompoundRiskAssessor.__new__(CompoundRiskAssessor)
@@ -182,6 +254,23 @@ class TestCalculateRiskScore:
         maturities: list[MaturityAlert] = []
         score = assessor.calculate_risk_score(risks, peg, maturities)
         assert score >= Decimal("80")
+
+    def test_score_non_operational_critical_does_not_clamp_to_80(self) -> None:
+        """is_operational=False の CRITICAL プロトコルは 80 クランプに算入しない。
+
+        監視不能プロトコル (probe 失敗) を危険域スコアに数えない二重防御
+        （2026-06-28 Lido 誤検知対策）。他コンポーネントが LOW なら 80 未満に留まる。
+        """
+        assessor = CompoundRiskAssessor.__new__(CompoundRiskAssessor)
+        risks = [
+            _make_protocol_health(RiskLevel.CRITICAL, is_operational=False),
+            _make_protocol_health(RiskLevel.LOW),
+            _make_protocol_health(RiskLevel.LOW),
+        ]
+        peg = _make_peg_status(RiskLevel.LOW)
+        maturities: list[MaturityAlert] = []
+        score = assessor.calculate_risk_score(risks, peg, maturities)
+        assert score < Decimal("80")
 
     def test_score_critical_peg_clamps_to_80(self) -> None:
         assessor = CompoundRiskAssessor.__new__(CompoundRiskAssessor)

--- a/backend/tests/protocols/test_risk/test_protocol_monitor.py
+++ b/backend/tests/protocols/test_risk/test_protocol_monitor.py
@@ -199,7 +199,12 @@ class TestCheckAaveHealth:
         mock_monitoring_service: MagicMock,
         mock_aave_client: Mock,
     ) -> None:
-        """monitoring 例外時は raise せず CRITICAL / is_operational=False を返す。"""
+        """monitoring 例外時は raise せず LOW / is_operational=False を返す。
+
+        probe 失敗は「監視不能」であって「プロトコルが危険」ではないため、避難トリガー
+        (CRITICAL) にはしない (2026-06-28 Lido 誤検知対策)。監視不能は is_operational=False
+        で可視化する。
+        """
         mock_monitoring_service.get_status.side_effect = RuntimeError(
             "https://rpc.example/v2/secret-api-key"
         )
@@ -207,12 +212,14 @@ class TestCheckAaveHealth:
             mock_lido_client, mock_pendle_client, mock_monitoring_service, mock_aave_client
         )
         result = await monitor.check_aave_health()
-        assert result.risk_level == RiskLevel.CRITICAL
+        assert result.risk_level == RiskLevel.LOW
         assert result.is_operational is False
         assert result.tvl_usd == Decimal("0")
         # Security Rule 8: alerts は無認証 API で外部露出されるため固定文言のみ。
         # 例外詳細 (RPC URL / APIキー等) が漏れていないことを検証する。
-        assert result.alerts == ["Aave ヘルスチェックエラー（詳細はログ参照）"]
+        assert result.alerts == [
+            "Aave の稼働状況を一時的に確認できませんでした（監視のみ・資産への影響なし）"
+        ]
         assert "secret-api-key" not in result.alerts[0]
 
     @pytest.mark.asyncio
@@ -223,13 +230,17 @@ class TestCheckAaveHealth:
         mock_monitoring_service: MagicMock,
         mock_aave_client: Mock,
     ) -> None:
-        """Aave クライアント例外時も fail-open（raise しない）。"""
+        """Aave クライアント例外時も fail-open（raise しない）。
+
+        probe 失敗は監視不能であり危険ではないため LOW + is_operational=False を返す
+        （避難トリガーにしない / 2026-06-28 Lido 誤検知対策）。
+        """
         mock_aave_client.get_account_data.side_effect = RuntimeError("rpc down")
         monitor = _build_aave_monitor(
             mock_lido_client, mock_pendle_client, mock_monitoring_service, mock_aave_client
         )
         result = await monitor.check_aave_health()
-        assert result.risk_level == RiskLevel.CRITICAL
+        assert result.risk_level == RiskLevel.LOW
         assert result.is_operational is False
 
     @pytest.mark.asyncio
@@ -304,6 +315,40 @@ class TestCheckLidoHealth:
         result = await protocol_monitor.check_lido_health()
         assert result.is_operational is True
 
+    @pytest.mark.asyncio
+    async def test_lido_health_probe_failure_returns_low_not_critical(
+        self, mock_lido_client: AsyncMock, mock_pendle_client: AsyncMock
+    ) -> None:
+        """Lido probe (RPC/API) 失敗時は LOW + is_operational=False を返す。
+
+        probe 失敗は監視不能であって危険ではないため CRITICAL にしない
+        （2026-06-28 Lido 誤検知: Holesky RPC 403 で CRITICAL → 避難アラート乱発）。
+        例外詳細 (RPC URL 等) を alerts に露出しないことも検証 (Security Rule 8)。
+        """
+        mock_lido_client.get_staking_apr.side_effect = RuntimeError(
+            "https://holesky.rpc.example/v2/secret-api-key 403"
+        )
+        monitor = ProtocolMonitor(lido_client=mock_lido_client, pendle_client=mock_pendle_client)
+        result = await monitor.check_lido_health()
+        assert result.risk_level == RiskLevel.LOW
+        assert result.is_operational is False
+        assert result.tvl_usd == Decimal("0")
+        assert result.alerts == [
+            "Lido の稼働状況を一時的に確認できませんでした（監視のみ・資産への影響なし）"
+        ]
+        assert "secret-api-key" not in result.alerts[0]
+
+    @pytest.mark.asyncio
+    async def test_lido_health_ratio_probe_failure_returns_low(
+        self, mock_lido_client: AsyncMock, mock_pendle_client: AsyncMock
+    ) -> None:
+        """stETH/ETH レート取得の probe 失敗も LOW + is_operational=False（避難トリガーにしない）。"""
+        mock_lido_client.get_steth_eth_ratio.side_effect = RuntimeError("rpc down")
+        monitor = ProtocolMonitor(lido_client=mock_lido_client, pendle_client=mock_pendle_client)
+        result = await monitor.check_lido_health()
+        assert result.risk_level == RiskLevel.LOW
+        assert result.is_operational is False
+
 
 class TestCheckPendleHealth:
     @pytest.mark.asyncio
@@ -369,6 +414,29 @@ class TestCheckPendleHealth:
     ) -> None:
         result = await protocol_monitor.check_pendle_health()
         assert isinstance(result.last_checked, datetime)
+
+    @pytest.mark.asyncio
+    async def test_pendle_health_probe_failure_returns_low_not_critical(
+        self, mock_lido_client: AsyncMock, mock_pendle_client: AsyncMock
+    ) -> None:
+        """Pendle probe (market 情報 API) 失敗時は LOW + is_operational=False を返す。
+
+        probe 失敗は監視不能であって危険ではないため CRITICAL にしない
+        （避難トリガーにしない / 2026-06-28 Lido 誤検知対策）。
+        例外詳細 (endpoint 情報等) を alerts に露出しないことも検証 (Security Rule 8)。
+        """
+        mock_pendle_client.get_market_info.side_effect = RuntimeError(
+            "https://api.pendle.example/secret-endpoint timeout"
+        )
+        monitor = ProtocolMonitor(lido_client=mock_lido_client, pendle_client=mock_pendle_client)
+        result = await monitor.check_pendle_health()
+        assert result.risk_level == RiskLevel.LOW
+        assert result.is_operational is False
+        assert result.tvl_usd == Decimal("0")
+        assert result.alerts == [
+            "Pendle の稼働状況を一時的に確認できませんでした（監視のみ・資産への影響なし）"
+        ]
+        assert "secret-endpoint" not in result.alerts[0]
 
 
 class TestCheckAll:


### PR DESCRIPTION
## 背景

本番で「複合リスク避難 成立 lido」の緊急 Slack アラートが **48h で 286 回**発火していた（2026-06-28 起票の既知インシデント `project_lido_compound_risk_false_positive.md`）。実資金は Lido に $0、避難は dry_run stub で資金は動かない（無害）だが、安全装置がオオカミ少年化していた。

## 真因

`protocol_monitor.py` の `check_aave/lido/pendle_health` が、RPC/API probe 失敗の except 節で **fail-CLOSED = `risk_level=RiskLevel.CRITICAL`** を返していた。本番の実 LidoClient が Holesky RPC 403 で `get_steth_eth_ratio`/`get_staking_apr` 例外 → CRITICAL → `compound_risk.assess()` が `any(p.risk_level==CRITICAL)` で `should_evacuate=True` → 10分ごとに Slack EMERGENCY。

**probe 失敗（監視できていない）を「プロトコルが危険（CRITICAL）」と誤認していた**のが根本原因。

## 修正（Tier S・安全装置系）

**一次防御** `protocol_monitor.py`（3箇所の except 節）:
- `risk_level=CRITICAL → LOW`（probe 失敗を避難トリガーにしない）。`is_operational=False` は維持（監視不能を可視化）。
- `logger.exception → logger.warning`（監視不能は想定内の degraded 状態）。
- alerts を固定文言に統一（旧 lido/pendle は `f"...: {exc}"` で例外を外部露出 = 無認証 GET /api/protocols/health 経由で **Security Rule 8 違反**だった）。
- 本当の危険（HF<1.6 等）は client 正常応答時の分岐で CRITICAL 判定されるパスなので**危険検知能力に影響なし**。

**二次防御（二重防御）** `compound_risk.py`（2箇所）:
- `assess()` の避難判定と `calculate_risk_score()` の has_critical を `CRITICAL and p.is_operational` に。万一 CRITICAL + 監視不能が来ても避難根拠から除外。

## テスト

- `protocol_monitor`: aave/lido/pendle の probe 失敗 → `LOW` + `is_operational=False` + 固定文言 alerts + 例外詳細（RPC URL/APIキー）非露出を検証。
- `compound_risk`: `CRITICAL だが is_operational=False → should_evacuate=False` / `CRITICAL かつ is_operational=True → should_evacuate=True`（退行防止）/ 避難理由に監視不能プロトコルを含めない / スコア 80 クランプに監視不能 CRITICAL を算入しない。

## DoD ゲート

- **Gate 1 ruff check**: `All checks passed!`
- **Gate 2 ruff format**: PASS
- **Gate 3 mypy**（`app/protocols/risk/`）: `Success: no issues found`
  - ※ verify.sh 全体の mypy は `app/fees/billing_adapter.py` / `app/users/settings_router.py` の `stripe` import で 2 件 error になるが、これは #969 由来の**本 PR と無関係な既存 error**。`stripe>=11.0.0` は requirements.txt にあり CI では解決される（ローカル venv 未インストールのみの環境要因）。本 PR の 4 ファイルは mypy クリーン。
- **pytest**: backend 全 **4680 passed, 21 skipped**（`tests/protocols/test_risk/` 134 件含む）。

## 参照

- `project_lido_compound_risk_false_positive.md`
- `CLAUDE.lessons.md` 2026-07-08 セクション追記済み

## スコープ外（別 PR）

- staging-v4 / 本番反映は別途（本番は Tier S・3段プロトコル経由）。
- AI 常時 HOLD（既知の構造的ゲート）は別 PR・別方針相談（`project_ai_hold_escape_cab.md`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)