### PR TITLE
fix(ai): finance feed の JSON抽出を頑健化 (hawkish→偽unknown 誤緩和の防止)

### DIFF
--- a/CLAUDE.lessons.md
+++ b/CLAUDE.lessons.md
@@ -1213,3 +1213,18 @@ deploy_staging.sh)が稼働中だった。ps の ELAPSED は MM:SS 表記、誤�
 - 安全装置の except 節を書くときは「fail-open / fail-closed のどちらが安全か」を必ず明示的に判断する。**外部 probe の失敗は原則 fail-open (監視不能フラグで可視化)**、実データが「危険」を示したときのみ避難トリガーにする。
 - 外部例外を alerts / API レスポンスにそのまま載せない (RPC URL に API キーが埋まる = Security Rule 8)。固定文言 + サーバーログ限定。
 - 安全装置は「発火しないこと」ではなく「正しい条件でのみ発火すること」でテストする。エラー経路テストは CRITICAL 期待ではなく LOW + is_operational=False を期待値にし、compound 側で「CRITICAL だが監視不能 → 避難しない」「CRITICAL かつ稼働中 → 避難する (退行防止)」を両方カバーする。
+
+## 2026-07-08 パース失敗を「緩和トリガーになる既定値」に落とすと安全装置が逆流する (Finance feed fed_stance=unknown 誤緩和)
+
+**何が起きたか**: 「本番 AI が常時 HOLD で BUY 提案が出ない」を調査中に、逆の潜在バグを発見。本番 BUY ゲート (`ai/agents.py` の `indicator_and_macro_agree_bullish()`) は、`fed_stance ∈ {"unknown","neutral"}` のとき Macro 要件を落として Indicator 単独 BULLISH≥70% で BUY を通す設計 (`_BULLISH_RELAX_FED_STANCES`、2026-05 の「マクロ欠測で永久 HOLD を避ける」意図)。一方 `data_feeds/finance_feed.py` の JSON 抽出が脆く、Perplexity sonar-pro が JSON を prose で囲む / ```json フェンスを付ける / 文字列値に生改行を混ぜると `json.loads(content)` が間欠失敗し、except 節が **fed_stance を既定 "unknown" に落として updated_at をセットしたまま返す**。本番 live 検証で「macro_summary に生 JSON エンベロープが丸ごと入り fed_stance=unknown / key_indicators=[]」を再現 (中身は本物の hawkish、CPI 4.2%・Fed 3.50-3.75%・9 citations)。
+
+**根本原因の言語化**: **安全判断の入力データで「パース失敗」を「安全側を緩めるほうの既定値」にフォールバックさせると、外部応答が少し崩れるたびに安全装置が逆流する**。ここでは「本物の hawkish → パース失敗 → ラベルだけ unknown → BUY ゲート緩和 → hawkish 局面で誤 BUY」という、`compound_risk` の probe 失敗誤検知 (上記 2026-07-08 前段) と**同種**の fail-open/closed 誤りが、今度は「緩めすぎる方向」で起きていた。`unknown` を緩和トリガーにする設計自体は妥当だが、「genuine unknown」と「parse 失敗由来の偽 unknown」を区別せず同一視したのが穴。
+
+**修正 (PR は本コミット, `data_feeds/finance_feed.py`)**:
+- `_extract_finance_json()` を新設: フェンス除去 → `json.loads(strict=False)` (文字列内の生改行/制御文字を許容) → 失敗時は本文中の最初の均衡した `{...}` ブロックだけを抽出して再 parse。prose 囲みでも directional ラベル (hawkish 等) を落とさない。
+- 抽出不能時は **fed_stance を "unknown" に落とさず updated_at=None で返す** → `update_finance_cache` の last-known-good 維持ロジックが「直近の正しい fed_stance を parse 失敗で上書きしない」。
+
+**教訓 (再発防止)**:
+- **安全判断の入力を組み立てるとき、パース/取得失敗のフォールバック値が「ゲートを緩める側」か「締める側」かを必ず意識する**。緩める側に落ちる既定値 (ここでは relax 対象の "unknown") は、外部応答の揺らぎで安全装置を無効化する経路になる。
+- 外部 LLM の JSON 応答は「フェンス除去 + `json.loads`」だけでは不十分。prose 囲み・生改行を想定し、均衡ブレース抽出 + `strict=False` で頑健化する。失敗を silent default にせず warning + last-known-good 維持。
+- 「HOLD しか出ない」の調査でも、ゲートの**両方向**(締めすぎ/緩めすぎ) を見る。今回は「BUY が出ない」入口から入って「hawkish で誤 BUY し得る」出口のバグに到達した。本物の hawkish は正しく HOLD させるのが正解 (Fed が実際に hawkish なら BUY を強制しない)。

--- a/backend/app/data_feeds/finance_feed.py
+++ b/backend/app/data_feeds/finance_feed.py
@@ -79,6 +79,75 @@ _finance_cache: Optional[FinanceFeedResult] = None
 _finance_lock = asyncio.Lock()
 
 
+# ============================================================
+# JSON extraction (robust)
+# ============================================================
+def _extract_finance_json(content: str) -> Optional[dict[str, Any]]:
+    """Perplexity の応答本文から最初の JSON オブジェクトを頑健に抽出する。
+
+    2026-07-08 発見のバグ対策: sonar-pro は指示に反して JSON を prose で囲む /
+    ```json フェンスを付ける / 文字列値に生の改行や ``**bold**`` を混ぜる ことが
+    あり、素の ``json.loads(content)`` が間欠的に失敗していた。失敗すると
+    ``fetch_finance_data`` が既定 ``fed_stance="unknown"`` にフォールバックし、
+    本物の hawkish が黙って "unknown" 化 → BUY ゲート緩和 (agents.py の
+    ``_BULLISH_RELAX_FED_STANCES``) を誤って発火させる安全逆流が起きていた。
+
+    対策:
+      1. ```` ```json ```` フェンスを剥がして直接 ``json.loads`` (strict=False で
+         文字列内の制御文字/改行を許容)。
+      2. 失敗したら本文中の最初の均衡した ``{...}`` ブロックだけを取り出して再試行
+         (前後に prose が付いていても JSON 本体を拾える)。
+    どちらも dict を得られなければ ``None`` を返す (呼び出し側が last-known-good を維持)。
+    """
+    clean = content.strip()
+    if clean.startswith("```"):
+        clean = clean.split("\n", 1)[1] if "\n" in clean else clean[3:]
+    if clean.endswith("```"):
+        clean = clean[:-3]
+    clean = clean.strip()
+    if clean.startswith("json"):
+        clean = clean[4:].strip()
+
+    # 1) まず直接 parse (strict=False で文字列内の生改行/タブを許容)
+    try:
+        obj = json.loads(clean, strict=False)
+        if isinstance(obj, dict):
+            return obj
+    except json.JSONDecodeError:
+        pass
+
+    # 2) 本文中の最初の均衡した {...} ブロックを抽出して parse
+    start = clean.find("{")
+    if start == -1:
+        return None
+    depth = 0
+    in_str = False
+    escaped = False
+    for i in range(start, len(clean)):
+        ch = clean[i]
+        if in_str:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_str = False
+        elif ch == '"':
+            in_str = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                candidate = clean[start : i + 1]
+                try:
+                    obj = json.loads(candidate, strict=False)
+                except json.JSONDecodeError:
+                    return None
+                return obj if isinstance(obj, dict) else None
+    return None
+
+
 def get_cached_finance() -> FinanceFeedResult:
     """Get cached finance data. Returns default if no cache."""
     if _finance_cache is not None:
@@ -135,52 +204,52 @@ async def fetch_finance_data(client: httpx.AsyncClient) -> FinanceFeedResult:
         content = data.get("choices", [{}])[0].get("message", {}).get("content", "")
         citations = data.get("citations", [])
 
-        try:
-            clean = content.strip()
-            if clean.startswith("```"):
-                clean = clean.split("\n", 1)[1] if "\n" in clean else clean[3:]
-            if clean.endswith("```"):
-                clean = clean[:-3]
-            clean = clean.strip()
-            if clean.startswith("json"):
-                clean = clean[4:].strip()
-
-            parsed = json.loads(clean)
-
-            fed_stance = parsed.get("fed_stance", "unknown")
-            if fed_stance not in _VALID_FED_STANCES:
-                fed_stance = "unknown"
-
-            stablecoin_risk = parsed.get("stablecoin_risk", "low")
-            if stablecoin_risk not in _VALID_STABLECOIN_RISKS:
-                stablecoin_risk = "low"
-
-            # key_indicators may be list[str] or list[dict] depending on Perplexity API version.
-            # Coerce dicts to "name: value" strings to avoid pydantic ValidationError.
-            raw_indicators: list[object] = parsed.get("key_indicators", [])[:5]
-            key_indicators: list[str] = [
-                (
-                    ": ".join(filter(None, [str(item.get("name", "")), str(item.get("value", ""))]))
-                    if isinstance(item, dict)
-                    else str(item)
-                )
-                for item in raw_indicators
-            ]
-
-            return FinanceFeedResult(
-                macro_summary=str(parsed.get("macro_summary", content[:400])),
-                fed_stance=fed_stance,
-                stablecoin_risk=stablecoin_risk,
-                key_indicators=key_indicators,
-                sources_count=len(citations),
-                updated_at=datetime.now(timezone.utc),
+        parsed = _extract_finance_json(content)
+        if parsed is None:
+            # [fail-safe] JSON 抽出に失敗したときは fed_stance を既定 "unknown" に落とさない。
+            # "unknown" は BUY ゲートの緩和トリガー (agents.py _BULLISH_RELAX_FED_STANCES) の
+            # ため、本物の directional マクロ (hawkish 等) がパース失敗で "unknown" 化すると、
+            # macro 要件が外れて hawkish 局面で誤 BUY を発火し得る (2026-07-08 発見の安全逆流)。
+            # updated_at=None で返し、update_finance_cache の last-known-good 維持ロジックに
+            # 「今回は上書きしない」と伝える (直近の正しい fed_stance を parse 失敗で潰さない)。
+            logger.warning(
+                "Perplexity Finance: JSON抽出失敗、last-known-good維持 "
+                "(fed_stanceをunknownに落とさない). content[:200]=%s",
+                content[:200],
             )
-        except (json.JSONDecodeError, KeyError):
             return FinanceFeedResult(
                 macro_summary=content[:500],
                 sources_count=len(citations),
-                updated_at=datetime.now(timezone.utc),
             )
+
+        fed_stance = parsed.get("fed_stance", "unknown")
+        if fed_stance not in _VALID_FED_STANCES:
+            fed_stance = "unknown"
+
+        stablecoin_risk = parsed.get("stablecoin_risk", "low")
+        if stablecoin_risk not in _VALID_STABLECOIN_RISKS:
+            stablecoin_risk = "low"
+
+        # key_indicators may be list[str] or list[dict] depending on Perplexity API version.
+        # Coerce dicts to "name: value" strings to avoid pydantic ValidationError.
+        raw_indicators: list[object] = parsed.get("key_indicators") or []
+        key_indicators: list[str] = [
+            (
+                ": ".join(filter(None, [str(item.get("name", "")), str(item.get("value", ""))]))
+                if isinstance(item, dict)
+                else str(item)
+            )
+            for item in raw_indicators[:5]
+        ]
+
+        return FinanceFeedResult(
+            macro_summary=str(parsed.get("macro_summary", content[:400])),
+            fed_stance=fed_stance,
+            stablecoin_risk=stablecoin_risk,
+            key_indicators=key_indicators,
+            sources_count=len(citations),
+            updated_at=datetime.now(timezone.utc),
+        )
 
     except httpx.HTTPStatusError as exc:
         body_preview = ""

--- a/backend/tests/data_feeds/test_finance_feed.py
+++ b/backend/tests/data_feeds/test_finance_feed.py
@@ -414,3 +414,125 @@ async def test_fetch_finance_data_mixed_indicator_types() -> None:
     assert result.key_indicators[0] == "CPI: 3.1%"
     assert "FED rate" in result.key_indicators[1]
     assert result.key_indicators[2] == "BTC dominance: 55%"
+
+
+# ---------------------------------------------------------------------------
+# 2026-07-08: robust JSON extraction — sonar-pro が JSON を prose/フェンスで囲む /
+# 文字列に生改行を混ぜると、旧 json.loads(content) が失敗し fed_stance が黙って
+# "unknown" に落ち、本物の hawkish が BUY ゲート緩和 (unknown=relax) を誤発火させて
+# いた。抽出を頑健化し、抽出失敗時は last-known-good を維持する。
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_finance_data_prose_wrapped_json_extracts_fed_stance() -> None:
+    """JSON が前後の prose で囲まれていても fed_stance を正しく抽出する（旧実装は失敗）。"""
+    inner = {
+        "macro_summary": "Restrictive but on-hold Fed; CPI 4.2% YoY vs 2% target.",
+        "fed_stance": "hawkish",
+        "stablecoin_risk": "low",
+        "key_indicators": ["Fed funds 3.50-3.75%", "CPI 4.2%"],
+    }
+    content = (
+        f"Here is the current analysis:\n\n{json.dumps(inner)}\n\nSources: [1] fed.gov [2] bls.gov"
+    )
+    mock_resp = _make_mock_response(content, citations=["https://fed.gov", "https://bls.gov"])
+
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = mock_resp
+        async with httpx.AsyncClient() as client:
+            with patch.dict(os.environ, {"PERPLEXITY_API_KEY": "test-key"}):
+                result = await fetch_finance_data(client)
+
+    assert result.fed_stance == "hawkish", "prose 囲みでも directional ラベルを落とさない"
+    assert result.macro_summary.startswith("Restrictive but on-hold Fed")
+    assert result.key_indicators == ["Fed funds 3.50-3.75%", "CPI 4.2%"]
+    assert result.updated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_fetch_finance_data_markdown_fenced_json() -> None:
+    """```json フェンス + 末尾 prose でも fed_stance を抽出する。"""
+    inner = {"macro_summary": "Fed hawkish.", "fed_stance": "hawkish", "stablecoin_risk": "medium"}
+    content = f"```json\n{json.dumps(inner)}\n```\nLet me know if you need more detail."
+    mock_resp = _make_mock_response(content)
+
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = mock_resp
+        async with httpx.AsyncClient() as client:
+            with patch.dict(os.environ, {"PERPLEXITY_API_KEY": "test-key"}):
+                result = await fetch_finance_data(client)
+
+    assert result.fed_stance == "hawkish"
+    assert result.stablecoin_risk == "medium"
+    assert result.updated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_fetch_finance_data_literal_newline_in_string() -> None:
+    """文字列値に生の改行が入っていても (strict=False) parse できる。"""
+    # 生改行を含む JSON 文字列（標準 json.loads は "Invalid control character" で失敗）
+    content = (
+        '{"macro_summary": "First line.\nSecond line.", '
+        '"fed_stance": "neutral", "stablecoin_risk": "low", "key_indicators": []}'
+    )
+    mock_resp = _make_mock_response(content)
+
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = mock_resp
+        async with httpx.AsyncClient() as client:
+            with patch.dict(os.environ, {"PERPLEXITY_API_KEY": "test-key"}):
+                result = await fetch_finance_data(client)
+
+    assert result.fed_stance == "neutral"
+    assert result.updated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_fetch_finance_data_unextractable_returns_updated_at_none() -> None:
+    """抽出不能な本文は fed_stance を "unknown" 化しない印として updated_at=None を返す。
+
+    これにより update_finance_cache が last-known-good を維持し、直近の正しい
+    fed_stance を parse 失敗で潰さない（BUY ゲート緩和の誤発火防止）。
+    """
+    mock_resp = _make_mock_response("Sorry, I cannot provide structured data right now.")
+
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = mock_resp
+        async with httpx.AsyncClient() as client:
+            with patch.dict(os.environ, {"PERPLEXITY_API_KEY": "test-key"}):
+                result = await fetch_finance_data(client)
+
+    assert result.updated_at is None, "抽出失敗は last-known-good 維持のため updated_at=None"
+    assert result.fed_stance == "unknown"  # default だが cache には書かれない
+
+
+@pytest.mark.asyncio
+async def test_update_finance_cache_preserves_last_good_on_parse_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """parse 失敗 tick は直近の本物 fed_stance を上書きしない（安全逆流の再発防止）。"""
+    from datetime import datetime, timezone
+
+    import app.data_feeds.finance_feed as ff
+
+    saved_cache = ff._finance_cache
+    try:
+        # 直近の正しい hawkish 読みが cache 済み
+        ff._finance_cache = FinanceFeedResult(
+            macro_summary="Restrictive Fed.",
+            fed_stance="hawkish",
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # 次の tick は抽出失敗 (updated_at=None) を返す
+        async def _fake_fetch(_client: object) -> FinanceFeedResult:
+            return FinanceFeedResult(macro_summary="garbage, unparseable")
+
+        monkeypatch.setattr(ff, "fetch_finance_data", _fake_fetch)
+        await ff.update_finance_cache()
+
+        # cache は hawkish のまま（unknown で上書きされていない）
+        assert ff.get_cached_finance().fed_stance == "hawkish"
+    finally:
+        ff._finance_cache = saved_cache


### PR DESCRIPTION
## 背景

「本番 AI が常時 HOLD で BUY 提案が出ない」を調査する過程で、**逆向きの潜在バグ**（本来 HOLD すべき hawkish 局面で誤 BUY し得る安全逆流）を発見した。

## 実ゲートの構造

本番 BUY ゲート `ai/agents.py:indicator_and_macro_agree_bullish()` は、`fed_stance ∈ {"unknown","neutral"}`（`_BULLISH_RELAX_FED_STANCES`）のとき Macro 要件を落として **Indicator 単独 BULLISH≥70% で BUY を通す**（2026-05 の「マクロ欠測で永久 HOLD を避ける」意図）。

## バグ（本番 live 検証で再現）

`data_feeds/finance_feed.py` の JSON 抽出が脆く、Perplexity sonar-pro が JSON を prose で囲む / ` ```json ` フェンスを付ける / 文字列値に生改行を混ぜると `json.loads(content)` が間欠失敗 → except 節が **`fed_stance` を既定 `"unknown"` に落とし、`updated_at` をセットしたまま返す**。

本番 active backend での live 検証:
- Perplexity 応答は**本物の hawkish**（`Fed funds 3.50-3.75%` / `CPI 4.2% YoY` / `restrictive but on-hold Fed` / 9 citations）
- なのに抽出結果は `fed_stance=unknown` / `key_indicators=[]`、`macro_summary` に生 JSON エンベロープが丸ごと混入

→ **本物の hawkish がラベルだけ `unknown` 化 → BUY ゲート緩和を誤発火 → hawkish 局面で Indicator 単独 BUY が成立し得る**（`compound_risk` の probe 失敗誤検知と同種の fail-open/closed 誤り、今度は「緩めすぎる」方向）。

## 修正（`data_feeds/finance_feed.py`）

- **`_extract_finance_json()` を新設**: フェンス除去 → `json.loads(strict=False)`（文字列内の生改行/制御文字を許容）→ 失敗時は本文中の最初の**均衡した `{...}` ブロック**だけを抽出して再 parse。prose 囲み・生改行でも directional ラベル（hawkish 等）を落とさない。
- **抽出不能時は `fed_stance` を `"unknown"` に落とさず `updated_at=None` で返す** → `update_finance_cache` の last-known-good 維持ロジックが「直近の正しい `fed_stance` を parse 失敗で上書きしない」。

## テスト

- prose 囲み / ` ```json ` フェンス / 文字列内の生改行 → `fed_stance` を正しく抽出（旧実装は失敗）
- 抽出不能 → `updated_at=None`（last-known-good 維持の印）
- `update_finance_cache` が parse 失敗 tick で直近の `hawkish` を維持（unknown で上書きしない）
- `data_feeds/` + `ai/` 全 **300 passed**、mypy/ruff クリーン

## この修正の意味（重要）

**Fed は実際に hawkish**（実データ確認済み）。よって本番 AI が今 HOLD なのは**バグではなく正しい慎重動作**。本 PR は「HOLD を減らす」ためではなく、**parse 失敗経由で hawkish ゲートを迂回する誤 BUY 経路を塞ぐ**安全修正。BUY を実際に流す土台（`AI_INDICATOR_MOMENTUM_ENABLED` の本番投入）は別途 3段プロトコルで、この修正とセットで反映する。

## 参照

- `CLAUDE.lessons.md` 2026-07-08「パース失敗を緩和トリガーになる既定値に落とすと安全装置が逆流する」
- 関連: 同日 PR #970（compound_risk probe 失敗の fail-CLOSED 誤検知）と同種の教訓

🤖 Generated with [Claude Code](https://claude.com/claude-code)