### PR TITLE
feat(pendle): Phase-D D5a — 流動性ガード(必須)+ RiskMode aggressive routing 修正

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -493,15 +493,17 @@ def _resolve_protocol_routing(
 ) -> tuple[str, str, str]:
     """Proposal の (operation, asset, protocol) を決める (Phase-B)。
 
-    既定 (フラグ無効 / SELL / optimizer 失敗 / aave 推奨) は Aave 既定経路
-    ``(SUPPLY|WITHDRAW, "USDC", "aave")``。フラグ有効かつ BUY かつ AI Optimizer が
-    lido/pendle を推奨した場合のみ該当プロトコルへルーティングする:
-      - Lido → ``("STAKE_ETH", "ETH", "lido")``
-      - Pendle → ``("BUY_PT", "PT-stETH", "pendle")``
+    既定 (フラグ無効 / SELL / optimizer 失敗 / aave 推奨 / risk_mode 非適格) は Aave 既定経路
+    ``(SUPPLY|WITHDRAW, "USDC", "aave")``。フラグ有効かつ BUY かつ AI Optimizer が lido/pendle を
+    推奨し、**かつ user.risk_mode がそのプロトコルを許可** (``RISK_MODE_PROTOCOLS``) する場合のみ
+    該当プロトコルへルーティングする:
+      - Lido → ``("STAKE_ETH", "ETH", "lido")`` (balanced 以上)
+      - Pendle → ``("BUY_PT", "PT-yoUSD", "pendle")`` (aggressive のみ / D5)
 
-    いずれの場合も on-chain 実行は行わず、Proposal を DB に作成するのみ
-    (実際の ETH staking / Pendle swap の broadcast は Phase-D / 人間承認後)。
-    Health Factor チェック・緊急停止フラグには一切触れない。
+    [D5] risk_mode eligibility ゲート: optimizer ランキングだけでなく risk_mode で eligible な
+    protocol を絞る (conservative が pendle を掴む等の誤ルーティング防止)。未知/None は conservative
+    相当 (aave のみ)。いずれも on-chain 実行はせず Proposal を DB 作成するのみ (broadcast は Phase-D /
+    人間承認後)。Health Factor チェック・緊急停止フラグには触れない。
     """
     aave_operation = "SUPPLY" if result.final_action == TradeAction.BUY else "WITHDRAW"
     aave_default = (aave_operation, _PROPOSAL_ASSET, "aave")
@@ -525,11 +527,19 @@ def _resolve_protocol_routing(
         logger.warning("AI Optimizer 比較に失敗、Aave 既定にフォールバック: %s", exc)
         return aave_default
 
-    if recommended in (Protocol.LIDO, Protocol.LIDO_AAVE):
+    # [D5] risk_mode で eligible な protocol を絞る（未知/None は conservative 相当 = aave のみ）。
+    from app.auth.models import RISK_MODE_PROTOCOLS, RiskMode  # noqa: PLC0415
+
+    try:
+        allowed_protocols = RISK_MODE_PROTOCOLS.get(RiskMode(risk_mode or ""), frozenset({"aave"}))
+    except ValueError:
+        allowed_protocols = frozenset({"aave"})
+
+    if recommended in (Protocol.LIDO, Protocol.LIDO_AAVE) and "lido" in allowed_protocols:
         return ("STAKE_ETH", "ETH", "lido")
-    if recommended in (Protocol.PENDLE_PT, Protocol.PENDLE_YT):
-        return ("BUY_PT", "PT-stETH", "pendle")
-    # AAVE / IDLE / その他 → Aave 既定経路
+    if recommended in (Protocol.PENDLE_PT, Protocol.PENDLE_YT) and "pendle" in allowed_protocols:
+        return ("BUY_PT", "PT-yoUSD", "pendle")
+    # AAVE / IDLE / risk_mode 非適格 / その他 → Aave 既定経路
     return aave_default
 
 

--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -685,8 +685,43 @@ class PendleDryRunNotBroadcast(ProtocolExecutionNotWiredError):
     """
 
 
+def _pendle_liquidity_blocked(config: Any, amount_usd: Decimal) -> Optional[str]:
+    """[Phase D / D5] 流動性ガード: 1 投入が薄い PT プールを壊さないか検査する。
+
+    唯一の必須物理制約。対象 market の ``tvl_usd``（= Pendle API の liquidity.usd）を取得し、
+    1 投入 ≤ ``max_pool_liquidity_pct``（プール流動性の数%）かつ ≤ ``max_trade_usd_cap``
+    （絶対上限 USD）であることを要求する。ブロック時は理由文字列、問題なければ None。
+
+    fail-closed: ``get_market_info`` は API 失敗時 tvl_usd=0 に fail-open するため、tvl<=0（未知）は
+    「壊さない保証ができない」= block する（不確実なら止める）。
+    """
+    from app.protocols.pendle.client import get_pendle_client  # noqa: PLC0415
+
+    try:
+        client = get_pendle_client(config)
+        market_info = asyncio.run(client.get_market_info(config.market_address))
+        tvl_usd = Decimal(str(market_info.tvl_usd))
+    except Exception as exc:  # noqa: BLE001
+        return f"liquidity guard: market_info 取得失敗のため fail-closed ({exc})"
+
+    if tvl_usd <= 0:
+        return "liquidity guard: プール流動性が不明/ゼロのため fail-closed (tvl_usd<=0)"
+
+    pool_cap = tvl_usd * config.max_pool_liquidity_pct
+    if amount_usd > pool_cap:
+        return (
+            f"liquidity guard: 1 投入 {amount_usd} がプール流動性上限 "
+            f"{pool_cap} (tvl {tvl_usd} × {config.max_pool_liquidity_pct}) を超過"
+        )
+    if amount_usd > config.max_trade_usd_cap:
+        return (
+            f"liquidity guard: 1 投入 {amount_usd} が絶対上限 {config.max_trade_usd_cap} USD を超過"
+        )
+    return None
+
+
 def _pendle_execution_blocked(proposal: Proposal, db: Session) -> Optional[str]:
-    """[Phase D / D3] Pendle broadcast 執行直前のグローバル安全ゲート。
+    """[Phase D / D3-D5] Pendle broadcast 執行直前のグローバル安全ゲート。
 
     Pendle は ``_dispatch_custodial_execution`` から直接呼ばれ、``_execute_aave_for_proposal``
     内の HARD_STOP / risk_limiter ゲートを通らない（Gap A）。broadcast 前に同等のゲートを
@@ -725,6 +760,15 @@ def _pendle_execution_blocked(proposal: Proposal, db: Session) -> Optional[str]:
     )
     if limit_violation is not None:
         return f"risk_limiter ({limit_violation})"
+
+    # [D5] 流動性ガード（薄いプール保護・必須物理制約）。BUY_PT/SELL_PT 双方に適用。
+    from app.protocols.pendle.config import get_pendle_config  # noqa: PLC0415
+
+    liquidity_block = _pendle_liquidity_blocked(
+        get_pendle_config(), Decimal(str(proposal.amount_usd))
+    )
+    if liquidity_block is not None:
+        return liquidity_block
     return None
 
 

--- a/backend/app/protocols/pendle/config.py
+++ b/backend/app/protocols/pendle/config.py
@@ -95,6 +95,15 @@ class PendleConfig:
     max_single_trade_pct: Decimal = field(
         default_factory=lambda: _get_env_decimal("PENDLE_MAX_SINGLE_TRADE_PCT", "0.10")
     )
+    # [Phase D / D5] 流動性ガード: 1 投入 ≤ プール流動性(tvl_usd)の割合（デフォルト 5%）。
+    # 薄い PT プールを 1 回の swap で壊さないための物理制約。
+    max_pool_liquidity_pct: Decimal = field(
+        default_factory=lambda: _get_env_decimal("PENDLE_MAX_POOL_LIQUIDITY_PCT", "0.05")
+    )
+    # [Phase D / D5] 流動性ガード: 1 投入の絶対上限（USD）。プール流動性%と併せて被害上限を縛る。
+    max_trade_usd_cap: Decimal = field(
+        default_factory=lambda: _get_env_decimal("PENDLE_MAX_TRADE_USD_CAP", "5000")
+    )
 
     def token_decimals(self, token: str) -> int:
         """トークン識別子から decimals を解決する。

--- a/backend/tests/automation/test_phase_b_multiprotocol.py
+++ b/backend/tests/automation/test_phase_b_multiprotocol.py
@@ -80,7 +80,7 @@ class TestResolveProtocolRouting:
         _patch_compare(monkeypatch, Protocol.PENDLE_PT)
         assert _resolve_protocol_routing(_cv(TradeAction.BUY), "aggressive", Decimal("1000")) == (
             "BUY_PT",
-            "PT-stETH",
+            "PT-yoUSD",
             "pendle",
         )
 
@@ -98,8 +98,48 @@ class TestResolveProtocolRouting:
         _patch_compare(monkeypatch, Protocol.PENDLE_YT)
         assert _resolve_protocol_routing(_cv(TradeAction.BUY), "aggressive", Decimal("1000")) == (
             "BUY_PT",
-            "PT-stETH",
+            "PT-yoUSD",
             "pendle",
+        )
+
+    # [D5] risk_mode eligibility ゲート — optimizer が推奨しても risk_mode が許可しなければ aave。
+    def test_pendle_gated_for_balanced(self, monkeypatch) -> None:
+        """balanced は pendle 非適格 → optimizer が pendle 推奨でも aave にフォールバック。"""
+        monkeypatch.setenv("AI_OPTIMIZER_MULTIPROTOCOL_ENABLED", "true")
+        _patch_compare(monkeypatch, Protocol.PENDLE_PT)
+        assert _resolve_protocol_routing(_cv(TradeAction.BUY), "balanced", Decimal("1000")) == (
+            "SUPPLY",
+            "USDC",
+            "aave",
+        )
+
+    def test_pendle_gated_for_conservative(self, monkeypatch) -> None:
+        monkeypatch.setenv("AI_OPTIMIZER_MULTIPROTOCOL_ENABLED", "true")
+        _patch_compare(monkeypatch, Protocol.PENDLE_PT)
+        assert _resolve_protocol_routing(_cv(TradeAction.BUY), "conservative", Decimal("1000")) == (
+            "SUPPLY",
+            "USDC",
+            "aave",
+        )
+
+    def test_lido_gated_for_conservative(self, monkeypatch) -> None:
+        """conservative は lido 非適格 → aave にフォールバック。"""
+        monkeypatch.setenv("AI_OPTIMIZER_MULTIPROTOCOL_ENABLED", "true")
+        _patch_compare(monkeypatch, Protocol.LIDO)
+        assert _resolve_protocol_routing(_cv(TradeAction.BUY), "conservative", Decimal("1000")) == (
+            "SUPPLY",
+            "USDC",
+            "aave",
+        )
+
+    def test_unknown_risk_mode_defaults_to_aave_only(self, monkeypatch) -> None:
+        """未知/None risk_mode は conservative 相当 = aave のみ。"""
+        monkeypatch.setenv("AI_OPTIMIZER_MULTIPROTOCOL_ENABLED", "true")
+        _patch_compare(monkeypatch, Protocol.PENDLE_PT)
+        assert _resolve_protocol_routing(_cv(TradeAction.BUY), None, Decimal("1000")) == (
+            "SUPPLY",
+            "USDC",
+            "aave",
         )
 
     def test_aave_recommendation_stays_aave(self, monkeypatch) -> None:
@@ -130,6 +170,6 @@ class TestResolveProtocolRouting:
         expected = {
             "aave": ("SUPPLY", "USDC"),
             "lido": ("STAKE_ETH", "ETH"),
-            "pendle": ("BUY_PT", "PT-stETH"),
+            "pendle": ("BUY_PT", "PT-yoUSD"),
         }
         assert (op, asset) == expected[proto]

--- a/backend/tests/test_pendle_liquidity_guard.py
+++ b/backend/tests/test_pendle_liquidity_guard.py
@@ -1,0 +1,74 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_pendle_liquidity_guard.py
+"""[Phase D / D5] 流動性ガード (_pendle_liquidity_blocked)。
+
+1 投入がプール流動性(tvl_usd)の数% + 絶対上限を超えないことを検査し、tvl 未知(API失敗/0)は
+fail-closed で block することを検証する。
+"""
+
+import os
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-pendle-liq")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "admin@example.com")
+
+import app.protocols.pendle.client as pendle_client_mod  # noqa: E402
+from app.proposals.router import _pendle_liquidity_blocked  # noqa: E402
+from app.protocols.pendle.config import PendleConfig  # noqa: E402
+
+_MARKET = "0x1111111111111111111111111111111111111111"
+
+
+def _config() -> PendleConfig:
+    return PendleConfig(
+        market_address=_MARKET,
+        max_pool_liquidity_pct=Decimal("0.05"),
+        max_trade_usd_cap=Decimal("5000"),
+    )
+
+
+def _patch_market(monkeypatch: pytest.MonkeyPatch, *, tvl: object, raises: bool = False) -> None:
+    class _Client:
+        async def get_market_info(self, market_address: str) -> object:
+            if raises:
+                raise RuntimeError("pendle API down")
+            return SimpleNamespace(tvl_usd=tvl)
+
+    monkeypatch.setattr(pendle_client_mod, "get_pendle_client", lambda cfg: _Client())
+
+
+def test_pass_when_within_pool_and_abs_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """tvl 十分・amount ≤ 5% かつ ≤ 絶対上限 → None(通過)。"""
+    _patch_market(monkeypatch, tvl=Decimal("114000"))
+    assert _pendle_liquidity_blocked(_config(), Decimal("1000")) is None
+
+
+def test_block_when_exceeds_pool_pct(monkeypatch: pytest.MonkeyPatch) -> None:
+    """amount > tvl×5%(=5700) → block。"""
+    _patch_market(monkeypatch, tvl=Decimal("114000"))
+    reason = _pendle_liquidity_blocked(_config(), Decimal("6000"))
+    assert reason is not None and "プール流動性上限" in reason
+
+
+def test_block_when_exceeds_abs_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """pool% は満たすが絶対上限 5000 を超える → block。"""
+    _patch_market(monkeypatch, tvl=Decimal("1000000"))  # 5% = 50000 で余裕
+    reason = _pendle_liquidity_blocked(_config(), Decimal("6000"))
+    assert reason is not None and "絶対上限" in reason
+
+
+def test_block_when_tvl_zero_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """tvl=0(API失敗の fail-open 値) → fail-closed で block。"""
+    _patch_market(monkeypatch, tvl=Decimal("0"))
+    reason = _pendle_liquidity_blocked(_config(), Decimal("1"))
+    assert reason is not None and "fail-closed" in reason
+
+
+def test_block_when_market_info_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_market_info 例外 → fail-closed で block(壊さない保証ができない)。"""
+    _patch_market(monkeypatch, tvl=Decimal("0"), raises=True)
+    reason = _pendle_liquidity_blocked(_config(), Decimal("1000"))
+    assert reason is not None and "fail-closed" in reason


### PR DESCRIPTION
## 概要 (Phase-D D5a) — ⚠️ stacked on #980 (D4) ← #979 ← #978

> **base = `feat/phase-d-d4-pendle-redeem` (PR #980)**。#978→#979→#980 マージ後、base は自動で main へ繰り上がる。

D5 の3部構成のうち**バック中核（①流動性ガード ②routing 修正）**を実装（Asana 1216418536869173）。③リスク開示/同意 UI と optimizer 実 APY 配線は **D5b**（別 PR）に分離。全て **dormant 既定**で proposal 生成挙動も broadcast も変えない。

## ① 流動性ガード（薄いプール破壊防止・唯一の必須物理制約）
- `config`: `PENDLE_MAX_POOL_LIQUIDITY_PCT`（既定 5%）+ `PENDLE_MAX_TRADE_USD_CAP`（既定 $5000）
- `router._pendle_liquidity_blocked(config, amount)`: market の `tvl_usd`（= Pendle API `liquidity.usd`）を取得し **1 投入 ≤ tvl×5% かつ ≤ 絶対上限** を要求
- ★ **fail-closed**: `get_market_info` は API 失敗時 `tvl_usd=0` に fail-**open** するため、`tvl<=0`/取得失敗は **block**（壊さない保証ができないなら止める）
- `_pendle_execution_blocked`（broadcast 直前ゲート）末尾に合流 → BUY_PT/SELL_PT 双方に適用・**dry-run は不変**

## ② routing 修正（`_resolve_protocol_routing`）
- pendle の asset を **`PT-stETH` → `PT-yoUSD`**（D1/D4 の実ターゲット）
- ★ **risk_mode eligibility ゲート**: optimizer 推奨を `RISK_MODE_PROTOCOLS` と突合し非適格なら aave フォールバック（lido=balanced 以上 / pendle=**aggressive のみ** / 未知=aave）。従来はランキング任せで conservative でも pendle を掴み得た誤ルーティングを塞ぐ
- `AI_OPTIMIZER_MULTIPROTOCOL_ENABLED` dormant 既定は維持（フラグ On は D6）

## DoD
- [x] ruff / format / mypy — 対象ファイル pass（既存 `stripe` stub は無関係）
- [x] pytest — 新規 `test_pendle_liquidity_guard.py`(5) + 既存 multiprotocol routing を PT-yoUSD / eligibility ゲートに更新 +4件。回帰 **923 passed**
- [x] broadcast / 本番 DB write / 秘密鍵参照 / 依存追加 **なし**（dormant）

## スコープ外 → D5b（別 PR）
- **リスク開示/同意 UI**（消費者 aggressive 選択 + 満期ロック/裏付け/スリッページ同意）。現状 `/liff-chat` に消費者向け aggressive 選択 UI が無く、大きめの新規フロント機能のため分離。
- **optimizer 実APY配線**（`PENDLE_IMPLIED_APY=5.2` を `PendleSignalAdapter.get_pt_apy` 実値へ）。ランキング品質のみに影響。

Closes（①②のみ・③はD5b継続）: https://app.asana.com/1/817733952351708/project/1213741124336104/task/1216418536869173

🤖 Generated with [Claude Code](https://claude.com/claude-code)