### PR TITLE
feat(auto-execute): AUTO_EXECUTEユーザーへの提案生成+即時自動実行を配線 (#988 main反映)

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -593,10 +593,16 @@ def _create_proposals_for_users(
     reason = result.final_reason or "AI判定による提案"
     now = datetime.now(timezone.utc)
 
+    # AUTO_EXECUTE（完全おまかせ・無承認自動実行）ユーザーもここで提案対象に含める
+    # （2026-07-16）。生成後 run_auto_execution_for_ai_decision が有効な委譲(SCW) grant を
+    # 持つ AUTO_EXECUTE ユーザーの pending 分だけを即時実行する。grant が無い/対象外
+    # operation の場合は 'pending' のまま従来の手動フローに委ねる。
     active_users = db.scalars(
         select(User).where(
             User.is_active == True,  # noqa: E712
-            User.execution_policy == ExecutionPolicy.REQUIRE_APPROVAL.value,
+            User.execution_policy.in_(
+                [ExecutionPolicy.REQUIRE_APPROVAL.value, ExecutionPolicy.AUTO_EXECUTE.value]
+            ),
         )
     ).all()
 
@@ -793,10 +799,16 @@ def _create_safe_yield_proposals_for_users(
     now = datetime.now(timezone.utc)
     reason = "遊休USDCを安全利回り（Aave USDC）へ配分します。相場の方向性に依らず実行できる安全な運用です。"
 
+    # AUTO_EXECUTE ユーザーも対象に含める（2026-07-16）。B1 が生成する提案は常に
+    # SUPPLY/USDC/aave 固定で _should_use_scw_route が True になり得る唯一の operation
+    # （WITHDRAWの危険性が原理的にない）。HFを改善する方向で本質的に安全なため、
+    # 本流 (_create_proposals_for_users) と同様に含める。
     active_users = db.scalars(
         select(User).where(
             User.is_active == True,  # noqa: E712
-            User.execution_policy == ExecutionPolicy.REQUIRE_APPROVAL.value,
+            User.execution_policy.in_(
+                [ExecutionPolicy.REQUIRE_APPROVAL.value, ExecutionPolicy.AUTO_EXECUTE.value]
+            ),
         )
     ).all()
 
@@ -1102,11 +1114,39 @@ def run_ai_judgment_job(db: Optional[Session] = None) -> dict[str, Any]:
 
         db.commit()
 
+        # AUTO_EXECUTE（完全おまかせ）ユーザーの pending 提案のうち、有効な委譲(SCW) grant を
+        # 持つ分だけを即時実行する（2026-07-16）。提案作成トランザクションと分離し、外部I/O
+        # (Privy sendCalls 等) の失敗が他ユーザーの提案生成をブロックしないようにする。
+        # fail-open: 例外は auto_execute 内部で握りつぶされる設計だが、二重の安全のため
+        # ここでも捕捉し、判定ジョブ全体の成功(proposals_created 等)を道連れにしない。
+        auto_execute_result: dict[str, int] = {
+            "auto_executed": 0,
+            "auto_execute_skipped": 0,
+            "auto_execute_failed": 0,
+        }
+        if proposals_created > 0:
+            try:
+                from app.proposals.auto_execute import (  # noqa: PLC0415
+                    run_auto_execution_for_ai_decision,
+                )
+
+                auto_execute_result = run_auto_execution_for_ai_decision(db, decision.id)
+                db.commit()
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "auto-execution for ai_decision_id=%d failed (fail-open, judgment job "
+                    "continues): %s",
+                    decision.id,
+                    exc,
+                )
+                db.rollback()
+
         return {
             "action": result.final_action.value,
             "confidence": result.final_confidence,
             "proposals_created": proposals_created,
             "decision_id": decision.id,
+            **auto_execute_result,
         }
 
     except Exception as exc:

--- a/backend/app/proposals/auto_execute.py
+++ b/backend/app/proposals/auto_execute.py
@@ -1,0 +1,158 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/app/proposals/auto_execute.py
+"""「完全おまかせ」(execution_policy=AUTO_EXECUTE) ユーザー向けの無承認自動実行。
+
+AI 判定 tick で生成された pending proposal のうち、AUTO_EXECUTE ポリシーかつ有効な
+委譲(SCW) grant を持つユーザーの分だけを対象に、人間の承認クリックを介さず
+``_run_approval_and_execution(is_auto_execution=True)`` を呼んで即時実行する。
+
+対象外（grant なし / WITHDRAW 等 SCW 非対応 operation）の proposal は 'pending' の
+まま何もしない — 既存のユーザー向け手動承認フローに委ねる。委譲(SCW)経路にも
+HARD_STOP・risk_limiter・PolicyEngine Rule8（有効委譲枠必須）・emergency stop は
+（``_run_approval_and_execution`` 経由で）等しく適用される。
+
+2026-07-16、実装計画: `.claude-uata/plans/floating-imagining-key.md` §1 参照。
+"""
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.auth.constants import ExecutionPolicy
+from app.auth.models import User
+from app.users.models import get_active_grant
+
+from .execution_route import RouteMismatchError
+from .models import Proposal
+from .router import (
+    DepositBelowMinimumError,
+    PolicyViolationError,
+    ProtocolExecutionNotWiredError,
+    _run_approval_and_execution,
+    _should_use_scw_route,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _notify_auto_execution_issue(proposal_id: int, reason: str) -> None:
+    """無承認自動実行がスキップ/失敗した際に管理者へ Slack 通知する（best-effort）。"""
+    try:
+        from app.notifications.factory import get_notification_service  # noqa: PLC0415
+        from app.notifications.schemas import (  # noqa: PLC0415
+            NotificationChannel,
+            NotificationMessage,
+            NotificationSeverity,
+        )
+
+        message = NotificationMessage(
+            channel=NotificationChannel.SLACK,
+            severity=NotificationSeverity.ALERT,
+            title=f"AUTO_EXECUTE auto-execution issue (proposal #{proposal_id})",
+            body=f"proposal_id: {proposal_id}\nreason: {reason}",
+        )
+        get_notification_service().send(message)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("auto_execute notification failed (non-fatal): %s", exc)
+
+
+def run_auto_execution_for_ai_decision(db: Session, ai_decision_id: int) -> dict[str, int]:
+    """指定 AIDecision に紐づく pending proposal のうち、AUTO_EXECUTE ユーザー分を即時実行する。
+
+    :returns: {"auto_executed": int, "auto_execute_skipped": int, "auto_execute_failed": int}
+    """
+    auto_executed = 0
+    auto_execute_skipped = 0
+    auto_execute_failed = 0
+
+    targets = db.scalars(
+        select(Proposal)
+        .join(User, User.id == Proposal.user_id)
+        .where(
+            Proposal.ai_decision_id == ai_decision_id,
+            Proposal.status == "pending",
+            User.execution_policy == ExecutionPolicy.AUTO_EXECUTE.value,
+        )
+    ).all()
+
+    for proposal in targets:
+        # NOTE: db.begin_nested() は使わない。_run_approval_and_execution は自身の判断で
+        # 複数回 db.commit() する設計（approve_proposal と共有、HTTPの1リクエスト=1トランザクション
+        # 前提）のため、外側で SAVEPOINT を張ると commit() 時にネストしたトランザクションが
+        # 閉じてしまい "Can't operate on closed transaction" になる（_create_proposals_for_users
+        # とは前提が異なる）。DepositBelowMinimumError/PolicyViolationError は proposal へ
+        # 書き込む前に raise される、RouteMismatchError/ProtocolExecutionNotWiredError は
+        # 自身の db.commit() 済みで raise される — いずれも rollback 不要。真に未想定な例外
+        # (DB エラー等) のときのみ明示的に db.rollback() して次の proposal へ安全に進む。
+        try:
+            grant = get_active_grant(proposal.user_id, db)
+            if grant is None or not _should_use_scw_route(proposal, grant):
+                # 委譲grantなし、または SCW 対象外 operation (WITHDRAW 等) →
+                # 自動実行しない。'pending' のまま既存の手動フローに委ねる。
+                logger.info(
+                    "proposal %d: auto-execution skipped (no eligible delegation route, "
+                    "operation=%s)",
+                    proposal.id,
+                    proposal.operation,
+                )
+                auto_execute_skipped += 1
+                continue
+
+            try:
+                _run_approval_and_execution(proposal, db, is_auto_execution=True)
+                auto_executed += 1
+            except (DepositBelowMinimumError, PolicyViolationError) as exc:
+                logger.warning(
+                    "proposal %d: auto-execution blocked before approval: %s",
+                    proposal.id,
+                    exc,
+                )
+                auto_execute_failed += 1
+                _notify_auto_execution_issue(proposal.id, str(exc))
+            except ProtocolExecutionNotWiredError as exc:
+                # Lido/Pendle 等の custodial 未配線 protocol。approved のまま据置き
+                # （_run_approval_and_execution 内で処理済み）。監査用に通知のみ行う。
+                logger.warning(
+                    "proposal %d: auto-execution hit unwired protocol: %s", proposal.id, exc
+                )
+                auto_execute_failed += 1
+                _notify_auto_execution_issue(proposal.id, str(exc))
+            except RouteMismatchError as exc:
+                # P0-2 誤執行検出（'failed' 化済み）。EMERGENCY 相当のため必ず通知する。
+                logger.error(
+                    "proposal %d: auto-execution hit route mismatch (手動介入必須): %s",
+                    proposal.id,
+                    exc,
+                )
+                auto_execute_failed += 1
+                _notify_auto_execution_issue(proposal.id, f"route mismatch: {exc}")
+        except Exception as exc:  # noqa: BLE001
+            # 1件の未想定例外（DB エラー等）が他 proposal の自動実行を止めないようにする。
+            logger.error(
+                "proposal %d: auto-execution failed with unexpected error (skipping, "
+                "continuing to next proposal): %s",
+                proposal.id,
+                exc,
+            )
+            auto_execute_failed += 1
+            try:
+                db.rollback()
+            except Exception:  # noqa: BLE001, S110
+                pass
+            _notify_auto_execution_issue(proposal.id, str(exc))
+
+    if auto_executed or auto_execute_skipped or auto_execute_failed:
+        logger.info(
+            "[auto_execute] ai_decision_id=%d executed=%d skipped=%d failed=%d",
+            ai_decision_id,
+            auto_executed,
+            auto_execute_skipped,
+            auto_execute_failed,
+        )
+
+    return {
+        "auto_executed": auto_executed,
+        "auto_execute_skipped": auto_execute_skipped,
+        "auto_execute_failed": auto_execute_failed,
+    }

--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -664,6 +664,22 @@ def _execute_aave_for_proposal(proposal: Proposal, db: Session) -> None:
         _notify_aave_failure(proposal.id, error_message, failed_at)
 
 
+class DepositBelowMinimumError(Exception):
+    """A-2 入金ゲート違反（残高 < MIN_DEPOSIT_USD）。detail は HTTP 422 の detail dict と同型。"""
+
+    def __init__(self, detail: dict[str, str]) -> None:
+        self.detail = detail
+        super().__init__(detail.get("message", "deposit below minimum"))
+
+
+class PolicyViolationError(Exception):
+    """PolicyEngine hard rule 違反（Rule8 の有効委譲枠必須を含む）。"""
+
+    def __init__(self, violations: list[str]) -> None:
+        self.violations = violations
+        super().__init__("; ".join(violations))
+
+
 class ProtocolExecutionNotWiredError(Exception):
     """custodial 自動執行がまだ配線されていない protocol を指す。
 
@@ -1256,6 +1272,93 @@ def list_proposal_history(
     )
 
 
+def _run_approval_and_execution(
+    proposal: Proposal, db: Session, *, is_auto_execution: bool
+) -> None:
+    """承認判定〜（AUTO_EXECUTION_ENABLED 有効時のみ）執行までの中核ロジック。
+
+    approve_proposal（HTTP、人間がボタンを押す承認フロー）とスケジューラ発の
+    無承認自動実行（2026-07-16、AUTO_EXECUTEユーザー向け・app.proposals.auto_execute）の
+    両方から呼ばれる共有関数。呼び出し元が例外を自分の作法で処理する
+    （HTTP は HTTPException に変換、scheduler はログ+Slack通知して次のproposalへ継続）。
+
+    :param is_auto_execution: PolicyEngine Rule8（AUTO 執行は有効委譲枠必須）に渡す値。
+        HTTP 経路（人間がクリック）は False 固定。scheduler 経路（無承認）は True 固定。
+    """
+    # A-2 入金ゲート: 残高が運用開始の最低入金額 (MIN_DEPOSIT_USD) 未満なら承認・執行を拒否。
+    # 判定不能 (None) は fail-open（RPC 失敗等インフラ起因で正規の承認を止めない）、
+    # 確定した不足のみブロックする。提案生成側でも同ゲートを通すため、ここは防御的二重化。
+    from app.users.deposit_policy import MIN_DEPOSIT_USD  # noqa: PLC0415
+    from app.users.deposit_resolver import resolve_user_deposit_usd  # noqa: PLC0415
+
+    _deposit_usd = resolve_user_deposit_usd(db, proposal.user_id)
+    if _deposit_usd is not None and _deposit_usd < MIN_DEPOSIT_USD:
+        raise DepositBelowMinimumError(
+            {
+                "code": "DEPOSIT_BELOW_MINIMUM",
+                "message": (
+                    f"運用開始には最低 ${MIN_DEPOSIT_USD} の入金が必要です"
+                    f"（現在: ${_deposit_usd}）。"
+                ),
+                "min_deposit_usd": str(MIN_DEPOSIT_USD),
+                "current_deposit_usd": str(_deposit_usd),
+            }
+        )
+
+    # AUTO 執行フラグ（実行段階のマスタースイッチ）は is_auto_execution（Rule8 用）とは独立。
+    auto_execution_enabled = os.getenv("AUTO_EXECUTION_ENABLED", "false").lower() == "true"
+
+    # Step 1: PolicyEngine hard rule 検算（承認前に必ず通す）
+    ctx = PolicyContext(
+        user_id=proposal.user_id,
+        asset=proposal.asset,
+        operation=proposal.operation,
+        amount_usd=Decimal(str(proposal.amount_usd)),
+        expected_hf_after=Decimal(str(proposal.expected_hf_after))
+        if proposal.expected_hf_after is not None
+        else None,
+        proposal_id=proposal.id,
+        is_auto_execution=is_auto_execution,
+    )
+    policy_result = get_policy_engine().check(ctx, db)
+    if policy_result.blocked:
+        raise PolicyViolationError(policy_result.violations)
+
+    # Step 2: 承認済みにマーク
+    proposal.status = "approved"
+    proposal.approved_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(proposal)
+
+    # Step 2: Aave 自動実行 (AUTO_EXECUTION_ENABLED=true の場合のみ)
+    # non-custodial 方式2 では default=false。partner 手動署名 (submit_partner_tx) のみが実 tx を立てる。
+    # AAVE_WALLET_PRIVATE_KEY が署名する経路はこのフラグで完全に無効化される。
+    if auto_execution_enabled:
+        from .execution_route import RouteMismatchError  # noqa: PLC0415
+
+        try:
+            # protocol (aave/lido/pendle) で執行ハンドラを振り分ける。
+            # Lido/Pendle は HUMAN-REVIEW 未配線のため ProtocolExecutionNotWiredError。
+            _dispatch_custodial_execution(proposal, db)
+        except RouteMismatchError:
+            db.commit()  # status='failed' / error_message を永続化
+            raise
+        except ProtocolExecutionNotWiredError as exc:
+            # Lido/Pendle の custodial 自動執行は未配線 (HUMAN-REVIEW)。
+            # approved のまま据置き (Aave として誤実行しない)。
+            logger.warning("proposal %d: custodial execution 未配線: %s", proposal.id, exc)
+            db.commit()
+            raise
+        db.commit()
+        db.refresh(proposal)
+    else:
+        logger.info(
+            "proposal %d: AUTO_EXECUTION_ENABLED=false — skipping custodial auto-execution; "
+            "waiting for partner manual approve via submit-tx",
+            proposal.id,
+        )
+
+
 @router.post("/{proposal_id}/approve", response_model=ProposalResponse, summary="提案承認・実行")
 def approve_proposal(
     proposal_id: int,
@@ -1284,98 +1387,34 @@ def approve_proposal(
             detail=f"Cannot approve proposal with status '{proposal.status}'",
         )
 
-    # A-2 入金ゲート: 残高が運用開始の最低入金額 (MIN_DEPOSIT_USD) 未満なら承認・執行を拒否。
-    # 判定不能 (None) は fail-open（RPC 失敗等インフラ起因で正規の承認を止めない）、
-    # 確定した不足のみブロックする。提案生成側でも同ゲートを通すため、ここは防御的二重化。
-    from app.users.deposit_policy import MIN_DEPOSIT_USD  # noqa: PLC0415
-    from app.users.deposit_resolver import resolve_user_deposit_usd  # noqa: PLC0415
+    from .execution_route import RouteMismatchError  # noqa: PLC0415
 
-    _deposit_usd = resolve_user_deposit_usd(db, proposal.user_id)
-    if _deposit_usd is not None and _deposit_usd < MIN_DEPOSIT_USD:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={
-                "code": "DEPOSIT_BELOW_MINIMUM",
-                "message": (
-                    f"運用開始には最低 ${MIN_DEPOSIT_USD} の入金が必要です"
-                    f"（現在: ${_deposit_usd}）。"
-                ),
-                "min_deposit_usd": str(MIN_DEPOSIT_USD),
-                "current_deposit_usd": str(_deposit_usd),
-            },
-        )
-
-    # AUTO 執行フラグは PolicyContext (Rule8: AUTO 執行は有効委譲枠必須) より前に評価する。
-    auto_execution_enabled = os.getenv("AUTO_EXECUTION_ENABLED", "false").lower() == "true"
-
-    # Step 1: PolicyEngine hard rule 検算（承認前に必ず通す）
     # 本エンドポイントは人間がボタンを押す承認フロー（build_partner_tx と同型）であり
     # AUTO 執行ではないため is_auto_execution=False 固定（Rule8 の delegation grant 要件は
-    # 対象外）。以前は auto_execution_enabled をそのまま渡していたため、
-    # AUTO_EXECUTION_ENABLED=true にした瞬間、委譲枠を持たない既存 custodial ユーザーの
-    # 人間承認までRule8でブロックされる回帰があった（2026-07-16 発見）。
-    # スケジューラ発の無承認自動実行では is_auto_execution=True を別途使う想定。
-    ctx = PolicyContext(
-        user_id=proposal.user_id,
-        asset=proposal.asset,
-        operation=proposal.operation,
-        amount_usd=Decimal(str(proposal.amount_usd)),
-        expected_hf_after=Decimal(str(proposal.expected_hf_after))
-        if proposal.expected_hf_after is not None
-        else None,
-        proposal_id=proposal.id,
-        is_auto_execution=False,
-    )
-    policy_result = get_policy_engine().check(ctx, db)
-    if policy_result.blocked:
+    # 対象外）。スケジューラ発の無承認自動実行（AUTO_EXECUTE ユーザー）は
+    # is_auto_execution=True で _run_approval_and_execution を別途呼ぶ
+    # （app.proposals.auto_execute 参照）。
+    try:
+        _run_approval_and_execution(proposal, db, is_auto_execution=False)
+    except DepositBelowMinimumError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.detail
+        ) from exc
+    except PolicyViolationError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={
-                "code": "POLICY_VIOLATION",
-                "violations": policy_result.violations,
-            },
-        )
-
-    # Step 2: 承認済みにマーク
-    proposal.status = "approved"
-    proposal.approved_at = datetime.now(timezone.utc)
-    db.commit()
-    db.refresh(proposal)
-
-    # Step 2: Aave 自動実行 (AUTO_EXECUTION_ENABLED=true の場合のみ)
-    # non-custodial 方式2 では default=false。partner 手動署名 (submit_partner_tx) のみが実 tx を立てる。
-    # AAVE_WALLET_PRIVATE_KEY が署名する経路はこのフラグで完全に無効化される。
-    # （auto_execution_enabled は上の PolicyContext 構築前に評価済み）
-    if auto_execution_enabled:
-        from .execution_route import RouteMismatchError  # noqa: PLC0415
-
-        try:
-            # protocol (aave/lido/pendle) で執行ハンドラを振り分ける。
-            # Lido/Pendle は HUMAN-REVIEW 未配線のため ProtocolExecutionNotWiredError。
-            _dispatch_custodial_execution(proposal, db)
-        except RouteMismatchError as exc:
-            db.commit()  # status='failed' / error_message を永続化
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=f"誤執行検出: {exc} (手動介入必須)",
-            ) from exc
-        except ProtocolExecutionNotWiredError as exc:
-            # Lido/Pendle の custodial 自動執行は未配線 (HUMAN-REVIEW)。
-            # approved のまま据置き、501 で明示する (Aave として誤実行しない)。
-            logger.warning("proposal %d: custodial execution 未配線: %s", proposal.id, exc)
-            db.commit()
-            raise HTTPException(
-                status_code=status.HTTP_501_NOT_IMPLEMENTED,
-                detail=str(exc),
-            ) from exc
-        db.commit()
-        db.refresh(proposal)
-    else:
-        logger.info(
-            "proposal %d: AUTO_EXECUTION_ENABLED=false — skipping custodial auto-execution; "
-            "waiting for partner manual approve via submit-tx",
-            proposal.id,
-        )
+            detail={"code": "POLICY_VIOLATION", "violations": exc.violations},
+        ) from exc
+    except RouteMismatchError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"誤執行検出: {exc} (手動介入必須)",
+        ) from exc
+    except ProtocolExecutionNotWiredError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail=str(exc),
+        ) from exc
 
     return ProposalResponse.model_validate(proposal)
 

--- a/backend/tests/test_ai_judgment_scheduler.py
+++ b/backend/tests/test_ai_judgment_scheduler.py
@@ -609,14 +609,49 @@ def test_run_job_degraded_context_has_required_keys(db_session):
 # ---------------------------------------------------------------------------
 
 
-def test_buy_creates_proposal_only_for_require_approval_users(db_session):
-    """BUY 判定時、execution_policy='require_approval' のユーザーのみ Proposal が作成されること。"""
+def test_buy_creates_proposal_for_require_approval_and_auto_execute_users(db_session):
+    """2026-07-16: BUY 判定時、execution_policy='require_approval'/'auto_execute' の
+    両方に Proposal が作成されること（'proposal_only' は対象外のまま）。
+    AUTO_EXECUTE ユーザーは委譲(SCW) grant を持たないため、提案は作られるが
+    auto-execution 側では skip され 'pending' のまま残る（別テストで検証）。
+    """
     approval_user = _add_active_user(
         db_session, "approval@example.com", execution_policy="require_approval"
     )
-    _add_active_user(db_session, "auto@example.com", execution_policy="auto_execute")
+    auto_user = _add_active_user(db_session, "auto@example.com", execution_policy="auto_execute")
     _add_active_user(db_session, "proposal@example.com", execution_policy="proposal_only")
     _add_fund_allocation(db_session, approval_user)
+    _add_fund_allocation(db_session, auto_user)
+    db_session.commit()
+
+    mock_result = _make_cross_validation_result(TradeAction.BUY)
+
+    with (
+        patch("app.automation.ai_judgment_scheduler.AIService") as MockAIService,
+        patch("app.automation.ai_judgment_scheduler.KnowledgeService") as MockKnowledgeService,
+    ):
+        MockAIService.return_value.judge_with_rag.return_value = mock_result
+        MockKnowledgeService.return_value.search.return_value = []
+
+        result = run_ai_judgment_job(db=db_session)
+
+    assert result["proposals_created"] == 2
+    proposals = db_session.scalars(select(Proposal)).all()
+    assert len(proposals) == 2
+    proposal_user_ids = {p.user_id for p in proposals}
+    assert proposal_user_ids == {approval_user.id, auto_user.id}
+    # 委譲grantが無いため auto-execution は skip（'pending' のまま・自動実行しない）。
+    assert all(p.status == "pending" for p in proposals)
+    assert result["auto_executed"] == 0
+    assert result["auto_execute_skipped"] == 1
+
+
+def test_auto_execute_user_without_grant_stays_pending_on_buy(db_session):
+    """2026-07-16: auto_execute ユーザーは提案が作られるが、有効な委譲(SCW) grant が
+    無い限り自動実行されず 'pending' のまま残る（既存の手動フローに委ねる）。
+    """
+    auto_user = _add_active_user(db_session, "auto@example.com", execution_policy="auto_execute")
+    _add_fund_allocation(db_session, auto_user)
     db_session.commit()
 
     mock_result = _make_cross_validation_result(TradeAction.BUY)
@@ -631,30 +666,11 @@ def test_buy_creates_proposal_only_for_require_approval_users(db_session):
         result = run_ai_judgment_job(db=db_session)
 
     assert result["proposals_created"] == 1
+    assert result["auto_executed"] == 0
+    assert result["auto_execute_skipped"] == 1
     proposals = db_session.scalars(select(Proposal)).all()
     assert len(proposals) == 1
-    assert proposals[0].user_id is not None
-
-
-def test_auto_execute_user_gets_no_proposal_on_buy(db_session):
-    """auto_execute ユーザーには BUY 判定でも Proposal が作成されないこと。"""
-    _add_active_user(db_session, "auto@example.com", execution_policy="auto_execute")
-    db_session.commit()
-
-    mock_result = _make_cross_validation_result(TradeAction.BUY)
-
-    with (
-        patch("app.automation.ai_judgment_scheduler.AIService") as MockAIService,
-        patch("app.automation.ai_judgment_scheduler.KnowledgeService") as MockKnowledgeService,
-    ):
-        MockAIService.return_value.judge_with_rag.return_value = mock_result
-        MockKnowledgeService.return_value.search.return_value = []
-
-        result = run_ai_judgment_job(db=db_session)
-
-    assert result["proposals_created"] == 0
-    proposals = db_session.scalars(select(Proposal)).all()
-    assert len(proposals) == 0
+    assert proposals[0].status == "pending"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_auto_execute_trigger.py
+++ b/backend/tests/test_auto_execute_trigger.py
@@ -1,0 +1,279 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_auto_execute_trigger.py
+"""run_auto_execution_for_ai_decision の単体テスト（2026-07-16「完全おまかせ」配線）。
+
+AUTO_EXECUTE ユーザーの pending proposal のうち、有効な委譲(SCW) grant を持つ分だけを
+即時実行し、それ以外（grant なし / WITHDRAW 等 SCW 非対応 operation）は 'pending' の
+まま custodial 単一鍵経路へ絶対に落とさないことを検証する（Step 0.5 の安全境界の
+scheduler 側での再確認）。HARD_STOP 等の transient ゲートも通ることを確認する。
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-auto-execute-trigger")
+
+from app.ai.models import AIDecision  # noqa: E402
+from app.auth.models import User  # noqa: E402
+from app.automation.safety_gate import HardStopResult  # noqa: E402
+from app.database import Base  # noqa: E402
+from app.proposals.models import Proposal  # noqa: E402
+from app.users.models import DelegationGrant  # noqa: E402
+
+
+def _wallet_for(uid: int) -> str:
+    return "0x" + f"{uid:040x}"
+
+
+@pytest.fixture()
+def db_session() -> Generator[Session, None, None]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestSession()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        os.unlink(path)
+
+
+@pytest.fixture()
+def enabled_env(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+    monkeypatch.setenv("DELEGATION_PRIVY_POLICY_ENABLED", "true")
+    monkeypatch.setenv("PRIVY_SERVER_SIGNER_ID", "kq_server_1")
+    monkeypatch.setenv("PRIVY_APP_ID", "app123")
+    monkeypatch.setenv("PRIVY_APP_SECRET", "secret123")
+    monkeypatch.setenv("AUTO_EXECUTION_ENABLED", "true")
+    yield
+
+
+def _make_user(db: Session, uid: int, execution_policy: str = "auto_execute") -> User:
+    user = User(
+        id=uid,
+        email=f"autoexec{uid}@test.com",
+        username=f"autoexec{uid}",
+        hashed_password="x",
+        role="viewer",
+        is_active=True,
+        wallet_address=_wallet_for(uid),
+        execution_policy=execution_policy,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _make_decision(db: Session, decision_id: int = 1) -> AIDecision:
+    decision = AIDecision(
+        id=decision_id,
+        query="q",
+        action="BUY",
+        confidence=80,
+        primary_provider="claude",
+        primary_action="BUY",
+        primary_confidence=80,
+    )
+    db.add(decision)
+    db.flush()
+    return decision
+
+
+def _make_proposal(
+    db: Session, user_id: int, decision_id: int, operation: str = "SUPPLY"
+) -> Proposal:
+    proposal = Proposal(
+        user_id=user_id,
+        ai_decision_id=decision_id,
+        operation=operation,
+        asset="USDC",
+        protocol="aave",
+        amount=Decimal("1000"),
+        amount_usd=Decimal("1000.00"),
+        reason="auto execute trigger test",
+        status="pending",
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    db.add(proposal)
+    db.flush()
+    return proposal
+
+
+def _make_grant(db: Session, user_id: int, **overrides: object) -> DelegationGrant:
+    now = datetime.now(timezone.utc)
+    defaults: dict[str, object] = dict(
+        user_id=user_id,
+        wallet_address="0xSCW",
+        status="active",
+        max_single_trade_pct=Decimal("10"),
+        max_daily_trade_pct=Decimal("30"),
+        hf_floor=Decimal("1.6"),
+        allowed_protocols=["aave"],
+        allowed_assets=["USDC"],
+        privy_signer_id="s1",
+        privy_policy_id="p1",
+        consent_at=now,
+        expires_at=now + timedelta(days=30),
+    )
+    defaults.update(overrides)
+    grant = DelegationGrant(**defaults)
+    db.add(grant)
+    db.flush()
+    return grant
+
+
+def test_no_grant_stays_pending_and_is_skipped(db_session: Session, enabled_env: None) -> None:
+    """委譲grantが無いAUTO_EXECUTEユーザーの提案は実行されず 'pending' のまま。"""
+    from app.proposals.auto_execute import run_auto_execution_for_ai_decision
+
+    user = _make_user(db_session, uid=1)
+    decision = _make_decision(db_session)
+    proposal = _make_proposal(db_session, user.id, decision.id)
+    db_session.commit()
+
+    with patch("app.aave.service.MultiChainAaveService.execute_rebalance") as mock_execute:
+        result = run_auto_execution_for_ai_decision(db_session, decision.id)
+
+    mock_execute.assert_not_called()
+    assert result == {"auto_executed": 0, "auto_execute_skipped": 1, "auto_execute_failed": 0}
+    db_session.refresh(proposal)
+    assert proposal.status == "pending"
+
+
+def test_grant_with_supply_executes_via_scw(db_session: Session, enabled_env: None) -> None:
+    """SCW 対象(SUPPLY)+有効grant → 委譲経路で即時実行され 'executed' になる。"""
+    from app.proposals.auto_execute import run_auto_execution_for_ai_decision
+    from app.proposals.scw_executor import ScwExecutionResult
+
+    user = _make_user(db_session, uid=2)
+    decision = _make_decision(db_session)
+    proposal = _make_proposal(db_session, user.id, decision.id, operation="SUPPLY")
+    _make_grant(db_session, user.id)
+    db_session.commit()
+
+    fake_client = type(
+        "FakeClient",
+        (),
+        {
+            "build_deposit_txs": lambda self, *a, **kw: {
+                "approve_tx": {"to": "0xtoken", "data": "0xa", "value": "0x0"},
+                "supply_tx": {"to": "0xpool", "data": "0xs", "value": "0x0"},
+            }
+        },
+    )()
+    fake_service = type(
+        "FakeService",
+        (),
+        {"get_service": lambda self, chain: type("S", (), {"client": fake_client})()},
+    )()
+
+    with (
+        patch(
+            "app.automation.safety_gate.evaluate_hard_stop",
+            return_value=HardStopResult(blocked=False),
+        ),
+        patch("app.aave.service.MultiChainAaveService", lambda: fake_service),
+        patch(
+            "app.proposals.scw_executor.execute_calls_via_scw",
+            return_value=ScwExecutionResult(tx_hash="0xauto1", status="submitted", raw={}),
+        ),
+    ):
+        result = run_auto_execution_for_ai_decision(db_session, decision.id)
+
+    assert result == {"auto_executed": 1, "auto_execute_skipped": 0, "auto_execute_failed": 0}
+    db_session.refresh(proposal)
+    assert proposal.status == "executed"
+    assert proposal.tx_hash == "0xauto1"
+
+
+def test_grant_with_withdraw_never_falls_back_to_custodial(
+    db_session: Session, enabled_env: None
+) -> None:
+    """有効grantがあってもWITHDRAWはSCW対象外 → custodial単一鍵経路に絶対に落ちず
+    'pending' のまま skip される（Step 0.5 の安全境界の scheduler 側再確認）。"""
+    from app.proposals.auto_execute import run_auto_execution_for_ai_decision
+
+    user = _make_user(db_session, uid=3)
+    decision = _make_decision(db_session)
+    proposal = _make_proposal(db_session, user.id, decision.id, operation="WITHDRAW")
+    _make_grant(db_session, user.id)
+    db_session.commit()
+
+    with patch("app.aave.service.MultiChainAaveService.execute_rebalance") as mock_execute:
+        result = run_auto_execution_for_ai_decision(db_session, decision.id)
+
+    mock_execute.assert_not_called()
+    assert result == {"auto_executed": 0, "auto_execute_skipped": 1, "auto_execute_failed": 0}
+    db_session.refresh(proposal)
+    assert proposal.status == "pending"
+
+
+def test_hard_stop_holds_as_approved_transient(db_session: Session, enabled_env: None) -> None:
+    """HARD_STOP発火時は執行を待避し 'approved' のまま据え置く（transient・再試行可能）。"""
+    from app.proposals.auto_execute import run_auto_execution_for_ai_decision
+
+    user = _make_user(db_session, uid=4)
+    decision = _make_decision(db_session)
+    proposal = _make_proposal(db_session, user.id, decision.id, operation="SUPPLY")
+    _make_grant(db_session, user.id)
+    db_session.commit()
+
+    with patch(
+        "app.automation.safety_gate.evaluate_hard_stop",
+        return_value=HardStopResult(blocked=True, reason="emergency_stop", source="rule_engine"),
+    ):
+        result = run_auto_execution_for_ai_decision(db_session, decision.id)
+
+    assert result == {"auto_executed": 1, "auto_execute_skipped": 0, "auto_execute_failed": 0}
+    db_session.refresh(proposal)
+    assert proposal.status == "approved"
+    assert proposal.tx_hash is None
+
+
+def test_one_proposal_failure_does_not_stop_others(db_session: Session, enabled_env: None) -> None:
+    """1件の未想定例外が他のAUTO_EXECUTE proposalの処理を止めない。"""
+    from app.proposals.auto_execute import run_auto_execution_for_ai_decision
+
+    user1 = _make_user(db_session, uid=5)
+    user2 = _make_user(db_session, uid=6)
+    decision = _make_decision(db_session)
+    p1 = _make_proposal(db_session, user1.id, decision.id, operation="SUPPLY")
+    p2 = _make_proposal(db_session, user2.id, decision.id, operation="SUPPLY")
+    _make_grant(db_session, user1.id)
+    # user2 には grant を与えない -> skip されるだけで例外にはならないが、
+    # get_active_grant 自体が例外を投げるケースを模してロバスト性を検証する。
+    db_session.commit()
+
+    call_count = {"n": 0}
+    real_get_active_grant = __import__(
+        "app.users.models", fromlist=["get_active_grant"]
+    ).get_active_grant
+
+    def flaky_get_active_grant(user_id: int, db: Session):
+        call_count["n"] += 1
+        if user_id == user1.id:
+            raise RuntimeError("simulated DB error for user1")
+        return real_get_active_grant(user_id, db)
+
+    with patch("app.proposals.auto_execute.get_active_grant", side_effect=flaky_get_active_grant):
+        result = run_auto_execution_for_ai_decision(db_session, decision.id)
+
+    assert result["auto_execute_failed"] == 1
+    assert result["auto_execute_skipped"] == 1
+    db_session.refresh(p1)
+    db_session.refresh(p2)
+    assert p1.status == "pending"  # user1 は例外 -> savepoint rollback で pending のまま
+    assert p2.status == "pending"  # user2 は grant なし -> skip


### PR DESCRIPTION
## Summary
PR #988 の内容を main へ反映する。#988 は #986(Step0/0.5) をbaseにした積み上げPRで、#986のブランチに対してマージされていたが、#986がsquash mergeでmainに乗った後もこのブランチ自体はmainの祖先から外れたままだったため、#988の実体（`auto_execute.py`等）がmainに反映されていなかった（積み上げPRの典型的な落とし穴）。

本PRはこのブランチを最新mainへrebaseし直したもの。git rebase時に「#986相当のコミットは既にmain上にある」と正しく検出されてskipされ、純粋に#988の差分のみが残っていることを確認済み（`git diff origin/main --stat`で5ファイルのみ、#987が触ったファイルへの巻き戻しは無し）。

内容自体は #988 の説明を参照:
- `ai_judgment_scheduler.py`: AUTO_EXECUTEユーザーも提案生成対象に追加
- `proposals/router.py`: `approve_proposal`の中核ロジックを`_run_approval_and_execution`に抽出（ロジック変更なし）
- `proposals/auto_execute.py`(新規): 有効な委譲(SCW) grantを持つAUTO_EXECUTEユーザーのpending提案のみ即時実行、それ以外は絶対にcustodial単一鍵経路に落とさずpending維持

3フラグ(`NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED`/`DELEGATION_PRIVY_POLICY_ENABLED`/`AUTO_EXECUTION_ENABLED`)は全環境false継続のため、本PRマージのみでは実行に一切影響なし。

## Test plan
- [x] rebase後のbranchでbackend全体テスト再実行: 4766 passed, 21 skipped(#987マージ後のmainベースなので+2、既存分含め全green)
- [x] `ruff check .` / `ruff format --check .` backend全体 pass
- [x] git diff で#987が触ったファイル(`settings_router.py`/`settings_schemas.py`/`OpModePanel.tsx`/`delegation.ts`/`test_delegation_grants.py`)に一切触れていないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Edj3hjkB6XrjYezmARpQEq