### PR TITLE
feat(ai): B1 — HOLD時でも遊休USDCを安全利回り(Aave供給)へ配分提案(方向性ゲート切離し)

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -486,6 +486,18 @@ def _multiprotocol_routing_enabled() -> bool:
     return os.getenv("AI_OPTIMIZER_MULTIPROTOCOL_ENABLED", "false").lower() == "true"
 
 
+def _safe_yield_on_hold_enabled() -> bool:
+    """[B1] HOLD 判定時でも「遊休USDC→Aave USDC 供給」の安全利回り提案を出すか。
+
+    既定無効 (従来どおり HOLD では提案ゼロ)。env で明示的に opt-in する。SUPPLY は HF を
+    改善する方向で本質的に安全なため、相場の方向性ゲート (Indicator+Macro≥70%) を待たずに
+    ドル建て安全利回りへ配分する。方向性トレード (BUY/SELL) の挙動には一切影響しない。
+    """
+    import os  # noqa: PLC0415
+
+    return os.getenv("AI_SAFE_YIELD_ON_HOLD_ENABLED", "false").lower() == "true"
+
+
 def _resolve_protocol_routing(
     result: CrossValidationResult,
     risk_mode: str | None,
@@ -764,6 +776,158 @@ def _create_proposals_for_users(
     return count
 
 
+def _create_safe_yield_proposals_for_users(
+    db: Session,
+    decision: AIDecision,
+    result: CrossValidationResult,
+) -> int:
+    """[B1] HOLD 判定時に「遊休USDC→Aave USDC 供給」の安全利回り提案を作成する。
+
+    ``_create_proposals_for_users`` の安全版。方向性ルーティング (_resolve_protocol_routing) は
+    通さず ``operation=SUPPLY / asset=USDC / protocol=aave`` に固定する。SUPPLY は Health Factor を
+    改善する方向で本質的に安全なため、相場ゲート (Indicator+Macro≥70%) を待たずにドル建て安全利回りへ
+    配分する。dedup / 入金ゲート / fee ゲート / per-user savepoint は本流と同一機構を再利用する。
+    BUY/SELL 経路 (``_create_proposals_for_users``) には一切影響しない。
+    """
+    expires_at = datetime.now(timezone.utc) + timedelta(hours=_PROPOSAL_EXPIRES_HOURS)
+    now = datetime.now(timezone.utc)
+    reason = "遊休USDCを安全利回り（Aave USDC）へ配分します。相場の方向性に依らず実行できる安全な運用です。"
+
+    active_users = db.scalars(
+        select(User).where(
+            User.is_active == True,  # noqa: E712
+            User.execution_policy == ExecutionPolicy.REQUIRE_APPROVAL.value,
+        )
+    ).all()
+
+    import os  # noqa: PLC0415
+
+    from app.fees.trade_gate import calculate_fee_by_market  # noqa: PLC0415
+
+    fixed_cost = Decimal(os.getenv("TRADE_FIXED_COST_USD", "0.27"))
+
+    count = 0
+    for user in active_users:
+        try:
+            with db.begin_nested():
+                if not _is_user_due_for_judgment(user, now):
+                    continue
+
+                # 自己修復: 期限切れ pending を先に expire (本流と同じ・永久ブロック防止)。
+                try:
+                    _stale = db.scalars(
+                        select(Proposal).where(
+                            Proposal.user_id == user.id,
+                            Proposal.status == "pending",
+                            Proposal.expires_at < now,
+                        )
+                    ).all()
+                    for _sp in _stale:
+                        _sp.status = "expired"
+                    if _stale:
+                        db.flush()
+                except Exception as _stale_exc:  # noqa: BLE001
+                    logger.warning(
+                        "[safe_yield] stale expire failed for user %d (fail-open): %s",
+                        user.id,
+                        _stale_exc,
+                    )
+
+                # dedup: pending が1つでもあれば作らない (本流と同一)。
+                try:
+                    _pending_raw = db.scalar(
+                        select(func.count(Proposal.id)).where(
+                            Proposal.user_id == user.id,
+                            Proposal.status == "pending",
+                        )
+                    )
+                    _pending_count = int(_pending_raw) if isinstance(_pending_raw, int) else 0
+                except Exception as _guard_exc:  # noqa: BLE001
+                    _pending_count = 0
+                if _pending_count > 0:
+                    continue
+
+                # 遊休額 (fund_allocation or wallet USDC × 10%)。0/入金未満は skip (本流と同一)。
+                proposal_amount_usd = _resolve_proposal_amount(db, user.id)
+                if proposal_amount_usd <= Decimal("0"):
+                    continue
+
+                _default_apy = Decimal("4")
+                _expected_profit = (
+                    proposal_amount_usd
+                    * _default_apy
+                    / Decimal("100")
+                    * Decimal("30")
+                    / Decimal("365")
+                )
+                market_fee = calculate_fee_by_market(
+                    trade_amount_usd=proposal_amount_usd,
+                    tier=normalize_tier(user.tier, user_id=user.id).value,
+                    current_apy=_default_apy,
+                    expected_profit_usd=_expected_profit,
+                    fixed_cost_usd=fixed_cost,
+                )
+                if not market_fee.should_trade:
+                    logger.info(
+                        "[safe_yield] should_trade=False for user %d — skip (%s)",
+                        user.id,
+                        market_fee.reason,
+                    )
+                    continue
+
+                # 安全利回り: 方向性ルーティングを通さず SUPPLY/USDC/aave 固定。
+                operation, asset, protocol = ("SUPPLY", _PROPOSAL_ASSET, "aave")
+                estimated_gas_usd = estimate_static_gas_cost_usd(operation)
+                proposal = Proposal(
+                    user_id=user.id,
+                    ai_decision_id=decision.id,
+                    operation=operation,
+                    asset=asset,
+                    protocol=protocol,
+                    amount=proposal_amount_usd,
+                    amount_usd=proposal_amount_usd,
+                    reason=reason,
+                    expires_at=expires_at,
+                    fee_rate=market_fee.fee_rate,
+                    fee_amount=market_fee.fee_amount,
+                    estimated_gas_usd=estimated_gas_usd,
+                )
+                db.add(proposal)
+                user.last_judgment_at = now
+                count += 1
+
+                try:
+                    from app.notifications.factory import get_notification_service  # noqa: PLC0415
+                    from app.notifications.templates import (
+                        ai_proposal_notification,  # noqa: PLC0415
+                    )
+
+                    _payload = ai_proposal_notification(
+                        operation=operation,
+                        asset=asset,
+                        amount=proposal_amount_usd,
+                        confidence=result.final_confidence,
+                    )
+                    _payload.notification_message.user_id = user.id
+                    get_notification_service().send(_payload.notification_message)
+                except Exception as _notif_exc:  # noqa: BLE001
+                    logger.warning(
+                        "[safe_yield] notification failed for user %d (skip): %s",
+                        user.id,
+                        _notif_exc,
+                    )
+        except Exception as _user_exc:  # noqa: BLE001
+            logger.error(
+                "[safe_yield] proposal creation failed for user %d (skip): %s",
+                user.id,
+                _user_exc,
+            )
+
+    if count:
+        logger.info("[safe_yield] created %d safe-yield SUPPLY proposal(s) on HOLD", count)
+    return count
+
+
 def run_ai_judgment_job(db: Optional[Session] = None) -> dict[str, Any]:
     """AI 判定を実行して DB に保存する同期関数。
 
@@ -931,6 +1095,10 @@ def run_ai_judgment_job(db: Optional[Session] = None) -> dict[str, Any]:
         proposals_created = 0
         if routing_result.final_action in (TradeAction.BUY, TradeAction.SELL):
             proposals_created = _create_proposals_for_users(db, decision, routing_result)
+        elif _safe_yield_on_hold_enabled() and routing_result.final_action == TradeAction.HOLD:
+            # [B1] HOLD でも遊休USDCは安全利回り(Aave USDC供給)へ配分を提案する。
+            # 方向性ゲート(Indicator+Macro≥70%)に依らない安全な運用のみ通す。
+            proposals_created = _create_safe_yield_proposals_for_users(db, decision, result)
 
         db.commit()
 

--- a/backend/tests/automation/test_safe_yield_on_hold.py
+++ b/backend/tests/automation/test_safe_yield_on_hold.py
@@ -1,0 +1,121 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/automation/test_safe_yield_on_hold.py
+"""[B1] HOLD 時の安全利回り提案 (_create_safe_yield_proposals_for_users) の単体テスト。
+
+HOLD 判定でも遊休USDC→Aave USDC 供給を提案し(方向性ゲート非依存)、SUPPLY/USDC/aave 固定で
+作られること、dedup/入金ゲート/fee ゲートで skip されること、フラグ既定 off を検証する。
+"""
+
+import os
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-safe-yield")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "admin@example.com")
+
+import app.automation.ai_judgment_scheduler as sched  # noqa: E402
+from app.automation.ai_judgment_scheduler import (  # noqa: E402
+    _create_safe_yield_proposals_for_users,
+    _safe_yield_on_hold_enabled,
+)
+from app.proposals.models import Proposal  # noqa: E402
+
+
+def _mk_user(uid: int = 11) -> MagicMock:
+    u = MagicMock()
+    u.id = uid
+    u.tier = "LOWER"
+    return u
+
+
+def _mk_db(users: list, pending: int = 0) -> MagicMock:
+    db = MagicMock()
+    active_res = MagicMock()
+    active_res.all.return_value = users
+    stale_res = MagicMock()
+    stale_res.all.return_value = []
+    # scalars: 1回目=active users、以降(各userのstale)=空
+    db.scalars.side_effect = [active_res] + [stale_res for _ in users]
+    db.scalar.return_value = pending  # dedup count
+    return db
+
+
+def _added_proposals(db: MagicMock) -> list:
+    return [c.args[0] for c in db.add.call_args_list if isinstance(c.args[0], Proposal)]
+
+
+def _patch(monkeypatch: pytest.MonkeyPatch, *, amount: Decimal, should_trade: bool = True) -> None:
+    monkeypatch.setattr(sched, "_is_user_due_for_judgment", lambda u, now: True)
+    monkeypatch.setattr(sched, "_resolve_proposal_amount", lambda db, uid: amount)
+    monkeypatch.setattr(
+        sched, "normalize_tier", lambda tier, user_id=None: MagicMock(value="LOWER")
+    )
+    monkeypatch.setattr(sched, "estimate_static_gas_cost_usd", lambda op: Decimal("2"))
+    fee = MagicMock()
+    fee.should_trade = should_trade
+    fee.fee_rate = Decimal("0")
+    fee.fee_amount = Decimal("0")
+    fee.reason = "ok"
+    monkeypatch.setattr("app.fees.trade_gate.calculate_fee_by_market", lambda **kw: fee)
+    monkeypatch.setattr("app.notifications.factory.get_notification_service", lambda: MagicMock())
+
+
+def _decision() -> MagicMock:
+    d = MagicMock()
+    d.id = 1
+    return d
+
+
+def _result() -> MagicMock:
+    r = MagicMock()
+    r.final_confidence = 50
+    return r
+
+
+def test_flag_default_off() -> None:
+    assert _safe_yield_on_hold_enabled() is False
+
+
+def test_flag_on_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AI_SAFE_YIELD_ON_HOLD_ENABLED", "true")
+    assert _safe_yield_on_hold_enabled() is True
+
+
+def test_creates_safe_supply_proposal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """funded user + no pending → SUPPLY/USDC/aave の提案が1件。"""
+    _patch(monkeypatch, amount=Decimal("100"))
+    db = _mk_db([_mk_user()], pending=0)
+    n = _create_safe_yield_proposals_for_users(db, _decision(), _result())
+    assert n == 1
+    props = _added_proposals(db)
+    assert len(props) == 1
+    p = props[0]
+    assert (p.operation, p.asset, p.protocol) == ("SUPPLY", "USDC", "aave")
+    assert p.amount_usd == Decimal("100")
+    assert "安全利回り" in p.reason
+
+
+def test_skip_when_pending_exists(monkeypatch: pytest.MonkeyPatch) -> None:
+    """pending が1つでもあれば作らない (dedup)。"""
+    _patch(monkeypatch, amount=Decimal("100"))
+    db = _mk_db([_mk_user()], pending=1)
+    assert _create_safe_yield_proposals_for_users(db, _decision(), _result()) == 0
+    assert _added_proposals(db) == []
+
+
+def test_skip_when_amount_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """入金未満/遊休なし (amount<=0) は skip。"""
+    _patch(monkeypatch, amount=Decimal("0"))
+    db = _mk_db([_mk_user()], pending=0)
+    assert _create_safe_yield_proposals_for_users(db, _decision(), _result()) == 0
+    assert _added_proposals(db) == []
+
+
+def test_skip_when_fee_gate_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """fee ゲート should_trade=False は skip (少額でガス倒れ防止)。"""
+    _patch(monkeypatch, amount=Decimal("100"), should_trade=False)
+    db = _mk_db([_mk_user()], pending=0)
+    assert _create_safe_yield_proposals_for_users(db, _decision(), _result()) == 0
+    assert _added_proposals(db) == []


### PR DESCRIPTION
## なぜ（本番40日提案ゼロの真因）

本番AIは実ユーザー提案が **2026-06-03 以降ゼロ（約40日）**。read-only 実機調査で真因確定:
- `ai_judgment_scheduler.py` は **BUY/SELL 判定時のみ提案作成**（HOLD → 提案ゼロ）。
- BUY の条件は「Indicator+Macro が強気≥70%」の方向性 AND ゲート。今は `fed_stance=hawkish` で、momentum(#936) が Indicator を上げても Macro 緩和条件が発火せず **全件 HOLD**。

だが **「遊休USDCを Aave に預けて ~3% もらう」= ドル建てで値下がりせず HF を改善する“いつでも得”な安全行動**。相場の強気とは無関係なのに、方向性トレードと同じゲートで審査していたため、安全な利回りすら永久に提案されなかった。

## B1: 安全利回り配分を方向性ゲートから切り離す

- `_safe_yield_on_hold_enabled()` = env `AI_SAFE_YIELD_ON_HOLD_ENABLED`（既定 false・kill switch）
- `_create_safe_yield_proposals_for_users()`（新規）: **HOLD 時**に `operation=SUPPLY / asset=USDC / protocol=aave` 固定で提案。**dedup（pending 1件）/ 入金ゲート / fee ゲート / per-user savepoint は本流と同一機構を再利用**
- `run_ai_judgment_job` に HOLD 分岐追加（flag on かつ `final_action==HOLD` のときのみ）
- **BUY/SELL 経路は byte 不変**（別関数）

### 安全性
SUPPLY（供給）は HF を改善する方向で本質的に安全。HARD_STOP / 入金ゲート / fee ゲート / 非カストディアル本人署名は**すべて既存機構が適用**。**執行コードは一切変更なし**。方向性トレード（値上がり/値下がりの賭け）の挙動は不変。

## DoD
- [x] ruff / format / mypy 対象 pass（既存 `stripe` stub は無関係）
- [x] 新規 `test_safe_yield_on_hold.py`(6: 生成 / dedup / 入金0 skip / fee skip / flag 既定off)。回帰 proposal/scheduler/multiprotocol **315 passed**
- [x] 執行変更なし / 依存追加なし

## Rollout（本 PR マージ後）
1. デプロイ（コードは既定 off で無影響）
2. **本番で `AI_SAFE_YIELD_ON_HOLD_ENABLED=true`** → 次の HOLD tick で **入金済みユーザーに安全利回り SUPPLY 提案が実際に出る**。**HUMAN-REVIEW**（本番 proposal 生成の挙動変更）+ 反映後に proposals 生成を監視
- ※ staging-v4 は demo seed で常時 BUY のため HOLD 分岐の実地確認には不向き。実挙動確認は本番 HOLD tick での flag on が最短

## スコープ外
- B2（AND ゲート/閾値 70→65・hawkish でも方向性BUY可）= Tier S・**森先生の規制判断とセット**。今回やらない
- Macro が hawkish を返す件 / technical_signal の監査保存は別タスク

🤖 Generated with [Claude Code](https://claude.com/claude-code)