### PR TITLE
fix(liff): 委譲consent再試行時のDuplicate signer 400エラーを修正

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
@@ -13,6 +13,7 @@ import { track, EV } from "@/lib/posthog"
 import {
   DEFAULT_DELEGATION_PARAMS,
   DelegationNotReadyError,
+  getDelegation,
   grantDelegation,
   prepareDelegation,
   revokeDelegation,
@@ -68,6 +69,20 @@ export function OpModePanel() {
   // （addSigners）→ backend に grant 確定。失敗時は signer をロールバックする。
   // 戻り値: consent + grant が成功したか。
   async function runDelegationConsent(): Promise<boolean> {
+    // 既に有効な委譲grant(signer/policy付き)があれば再consent不要。addSigners()を
+    // 同じPrivy signerに対して再度呼ぶと「Duplicate signer(s) provided when updating
+    // wallet」400で必ず失敗する(2026-07-17 本番実機で確認: 一度成功した後、モードを
+    // 切り替えて再度「おまかせ」を選ぶと再現)。既存の有効grantを検出したら
+    // addSigners自体をスキップし、そのまま利用する。
+    try {
+      const existing = await getDelegation()
+      if (existing && existing.privy_signer_id && existing.privy_policy_id) {
+        return true
+      }
+    } catch {
+      // 既存grant確認に失敗しても、通常のconsentフローにフォールバックする(非致命的)。
+    }
+
     let prep
     try {
       prep = await prepareDelegation(DEFAULT_DELEGATION_PARAMS)


### PR DESCRIPTION
## Summary
本番実機テスト中(hkobayashi本人によるproduction PWAでの「完全おまかせ」consent検証)に発見。一度「おまかせ」consentが成功すると(Privy側にsignerが登録される)、モードを切り替えて再度「おまかせ」を選んだ際、`addSigners()`が同じPrivy signerに対して再度呼ばれ、Privy側で

```json
{"error": "Duplicate signer(s) provided when updating wallet. To address, ensure each additional signer has not already been added.", "code": "invalid_data"}
```

という400エラーで必ず失敗していた。ブラウザConsoleで実機確認済み。

## 実機での再現・確認手順
1. production(app.ultra-auto-trade.com)でPrivyログイン→「おまかせ」選択→consent成功(delegation_grants id=1作成、signer/policy両方あり)
2. 「アクティブ」→再度「おまかせ」を選択
3. `PATCH https://auth.privy.io/api/v1/wallets/{id} 400` + 上記エラー
4. `おまかせ運用の設定を取りやめました` トースト → モードは「アクティブ」のまま

## 修正
`runDelegationConsent()`冒頭で`getDelegation()`(GET /api/user/delegation)を呼び、既に有効な委譲grant(privy_signer_id/privy_policy_id両方あり)が存在すれば`addSigners()`をスキップしてそのまま利用する。確認自体が失敗した場合は従来通りのconsentフローにフォールバック(非致命的)。

## Test plan
- [x] `tsc --noEmit` pass
- [x] eslint pass
- [x] 実機で発見したバグの根本原因(Privy「Duplicate signer」)に対する直接対処
- [ ] production再デプロイ後、実際に「アクティブ→おまかせ」の再切替が成功することを本人が実機確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Edj3hjkB6XrjYezmARpQEq