### PR TITLE
feat(fees): 月額徴収を撤廃(当面無料)・徴収UIを既定非表示(可逆)

### DIFF
--- a/frontend/app/(liff)/liff-fee-approve/page.tsx
+++ b/frontend/app/(liff)/liff-fee-approve/page.tsx
@@ -11,6 +11,7 @@ import { useLiff } from '@/hooks/useLiff'
 import { FeeApproveCard } from '@/components/user/FeeApproveCard'
 import { StripePaymentMethodCard } from '@/components/user/StripePaymentMethodCard'
 import FeePlanSection from '@/components/user/FeePlanSection'
+import { isFeeCollectionEnabled } from '@/lib/flags'
 import { BrowserLoginPrompt } from '../_components/BrowserLoginPrompt'
 
 export default function LiffFeeApprovePage() {
@@ -68,11 +69,17 @@ export default function LiffFeeApprovePage() {
       <div className="mb-4">
         <FeePlanSection />
       </div>
-      {/* F-7: サブスク月額分はクレカ(Stripe)で回収。成功報酬+yield超過分はon-chainで回収(下記)。 */}
-      <div className="mb-4">
-        <StripePaymentMethodCard />
-      </div>
-      <FeeApproveCard />
+      {/* 月額徴収撤廃（2026-07-09・当面無料）により、カード登録(Stripe)+on-chain allowance 承認の
+          徴収UIは既定で非表示。徴収を再開する場合のみ isFeeCollectionEnabled で表示する。 */}
+      {isFeeCollectionEnabled() && (
+        <>
+          {/* F-7: サブスク月額分はクレカ(Stripe)で回収。成功報酬+yield超過分はon-chainで回収(下記)。 */}
+          <div className="mb-4">
+            <StripePaymentMethodCard />
+          </div>
+          <FeeApproveCard />
+        </>
+      )}
     </div>
   )
 }

--- a/frontend/app/(user)/fee-approve/page.tsx
+++ b/frontend/app/(user)/fee-approve/page.tsx
@@ -8,6 +8,7 @@
 
 import dynamic from 'next/dynamic'
 import FeePlanSection from '@/components/user/FeePlanSection'
+import { isFeeCollectionEnabled } from '@/lib/flags'
 
 const FeeApproveCard = dynamic(
   () => import('@/components/user/FeeApproveCard').then((m) => ({ default: m.FeeApproveCard })),
@@ -33,9 +34,15 @@ export default function FeeApprovePage() {
       </div>
       {/* B-3: 承認前に料率・課金日・「現在は徴収なし」を提示（孤立していた本ページに文脈を付与） */}
       <FeePlanSection />
-      {/* F-7: サブスク月額分はクレカ(Stripe)で回収。成功報酬+yield超過分はon-chainで回収(下記)。 */}
-      <StripePaymentMethodCard />
-      <FeeApproveCard />
+      {/* 月額徴収撤廃（2026-07-09・当面無料）により、カード登録(Stripe)+on-chain allowance 承認の
+          徴収UIは既定で非表示。徴収を再開する場合のみ isFeeCollectionEnabled で表示する。 */}
+      {isFeeCollectionEnabled() && (
+        <>
+          {/* F-7: サブスク月額分はクレカ(Stripe)で回収。成功報酬+yield超過分はon-chainで回収(下記)。 */}
+          <StripePaymentMethodCard />
+          <FeeApproveCard />
+        </>
+      )}
     </main>
   )
 }

--- a/frontend/components/user/FeePlanSection.tsx
+++ b/frontend/components/user/FeePlanSection.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { apiFetch } from '@/lib/api/client'
+import { isFeeCollectionEnabled } from '@/lib/flags'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 
@@ -141,8 +142,9 @@ export default function FeePlanSection({ showPaymentLink = false }: { showPaymen
           <p className="text-xs text-amber-400/90">{t('notActiveNote')}</p>
         </div>
 
-        {/* 決済手段（自動引き落とし = operator allowance 承認）への導線。/fees からのみ表示。 */}
-        {showPaymentLink && (
+        {/* 決済手段（自動引き落とし = operator allowance 承認）への導線。/fees からのみ表示。
+            月額徴収撤廃（2026-07-09・当面無料）により既定で非表示。isFeeCollectionEnabled で gate。 */}
+        {showPaymentLink && isFeeCollectionEnabled() && (
           <Link
             href="/fee-approve"
             className="block w-full text-center rounded-lg border border-zinc-700 bg-zinc-800/60 px-3 py-2.5 text-sm text-zinc-200 hover:bg-zinc-800 transition-colors"

--- a/frontend/lib/flags.ts
+++ b/frontend/lib/flags.ts
@@ -61,3 +61,19 @@ export function isAutoModeEnabled(): boolean {
 export function isReferralEnabled(): boolean {
   return process.env.NEXT_PUBLIC_REFERRAL_ENABLED === 'true'
 }
+
+/**
+ * 手数料（月額利用料）の徴収 UI を表示するか。
+ *
+ * 既定 false。2026-07-09 に「月額徴収自体を撤廃・当面無料（収益モデルなし）」と決定
+ * （hkobayashi）。徴収 UI（Stripe カード登録 / on-chain allowance 承認 / 支払い方法設定
+ * への導線）はこのフラグで gate し、既定で非表示にする。
+ *
+ * バックエンド側の徴収も既定 OFF（`ENABLE_MONTHLY_FEE_BATCH` 既定 0 /
+ * `FEE_TRANSFER_ENABLED` 既定 false）。将来、料率・法務・決済が整い徴収を再開する場合は、
+ * env `NEXT_PUBLIC_FEE_COLLECTION_ENABLED=true` + フロント再ビルド + バックエンド徴収フラグ
+ * を同時に有効化する（code-ready-behind-flag）。コードは残置＝可逆。
+ */
+export function isFeeCollectionEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_FEE_COLLECTION_ENABLED === 'true'
+}


### PR DESCRIPTION
## 決定（2026-07-09 hkobayashi）
**月額徴収自体を撤廃し、当面無料（収益モデルなし）。** 範囲=**徴収OFF + ユーザー向け徴収UIを既定非表示**、コードは残置＝可逆。

## 現状（徴収の実態）
| 環境 | 徴収 |
|---|---|
| 本番 5.223.88.14 | `ENABLE_MONTHLY_FEE_BATCH` 未設定=OFF / `FEE_TRANSFER_ENABLED` 既定false → **元々徴収していない**（phase1確認済） |
| staging-v4 | `=1` / `true`（テスト環境のみ） |

## 変更（frontend・flag gate）
- `lib/flags.ts` に **`isFeeCollectionEnabled()`（既定 false）** を追加（既存の code-ready-behind-flag パターン）。
- **徴収UIの実体を gate（既定非表示）**：
  - `FeePlanSection` の「お支払い方法を設定する」リンク（`/fee-approve` への導線）
  - `/fee-approve` と `/liff-fee-approve` の **`StripePaymentMethodCard`（カード登録）＋ `FeeApproveCard`（on-chain allowance 承認）**
- `FeePlanSection` の料金プラン表示＋**「現在無料」注記**（`notActiveNote`）は情報提供として残置。
- 再開時は env `NEXT_PUBLIC_FEE_COLLECTION_ENABLED=true` ＋ 再ビルド ＋ backend 徴収フラグを同時 ON。

## 検証
- `tsc --noEmit` **exit 0 / error 0**
- 徴収UI（Stripe/FeeApprove）は上記2ページのみ・**両方 gate 済み**（grep で漏れ無し確認）。liff-confirm はコメントのみ（実UIなし）。

## スコープ外（別トラック）
- **backend 徴収**は既定 OFF のためコード変更不要。**staging-v4 env の OFF 化**は ops（別途）。
- **terms 同意項目「月額利用料・成功報酬に同意します」**（規約 ver05 / 第7条）の扱いは**法務判断**（別途）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)