### PR TITLE
feat(pendle): Phase-D D2 — Pendle BUY_PT dry-run calldata構築(broadcastなし)

### DIFF
--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -657,19 +657,108 @@ def _execute_lido_for_proposal(proposal: Proposal, db: Session) -> None:
     )
 
 
-def _execute_pendle_for_proposal(proposal: Proposal, db: Session) -> None:
-    """[Phase D / HUMAN-REVIEW 未配線] Pendle BUY_PT/SELL_PT の custodial 実行。
+class PendleDryRunNotBroadcast(ProtocolExecutionNotWiredError):
+    """[Phase D / D2] Pendle BUY_PT の calldata を dry-run 構築したが broadcast は未配線。
 
-    実装方針 (HUMAN-REVIEW + Opus で配線すること):
-      1. PendleService/RouterV4 で swap calldata 取得 (dry_run=True は安全・本番前確認用)
-      2. PENDLE_ENABLE_ONCHAIN_WRITE=true かつ dry_run=False で broadcast (要レビュー)
-      3. receipt 確認 → proposal.status='executed' / tx_hash 保存
-
-    現状は実 broadcast を含まないため未配線として明示的に raise する。
+    D2 では未署名 tx (swapExactTokenForPt calldata) を **構築するのみ** で、実 broadcast は
+    D3 (非カストSCW/Privy 本人署名) で配線する。構築成功後もこの例外を送出することで、caller は
+    proposal を 'approved' 据え置き (501) にし、Aave として誤実行しない (fail-closed 契約は不変)。
+    ``ProtocolExecutionNotWiredError`` の subclass のため既存の 501 ハンドリングを踏襲する。
     """
-    raise ProtocolExecutionNotWiredError(
-        f"Pendle (proposal={proposal.id}, op={proposal.operation}) の custodial 自動執行は "
-        "未配線です (HUMAN-REVIEW-REQUIRED)。"
+
+
+def _execute_pendle_for_proposal(proposal: Proposal, db: Session) -> None:
+    """[Phase D / D2] Pendle BUY_PT の自動執行 = dry-run calldata 構築 (broadcast なし)。
+
+    stablecoin PT (yoUSD 等・token_in=USDC≒1USD) 向けに RouterV4 Hosted SDK で
+    swapExactTokenForPt の未署名 tx を **構築するのみ** で broadcast しない。構築できたら
+    ``PendleDryRunNotBroadcast`` を送出し、proposal は 'approved' のまま (501)。実 broadcast
+    (partner 本人署名) は D3 で配線する (HUMAN-REVIEW-REQUIRED)。
+
+    非カストディアル不変: サーバー鍵 (``PENDLE_WALLET_PRIVATE_KEY``) は一切参照せず、PT は
+    partner 本人 wallet (SCW 優先) に着金する未署名 tx を組む。SDK calldata の宛先が Router で
+    あることは ``build_buy_pt_tx`` 内で照合する (fail-closed)。
+
+    amount: stablecoin PT のみ token_in=USDC(≒1USD) のため ``proposal.amount_usd`` をそのまま
+    USDC 数量として扱える (Lido/ETH のような USD→token 価格換算が不要)。非 stablecoin market は
+    ``PENDLE_STABLE_UNDERLYING=false`` (既定) で fail-closed 拒否し、誤数量署名を防ぐ。
+    """
+    if (proposal.operation or "").upper() != "BUY_PT":
+        raise ProtocolExecutionNotWiredError(
+            f"Pendle は BUY_PT のみ自動執行対応です "
+            f"(proposal={proposal.id}, op={proposal.operation})。"
+        )
+
+    from app.protocols.pendle.client import (  # noqa: PLC0415
+        PendleBuildTxError,
+        get_pendle_router_v4_client,
+    )
+    from app.protocols.pendle.config import get_pendle_config  # noqa: PLC0415
+
+    config = get_pendle_config()
+
+    # stablecoin PT 以外は USD→token 換算が未配線のため fail-closed (誤数量署名防止)。
+    if not config.stable_underlying:
+        raise ProtocolExecutionNotWiredError(
+            f"Pendle proposal={proposal.id}: 非 stablecoin market の USD→token 換算が未配線 "
+            "(PENDLE_STABLE_UNDERLYING=false)。誤数量署名防止のため fail-closed (HUMAN-REVIEW)。"
+        )
+
+    # 受取/署名者 wallet (SCW 優先。build_partner_tx と同型)。
+    user = db.get(UserModel, proposal.user_id)
+    wallet_address = ""
+    if user is not None:
+        wallet_address = (user.smart_wallet_address or user.wallet_address or "") or ""
+    if not wallet_address:
+        raise ProtocolExecutionNotWiredError(
+            f"Pendle proposal={proposal.id}: wallet 未設定のため未署名 tx を構築できません "
+            "(Privy で wallet を作成してください)。"
+        )
+
+    # stablecoin PT: token_in=USDC(≒1USD) のため amount_usd をそのまま USDC 数量に使う。
+    amount_in = Decimal(str(proposal.amount_usd))
+    if amount_in <= 0:
+        raise ProtocolExecutionNotWiredError(
+            f"Pendle proposal={proposal.id}: amount_usd が 0 以下です (amount={amount_in})。"
+        )
+
+    try:
+        client = get_pendle_router_v4_client(config)
+        unsigned_tx = asyncio.run(
+            client.build_buy_pt_tx(
+                market_address=config.market_address,
+                token_in=config.underlying_token_address,
+                amount_in=amount_in,
+                from_address=wallet_address,
+                token_in_decimals=config.underlying_token_decimals,
+            )
+        )
+    except PendleBuildTxError as exc:
+        # calldata 取得失敗 / Router 不一致は fail-closed。broadcast しない。
+        raise ProtocolExecutionNotWiredError(
+            f"Pendle proposal={proposal.id}: dry-run calldata 構築失敗: {exc}"
+        ) from exc
+    except Exception as exc:  # noqa: BLE001
+        raise ProtocolExecutionNotWiredError(
+            f"Pendle proposal={proposal.id}: dry-run calldata 構築失敗: {exc}"
+        ) from exc
+
+    _to = str(unsigned_tx.get("to", "") or "")
+    _data = str(unsigned_tx.get("data", "") or "")
+    _data_bytes = (len(_data) - 2) // 2 if _data.startswith("0x") else 0
+    logger.info(
+        "proposal %d: Pendle BUY_PT dry-run calldata 構築成功 — to=%s data_bytes=%d chainId=%s "
+        "amount_usdc=%s (broadcast は D3 で配線 / HUMAN-REVIEW)",
+        proposal.id,
+        _to,
+        _data_bytes,
+        unsigned_tx.get("chainId"),
+        amount_in,
+    )
+    raise PendleDryRunNotBroadcast(
+        f"Pendle proposal={proposal.id}: dry-run calldata 構築成功 (to={_to}, "
+        f"data_bytes={_data_bytes})。実 broadcast は D3 (非カストSCW/Privy 署名) で配線 "
+        "(HUMAN-REVIEW-REQUIRED)。"
     )
 
 

--- a/backend/app/protocols/pendle/client.py
+++ b/backend/app/protocols/pendle/client.py
@@ -426,6 +426,8 @@ class PendleRouterV4Client:
         "ethereum": 1,
         "polygon": 137,
         "sepolia": 421614,  # Arbitrum Sepolia
+        "base": 8453,  # [Phase D] Base Mainnet (yoUSD stablecoin PT)
+        "base_sepolia": 84532,  # [Phase D] Base Sepolia (staging-v4 検証)
     }
 
     def __init__(

--- a/backend/app/protocols/pendle/config.py
+++ b/backend/app/protocols/pendle/config.py
@@ -44,6 +44,19 @@ class PendleConfig:
             "0x0000000000000000000000000000000000000003",  # dummy address
         )
     )
+    # 入力トークン (underlying) の decimals。stablecoin PT では USDC=6 を明示する。
+    # underlying_token_address は *アドレス* のため token_decimals(symbol) では解決できず、
+    # 明示しないと 18 に既定化して桁ズレ（USDC で 10^12 倍）を起こす。
+    underlying_token_decimals: int = field(
+        default_factory=lambda: int(os.getenv("PENDLE_UNDERLYING_TOKEN_DECIMALS", "6"))
+    )
+    # 入力トークンが USD ペッグの stablecoin (USDC 等) か。True の場合のみ proposal.amount_usd
+    # をそのまま入力トークン数量として扱う (1 USDC≒1 USD)。False (既定) は USD→token 価格換算が
+    # 未配線のため自動執行を fail-closed で拒否する (ETH や非ステーブル PT の誤数量署名防止)。
+    # [Phase D] yoUSD 等 stablecoin PT market を対象にする環境でのみ true を設定する。
+    stable_underlying: bool = field(
+        default_factory=lambda: os.getenv("PENDLE_STABLE_UNDERLYING", "false").lower() == "true"
+    )
     # RPC エンドポイント（Arbitrum Sepolia）
     rpc_url: str = field(
         default_factory=lambda: os.getenv(

--- a/backend/tests/test_pendle_dry_run_execution.py
+++ b/backend/tests/test_pendle_dry_run_execution.py
@@ -1,0 +1,200 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_pendle_dry_run_execution.py
+"""[Phase D / D2] Pendle BUY_PT の dry-run calldata 構築 (_execute_pendle_for_proposal)。
+
+RouterV4 Hosted SDK で swapExactTokenForPt の未署名 tx を **構築するのみ** で broadcast
+しないことを保証する。構築できたら ``PendleDryRunNotBroadcast`` を送出し proposal は
+'approved' 据え置き (501)。stablecoin PT (USDC 入力) のみ許可し、非 stablecoin / wallet
+未設定 / BUY_PT 以外は fail-closed で拒否する (誤数量署名防止)。
+"""
+
+import os
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-pendle-dryrun")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "admin@example.com")
+
+import app.proposals.router as router_mod  # noqa: E402
+import app.protocols.pendle.client as pendle_client_mod  # noqa: E402
+import app.protocols.pendle.config as pendle_config_mod  # noqa: E402
+from app.proposals.router import (  # noqa: E402
+    PendleDryRunNotBroadcast,
+    ProtocolExecutionNotWiredError,
+    _execute_pendle_for_proposal,
+)
+from app.protocols.pendle.client import PendleBuildTxError  # noqa: E402
+from app.protocols.pendle.config import PendleConfig  # noqa: E402
+
+_ROUTER = "0x888888888889758F76e7103c6CbF23ABbF58F946"
+_MARKET = "0x1111111111111111111111111111111111111111"  # yoUSD market (stub)
+_USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"  # Base USDC
+_WALLET = "0x7f9300000000000000000000000000000000a0Ff"
+
+
+def _mk_proposal(operation: str = "BUY_PT", amount_usd: object = Decimal("100.00")) -> MagicMock:
+    p = MagicMock()
+    p.id = 42
+    p.protocol = "pendle"
+    p.operation = operation
+    p.amount_usd = amount_usd
+    p.user_id = 11
+    return p
+
+
+def _mk_db(wallet: object = _WALLET, smart: object = None) -> MagicMock:
+    db = MagicMock()
+    user = MagicMock()
+    user.wallet_address = wallet
+    user.smart_wallet_address = smart
+    db.get.return_value = user
+    return db
+
+
+class _FakeRouterClient:
+    """build_buy_pt_tx が呼ばれた引数を記録する async スタブ。"""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.raise_exc: Exception | None = None
+
+    async def build_buy_pt_tx(self, **kwargs: object) -> dict[str, object]:
+        self.calls.append(kwargs)
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        return {
+            "to": _ROUTER,
+            "data": "0x" + "ab" * 100,  # 100 bytes calldata
+            "from": kwargs["from_address"],
+            "chainId": 8453,
+            "value": "0x0",
+        }
+
+
+def _patch_pendle(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    stable: bool = True,
+    fake: _FakeRouterClient | None = None,
+) -> _FakeRouterClient:
+    config = PendleConfig(
+        market_address=_MARKET,
+        underlying_token_address=_USDC,
+        underlying_token_decimals=6,
+        stable_underlying=stable,
+    )
+    monkeypatch.setattr(pendle_config_mod, "get_pendle_config", lambda: config)
+    client = fake if fake is not None else _FakeRouterClient()
+    monkeypatch.setattr(pendle_client_mod, "get_pendle_router_v4_client", lambda cfg: client)
+    return client
+
+
+def test_dry_run_builds_calldata_and_raises_not_broadcast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BUY_PT + stablecoin + wallet 設定 → calldata 構築し PendleDryRunNotBroadcast 送出。"""
+    client = _patch_pendle(monkeypatch)
+    with pytest.raises(PendleDryRunNotBroadcast):
+        _execute_pendle_for_proposal(_mk_proposal(), _mk_db())
+
+    # build_buy_pt_tx が stablecoin (USDC=6桁) の正しい引数で 1 回だけ呼ばれた。
+    assert len(client.calls) == 1
+    call = client.calls[0]
+    assert call["market_address"] == _MARKET
+    assert call["token_in"] == _USDC
+    assert call["amount_in"] == Decimal("100.00")  # amount_usd をそのまま USDC 数量に
+    assert call["from_address"] == _WALLET
+    assert call["token_in_decimals"] == 6  # USDC 桁ズレ防止
+
+
+def test_dry_run_prefers_smart_wallet_address(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SCW ユーザーは smart_wallet_address を署名者/着金先にする。"""
+    client = _patch_pendle(monkeypatch)
+    smart = "0xSMART00000000000000000000000000000000cafe"
+    with pytest.raises(PendleDryRunNotBroadcast):
+        _execute_pendle_for_proposal(_mk_proposal(), _mk_db(wallet=_WALLET, smart=smart))
+    assert client.calls[0]["from_address"] == smart
+
+
+def test_dry_run_is_subclass_of_not_wired(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PendleDryRunNotBroadcast は ProtocolExecutionNotWiredError の subclass (501 踏襲)。"""
+    _patch_pendle(monkeypatch)
+    with pytest.raises(ProtocolExecutionNotWiredError):
+        _execute_pendle_for_proposal(_mk_proposal(), _mk_db())
+
+
+def test_non_buy_pt_operation_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BUY_PT 以外は SDK を呼ばず ProtocolExecutionNotWiredError で拒否。"""
+    client = _patch_pendle(monkeypatch)
+    with pytest.raises(ProtocolExecutionNotWiredError) as exc:
+        _execute_pendle_for_proposal(_mk_proposal(operation="SUPPLY"), _mk_db())
+    assert not isinstance(exc.value, PendleDryRunNotBroadcast)
+    assert client.calls == []
+
+
+def test_non_stable_underlying_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """非 stablecoin market は USD→token 換算未配線のため SDK を呼ばず拒否 (誤数量署名防止)。"""
+    client = _patch_pendle(monkeypatch, stable=False)
+    with pytest.raises(ProtocolExecutionNotWiredError):
+        _execute_pendle_for_proposal(_mk_proposal(), _mk_db())
+    assert client.calls == []
+
+
+def test_missing_wallet_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """wallet 未設定は未署名 tx を組めないため SDK を呼ばず拒否。"""
+    client = _patch_pendle(monkeypatch)
+    with pytest.raises(ProtocolExecutionNotWiredError):
+        _execute_pendle_for_proposal(_mk_proposal(), _mk_db(wallet="", smart=None))
+    assert client.calls == []
+
+
+def test_non_positive_amount_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """amount_usd<=0 は拒否。"""
+    _patch_pendle(monkeypatch)
+    with pytest.raises(ProtocolExecutionNotWiredError):
+        _execute_pendle_for_proposal(_mk_proposal(amount_usd=Decimal("0")), _mk_db())
+
+
+def test_build_failure_raises_not_wired(monkeypatch: pytest.MonkeyPatch) -> None:
+    """calldata 取得失敗 (Router 不一致等) は握りつぶさず fail-closed で 501 相当。"""
+    fake = _FakeRouterClient()
+    fake.raise_exc = PendleBuildTxError("router address mismatch")
+    _patch_pendle(monkeypatch, fake=fake)
+    with pytest.raises(ProtocolExecutionNotWiredError) as exc:
+        _execute_pendle_for_proposal(_mk_proposal(), _mk_db())
+    # dry-run 成功シグナルではなく素の未配線エラー (broadcast されていない)。
+    assert not isinstance(exc.value, PendleDryRunNotBroadcast)
+
+
+def test_dry_run_never_calls_aave(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pendle dry-run は Aave 経路を絶対に呼ばない (誤実行防止)。"""
+    _patch_pendle(monkeypatch)
+
+    def _must_not_run(p: object, db: object) -> None:
+        raise AssertionError("Pendle 提案で Aave 経路を実行してはならない")
+
+    monkeypatch.setattr(router_mod, "_execute_aave_for_proposal", _must_not_run)
+    with pytest.raises(PendleDryRunNotBroadcast):
+        _execute_pendle_for_proposal(_mk_proposal(), _mk_db())
+
+
+@pytest.mark.parametrize(
+    ("chain", "expected_chain_id"),
+    [
+        ("base", 8453),
+        ("base_sepolia", 84532),
+        ("arbitrum", 42161),
+    ],
+)
+def test_chain_id_map_includes_base(chain: str, expected_chain_id: int) -> None:
+    """RouterV4Client が Base / Base Sepolia の chainId を正しく解決する。
+
+    map に無いと 42161 (Arbitrum) に既定化し、Base 向け calldata を Arbitrum で組む事故になる。
+    """
+    from app.protocols.pendle.client import PendleRouterV4Client
+
+    config = PendleConfig(chain=chain)
+    client = PendleRouterV4Client(config)
+    assert client._chain_id == expected_chain_id


### PR DESCRIPTION
## 概要 (Phase-D D2)

aggressive tier (yoUSD stablecoin PT / Base) 実運用配線の第一スライス。
`_execute_pendle_for_proposal` の `raise ProtocolExecutionNotWiredError` を **dry-run 実装** に置換する。

RouterV4 Hosted SDK で `swapExactTokenForPt` の未署名 tx を **構築するのみ**で broadcast しない。構築成功時は `PendleDryRunNotBroadcast`(`ProtocolExecutionNotWiredError` の subclass)を送出し、proposal は `approved` 据え置き(既存の 501 ハンドリング踏襲)。実 broadcast(partner 本人署名)は **D3** で配線する。

## 設計の核

- **yoUSD = stablecoin PT** のため token_in=USDC(1 USDC≒1 USD)。`proposal.amount_usd` をそのまま USDC 数量に使え、Lido/ETH を止めている USD→token 価格換算ブロッカー(`_resolve_onchain_token_amount` → 501)を回避できる。これが D1 で stablecoin PT を選んだ理由。
- 非 stablecoin market は `PENDLE_STABLE_UNDERLYING=false`(既定)で **fail-closed 拒否**(誤数量署名防止)。
- **非カストディアル不変**: サーバー鍵不参照・PT は partner 本人(SCW 優先)着金。SDK calldata の宛先=Router 照合は `build_buy_pt_tx` 内で維持。

## 変更

| ファイル | 変更 |
|---|---|
| `proposals/router.py` | `_execute_pendle_for_proposal` dry-run 実装 + `PendleDryRunNotBroadcast` 追加 |
| `protocols/pendle/client.py` | `_CHAIN_ID_MAP` に `base`(8453)/`base_sepolia`(84532) 追加(無いと Arbitrum に誤既定化) |
| `protocols/pendle/config.py` | `underlying_token_decimals`(USDC=6) + `stable_underlying` フラグ |
| `tests/test_pendle_dry_run_execution.py` | 新規 12 件(calldata 構築・fail-closed 各種・chainId 解決) |

## fail-closed 分岐(いずれも broadcast せず 501 相当)
BUY_PT 以外 / `stable_underlying=false` / wallet 未設定 / amount_usd≤0 / SDK 構築失敗(Router 不一致等)

## DoD
- [x] ruff check / format — 対象ファイル pass
- [x] mypy — 対象 3 ファイル pass(既存 `stripe` stub 警告は本 PR 無関係)
- [x] pytest — `test_pendle_dry_run_execution.py` 12 件 + pendle/proposal 網羅 **580 passed**
- [x] broadcast / 本番 DB write / 秘密鍵参照 / 依存追加 **なし**(Tier-B 安全スライス)

## スコープ外(後続)
D3=非カストSCW/Privy 署名で実 broadcast配線 / D4=redeem / D5=流動性ガード+routing+同意UI / D6=本番反映(3段プロトコル+Opus安全レビュー)

Closes: https://app.asana.com/1/817733952351708/project/1213741124336104/task/1216418515401737

🤖 Generated with [Claude Code](https://claude.com/claude-code)