### PR TITLE
fix(proposals): 期限切れ提案が新規提案を永久ブロックする不具合を修正

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -584,6 +584,39 @@ def _create_proposals_for_users(
                     )
                     continue
 
+                # 自己修復: 重複判定の前に、このユーザーの「期限切れなのに pending の
+                # まま残っている提案」を先に expired 化する (2026-07-08)。
+                # proposal_timeout_loop が停止している環境 (DISABLE_BACKGROUND_MONITORING=1
+                # の staging-v4 等) では期限切れ提案が pending のまま残り続け、下の重複ガードが
+                # そのユーザーへの新規提案を「永久に」ブロックしてしまう不具合があった
+                # (id 8 / user 10 が 6 日間 pending のまま新規提案ゼロ)。ここで能動的に
+                # expire することで、監視ループの有無に依存せず永久ブロックを防ぐ。
+                # 例外は握りつぶし (fail-open): expire に失敗しても提案生成は継続する。
+                try:
+                    _stale = db.scalars(
+                        select(Proposal).where(
+                            Proposal.user_id == user.id,
+                            Proposal.status == "pending",
+                            Proposal.expires_at < now,
+                        )
+                    ).all()
+                    for _sp in _stale:
+                        _sp.status = "expired"
+                    if _stale:
+                        db.flush()
+                        logger.info(
+                            "Self-heal: expired %d stale pending proposal(s) for user %d "
+                            "before dedup check",
+                            len(_stale),
+                            user.id,
+                        )
+                except Exception as _stale_exc:  # noqa: BLE001
+                    logger.warning(
+                        "stale pending expire failed for user %d (fail-open): %s",
+                        user.id,
+                        _stale_exc,
+                    )
+
                 # 既存の pending 提案がある場合はスキップ (2026-05-21 P0 重複作成ガード)
                 # 承認待ち提案がすでに存在するのに新たな提案を作ると、管理者が連続
                 # approve した際に同一ユーザーへの Aave/Lido/Pendle 操作が重複する。

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -538,11 +538,17 @@ def create_app() -> FastAPI:
         Controlled by environment variables:
             ENABLE_DAILY_REPORTS=1: enable daily reports
             ENABLE_WEEKLY_REPORTS=1: enable weekly reports
-            DISABLE_BACKGROUND_MONITORING=1: disable all 7 operational loops
+            DISABLE_BACKGROUND_MONITORING=1: disable the side-effecting
+                operational loops (NOT proposal_timeout — see below)
 
-        7 operational loops (always-on unless DISABLE_BACKGROUND_MONITORING=1):
-            proposal_timeout / rebalance_check / price_monitor / health_check /
-            latency_monitor / rss_fetch / dca
+        proposal_timeout is always-on (pure housekeeping: expires stale pending
+        proposals). It is intentionally NOT gated by DISABLE_BACKGROUND_MONITORING
+        so that disabling monitoring in Shadow Mode never causes expired proposals
+        to permanently block new ones (2026-07-08 fix).
+
+        7 side-effecting loops (disabled by DISABLE_BACKGROUND_MONITORING=1):
+            rebalance_check / price_monitor / health_check / latency_monitor /
+            rss_fetch / dca / compound_risk_monitor
         """
         from app.automation.scheduled_tasks import get_scheduled_task_manager  # noqa: PLC0415
         from app.notifications.config import get_notification_settings  # noqa: PLC0415
@@ -577,22 +583,33 @@ def create_app() -> FastAPI:
             except BaseException as exc:
                 logger.error("Failed to start report tasks: %s", exc)
 
-        # --- 7 operational loops (always-on, fail-safe each) ---
-        # DISABLE_BACKGROUND_MONITORING=1 はこの 8 ループ (proposal_timeout 〜
-        # compound_risk_monitor) のみを止める。oracle_monitor / monthly_fee_batch は
-        # 各々が独立した opt-in フラグを持つため、ここで return して巻き込まないこと
-        # (2026-07-08: DISABLE_BACKGROUND_MONITORING=1 の staging-v4 で
-        # ENABLE_MONTHLY_FEE_BATCH=1 が無反応になるバグとして発見)。
+        # --- proposal_timeout: 常時ON (housekeeping, 2026-07-08 にフラグから分離) ---
+        # 期限切れ pending 提案を canceled 化する純粋な DB housekeeping ループ。副作用は
+        # status 遷移と LINE_NOTIFY_TOKEN 設定時のみの通知だけで、実資金・オンチェーン操作を
+        # 伴わない。以前は下の 7 副作用ループと同じ DISABLE_BACKGROUND_MONITORING に束ねられて
+        # おり、Shadow Mode で副作用ループを止める目的でフラグを立てると、無害な期限切れ処理
+        # まで一緒に止まっていた。その結果 staging-v4 (DISABLE_BACKGROUND_MONITORING=1) で
+        # 期限切れ提案が pending のまま残り、_create_proposals_for_users の重複ガードがその
+        # ユーザーへの新規提案を永久ブロックする不具合が発生していた (id 8 / user 10)。
+        # housekeeping はフラグから分離し、監視の有効/無効に関わらず常時稼働させる。
+        try:
+            await scheduled_manager.start_proposal_timeout(
+                on_error=_make_scheduler_error_handler("proposal_timeout_loop"),
+            )
+            logger.info("Operational loop started: proposal_timeout (always-on)")
+        except BaseException as exc:
+            logger.error("Failed to start loop proposal_timeout: %s", exc)
+
+        # --- 7 operational loops (副作用あり, DISABLE_BACKGROUND_MONITORING で一括停止可) ---
+        # DISABLE_BACKGROUND_MONITORING=1 はこの 7 ループ (rebalance_check 〜
+        # compound_risk_monitor) を止める。proposal_timeout は上で常時ONに分離済み。
+        # oracle_monitor / monthly_fee_batch は各々が独立した opt-in フラグを持つため、
+        # ここで return して巻き込まないこと (2026-07-08: DISABLE_BACKGROUND_MONITORING=1 の
+        # staging-v4 で ENABLE_MONTHLY_FEE_BATCH=1 が無反応になるバグとして発見)。
         if not _is_background_monitoring_enabled():
             logger.info("Operational loops disabled (DISABLE_BACKGROUND_MONITORING=1)")
         else:
             _loops: list[tuple[str, object]] = [
-                (
-                    "proposal_timeout",
-                    scheduled_manager.start_proposal_timeout(
-                        on_error=_make_scheduler_error_handler("proposal_timeout_loop"),
-                    ),
-                ),
                 (
                     "rebalance_check",
                     scheduled_manager.start_rebalance_check(

--- a/backend/tests/test_ai_judgment_scheduler.py
+++ b/backend/tests/test_ai_judgment_scheduler.py
@@ -850,6 +850,107 @@ def test_buy_updates_last_judgment_at(db_session):
     assert user.last_judgment_at is not None
 
 
+def test_stale_pending_does_not_permanently_block(db_session):
+    """期限切れ(expires_at<now)なのに pending のまま残った提案が、新規提案を永久に
+    ブロックしないこと (2026-07-08 自己修復)。
+
+    proposal_timeout_loop が停止している環境 (DISABLE_BACKGROUND_MONITORING=1 の
+    staging-v4 等) では期限切れ提案が pending のまま残り、重複ガードがそのユーザーへの
+    新規提案を永久にブロックしていた (id 8 / user 10)。_create_proposals_for_users が
+    重複判定の前に期限切れ pending を能動的に expired 化することで防ぐ。
+    """
+    from datetime import datetime, timedelta, timezone  # noqa: PLC0415
+
+    user = User(
+        email="stale_pending@example.com",
+        username="stale_pending",
+        hashed_password="x",
+        is_active=True,
+        execution_policy="require_approval",
+        tier=InvestmentTier.UPPER.value,
+        last_judgment_at=None,
+    )
+    db_session.add(user)
+    db_session.flush()
+    _add_fund_allocation(db_session, user)
+
+    # 期限切れ (2 日前) なのに pending のまま残っている既存提案
+    stale = Proposal(
+        user_id=user.id,
+        operation="SUPPLY",
+        asset="USDC",
+        amount=Decimal("1000"),
+        amount_usd=Decimal("1000"),
+        reason="stale",
+        status="pending",
+        expires_at=datetime.now(timezone.utc) - timedelta(days=2),
+    )
+    db_session.add(stale)
+    db_session.commit()
+
+    mock_result = _make_cross_validation_result(TradeAction.BUY)
+    with (
+        patch("app.automation.ai_judgment_scheduler.AIService") as MockAIService,
+        patch("app.automation.ai_judgment_scheduler.KnowledgeService") as MockKnowledgeService,
+    ):
+        MockAIService.return_value.judge_with_rag.return_value = mock_result
+        MockKnowledgeService.return_value.search.return_value = []
+        result = run_ai_judgment_job(db=db_session)
+
+    # 期限切れ提案は expired 化され、新規提案が 1 件生成される
+    assert result["proposals_created"] == 1
+    db_session.refresh(stale)
+    assert stale.status == "expired"
+
+
+def test_fresh_pending_still_blocks_new_proposal(db_session):
+    """期限内(expires_at>now)の pending 提案は従来どおり新規提案をブロックすること。
+
+    自己修復 (期限切れ expire) が正常な重複ガードを壊していないことの退行防止。
+    """
+    from datetime import datetime, timedelta, timezone  # noqa: PLC0415
+
+    user = User(
+        email="fresh_pending@example.com",
+        username="fresh_pending",
+        hashed_password="x",
+        is_active=True,
+        execution_policy="require_approval",
+        tier=InvestmentTier.UPPER.value,
+        last_judgment_at=None,
+    )
+    db_session.add(user)
+    db_session.flush()
+    _add_fund_allocation(db_session, user)
+
+    # 期限内 (2 日後) の既存 pending 提案 → 従来どおりブロックされるべき
+    fresh = Proposal(
+        user_id=user.id,
+        operation="SUPPLY",
+        asset="USDC",
+        amount=Decimal("1000"),
+        amount_usd=Decimal("1000"),
+        reason="fresh",
+        status="pending",
+        expires_at=datetime.now(timezone.utc) + timedelta(days=2),
+    )
+    db_session.add(fresh)
+    db_session.commit()
+
+    mock_result = _make_cross_validation_result(TradeAction.BUY)
+    with (
+        patch("app.automation.ai_judgment_scheduler.AIService") as MockAIService,
+        patch("app.automation.ai_judgment_scheduler.KnowledgeService") as MockKnowledgeService,
+    ):
+        MockAIService.return_value.judge_with_rag.return_value = mock_result
+        MockKnowledgeService.return_value.search.return_value = []
+        result = run_ai_judgment_job(db=db_session)
+
+    assert result["proposals_created"] == 0
+    db_session.refresh(fresh)
+    assert fresh.status == "pending"
+
+
 # ---------------------------------------------------------------------------
 # F-6: tier 正規化のテスト
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概要
staging-v4 で AI が BUY 判定を出しても `proposals_created=0` が続く事象を実機調査した結果発見した、**期限切れ提案がユーザーへの新規提案を永久ブロックする不具合**を修正する。

## 真因（実機データで確定）
- staging-v4 は `DISABLE_BACKGROUND_MONITORING=1`。このフラグが pending→canceled 化を行う `proposal_timeout_loop` を、rebalance/compound-risk 等**実副作用を持つ7ループと一括で停止**していた。
- 結果、期限切れ（`expires_at<now`）なのに `status=pending` のまま残る提案が発生（**id 8 / user 10 が 2026-07-02 に期限切れ後 6 日間 pending**）。
- `_create_proposals_for_users` の重複ガードが「pending あり = skip」で判定するため、**当該ユーザーは AI が毎サイクル BUY を出しても新規提案を永久に受け取れない**。
- AI 判定スケジューラは別系統で稼働し続けるため、ログ上は BUY(86%) が出ているのに提案ゼロ、という食い違いになる。

## 修正
1. **自己修復** (`ai_judgment_scheduler.py`): `_create_proposals_for_users` が重複判定の前に、当該ユーザーの期限切れ pending を能動的に `expired` 化。監視ループの有無に依存せず永久ブロックを防ぐ（fail-open）。
2. **ゲート分離** (`main.py`): `proposal_timeout_loop` を `DISABLE_BACKGROUND_MONITORING` から外し常時ON化。純粋な DB housekeeping（status 遷移＋LINE_NOTIFY_TOKEN 設定時のみ通知）で実資金・オンチェーン操作を伴わないため安全。副作用を持つ7ループは従来通りフラグ制御。
3. **テスト**: 期限切れ pending → expired 化＋新規生成 / 期限内 pending → 従来通りブロック（退行防止）の2本を追加。

## 検証
- `pytest tests/test_ai_judgment_scheduler.py tests/automation/test_proposal_expiry_reminder.py tests/test_proposal_deadletter.py` → **85 passed**
- `ruff check` / `ruff format --check` → pass（変更3ファイル）
- `mypy` → 変更ファイルは clean（既存の `stripe` stub 欠落エラーはローカルvenv固有・本PR無関係）
- **staging-v4 は即時アンブロック済**（id 8 → expired、user 10 復活）

## 本番への影響
`DISABLE_BACKGROUND_MONITORING` の既定は `0`（有効）で、本番は実トレードのため監視ループが必要＝**まず設定されていない見込み**。ただしランタイム実値は3段プロトコルの Phase-1 read-only で確認すること。いずれにせよ自己修復(1)は本番も硬くする。

参照: memory `project_staging_v4_tester_enablement` / `project_ai_hold_escape_cab`

🤖 Generated with [Claude Code](https://claude.com/claude-code)