### PR TITLE
fix(risk): Base等Lido非対応chainではLido probeを回さない(ログノイズ除去)

### DIFF
--- a/backend/app/protocols/risk/protocol_monitor.py
+++ b/backend/app/protocols/risk/protocol_monitor.py
@@ -14,6 +14,24 @@ from .schemas import ProtocolHealth, RiskLevel
 
 logger = logging.getLogger(__name__)
 
+# Lido (stETH) が展開されている chain。本プロジェクトの稼働 chain である Base には
+# Lido は存在しない。Base 稼働時に Lido probe を叩くと getTotalPooledEther().call() が
+# 必ず失敗し、get_steth_eth_ratio 内の logger.exception が毎回フル traceback を吐く
+# (障害ではない無害ノイズ)。稼働 chain が Lido 非対応なら probe をそもそも回さない。
+_LIDO_SUPPORTED_CHAINS = frozenset({"mainnet", "ethereum", "holesky", "hoodi", "sepolia"})
+
+
+def _lido_supported_on_active_chain() -> bool:
+    """稼働中の chain (AAVE_ACTIVE_CHAINS) に Lido 展開 chain が含まれるか。
+
+    含まれない (例: Base 単独稼働) 場合は False。既定は "base" のため Lido 非対応。
+    """
+    import os  # noqa: PLC0415
+
+    raw = os.getenv("AAVE_ACTIVE_CHAINS", "base")
+    active = {c.strip().lower() for c in raw.split(",") if c.strip()}
+    return bool(active & _LIDO_SUPPORTED_CHAINS)
+
 
 class ProtocolMonitor:
     """各プロトコルのヘルス状態を監視するクラス。"""
@@ -157,6 +175,24 @@ class ProtocolMonitor:
         - ペグ乖離 > 2% → HIGH
         - TVL 推定: $15B
         """
+        # Base 等 Lido 非対応 chain では probe (RPC) を回さない。回すと必ず失敗して
+        # get_steth_eth_ratio が毎回フル traceback を吐くため、監視対象外として即 return。
+        # probe 失敗時と同じ安全な形 (LOW + is_operational=False) を返し、避難トリガーには
+        # ならない (2026-06-28 誤検知修正と整合)。
+        if not _lido_supported_on_active_chain():
+            logger.debug("check_lido_health: Lido は稼働 chain に未展開のため probe をスキップ")
+            return ProtocolHealth(
+                protocol="lido",
+                risk_level=RiskLevel.LOW,
+                tvl_usd=Decimal("0"),
+                tvl_change_24h_pct=Decimal("0"),
+                is_operational=False,
+                last_checked=datetime.now(tz=timezone.utc),
+                alerts=[
+                    "Lido は現在の稼働チェーンに未展開のため監視対象外です（資産への影響なし）"
+                ],
+            )
+
         logger.info("check_lido_health: Lido ヘルスチェック実行")
         alerts: list[str] = []
         risk_level = RiskLevel.LOW

--- a/backend/tests/protocols/test_risk/test_protocol_monitor.py
+++ b/backend/tests/protocols/test_risk/test_protocol_monitor.py
@@ -266,6 +266,13 @@ class TestCheckAaveHealth:
 
 
 class TestCheckLidoHealth:
+    @pytest.fixture(autouse=True)
+    def _lido_supported_chain(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # check_lido_health は Lido 展開 chain のみで probe を実行する (Base ではスキップ)。
+        # 本クラスは probe ロジック (APR / peg / probe 失敗) の検証なので、Lido 対応 chain を
+        # 明示設定して probe を必ず走らせる。
+        monkeypatch.setenv("AAVE_ACTIVE_CHAINS", "ethereum")
+
     @pytest.mark.asyncio
     async def test_lido_health_low_risk_normal(self, protocol_monitor: ProtocolMonitor) -> None:
         """正常な APR とペグのとき LOW リスクを返す。"""
@@ -459,3 +466,61 @@ class TestCheckAll:
         results = await protocol_monitor.check_all()
         protocols = {r.protocol for r in results}
         assert protocols == {"aave", "lido", "pendle"}
+
+
+class TestCheckLidoHealthChainGate:
+    """Base 等 Lido 非対応 chain では probe をそもそも回さないこと (ログノイズ対策)。"""
+
+    @pytest.mark.asyncio
+    async def test_lido_probe_skipped_on_base(
+        self,
+        mock_lido_client: AsyncMock,
+        mock_pendle_client: AsyncMock,
+        mock_monitoring_service: MagicMock,
+        mock_aave_client: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """AAVE_ACTIVE_CHAINS=base のとき probe を呼ばず、LOW + is_operational=False を返す。
+
+        Base に Lido は未展開で、probe を叩くと get_steth_eth_ratio が毎回フル traceback を
+        吐く。probe をそもそも呼ばないことを assert_not_called で検証する。
+        """
+        monkeypatch.setenv("AAVE_ACTIVE_CHAINS", "base")
+        monitor = ProtocolMonitor(
+            lido_client=mock_lido_client,
+            pendle_client=mock_pendle_client,
+            monitoring_service=mock_monitoring_service,
+            aave_client=mock_aave_client,
+        )
+        result = await monitor.check_lido_health()
+
+        assert result.protocol == "lido"
+        assert result.risk_level == RiskLevel.LOW
+        assert result.is_operational is False
+        assert "未展開" in result.alerts[0]
+        # probe (RPC) をそもそも呼んでいないこと
+        mock_lido_client.get_steth_eth_ratio.assert_not_called()
+        mock_lido_client.get_staking_apr.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_lido_probe_runs_on_ethereum(
+        self,
+        mock_lido_client: AsyncMock,
+        mock_pendle_client: AsyncMock,
+        mock_monitoring_service: MagicMock,
+        mock_aave_client: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """AAVE_ACTIVE_CHAINS=ethereum (Lido 対応) のとき probe を実行する (退行防止)。"""
+        monkeypatch.setenv("AAVE_ACTIVE_CHAINS", "ethereum")
+        monitor = ProtocolMonitor(
+            lido_client=mock_lido_client,
+            pendle_client=mock_pendle_client,
+            monitoring_service=mock_monitoring_service,
+            aave_client=mock_aave_client,
+        )
+        result = await monitor.check_lido_health()
+
+        assert result.is_operational is True
+        mock_lido_client.get_steth_eth_ratio.assert_called_once()
+        mock_lido_client.get_staking_apr.assert_called_once()


### PR DESCRIPTION
## 背景
本番(Base稼働)のログに `get_steth_eth_ratio 失敗` のフル traceback が**毎判定サイクルで多発**していた（2026-07-09 の本番AI判定調査で確認）。

Lido (stETH) は Ethereum 系 chain（mainnet/holesky 等）のみに展開されており、**Base には存在しない**。そのため `check_lido_health` が呼ぶ `get_steth_eth_ratio` の `getTotalPooledEther().call()` が必ず失敗し、client 内の `logger.exception` がフル traceback を吐いていた。**障害ではない無害ノイズ**だが、ログを汚し他の問題を埋もれさせる。避難トリガー化は #970 で既に無効化済み。

## 修正
`check_lido_health` の冒頭で、稼働 chain（`AAVE_ACTIVE_CHAINS`）に Lido 展開 chain が含まれない場合は **probe(RPC) をそもそも呼ばず即 return**。

- 返す形は probe 失敗時と**同一の安全な形**（`risk_level=LOW` / `is_operational=False` / 説明 alert）＝避難トリガーにならない（#970 と整合）。
- `_LIDO_SUPPORTED_CHAINS = {mainnet, ethereum, holesky, hoodi, sepolia}`（`lido/client.py` の `_CHAIN_ID_MAP` と一致）。
- Base 既定（`AAVE_ACTIVE_CHAINS` 既定 `"base"`）では probe をスキップ。

## テスト
- 新規 `TestCheckLidoHealthChainGate` 2本: **base → probe 未呼出**（`assert_not_called`）で LOW/not-operational、**ethereum → probe 実行**（退行防止）。
- 既存 `TestCheckLidoHealth`（probe ロジック=APR/peg/probe失敗 の検証）は Lido 対応 chain 前提のため、autouse fixture で `AAVE_ACTIVE_CHAINS=ethereum` を設定。
- `tests/protocols/` risk/compound/lido/monitor **281 passed**。ruff/format/mypy clean。

## スコープ外
- Pendle は Base 展開ありのため触らない。
- AI 判定・避難ロジックへの機能影響なし（**ログノイズ除去のみ**）。

参照: memory `project_lido_compound_risk_false_positive`（#970 の避難トリガー化無効化と対）

🤖 Generated with [Claude Code](https://claude.com/claude-code)