### PR TITLE
fix(liff): 「おまかせ」説明文がconsent有効化後も「準備中」のまま固定されていたのを修正

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
@@ -141,7 +141,10 @@ export function OpModePanel() {
     {
       id: "managed" as UserMode,
       label: t("managedLabel"),
-      desc: t("managedDesc"),
+      // CONSENT_ENABLED=false のときは「準備中」文言、true(委譲consentフローが実際に
+      // 動く環境)では実際の上限内自動実行の説明に切り替える(2026-07-17、実装完了に
+      // 追随して固定「準備中」文言のまま出し続けないようにする)。
+      desc: CONSENT_ENABLED ? t("managedDescLive") : t("managedDesc"),
       icon: Bot,
       color: "text-[#1D9E75]",
       bg: "bg-[#1D9E75]/10",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -911,6 +911,7 @@
         "activeBadge": "Active",
         "managedLabel": "Automated",
         "managedDesc": "AI analyzes the market and displays proposals. Automated trading and rebalancing are coming soon (available in v4).",
+        "managedDescLive": "AI analyzes the market and executes automatically within pre-approved limits (per-trade and daily amount caps, minimum Health Factor). Proposals outside those limits still require your approval.",
         "activeLabel": "Active",
         "activeDesc": "AI proposes. You approve before execution.",
         "toastSwitched": "Switched to \"{mode}\"",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -911,6 +911,7 @@
         "activeBadge": "設定中",
         "managedLabel": "おまかせ",
         "managedDesc": "AIが市場を分析し提案を表示します。自動売買・自動リバランスは準備中です（v4提供予定）。",
+        "managedDescLive": "AIが市場を分析し、あらかじめ承認した上限（1回・1日あたりの取引額、Health Factor下限）の範囲内で自動的に実行します。範囲外の提案は人間の承認を求めます。",
         "activeLabel": "アクティブ",
         "activeDesc": "AIが提案。自分で承認してから実行。",
         "toastSwitched": "「{mode}」に切り替えました",


### PR DESCRIPTION
## Summary
staging-v4でChrome実機確認中に発見。`NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED=true`の環境でも、OpModePanelの「おまかせ」説明文が「自動売買・自動リバランスは準備中です（v4提供予定）」という固定文言のままだった。委譲consentフロー自体（PR #835）も自動実行エンジン（PR #986-989）も実装・有効化済みで実際には動くのに、UIが「まだ準備中」と誤解を招く表示をしていた。

本番でこの機能を有効化してユーザー自身が「おまかせ」を試す前に修正が必要と判断。

## 変更
- `managedDescLive`キーを新設し、`CONSENT_ENABLED`がtrueのときはそちらを表示するよう`OpModePanel.tsx`を修正
- `CONSENT_ENABLED=false`の環境（現行本番含む大半）では従来通り「準備中」文言のまま（変更なし）

## Test plan
- [x] `tsc --noEmit` pass
- [x] `node scripts/check-i18n-keys.mjs` pass（新規欠落なし）
- [x] eslint pass
- [x] staging-v4実機（Chrome、既存Privyセッションでログイン確認）で修正前の「準備中」誤表示を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Edj3hjkB6XrjYezmARpQEq