### PR TITLE
feat(pendle): Phase-D D3 — Pendle USDC→PT swap を SCW/Privy委譲署名でbroadcast配線 (既定OFF/dormant)

### DIFF
--- a/backend/app/privy/policy_mapper.py
+++ b/backend/app/privy/policy_mapper.py
@@ -47,9 +47,10 @@ _ACTION_ALLOW = "ALLOW"
 # 委譲経路が署名する method（UserOp 署名 = 経路A の本丸 / 直 tx も許容）
 _DELEGATED_METHODS = ("eth_signUserOperation", "eth_sendTransaction")
 
-# 委譲可能なプロトコル → コントラクト解決関数（Phase 2-D は Aave のみ）。
-# Lido / Pendle はコントラクトレジストリ未整備のため Phase 3（マルチプロトコル executor）で追加する。
-_SUPPORTED_PROTOCOLS: frozenset[str] = frozenset({"aave"})
+# 委譲可能なプロトコル → コントラクト解決関数。
+# Aave: V3 Pool。Pendle [Phase D / D3]: RouterV4 + underlying(USDC)（approve 宛先）。
+# Lido はレジストリ未整備のため後続で追加する。
+_SUPPORTED_PROTOCOLS: frozenset[str] = frozenset({"aave", "pendle"})
 
 
 class PolicyMappingError(ValueError):
@@ -80,6 +81,21 @@ def resolve_protocol_contracts(allowed_protocols: list[str], chain_name: str) ->
             addr = config.pool_address.lower()
             if addr not in contracts:
                 contracts.append(addr)
+        elif protocol == "pendle":
+            # [Phase D / D3] Pendle swap は RouterV4 宛（swap）+ underlying(USDC) 宛（approve）の
+            # 2 コントラクトを allowlist する必要がある（batch: approve → swap）。両方を追加しないと
+            # Privy policy が approve tx を拒否する。アドレスは PendleConfig（env）から取得する。
+            from app.protocols.pendle.config import get_pendle_config  # noqa: PLC0415
+
+            pconf = get_pendle_config()
+            for addr in (pconf.router_address, pconf.underlying_token_address):
+                if not addr:
+                    raise PolicyMappingError(
+                        "Pendle router_address / underlying_token_address が未設定です"
+                    )
+                low = addr.lower()
+                if low not in contracts:
+                    contracts.append(low)
     return contracts
 
 

--- a/backend/app/proposals/pendle_scw.py
+++ b/backend/app/proposals/pendle_scw.py
@@ -1,0 +1,92 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/app/proposals/pendle_scw.py
+"""[Phase D / D3] Pendle BUY_PT swap を ERC-5792 calls に変換する（委譲 SCW 経路）。
+
+RouterV4 Hosted SDK が返す swap 結果（``RouterV4SwapResult``: swap calldata + 必要な ERC20
+``approvals``）を、``scw_executor.execute_calls_via_scw`` が受け取る ``[{to,value,data}]`` 形式に
+変換する。``scw_executor.build_supply_calls``（Aave 版）の Pendle 相当。
+
+- approve → swap の順を保持して batch する（SCW が 1 UserOp で実行）。
+- approve calldata は web3 v7 ``Contract.encode_abi("approve", args=[spender, amount])`` で
+  オフライン生成する（``app/aave/client.py`` の ``build_deposit_txs`` を踏襲・provider 不要）。
+- spender は必ず SDK approvals の値を使い、swap の宛先 Router（``result.to``・SDK 側で Router
+  照合済）と一致することを検証する（不一致は fail-closed）。
+- approvals 欠損 / calldata 欠損 / spender 不一致は例外（空 tx・任意宛先送信の温床を断つ）。
+
+本 module は web3 encode（純関数）のみで、Privy 送信・秘密鍵・broadcast は一切行わない。
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from web3 import Web3
+
+from app.aave.client import _ERC20_ABI_MINIMAL
+from app.protocols.pendle.schemas import RouterV4SwapResult
+
+logger = logging.getLogger(__name__)
+
+
+class PendleScwCallsError(RuntimeError):
+    """Pendle swap を ERC-5792 calls に変換できない（fail-closed）。"""
+
+
+def _encode_approve(token: str, spender: str, amount_raw: str) -> str:
+    """ERC20 ``approve(spender, amount)`` calldata をオフライン生成する（web3 v7）。"""
+    w3 = Web3()  # provider 不要: encode_abi は純粋なオフライン ABI エンコード
+    token_contract = w3.eth.contract(
+        address=Web3.to_checksum_address(token),
+        abi=_ERC20_ABI_MINIMAL,
+    )
+    data: str = token_contract.encode_abi(
+        "approve",
+        args=[Web3.to_checksum_address(spender), int(amount_raw)],
+    )
+    return data
+
+
+def build_pendle_swap_calls(result: RouterV4SwapResult) -> list[dict[str, Any]]:
+    """``RouterV4SwapResult`` を ERC-5792 calls（approve(s) → swap）に変換する。
+
+    各 call は ``{to, value, data}`` のみ（from/nonce/gas は SCW/bundler が決める）。
+
+    Raises:
+        PendleScwCallsError: swap 失敗 / calldata・宛先欠損 / approval 情報欠損 /
+            spender が swap 宛先 Router と不一致。
+    """
+    if not result.success:
+        raise PendleScwCallsError(f"swap result not successful: {result.error or 'unknown'}")
+    router_to = result.to
+    if not router_to or not result.calldata:
+        raise PendleScwCallsError("swap result missing to/calldata")
+
+    router_cs = Web3.to_checksum_address(router_to)
+    calls: list[dict[str, Any]] = []
+    for approval in result.approvals:
+        if not approval.token or not approval.spender or approval.amount is None:
+            raise PendleScwCallsError(
+                "approval missing token/spender/amount (SCW approve を組めない)"
+            )
+        # spender は必ず swap 宛先 Router と一致すること（任意コントラクトへの approve を拒否）。
+        if Web3.to_checksum_address(approval.spender) != router_cs:
+            raise PendleScwCallsError(
+                f"approval spender {approval.spender} != swap router {router_to}"
+            )
+        calls.append(
+            {
+                "to": Web3.to_checksum_address(approval.token),
+                "value": "0x0",
+                "data": _encode_approve(approval.token, approval.spender, approval.amount),
+            }
+        )
+
+    # swap 本体は最後（approve 群の後）。
+    calls.append({"to": router_cs, "value": "0x0", "data": result.calldata})
+    logger.info(
+        "build_pendle_swap_calls: %d approve(s) + 1 swap (router=%s)",
+        len(calls) - 1,
+        router_cs[:10] + "...",
+    )
+    return calls

--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -322,18 +322,35 @@ def _should_use_scw_route(proposal: Proposal, grant: Optional[DelegationGrant]) 
     """委譲(SCW)経路で執行するか（dormant 既定 False）。
 
     True 条件: delegation policy 有効（フラグ+L0 signer+creds）かつ 有効 grant に
-    privy_signer_id/privy_policy_id があり、operation が SUPPLY のとき。
-    出金(WITHDRAW)は委譲対象外＝常に custodial(本人署名)維持。
+    privy_signer_id/privy_policy_id があり、対象 (protocol, operation) が委譲可能なとき。
+      - Aave: operation == SUPPLY（従来どおり。出金 WITHDRAW は常に custodial 本人署名）。
+      - Pendle [Phase D / D3]: operation == BUY_PT かつ grant.allowed_protocols に "pendle"。
+    それ以外の (protocol, operation) は custodial 維持（False）。
     """
-    if proposal.operation != "SUPPLY":
+    protocol = (proposal.protocol or "aave").lower()
+    if protocol in ("", "aave"):
+        if proposal.operation != "SUPPLY":
+            return False
+    elif protocol == "pendle":
+        if proposal.operation != "BUY_PT":
+            return False
+    else:
         return False
+
     from app.privy.delegation_service import is_delegation_policy_enabled  # noqa: PLC0415
 
     if not is_delegation_policy_enabled():
         return False
     if grant is None:
         return False
-    return bool(grant.privy_signer_id and grant.privy_policy_id)
+    if not (grant.privy_signer_id and grant.privy_policy_id):
+        return False
+    # Pendle は grant が明示的に "pendle" を委譲していることを要求する（Aave は従来挙動維持）。
+    if protocol == "pendle":
+        allowed = [str(p).lower() for p in (grant.allowed_protocols or [])]
+        if "pendle" not in allowed:
+            return False
+    return True
 
 
 def _execute_supply_via_scw(
@@ -667,21 +684,107 @@ class PendleDryRunNotBroadcast(ProtocolExecutionNotWiredError):
     """
 
 
+def _pendle_execution_blocked(proposal: Proposal, db: Session) -> Optional[str]:
+    """[Phase D / D3] Pendle broadcast 執行直前のグローバル安全ゲート。
+
+    Pendle は ``_dispatch_custodial_execution`` から直接呼ばれ、``_execute_aave_for_proposal``
+    内の HARD_STOP / risk_limiter ゲートを通らない（Gap A）。broadcast 前に同等のゲートを
+    適用して bypass を防ぐ。ブロック時は理由文字列を返す（呼び出し元は proposal を 'approved'
+    据え置き = transient 再試行）。Aave 経路のロジックは一切変更しない（本関数に複製）。
+    """
+    from app.aave.risk_limiter import check_trade_within_limits  # noqa: PLC0415
+    from app.automation.safety_gate import evaluate_hard_stop  # noqa: PLC0415
+    from app.automation.state import get_monitoring_service  # noqa: PLC0415
+
+    hf_for_gate: Optional[Decimal] = None
+    try:
+        from app.aave.monitor import get_health_factor as _gate_get_hf  # noqa: PLC0415
+
+        hf_for_gate = _gate_get_hf()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("proposal %d: Pendle safety-gate HF fetch failed: %s", proposal.id, exc)
+
+    daily_traded = _daily_traded_usd_for_user(proposal.user_id, db, exclude_proposal_id=proposal.id)
+    total_assets: Optional[Decimal] = None  # per-user 総資産は未配線（Aave 経路と同）
+
+    hard_stop = evaluate_hard_stop(
+        get_monitoring_service(),
+        hf_for_gate,
+        daily_traded_usd=daily_traded,
+        total_assets_usd=total_assets,
+    )
+    if hard_stop.blocked:
+        return f"HARD_STOP (source={hard_stop.source}, reason={hard_stop.reason})"
+
+    limit_violation = check_trade_within_limits(
+        amount_usd=Decimal(str(proposal.amount_usd)),
+        total_assets_usd=total_assets,
+        daily_traded_usd=daily_traded,
+        hf=hf_for_gate,
+    )
+    if limit_violation is not None:
+        return f"risk_limiter ({limit_violation})"
+    return None
+
+
+def _execute_pendle_via_scw(
+    proposal: Proposal, chain: str, grant: DelegationGrant, user: Optional[UserModel], db: Session
+) -> Any:
+    """[Phase D / D3] 委譲(SCW)経路で Pendle BUY_PT swap を broadcast する。
+
+    ``_execute_supply_via_scw``(Aave)の姉妹。RouterV4 で swap 結果(approvals 付き)を取得し、
+    ``build_pendle_swap_calls`` で approve→swap の ERC-5792 calls に変換して
+    ``execute_calls_via_scw`` に渡す。HARD_STOP / risk_limiter は呼び出し元が通過済み。
+    サーバー鍵は参照せず、PT は SCW 本人着金（非カストディアル不変）。
+    """
+    from app.proposals.pendle_scw import build_pendle_swap_calls  # noqa: PLC0415
+    from app.proposals.scw_executor import execute_calls_via_scw  # noqa: PLC0415
+    from app.protocols.pendle.client import get_pendle_router_v4_client  # noqa: PLC0415
+    from app.protocols.pendle.config import get_pendle_config  # noqa: PLC0415
+
+    scw_address = grant.wallet_address or (user.smart_wallet_address if user else None)
+    if not scw_address:
+        raise ValueError("SCW route requires a smart wallet address (grant/user)")
+    privy_wallet_id = _resolve_privy_wallet_id(user)
+
+    config = get_pendle_config()
+    client = get_pendle_router_v4_client(config)
+    result = asyncio.run(
+        client.build_buy_pt_swap_result(
+            market_address=config.market_address,
+            token_in=config.underlying_token_address,
+            amount_in=Decimal(str(proposal.amount_usd)),  # stablecoin 1:1（D2 と同）
+            from_address=scw_address,
+            token_in_decimals=config.underlying_token_decimals,
+        )
+    )
+    if not result.success:
+        raise ProtocolExecutionNotWiredError(
+            f"Pendle proposal={proposal.id}: swap calldata 取得失敗: {result.error}"
+        )
+    calls = build_pendle_swap_calls(result)
+    return execute_calls_via_scw(
+        privy_wallet_id=privy_wallet_id,
+        chain_name=chain,
+        calls=calls,
+        idempotency_key=f"proposal-{proposal.id}",
+    )
+
+
 def _execute_pendle_for_proposal(proposal: Proposal, db: Session) -> None:
-    """[Phase D / D2] Pendle BUY_PT の自動執行 = dry-run calldata 構築 (broadcast なし)。
+    """[Phase D / D2-D3] Pendle BUY_PT の自動執行。
 
-    stablecoin PT (yoUSD 等・token_in=USDC≒1USD) 向けに RouterV4 Hosted SDK で
-    swapExactTokenForPt の未署名 tx を **構築するのみ** で broadcast しない。構築できたら
-    ``PendleDryRunNotBroadcast`` を送出し、proposal は 'approved' のまま (501)。実 broadcast
-    (partner 本人署名) は D3 で配線する (HUMAN-REVIEW-REQUIRED)。
+    既定は **dry-run**（D2）: RouterV4 で swapExactTokenForPt の未署名 tx を構築するのみで
+    broadcast せず ``PendleDryRunNotBroadcast`` を送出（proposal は 'approved' 据え置き / 501）。
 
-    非カストディアル不変: サーバー鍵 (``PENDLE_WALLET_PRIVATE_KEY``) は一切参照せず、PT は
-    partner 本人 wallet (SCW 優先) に着金する未署名 tx を組む。SDK calldata の宛先が Router で
-    あることは ``build_buy_pt_tx`` 内で照合する (fail-closed)。
+    **二段ガード全 true のときのみ broadcast**（D3・既定 OFF / dormant）:
+      1. ``PENDLE_ENABLE_ONCHAIN_WRITE=true``（config.enable_onchain_write）
+      2. ``_should_use_scw_route``（delegation policy 有効 + grant に signer/policy + allowed=pendle）
+    → HARD_STOP 安全ゲート通過後、SCW/Privy 委譲署名で broadcast し executed/tx_hash を保存する。
 
-    amount: stablecoin PT のみ token_in=USDC(≒1USD) のため ``proposal.amount_usd`` をそのまま
-    USDC 数量として扱える (Lido/ETH のような USD→token 価格換算が不要)。非 stablecoin market は
-    ``PENDLE_STABLE_UNDERLYING=false`` (既定) で fail-closed 拒否し、誤数量署名を防ぐ。
+    非カストディアル不変: サーバー鍵は一切参照せず PT は SCW 本人着金。amount は stablecoin PT
+    (token_in=USDC≒1USD) のみ ``proposal.amount_usd`` をそのまま USDC 数量に使う（非 stablecoin は
+    ``PENDLE_STABLE_UNDERLYING=false`` 既定で fail-closed）。
     """
     if (proposal.operation or "").upper() != "BUY_PT":
         raise ProtocolExecutionNotWiredError(
@@ -721,6 +824,73 @@ def _execute_pendle_for_proposal(proposal: Proposal, db: Session) -> None:
         raise ProtocolExecutionNotWiredError(
             f"Pendle proposal={proposal.id}: amount_usd が 0 以下です (amount={amount_in})。"
         )
+
+    # ── broadcast 分岐（D3・二段ガード全 true のときのみ実 broadcast。既定は dry-run）──
+    grant = get_active_grant(proposal.user_id, db)
+    if config.enable_onchain_write and _should_use_scw_route(proposal, grant) and grant is not None:
+        from app.transactions.models import Transaction  # noqa: PLC0415
+
+        chain = config.chain  # Pendle 実行チェーン（base / base_sepolia）
+        # Gap A: Pendle broadcast は Aave 経路の HARD_STOP/risk_limiter を通らないため執行直前に適用。
+        block_reason = _pendle_execution_blocked(proposal, db)
+        if block_reason is not None:
+            logger.warning(
+                "proposal %d: Pendle broadcast HELD by safety gate (%s) — "
+                "status remains 'approved' for retry",
+                proposal.id,
+                block_reason,
+            )
+            return  # transient: 条件解消後に再執行
+        # broadcast 呼び出しのみ try で包む。**submitted 後の bookkeeping 例外で failed 化しない**
+        # （broadcast 済みなのに failed→再執行で二重送信するのを防ぐ）。ScwNotEnabledError は
+        # ルート判定で除外済みだが防御的に捕捉する。
+        try:
+            result = _execute_pendle_via_scw(proposal, chain, grant, user, db)
+        except (RuntimeError, ValueError, ProtocolExecutionNotWiredError) as exc:
+            # RuntimeError = ScwExecutionError/ScwNotEnabledError/PendleScwCallsError を包含。
+            # ValueError = SCW アドレス欠如。いずれも broadcast 不成立 → failed 記録。
+            error_message = f"{type(exc).__name__}: {exc}"
+            failed_at = datetime.now(timezone.utc)
+            proposal.execution_attempts += 1
+            proposal.status = "failed"
+            proposal.error_message = error_message
+            proposal.executed_at = failed_at
+            _record_failed_transaction(proposal, chain, error_message, db)
+            logger.error(
+                "proposal %d: Pendle SCW execution failed: %s",
+                proposal.id,
+                exc,
+                exc_info=True,
+            )
+            return
+
+        # broadcast は submitted。以降は必ず executed として確定する。
+        proposal.execution_attempts += 1
+        proposal.tx_hash = result.tx_hash
+        proposal.status = "executed"
+        proposal.executed_at = datetime.now(timezone.utc)
+        tx_status = "completed" if result.tx_hash else "pending"
+        tx = Transaction(
+            user_id=proposal.user_id,
+            operation=proposal.operation,
+            asset=proposal.asset,
+            amount=proposal.amount,
+            amount_usd=proposal.amount_usd,
+            tx_hash=result.tx_hash,
+            chain=chain,
+            status=tx_status,
+            ai_decision_id=proposal.ai_decision_id,
+            is_dry_run=False,
+        )
+        db.add(tx)
+        logger.info(
+            "proposal %d: Pendle BUY_PT executed via SCW — tx=%s status=%s (attempt=%d)",
+            proposal.id,
+            result.tx_hash,
+            result.status,
+            proposal.execution_attempts,
+        )
+        return
 
     try:
         client = get_pendle_router_v4_client(config)

--- a/backend/app/protocols/pendle/client.py
+++ b/backend/app/protocols/pendle/client.py
@@ -920,6 +920,46 @@ class PendleRouterV4Client:
             )
             return RouterV4SwapResult(success=False, error=str(exc))
 
+    async def build_buy_pt_swap_result(
+        self,
+        market_address: str,
+        token_in: str,
+        amount_in: Decimal,
+        from_address: str,
+        slippage: Decimal | None = None,
+        token_in_decimals: int | None = None,
+    ) -> RouterV4SwapResult:
+        """[Phase D / D3] PT 購入 (swapExactTokenForPt) の **swap 結果 (approvals 付き)** を返す。
+
+        ``build_buy_pt_tx`` は未署名 tx dict のみ返し approvals を捨てるが、SCW 委譲署名の
+        batch (approve → swap) には approvals が必要なため、``RouterV4SwapResult``
+        (``.to`` / ``.calldata`` / ``.approvals``) をそのまま返す。receiver/from は署名者
+        (partner 本人 / SCW) に固定し PT は本人着金。``enable_onchain_write`` ガードは通さず
+        (broadcast は SCW 側が行う)、SDK 呼び出し + Router 照合 + calldata 欠損の fail-closed
+        は ``_execute_swap`` 内で維持する。
+
+        Raises:
+            PendleBuildTxError: from_address 空 / amount_in<=0。
+        """
+        if not from_address:
+            raise PendleBuildTxError("from_address は必須です (署名者)")
+        if amount_in <= 0:
+            raise PendleBuildTxError("amount_in は正の値である必要があります")
+
+        effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
+        in_decimals = self._resolve_decimals(token_in, token_in_decimals)
+        req = RouterV4SwapRequest(
+            market_address=market_address,
+            token_in=token_in,
+            token_out="PT",  # noqa: S106 — トークン種別リテラル (パスワードではない)
+            amount_in=amount_in,
+            slippage=effective_slippage,
+            receiver=from_address,  # 非カストディアル: PT は署名者本人へ着金
+        )
+        return await self._execute_swap(
+            req, "swapExactTokenForPt", amount_in_decimals=in_decimals, amount_out_decimals=18
+        )
+
     async def build_buy_pt_tx(
         self,
         market_address: str,
@@ -955,25 +995,15 @@ class PendleRouterV4Client:
         Raises:
             PendleBuildTxError: calldata 取得失敗 / Router 不一致 / 引数不正。
         """
-        if not from_address:
-            raise PendleBuildTxError("from_address は必須です (partner 署名)")
-        if amount_in <= 0:
-            raise PendleBuildTxError("amount_in は正の値である必要があります")
-
-        effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
-        in_decimals = self._resolve_decimals(token_in, token_in_decimals)
-        req = RouterV4SwapRequest(
+        # swap 結果 (approvals 付き) を取得し、未署名 tx dict に整形する。前提チェック
+        # (from_address 空 / amount_in<=0) と enable_onchain_write 非適用は共通実装に集約。
+        result = await self.build_buy_pt_swap_result(
             market_address=market_address,
             token_in=token_in,
-            token_out="PT",  # noqa: S106 — トークン種別リテラル (パスワードではない)
             amount_in=amount_in,
-            slippage=effective_slippage,
-            receiver=from_address,  # 非カストディアル: PT は partner 本人へ着金
-        )
-        # PT は 18 桁。入力トークンのみ decimals を解決する。enable_onchain_write ガードは
-        # 通さず（partner broadcast のため）、SDK 呼び出し + Router 照合のみ行う。
-        result = await self._execute_swap(
-            req, "swapExactTokenForPt", amount_in_decimals=in_decimals, amount_out_decimals=18
+            from_address=from_address,
+            slippage=slippage,
+            token_in_decimals=token_in_decimals,
         )
         if not result.success or not result.calldata or not result.to:
             raise PendleBuildTxError(result.error or "未署名 tx の calldata 取得に失敗しました")

--- a/backend/tests/test_pendle_scw.py
+++ b/backend/tests/test_pendle_scw.py
@@ -1,0 +1,86 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_pendle_scw.py
+"""[Phase D / D3] build_pendle_swap_calls — Pendle swap を ERC-5792 calls に変換。
+
+approve → swap の順で ``{to,value,data}`` を生成し、approve calldata が正しく ABI エンコード
+されること、spender≠Router / 欠損は fail-closed になることを検証する（broadcast しない）。
+"""
+
+import pytest
+from web3 import Web3
+
+from app.proposals.pendle_scw import PendleScwCallsError, build_pendle_swap_calls
+from app.protocols.pendle.schemas import RouterV4Approval, RouterV4SwapResult
+
+_ROUTER = "0x888888888889758F76e7103c6CbF23ABbF58F946"
+_USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+_SWAP_DATA = "0x" + "de" * 120
+# approve(address,uint256) セレクタ
+_APPROVE_SELECTOR = "0x095ea7b3"
+
+
+def _result(**overrides: object) -> RouterV4SwapResult:
+    base: dict[str, object] = {
+        "success": True,
+        "to": _ROUTER,
+        "calldata": _SWAP_DATA,
+        "approvals": [RouterV4Approval(token=_USDC, spender=_ROUTER, amount="100000000")],
+    }
+    base.update(overrides)
+    return RouterV4SwapResult(**base)  # type: ignore[arg-type]
+
+
+def test_builds_approve_then_swap() -> None:
+    calls = build_pendle_swap_calls(_result())
+    assert len(calls) == 2
+    approve_call, swap_call = calls
+
+    # approve は USDC 宛・approve セレクタ・value 0。
+    assert approve_call["to"] == Web3.to_checksum_address(_USDC)
+    assert approve_call["value"] == "0x0"
+    assert approve_call["data"].startswith(_APPROVE_SELECTOR)
+    # spender(Router) と amount(100000000) が calldata に埋まっている。
+    assert _ROUTER.lower()[2:] in approve_call["data"].lower()
+    assert hex(100000000)[2:] in approve_call["data"].lower()
+
+    # swap は Router 宛・SDK calldata そのまま。
+    assert swap_call["to"] == Web3.to_checksum_address(_ROUTER)
+    assert swap_call["value"] == "0x0"
+    assert swap_call["data"] == _SWAP_DATA
+
+
+def test_no_approvals_only_swap() -> None:
+    """approvals が空でも swap 単体は組む（既に approve 済みのケース）。"""
+    calls = build_pendle_swap_calls(_result(approvals=[]))
+    assert len(calls) == 1
+    assert calls[0]["to"] == Web3.to_checksum_address(_ROUTER)
+
+
+def test_fail_when_result_unsuccessful() -> None:
+    with pytest.raises(PendleScwCallsError):
+        build_pendle_swap_calls(_result(success=False, error="boom"))
+
+
+def test_fail_when_missing_to() -> None:
+    with pytest.raises(PendleScwCallsError):
+        build_pendle_swap_calls(_result(to=None))
+
+
+def test_fail_when_missing_calldata() -> None:
+    with pytest.raises(PendleScwCallsError):
+        build_pendle_swap_calls(_result(calldata=""))
+
+
+def test_fail_when_spender_not_router() -> None:
+    """approve の spender が swap 宛先 Router と異なる → 任意コントラクト approve を拒否。"""
+    bad = RouterV4Approval(
+        token=_USDC, spender="0x00000000000000000000000000000000deadbeef", amount="1"
+    )
+    with pytest.raises(PendleScwCallsError):
+        build_pendle_swap_calls(_result(approvals=[bad]))
+
+
+def test_fail_when_approval_amount_missing() -> None:
+    bad = RouterV4Approval(token=_USDC, spender=_ROUTER, amount=None)
+    with pytest.raises(PendleScwCallsError):
+        build_pendle_swap_calls(_result(approvals=[bad]))

--- a/backend/tests/test_pendle_scw_execution.py
+++ b/backend/tests/test_pendle_scw_execution.py
@@ -1,0 +1,203 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_pendle_scw_execution.py
+"""[Phase D / D3] _execute_pendle_for_proposal の broadcast 分岐（SCW 委譲署名）。
+
+二段ガード全 true のときのみ SCW broadcast し executed/tx_hash をセットすること、いずれか
+欠ければ D2 dry-run に留まること、HARD_STOP 発火時は broadcast せず approved 据え置きになること、
+Aave 経路を絶対に呼ばないことを検証する（実 broadcast はしない・全て monkeypatch）。
+"""
+
+import os
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-pendle-scw-exec")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "admin@example.com")
+
+import app.privy.delegation_service as delegation_mod  # noqa: E402
+import app.proposals.router as router_mod  # noqa: E402
+import app.protocols.pendle.client as pendle_client_mod  # noqa: E402
+import app.protocols.pendle.config as pendle_config_mod  # noqa: E402
+from app.proposals.router import (  # noqa: E402
+    PendleDryRunNotBroadcast,
+    _execute_pendle_for_proposal,
+)
+from app.protocols.pendle.config import PendleConfig  # noqa: E402
+
+_MARKET = "0x1111111111111111111111111111111111111111"
+_USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+_WALLET = "0x7f9300000000000000000000000000000000a0Ff"
+
+
+def _mk_proposal() -> MagicMock:
+    p = MagicMock()
+    p.id = 77
+    p.protocol = "pendle"
+    p.operation = "BUY_PT"
+    p.amount_usd = Decimal("50.00")
+    p.amount = Decimal("50.00")
+    p.asset = "PT-yoUSD"
+    p.user_id = 11
+    p.ai_decision_id = None
+    p.execution_attempts = 0
+    return p
+
+
+def _mk_db() -> MagicMock:
+    db = MagicMock()
+    user = MagicMock()
+    user.wallet_address = _WALLET
+    user.smart_wallet_address = None
+    db.get.return_value = user
+    return db
+
+
+class _FakeDryRunClient:
+    async def build_buy_pt_tx(self, **kwargs: object) -> dict[str, object]:
+        return {"to": "0xRouter", "data": "0x" + "ab" * 10, "from": _WALLET, "chainId": 8453}
+
+
+def _patch_common(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    enable_onchain_write: bool,
+    delegation_enabled: bool,
+    allowed_protocols: list[str] | None = None,
+) -> None:
+    config = PendleConfig(
+        market_address=_MARKET,
+        underlying_token_address=_USDC,
+        underlying_token_decimals=6,
+        stable_underlying=True,
+        chain="base_sepolia",
+    )
+    config.enable_onchain_write = enable_onchain_write
+    monkeypatch.setattr(pendle_config_mod, "get_pendle_config", lambda: config)
+    monkeypatch.setattr(delegation_mod, "is_delegation_policy_enabled", lambda: delegation_enabled)
+    # dry-run フォールバック用のフェイク client（実 SDK を叩かない）。
+    monkeypatch.setattr(
+        pendle_client_mod, "get_pendle_router_v4_client", lambda cfg: _FakeDryRunClient()
+    )
+    grant = MagicMock()
+    grant.privy_signer_id = "signer-1"
+    grant.privy_policy_id = "policy-1"
+    grant.wallet_address = _WALLET
+    grant.allowed_protocols = allowed_protocols if allowed_protocols is not None else ["pendle"]
+    monkeypatch.setattr(router_mod, "get_active_grant", lambda uid, db: grant)
+
+
+def test_broadcast_when_all_gates_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    """二段ガード全 true → SCW 実行し executed/tx_hash をセット。"""
+    _patch_common(monkeypatch, enable_onchain_write=True, delegation_enabled=True)
+    monkeypatch.setattr(router_mod, "_pendle_execution_blocked", lambda p, db: None)
+    called: dict[str, object] = {}
+
+    def _fake_scw(
+        proposal: object, chain: object, grant: object, user: object, db: object
+    ) -> object:
+        called["chain"] = chain
+        return SimpleNamespace(tx_hash="0xdeadbeef", status="submitted")
+
+    monkeypatch.setattr(router_mod, "_execute_pendle_via_scw", _fake_scw)
+
+    p, db = _mk_proposal(), _mk_db()
+    _execute_pendle_for_proposal(p, db)  # broadcast 分岐は raise しない
+
+    assert p.status == "executed"
+    assert p.tx_hash == "0xdeadbeef"
+    assert p.execution_attempts == 1
+    assert called["chain"] == "base_sepolia"
+    db.add.assert_called_once()
+
+
+def test_dry_run_when_onchain_write_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PENDLE_ENABLE_ONCHAIN_WRITE=false → broadcast せず D2 dry-run。"""
+    _patch_common(monkeypatch, enable_onchain_write=False, delegation_enabled=True)
+
+    def _must_not_scw(*a: object, **k: object) -> object:
+        raise AssertionError("onchain_write=false で SCW を呼んではならない")
+
+    monkeypatch.setattr(router_mod, "_execute_pendle_via_scw", _must_not_scw)
+    with pytest.raises(PendleDryRunNotBroadcast):
+        _execute_pendle_for_proposal(_mk_proposal(), _mk_db())
+
+
+def test_dry_run_when_delegation_dormant(monkeypatch: pytest.MonkeyPatch) -> None:
+    """delegation policy 無効（dormant）→ broadcast せず D2 dry-run。"""
+    _patch_common(monkeypatch, enable_onchain_write=True, delegation_enabled=False)
+
+    def _must_not_scw(*a: object, **k: object) -> object:
+        raise AssertionError("delegation dormant で SCW を呼んではならない")
+
+    monkeypatch.setattr(router_mod, "_execute_pendle_via_scw", _must_not_scw)
+    with pytest.raises(PendleDryRunNotBroadcast):
+        _execute_pendle_for_proposal(_mk_proposal(), _mk_db())
+
+
+def test_dry_run_when_grant_missing_pendle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """grant.allowed_protocols に pendle が無い → broadcast せず D2 dry-run。"""
+    _patch_common(
+        monkeypatch, enable_onchain_write=True, delegation_enabled=True, allowed_protocols=["aave"]
+    )
+
+    def _must_not_scw(*a: object, **k: object) -> object:
+        raise AssertionError("pendle 未委譲で SCW を呼んではならない")
+
+    monkeypatch.setattr(router_mod, "_execute_pendle_via_scw", _must_not_scw)
+    with pytest.raises(PendleDryRunNotBroadcast):
+        _execute_pendle_for_proposal(_mk_proposal(), _mk_db())
+
+
+def test_hard_stop_blocks_broadcast(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HARD_STOP 発火 → broadcast せず approved 据え置き（raise しない・executed にしない）。"""
+    _patch_common(monkeypatch, enable_onchain_write=True, delegation_enabled=True)
+    monkeypatch.setattr(
+        router_mod, "_pendle_execution_blocked", lambda p, db: "HARD_STOP (source=x, reason=y)"
+    )
+
+    def _must_not_scw(*a: object, **k: object) -> object:
+        raise AssertionError("HARD_STOP 時に SCW を呼んではならない")
+
+    monkeypatch.setattr(router_mod, "_execute_pendle_via_scw", _must_not_scw)
+
+    p, db = _mk_proposal(), _mk_db()
+    _execute_pendle_for_proposal(p, db)  # 据え置き = raise しない
+    assert p.status != "executed"
+
+
+def test_scw_failure_marks_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SCW 送信失敗 → failed + 失敗トランザクション記録（raise しない）。"""
+    from app.proposals.scw_executor import ScwExecutionError
+
+    _patch_common(monkeypatch, enable_onchain_write=True, delegation_enabled=True)
+    monkeypatch.setattr(router_mod, "_pendle_execution_blocked", lambda p, db: None)
+    monkeypatch.setattr(router_mod, "_record_failed_transaction", lambda *a, **k: None)
+
+    def _fail_scw(*a: object, **k: object) -> object:
+        raise ScwExecutionError("Privy send_calls failed")
+
+    monkeypatch.setattr(router_mod, "_execute_pendle_via_scw", _fail_scw)
+
+    p, db = _mk_proposal(), _mk_db()
+    _execute_pendle_for_proposal(p, db)
+    assert p.status == "failed"
+    assert "ScwExecutionError" in (p.error_message or "")
+
+
+def test_broadcast_never_calls_aave(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_common(monkeypatch, enable_onchain_write=True, delegation_enabled=True)
+    monkeypatch.setattr(router_mod, "_pendle_execution_blocked", lambda p, db: None)
+    monkeypatch.setattr(
+        router_mod,
+        "_execute_pendle_via_scw",
+        lambda *a, **k: SimpleNamespace(tx_hash="0x1", status="submitted"),
+    )
+
+    def _must_not_run(p: object, db: object) -> None:
+        raise AssertionError("Pendle broadcast で Aave 経路を実行してはならない")
+
+    monkeypatch.setattr(router_mod, "_execute_aave_for_proposal", _must_not_run)
+    _execute_pendle_for_proposal(_mk_proposal(), _mk_db())

--- a/backend/tests/test_privy_policy_mapper.py
+++ b/backend/tests/test_privy_policy_mapper.py
@@ -45,6 +45,17 @@ def test_resolve_unsupported_protocol_fails_closed() -> None:
     assert "lido" in str(ei.value)
 
 
+def test_resolve_pendle_contracts_router_and_underlying() -> None:
+    """[Phase D / D3] Pendle は RouterV4 + underlying(USDC) の 2 宛先を allowlist する。"""
+    from app.protocols.pendle.config import get_pendle_config
+
+    conf = get_pendle_config()
+    contracts = resolve_protocol_contracts(["pendle"], "base")
+    assert conf.router_address.lower() in contracts
+    assert conf.underlying_token_address.lower() in contracts
+    assert len(contracts) == 2  # approve(USDC) + swap(Router)
+
+
 def test_resolve_bad_chain_raises() -> None:
     with pytest.raises(PolicyMappingError):
         resolve_protocol_contracts(["aave"], "no_such_chain")
@@ -131,7 +142,7 @@ def test_build_policy_unsupported_protocol_raises() -> None:
     with pytest.raises(PolicyMappingError):
         build_delegation_policy(
             wallet_address=_WALLET,
-            allowed_protocols=["aave", "pendle"],
+            allowed_protocols=["aave", "lido"],  # lido は未対応（fail-closed）
             chain_name="base",
         )
 

--- a/backend/tests/test_proposal_scw_routing.py
+++ b/backend/tests/test_proposal_scw_routing.py
@@ -39,7 +39,9 @@ def _grant(**kw: object) -> SimpleNamespace:
 
 
 def _supply_proposal() -> SimpleNamespace:
-    return SimpleNamespace(id=7, asset="USDC", amount_usd=Decimal("5"), operation="SUPPLY")
+    return SimpleNamespace(
+        id=7, asset="USDC", amount_usd=Decimal("5"), operation="SUPPLY", protocol=None
+    )
 
 
 # ---- _resolve_privy_wallet_id ----
@@ -74,7 +76,9 @@ def test_route_true_when_enabled_supply_with_ids(enabled_env: None) -> None:
 
 
 def test_route_false_for_withdraw(enabled_env: None) -> None:
-    p = SimpleNamespace(id=8, asset="USDC", amount_usd=Decimal("5"), operation="WITHDRAW")
+    p = SimpleNamespace(
+        id=8, asset="USDC", amount_usd=Decimal("5"), operation="WITHDRAW", protocol=None
+    )
     assert _should_use_scw_route(p, _grant()) is False
 
 
@@ -85,6 +89,34 @@ def test_route_false_when_no_grant(enabled_env: None) -> None:
 def test_route_false_when_grant_missing_ids(enabled_env: None) -> None:
     assert _should_use_scw_route(_supply_proposal(), _grant(privy_signer_id=None)) is False
     assert _should_use_scw_route(_supply_proposal(), _grant(privy_policy_id=None)) is False
+
+
+# ---- Pendle [Phase D / D3] ----
+
+
+def _pendle_proposal() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=9, asset="PT-yoUSD", amount_usd=Decimal("50"), operation="BUY_PT", protocol="pendle"
+    )
+
+
+def test_route_true_pendle_buy_pt_with_grant(enabled_env: None) -> None:
+    """Pendle BUY_PT + grant.allowed_protocols に pendle → True。"""
+    assert _should_use_scw_route(_pendle_proposal(), _grant(allowed_protocols=["pendle"])) is True
+
+
+def test_route_false_pendle_without_allowed_protocol(enabled_env: None) -> None:
+    """grant が pendle を委譲していない → False（Aave のみ委譲では Pendle を broadcast しない）。"""
+    assert _should_use_scw_route(_pendle_proposal(), _grant(allowed_protocols=["aave"])) is False
+    assert _should_use_scw_route(_pendle_proposal(), _grant(allowed_protocols=None)) is False
+
+
+def test_route_false_pendle_wrong_operation(enabled_env: None) -> None:
+    """Pendle は BUY_PT のみ委譲対象（SELL_PT/その他は custodial）。"""
+    p = SimpleNamespace(
+        id=10, asset="PT-yoUSD", amount_usd=Decimal("50"), operation="SELL_PT", protocol="pendle"
+    )
+    assert _should_use_scw_route(p, _grant(allowed_protocols=["pendle"])) is False
 
 
 # ---- _execute_supply_via_scw ----


### PR DESCRIPTION
## 概要 (Phase-D D3) — ⚠️ stacked on #978 (D2)

> **base = `feat/phase-d-d2-pendle-dryrun` (PR #978)**。D2 マージ後に base を main へ切替（自動リターゲット）。

Aave の `_execute_supply_via_scw` を踏襲し、Pendle BUY_PT swap を **非カストSCW/Privy 委譲署名で broadcast** する経路を配線する（Asana 1216418536804307）。

**全経路 既定 OFF（dormant）。このコードは何も broadcast しない。** 実 Base Sepolia broadcast 検証（receipt status=1 / PT 残高）は test wallet + Privy creds + env を人間が用意する **human-in-the-loop** ステップ。実資金移動 = **Tier S / HUMAN-REVIEW / Opus 安全レビュー必須**（CLAUDE.md 鉄則10）。

## 二段ガード（全 true のときのみ broadcast・1つ欠ければ D2 dry-run）
1. `PENDLE_ENABLE_ONCHAIN_WRITE=true`（既定 false）
2. `_should_use_scw_route`: `is_delegation_policy_enabled()`（`DELEGATION_PRIVY_POLICY_ENABLED`+`PRIVY_SERVER_SIGNER_ID`+`PRIVY_APP_ID`+`PRIVY_APP_SECRET`）+ grant に `privy_signer_id`/`privy_policy_id` + `allowed_protocols` に `"pendle"`

## 実装
| ファイル | 変更 |
|---|---|
| `protocols/pendle/client.py` | `build_buy_pt_swap_result`（approvals 付き結果）追加・`build_buy_pt_tx` は委譲（挙動不変） |
| `proposals/pendle_scw.py`（新規） | `build_pendle_swap_calls` = approve→swap を ERC-5792 calls に変換。approve は web3 v7 `encode_abi`（`aave/client._ERC20_ABI_MINIMAL` 再利用）。spender≠Router / 欠損は fail-closed |
| `proposals/router.py` | `_execute_pendle_via_scw`（`execute_calls_via_scw` 再利用）+ `_execute_pendle_for_proposal` broadcast 分岐 + `_should_use_scw_route` を Pendle BUY_PT に拡張（Aave 不変） |
| `privy/policy_mapper.py` | `_SUPPORTED_PROTOCOLS`/`resolve_protocol_contracts` に pendle（RouterV4 + underlying USDC の 2 宛先 allowlist） |

## 安全上の要点
- **Gap A 解消**: Pendle は `_dispatch_custodial_execution` 直呼びで Aave の HARD_STOP/risk_limiter を通らなかった。broadcast 前に `_pendle_execution_blocked`（HARD_STOP + risk_limiter）を適用。ブロック時は approved 据え置き（transient 再試行）。Aave 経路のロジックは複製で対応し**一切変更していない**。
- **二重送信防止**: broadcast 呼び出しのみ try で包み、submitted 後の bookkeeping 例外では failed 化しない。
- **policy allowlist**: approve(USDC 宛) と swap(Router 宛) の両方が Privy policy を通るよう 2 宛先を allowlist。

## DoD
- [x] ruff / format — 対象ファイル pass
- [x] mypy — 対象 4 ファイル pass（既存 `stripe` stub は本 PR 無関係）
- [x] pytest — 新規 `test_pendle_scw.py`(7) + `test_pendle_scw_execution.py`(7) + routing/policy_mapper 追記。回帰 pendle/proposal/scw/privy/aave/policy **1431 passed / 4 skipped**
- [x] broadcast / 本番 DB write / 秘密鍵参照 / 依存追加 **なし**（全 dormant）

## スコープ外
D4=PT→USDC redeem / D5=aggressive routing+流動性ガード+同意UI / D6=本番反映(3段+Opusレビュー+段階解放)

## 実 broadcast 検証（人間ステップ・Claude 実行不可）
staging-v4(Base Sepolia)で test wallet + Privy creds を用意し env（`PENDLE_CHAIN=base_sepolia` / `PENDLE_MARKET_ADDRESS=<yoUSD市場>` / `PENDLE_UNDERLYING_TOKEN_ADDRESS=<Base Sepolia USDC>` / `PENDLE_STABLE_UNDERLYING=true` / `PENDLE_ENABLE_ONCHAIN_WRITE=true` / `DELEGATION_PRIVY_POLICY_ENABLED=true` / `PRIVY_SERVER_SIGNER_ID` / `PRIVY_APP_ID` / `PRIVY_APP_SECRET`）を設定。test user に `allowed_protocols=["pendle"]` grant を作成 → BUY_PT proposal approve → receipt status=1 / PT 残高増を確認。

Closes: https://app.asana.com/1/817733952351708/project/1213741124336104/task/1216418536804307

🤖 Generated with [Claude Code](https://claude.com/claude-code)