### PR TITLE
fix(backend): 本番エラーマスクがdict detailの構造化エラーを握りつぶす不具合を修正

### DIFF
--- a/backend/app/error_handlers.py
+++ b/backend/app/error_handlers.py
@@ -62,6 +62,19 @@ def register_error_handlers(app: FastAPI) -> None:
             _add_cors_headers(response, request)
             return response
         if _is_production and exc.status_code >= 400:
+            # dict の detail は自前コードが意図的に構築した安全な構造化エラー
+            # (例: {"code": "DEPOSIT_BELOW_MINIMUM", "message": ..., ...})。
+            # マスクすると frontend の detail.code 分岐が壊れ、汎用エラーしか
+            # 出せなくなる(2026-07-17 本番実機: おまかせ切替の入金ゲートで発見。
+            # DEPOSIT_BELOW_MINIMUM が "Validation error" に潰され、正しい
+            # トースト文言 [最低$200の入金が必要] が表示できなかった)。
+            # detail=str(exc) 由来の生文字列のみ引き続きマスクする(内部情報漏洩防止、
+            # 本ハンドラの本来の目的)。
+            if isinstance(exc.detail, dict):
+                return JSONResponse(
+                    status_code=exc.status_code,
+                    content={"detail": exc.detail},
+                )
             safe_detail = SAFE_MESSAGES.get(exc.status_code, str(exc.detail))
             return JSONResponse(
                 status_code=exc.status_code,

--- a/backend/tests/test_error_handler_structured_detail.py
+++ b/backend/tests/test_error_handler_structured_detail.py
@@ -1,0 +1,72 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_error_handler_structured_detail.py
+"""production 環境の 4xx エラーで dict の detail(自前コードが構築した安全な構造化
+エラー)がマスクされず、frontend の detail.code 分岐(DEPOSIT_BELOW_MINIMUM 等)が
+機能することを検証する。detail=str(exc) 由来の生文字列は引き続きマスクされる
+（内部情報漏洩防止、本ハンドラの本来の目的）ことも確認する。
+
+2026-07-17 本番実機で発見: おまかせ切替の入金ゲート(DEPOSIT_BELOW_MINIMUM)が
+"Validation error" に潰され、正しいトースト文言が出せなかった不具合の回帰テスト。
+"""
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+import app.error_handlers as error_handlers_module
+from app.error_handlers import register_error_handlers
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    register_error_handlers(app)
+
+    @app.get("/dict-detail")
+    async def dict_detail_route() -> None:
+        raise HTTPException(
+            status_code=422,
+            detail={"code": "DEPOSIT_BELOW_MINIMUM", "message": "最低$200の入金が必要です"},
+        )
+
+    @app.get("/string-detail")
+    async def string_detail_route() -> None:
+        raise HTTPException(status_code=400, detail="ValueError: internal db path leaked")
+
+    return app
+
+
+def test_production_preserves_dict_detail(monkeypatch) -> None:
+    """production でも dict detail はマスクされず、code フィールドが読める。"""
+    monkeypatch.setattr(error_handlers_module, "_is_production", True)
+    client = TestClient(_make_app(), raise_server_exceptions=False)
+
+    response = client.get("/dict-detail")
+
+    assert response.status_code == 422
+    body = response.json()
+    assert body["detail"]["code"] == "DEPOSIT_BELOW_MINIMUM"
+    assert body["detail"]["message"] == "最低$200の入金が必要です"
+
+
+def test_production_masks_string_detail(monkeypatch) -> None:
+    """production では文字列 detail は引き続き安全なメッセージにマスクされる。"""
+    monkeypatch.setattr(error_handlers_module, "_is_production", True)
+    client = TestClient(_make_app(), raise_server_exceptions=False)
+
+    response = client.get("/string-detail")
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["detail"] == "Bad request"
+    assert "internal db path" not in body["detail"]
+
+
+def test_non_production_passes_through_unmasked(monkeypatch) -> None:
+    """production 以外(development/staging)では従来通りマスクしない。"""
+    monkeypatch.setattr(error_handlers_module, "_is_production", False)
+    client = TestClient(_make_app(), raise_server_exceptions=False)
+
+    dict_response = client.get("/dict-detail")
+    assert dict_response.json()["detail"]["code"] == "DEPOSIT_BELOW_MINIMUM"
+
+    string_response = client.get("/string-detail")
+    assert "internal db path leaked" in string_response.json()["detail"]


### PR DESCRIPTION
## Summary
本番実機テスト中(hkobayashi本人によるproduction PWAでの「完全おまかせ」consent検証)に発見。`app/error_handlers.py`のグローバル例外ハンドラが、`APP_ENV=production`のとき**全ての4xxエラーのdetailを一律SAFE_MESSAGESの汎用文言に置き換えていた**ため、自前コードが意図的に構築した安全な構造化エラー（例: `{"code": "DEPOSIT_BELOW_MINIMUM", "message": "..."}`)まで握りつぶされていた。

## 実機での発見経緯
1. production(app.ultra-auto-trade.com)で残高$0のアカウントから「おまかせ」への切替を試行
2. バックエンドは正しく`422 {"code": "DEPOSIT_BELOW_MINIMUM", ...}`を返していたはず
3. しかしフロントエンドが受け取ったのは`{"detail": "Validation error"}`という汎用文字列
4. `OpModePanel.tsx`の`body?.detail?.code === "DEPOSIT_BELOW_MINIMUM"`分岐が一致せず、汎用の「切り替えに失敗しました」トーストになっていた(本来は「完全おまかせ運用には最低$200の入金が必要です」と出るべき)

同様の構造化detail(例: `approve_proposal`の`POLICY_VIOLATION`)を使う他のエンドポイントも、本番でのみ同じ問題を抱えていた可能性がある。staging/developmentでは`_is_production=False`のためこのマスクが効かず、これまで発覚していなかった。

## 修正
`exc.detail`が`dict`の場合はマスクせずそのまま返す。`detail=str(exc)`由来の生文字列(内部例外の情報漏洩リスクがある)のみ引き続きマスクする。本ハンドラ本来の目的(内部情報漏洩防止)は維持。

## Test plan
- [x] 新規テスト`test_error_handler_structured_detail.py`(3件: production+dict detailは保持/production+string detailはマスク/非production両方保持)
- [x] 既存`test_cors_500_handler.py`(4件、500系は無変更のため回帰なし確認)
- [x] backend全体テスト(4769 passed, 21 skipped)
- [x] `ruff check` / `mypy` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Edj3hjkB6XrjYezmARpQEq