### PR TITLE
fix(liff): おまかせ運用トーストの文言是正 (UAT #5)

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -919,8 +919,8 @@
         "toastDepositRequired": "A minimum deposit of ${gate} is required for fully-managed mode",
         "consentNotReady": "Auto mode is being prepared. Please try again later.",
         "consentNoWallet": "Wallet not found. Please log in again.",
-        "consentCancelled": "Auto mode authorization was cancelled.",
-        "consentFailed": "Failed to enable auto mode."
+        "consentCancelled": "Auto mode setup was cancelled. Please continue with Active mode for now.",
+        "consentFailed": "Couldn't enable Auto mode. Please continue with Active mode for now."
       },
       "txHistory": {
         "title": "Transaction History",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -919,8 +919,8 @@
         "toastDepositRequired": "完全おまかせ運用には最低 ${gate} の入金が必要です",
         "consentNotReady": "おまかせ運用は現在準備中です。もう少しお待ちください",
         "consentNoWallet": "ウォレットが見つかりません。再ログインしてください",
-        "consentCancelled": "おまかせ運用の許可がキャンセルされました",
-        "consentFailed": "おまかせ運用の設定に失敗しました"
+        "consentCancelled": "おまかせ運用の設定を取りやめました。現在は「アクティブ」モードでご利用ください。",
+        "consentFailed": "おまかせ運用の設定に失敗しました。現在は「アクティブ」モードでご利用ください。"
       },
       "txHistory": {
         "title": "取引履歴",


### PR DESCRIPTION
## UAT #5

テスターが staging-v4 で「おまかせ運用」に切り替えようとした際:
- `おまかせ運用の許可がキャンセルされました` トースト → 「既存の許可を取り消された」ように読め混乱
- モード変更できず「アクティブのみ有効」で、次に何をすべきか不明（おまかせは "自動売買・自動リバランスは準備中(v4提供予定)"）

原因: `NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED=true`(staging) で managed 選択時に委譲consentフローが走り、キャンセル/失敗で `consentCancelled`/`consentFailed` トーストが出る（`OpModePanel.tsx:77,95`）。文言が誤解を招いていた。

## 修正（文言のみ・挙動不変）
`consentCancelled` / `consentFailed`（ja/en）を、状況が分かり次の行動が示される文言に是正:
- ja: 「おまかせ運用の設定を取りやめました。現在は『アクティブ』モードでご利用ください。」
- en: "Auto mode setup was cancelled. Please continue with Active mode for now."

## DoD
- [x] JSON valid / i18n キー不変（新規欠落なし）/ tsc 0 error
- [x] 挙動変更なし（i18n文言のみ）

## 関連（同UATの他項目・本PR対象外）
- #3/#4（$12,500・PT-stETH のモック表示）→ staging DB のテストデータを USDC ドル建てに是正済（DB UPDATE・コードでなくデータ）
- #1（同意ゲート）→ バグではない（テストユーザーが liff-v4 既同意）
- #6（CSV DL blob）→ 既に `saveBlob`(#976) で修正・デプロイ済。実機PWA目視のみ残

🤖 Generated with [Claude Code](https://claude.com/claude-code)