### PR TITLE
feat(ai): BUYのmacro-neutral緩和をprompt(v4/v5)に伝播 (A-track A2)

### DIFF
--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -140,9 +140,16 @@ Decision rules (v4 — AND-condition for directional trades):
 - HARD STOP (always HOLD): Risk Agent detects COMPOUND RISK, or HF < 1.6
 - SELL: BOTH Indicator AND Macro Agent report BEARISH with confidence >= 70%
 - BUY: BOTH Indicator AND Macro Agent report BULLISH with confidence >= 70%
-- HOLD: Use HOLD when agents disagree, when only one agent is directional,
-  or when confidence < 70% for either Indicator or Macro
-- Single-agent BEARISH/BULLISH alone is NOT sufficient for SELL/BUY
+- BUY exception (macro-neutral relaxation): if the Macro Agent's Key data shows
+  fed_stance = "neutral" or "unknown", then BUY is allowed on the Indicator Agent
+  being BULLISH with confidence >= 70% ALONE (the Macro Agent need not be BULLISH).
+  When macro direction is absent, favourable on-chain reality drives the BUY.
+  This relaxation applies to BUY ONLY — it NEVER applies to SELL.
+- HOLD: Use HOLD when agents disagree, when only one agent is directional
+  (except the BUY exception above), or when confidence < 70% for the Indicator
+  Agent
+- Single-agent BEARISH alone is NOT sufficient for SELL; single-agent BULLISH is
+  sufficient for BUY only under the macro-neutral relaxation above
 
 Weight for confidence calculation: Risk Agent 40%, Indicator 25%, Macro 20%, Pattern 15%
 
@@ -185,9 +192,17 @@ Decision rules (v5 — AND-condition for directional trades):
 - SELL: BOTH Indicator Agent AND Macro Agent must independently report BEARISH
   with confidence >= 70%. A single BEARISH agent alone is NOT sufficient for SELL.
 - BUY: BOTH Indicator Agent AND Macro Agent must independently report BULLISH
-  with confidence >= 70%. A single BULLISH agent alone is NOT sufficient for BUY.
-- HOLD: Use HOLD whenever agents disagree, when only one agent is directional,
-  or when confidence < 70% for either core agent (Indicator or Macro).
+  with confidence >= 70%. A single BULLISH agent alone is NOT sufficient for BUY,
+  EXCEPT under the macro-neutral relaxation below.
+- BUY exception (macro-neutral relaxation): if the Macro Agent's Key data shows
+  fed_stance = "neutral" or "unknown", BUY is allowed on the Indicator Agent being
+  BULLISH with confidence >= 70% ALONE (the Macro Agent need not be BULLISH). When
+  macro direction is absent, favourable on-chain reality drives the BUY. This
+  relaxation is ASYMMETRIC — it applies to BUY ONLY, NEVER to SELL (SELL always
+  requires both Indicator and Macro BEARISH >= 70%).
+- HOLD: Use HOLD whenever agents disagree, when only one agent is directional
+  (except the BUY exception above), or when confidence < 70% for the Indicator
+  Agent (for BUY) or for either core agent (for SELL).
 - Pattern Agent and Risk Agent are supporting signals — they inform confidence
   calculation but cannot alone trigger SELL or BUY.
 

--- a/backend/tests/test_ai_buy_macro_neutral_relax.py
+++ b/backend/tests/test_ai_buy_macro_neutral_relax.py
@@ -1,0 +1,53 @@
+"""A2: BUY の macro-neutral 緩和が prompt(v4/v5) に伝播され、Python ガードと整合すること。
+
+背景 (2026-07-08):
+    本番 BUY の実質ゲートは Python 側 `MultiAgentContext.indicator_and_macro_agree_bullish`
+    で「fed_stance ∈ {neutral, unknown} なら Indicator BULLISH>=70 単独で成立」に緩和済み。
+    しかし LLM に渡す prompt v4/v5 は「Indicator AND Macro 両方 BULLISH>=70」の AND のまま
+    だったため、macro が neutral の本番では LLM 自身が HOLD を出し続け、Python ガードが
+    許可していても BUY に昇格しなかった (proposals ゼロ)。本 PR で prompt に同じ緩和を伝播する。
+"""
+
+from app.ai.agents import MultiAgentContext
+from app.ai.prompts import get_prompt_template
+
+
+def _system(version: str) -> str:
+    return get_prompt_template(version).system_prompt.lower()
+
+
+def test_v4_prompt_has_macro_neutral_buy_relaxation():
+    text = _system("v4")
+    assert "fed_stance" in text
+    assert "neutral" in text and "unknown" in text
+    # BUY 単独許可の明示
+    assert "buy" in text and "alone" in text
+
+
+def test_v5_prompt_has_macro_neutral_buy_relaxation():
+    text = _system("v5")
+    assert "fed_stance" in text
+    assert "neutral" in text and "unknown" in text
+    assert "buy" in text and "alone" in text
+
+
+def test_relaxation_is_buy_only_not_sell():
+    """緩和は BUY のみ・SELL には適用しないことが prompt に明記されていること (#365 SELL-spam 防止)。"""
+    for version in ("v4", "v5"):
+        text = _system(version)
+        # SELL は緩和対象外である旨 (never/only を BUY 文脈で明示)
+        assert "never" in text or "only" in text
+
+
+def test_prompt_relaxation_matches_python_guard_fed_stances():
+    """prompt に書いた緩和対象 fed_stance が Python ガードの _BULLISH_RELAX_FED_STANCES と一致。
+
+    片方だけ変更されて prompt と rule engine が乖離する drift を防ぐ。
+    """
+    # Pydantic private 属性はクラス経由だと descriptor が返るためインスタンス経由で読む。
+    guard_stances = MultiAgentContext()._BULLISH_RELAX_FED_STANCES
+    assert guard_stances == frozenset({"neutral", "unknown"})
+    for version in ("v4", "v5"):
+        text = _system(version)
+        for stance in guard_stances:
+            assert stance in text, f"{version} prompt missing fed_stance '{stance}'"


### PR DESCRIPTION
## 背景（1ヶ月「本番でBUYが出ない」の最後のピース）
本番BUYの実質ゲートは Python 側 `MultiAgentContext.indicator_and_macro_agree_bullish` で **「fed_stance ∈ {neutral, unknown} なら Indicator BULLISH≥70 単独で成立」**に緩和済み（`service.py` の AND-condition ガードはこの条件が真ならクランプしない）。

しかし LLM に渡す **prompt v4/v5 は「Indicator AND Macro 両方 BULLISH≥70」の AND のまま**で、この緩和が prompt に伝わっていなかった。macro=neutral が常態の本番では **LLM 自身が HOLD を出し続け**、Python ガードが許可していても BUY に昇格せず提案ゼロだった（memory「prompt未伝播」）。

## 修正
prompt v4/v5 の BUY ルールに、Python ガードと**同一**の緩和条項を追記：
> Macro Agent の Key data の `fed_stance` が `neutral`/`unknown` なら、Indicator BULLISH≥70 **単独**で BUY 可（Macro は BULLISH でなくてよい）。

- **BUY のみの非対称緩和**。SELL には適用しない（`#365` SELL-spam 再発防止。Python ガードの設計と一致）。
- LLM は `to_decision_prompt()` の `Key data: {...}` で macro の `fed_stance` を**実際に見えている**ため prompt 条項は機能する。
- **ガードを超えて緩めるものではない** — 既にガードが許可済みの範囲に LLM を一致させるだけ。判断主体は LLM のまま（防御的）。

## テスト
- `tests/test_ai_buy_macro_neutral_relax.py` 新規4本（v4/v5に緩和条項存在 / BUYのみ / **prompt の fed_stance 集合が `_BULLISH_RELAX_FED_STANCES` と一致=drift防止**）
- 退行: `test_ai_sell_and_condition` / `test_agents` / `test_consensus_config_prompts` / `test_prompt_reason_language` 含め **122 passed**、ruff/format pass

## A-track 位置づけ & ロールアウト
- **A1** = `AI_INDICATOR_MOMENTUM_ENABLED=true`（実BTC/USDTのBUY_LEANでIndicatorをconf≥70へ。機構は既存）
- **A2** = 本PR。**A1だけでは LLM が HOLD し続ける**ため、A1+A2 が揃って初めて本番BUYに到達する。
- 本番反映前に **staging soak + トレーサ**（`python -m app.diagnostics.proposal_chain`、PR #973）で計測。Tier S・規制近接のため 3段プロトコル経由でデプロイ。

参照: memory `project_ai_hold_escape_cab` / `project_proposal_expiry_permanent_block`

🤖 Generated with [Claude Code](https://claude.com/claude-code)