### PR TITLE
fix(frontend): CSVダウンロードをモバイル/アプリ内ブラウザ/iOS PWAで堅牢化

### DIFF
--- a/frontend/app/(admin)/trades/page.tsx
+++ b/frontend/app/(admin)/trades/page.tsx
@@ -15,6 +15,7 @@ import type { TxHashLinkProps } from "@/components/shared/TxHashLink";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { saveBlob } from "@/lib/saveBlob";
 import {
   Select,
   SelectContent,
@@ -77,12 +78,7 @@ function exportCsv(trades: AdminTransaction[], headers: string[]) {
   ]);
   const csv = [headers, ...rows].map((r) => r.join(",")).join("\n");
   const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = `trades-${new Date().toISOString().slice(0, 10)}.csv`;
-  a.click();
-  URL.revokeObjectURL(url);
+  void saveBlob(blob, `trades-${new Date().toISOString().slice(0, 10)}.csv`);
 }
 
 // -----------------------------------------------------------------------

--- a/frontend/app/(liff)/liff-chat/_components/panels/TaxPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TaxPanel.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react"
 import { FileDown, ChevronRight, Loader2, AlertCircle } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { getAuthToken } from "@/lib/auth/token-key"
+import { saveBlob } from "@/lib/saveBlob"
 
 type TFn = ReturnType<typeof useTranslations>
 
@@ -68,12 +69,7 @@ export function TaxPanel() {
       const ext = blob.type.includes("pdf") ? "pdf" : "csv"
       resolvedName = `${filename}.${ext}`
     }
-    const objectUrl = URL.createObjectURL(blob)
-    const link = document.createElement("a")
-    link.href = objectUrl
-    link.download = resolvedName
-    link.click()
-    URL.revokeObjectURL(objectUrl)
+    await saveBlob(blob, resolvedName)
   }
 
   function buildDownloadUrl(path: string): string {

--- a/frontend/app/(user)/history/page.tsx
+++ b/frontend/app/(user)/history/page.tsx
@@ -15,6 +15,7 @@ import { apiFetch } from '@/lib/api/client'
 import { Skeleton } from '@/components/ui/skeleton'
 import AuthGuard from '@/components/AuthGuard'
 import { getStoredToken } from '@/lib/auth'
+import { saveBlob } from '@/lib/saveBlob'
 
 // ---------------------------------------------------------------------------
 // API response types
@@ -86,12 +87,7 @@ async function downloadCryptactCsv(year: number | null): Promise<void> {
   })
   if (!res.ok) throw new Error(`CSV取得失敗: ${res.status}`)
   const blob = await res.blob()
-  const href = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = href
-  a.download = year ? `cryptact_aave_${year}.csv` : 'cryptact_aave.csv'
-  a.click()
-  URL.revokeObjectURL(href)
+  await saveBlob(blob, year ? `cryptact_aave_${year}.csv` : 'cryptact_aave.csv')
 }
 
 function HistoryPageContent() {

--- a/frontend/app/user/performance/page.tsx
+++ b/frontend/app/user/performance/page.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary'
 import { convertUSDCtoJPY, formatJPY } from '@/lib/jpy-converter'
+import { saveBlob } from '@/lib/saveBlob'
 
 const PerformanceBarChart = dynamic(() => import('./PerformanceBarChart'), { ssr: false })
 import { useAuth } from '@/lib/auth'
@@ -41,12 +42,7 @@ function MonthlyReportDownloadButton() {
       const contentDisposition = res.headers.get('Content-Disposition') ?? ''
       const filenameMatch = contentDisposition.match(/filename="([^"]+)"/)
       const filename = filenameMatch ? filenameMatch[1] : `monthly_report_${year}_${String(month).padStart(2, '0')}.csv`
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement('a')
-      a.href = url
-      a.download = filename
-      a.click()
-      URL.revokeObjectURL(url)
+      await saveBlob(blob, filename)
     } catch {
       // ダウンロード失敗時はコンソールのみ（UIは状態をリセット）
     } finally {

--- a/frontend/lib/saveBlob.ts
+++ b/frontend/lib/saveBlob.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+/**
+ * Blob を端末にファイル保存する共通ユーティリティ（モバイル / アプリ内ブラウザ / iOS PWA 堅牢版）。
+ *
+ * 背景（2026-07-09）:
+ *   各画面（TaxPanel / performance / history / trades）にコピーされていた
+ *   「anchor.download + createObjectURL」方式は、端末依存で無言失敗していた:
+ *     1. URL.revokeObjectURL を link.click() 直後に同期実行 → モバイルでは DL 処理が
+ *        非同期のため revoke が先行し、DL がキャンセルされる。
+ *     2. anchor を DOM に append せず click → 一部エンジン（iOS Safari / WebView）で発火しない。
+ *     3. LINE アプリ内ブラウザ / iOS PWA(standalone) は blob + download 属性の DL を丸ごと拒否。
+ *   → 「通常ブラウザ = 成功 / アプリ内・PWA = 失敗」という報告に一致。
+ *
+ * 対策:
+ *   (a) モバイル / standalone(PWA) では Web Share API(files) を優先し、ネイティブの
+ *       共有・保存シート経由で保存させる（アプリ内ブラウザ / iOS PWA でも動く）。
+ *   (b) それ以外（デスクトップ等）は DOM に append した anchor で download し、
+ *       revoke は十分に遅延させて click の非同期 DL 処理との race を避ける。
+ *   デスクトップの挙動は従来どおり（Web Share は使わない）に保つ。
+ */
+export async function saveBlob(blob: Blob, filename: string): Promise<void> {
+  const nav = navigator as Navigator & {
+    canShare?: (data?: { files?: File[] }) => boolean
+    share?: (data?: { files?: File[]; title?: string }) => Promise<void>
+  }
+
+  // standalone(PWA) or モバイル UA のときのみ Web Share を優先する（デスクトップ挙動は不変）。
+  const preferShare =
+    (typeof window !== 'undefined' &&
+      window.matchMedia?.('(display-mode: standalone)')?.matches === true) ||
+    /iphone|ipad|ipod|android/i.test(navigator.userAgent || '')
+
+  if (preferShare && typeof nav.canShare === 'function' && typeof nav.share === 'function') {
+    try {
+      const file = new File([blob], filename, { type: blob.type || 'text/csv' })
+      if (nav.canShare({ files: [file] })) {
+        await nav.share({ files: [file], title: filename })
+        return
+      }
+    } catch {
+      // 共有非対応 / ユーザーキャンセル / user-gesture 失効 → 下の anchor 方式へフォールバック。
+    }
+  }
+
+  // デスクトップ / 対応ブラウザ: DOM に append した anchor で download。
+  const objectUrl = URL.createObjectURL(blob)
+  try {
+    const link = document.createElement('a')
+    link.href = objectUrl
+    link.download = filename
+    link.rel = 'noopener'
+    link.style.display = 'none'
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  } finally {
+    // click 後の DL 処理は非同期で走るため、revoke は十分に遅延させる（race による DL 中断を回避）。
+    setTimeout(() => URL.revokeObjectURL(objectUrl), 10_000)
+  }
+}


### PR DESCRIPTION
## 背景
テスターが **v4 staging (PWA / LINE) で CSV をダウンロードできない**という報告。ユーザーのモバイル(通常ブラウザ)では成功。Chrome 実機 + curl で切り分け:

| 層 | 結果 |
|---|---|
| バックエンド `/api/proposals/tax/cryptact-csv` | ✅ **200**・正しいCSV(BOM+ヘッダ)を返す |
| デスクトップChrome(/liff-chat→TAX&REPORTS→Cryptact CSV) | ✅ fetch **200**・成功(=ユーザーのモバイルと同じ) |
| staging-v4データ | executed提案0件=CSVはヘッダのみ(でも200でDLされる。データ不足が原因ではない) |

→ 原因は **client 側の blob ダウンロード方式**。各画面にコピーされていた `anchor.download + createObjectURL` 方式に、端末依存で無言失敗する弱点が3つあった。

## 根本原因(4画面共通の同一バグ)
1. **`URL.revokeObjectURL` を `link.click()` 直後に同期実行** → モバイルでは DL 処理が非同期のため revoke が先行して DL がキャンセルされる
2. **anchor を DOM に append せず `.click()`** → 一部エンジン(iOS Safari / WebView)で発火しない
3. **LINE アプリ内ブラウザ / iOS PWA(standalone) は blob+download 属性の DL を丸ごと拒否**

「通常ブラウザ=成功 / アプリ内・PWA=失敗」に完全に整合。

## 修正
共通ユーティリティ `frontend/lib/saveBlob.ts` を新設し、4画面(`TaxPanel` / `performance` / `history` / `trades`)の重複 DL コードを集約・堅牢化:
- **モバイル / standalone(PWA)** では **Web Share API(files)** を優先 → ネイティブの共有・保存シートで保存(アプリ内ブラウザ / iOS PWA でも動く)。非対応・キャンセル・gesture失効時は anchor へフォールバック
- それ以外は **DOM に append した anchor** で download し、**revoke を 10s 遅延**(click の非同期DLとの race を回避)
- **デスクトップの挙動は従来どおり不変**(Web Share はモバイル/PWA 限定でゲート)

## 検証
- `tsc --noEmit` **exit 0 / error 0**
- Chrome 実機で happy path(fetch 200)を確認・デスクトップ経路は不変
- **モバイル / webView 経路(テスター再現環境)の最終確認は staging-v4 反映後に実機で**

## スコープ
バックエンド・データは正常。**フロントの DL 方式のみ**の修正。同じバグを持っていた 4 画面すべてを共通化で解消。

🤖 Generated with [Claude Code](https://claude.com/claude-code)