### PR TITLE
fix(proposals): approve_proposalのis_auto_execution誤結線+custodial fallback暗黙落下を修正

### DIFF
--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -556,6 +556,21 @@ def _execute_aave_for_proposal(proposal: Proposal, db: Session) -> None:
                 "proposal %d: routing via delegated SCW path (policy_id present)", proposal.id
             )
             result = _execute_supply_via_scw(proposal, chain, _grant, _user, db)
+        elif _grant is not None:
+            # 有効な委譲grantを持つ非カストディアルユーザーだが、対象外操作
+            # （例: WITHDRAW は常に custodial 扱い対象外、_should_use_scw_route L332-334）。
+            # この場合サーバー単一鍵(AAVE_WALLET_PRIVATE_KEY)の custodial 経路に暗黙で
+            # 落とさない（本人の資産構造が custodial ファンドプールと異なるため）。
+            # HARD_STOP/risk_limiter と同様 transient 扱いで 'approved' のまま据え置き、
+            # ユーザーは既存の非カストディアル手動署名フロー(build-tx/submit-tx)で対応する。
+            logger.warning(
+                "proposal %d: delegation grant present but operation not SCW-eligible "
+                "(operation=%s) — holding as 'approved', not falling back to custodial "
+                "single-key execution",
+                proposal.id,
+                proposal.operation,
+            )
+            return
         else:
             multi_service = MultiChainAaveService()
             result = multi_service.execute_rebalance(
@@ -1294,6 +1309,12 @@ def approve_proposal(
     auto_execution_enabled = os.getenv("AUTO_EXECUTION_ENABLED", "false").lower() == "true"
 
     # Step 1: PolicyEngine hard rule 検算（承認前に必ず通す）
+    # 本エンドポイントは人間がボタンを押す承認フロー（build_partner_tx と同型）であり
+    # AUTO 執行ではないため is_auto_execution=False 固定（Rule8 の delegation grant 要件は
+    # 対象外）。以前は auto_execution_enabled をそのまま渡していたため、
+    # AUTO_EXECUTION_ENABLED=true にした瞬間、委譲枠を持たない既存 custodial ユーザーの
+    # 人間承認までRule8でブロックされる回帰があった（2026-07-16 発見）。
+    # スケジューラ発の無承認自動実行では is_auto_execution=True を別途使う想定。
     ctx = PolicyContext(
         user_id=proposal.user_id,
         asset=proposal.asset,
@@ -1303,7 +1324,7 @@ def approve_proposal(
         if proposal.expected_hf_after is not None
         else None,
         proposal_id=proposal.id,
-        is_auto_execution=auto_execution_enabled,
+        is_auto_execution=False,
     )
     policy_result = get_policy_engine().check(ctx, db)
     if policy_result.blocked:

--- a/backend/tests/test_approve_policy_wiring.py
+++ b/backend/tests/test_approve_policy_wiring.py
@@ -183,6 +183,65 @@ class TestApprovePolicyWiring:
         assert "POLICY_VIOLATION" in r.json()["detail"]["code"]
 
 
+class TestApproveProposalIsAutoExecutionFixed:
+    """2026-07-16 発見の回帰テスト: approve_proposal は PolicyContext.is_auto_execution に
+    グローバル env AUTO_EXECUTION_ENABLED をそのまま渡していたため、AUTO_EXECUTION_ENABLED=true
+    にした瞬間、委譲枠(delegation grant)を持たない既存 custodial ユーザーの人間承認まで
+    Rule8（AUTO 執行は有効委譲枠必須）でブロックされる回帰があった。
+    build_partner_tx と同様、is_auto_execution=False を固定で渡すことを検証する。
+    """
+
+    def test_is_auto_execution_false_even_when_auto_execution_enabled_true(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AUTO_EXECUTION_ENABLED", "true")
+        token = _admin_token(client)
+        pid = _create_pending_proposal(client, token)
+
+        captured_ctx = []
+
+        def capture_check(ctx, db):  # type: ignore[no-untyped-def]
+            captured_ctx.append(ctx)
+            return PolicyResult(passed=True)
+
+        with patch("app.proposals.router.get_policy_engine") as mock_engine_factory:
+            mock_engine = mock_engine_factory.return_value
+            mock_engine.check.side_effect = capture_check
+
+            client.post(
+                f"/api/proposals/{pid}/approve",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert len(captured_ctx) == 1
+        assert captured_ctx[0].is_auto_execution is False
+
+    def test_is_auto_execution_false_when_auto_execution_disabled(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AUTO_EXECUTION_ENABLED", "false")
+        token = _admin_token(client)
+        pid = _create_pending_proposal(client, token)
+
+        captured_ctx = []
+
+        def capture_check(ctx, db):  # type: ignore[no-untyped-def]
+            captured_ctx.append(ctx)
+            return PolicyResult(passed=True)
+
+        with patch("app.proposals.router.get_policy_engine") as mock_engine_factory:
+            mock_engine = mock_engine_factory.return_value
+            mock_engine.check.side_effect = capture_check
+
+            client.post(
+                f"/api/proposals/{pid}/approve",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert len(captured_ctx) == 1
+        assert captured_ctx[0].is_auto_execution is False
+
+
 class TestBuildPartnerTxPolicyWiring:
     """2026-07-03 棚卸しで検出: build-tx (Privy 非カストディアル主経路) が approve_proposal
     を経由しないため PolicyEngine を一切通っていなかった問題の回帰テスト。"""

--- a/backend/tests/test_custodial_fallback_hardening.py
+++ b/backend/tests/test_custodial_fallback_hardening.py
@@ -1,0 +1,177 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_custodial_fallback_hardening.py
+"""_execute_aave_for_proposal の custodial fallback ハードニング（2026-07-16 Step 0.5）。
+
+有効な委譲(SCW) grant を持つユーザーの操作が _should_use_scw_route で対象外
+（例: WITHDRAW は常に custodial 扱い対象外）と判定された場合に、サーバー単一鍵
+(AAVE_WALLET_PRIVATE_KEY) の custodial 経路へ暗黙に落とさないことを検証する。
+grant が無い（従来の custodial ファンドプールユーザー）場合は従来どおり custodial
+経路が使われることも合わせて確認する。
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-custodial-fallback")
+
+from app.aave.schemas import (  # noqa: E402
+    AaveOperationResult,
+    AaveOperationStatus,
+    AaveOperationType,
+)
+from app.auth.models import User  # noqa: E402
+from app.automation.safety_gate import HardStopResult  # noqa: E402
+from app.database import Base  # noqa: E402
+from app.proposals.models import Proposal  # noqa: E402
+
+_WALLET = "0xCustodialFallback00000000000000000000001"
+
+
+@pytest.fixture()
+def db_session() -> Generator[Session, None, None]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestSession()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        os.unlink(path)
+
+
+def _make_user(db: Session, uid: int = 21) -> User:
+    user = User(
+        id=uid,
+        email=f"custodialfallback{uid}@test.com",
+        username=f"custodialfallback{uid}",
+        hashed_password="x",
+        role="partner",
+        is_active=True,
+        wallet_address=_WALLET,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _make_proposal(db: Session, user_id: int, operation: str = "WITHDRAW") -> Proposal:
+    proposal = Proposal(
+        user_id=user_id,
+        operation=operation,
+        asset="USDC",
+        amount=Decimal("1000"),
+        amount_usd=Decimal("1000.00"),
+        reason="custodial fallback hardening test",
+        status="approved",
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    db.add(proposal)
+    db.flush()
+    return proposal
+
+
+def _fake_result() -> AaveOperationResult:
+    return AaveOperationResult(
+        operation=AaveOperationType.WITHDRAW,
+        status=AaveOperationStatus.SUCCESS,
+        asset_symbol="USDC",
+        amount=Decimal("1000"),
+        tx_hash="0xexec",
+    )
+
+
+def _grant() -> SimpleNamespace:
+    return SimpleNamespace(
+        wallet_address="0xSCW", privy_signer_id="s1", privy_policy_id="p1", allowed_protocols=[]
+    )
+
+
+def test_grant_present_but_scw_ineligible_does_not_fall_back_to_custodial(
+    db_session: Session,
+) -> None:
+    """grant あり + WITHDRAW（_should_use_scw_route=False）→ custodial 経路(execute_rebalance)
+    を呼ばず、status='approved' のまま据え置く（HARD_STOP/risk_limiter と同じ transient 扱い）。
+    """
+    from app.proposals.router import _execute_aave_for_proposal
+
+    user = _make_user(db_session)
+    proposal = _make_proposal(db_session, user_id=user.id, operation="WITHDRAW")
+    db_session.commit()
+
+    called: list[bool] = []
+
+    def _mock_execute(**kwargs: object) -> AaveOperationResult:
+        called.append(True)
+        return _fake_result()
+
+    with (
+        patch(
+            "app.automation.safety_gate.evaluate_hard_stop",
+            return_value=HardStopResult(blocked=False),
+        ),
+        patch("app.proposals.router.get_active_grant", return_value=_grant()),
+        patch(
+            "app.aave.service.MultiChainAaveService.execute_rebalance",
+            side_effect=_mock_execute,
+        ),
+    ):
+        _execute_aave_for_proposal(proposal, db_session)
+
+    assert called == []  # custodial 単一鍵経路は呼ばれない
+    assert proposal.status == "approved"  # transient: failed にも executed にもしない
+    assert proposal.tx_hash is None
+
+
+def test_no_grant_still_uses_custodial_path(db_session: Session) -> None:
+    """grant が存在しない（従来の custodial ファンドプールユーザー）場合は
+    引き続き custodial 経路(execute_rebalance)が使われ、挙動が変わらないことを確認する。
+    """
+    from app.proposals.router import _execute_aave_for_proposal
+
+    user = _make_user(db_session, uid=22)
+    proposal = _make_proposal(db_session, user_id=user.id, operation="SUPPLY")
+    db_session.commit()
+
+    called: list[bool] = []
+
+    def _mock_execute(**kwargs: object) -> AaveOperationResult:
+        called.append(True)
+        return AaveOperationResult(
+            operation=AaveOperationType.DEPOSIT,
+            status=AaveOperationStatus.SUCCESS,
+            asset_symbol="USDC",
+            amount=Decimal("1000"),
+            tx_hash="0xexec",
+        )
+
+    with (
+        patch(
+            "app.automation.safety_gate.evaluate_hard_stop",
+            return_value=HardStopResult(blocked=False),
+        ),
+        patch("app.proposals.router.get_active_grant", return_value=None),
+        patch(
+            "app.aave.service.MultiChainAaveService.execute_rebalance",
+            side_effect=_mock_execute,
+        ),
+    ):
+        _execute_aave_for_proposal(proposal, db_session)
+
+    assert called == [True]
+    assert proposal.status == "executed"
+    assert proposal.tx_hash == "0xexec"

--- a/backend/tests/test_phase2d_a_wiring.py
+++ b/backend/tests/test_phase2d_a_wiring.py
@@ -3,11 +3,15 @@
 """スライス2-D-A: 既存安全装置の AUTO 執行経路への結線。
 
 検証:
-- PolicyEngine Rule8 発火: AUTO_EXECUTION_ENABLED=true で有効な委譲枠が無い承認は 422 拒否。
-- 手動承認 (AUTO 無効) は委譲枠なしでも通る（Rule8 は AUTO 経路のみ）。
+- 手動承認 (approve_proposal) は AUTO_EXECUTION_ENABLED の値に関わらず委譲枠なしで通る
+  （2026-07-16 修正: is_auto_execution=False 固定。Rule8 は本エンドポイント対象外）。
 - risk_limiter %クランプ結線: check_trade_within_limits が違反を返すと execute_rebalance を
   呼ばず status を 'approved' 据え置き（transient）。
 - _daily_traded_usd_for_user: 当日 approved/executed 合計（自分以外）。
+
+PolicyEngine Rule8（AUTO 執行は有効委譲枠必須）自体は健在。適用対象は将来の
+スケジューラ発・無承認自動実行（is_auto_execution=True で呼ばれる経路）のみで、
+そちらのテストは backend/tests/test_auto_execute_trigger.py（PR3以降）に分離する。
 """
 
 from __future__ import annotations
@@ -256,22 +260,41 @@ def _create_proposal(client: TestClient, token: str) -> int:
     return int(r.json()["id"])
 
 
-def test_auto_execution_without_grant_blocked(client: TestClient, test_db: tuple) -> None:
-    """AUTO 有効 + 委譲枠なし → Rule8 で 422 fail-closed。"""
+def test_auto_execution_flag_no_longer_requires_grant_for_human_approval(
+    client: TestClient, test_db: tuple
+) -> None:
+    """2026-07-16 修正の回帰テスト: approve_proposal は is_auto_execution=False 固定
+    （build_partner_tx と同型、本人がクリックする承認フローのため）。
+    AUTO_EXECUTION_ENABLED=true でも、委譲枠を持たない custodial ユーザーの承認は
+    Rule8（有効委譲枠必須）でブロックされず、custodial 単一鍵実行まで進む。
+    Rule8 は将来のスケジューラ発の無承認自動実行（is_auto_execution=True）専用に予約する。
+    """
     _override, SessionLocal = test_db
     token = _admin_token(client, SessionLocal)
     proposal_id = _create_proposal(client, token)
 
-    with patch.dict(os.environ, {"AUTO_EXECUTION_ENABLED": "true"}):
+    fake_result = AaveOperationResult(
+        operation=AaveOperationType.DEPOSIT,
+        status=AaveOperationStatus.SUCCESS,
+        asset_symbol="USDC",
+        amount=Decimal("1000.00"),
+        tx_hash="0xauto",
+    )
+
+    with (
+        patch.dict(os.environ, {"AUTO_EXECUTION_ENABLED": "true"}),
+        patch(
+            "app.aave.service.MultiChainAaveService.execute_rebalance",
+            return_value=fake_result,
+        ),
+    ):
         r = client.post(
             f"/api/proposals/{proposal_id}/approve",
             headers={"Authorization": f"Bearer {token}"},
         )
 
-    assert r.status_code == 422
-    detail = r.json()["detail"]
-    assert detail["code"] == "POLICY_VIOLATION"
-    assert any("delegation grant" in v for v in detail["violations"])
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "executed"
 
 
 def test_manual_approve_without_grant_ok(client: TestClient, test_db: tuple) -> None:

--- a/backend/tests/test_proposal_execute_failure.py
+++ b/backend/tests/test_proposal_execute_failure.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import os
 import tempfile
-from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Generator
 from unittest.mock import patch
@@ -109,42 +108,14 @@ def _create_proposal(client: TestClient, token: str) -> int:
     return int(r.json()["id"])
 
 
-def _create_active_grant(session_local: object, user_id: int = 1) -> None:
-    """AUTO 執行に必須の有効な委譲枠を作る（PolicyEngine Rule8 / スライス2-D-A）。
-
-    AUTO_EXECUTION_ENABLED=true の承認は有効な delegation grant が無いと
-    fail-closed で 422 拒否される。本テスト群は AUTO 執行成功/失敗を検証するため、
-    枠の存在を前提条件としてセットアップする。
-    """
-    from app.users.models import DelegationGrant  # noqa: PLC0415
-
-    now = datetime.now(timezone.utc)
-    db = session_local()
-    try:
-        db.add(
-            DelegationGrant(
-                user_id=user_id,
-                wallet_address="0x" + "a" * 40,
-                status="active",
-                max_single_trade_pct=Decimal("10"),
-                max_daily_trade_pct=Decimal("30"),
-                hf_floor=Decimal("1.6"),
-                allowed_protocols=["aave"],
-                allowed_assets=["USDC"],
-                consent_at=now,
-                expires_at=now + timedelta(days=30),
-            )
-        )
-        db.commit()
-    finally:
-        db.close()
-
-
 def test_aave_execution_success_marks_proposal_executed(client: TestClient, test_db: tuple) -> None:
-    """Aave 実行成功 → proposal.status='executed', transaction(status='completed') 記録。"""
+    """Aave 実行成功 → proposal.status='executed', transaction(status='completed') 記録。
+
+    approve_proposal は is_auto_execution=False 固定（2026-07-16 Step 0）のため、
+    Rule8（有効委譲枠必須）の対象外＝delegation grant は不要。
+    """
     _override, SessionLocal = test_db
     token = _admin_token(client, SessionLocal)
-    _create_active_grant(SessionLocal, user_id=1)
     proposal_id = _create_proposal(client, token)
 
     fake_result = AaveOperationResult(
@@ -195,7 +166,6 @@ def test_aave_execution_failure_marks_proposal_failed(client: TestClient, test_d
     """Aave 実行失敗 → proposal.status='failed', error_message 記録, transaction(status='failed') 記録。"""
     _override, SessionLocal = test_db
     token = _admin_token(client, SessionLocal)
-    _create_active_grant(SessionLocal, user_id=1)
     proposal_id = _create_proposal(client, token)
 
     boom = RuntimeError("RPC connection refused")
@@ -248,7 +218,6 @@ def test_aave_execution_failure_sends_slack_notification(
     """Aave 実行失敗時に通知サービスの send() が呼ばれることを検証（mock）。"""
     _override, SessionLocal = test_db
     token = _admin_token(client, SessionLocal)
-    _create_active_grant(SessionLocal, user_id=1)
     proposal_id = _create_proposal(client, token)
 
     boom = RuntimeError("web3 provider unreachable")


### PR DESCRIPTION
## Summary
「完全おまかせ」(execution_policy=AUTO_EXECUTE、非カストディアル委譲SCW自動実行) を配線する作業(Asana親案件・hkobayashi承認済プラン)の前提となる、Tier S安全修正2点(Step0/0.5)。実装計画: `.claude-uata/plans/floating-imagining-key.md` 参照。

- **Step 0**: `approve_proposal()` が `PolicyContext.is_auto_execution` にグローバル env `AUTO_EXECUTION_ENABLED` をそのまま渡していた。姉妹エンドポイント `build_partner_tx` は同様の状況で `is_auto_execution=False` を固定で渡しており「本経路は人間が署名する手動フローでAUTO執行ではない」と明記している。`approve_proposal` だけこの規約から外れていた。現在は無害(`AUTO_EXECUTION_ENABLED`が全環境false)だが、有効化した瞬間、委譲枠を持たない既存custodialユーザーの人間承認までRule8(有効委譲枠必須)でブロックされる回帰があった。→ `is_auto_execution=False`に固定。Rule8は将来のスケジューラ発・無承認自動実行専用に予約する。
- **Step 0.5**: `_execute_aave_for_proposal` が、有効な委譲grantを持つがSCW対象外操作(WITHDRAW等、`_should_use_scw_route`は常にWITHDRAWをFalseにする設計)のユーザーを、サーバー単一鍵(`AAVE_WALLET_PRIVATE_KEY`)のcustodial経路へ暗黙に落としていた。HARD_STOP/risk_limiterと同型のtransient据え置き(`'approved'`のまま)ガードを追加。

## 既存テストの更新(挙動修正に伴う意図的な変更)
- `test_phase2d_a_wiring.py::test_auto_execution_without_grant_blocked`: 旧仕様(Rule8がapprove_proposalをブロック)を固定化していたテストをリネーム・反転。docstringも修正意図を明記。
- `test_proposal_execute_failure.py`: Rule8を通すためだけに付与していた不要な`_create_active_grant`ヘルパー呼び出しを削除(Step0修正でRule8対象外になったため不要)。

## Test plan
- [x] `ruff check .` / `ruff format --check .` pass
- [x] `pytest tests/` 全件(4759 passed, 21 skipped) pass — フルスイート実行済み
- [x] 新規テスト: `test_custodial_fallback_hardening.py`(grant+SCW対象外→custodial非到達 / grantなし→従来通りcustodial実行)
- [x] 新規テスト: `test_approve_policy_wiring.py::TestApproveProposalIsAutoExecutionFixed`(AUTO_EXECUTION_ENABLED true/false 両方でis_auto_execution=False固定を確認)
- [ ] staging-v4での実機確認(次PRで委譲フラグ群を段階的に有効化する際にまとめて実施予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Edj3hjkB6XrjYezmARpQEq