### PR TITLE
feat(privy): 委譲consent完了時にprivy_wallet_idを解決してbackendへ送信

### DIFF
--- a/backend/app/users/settings_router.py
+++ b/backend/app/users/settings_router.py
@@ -473,6 +473,13 @@ def create_delegation_grant(
         privy_signer_id=request.privy_signer_id,
     )
     db.add(grant)
+
+    # 委譲 SCW 執行が要求する per-user Privy wallet ID。ログイン時点では未委譲で null のため
+    # 取得できず、consent(addSigners) 完了後の本エンドポイント呼び出し時が唯一の確実な解決経路
+    # （2026-07-16）。未指定時は _resolve_privy_wallet_id が env フォールバックに頼る旧経路のまま。
+    if request.privy_wallet_id and current_user.privy_wallet_id != request.privy_wallet_id:
+        current_user.privy_wallet_id = request.privy_wallet_id
+
     db.commit()
     db.refresh(grant)
     logger.info(

--- a/backend/app/users/settings_schemas.py
+++ b/backend/app/users/settings_schemas.py
@@ -103,6 +103,11 @@ class DelegationGrantRequest(BaseModel):
     # /delegation/prepare で作成した policy_id と SERVER_SIGNER_ID を grant 確定時に保存する。
     privy_policy_id: Optional[str] = Field(default=None, max_length=255)
     privy_signer_id: Optional[str] = Field(default=None, max_length=255)
+    # Privy 内部 wallet ID（アドレスではない）。ログイン時点(wallet-connect)では embedded wallet
+    # が未委譲のため常に null（Privy SDK 仕様）で取得できず、addSigners 成功後（＝本エンドポイント
+    # 呼び出し時）に初めて解決可能になる。委譲(SCW)執行の wallet_sendCalls が要求する識別子で、
+    # users.privy_wallet_id へ保存する（2026-07-16、per-user 解決の唯一の確実な経路）。
+    privy_wallet_id: Optional[str] = Field(default=None, max_length=64)
 
     @field_validator("max_single_trade_pct")
     @classmethod

--- a/backend/tests/test_delegation_grants.py
+++ b/backend/tests/test_delegation_grants.py
@@ -293,3 +293,47 @@ class TestDelegationAPI:
         data = r.json()
         assert data["privy_policy_id"] is None
         assert data["privy_signer_id"] is None
+
+    def test_grant_persists_privy_wallet_id_to_user(
+        self, client: TestClient, test_db: tuple
+    ) -> None:
+        """2026-07-16: grant に privy_wallet_id を渡すと users.privy_wallet_id へ保存される
+        （ログイン時点では未委譲で null のため、consent 完了時点(本エンドポイント)が唯一の
+        確実な解決経路）。"""
+        _override, SessionLocal = test_db
+        token = register_and_login(client)
+        h = {"Authorization": f"Bearer {token}"}
+        payload = dict(self._VALID)
+        payload["privy_wallet_id"] = "frob784a2upmpff5z7yi300u"
+        r = client.post("/api/user/delegation/grant", json=payload, headers=h)
+        assert r.status_code == 200, r.text
+
+        from app.auth.models import User  # noqa: PLC0415
+
+        db = SessionLocal()
+        try:
+            user = db.query(User).filter(User.email == os.environ["INITIAL_ADMIN_EMAIL"]).first()
+            assert user is not None
+            assert user.privy_wallet_id == "frob784a2upmpff5z7yi300u"
+        finally:
+            db.close()
+
+    def test_grant_without_privy_wallet_id_does_not_touch_user(
+        self, client: TestClient, test_db: tuple
+    ) -> None:
+        """後方互換: privy_wallet_id を渡さない既存フローは user.privy_wallet_id を変更しない。"""
+        _override, SessionLocal = test_db
+        token = register_and_login(client)
+        h = {"Authorization": f"Bearer {token}"}
+        r = client.post("/api/user/delegation/grant", json=self._VALID, headers=h)
+        assert r.status_code == 200, r.text
+
+        from app.auth.models import User  # noqa: PLC0415
+
+        db = SessionLocal()
+        try:
+            user = db.query(User).filter(User.email == os.environ["INITIAL_ADMIN_EMAIL"]).first()
+            assert user is not None
+            assert user.privy_wallet_id is None
+        finally:
+            db.close()

--- a/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState } from "react"
 import { Bot, MousePointer2 } from "lucide-react"
 import { useTranslations } from "next-intl"
-import { useSigners, useWallets } from "@privy-io/react-auth"
+import { useSigners, useUser, useWallets } from "@privy-io/react-auth"
 import { getAuthToken } from "@/lib/auth/token-key"
 import { isAutoModeEnabled } from "@/lib/flags"
 import { DEPOSIT_GATE_USD } from "@/lib/web3/config"
@@ -34,6 +34,7 @@ export function OpModePanel() {
   const [toast, setToast] = useState<string | null>(null)
   const { addSigners, removeSigners } = useSigners()
   const { wallets } = useWallets()
+  const { refreshUser } = useUser()
 
   function showToast(msg: string) {
     setToast(msg)
@@ -43,6 +44,24 @@ export function OpModePanel() {
   function embeddedEoaAddress(): string | null {
     // Privy embedded wallet (TEE) を委譲対象 EOA とする。外部 wallet は除外。
     return wallets.find((w) => w.walletClientType === "privy")?.address ?? null
+  }
+
+  // Privy 内部 wallet ID を解決する。Wallet.id はログイン時点(未委譲)では常に null
+  // （Privy SDK 仕様: "Null if the wallet is not delegated"）で、addSigners 成功直後に
+  // refreshUser() で最新の linkedAccounts を取得して初めて埋まる。委譲(SCW)執行の
+  // wallet_sendCalls が要求する識別子（2026-07-16、per-user 解決の唯一の確実な経路）。
+  async function resolvePrivyWalletId(eoa: string): Promise<string | undefined> {
+    try {
+      const refreshed = await refreshUser()
+      const account = refreshed.linkedAccounts.find(
+        (a) => a.type === "wallet" && a.address === eoa
+      )
+      return account && account.type === "wallet" && account.id ? account.id : undefined
+    } catch {
+      // 解決できなくても致命的ではない（_resolve_privy_wallet_id が env フォールバックに頼る）
+      console.warn("[opMode] privy_wallet_id resolution failed after addSigners")
+      return undefined
+    }
   }
 
   // managed への切替時: 委譲枠を作成（prepare）→ Privy で session signer を consent
@@ -78,11 +97,14 @@ export function OpModePanel() {
       return false
     }
 
+    const privyWalletId = await resolvePrivyWalletId(eoa)
+
     try {
       await grantDelegation({
         ...DEFAULT_DELEGATION_PARAMS,
         privy_policy_id: prep.privy_policy_id,
         privy_signer_id: prep.privy_signer_id,
+        ...(privyWalletId ? { privy_wallet_id: privyWalletId } : {}),
       })
     } catch {
       // grant 保存失敗 → 付与済み signer をロールバック（非カストディアル維持）

--- a/frontend/lib/api/delegation.ts
+++ b/frontend/lib/api/delegation.ts
@@ -22,6 +22,15 @@ export interface DelegationGrantParams {
   expires_in_days: number
 }
 
+export interface DelegationGrantExtra {
+  privy_policy_id?: string
+  privy_signer_id?: string
+  // Privy 内部 wallet ID（アドレスではない）。addSigners 成功直後のみ解決可能
+  // （ログイン時点では未委譲で null。Privy SDK 仕様）。委譲(SCW)執行の
+  // wallet_sendCalls が要求する識別子で、渡すと users.privy_wallet_id へ保存される。
+  privy_wallet_id?: string
+}
+
 export interface DelegationPrepareResponse {
   privy_policy_id: string
   privy_signer_id: string
@@ -91,7 +100,7 @@ export async function prepareDelegation(
 
 /** L3: consent 済みの枠 + Privy 識別子を保存して grant を確定する。 */
 export async function grantDelegation(
-  params: DelegationGrantParams & { privy_policy_id: string; privy_signer_id: string }
+  params: DelegationGrantParams & DelegationGrantExtra
 ): Promise<DelegationGrantResponse> {
   const res = await authedFetch("/api/user/delegation/grant", {
     method: "POST",


### PR DESCRIPTION
## Summary
「完全おまかせ」(非カストディアル委譲SCW自動実行) を配線する作業の2本目(PR1 #986 とは独立、どちらが先にマージされても衝突しない)。実装計画: `.claude-uata/plans/floating-imagining-key.md` §2 参照。

`_resolve_privy_wallet_id`（`backend/app/proposals/router.py`）は `user.privy_wallet_id` を優先し、無ければグローバル env `PRIVY_DELEGATED_WALLET_ID` にフォールバックする設計だが、frontendがこの値をこれまで一切送信していなかった。このままSCWルートを有効化すると、**複数の非カストディアルユーザーが同じ1つのPrivy walletに対して実行されてしまう**危険な状態になるため、AUTO_EXECUTE配線の前提として先に埋める。

## 実装
Privy SDKの型定義(`@privy-io/react-auth`)で `Wallet.id` の仕様を確認: `"The server wallet ID of the wallet. Null if the wallet is not delegated."` — つまりログイン時点(wallet-connect)では常に `null` で取得不可。`addSigners()`（委譲consent）成功後にのみ解決可能。

- **frontend** (`OpModePanel.tsx`): `runDelegationConsent()` で `addSigners()` 成功後、`useUser().refreshUser()` で最新の `linkedAccounts` を取得し、対象walletの `.id` を解決 → `grantDelegation()` のペイロードに `privy_wallet_id` として含める。解決失敗時は non-fatal（従来通りenv fallbackに委ねる）。
- **backend**: `DelegationGrantRequest` に `privy_wallet_id`(任意)追加、`create_delegation_grant` で `current_user.privy_wallet_id` に保存(未指定時は既存挙動のまま変更なし)。

いずれも `NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED` / `DELEGATION_PRIVY_POLICY_ENABLED` dormantフラグ配下(全環境false)のため、**現行の本番/staging挙動に一切影響なし**。

## Test plan
- [x] backend: `test_delegation_grants.py` に2件追加(`privy_wallet_id`を渡すとuser列に保存される/未指定時は変更されない)。既存23件 + 新規2件、計25件 pass。
- [x] `ruff check` / backend全体テストスイート(PR1側で確認済みの4759件、本PRはbackendスキーマ変更のみで影響範囲は上記追加テストでカバー)
- [x] frontend: `tsc --noEmit` pass、`npm run build` pass、`eslint` pass
- [ ] frontend unit test: このリポジトリに frontend 単体テスト基盤(jest/vitest)が存在しないため、型チェック+ビルドで代替。実際の `addSigners`→`refreshUser`→`grantDelegation` の一連の動作確認は、実装計画のPhase B(staging-v4でのフラグ段階有効化・人間承認ゲート)で実機Privyログインにより検証する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Edj3hjkB6XrjYezmARpQEq