### PR TITLE
fix(pendle): 実在しない SDK API に書かれていた calldata 経路を実 Convert API へ修正 + 流動性ガードの常時 block を解消

### DIFF
--- a/backend/app/auth/models.py
+++ b/backend/app/auth/models.py
@@ -58,6 +58,7 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS aggressive_ack_version VARCHAR(20) NU
 """
 
 import logging
+import os
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
@@ -139,9 +140,49 @@ RISK_MODE_JP_LABELS: dict[RiskMode, str] = {
     RiskMode.AGGRESSIVE: "ハイリスク",
 }
 
-#: Phase 1 で選択許可されているモード。
-#: Phase 2 で BALANCED / AGGRESSIVE を解禁する想定 (DB 側の制約ではなく API 層で強制)。
-PHASE_1_ALLOWED_RISK_MODES: frozenset[RiskMode] = frozenset({RiskMode.CONSERVATIVE})
+
+def _allowed_risk_modes_from_env() -> frozenset[RiskMode]:
+    """``ALLOWED_RISK_MODES`` env から選択許可モードを解決する（既定 conservative のみ）。
+
+    **なぜ env 化したか** (2026-07-17): 本定数はハードコードだったため、staging だけで
+    aggressive を検証しようとすると同じコードが本番にも入り**本番も同時に開いてしまう**
+    （`docs/ops/phase_d_pendle_aggressive_d6_runbook.md` §5 は PHASE_1 緩和を**規制判断**と
+    位置づけている）。env 化により「staging-v4 だけ開けて本番は閉じたまま」が可能になる。
+
+    仕様:
+      - 未設定 / 空 → ``{CONSERVATIVE}``（**既定は従来どおり閉じたまま**）
+      - ``ALLOWED_RISK_MODES=conservative,aggressive`` のようにカンマ区切りで指定
+      - 未知の値は警告して無視する（typo で意図せず広がらないよう fail-safe）
+      - CONSERVATIVE は常に含める（全モードを塞いで詰むのを防ぐ最小権限）
+
+    **これを開けても aggressive が即使えるわけではない**: `PUT /auth/risk-mode` の 412
+    （リスク開示同意必須）と、委譲枠側の Pendle ゲートが別途効く（多層防御）。
+    """
+    raw = os.getenv("ALLOWED_RISK_MODES", "").strip()
+    if not raw:
+        return frozenset({RiskMode.CONSERVATIVE})
+
+    modes: set[RiskMode] = {RiskMode.CONSERVATIVE}
+    for token in raw.split(","):
+        value = token.strip().lower()
+        if not value:
+            continue
+        try:
+            modes.add(RiskMode(value))
+        except ValueError:
+            logger.warning(
+                "ALLOWED_RISK_MODES に未知の値 %r が含まれています (無視します)。"
+                "有効値: conservative / balanced / aggressive",
+                value,
+            )
+    return frozenset(modes)
+
+
+#: 選択許可されているリスクモード（DB 制約ではなく API 層で強制）。
+#: 既定は CONSERVATIVE のみ。解禁は `ALLOWED_RISK_MODES` env で環境ごとに行う
+#: （`_allowed_risk_modes_from_env` の docstring 参照）。名前の "PHASE_1" は導入時の経緯由来で、
+#: 参照箇所（auth/router.py・テスト）を無用に壊さないため維持している。
+PHASE_1_ALLOWED_RISK_MODES: frozenset[RiskMode] = _allowed_risk_modes_from_env()
 
 #: 各 risk_mode の解禁 Phase (Phase 2-3 の段階解禁を見据えた設計)。
 RISK_MODE_PHASE: dict[RiskMode, int] = {

--- a/backend/app/proposals/pendle_scw.py
+++ b/backend/app/proposals/pendle_scw.py
@@ -70,6 +70,9 @@ def build_pendle_swap_calls(result: RouterV4SwapResult) -> list[dict[str, Any]]:
                 "approval missing token/spender/amount (SCW approve を組めない)"
             )
         # spender は必ず swap 宛先 Router と一致すること（任意コントラクトへの approve を拒否）。
+        # Convert API は spender を返さないため client が「Router 照合済みの tx.to」を spender として
+        # 補完する（client._extract_approvals）。よって通常ここは常に一致するが、供給元が変わっても
+        # 「照合済み Router 以外へ approve しない」不変条件が破れないよう多層防御として残す。
         if Web3.to_checksum_address(approval.spender) != router_cs:
             raise PendleScwCallsError(
                 f"approval spender {approval.spender} != swap router {router_to}"

--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -733,6 +733,13 @@ def _pendle_liquidity_blocked(config: Any, amount_usd: Decimal) -> Optional[str]
 
     fail-closed: ``get_market_info`` は API 失敗時 tvl_usd=0 に fail-open するため、tvl<=0（未知）は
     「壊さない保証ができない」= block する（不確実なら止める）。
+
+    **併せて market と PT の対応も検証する**（安全レビュー H2/M2）。``PENDLE_MARKET_ADDRESS``
+    （本ガードが流動性を見る対象）と ``PENDLE_PT_TOKEN_ADDRESS``（実際に買う対象 = Convert API の
+    tokensOut）は独立した env で、swap 呼び出しに market は送られない。両者が別 market を指すと
+    **ガードは別プールの流動性を承認する**（例: 満期ロールで PT だけ更新し market を忘れると、
+    $114k プールの 5% を承認して実際は $40k プールに 14% 投入する）。運用者の注意力を
+    Tier S の資金経路の安全装置にしない。
     """
     from app.protocols.pendle.client import get_pendle_client  # noqa: PLC0415
 
@@ -745,6 +752,29 @@ def _pendle_liquidity_blocked(config: Any, amount_usd: Decimal) -> Optional[str]
 
     if tvl_usd <= 0:
         return "liquidity guard: プール流動性が不明/ゼロのため fail-closed (tvl_usd<=0)"
+
+    # market が扱う PT と、実際に売買する PT が一致すること（不一致 = 設定ミス → fail-closed）。
+    market_pt = (market_info.pt_address or "").lower()
+    configured_pt = (config.pt_token_address or "").lower()
+    if not market_pt:
+        return (
+            "liquidity guard: market の PT アドレスを解決できないため fail-closed "
+            "(PENDLE_MARKET_ADDRESS と PENDLE_PT_TOKEN_ADDRESS の対応を検証できない)"
+        )
+    if market_pt != configured_pt:
+        return (
+            f"liquidity guard: market({config.market_address}) が扱う PT {market_pt} と "
+            f"PENDLE_PT_TOKEN_ADDRESS {configured_pt} が不一致 = 流動性を見ている market と "
+            "実際に売買する PT が別物のため fail-closed"
+        )
+    # PT decimals の取り違えは、**低すぎる側が黙って成功する**（$10k 売却のつもりが dust だけ
+    # 売れて executed 記録が残る）。実 decimals と突合して silent under-sell を防ぐ。
+    if market_info.pt_decimals is not None and market_info.pt_decimals != config.pt_token_decimals:
+        return (
+            f"liquidity guard: PT の実 decimals {market_info.pt_decimals} と "
+            f"PENDLE_PT_TOKEN_DECIMALS {config.pt_token_decimals} が不一致のため fail-closed "
+            "(数量が桁ずれする)"
+        )
 
     pool_cap = tvl_usd * config.max_pool_liquidity_pct
     if amount_usd > pool_cap:
@@ -780,7 +810,16 @@ def _pendle_execution_blocked(proposal: Proposal, db: Session) -> Optional[str]:
         logger.warning("proposal %d: Pendle safety-gate HF fetch failed: %s", proposal.id, exc)
 
     daily_traded = _daily_traded_usd_for_user(proposal.user_id, db, exclude_proposal_id=proposal.id)
-    total_assets: Optional[Decimal] = None  # per-user 総資産は未配線（Aave 経路と同）
+    # [安全レビュー H3 / 2026-07-17] per-user 総資産は未配線（Aave SCW 経路と同じ既存状態）。
+    #
+    # **その帰結を明示する**: `risk_limiter.check_trade_within_limits` は単一 10% / 日次 30% の
+    # 両方を `total_assets_usd is not None and > 0` でガードしているため、None を渡す本経路では
+    # **CLAUDE.md Rule 3/4（ABSOLUTE）が実際には効かない**。さらに Pendle 単独ユーザーは
+    # `get_health_factor()` が失敗して hf=None になるため HF floor も効かない。
+    # 結果、Pendle broadcast の金額上限は **流動性ガード（プール% と PENDLE_MAX_TRADE_USD_CAP）
+    # だけ**が担っている。だから同 cap の既定値を 5000 → 20 に下げてある（config.py 参照）。
+    # 恒久対応（total_assets の配線）は Aave 経路と共通の別課題。
+    total_assets: Optional[Decimal] = None
 
     hard_stop = evaluate_hard_stop(
         get_monitoring_service(),
@@ -815,8 +854,10 @@ def _build_pendle_swap_result(proposal: Proposal, config: Any, from_address: str
     """[Phase D / D3-D4] proposal.operation に応じて Pendle swap 結果(approvals 付き)を構築する。
 
     - BUY_PT(入口): USDC→PT (token_in=USDC・6桁)。amount_usd をそのまま USDC 数量に使う。
-    - SELL_PT(満期出口 redeem): PT→USDC (token_out=USDC・出力6桁 / PT=18桁)。stablecoin PT は
-      満期で 1:1 のため amount_usd を PT 数量とみなす（満期前は二次市場の流動性に依存）。
+    - SELL_PT(満期出口 redeem): PT→USDC (token_out=USDC・出力6桁 / PT は
+      ``PENDLE_PT_TOKEN_DECIMALS``。**18 桁固定ではない** — PT-yoUSD は 6 桁で、18 と誤ると
+      売却数量が 10^12 倍ずれる)。stablecoin PT は満期で 1:1 のため amount_usd を PT 数量と
+      みなす（満期前は二次市場の流動性に依存）。
 
     どちらも RouterV4 Hosted SDK 呼び出しのみ（broadcast なし）。stablecoin 前提は呼び出し元が
     ``config.stable_underlying`` で担保済み。

--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -769,11 +769,31 @@ def _pendle_liquidity_blocked(config: Any, amount_usd: Decimal) -> Optional[str]
         )
     # PT decimals の取り違えは、**低すぎる側が黙って成功する**（$10k 売却のつもりが dust だけ
     # 売れて executed 記録が残る）。実 decimals と突合して silent under-sell を防ぐ。
-    if market_info.pt_decimals is not None and market_info.pt_decimals != config.pt_token_decimals:
+    # decimals が取れない場合も fail-closed にする（「verify すると書いた項目が API 次第で
+    # 無言スキップされる」構造は H2 を生んだ原因そのもの / 安全レビュー N2）。
+    if market_info.pt_decimals is None:
+        return (
+            "liquidity guard: PT の decimals を解決できないため fail-closed "
+            "(PENDLE_PT_TOKEN_DECIMALS の妥当性を検証できない)"
+        )
+    if market_info.pt_decimals != config.pt_token_decimals:
         return (
             f"liquidity guard: PT の実 decimals {market_info.pt_decimals} と "
             f"PENDLE_PT_TOKEN_DECIMALS {config.pt_token_decimals} が不一致のため fail-closed "
             "(数量が桁ずれする)"
+        )
+
+    # 満期ガード（安全レビュー N1）。`min_days_to_maturity` は `PendleService.mint` と
+    # `PendleMarketCache` にしか無く、broadcast 経路は `config.market_address` を直参照するため
+    # **どちらも通らない**。本 PR 以前は get_market_info が常に fallback(tvl=0) で常時 block
+    # だったため顕在化しなかったが、経路が live になった今は素通りする。
+    # 満期後の BUY_PT は revert（gas 損）、満期直前は利回りほぼゼロで資金をロックして
+    # 「成功」記録だけが残る。market_info は既に手元にあるのでここで縛る。
+    if market_info.days_to_maturity < config.min_days_to_maturity:
+        return (
+            f"liquidity guard: 満期まで {market_info.days_to_maturity} 日 "
+            f"(最低 {config.min_days_to_maturity} 日) のため fail-closed "
+            f"(market={config.market_address} のロール漏れの可能性)"
         )
 
     pool_cap = tvl_usd * config.max_pool_liquidity_pct

--- a/backend/app/protocols/pendle/client.py
+++ b/backend/app/protocols/pendle/client.py
@@ -289,22 +289,58 @@ class PendleWebClient(AbstractPendleClient):
     """
 
     _API_BASE = "https://api-v2.pendle.finance/core/v1"
+    # **base を必ず含めること**: 2026-07-17 まで base が無く、`PENDLE_CHAIN=base` でも
+    # 42161(Arbitrum) に既定化 → market data が 404 → except 節のフォールバック
+    # （stETH / tvl=0 / APY 5.2% の**架空値**）が返っていた。tvl=0 は流動性ガードが
+    # 全 block する値なので、Phase-D の Pendle は「静かに常時 block」状態だった。
+    # D2 で PendleRouterV4Client 側だけ base を追加し、本クラスが漏れていた。
     _CHAIN_ID_MAP: dict[str, str] = {
         "arbitrum": "42161",
         "ethereum": "1",
         "polygon": "137",
-        "sepolia": "421614",  # Arbitrum Sepolia
+        "sepolia": "421614",  # Arbitrum Sepolia（Pendle 未対応 = 404）
+        "base": "8453",  # [Phase D] Base Mainnet (yoUSD stablecoin PT)
+        "base_sepolia": "84532",  # Base Sepolia（Pendle 未対応 = 404）
     }
     _REQUEST_TIMEOUT = 10.0
 
     def __init__(self, config: PendleConfig) -> None:
         self._config = config
-        self._chain_id = self._CHAIN_ID_MAP.get(config.chain, "42161")
+        chain_id = self._CHAIN_ID_MAP.get(config.chain)
+        if chain_id is None:
+            # 黙って別チェーンに既定化すると「404 → 架空のフォールバック値」で気づけない。
+            # 明示的に警告して、設定ミスを観測可能にする。
+            logger.warning(
+                "PendleWebClient: 未知の chain=%r。%s に既定化する（market data は 404 になり "
+                "フォールバック値が返るため、PENDLE_CHAIN を確認すること）",
+                config.chain,
+                "42161",
+            )
+            chain_id = "42161"
+        self._chain_id = chain_id
         logger.info(
             "PendleWebClient initialized (chain=%s, chain_id=%s)",
             config.chain,
             self._chain_id,
         )
+
+    @staticmethod
+    def _parse_expiry(raw: Any) -> datetime:
+        """``expiry`` を datetime にする。
+
+        実 API は ISO8601 文字列（``"2026-09-24T00:00:00.000Z"``）を返すが、UNIX 秒（int/数字文字列）
+        で返る経路も想定して両対応にする。解釈できない値は ValueError を送出し、呼び出し側の
+        フォールバック（＝tvl=0 で流動性ガードが block）に落とす（fail-closed 側に倒す）。
+        """
+        if isinstance(raw, (int, float)):
+            return datetime.fromtimestamp(int(raw), tz=timezone.utc)
+        if isinstance(raw, str) and raw.strip():
+            value = raw.strip()
+            if value.isdigit():
+                return datetime.fromtimestamp(int(value), tz=timezone.utc)
+            # "...Z" は Python 3.10 以前の fromisoformat が解釈できないため +00:00 に正規化する。
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        raise ValueError(f"expiry を解釈できません: {raw!r}")
 
     async def _fetch_market_data(self, market_address: str) -> dict[str, Any]:
         """Pendle API からマーケットデータを取得する。"""
@@ -320,9 +356,10 @@ class PendleWebClient(AbstractPendleClient):
         try:
             data = await self._fetch_market_data(market_address)
 
-            # 満期日時（UNIX タイムスタンプ）
-            expiry_ts = int(data.get("expiry", 0))
-            maturity = datetime.fromtimestamp(expiry_ts, tz=timezone.utc)
+            # 満期日時。実 API は **ISO8601 文字列**（"2026-09-24T00:00:00.000Z"）を返す。
+            # 旧実装は int() で UNIX 秒として解釈しており必ず ValueError → except 節の
+            # フォールバック（tvl=0）に落ちていた＝流動性ガードが常に block していた。
+            maturity = self._parse_expiry(data.get("expiry"))
             days_to_maturity = max(0, (maturity - datetime.now(tz=timezone.utc)).days)
 
             # implied APY は小数形式（0.052 = 5.2%）→ % 変換
@@ -397,18 +434,24 @@ class PendleWebClient(AbstractPendleClient):
 class PendleRouterV4Client:
     """Pendle RouterV4 クライアント（YT/PT 売買 + add_liquidity）。
 
-    Pendle Hosted SDK（https://api-v2.pendle.finance/sdk/api/v1）を使って calldata を生成する。
+    Pendle Hosted SDK の **Convert API**（``/core/v2/sdk/{chainId}/convert``）で calldata を生成する。
+
+    **2026-07-17 修正**: 旧実装は ``https://api-v2.pendle.finance/sdk/api/v1/{chain}/swapExactTokenForPt``
+    を叩いていたが、この経路は**実在しない**（全チェーンで 404 "fault filter abort"、実 API で確認）。
+    Pendle は個別エンドポイント（/swap 等）を廃止し Convert API に統合済み。旧実装は URL・パラメータ名・
+    レスポンス形の全てが実物と食い違っており、動かせば必ず 404 で fail-closed に落ちていた
+    （全経路 dormant + テストが HTTP をモックしていたため未検出。本番影響はゼロ）。
 
     フェーズ境界（誤送信防止）:
-    - **Phase 1（本実装）は calldata 取得まで**。tx 送信・署名・web3 import は一切行わない
-      （tx_hash は常に None）。
-    - tx 送信は **Phase 2** で `config.enable_onchain_write=True`（PENDLE_ENABLE_ONCHAIN_WRITE）
-      かつ `config.wallet_private_key` が揃った場合のみ実装・許可する（二段ガード）。
+    - **本クラスは calldata 取得まで**。tx 送信・署名・web3 import は一切行わない（tx_hash は常に None）。
+    - 実 broadcast は委譲 SCW 経路（`app/proposals/pendle_scw.py` → `scw_executor`）が二段ガード
+      （`PENDLE_ENABLE_ONCHAIN_WRITE` + `_should_use_scw_route`）の下でのみ行う。
 
     設計方針:
     - calldata は SDK が生成するため、こちらでの ABI encode は不要。
-    - SDK レスポンスの tx.to / approvals.spender は必ず Router アドレスと照合する
-      （改竄・誘導された任意コントラクト宛 calldata を拒否）。
+    - **`routes[0].tx.to` は必ず Router アドレスと照合する**（改竄・誘導された任意コントラクト宛
+      calldata を拒否）。Convert API は approve の spender を返さないため、照合済みの Router を
+      spender として補完する（`_extract_approvals` 参照）。
     - 金額は必ず Decimal 型。float 使用禁止。token decimals を解決して桁ズレを防ぐ。
     - 秘密鍵は config 経由で環境変数から取得。ログに出力しない。
     - 外部 HTTP 失敗・照合不一致は例外を握りつぶさず RouterV4SwapResult(success=False) を返す
@@ -416,18 +459,36 @@ class PendleRouterV4Client:
     - slippage デフォルト 0.5%（Decimal("0.005")）。
     """
 
-    _SDK_BASE = "https://api-v2.pendle.finance/sdk/api/v1"
+    #: Convert API のベース。個別エンドポイント（swapExactTokenForPt 等）は廃止済み。
+    _SDK_BASE = "https://api-v2.pendle.finance/core"
     _DEFAULT_SLIPPAGE = Decimal("0.005")
     _REQUEST_TIMEOUT: float = 15.0
 
-    # チェーン ID マッピング（Pendle SDK が使用するチェーン ID）
+    #: **YT 売買 (`buy_yt` / `sell_yt`) は実 API では成立しない**（既知・未対応）。
+    #: Convert API は tokensIn/tokensOut に実トークンアドレスを要求するが、これらは旧 SDK 規約の
+    #: リテラル "YT" を渡しており、YT アドレスの設定項目も無い。呼んでも API が 400 を返して
+    #: `success=False` になる（fail-closed で害は無い）。本製品は Phase-D で **PT 専用**
+    #: （`RISK_MODE_PROTOCOLS` の aggressive は stablecoin PT のみ）のため未修正のまま残す。
+    #: YT を扱うなら PT と同様に `PENDLE_YT_TOKEN_ADDRESS` / decimals の追加が要る。
+    #: aggregator を有効にするか。**SELL_PT(PT→USDC) には必須**（false だと
+    #: "tokenOut must be in the SY token out list" で 400。yoUSD→USDC の変換に aggregator が要る）。
+    #: BUY_PT では on/off で結果が変わらず、いずれの場合も `tx.to` は RouterV4 のまま
+    #: （aggregator は Router 内部で呼ばれる）＝宛先 allowlist の fail-closed 性は保たれる。
+    #: 実 API で両方向・両設定を確認済み（2026-07-17）。
+    _ENABLE_AGGREGATOR = "true"
+
+    # チェーン ID マッピング（Pendle SDK が使用するチェーン ID）。
+    # **Pendle API は mainnet のみ対応**（1, 56, 143, 999, 8453, 9745, 42161, 10, 146, 5000, 80094）。
+    # testnet は 400 "Unsupported chain id" で拒否されるため、testnet 上での検証経路は存在しない
+    # （実 API で確認済み 2026-07-17）。sepolia / base_sepolia を残すのは設定ミスを
+    # 「動くように見えて実は 400」ではなく明示的な失敗として観測するため。
     _CHAIN_ID_MAP: dict[str, int] = {
         "arbitrum": 42161,
         "ethereum": 1,
         "polygon": 137,
-        "sepolia": 421614,  # Arbitrum Sepolia
+        "sepolia": 421614,  # Arbitrum Sepolia（Pendle 未対応 = 400）
         "base": 8453,  # [Phase D] Base Mainnet (yoUSD stablecoin PT)
-        "base_sepolia": 84532,  # [Phase D] Base Sepolia (staging-v4 検証)
+        "base_sepolia": 84532,  # Base Sepolia（Pendle 未対応 = 400）
     }
 
     def __init__(
@@ -449,26 +510,36 @@ class PendleRouterV4Client:
             self._config.router_address[:10] + "...",
         )
 
-    async def _call_sdk(self, endpoint: str, params: dict[str, Any]) -> dict[str, Any]:
-        """Pendle Hosted SDK を呼び出して calldata を取得する。
+    async def _call_sdk(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Pendle Convert API を呼び出して calldata を取得する。
+
+        swap / mint / redeem は Convert API に統合されており、動作は tokensIn/tokensOut の
+        組み合わせから API 側が決める（旧 SDK の endpoint 名は不要）。
 
         Args:
-            endpoint: SDK エンドポイント（例: "swapExactTokenForYt"）
-            params: クエリパラメータ
+            params: クエリパラメータ（tokensIn / tokensOut / amountsIn / receiver / slippage 等）
 
         Returns:
-            SDK レスポンス dict
+            Convert API レスポンス dict
 
         Raises:
             httpx.HTTPError: HTTP エラー
             Exception: その他のエラー
         """
-        url = f"{self._SDK_BASE}/{self._chain_id}/{endpoint}"
+        url = f"{self._SDK_BASE}/v2/sdk/{self._chain_id}/convert"
         async with httpx.AsyncClient(timeout=self._REQUEST_TIMEOUT) as client:
             response = await client.get(url, params=params)
             response.raise_for_status()
             data: dict[str, Any] = response.json()
             return data
+
+    @staticmethod
+    def _first_route(sdk_response: dict[str, Any]) -> dict[str, Any]:
+        """Convert API レスポンスの最初の route を返す（無ければ空 dict）。"""
+        routes = sdk_response.get("routes") or []
+        if routes and isinstance(routes[0], dict):
+            return routes[0]
+        return {}
 
     def _amount_to_wei(self, amount: Decimal, decimals: int = 18) -> int:
         """Decimal 量を wei 単位の int に変換する。"""
@@ -577,9 +648,17 @@ class PendleRouterV4Client:
             return False
         return a.lower() == b.lower()
 
-    def _extract_approvals(self, sdk_response: dict[str, Any]) -> list[RouterV4Approval]:
-        """SDK レスポンスから approvals 配列を取り出す（無ければ空）。"""
-        raw = sdk_response.get("data", {}).get("approvals", []) or []
+    def _extract_approvals(
+        self, sdk_response: dict[str, Any], spender: str
+    ) -> list[RouterV4Approval]:
+        """Convert API の ``requiredApprovals`` を取り出す（無ければ空）。
+
+        **Convert API は spender を返さない**（``{token, amount}`` のみ）。approve 先は常に
+        route の ``tx.to``＝Router なので、呼び出し側が `_verify_router` で Router と照合済みの
+        宛先を ``spender`` として渡すこと。これにより「照合済み Router 以外へは絶対に approve
+        しない」という不変条件を、API の返り値に依存せずこちら側で保証する。
+        """
+        raw = sdk_response.get("requiredApprovals") or []
         approvals: list[RouterV4Approval] = []
         for item in raw:
             if not isinstance(item, dict):
@@ -587,28 +666,45 @@ class PendleRouterV4Client:
             approvals.append(
                 RouterV4Approval(
                     token=item.get("token"),
-                    spender=item.get("spender"),
+                    spender=spender,
                     amount=(str(item["amount"]) if item.get("amount") is not None else None),
                 )
             )
         return approvals
 
     def _verify_router(self, sdk_response: dict[str, Any]) -> tuple[bool, str | None, str]:
-        """SDK レスポンスの tx.to と approvals.spender を Router アドレスと照合する。
+        """Convert API の ``routes[0].tx.to`` を Router アドレスと照合する。
+
+        aggregator 有効時も Router が内部で aggregator を呼ぶ形になり ``tx.to`` は Router のまま
+        （実 API で両方向確認済み）。よって「宛先が Router であること」だけを fail-closed 条件に
+        できる。approve の spender は本メソッドで照合した宛先を `_extract_approvals` に渡して補完する。
 
         Returns:
             (ok, to_address, error): ok=False のとき error に理由を格納する。
         """
-        to_addr = sdk_response.get("data", {}).get("tx", {}).get("to")
+        to_addr = self._first_route(sdk_response).get("tx", {}).get("to")
         if not self._addr_eq(to_addr, self._config.router_address):
             return False, None, "router address mismatch"
-        # approvals がある場合は spender も Router であることを照合する。
-        for approval in self._extract_approvals(sdk_response):
-            if approval.spender is not None and not self._addr_eq(
-                approval.spender, self._config.router_address
-            ):
-                return False, None, "router address mismatch"
         return True, to_addr, ""
+
+    def _extract_amount_out(
+        self, sdk_response: dict[str, Any], token_out: str, decimals: int
+    ) -> Decimal:
+        """Convert API の ``routes[0].outputs`` から token_out の受取量を取り出す。
+
+        outputs は複数返り得るため token_out に一致するものを優先し、無ければ先頭を使う。
+        """
+        outputs = self._first_route(sdk_response).get("outputs") or []
+        chosen: dict[str, Any] | None = None
+        for item in outputs:
+            if isinstance(item, dict) and self._addr_eq(item.get("token"), token_out):
+                chosen = item
+                break
+        if chosen is None and outputs and isinstance(outputs[0], dict):
+            chosen = outputs[0]
+        if not chosen or chosen.get("amount") is None:
+            return Decimal("0")
+        return self._wei_to_decimal(int(str(chosen["amount"])), decimals=decimals)
 
     async def resolve_market_address(self, underlying_asset: str) -> str | None:
         """underlying_asset シンボルから market address を動的解決する。
@@ -763,17 +859,21 @@ class PendleRouterV4Client:
             return guard
         effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
         in_decimals = self._resolve_decimals(token_in, token_in_decimals)
+        # Convert API は tokensOut に **PT の実アドレス**を要求する（旧 SDK のリテラル "PT" は不可）。
+        # PT の decimals も config 由来（18 固定は誤り。PT-yoUSD は 6）。
         req = RouterV4SwapRequest(
             market_address=market_address,
             token_in=token_in,
-            token_out="PT",  # noqa: S106 — トークン種別リテラル (パスワードではない)
+            token_out=self._config.pt_token_address,
             amount_in=amount_in,
             slippage=effective_slippage,
             receiver=receiver,
         )
-        # PT は 18 桁。入力トークンのみ decimals を解決する。
         return await self._execute_swap(
-            req, "swapExactTokenForPt", amount_in_decimals=in_decimals, amount_out_decimals=18
+            req,
+            "swapExactTokenForPt",
+            amount_in_decimals=in_decimals,
+            amount_out_decimals=self._config.pt_token_decimals,
         )
 
     async def sell_pt(
@@ -812,17 +912,21 @@ class PendleRouterV4Client:
             return guard
         effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
         out_decimals = self._resolve_decimals(token_out, token_out_decimals)
+        # tokensIn は **PT の実アドレス**（旧 SDK のリテラル "PT" は不可）。PT の decimals を
+        # 18 固定にすると PT-yoUSD(6桁) で**売却数量が 10^12 倍ズレる**ため config 由来にする。
         req = RouterV4SwapRequest(
             market_address=market_address,
-            token_in="PT",  # noqa: S106 — トークン種別リテラル (パスワードではない)
+            token_in=self._config.pt_token_address,
             token_out=token_out,
             amount_in=pt_amount_in,
             slippage=effective_slippage,
             receiver=receiver,
         )
-        # PT は 18 桁。出力トークンのみ decimals を解決する。
         return await self._execute_swap(
-            req, "swapExactPtForToken", amount_in_decimals=18, amount_out_decimals=out_decimals
+            req,
+            "swapExactPtForToken",
+            amount_in_decimals=self._config.pt_token_decimals,
+            amount_out_decimals=out_decimals,
         )
 
     async def _execute_swap(
@@ -832,14 +936,15 @@ class PendleRouterV4Client:
         amount_in_decimals: int = 18,
         amount_out_decimals: int = 18,
     ) -> RouterV4SwapResult:
-        """SDK を呼び出して swap calldata を取得する（Phase 1 は送信しない）。
+        """Convert API を呼び出して swap calldata を取得する（送信はしない）。
 
         外部 HTTP 失敗・Router 不一致・calldata 欠損は例外を握りつぶさず
         RouterV4SwapResult(success=False) を返す（fail-closed）。
 
         Args:
             req: swap リクエスト
-            sdk_endpoint: SDK エンドポイント名
+            sdk_endpoint: 動作の識別ラベル（ログ/診断用）。Convert API は tokensIn/tokensOut から
+                動作を決めるため URL には使わない（旧個別エンドポイントは廃止済み）。
             amount_in_decimals: 入力トークンの decimals（USDC=6 等の桁ズレ防止）
             amount_out_decimals: 出力トークンの decimals（amount_out 復元に使用）
 
@@ -848,57 +953,58 @@ class PendleRouterV4Client:
         """
         try:
             amount_wei = self._amount_to_wei(req.amount_in, decimals=amount_in_decimals)
-            # slippage は SDK に対して小数形式で渡す（0.005 = 0.5%）
+            # Convert API は tokensIn/tokensOut/amountsIn（複数形）。market は指定しない
+            # ——対象 market は PT アドレス側で一意に決まるため。
+            # slippage は小数形式で渡す（0.005 = 0.5%）。
             params: dict[str, Any] = {
-                "chainId": self._chain_id,
-                "market": req.market_address,
-                "tokenIn": req.token_in,
-                "tokenOut": req.token_out,
-                "amountIn": str(amount_wei),
+                "tokensIn": req.token_in,
+                "tokensOut": req.token_out,
+                "amountsIn": str(amount_wei),
                 "slippage": str(req.slippage),
                 "receiver": req.receiver,
+                "enableAggregator": self._ENABLE_AGGREGATOR,
             }
 
             logger.info(
-                "PendleRouterV4Client._execute_swap: endpoint=%s, market=%s, amountIn=%s",
+                "PendleRouterV4Client._execute_swap: action=%s, market=%s, amountIn=%s",
                 sdk_endpoint,
                 req.market_address[:10] + "...",
                 req.amount_in,
             )
 
-            sdk_response = await self._call_sdk(sdk_endpoint, params)
+            sdk_response = await self._call_sdk(params)
 
-            # C2: SDK calldata の宛先 (tx.to) と approvals.spender を Router と照合する。
+            # C2: calldata の宛先 (routes[0].tx.to) を Router と照合する。
+            # approve の spender は照合済みの宛先で補完する（Convert API は spender を返さない）。
             router_ok, to_addr, router_err = self._verify_router(sdk_response)
-            if not router_ok:
+            if not router_ok or not to_addr:
                 logger.warning(
-                    "PendleRouterV4Client._execute_swap: %s (endpoint=%s)",
+                    "PendleRouterV4Client._execute_swap: %s (action=%s)",
                     router_err,
                     sdk_endpoint,
                 )
-                return RouterV4SwapResult(success=False, error=router_err)
+                return RouterV4SwapResult(success=False, error=router_err or "router mismatch")
 
-            calldata: str = sdk_response.get("data", {}).get("tx", {}).get("data", "")
+            calldata: str = self._first_route(sdk_response).get("tx", {}).get("data", "")
             # m1: calldata 欠損/空文字は空 tx 送信の温床。success=False で拒否する。
             if not calldata:
                 logger.warning(
-                    "PendleRouterV4Client._execute_swap: empty calldata (endpoint=%s)",
+                    "PendleRouterV4Client._execute_swap: empty calldata (action=%s)",
                     sdk_endpoint,
                 )
                 return RouterV4SwapResult(success=False, error="empty calldata")
 
-            out_amount_raw = sdk_response.get("data", {}).get("amountOut", "0")
-            amount_out = self._wei_to_decimal(
-                int(str(out_amount_raw)), decimals=amount_out_decimals
+            amount_out = self._extract_amount_out(
+                sdk_response, req.token_out, decimals=amount_out_decimals
             )
 
             return RouterV4SwapResult(
                 success=True,
-                tx_hash=None,  # tx 送信は Phase 2 以降（現フェーズは calldata 取得のみ）
+                tx_hash=None,  # 送信は委譲 SCW 経路が二段ガードの下で行う（本クラスは calldata のみ）
                 amount_out=amount_out,
                 calldata=calldata,
                 to=to_addr,
-                approvals=self._extract_approvals(sdk_response),
+                approvals=self._extract_approvals(sdk_response, spender=to_addr),
             )
 
         except httpx.HTTPStatusError as exc:
@@ -948,16 +1054,22 @@ class PendleRouterV4Client:
 
         effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
         in_decimals = self._resolve_decimals(token_in, token_in_decimals)
+        # Convert API は tokensOut に **PT の実アドレス**を要求する（対象 market は PT で一意）。
+        # 旧実装はリテラル "PT" を渡していたが、これは旧 SDK（market + tokenOut="PT"）の規約で
+        # Convert API では通らない。PT の decimals も 18 固定は誤り（PT-yoUSD は 6）。
         req = RouterV4SwapRequest(
             market_address=market_address,
             token_in=token_in,
-            token_out="PT",  # noqa: S106 — トークン種別リテラル (パスワードではない)
+            token_out=self._config.pt_token_address,
             amount_in=amount_in,
             slippage=effective_slippage,
             receiver=from_address,  # 非カストディアル: PT は署名者本人へ着金
         )
         return await self._execute_swap(
-            req, "swapExactTokenForPt", amount_in_decimals=in_decimals, amount_out_decimals=18
+            req,
+            "swapExactTokenForPt",
+            amount_in_decimals=in_decimals,
+            amount_out_decimals=self._config.pt_token_decimals,
         )
 
     async def build_sell_pt_swap_result(
@@ -988,17 +1100,22 @@ class PendleRouterV4Client:
 
         effective_slippage = slippage if slippage is not None else self._DEFAULT_SLIPPAGE
         out_decimals = self._resolve_decimals(token_out, token_out_decimals)
+        # tokensIn は **PT の実アドレス**（旧実装のリテラル "PT" は Convert API で通らない）。
+        # PT の decimals は config 由来。ここを 18 固定にすると PT-yoUSD(6桁) で
+        # **売却数量が 10^12 倍ズレる**（残高不足で失敗するか、意図しない量を売る）。
         req = RouterV4SwapRequest(
             market_address=market_address,
-            token_in="PT",  # noqa: S106 — トークン種別リテラル (パスワードではない)
+            token_in=self._config.pt_token_address,
             token_out=token_out,
             amount_in=pt_amount_in,
             slippage=effective_slippage,
             receiver=from_address,  # 非カストディアル: 出力トークンは署名者本人へ着金
         )
-        # PT は 18 桁。出力トークンのみ decimals を解決する。
         return await self._execute_swap(
-            req, "swapExactPtForToken", amount_in_decimals=18, amount_out_decimals=out_decimals
+            req,
+            "swapExactPtForToken",
+            amount_in_decimals=self._config.pt_token_decimals,
+            amount_out_decimals=out_decimals,
         )
 
     async def build_buy_pt_tx(
@@ -1103,13 +1220,15 @@ class PendleRouterV4Client:
 
         try:
             amount_wei = self._amount_to_wei(req.amount_in, decimals=in_decimals)
+            # Convert API は tokensOut に market(LP) アドレスを渡すと action="add-liquidity" になる
+            # （swap と同一エンドポイント。実 API で確認済み 2026-07-17）。
             params: dict[str, Any] = {
-                "chainId": self._chain_id,
-                "market": req.market_address,
-                "tokenIn": req.token_in,
-                "amountIn": str(amount_wei),
+                "tokensIn": req.token_in,
+                "tokensOut": req.market_address,
+                "amountsIn": str(amount_wei),
                 "slippage": str(req.slippage),
                 "receiver": req.receiver,
+                "enableAggregator": self._ENABLE_AGGREGATOR,
             }
 
             logger.info(
@@ -1119,31 +1238,32 @@ class PendleRouterV4Client:
                 req.amount_in,
             )
 
-            sdk_response = await self._call_sdk("addLiquiditySingleToken", params)
+            sdk_response = await self._call_sdk(params)
 
-            # C2: tx.to / approvals.spender を Router と照合する。
+            # C2: routes[0].tx.to を Router と照合する（spender は照合済み宛先で補完）。
             router_ok, to_addr, router_err = self._verify_router(sdk_response)
-            if not router_ok:
+            if not router_ok or not to_addr:
                 logger.warning("PendleRouterV4Client.add_liquidity: %s", router_err)
-                return RouterV4AddLiquidityResult(success=False, error=router_err)
+                return RouterV4AddLiquidityResult(
+                    success=False, error=router_err or "router mismatch"
+                )
 
-            calldata = sdk_response.get("data", {}).get("tx", {}).get("data", "")
+            calldata = self._first_route(sdk_response).get("tx", {}).get("data", "")
             # m1: calldata 欠損/空文字は拒否（空 tx 送信の温床）。
             if not calldata:
                 logger.warning("PendleRouterV4Client.add_liquidity: empty calldata")
                 return RouterV4AddLiquidityResult(success=False, error="empty calldata")
 
-            # LP トークンは 18 桁。
-            lp_amount_raw = sdk_response.get("data", {}).get("amountLpOut", "0")
-            lp_amount = self._wei_to_decimal(int(str(lp_amount_raw)))
+            # LP トークンは 18 桁。outputs の token は market(LP) アドレス。
+            lp_amount = self._extract_amount_out(sdk_response, req.market_address, decimals=18)
 
             return RouterV4AddLiquidityResult(
                 success=True,
-                tx_hash=None,  # tx 送信は Phase 2 以降
+                tx_hash=None,  # 送信は行わない（calldata 取得のみ）
                 lp_amount=lp_amount,
                 calldata=calldata,
                 to=to_addr,
-                approvals=self._extract_approvals(sdk_response),
+                approvals=self._extract_approvals(sdk_response, spender=to_addr),
             )
 
         except httpx.HTTPStatusError as exc:

--- a/backend/app/protocols/pendle/client.py
+++ b/backend/app/protocols/pendle/client.py
@@ -306,7 +306,7 @@ class PendleWebClient(AbstractPendleClient):
 
     def __init__(self, config: PendleConfig) -> None:
         self._config = config
-        chain_id = self._CHAIN_ID_MAP.get(config.chain)
+        chain_id = self._CHAIN_ID_MAP.get((config.chain or "").strip().lower())
         if chain_id is None:
             # 黙って別チェーンに既定化すると「404 → 架空のフォールバック値」で気づけない。
             # 明示的に警告して、設定ミスを観測可能にする。
@@ -367,7 +367,8 @@ class PendleWebClient(AbstractPendleClient):
             implied_apy = Decimal(str(implied_apy_raw)) * Decimal("100")
 
             # PT/YT 価格
-            pt_price = Decimal(str(data.get("pt", {}).get("price", {}).get("usd", "0.95")))
+            pt = data.get("pt") or {}
+            pt_price = Decimal(str(pt.get("price", {}).get("usd", "0.95")))
             yt_price = Decimal(str(data.get("yt", {}).get("price", {}).get("usd", "0.05")))
 
             # TVL（USD）
@@ -375,6 +376,9 @@ class PendleWebClient(AbstractPendleClient):
 
             # 原資産シンボル
             underlying = data.get("underlyingAsset", {}).get("symbol", "stETH")
+
+            # この market が実際に扱う PT の素性（config との突合用）。
+            pt_decimals_raw = pt.get("decimals")
 
             return PendleMarketInfo(
                 market_address=market_address,
@@ -385,6 +389,8 @@ class PendleWebClient(AbstractPendleClient):
                 pt_price=pt_price,
                 yt_price=yt_price,
                 tvl_usd=tvl_usd,
+                pt_address=pt.get("address"),
+                pt_decimals=(int(pt_decimals_raw) if pt_decimals_raw is not None else None),
             )
         except Exception as exc:
             logger.warning("get_market_info API 失敗、フォールバック値を使用: %s", exc)
@@ -497,7 +503,17 @@ class PendleRouterV4Client:
         market_cache: PendleMarketCache | None = None,
     ) -> None:
         self._config = config
-        self._chain_id = self._CHAIN_ID_MAP.get(config.chain, 42161)
+        chain_id = self._CHAIN_ID_MAP.get((config.chain or "").strip().lower())
+        if chain_id is None:
+            # 黙って別チェーンに既定化すると、設定ミスが「404 で動かない」としてしか現れず
+            # 原因に辿り着けない（PendleWebClient 側で実際に起きた）。必ず警告する。
+            logger.warning(
+                "PendleRouterV4Client: 未知の chain=%r。42161(Arbitrum) に既定化する "
+                "(Pendle API は mainnet のみ対応。PENDLE_CHAIN を確認すること)",
+                config.chain,
+            )
+            chain_id = 42161
+        self._chain_id = chain_id
         # market address キャッシュ（外部注入可能 / テスト容易性のため）
         # config を注入し、満期フィルタ（min_days_to_maturity）を有効化する
         self._market_cache = market_cache or PendleMarketCache(
@@ -649,28 +665,58 @@ class PendleRouterV4Client:
         return a.lower() == b.lower()
 
     def _extract_approvals(
-        self, sdk_response: dict[str, Any], spender: str
-    ) -> list[RouterV4Approval]:
-        """Convert API の ``requiredApprovals`` を取り出す（無ければ空）。
+        self,
+        sdk_response: dict[str, Any],
+        *,
+        spender: str,
+        expected_token: str,
+        expected_amount_wei: int,
+    ) -> tuple[list[RouterV4Approval], str]:
+        """Convert API の ``requiredApprovals`` を検証して取り出す。
 
-        **Convert API は spender を返さない**（``{token, amount}`` のみ）。approve 先は常に
-        route の ``tx.to``＝Router なので、呼び出し側が `_verify_router` で Router と照合済みの
-        宛先を ``spender`` として渡すこと。これにより「照合済み Router 以外へは絶対に approve
-        しない」という不変条件を、API の返り値に依存せずこちら側で保証する。
+        Returns:
+            ``(approvals, error)``。``error`` が空でないとき fail-closed（呼び出し側は
+            success=False にすること）。
+
+        **API の返り値を信用しない**。この layer は 3 つとも自前で縛る:
+
+        1. **spender**: Convert API は spender を返さない（``{token, amount}`` のみ）。approve 先は
+           常に route の ``tx.to``＝Router なので、`_verify_router` で照合済みの宛先を呼び出し側が
+           渡す。「照合済み Router 以外へは絶対に approve しない」を API 非依存で保証する。
+        2. **token**: swap の入力トークン（``tokensIn``）以外への approve を拒否する。
+        3. **amount**: swap の入力量と**厳密一致**でなければ拒否する。
+
+        2/3 が無いと、API が ``{"token": USDC, "amount": <uint256 max>}`` を返しただけで
+        **恒久的な無制限 approve** が成立してしまう（`tx.to` は Router のままなので Router 照合も
+        Privy policy も通過する）。その場合、損失の上限が「1 取引の額」ではなく「残高全部・永久」に
+        なる。実 API は現に ``amountsIn`` と同額しか返さないが、**この API 契約は 2026-07-17 まで
+        全面的に間違っていた**（実在しない endpoint を叩いていた）。「外部 API が今後も行儀よく
+        振る舞う」という前提は既に一度崩れているので、こちら側で縛れるものは縛る。
         """
         raw = sdk_response.get("requiredApprovals") or []
         approvals: list[RouterV4Approval] = []
         for item in raw:
             if not isinstance(item, dict):
                 continue
-            approvals.append(
-                RouterV4Approval(
-                    token=item.get("token"),
-                    spender=spender,
-                    amount=(str(item["amount"]) if item.get("amount") is not None else None),
+            token = item.get("token")
+            if not self._addr_eq(token, expected_token):
+                return [], (
+                    f"approval token mismatch: {token!r} は swap 入力 {expected_token!r} と異なる"
                 )
-            )
-        return approvals
+            raw_amount = item.get("amount")
+            if raw_amount is None:
+                return [], "approval amount missing"
+            try:
+                amount_wei = int(str(raw_amount))
+            except ValueError:
+                return [], f"approval amount not an integer: {raw_amount!r}"
+            if amount_wei != expected_amount_wei:
+                return [], (
+                    f"approval amount mismatch: {amount_wei} != swap 入力 {expected_amount_wei}"
+                    "（無制限 approve 等の過大請求を拒否）"
+                )
+            approvals.append(RouterV4Approval(token=token, spender=spender, amount=str(amount_wei)))
+        return approvals, ""
 
     def _verify_router(self, sdk_response: dict[str, Any]) -> tuple[bool, str | None, str]:
         """Convert API の ``routes[0].tx.to`` を Router アドレスと照合する。
@@ -994,6 +1040,19 @@ class PendleRouterV4Client:
                 )
                 return RouterV4SwapResult(success=False, error="empty calldata")
 
+            # approve は「照合済み Router 宛」かつ「swap 入力と同一 token・同一 amount」のみ許す。
+            approvals, appr_err = self._extract_approvals(
+                sdk_response,
+                spender=to_addr,
+                expected_token=req.token_in,
+                expected_amount_wei=amount_wei,
+            )
+            if appr_err:
+                logger.warning(
+                    "PendleRouterV4Client._execute_swap: %s (action=%s)", appr_err, sdk_endpoint
+                )
+                return RouterV4SwapResult(success=False, error=appr_err)
+
             amount_out = self._extract_amount_out(
                 sdk_response, req.token_out, decimals=amount_out_decimals
             )
@@ -1004,7 +1063,7 @@ class PendleRouterV4Client:
                 amount_out=amount_out,
                 calldata=calldata,
                 to=to_addr,
-                approvals=self._extract_approvals(sdk_response, spender=to_addr),
+                approvals=approvals,
             )
 
         except httpx.HTTPStatusError as exc:
@@ -1254,6 +1313,17 @@ class PendleRouterV4Client:
                 logger.warning("PendleRouterV4Client.add_liquidity: empty calldata")
                 return RouterV4AddLiquidityResult(success=False, error="empty calldata")
 
+            # approve は「照合済み Router 宛」かつ「入力と同一 token・同一 amount」のみ許す。
+            approvals, appr_err = self._extract_approvals(
+                sdk_response,
+                spender=to_addr,
+                expected_token=req.token_in,
+                expected_amount_wei=amount_wei,
+            )
+            if appr_err:
+                logger.warning("PendleRouterV4Client.add_liquidity: %s", appr_err)
+                return RouterV4AddLiquidityResult(success=False, error=appr_err)
+
             # LP トークンは 18 桁。outputs の token は market(LP) アドレス。
             lp_amount = self._extract_amount_out(sdk_response, req.market_address, decimals=18)
 
@@ -1263,7 +1333,7 @@ class PendleRouterV4Client:
                 lp_amount=lp_amount,
                 calldata=calldata,
                 to=to_addr,
-                approvals=self._extract_approvals(sdk_response, spender=to_addr),
+                approvals=approvals,
             )
 
         except httpx.HTTPStatusError as exc:

--- a/backend/app/protocols/pendle/config.py
+++ b/backend/app/protocols/pendle/config.py
@@ -58,6 +58,14 @@ class PendleConfig:
             "0x0000000000000000000000000000000000000004",  # dummy address
         )
     )
+    # PT トークンの decimals。**PT は 18 桁とは限らない**（PT-yoUSD-24SEP2026 は 6 桁。PT は
+    # 原資産の桁を継ぐため stablecoin PT は 6 になる）。underlying_token_decimals と同じ理由で
+    # 明示が要る: pt_token_address は *アドレス* なので token_decimals(symbol) では解決できない。
+    # ここを誤ると SELL_PT で **売却数量そのものが 10^12 倍ズレる**（BUY_PT は受取量の表示ズレ）。
+    # 市場ごとに異なるため env で設定する（既定 6 = stablecoin PT 想定）。
+    pt_token_decimals: int = field(
+        default_factory=lambda: int(os.getenv("PENDLE_PT_TOKEN_DECIMALS", "6"))
+    )
     # 入力トークンが USD ペッグの stablecoin (USDC 等) か。True の場合のみ proposal.amount_usd
     # をそのまま入力トークン数量として扱う (1 USDC≒1 USD)。False (既定) は USD→token 価格換算が
     # 未配線のため自動執行を fail-closed で拒否する (ETH や非ステーブル PT の誤数量署名防止)。

--- a/backend/app/protocols/pendle/config.py
+++ b/backend/app/protocols/pendle/config.py
@@ -109,8 +109,17 @@ class PendleConfig:
         default_factory=lambda: _get_env_decimal("PENDLE_MAX_POOL_LIQUIDITY_PCT", "0.05")
     )
     # [Phase D / D5] 流動性ガード: 1 投入の絶対上限（USD）。プール流動性%と併せて被害上限を縛る。
+    #
+    # **既定を 5000 → 20 に引き下げた（2026-07-17 安全レビュー H3）**。理由: Pendle 経路では
+    # CLAUDE.md Rule 3/4（単一 10% / 日次 30%）が **実際には効いていない**
+    # （`_pendle_execution_blocked` が risk_limiter に total_assets=None を渡すため、
+    # risk_limiter が両方の % 判定をスキップする。Aave SCW 経路も同じ既存問題）。
+    # つまり金額の歯止めは事実上「プール流動性% と本上限」だけで、本上限が唯一の絶対額。
+    # そこに 5000 を既定で与えると、env 設定を忘れた運用者に $5,000 の枠が黙って開く。
+    # 「運用者が設定を憶えていること」を安全装置にしない ＝ 忘れたら小さい方に倒す。
+    # 実運用で引き上げる場合は PENDLE_MAX_TRADE_USD_CAP を明示設定すること。
     max_trade_usd_cap: Decimal = field(
-        default_factory=lambda: _get_env_decimal("PENDLE_MAX_TRADE_USD_CAP", "5000")
+        default_factory=lambda: _get_env_decimal("PENDLE_MAX_TRADE_USD_CAP", "20")
     )
 
     def token_decimals(self, token: str) -> int:

--- a/backend/app/protocols/pendle/config.py
+++ b/backend/app/protocols/pendle/config.py
@@ -10,12 +10,32 @@ from decimal import Decimal
 
 
 def _get_env_decimal(name: str, default: str) -> Decimal:
-    """環境変数から Decimal 値を読み込む。未設定またはパース失敗時はデフォルト値を返す。"""
+    """環境変数から Decimal 値を読み込む。未設定またはパース失敗時はデフォルト値を返す。
+
+    ``Decimal("inf")`` / ``NaN`` は **パースに成功してしまう**（`Decimal("inf")` は有効値）。
+    これが金額上限に入ると `amount > inf` が常に False になりガードが無言で無効化されるため、
+    有限値でなければ default に倒す（安全レビュー P1）。
+    """
     raw = os.getenv(name, default)
     try:
-        return Decimal(raw)
+        value = Decimal(raw)
     except Exception:
         return Decimal(default)
+    if not value.is_finite():
+        return Decimal(default)
+    return value
+
+
+#: `PENDLE_MAX_TRADE_USD_CAP` の **env で越えられない絶対上限**（USD）。
+#:
+#: Pendle broadcast 経路では CLAUDE.md Rule 3/4（単一10%/日次30%）が実際には効いておらず
+#: （`_pendle_execution_blocked` が risk_limiter に total_assets=None を渡すため）、
+#: **本 cap が事実上唯一の絶対額ガード**。そこに env のタイポ（`20` → `200`）を捕まえる第二層が
+#: 無いのは、唯一のガードを 1 文字のミスに委ねることになる。
+#: `risk_limiter.SINGLE_TRADE_PCT_HARD_MAX` と同じ発想の hard clamp を置く。
+#: **これを引き上げる前に total_assets の配線を行うこと**（cap を上げた瞬間、その取引額を縛る
+#: ものが文字通り何も無くなる）。
+PENDLE_MAX_TRADE_USD_HARD_MAX = Decimal("100")
 
 
 @dataclass
@@ -118,8 +138,12 @@ class PendleConfig:
     # そこに 5000 を既定で与えると、env 設定を忘れた運用者に $5,000 の枠が黙って開く。
     # 「運用者が設定を憶えていること」を安全装置にしない ＝ 忘れたら小さい方に倒す。
     # 実運用で引き上げる場合は PENDLE_MAX_TRADE_USD_CAP を明示設定すること。
+    # hard clamp: env がこれを超える値を指定しても `PENDLE_MAX_TRADE_USD_HARD_MAX` で頭打ちにする。
     max_trade_usd_cap: Decimal = field(
-        default_factory=lambda: _get_env_decimal("PENDLE_MAX_TRADE_USD_CAP", "20")
+        default_factory=lambda: min(
+            _get_env_decimal("PENDLE_MAX_TRADE_USD_CAP", "20"),
+            PENDLE_MAX_TRADE_USD_HARD_MAX,
+        )
     )
 
     def token_decimals(self, token: str) -> int:

--- a/backend/app/protocols/pendle/schemas.py
+++ b/backend/app/protocols/pendle/schemas.py
@@ -22,6 +22,11 @@ class PendleMarketInfo(BaseModel):
     pt_price: Decimal = Field(..., description="PT 価格（0〜1、ディスカウント）")
     yt_price: Decimal = Field(..., description="YT 価格（0〜1）")
     tvl_usd: Decimal = Field(..., description="TVL（USD）")
+    # market が実際に扱う PT の素性。config (PENDLE_PT_TOKEN_ADDRESS / _DECIMALS) と突合して
+    # 「ガードが見る market」と「実際に買う PT」の乖離を検出するために使う（設定ミス検出）。
+    # API 失敗時のフォールバックでは None（＝突合できない → 呼び出し側で fail-closed）。
+    pt_address: Optional[str] = Field(default=None, description="この market の PT アドレス")
+    pt_decimals: Optional[int] = Field(default=None, description="この market の PT decimals")
 
 
 class PendleMintRequest(BaseModel):

--- a/backend/tests/protocols/test_pendle/convert_api_fixtures.py
+++ b/backend/tests/protocols/test_pendle/convert_api_fixtures.py
@@ -1,0 +1,77 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+"""Pendle Convert API のレスポンス形を組み立てる共通ヘルパ（テスト用）。
+
+**この形は実 API の応答に一致させること**。2026-07-17 まで各テストが旧 SDK（`/sdk/api/v1` +
+`{"data": {"tx": ..., "amountOut": ...}}`）の形を各ファイルで独自にモックしていたが、その
+エンドポイントは実在せず（全チェーンで 404）、実 API は Convert API
+（`/core/v2/sdk/{chainId}/convert`）で応答形も別物だった。モックが架空の契約を固定していたため、
+実装が壊れていることを誰も検出できなかった。
+
+同じ事故を繰り返さないため:
+  - モック形の定義は**本ファイル 1 箇所**に集約する（各テストで手書きしない）。
+  - 実 API との整合は `test_pendle_convert_api_contract.py`（live 疎通・opt-in）が担保する。
+
+実 API の応答例（Base 8453 / USDC → PT-yoUSD / 2026-07-17 実測）::
+
+    {
+      "action": "swap",
+      "requiredApprovals": [{"token": "0x8335...2913", "amount": "1000000"}],
+      "routes": [{
+        "tx": {"to": "0x8888888888897...F946", "data": "0xc81f847a...", "value": "0"},
+        "outputs": [{"token": "0x1fec...de29", "amount": "1033059"}],
+        "data": {"priceImpact": ...}
+      }]
+    }
+
+注意: ``requiredApprovals`` に **spender は含まれない**（approve 先は常に route の tx.to=Router）。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Pendle RouterV4（本番実アドレス）。
+ROUTER = "0x888888888889758F76e7103c6CbF23ABbF58F946"
+
+
+def convert_response(
+    *,
+    to: str = ROUTER,
+    data: str | None = "0xdeadbeef",
+    action: str = "swap",
+    outputs: list[dict[str, Any]] | None = None,
+    required_approvals: list[dict[str, Any]] | None = None,
+    include_tx: bool = True,
+    include_routes: bool = True,
+) -> dict[str, Any]:
+    """Convert API の応答を組み立てる。
+
+    :param to: ``routes[0].tx.to``。Router 以外にすると client は fail-closed で拒否する。
+    :param data: ``routes[0].tx.data``（calldata）。None/"" で欠損ケースを再現する。
+    :param outputs: ``routes[0].outputs``。未指定なら空（amount_out=0 相当）。
+    :param required_approvals: ``requiredApprovals``。実 API 同様 spender は含めないこと。
+    :param include_tx: False で ``tx`` キー自体を落とす（tx 欠損ケース）。
+    :param include_routes: False で ``routes`` を空にする（route 欠損ケース）。
+    """
+    tx: dict[str, Any] = {}
+    if include_tx:
+        tx["to"] = to
+        if data is not None:
+            tx["data"] = data
+
+    route: dict[str, Any] = {"tx": tx, "outputs": outputs or []}
+    return {
+        "action": action,
+        "requiredApprovals": required_approvals or [],
+        "routes": [route] if include_routes else [],
+    }
+
+
+def output(token: str, amount_wei: int) -> dict[str, Any]:
+    """``routes[0].outputs`` の 1 要素。"""
+    return {"token": token, "amount": str(amount_wei)}
+
+
+def approval(token: str, amount_wei: int) -> dict[str, Any]:
+    """``requiredApprovals`` の 1 要素（実 API 同様 spender は持たない）。"""
+    return {"token": token, "amount": str(amount_wei)}

--- a/backend/tests/protocols/test_pendle/test_pendle_convert_api_contract.py
+++ b/backend/tests/protocols/test_pendle/test_pendle_convert_api_contract.py
@@ -1,0 +1,180 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+"""Pendle Convert API の **契約テスト（実 API 疎通）**。
+
+## なぜ必要か
+
+2026-07-17 まで、Pendle の calldata クライアントは **実在しない API** に対して書かれていた
+（`/sdk/api/v1/{chain}/swapExactTokenForPt` → 全チェーンで 404）。URL・パラメータ名・応答形の
+すべてが実物と食い違っていたが、以下の理由で誰も検出できなかった:
+
+  1. 全経路が dormant（本番で一度も呼ばれない）
+  2. ユニットテストが `_call_sdk` をモックしており、**架空の応答形を自分で固定していた**
+
+つまり「テストは通るが実 API では必ず 404」という状態だった。本ファイルは実 API を叩いて
+**モックが実物とズレたら落ちる**ようにするための契約テスト。ユニットテストの mock 形は
+`convert_api_fixtures.convert_response()` に集約してあり、本テストがその形の正しさを担保する。
+
+## 実行方法
+
+外部ネットワークに依存するため既定では skip する（CI/オフラインで落とさない）::
+
+    PENDLE_LIVE_API_TEST=1 pytest tests/protocols/test_pendle/test_pendle_convert_api_contract.py -v
+
+**読み取り専用・無料・鍵不要・broadcast なし**（GET で calldata を組み立てるだけ）。
+実資金は 1 wei も動かない。
+
+## 既知の制約（実 API で確認済み 2026-07-17）
+
+- **Pendle は mainnet のみ対応**。testnet（Base Sepolia 84532 / Arbitrum Sepolia 421614）は
+  400 "Unsupported chain id" で拒否される ＝ **testnet 上での検証経路は存在しない**。
+- SELL_PT(PT→USDC) は `enableAggregator=true` が必須（false だと
+  "tokenOut must be in the SY token out list" で 400）。ただし aggregator 有効でも
+  `tx.to` は RouterV4 のままで、宛先 allowlist の fail-closed 性は保たれる。
+"""
+
+from __future__ import annotations
+
+import os
+from decimal import Decimal
+
+import pytest
+
+from app.protocols.pendle.client import PendleRouterV4Client
+from app.protocols.pendle.config import PendleConfig
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("PENDLE_LIVE_API_TEST") != "1",
+    reason="実 API 疎通テスト。PENDLE_LIVE_API_TEST=1 で有効化する",
+)
+
+# Base Mainnet / PT-yoUSD-24SEP2026（Phase-D D1 で採用した初期ターゲット）
+_CHAIN = "base"
+_MARKET = "0x250c15e59a7572195e248f668636723cca20a2b8"
+_PT = "0x1fec97ca2817da87f266fd1741bba61caf7cde29"
+_USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+_ROUTER = "0x888888888889758F76e7103c6CbF23ABbF58F946"
+# 実在するが残高不要の受取先（calldata 生成は残高を見ない）。
+_RECEIVER = "0x7f93f4Ba0eDf3b0D18a3fF4c9Ba1D5C5CBD8a0Ff"
+
+
+def _client() -> PendleRouterV4Client:
+    config = PendleConfig(sandbox=False)
+    config.chain = _CHAIN
+    config.router_address = _ROUTER
+    config.underlying_token_address = _USDC
+    config.pt_token_address = _PT
+    config.pt_token_decimals = 6  # PT-yoUSD-24SEP2026 は 6 桁（18 ではない）
+    config.underlying_token_decimals = 6  # USDC
+    config.market_address = _MARKET
+    config.stable_underlying = True
+    # calldata 取得のみ（broadcast はしない）。Q1 ガードを通すため True。
+    config.enable_onchain_write = True
+    return PendleRouterV4Client(config)
+
+
+@pytest.mark.asyncio
+async def test_buy_pt_live_calldata_targets_router() -> None:
+    """USDC → PT-yoUSD の calldata が実 API から取得でき、宛先が RouterV4 であること。"""
+    client = _client()
+    result = await client.build_buy_pt_swap_result(
+        market_address=_MARKET,
+        token_in=_USDC,
+        amount_in=Decimal("1"),  # 1 USDC
+        from_address=_RECEIVER,
+        token_in_decimals=6,
+    )
+    assert result.success is True, f"live SDK 失敗: {result.error}"
+    assert result.to is not None and result.to.lower() == _ROUTER.lower()
+    assert result.calldata and result.calldata.startswith("0x")
+    # 1 USDC で 1 PT 前後（PT は満期前ディスカウントで $1 未満 → 1 USDC で 1 超の PT）
+    assert result.amount_out is not None and result.amount_out > Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_buy_pt_live_approval_spender_is_verified_router() -> None:
+    """approve は「照合済み Router 宛」に限られること。
+
+    Convert API は spender を返さないため、client が tx.to（Router 照合済み）で補完する。
+    ここが崩れると任意コントラクトへ approve する余地が生まれる。
+    """
+    client = _client()
+    result = await client.build_buy_pt_swap_result(
+        market_address=_MARKET,
+        token_in=_USDC,
+        amount_in=Decimal("1"),
+        from_address=_RECEIVER,
+        token_in_decimals=6,
+    )
+    assert result.success is True, f"live SDK 失敗: {result.error}"
+    assert result.approvals, "USDC の approve が要求されるはず"
+    for approval in result.approvals:
+        assert approval.token is not None
+        assert approval.token.lower() == _USDC.lower()
+        assert approval.spender is not None
+        assert approval.spender.lower() == _ROUTER.lower()
+
+
+@pytest.mark.asyncio
+async def test_sell_pt_live_calldata_targets_router() -> None:
+    """PT-yoUSD → USDC（満期出口）の calldata も実 API から取得できること。
+
+    SELL_PT は aggregator が必須（yoUSD→USDC 変換）。それでも tx.to は Router のまま。
+    """
+    client = _client()
+    result = await client.build_sell_pt_swap_result(
+        market_address=_MARKET,
+        token_out=_USDC,
+        pt_amount_in=Decimal("1"),
+        from_address=_RECEIVER,
+        token_out_decimals=6,
+    )
+    assert result.success is True, f"live SDK 失敗: {result.error}"
+    assert result.to is not None and result.to.lower() == _ROUTER.lower()
+    assert result.calldata and result.calldata.startswith("0x")
+    assert result.amount_out is not None and result.amount_out > Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_market_info_live_returns_real_liquidity() -> None:
+    """流動性ガードの基準（tvl_usd）が実データで取れること。
+
+    `PendleWebClient` の chain map に "base" が無かった頃は 42161(Arbitrum) を叩いて 404 →
+    except 節のフォールバック（**stETH / tvl=0 / APY 5.2% の架空値**）が返っていた。
+    tvl=0 は流動性ガードが全 block する値なので、Pendle は「静かに常時 block」だった。
+    加えて expiry は ISO8601 文字列なのに int() でパースしており、これ単体でも必ず
+    フォールバックに落ちていた。両方直った状態を実データで固定する。
+    """
+    from app.protocols.pendle.client import PendleWebClient
+
+    config = PendleConfig(sandbox=False)
+    config.chain = _CHAIN
+    info = await PendleWebClient(config).get_market_info(_MARKET)
+
+    assert info.underlying_asset == "yoUSD", "フォールバック(stETH)が返っている"
+    assert info.tvl_usd > Decimal("0"), "tvl=0 では流動性ガードが全 block する"
+    assert info.implied_apy > Decimal("0")
+    # PT-yoUSD-24SEP2026
+    assert info.maturity.year == 2026 and info.maturity.month == 9
+    assert info.days_to_maturity > 0
+
+
+@pytest.mark.asyncio
+async def test_testnet_is_not_supported_by_pendle() -> None:
+    """**Pendle に testnet は無い**ことを実 API で固定する。
+
+    「Sepolia で安全に実証してから本番」という運用計画が立てられないことの根拠。
+    将来 Pendle が testnet を提供したら本テストが落ちるので、その時に運用計画を見直す。
+    """
+    client = _client()
+    client._chain_id = 84532  # Base Sepolia
+    result = await client.build_buy_pt_swap_result(
+        market_address=_MARKET,
+        token_in=_USDC,
+        amount_in=Decimal("1"),
+        from_address=_RECEIVER,
+        token_in_decimals=6,
+    )
+    assert result.success is False
+    assert result.error is not None
+    # 400 "Unsupported chain id ..." が返る（fail-closed で success=False）
+    assert "400" in result.error or "chain" in result.error.lower()

--- a/backend/tests/protocols/test_pendle/test_pendle_router_v4_client.py
+++ b/backend/tests/protocols/test_pendle/test_pendle_router_v4_client.py
@@ -10,33 +10,25 @@ from app.protocols.pendle.client import PendleRouterV4Client
 from app.protocols.pendle.config import PendleConfig
 from app.protocols.pendle.schemas import RouterV4AddLiquidityResult, RouterV4SwapResult
 
+from .convert_api_fixtures import convert_response, output
+
 MARKET = "0x" + "aa" * 20
 TOKEN_IN = "0x" + "bb" * 20
 TOKEN_OUT = "0x" + "cc" * 20
 RECEIVER = "0x" + "dd" * 20
-ROUTER = "0x888888888889758F76e7103c6CbF23ABbF58F946"
 
-# SDK が返すモックレスポンス（swap 系）。tx.to は Router アドレス（C2 照合をパスする）。
-_MOCK_SWAP_RESPONSE: dict = {
-    "data": {
-        "tx": {
-            "to": ROUTER,
-            "data": "0xdeadbeef",
-        },
-        "amountOut": str(int(Decimal("0.95") * Decimal(10**18))),
-    }
-}
+# Convert API が返すモックレスポンス（swap 系）。tx.to は Router アドレス（C2 照合をパスする）。
+# 応答形の定義は convert_api_fixtures に集約する（各ファイルで手書きしない）。
+_MOCK_SWAP_RESPONSE: dict = convert_response(
+    outputs=[output(TOKEN_OUT, int(Decimal("0.95") * Decimal(10**18)))],
+)
 
-# SDK が返すモックレスポンス（add_liquidity 系）。
-_MOCK_ADD_LIQ_RESPONSE: dict = {
-    "data": {
-        "tx": {
-            "to": ROUTER,
-            "data": "0xcafebabe",
-        },
-        "amountLpOut": str(int(Decimal("0.98") * Decimal(10**18))),
-    }
-}
+# add_liquidity 系。LP 受取量は outputs の token=market(LP) アドレスから 18 桁で復元される。
+_MOCK_ADD_LIQ_RESPONSE: dict = convert_response(
+    data="0xcafebabe",
+    action="add-liquidity",
+    outputs=[output(MARKET, int(Decimal("0.98") * Decimal(10**18)))],
+)
 
 
 @pytest.fixture
@@ -121,26 +113,34 @@ class TestBuyYt:
         assert type(result.amount_out) is Decimal
 
     @pytest.mark.asyncio
-    async def test_buy_yt_uses_swapExactTokenForYt_endpoint(
+    async def test_buy_yt_requests_yt_as_tokens_out(
         self, router_client: PendleRouterV4Client
     ) -> None:
-        """buy_yt が SDK の swapExactTokenForYt エンドポイントを呼ぶこと。"""
-        captured_endpoint: list[str] = []
+        """buy_yt が Convert API に tokensIn=入力トークン / tokensOut=YT を渡すこと。
 
-        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
-            captured_endpoint.append(endpoint)
+        旧テストは「SDK の swapExactTokenForYt エンドポイントを呼ぶこと」を検証していたが、
+        その個別エンドポイントは実在せず（Convert API に統合済み）、URL からは消えた。
+        動作は tokensIn/tokensOut の組み合わせで API 側が決めるため、等価な不変条件として
+        「渡すトークンの向き」を検証する。
+        """
+        captured_params: list[dict] = []
+
+        async def mock_call_sdk(params: dict) -> dict:
+            captured_params.append(params)
             return _MOCK_SWAP_RESPONSE
 
         with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
             await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
-        assert captured_endpoint[0] == "swapExactTokenForYt"
+        assert captured_params[0]["tokensIn"] == TOKEN_IN
+        assert captured_params[0]["tokensOut"] == "YT"
+        assert captured_params[0]["receiver"] == RECEIVER
 
     @pytest.mark.asyncio
     async def test_buy_yt_default_slippage(self, router_client: PendleRouterV4Client) -> None:
         """buy_yt のデフォルトスリッページが 0.005 であること。"""
         captured_params: list[dict] = []
 
-        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+        async def mock_call_sdk(params: dict) -> dict:
             captured_params.append(params)
             return _MOCK_SWAP_RESPONSE
 
@@ -153,7 +153,7 @@ class TestBuyYt:
         """buy_yt にカスタムスリッページを指定できること。"""
         captured_params: list[dict] = []
 
-        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+        async def mock_call_sdk(params: dict) -> dict:
             captured_params.append(params)
             return _MOCK_SWAP_RESPONSE
 
@@ -209,19 +209,24 @@ class TestSellYt:
         assert result.calldata == "0xdeadbeef"
 
     @pytest.mark.asyncio
-    async def test_sell_yt_uses_swapExactYtForToken_endpoint(
+    async def test_sell_yt_requests_yt_as_tokens_in(
         self, router_client: PendleRouterV4Client
     ) -> None:
-        """sell_yt が SDK の swapExactYtForToken エンドポイントを呼ぶこと。"""
-        captured_endpoint: list[str] = []
+        """sell_yt が Convert API に tokensIn=YT / tokensOut=出力トークンを渡すこと（売り方向）。
 
-        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
-            captured_endpoint.append(endpoint)
+        旧テストの swapExactYtForToken エンドポイントは実在しないため、等価な不変条件
+        （トークンの向きが売り方向であること）に置き換えた。
+        """
+        captured_params: list[dict] = []
+
+        async def mock_call_sdk(params: dict) -> dict:
+            captured_params.append(params)
             return _MOCK_SWAP_RESPONSE
 
         with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
             await router_client.sell_yt(MARKET, TOKEN_OUT, Decimal("1.0"), RECEIVER)
-        assert captured_endpoint[0] == "swapExactYtForToken"
+        assert captured_params[0]["tokensIn"] == "YT"
+        assert captured_params[0]["tokensOut"] == TOKEN_OUT
 
     @pytest.mark.asyncio
     async def test_sell_yt_error_returns_failure(self, router_client: PendleRouterV4Client) -> None:
@@ -257,19 +262,25 @@ class TestBuyPt:
         assert result.calldata == "0xdeadbeef"
 
     @pytest.mark.asyncio
-    async def test_buy_pt_uses_swapExactTokenForPt_endpoint(
+    async def test_buy_pt_requests_pt_as_tokens_out(
         self, router_client: PendleRouterV4Client
     ) -> None:
-        """buy_pt が SDK の swapExactTokenForPt エンドポイントを呼ぶこと。"""
-        captured_endpoint: list[str] = []
+        """buy_pt が tokensIn=入力トークン / tokensOut=**PT の実アドレス** を渡すこと（買い方向）。
 
-        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
-            captured_endpoint.append(endpoint)
+        旧テストの swapExactTokenForPt エンドポイントは実在しないため、等価な不変条件
+        （トークンの向きが買い方向であること）に置き換えた。さらに Convert API は
+        tokensOut に実アドレスを要求するため、旧 SDK 規約のリテラル "PT" では通らない。
+        """
+        captured_params: list[dict] = []
+
+        async def mock_call_sdk(params: dict) -> dict:
+            captured_params.append(params)
             return _MOCK_SWAP_RESPONSE
 
         with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
             await router_client.buy_pt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
-        assert captured_endpoint[0] == "swapExactTokenForPt"
+        assert captured_params[0]["tokensIn"] == TOKEN_IN
+        assert captured_params[0]["tokensOut"] == router_client._config.pt_token_address
 
     @pytest.mark.asyncio
     async def test_buy_pt_error_returns_failure(self, router_client: PendleRouterV4Client) -> None:
@@ -297,7 +308,7 @@ class TestBuyPt:
         """buy_pt のデフォルトスリッページが 0.005 であること。"""
         captured_params: list[dict] = []
 
-        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+        async def mock_call_sdk(params: dict) -> dict:
             captured_params.append(params)
             return _MOCK_SWAP_RESPONSE
 
@@ -318,19 +329,24 @@ class TestSellPt:
         assert result.calldata == "0xdeadbeef"
 
     @pytest.mark.asyncio
-    async def test_sell_pt_uses_swapExactPtForToken_endpoint(
+    async def test_sell_pt_requests_pt_as_tokens_in(
         self, router_client: PendleRouterV4Client
     ) -> None:
-        """sell_pt が SDK の swapExactPtForToken エンドポイントを呼ぶこと。"""
-        captured_endpoint: list[str] = []
+        """sell_pt が Convert API に tokensIn=PT / tokensOut=出力トークンを渡すこと（売り方向）。
 
-        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
-            captured_endpoint.append(endpoint)
+        旧テストの swapExactPtForToken エンドポイントは実在しないため、等価な不変条件
+        （トークンの向きが売り方向であること）に置き換えた。
+        """
+        captured_params: list[dict] = []
+
+        async def mock_call_sdk(params: dict) -> dict:
+            captured_params.append(params)
             return _MOCK_SWAP_RESPONSE
 
         with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
             await router_client.sell_pt(MARKET, TOKEN_OUT, Decimal("1.0"), RECEIVER)
-        assert captured_endpoint[0] == "swapExactPtForToken"
+        assert captured_params[0]["tokensIn"] == router_client._config.pt_token_address
+        assert captured_params[0]["tokensOut"] == TOKEN_OUT
 
     @pytest.mark.asyncio
     async def test_sell_pt_error_returns_failure(self, router_client: PendleRouterV4Client) -> None:
@@ -393,19 +409,25 @@ class TestAddLiquidity:
         assert type(result.lp_amount) is Decimal
 
     @pytest.mark.asyncio
-    async def test_add_liquidity_uses_addLiquiditySingleToken_endpoint(
+    async def test_add_liquidity_requests_market_as_tokens_out(
         self, router_client: PendleRouterV4Client
     ) -> None:
-        """add_liquidity が SDK の addLiquiditySingleToken エンドポイントを呼ぶこと。"""
-        captured_endpoint: list[str] = []
+        """add_liquidity が Convert API に tokensOut=market(LP) アドレスを渡すこと。
 
-        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
-            captured_endpoint.append(endpoint)
+        旧テストの addLiquiditySingleToken エンドポイントは実在しない。Convert API は swap と
+        同一エンドポイントで、tokensOut に market(LP) アドレスを渡すと action="add-liquidity"
+        になる。等価な不変条件として「LP を要求する向きで渡していること」を検証する。
+        """
+        captured_params: list[dict] = []
+
+        async def mock_call_sdk(params: dict) -> dict:
+            captured_params.append(params)
             return _MOCK_ADD_LIQ_RESPONSE
 
         with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
             await router_client.add_liquidity(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
-        assert captured_endpoint[0] == "addLiquiditySingleToken"
+        assert captured_params[0]["tokensIn"] == TOKEN_IN
+        assert captured_params[0]["tokensOut"] == MARKET
 
     @pytest.mark.asyncio
     async def test_add_liquidity_default_slippage(
@@ -414,7 +436,7 @@ class TestAddLiquidity:
         """add_liquidity のデフォルトスリッページが 0.005 であること。"""
         captured_params: list[dict] = []
 
-        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+        async def mock_call_sdk(params: dict) -> dict:
             captured_params.append(params)
             return _MOCK_ADD_LIQ_RESPONSE
 
@@ -427,7 +449,7 @@ class TestAddLiquidity:
         """add_liquidity にカスタムスリッページを指定できること。"""
         captured_params: list[dict] = []
 
-        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+        async def mock_call_sdk(params: dict) -> dict:
             captured_params.append(params)
             return _MOCK_ADD_LIQ_RESPONSE
 
@@ -478,10 +500,14 @@ class TestAddLiquidity:
     async def test_add_liquidity_passes_correct_params(
         self, router_client: PendleRouterV4Client
     ) -> None:
-        """add_liquidity が SDK に正しいパラメータを渡すこと。"""
+        """add_liquidity が Convert API に正しいパラメータを渡すこと。
+
+        Convert API のパラメータ名は複数形（tokensIn / tokensOut / amountsIn）で、
+        market は独立キーでは渡さない（対象 market は tokensOut 側で一意に決まる）。
+        """
         captured_params: list[dict] = []
 
-        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+        async def mock_call_sdk(params: dict) -> dict:
             captured_params.append(params)
             return _MOCK_ADD_LIQ_RESPONSE
 
@@ -489,10 +515,11 @@ class TestAddLiquidity:
             await router_client.add_liquidity(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
 
         p = captured_params[0]
-        assert p["market"] == MARKET
-        assert p["tokenIn"] == TOKEN_IN
+        assert p["tokensIn"] == TOKEN_IN
+        assert p["tokensOut"] == MARKET
         assert p["receiver"] == RECEIVER
-        assert "amountIn" in p
+        assert p["amountsIn"] == str(10**18)
+        assert "market" not in p
 
 
 class TestSecurityConstraints:

--- a/backend/tests/protocols/test_pendle/test_pendle_router_v4_guard.py
+++ b/backend/tests/protocols/test_pendle/test_pendle_router_v4_guard.py
@@ -29,28 +29,29 @@ from app.protocols.pendle.schemas import (
     RouterV4Approval,
 )
 
+from .convert_api_fixtures import ROUTER, approval, convert_response, output
+
 MARKET = "0x" + "aa" * 20
 TOKEN_IN = "0x" + "bb" * 20
 TOKEN_OUT = "0x" + "cc" * 20
 RECEIVER = "0x" + "dd" * 20
 
-_ROUTER_ADDRESS = "0x888888888889758F76e7103c6CbF23ABbF58F946"
+_ROUTER_ADDRESS = ROUTER
 
-_MOCK_SWAP_RESPONSE: dict = {
-    "data": {
-        "tx": {"to": _ROUTER_ADDRESS, "data": "0xdeadbeef"},
-        "amountOut": str(int(Decimal("0.95") * Decimal(10**18))),
-        "approvals": [{"spender": _ROUTER_ADDRESS, "token": TOKEN_IN}],
-    }
-}
+# Convert API の応答モック（swap 系）。outputs は buy_yt/sell_yt が要求する token_out が
+# リテラル "YT"/"PT" のため一致せず、client 実装どおり outputs[0] にフォールバックする。
+_MOCK_SWAP_RESPONSE: dict = convert_response(
+    required_approvals=[approval(TOKEN_IN, 10**18)],
+    outputs=[output(TOKEN_OUT, int(Decimal("0.95") * Decimal(10**18)))],
+)
 
-_MOCK_ADD_LIQ_RESPONSE: dict = {
-    "data": {
-        "tx": {"to": _ROUTER_ADDRESS, "data": "0xcafebabe"},
-        "amountLpOut": str(int(Decimal("0.98") * Decimal(10**18))),
-        "approvals": [{"spender": _ROUTER_ADDRESS, "token": TOKEN_IN}],
-    }
-}
+# add_liquidity 系。LP 受取量は outputs の token=market(LP) アドレスから 18 桁で復元される。
+_MOCK_ADD_LIQ_RESPONSE: dict = convert_response(
+    data="0xcafebabe",
+    action="add-liquidity",
+    required_approvals=[approval(TOKEN_IN, 10**18)],
+    outputs=[output(MARKET, int(Decimal("0.98") * Decimal(10**18)))],
+)
 
 
 @pytest.fixture
@@ -378,10 +379,11 @@ class TestApprovalsExtraction:
             result = await enabled_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
         assert result.approvals is not None
         assert len(result.approvals) == 1
-        approval = result.approvals[0]
-        assert isinstance(approval, RouterV4Approval)
-        assert approval.spender == "0x888888888889758F76e7103c6CbF23ABbF58F946"
-        assert approval.token == TOKEN_IN
+        extracted = result.approvals[0]
+        assert isinstance(extracted, RouterV4Approval)
+        # spender は API 由来ではなく、照合済み Router（routes[0].tx.to）で補完される
+        assert extracted.spender == ROUTER
+        assert extracted.token == TOKEN_IN
 
     @pytest.mark.asyncio
     async def test_approvals_extracted_from_add_liquidity(
@@ -398,13 +400,10 @@ class TestApprovalsExtraction:
     async def test_approvals_empty_when_not_in_response(
         self, enabled_client: PendleRouterV4Client
     ) -> None:
-        """SDK レスポンスに approvals がない場合は空リストが返ること。"""
-        response_no_approvals: dict = {
-            "data": {
-                "tx": {"to": _ROUTER_ADDRESS, "data": "0xdeadbeef"},
-                "amountOut": str(int(Decimal("0.95") * Decimal(10**18))),
-            }
-        }
+        """SDK レスポンスに requiredApprovals がない場合は空リストが返ること。"""
+        response_no_approvals = convert_response(
+            outputs=[output(TOKEN_OUT, int(Decimal("0.95") * Decimal(10**18)))],
+        )
         with patch.object(
             enabled_client, "_call_sdk", new=AsyncMock(return_value=response_no_approvals)
         ):

--- a/backend/tests/protocols/test_pendle/test_pendle_router_v4_guard.py
+++ b/backend/tests/protocols/test_pendle/test_pendle_router_v4_guard.py
@@ -40,8 +40,26 @@ _ROUTER_ADDRESS = ROUTER
 
 # Convert API の応答モック（swap 系）。outputs は buy_yt/sell_yt が要求する token_out が
 # リテラル "YT"/"PT" のため一致せず、client 実装どおり outputs[0] にフォールバックする。
+#
+# approve は client が「swap 入力と同一 token・同一 amount」でなければ拒否する（H1 対策）ため、
+# 本モックは **入力 TOKEN_IN / 1.0 (=1e18) の呼び出し専用**。別の額・別の入力トークンで使うと
+# 正しく fail-closed して落ちる。その場合は `_swap_response_for` を使うこと。
 _MOCK_SWAP_RESPONSE: dict = convert_response(
     required_approvals=[approval(TOKEN_IN, 10**18)],
+    outputs=[output(TOKEN_OUT, int(Decimal("0.95") * Decimal(10**18)))],
+)
+
+
+def _swap_response_for(token_in: str, amount_wei: int) -> dict:
+    """指定の swap 入力に整合する応答モック（approve 検証を通すため）。"""
+    return convert_response(
+        required_approvals=[approval(token_in, amount_wei)],
+        outputs=[output(TOKEN_OUT, int(Decimal("0.95") * Decimal(10**18)))],
+    )
+
+
+#: approve を要求しない応答（calldata だけを見たいテスト用）。
+_MOCK_SWAP_RESPONSE_NO_APPROVAL: dict = convert_response(
     outputs=[output(TOKEN_OUT, int(Decimal("0.95") * Decimal(10**18)))],
 )
 
@@ -145,8 +163,11 @@ class TestDryRunEnabled:
     async def test_sell_yt_dry_run_gets_calldata(
         self, enabled_client: PendleRouterV4Client
     ) -> None:
+        # sell_yt の入力はリテラル "YT"（旧 SDK 規約の名残で実アドレスではない）。approve は
+        # swap 入力と同一 token でなければ拒否されるため、calldata だけを見る本テストでは
+        # approve なしの応答を使う。YT 経路が実 API で成立しない件は client の docstring 参照。
         with patch.object(
-            enabled_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE)
+            enabled_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE_NO_APPROVAL)
         ):
             result = await enabled_client.sell_yt(
                 MARKET, TOKEN_OUT, Decimal("1.0"), RECEIVER, dry_run=True
@@ -240,7 +261,10 @@ class TestMaxSingleTradeGuard:
         """portfolio_value_usd=None はチェックをスキップし warning ログを出すこと（d）。"""
         with caplog.at_level(logging.WARNING, logger="app.protocols.pendle.client"):
             with patch.object(
-                enabled_client, "_call_sdk", new=AsyncMock(return_value=_MOCK_SWAP_RESPONSE)
+                enabled_client,
+                "_call_sdk",
+                # approve は swap 入力(999e18)と厳密一致でなければ拒否されるため額を揃える。
+                new=AsyncMock(return_value=_swap_response_for(TOKEN_IN, 999 * 10**18)),
             ):
                 result = await enabled_client.buy_yt(
                     MARKET, TOKEN_IN, Decimal("999"), RECEIVER, portfolio_value_usd=None

--- a/backend/tests/protocols/test_pendle/test_pendle_router_v4_security.py
+++ b/backend/tests/protocols/test_pendle/test_pendle_router_v4_security.py
@@ -1,9 +1,13 @@
 """PendleRouterV4Client セキュリティレビュー指摘の回帰テスト（C2/C3/M1/m1）。
 
-- C2: tx.to / approvals.spender を Router アドレスと照合し不一致を拒否
-- C3: 非18桁トークン（USDC=6）の amountIn 桁ズレを防ぐ decimals 解決
+- C2: routes[0].tx.to を Router アドレスと照合し不一致を拒否。approve の spender は
+  **API の返り値に依存せず**照合済み Router で補完する（Convert API は spender を返さない）
+- C3: 非18桁トークン（USDC=6）の amountsIn 桁ズレを防ぐ decimals 解決
 - M1: slippage 境界（0 / 0.05 / 0.051 / 負値）の Pydantic 制約
 - m1: calldata 欠損/空文字を success=False で拒否
+
+モックする応答形は `convert_api_fixtures.convert_response()`（実 API 準拠）に集約する。
+各ファイルで手書きすると、かつてのように架空の契約を固定してしまう。
 """
 
 from decimal import Decimal
@@ -16,11 +20,12 @@ from app.protocols.pendle.client import PendleRouterV4Client
 from app.protocols.pendle.config import PendleConfig
 from app.protocols.pendle.schemas import RouterV4SwapRequest
 
+from .convert_api_fixtures import ROUTER, approval, convert_response, output
+
 MARKET = "0x" + "aa" * 20
 TOKEN_IN = "0x" + "bb" * 20
 TOKEN_OUT = "0x" + "cc" * 20
 RECEIVER = "0x" + "dd" * 20
-ROUTER = "0x888888888889758F76e7103c6CbF23ABbF58F946"
 EVIL_CONTRACT = "0x" + "ee" * 20
 
 
@@ -37,20 +42,6 @@ def router_client() -> PendleRouterV4Client:
     return PendleRouterV4Client(config)
 
 
-def _swap_response(
-    *, to: str = ROUTER, data: str = "0xdeadbeef", approvals: list | None = None
-) -> dict:
-    resp: dict = {
-        "data": {
-            "tx": {"to": to, "data": data},
-            "amountOut": str(int(Decimal("0.95") * Decimal(10**18))),
-        }
-    }
-    if approvals is not None:
-        resp["data"]["approvals"] = approvals
-    return resp
-
-
 # --- C2: Router アドレス照合 ---
 
 
@@ -61,7 +52,7 @@ class TestRouterAddressVerification:
         with patch.object(
             router_client,
             "_call_sdk",
-            new=AsyncMock(return_value=_swap_response(to=EVIL_CONTRACT)),
+            new=AsyncMock(return_value=convert_response(to=EVIL_CONTRACT)),
         ):
             result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
         assert result.success is False
@@ -76,7 +67,7 @@ class TestRouterAddressVerification:
         with patch.object(
             router_client,
             "_call_sdk",
-            new=AsyncMock(return_value=_swap_response(to=ROUTER.lower())),
+            new=AsyncMock(return_value=convert_response(to=ROUTER.lower())),
         ):
             result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
         assert result.success is True
@@ -86,55 +77,99 @@ class TestRouterAddressVerification:
     @pytest.mark.asyncio
     async def test_buy_yt_rejects_missing_tx_to(self, router_client: PendleRouterV4Client) -> None:
         """tx.to 欠損は照合不能 → 拒否。"""
-        resp = {"data": {"tx": {"data": "0xdeadbeef"}, "amountOut": "0"}}
-        with patch.object(router_client, "_call_sdk", new=AsyncMock(return_value=resp)):
-            result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
-        assert result.success is False
-        assert result.error == "router address mismatch"
-
-    @pytest.mark.asyncio
-    async def test_buy_yt_rejects_wrong_approval_spender(
-        self, router_client: PendleRouterV4Client
-    ) -> None:
-        """approvals.spender が Router 以外なら拒否する。"""
-        approvals = [{"token": TOKEN_IN, "spender": EVIL_CONTRACT, "amount": "100"}]
         with patch.object(
             router_client,
             "_call_sdk",
-            new=AsyncMock(return_value=_swap_response(approvals=approvals)),
+            new=AsyncMock(return_value=convert_response(include_tx=False)),
         ):
             result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
         assert result.success is False
         assert result.error == "router address mismatch"
 
     @pytest.mark.asyncio
-    async def test_buy_yt_accepts_valid_approval_spender(
-        self, router_client: PendleRouterV4Client
-    ) -> None:
-        """approvals.spender が Router なら受理し、approvals を結果に保持する。"""
-        approvals = [{"token": TOKEN_IN, "spender": ROUTER, "amount": "100"}]
+    async def test_buy_yt_rejects_missing_route(self, router_client: PendleRouterV4Client) -> None:
+        """routes が空なら照合対象が存在しない → 拒否（fail-closed）。"""
         with patch.object(
             router_client,
             "_call_sdk",
-            new=AsyncMock(return_value=_swap_response(approvals=approvals)),
+            new=AsyncMock(return_value=convert_response(include_routes=False)),
+        ):
+            result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert result.error == "router address mismatch"
+
+    @pytest.mark.asyncio
+    async def test_approval_spender_ignores_api_supplied_spender(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """API が spender を混入させても無視し、照合済み Router を spender にすること。
+
+        旧テストは「API が返した spender が Router 以外なら拒否する」を検証していたが、
+        その挙動は既に存在しない（実 Convert API は spender を返さないため、client は
+        API 由来の spender を一切読まず、`_verify_router` で照合済みの宛先だけを使う）。
+        ここではより強い不変条件を検証する: **API が何を返そうと approve 先は照合済み
+        Router 以外にならない**（悪意ある spender の注入経路が存在しない）。
+        """
+        rogue = [{"token": TOKEN_IN, "spender": EVIL_CONTRACT, "amount": "100"}]
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(return_value=convert_response(required_approvals=rogue)),
+        ):
+            result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is True
+        assert len(result.approvals) == 1
+        # EVIL_CONTRACT は素通りせず、照合済み Router に置き換わる
+        assert result.approvals[0].spender == ROUTER
+        assert result.approvals[0].token == TOKEN_IN
+
+    @pytest.mark.asyncio
+    async def test_approval_spender_filled_from_verified_router(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """実 API 通り spender 無しで返っても、照合済み Router が補完されること。"""
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(
+                return_value=convert_response(required_approvals=[approval(TOKEN_IN, 100)])
+            ),
         ):
             result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
         assert result.success is True
         assert len(result.approvals) == 1
         assert result.approvals[0].spender == ROUTER
+        assert result.approvals[0].amount == "100"
+
+    @pytest.mark.asyncio
+    async def test_wrong_tx_to_yields_no_approvals(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """tx.to が Router 以外なら approvals ごと破棄されること（approve 先が漏れない）。"""
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(
+                return_value=convert_response(
+                    to=EVIL_CONTRACT, required_approvals=[approval(TOKEN_IN, 100)]
+                )
+            ),
+        ):
+            result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert result.error == "router address mismatch"
+        assert result.approvals == []
 
     @pytest.mark.asyncio
     async def test_add_liquidity_rejects_wrong_tx_to(
         self, router_client: PendleRouterV4Client
     ) -> None:
         """add_liquidity も tx.to を照合する。"""
-        resp = {
-            "data": {
-                "tx": {"to": EVIL_CONTRACT, "data": "0xcafebabe"},
-                "amountLpOut": "0",
-            }
-        }
-        with patch.object(router_client, "_call_sdk", new=AsyncMock(return_value=resp)):
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(return_value=convert_response(to=EVIL_CONTRACT, data="0xcafebabe")),
+        ):
             result = await router_client.add_liquidity(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
         assert result.success is False
         assert result.error == "router address mismatch"
@@ -146,19 +181,19 @@ class TestRouterAddressVerification:
 class TestTokenDecimals:
     @pytest.mark.asyncio
     async def test_buy_yt_usdc_uses_6_decimals(self, router_client: PendleRouterV4Client) -> None:
-        """token_in_decimals=6（USDC）で amountIn が 10^6 単位になること。"""
+        """token_in_decimals=6（USDC）で amountsIn が 10^6 単位になること。"""
         captured: list[dict] = []
 
-        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+        async def mock_call_sdk(params: dict) -> dict:
             captured.append(params)
-            return _swap_response()
+            return convert_response()
 
         with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
             await router_client.buy_yt(
                 MARKET, "USDC", Decimal("100"), RECEIVER, token_in_decimals=6
             )
         # 100 USDC * 10^6 = 100_000_000（18 桁なら 10^20 になってしまう）
-        assert captured[0]["amountIn"] == str(100 * 10**6)
+        assert captured[0]["amountsIn"] == str(100 * 10**6)
 
     @pytest.mark.asyncio
     async def test_buy_yt_usdc_resolved_from_config_map(
@@ -167,13 +202,13 @@ class TestTokenDecimals:
         """token_in_decimals 未指定でもシンボル 'USDC' から 6 桁を解決すること。"""
         captured: list[dict] = []
 
-        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+        async def mock_call_sdk(params: dict) -> dict:
             captured.append(params)
-            return _swap_response()
+            return convert_response()
 
         with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
             await router_client.buy_yt(MARKET, "usdc", Decimal("100"), RECEIVER)
-        assert captured[0]["amountIn"] == str(100 * 10**6)
+        assert captured[0]["amountsIn"] == str(100 * 10**6)
 
     @pytest.mark.asyncio
     async def test_buy_yt_unknown_token_defaults_18(
@@ -182,26 +217,52 @@ class TestTokenDecimals:
         """未知トークンは 18 桁にフォールバックすること（後方互換）。"""
         captured: list[dict] = []
 
-        async def mock_call_sdk(endpoint: str, params: dict) -> dict:
+        async def mock_call_sdk(params: dict) -> dict:
             captured.append(params)
-            return _swap_response()
+            return convert_response()
 
         with patch.object(router_client, "_call_sdk", side_effect=mock_call_sdk):
             await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
-        assert captured[0]["amountIn"] == str(10**18)
+        assert captured[0]["amountsIn"] == str(10**18)
 
     @pytest.mark.asyncio
     async def test_sell_yt_usdc_out_amount_uses_6_decimals(
         self, router_client: PendleRouterV4Client
     ) -> None:
-        """sell_yt の出力 USDC で amount_out が 6 桁前提で復元されること。"""
-        resp = {
-            "data": {
-                "tx": {"to": ROUTER, "data": "0xdeadbeef"},
-                "amountOut": str(100 * 10**6),  # 100 USDC (6 decimals)
-            }
-        }
-        with patch.object(router_client, "_call_sdk", new=AsyncMock(return_value=resp)):
+        """sell_yt の出力 USDC で amount_out が 6 桁前提で復元されること。
+
+        amount_out は routes[0].outputs のうち token_out に一致するものから復元されるため、
+        outputs は client が要求した token_out（ここでは "USDC"）に紐づけて置く。
+        """
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            # 100 USDC (6 decimals)
+            new=AsyncMock(return_value=convert_response(outputs=[output("USDC", 100 * 10**6)])),
+        ):
+            result = await router_client.sell_yt(
+                MARKET, "USDC", Decimal("1.0"), RECEIVER, token_out_decimals=6
+            )
+        assert result.success is True
+        assert result.amount_out == Decimal("100")
+
+    @pytest.mark.asyncio
+    async def test_amount_out_picks_matching_token_not_first(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """outputs が複数あるとき token_out に一致するものを選ぶこと（先頭決め打ちでない）。"""
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(
+                return_value=convert_response(
+                    outputs=[
+                        output(TOKEN_IN, 999 * 10**6),  # 別トークン（選ばれてはいけない）
+                        output("USDC", 100 * 10**6),
+                    ]
+                )
+            ),
+        ):
             result = await router_client.sell_yt(
                 MARKET, "USDC", Decimal("1.0"), RECEIVER, token_out_decimals=6
             )
@@ -294,7 +355,7 @@ class TestEmptyCalldata:
         with patch.object(
             router_client,
             "_call_sdk",
-            new=AsyncMock(return_value=_swap_response(data="")),
+            new=AsyncMock(return_value=convert_response(data="")),
         ):
             result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
         assert result.success is False
@@ -305,8 +366,11 @@ class TestEmptyCalldata:
         self, router_client: PendleRouterV4Client
     ) -> None:
         """tx.data 欠損なら success=False。"""
-        resp = {"data": {"tx": {"to": ROUTER}, "amountOut": "0"}}
-        with patch.object(router_client, "_call_sdk", new=AsyncMock(return_value=resp)):
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(return_value=convert_response(data=None)),
+        ):
             result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
         assert result.success is False
         assert result.error == "empty calldata"
@@ -316,8 +380,11 @@ class TestEmptyCalldata:
         self, router_client: PendleRouterV4Client
     ) -> None:
         """add_liquidity の calldata 空でも拒否する。"""
-        resp = {"data": {"tx": {"to": ROUTER, "data": ""}, "amountLpOut": "0"}}
-        with patch.object(router_client, "_call_sdk", new=AsyncMock(return_value=resp)):
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(return_value=convert_response(data="")),
+        ):
             result = await router_client.add_liquidity(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
         assert result.success is False
         assert result.error == "empty calldata"
@@ -335,7 +402,9 @@ class TestOnchainWriteGuard:
     @pytest.mark.asyncio
     async def test_tx_hash_always_none_in_phase1(self, router_client: PendleRouterV4Client) -> None:
         """Phase 1 は calldata 取得まで。成功時も tx_hash は None（送信していない）。"""
-        with patch.object(router_client, "_call_sdk", new=AsyncMock(return_value=_swap_response())):
+        with patch.object(
+            router_client, "_call_sdk", new=AsyncMock(return_value=convert_response())
+        ):
             result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
         assert result.success is True
         assert result.tx_hash is None

--- a/backend/tests/protocols/test_pendle/test_pendle_router_v4_security.py
+++ b/backend/tests/protocols/test_pendle/test_pendle_router_v4_security.py
@@ -110,7 +110,7 @@ class TestRouterAddressVerification:
         ここではより強い不変条件を検証する: **API が何を返そうと approve 先は照合済み
         Router 以外にならない**（悪意ある spender の注入経路が存在しない）。
         """
-        rogue = [{"token": TOKEN_IN, "spender": EVIL_CONTRACT, "amount": "100"}]
+        rogue = [{"token": TOKEN_IN, "spender": EVIL_CONTRACT, "amount": str(10**18)}]
         with patch.object(
             router_client,
             "_call_sdk",
@@ -124,6 +124,51 @@ class TestRouterAddressVerification:
         assert result.approvals[0].token == TOKEN_IN
 
     @pytest.mark.asyncio
+    async def test_approval_rejects_unlimited_amount(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """[安全レビュー H1] API が無制限 approve を要求しても拒否すること。
+
+        これを通すと `tx.to` は Router のままなので Router 照合も Privy policy も素通りし、
+        **恒久的な無制限 USDC allowance** が成立する（損失上限が「1 取引の額」ではなく
+        「残高全部・永久」になる）。実 API は現に amountsIn と同額しか返さないが、この API 契約は
+        2026-07-17 まで全面的に誤っていた実績があるため、外部の行儀に依存せず自前で縛る。
+        """
+        uint256_max = 2**256 - 1
+        rogue = [{"token": TOKEN_IN, "amount": str(uint256_max)}]
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(return_value=convert_response(required_approvals=rogue)),
+        ):
+            result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert result.error is not None and "approval amount mismatch" in result.error
+        # fail-closed: approve は 1 件も組み立てられない
+        assert result.approvals == []
+        assert result.calldata is None
+
+    @pytest.mark.asyncio
+    async def test_approval_rejects_foreign_token(
+        self, router_client: PendleRouterV4Client
+    ) -> None:
+        """[安全レビュー H1] swap 入力と別トークンへの approve を拒否すること。
+
+        これを通すと、API が指定した任意の保有トークンに対して Router への approve を
+        組み立てられてしまう（swap 対象外の資産まで危険に晒す）。
+        """
+        rogue = [{"token": EVIL_CONTRACT, "amount": str(10**18)}]
+        with patch.object(
+            router_client,
+            "_call_sdk",
+            new=AsyncMock(return_value=convert_response(required_approvals=rogue)),
+        ):
+            result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
+        assert result.success is False
+        assert result.error is not None and "approval token mismatch" in result.error
+        assert result.approvals == []
+
+    @pytest.mark.asyncio
     async def test_approval_spender_filled_from_verified_router(
         self, router_client: PendleRouterV4Client
     ) -> None:
@@ -132,14 +177,14 @@ class TestRouterAddressVerification:
             router_client,
             "_call_sdk",
             new=AsyncMock(
-                return_value=convert_response(required_approvals=[approval(TOKEN_IN, 100)])
+                return_value=convert_response(required_approvals=[approval(TOKEN_IN, 10**18)])
             ),
         ):
             result = await router_client.buy_yt(MARKET, TOKEN_IN, Decimal("1.0"), RECEIVER)
         assert result.success is True
         assert len(result.approvals) == 1
         assert result.approvals[0].spender == ROUTER
-        assert result.approvals[0].amount == "100"
+        assert result.approvals[0].amount == str(10**18)
 
     @pytest.mark.asyncio
     async def test_wrong_tx_to_yields_no_approvals(
@@ -151,7 +196,7 @@ class TestRouterAddressVerification:
             "_call_sdk",
             new=AsyncMock(
                 return_value=convert_response(
-                    to=EVIL_CONTRACT, required_approvals=[approval(TOKEN_IN, 100)]
+                    to=EVIL_CONTRACT, required_approvals=[approval(TOKEN_IN, 10**18)]
                 )
             ),
         ):

--- a/backend/tests/protocols/test_pendle/test_pendle_service_real_execution.py
+++ b/backend/tests/protocols/test_pendle/test_pendle_service_real_execution.py
@@ -18,6 +18,8 @@ from app.protocols.pendle.schemas import (
 )
 from app.protocols.pendle.service import PendleService
 
+from .convert_api_fixtures import ROUTER, convert_response, output
+
 _MARKET_ADDR = "0x" + "0" * 40
 
 
@@ -288,28 +290,10 @@ class TestGetMarketInfo:
         assert result == Decimal("0")
 
 
-_ROUTER = "0x888888888889758F76e7103c6CbF23ABbF58F946"
+_ROUTER = ROUTER
 _MARKET = "0x" + "aa" * 20
 _TOKEN_IN = "0x" + "bb" * 20  # noqa: S106 — トークンアドレス（パスワードではない）
 _RECEIVER = "0x" + "dd" * 20
-
-
-def _sdk_resp(
-    *,
-    to: str = _ROUTER,
-    data: str = "0xdeadbeef",
-    approvals: list | None = None,
-) -> dict:
-    """テスト用 SDK レスポンスを生成する。"""
-    resp: dict = {
-        "data": {
-            "tx": {"to": to, "data": data},
-            "amountOut": str(int(Decimal("0.95") * Decimal(10**18))),
-        }
-    }
-    if approvals is not None:
-        resp["data"]["approvals"] = approvals
-    return resp
 
 
 @pytest.fixture
@@ -337,16 +321,20 @@ class TestRouterV4RealCalldataPath:
     ) -> None:
         """_extract_approvals が非 dict 要素（文字列・None）を無視して dict のみを返すこと。
 
-        approvals リストに dict と非 dict が混在する場合、非 dict は continue でスキップされ、
-        有効な dict アイテムのみが RouterV4Approval として返される。
+        requiredApprovals に dict と非 dict が混在する場合、非 dict は continue でスキップされ、
+        有効な dict アイテムのみが RouterV4Approval として返される。実 Convert API の
+        requiredApprovals は spender を持たないため、spender は照合済み Router で補完される。
         """
-        # 非 dict 要素（文字列、None）を混在させた approvals を _call_sdk がモックで返す
+        # 非 dict 要素（文字列、None）を混在させた requiredApprovals をモックで返す
         mixed_approvals = [
             "invalid_string_item",  # 非 dict — continue 分岐を通す
             None,  # 非 dict — continue 分岐を通す
-            {"token": _TOKEN_IN, "spender": _ROUTER, "amount": "100"},  # 有効な dict
+            {"token": _TOKEN_IN, "amount": "100"},  # 有効な dict（実 API 同様 spender なし）
         ]
-        sdk_resp = _sdk_resp(approvals=mixed_approvals)
+        sdk_resp = convert_response(
+            required_approvals=mixed_approvals,
+            outputs=[output(_TOKEN_IN, int(Decimal("0.95") * Decimal(10**18)))],
+        )
 
         with patch.object(
             router_client_write_enabled,
@@ -370,9 +358,12 @@ class TestRouterV4RealCalldataPath:
     async def test_extract_approvals_all_non_dict_returns_empty(
         self, router_client_write_enabled: PendleRouterV4Client
     ) -> None:
-        """approvals が全て非 dict のとき空リストが返り、Router 照合が通過すること。"""
+        """requiredApprovals が全て非 dict のとき空リストが返り、Router 照合が通過すること。"""
         all_invalid_approvals: list = ["str_item", 42, None]
-        sdk_resp = _sdk_resp(approvals=all_invalid_approvals)
+        sdk_resp = convert_response(
+            required_approvals=all_invalid_approvals,
+            outputs=[output(_TOKEN_IN, int(Decimal("0.95") * Decimal(10**18)))],
+        )
 
         with patch.object(
             router_client_write_enabled,
@@ -389,3 +380,24 @@ class TestRouterV4RealCalldataPath:
         # 非 dict を全てスキップした結果、approvals は空 → Router 照合は通過し success=True
         assert result.success is True
         assert result.approvals == []
+
+    def test_extract_approvals_direct_call_uses_given_spender(
+        self, router_client_write_enabled: PendleRouterV4Client
+    ) -> None:
+        """_extract_approvals は渡された spender を各 approval に適用すること（直接呼び出し）。
+
+        `_extract_approvals(sdk_response, spender)` は spender を必須引数に取るようになった。
+        呼び出し側が `_verify_router` で照合済みの宛先を渡す契約であることをここで固定する。
+        """
+        sdk_resp = convert_response(
+            required_approvals=[
+                {"token": _TOKEN_IN, "amount": "100"},
+                "非 dict はスキップ",
+            ],
+        )
+        approvals = router_client_write_enabled._extract_approvals(sdk_resp, spender=_ROUTER)
+
+        assert len(approvals) == 1
+        assert approvals[0].spender == _ROUTER
+        assert approvals[0].token == _TOKEN_IN
+        assert approvals[0].amount == "100"

--- a/backend/tests/protocols/test_pendle/test_pendle_service_real_execution.py
+++ b/backend/tests/protocols/test_pendle/test_pendle_service_real_execution.py
@@ -329,7 +329,7 @@ class TestRouterV4RealCalldataPath:
         mixed_approvals = [
             "invalid_string_item",  # 非 dict — continue 分岐を通す
             None,  # 非 dict — continue 分岐を通す
-            {"token": _TOKEN_IN, "amount": "100"},  # 有効な dict（実 API 同様 spender なし）
+            {"token": _TOKEN_IN, "amount": str(10**18)},  # 有効な dict（実 API 同様 spender なし）
         ]
         sdk_resp = convert_response(
             required_approvals=mixed_approvals,
@@ -386,8 +386,9 @@ class TestRouterV4RealCalldataPath:
     ) -> None:
         """_extract_approvals は渡された spender を各 approval に適用すること（直接呼び出し）。
 
-        `_extract_approvals(sdk_response, spender)` は spender を必須引数に取るようになった。
-        呼び出し側が `_verify_router` で照合済みの宛先を渡す契約であることをここで固定する。
+        `_extract_approvals` は spender / expected_token / expected_amount_wei を必須の
+        キーワード引数に取る。呼び出し側が `_verify_router` で照合済みの宛先を spender として渡し、
+        token / amount は swap 入力と突合する契約であることをここで固定する。
         """
         sdk_resp = convert_response(
             required_approvals=[
@@ -395,8 +396,11 @@ class TestRouterV4RealCalldataPath:
                 "非 dict はスキップ",
             ],
         )
-        approvals = router_client_write_enabled._extract_approvals(sdk_resp, spender=_ROUTER)
+        approvals, error = router_client_write_enabled._extract_approvals(
+            sdk_resp, spender=_ROUTER, expected_token=_TOKEN_IN, expected_amount_wei=100
+        )
 
+        assert error == ""
         assert len(approvals) == 1
         assert approvals[0].spender == _ROUTER
         assert approvals[0].token == _TOKEN_IN

--- a/backend/tests/protocols/test_pendle/test_pendle_web_client_chain_expiry.py
+++ b/backend/tests/protocols/test_pendle/test_pendle_web_client_chain_expiry.py
@@ -1,0 +1,68 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+"""PendleWebClient の chain 解決 / expiry パース（実 API 不要のユニットテスト）。
+
+2026-07-17 に見つかった 2 件の回帰防止:
+
+1. **chain map に "base" が無く 42161(Arbitrum) に既定化していた** → market data が 404 →
+   except 節のフォールバック（stETH / tvl=0 / APY 5.2% の架空値）が返る。
+   `tvl_usd=0` は流動性ガードが全 block する値なので、Pendle は「静かに常時 block」だった。
+2. **expiry を int() でパースしていた** が実 API は ISO8601 文字列 → 必ず ValueError →
+   これ単体でもフォールバックに落ちていた。
+
+いずれも全経路 dormant + テストが HTTP をモックしていたため未検出だった。
+実 API との整合は `test_pendle_convert_api_contract.py`（live・opt-in）が担保する。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.protocols.pendle.client import PendleWebClient
+from app.protocols.pendle.config import PendleConfig
+
+
+def _client(chain: str) -> PendleWebClient:
+    config = PendleConfig(sandbox=False)
+    config.chain = chain
+    return PendleWebClient(config)
+
+
+class TestChainIdResolution:
+    def test_base_resolves_to_8453(self) -> None:
+        """PENDLE_CHAIN=base が Base Mainnet を指すこと（Arbitrum に既定化しない）。"""
+        assert _client("base")._chain_id == "8453"
+
+    def test_arbitrum_and_ethereum_unchanged(self) -> None:
+        assert _client("arbitrum")._chain_id == "42161"
+        assert _client("ethereum")._chain_id == "1"
+
+    def test_unknown_chain_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """未知 chain は既定化するが**必ず警告**する（黙って別チェーンを見に行かない）。"""
+        with caplog.at_level("WARNING"):
+            client = _client("bogus_chain")
+        assert client._chain_id == "42161"
+        assert any("未知の chain" in r.getMessage() for r in caplog.records)
+
+
+class TestExpiryParsing:
+    def test_iso8601_with_z(self) -> None:
+        """実 API の形式（"2026-09-24T00:00:00.000Z"）を解釈できること。"""
+        parsed = PendleWebClient._parse_expiry("2026-09-24T00:00:00.000Z")
+        assert parsed == datetime(2026, 9, 24, tzinfo=timezone.utc)
+
+    def test_unix_seconds_int(self) -> None:
+        """UNIX 秒（int）でも解釈できること（後方互換）。"""
+        ts = int(datetime(2026, 9, 24, tzinfo=timezone.utc).timestamp())
+        assert PendleWebClient._parse_expiry(ts) == datetime(2026, 9, 24, tzinfo=timezone.utc)
+
+    def test_unix_seconds_digit_string(self) -> None:
+        ts = int(datetime(2026, 9, 24, tzinfo=timezone.utc).timestamp())
+        assert PendleWebClient._parse_expiry(str(ts)) == datetime(2026, 9, 24, tzinfo=timezone.utc)
+
+    @pytest.mark.parametrize("bad", [None, "", "   ", "not-a-date", {}])
+    def test_unparseable_raises(self, bad: object) -> None:
+        """解釈不能なら例外 → 呼び出し側のフォールバック（tvl=0 で block）に落ちる。"""
+        with pytest.raises(ValueError):
+            PendleWebClient._parse_expiry(bad)

--- a/backend/tests/test_lido_pendle_partner_build_tx.py
+++ b/backend/tests/test_lido_pendle_partner_build_tx.py
@@ -90,13 +90,18 @@ def test_lido_build_stake_tx_does_not_use_private_key() -> None:
 # Pendle: PendleRouterV4Client.build_buy_pt_tx
 # ---------------------------------------------------------------------------
 def _sdk_response(to_addr: str, calldata: str = "0xdeadbeef") -> dict[str, Any]:
-    return {
-        "data": {
-            "tx": {"to": to_addr, "data": calldata},
-            "amountOut": "990000000000000000",
-            "approvals": [],
-        }
-    }
+    """Convert API の応答形。定義は `convert_api_fixtures` に集約している。
+
+    旧実装は `/sdk/api/v1` + `{"data": {"tx": ...}}` という**実在しない契約**を各テストが
+    独自にモックしており、実 API とのズレを誰も検出できなかった（2026-07-17 修正）。
+    """
+    from tests.protocols.test_pendle.convert_api_fixtures import convert_response, output
+
+    return convert_response(
+        to=to_addr,
+        data=calldata,
+        outputs=[output("0x" + "cc" * 20, 990000000000000000)],
+    )
 
 
 @pytest.mark.asyncio
@@ -107,8 +112,7 @@ async def test_pendle_build_buy_pt_tx_success(monkeypatch: pytest.MonkeyPatch) -
 
     captured: dict[str, Any] = {}
 
-    async def _fake_call_sdk(endpoint: str, params: dict[str, Any]) -> dict[str, Any]:
-        captured["endpoint"] = endpoint
+    async def _fake_call_sdk(params: dict[str, Any]) -> dict[str, Any]:
         captured["params"] = params
         return _sdk_response(_ROUTER, "0xabc123")
 
@@ -126,7 +130,10 @@ async def test_pendle_build_buy_pt_tx_success(monkeypatch: pytest.MonkeyPatch) -
     assert tx["value"] == "0x0"
     # receiver は partner 本人 (PT が本人着金)。
     assert captured["params"]["receiver"] == _PARTNER
-    assert captured["endpoint"] == "swapExactTokenForPt"
+    # Convert API は tokensOut に **PT の実アドレス**を要求する（旧 SDK のリテラル "PT" ではない）。
+    # 動作(swap/add-liquidity)は endpoint 名ではなく token の向きで決まる。
+    assert captured["params"]["tokensOut"] == client._config.pt_token_address
+    assert "market" not in captured["params"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_pendle_liquidity_guard.py
+++ b/backend/tests/test_pendle_liquidity_guard.py
@@ -17,7 +17,10 @@ os.environ.setdefault("INITIAL_ADMIN_EMAIL", "admin@example.com")
 
 import app.protocols.pendle.client as pendle_client_mod  # noqa: E402
 from app.proposals.router import _pendle_liquidity_blocked  # noqa: E402
-from app.protocols.pendle.config import PendleConfig  # noqa: E402
+from app.protocols.pendle.config import (  # noqa: E402
+    PENDLE_MAX_TRADE_USD_HARD_MAX,
+    PendleConfig,
+)
 
 _MARKET = "0x1111111111111111111111111111111111111111"
 _PT = "0x2222222222222222222222222222222222222222"
@@ -44,12 +47,18 @@ def _patch_market(
     raises: bool = False,
     pt_address: object = _PT,
     pt_decimals: object = _PT_DECIMALS,
+    days_to_maturity: int = 68,  # PT-yoUSD-24SEP2026 相当（min 7 を満たす）
 ) -> None:
     class _Client:
         async def get_market_info(self, market_address: str) -> object:
             if raises:
                 raise RuntimeError("pendle API down")
-            return SimpleNamespace(tvl_usd=tvl, pt_address=pt_address, pt_decimals=pt_decimals)
+            return SimpleNamespace(
+                tvl_usd=tvl,
+                pt_address=pt_address,
+                pt_decimals=pt_decimals,
+                days_to_maturity=days_to_maturity,
+            )
 
     monkeypatch.setattr(pendle_client_mod, "get_pendle_client", lambda cfg: _Client())
 
@@ -134,12 +143,6 @@ def test_block_when_pt_decimals_mismatch(monkeypatch: pytest.MonkeyPatch) -> Non
     assert reason is not None and "decimals" in reason
 
 
-def test_pt_decimals_unknown_does_not_block(monkeypatch: pytest.MonkeyPatch) -> None:
-    """decimals が API から取れない場合は decimals 突合をスキップする（tvl/PT 照合は継続）。"""
-    _patch_market(monkeypatch, tvl=Decimal("114000"), pt_decimals=None)
-    assert _pendle_liquidity_blocked(_config(), Decimal("100")) is None
-
-
 def test_default_abs_cap_is_small(monkeypatch: pytest.MonkeyPatch) -> None:
     """[安全レビュー H3] env 未設定時の絶対上限が小さいこと。
 
@@ -153,3 +156,67 @@ def test_default_abs_cap_is_small(monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = _config(max_trade_usd_cap=PendleConfig().max_trade_usd_cap)
     reason = _pendle_liquidity_blocked(cfg, Decimal("100"))
     assert reason is not None and "絶対上限" in reason
+
+
+# ---------------------------------------------------------------------------
+# [安全レビュー N1/N2/P1] 満期ガード / decimals 不明 / hard clamp
+# ---------------------------------------------------------------------------
+
+
+def test_block_when_past_or_near_maturity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """満期が近い/過ぎた market は fail-closed（N1）。
+
+    `min_days_to_maturity` は service.py / cache.py にしか無く、broadcast 経路は
+    config.market_address を直参照するため通らなかった。本 PR で経路が live になった結果
+    素通りするようになったため、ガードに追加した。満期後 BUY_PT は revert(gas 損)、
+    満期直前は利回りほぼゼロで資金をロックして「成功」記録だけ残る。
+    """
+    _patch_market(monkeypatch, tvl=Decimal("114000"), days_to_maturity=3)
+    reason = _pendle_liquidity_blocked(_config(), Decimal("10"))
+    assert reason is not None and "満期" in reason
+
+
+def test_pass_when_maturity_far_enough(monkeypatch: pytest.MonkeyPatch) -> None:
+    """min_days_to_maturity(既定7) を満たせば通過。"""
+    _patch_market(monkeypatch, tvl=Decimal("114000"), days_to_maturity=68)
+    assert _pendle_liquidity_blocked(_config(), Decimal("10")) is None
+
+
+def test_block_when_pt_decimals_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    """decimals が取れない場合も fail-closed（N2）。
+
+    「verify すると書いた項目が API 次第で無言スキップされる」構造は H2 を生んだ原因と同型。
+    """
+    _patch_market(monkeypatch, tvl=Decimal("114000"), pt_decimals=None)
+    reason = _pendle_liquidity_blocked(_config(), Decimal("10"))
+    assert reason is not None and "decimals を解決できない" in reason
+
+
+class TestMaxTradeUsdCapHardClamp:
+    """[P1] env で越えられない絶対上限。cap は唯一の金額ガードなので第二層が要る。"""
+
+    def test_env_cannot_exceed_hard_max(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """env のタイポ (20 → 200000) が hard clamp で頭打ちになること。"""
+        monkeypatch.setenv("PENDLE_MAX_TRADE_USD_CAP", "200000")
+        assert PendleConfig().max_trade_usd_cap == PENDLE_MAX_TRADE_USD_HARD_MAX
+
+    def test_env_below_hard_max_is_honored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PENDLE_MAX_TRADE_USD_CAP", "50")
+        assert PendleConfig().max_trade_usd_cap == Decimal("50")
+
+    def test_infinity_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`Decimal("inf")` はパース成功し `amount > inf` が常に False = ガード無効化。
+
+        有限値でなければ default に倒す。
+        """
+        monkeypatch.setenv("PENDLE_MAX_TRADE_USD_CAP", "inf")
+        assert PendleConfig().max_trade_usd_cap == Decimal("20")
+
+    def test_nan_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """NaN も比較が常に False になるため default に倒す。"""
+        monkeypatch.setenv("PENDLE_MAX_TRADE_USD_CAP", "NaN")
+        assert PendleConfig().max_trade_usd_cap == Decimal("20")
+
+    def test_garbage_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PENDLE_MAX_TRADE_USD_CAP", "not-a-number")
+        assert PendleConfig().max_trade_usd_cap == Decimal("20")

--- a/backend/tests/test_pendle_liquidity_guard.py
+++ b/backend/tests/test_pendle_liquidity_guard.py
@@ -20,22 +20,36 @@ from app.proposals.router import _pendle_liquidity_blocked  # noqa: E402
 from app.protocols.pendle.config import PendleConfig  # noqa: E402
 
 _MARKET = "0x1111111111111111111111111111111111111111"
+_PT = "0x2222222222222222222222222222222222222222"
+_OTHER_PT = "0x3333333333333333333333333333333333333333"
+_PT_DECIMALS = 6  # PT-yoUSD 相当（PT は 18 桁とは限らない）
 
 
-def _config() -> PendleConfig:
-    return PendleConfig(
-        market_address=_MARKET,
-        max_pool_liquidity_pct=Decimal("0.05"),
-        max_trade_usd_cap=Decimal("5000"),
-    )
+def _config(**overrides: object) -> PendleConfig:
+    kwargs: dict = {
+        "market_address": _MARKET,
+        "pt_token_address": _PT,
+        "pt_token_decimals": _PT_DECIMALS,
+        "max_pool_liquidity_pct": Decimal("0.05"),
+        "max_trade_usd_cap": Decimal("5000"),
+    }
+    kwargs.update(overrides)
+    return PendleConfig(**kwargs)
 
 
-def _patch_market(monkeypatch: pytest.MonkeyPatch, *, tvl: object, raises: bool = False) -> None:
+def _patch_market(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    tvl: object,
+    raises: bool = False,
+    pt_address: object = _PT,
+    pt_decimals: object = _PT_DECIMALS,
+) -> None:
     class _Client:
         async def get_market_info(self, market_address: str) -> object:
             if raises:
                 raise RuntimeError("pendle API down")
-            return SimpleNamespace(tvl_usd=tvl)
+            return SimpleNamespace(tvl_usd=tvl, pt_address=pt_address, pt_decimals=pt_decimals)
 
     monkeypatch.setattr(pendle_client_mod, "get_pendle_client", lambda cfg: _Client())
 
@@ -72,3 +86,70 @@ def test_block_when_market_info_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_market(monkeypatch, tvl=Decimal("0"), raises=True)
     reason = _pendle_liquidity_blocked(_config(), Decimal("1000"))
     assert reason is not None and "fail-closed" in reason
+
+
+# ---------------------------------------------------------------------------
+# [安全レビュー H2/M2] market と PT の対応検証
+#
+# PENDLE_MARKET_ADDRESS(本ガードが流動性を見る対象) と PENDLE_PT_TOKEN_ADDRESS(実際に買う対象
+# = Convert API の tokensOut) は独立した env で、swap 呼び出しに market は送られない。両者が
+# 別 market を指すと「ガードは別プールの流動性を承認する」状態になり、ガードが PASS と報告
+# しながら実際は薄いプールへ過大投入し得る。運用者の注意力を安全装置にしない。
+# ---------------------------------------------------------------------------
+
+
+def test_block_when_market_pt_mismatches_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """market が扱う PT と PENDLE_PT_TOKEN_ADDRESS が不一致 → fail-closed。
+
+    満期ロールで PT だけ更新し market を更新し忘れた場合を想定。旧実装では「$114k プールの
+    5%」を承認しつつ、実際は別プールへ投入していた。
+    """
+    _patch_market(monkeypatch, tvl=Decimal("114000"), pt_address=_OTHER_PT)
+    reason = _pendle_liquidity_blocked(_config(), Decimal("100"))
+    assert reason is not None and "不一致" in reason
+
+
+def test_block_when_market_pt_unresolvable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """market の PT アドレスが取れない → 対応を検証できないので fail-closed。"""
+    _patch_market(monkeypatch, tvl=Decimal("114000"), pt_address=None)
+    reason = _pendle_liquidity_blocked(_config(), Decimal("100"))
+    assert reason is not None and "PT アドレスを解決できない" in reason
+
+
+def test_pt_address_comparison_is_case_insensitive(monkeypatch: pytest.MonkeyPatch) -> None:
+    """checksum 表記の違いだけでは block しないこと（誤検知で運用を止めない）。"""
+    _patch_market(monkeypatch, tvl=Decimal("114000"), pt_address=_PT.upper())
+    assert _pendle_liquidity_blocked(_config(), Decimal("100")) is None
+
+
+def test_block_when_pt_decimals_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """実 PT decimals と設定が不一致 → fail-closed（silent under-sell 防止）。
+
+    decimals が実際より低いと SELL_PT は dust だけ売って **成功扱いで記録される**
+    （$10k 売却のつもりが実質ゼロ）。高すぎる側は revert するが、低い側は黙って通るため
+    ここで止める。
+    """
+    _patch_market(monkeypatch, tvl=Decimal("114000"), pt_decimals=18)
+    reason = _pendle_liquidity_blocked(_config(), Decimal("100"))
+    assert reason is not None and "decimals" in reason
+
+
+def test_pt_decimals_unknown_does_not_block(monkeypatch: pytest.MonkeyPatch) -> None:
+    """decimals が API から取れない場合は decimals 突合をスキップする（tvl/PT 照合は継続）。"""
+    _patch_market(monkeypatch, tvl=Decimal("114000"), pt_decimals=None)
+    assert _pendle_liquidity_blocked(_config(), Decimal("100")) is None
+
+
+def test_default_abs_cap_is_small(monkeypatch: pytest.MonkeyPatch) -> None:
+    """[安全レビュー H3] env 未設定時の絶対上限が小さいこと。
+
+    Pendle 経路では単一10%/日次30%(CLAUDE.md Rule 3/4)が実際には効いていないため、絶対上限が
+    唯一の金額ガードになる。既定 5000 だと env 設定を忘れた運用者に $5,000 の枠が黙って開く。
+    """
+    monkeypatch.delenv("PENDLE_MAX_TRADE_USD_CAP", raising=False)
+    assert PendleConfig().max_trade_usd_cap == Decimal("20")
+
+    _patch_market(monkeypatch, tvl=Decimal("1000000"))  # pool 5% = 50000 で余裕
+    cfg = _config(max_trade_usd_cap=PendleConfig().max_trade_usd_cap)
+    reason = _pendle_liquidity_blocked(cfg, Decimal("100"))
+    assert reason is not None and "絶対上限" in reason

--- a/backend/tests/test_risk_mode.py
+++ b/backend/tests/test_risk_mode.py
@@ -31,6 +31,7 @@ from app.auth.models import (  # noqa: E402
     RISK_MODE_PROTOCOLS,
     RISK_MODE_SUBSCRIPTION_RATES,
     RiskMode,
+    _allowed_risk_modes_from_env,
     get_risk_mode_label,
 )
 from app.database import Base, get_db  # noqa: E402
@@ -95,6 +96,41 @@ class TestPhase1RiskMode:
         assert RISK_MODE_PHASE[RiskMode.CONSERVATIVE] == 1
         assert RISK_MODE_PHASE[RiskMode.BALANCED] == 2
         assert RISK_MODE_PHASE[RiskMode.AGGRESSIVE] == 2
+
+
+class TestAllowedRiskModesFromEnv:
+    """``ALLOWED_RISK_MODES`` env による解禁制御（環境ごとに開けるための仕組み）。"""
+
+    def test_unset_defaults_to_conservative_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """**未設定なら従来どおり閉じたまま**（本番の既定挙動が変わらないこと）。"""
+        monkeypatch.delenv("ALLOWED_RISK_MODES", raising=False)
+        assert _allowed_risk_modes_from_env() == frozenset({RiskMode.CONSERVATIVE})
+
+    def test_blank_defaults_to_conservative_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ALLOWED_RISK_MODES", "   ")
+        assert _allowed_risk_modes_from_env() == frozenset({RiskMode.CONSERVATIVE})
+
+    def test_opens_aggressive_when_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """staging だけ aggressive を開ける（本番 env は未設定のまま閉じる）。"""
+        monkeypatch.setenv("ALLOWED_RISK_MODES", "conservative,aggressive")
+        modes = _allowed_risk_modes_from_env()
+        assert modes == frozenset({RiskMode.CONSERVATIVE, RiskMode.AGGRESSIVE})
+
+    def test_conservative_always_included(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """conservative を書き忘れても常に選べる（全モードを塞いで詰まないため）。"""
+        monkeypatch.setenv("ALLOWED_RISK_MODES", "aggressive")
+        assert RiskMode.CONSERVATIVE in _allowed_risk_modes_from_env()
+
+    def test_unknown_value_ignored_not_opened(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """typo は無視する（意図せず解禁が広がらない fail-safe）。"""
+        monkeypatch.setenv("ALLOWED_RISK_MODES", "aggresive,BOGUS")  # 綴り誤り
+        assert _allowed_risk_modes_from_env() == frozenset({RiskMode.CONSERVATIVE})
+
+    def test_case_and_space_tolerant(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ALLOWED_RISK_MODES", " AGGRESSIVE , balanced ")
+        assert _allowed_risk_modes_from_env() == frozenset(
+            {RiskMode.CONSERVATIVE, RiskMode.AGGRESSIVE, RiskMode.BALANCED}
+        )
 
 
 class TestRiskModeMetadata:

--- a/docs/ops/phase_d_pendle_aggressive_d6_runbook.md
+++ b/docs/ops/phase_d_pendle_aggressive_d6_runbook.md
@@ -36,14 +36,19 @@ Asana 親 1216418585178727（D1–D6）。
 
 ## 2. DB マイグレーション（手動 ALTER TABLE / Alembic autogenerate 禁止）
 
-D5b で User に列追加（`backend/app/auth/models.py` 冒頭コメント準拠）。staging / production 両方で実行:
+> **2026-07-17 実機確認: production / staging-v4 とも適用済み**（本番 users に `aggressive_ack_at` /
+> `aggressive_ack_version` の 2 列が存在することを phase1 read-only 確認で実測）。
+> **本節は実行不要**。まず下の確認コマンドで実態を見てから判断すること（「未適用前提」で流すと
+> 重複エラーになる）。
+
+D5b で User に列追加（`backend/app/auth/models.py` 冒頭コメント準拠）。**未適用の環境でのみ**実行:
 
 ```sql
 ALTER TABLE users ADD COLUMN IF NOT EXISTS aggressive_ack_at TIMESTAMP WITH TIME ZONE NULL;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS aggressive_ack_version VARCHAR(20) NULL;
 ```
 
-確認: `docker exec <postgres> psql -U ultra -d <db> -c "\d users" | grep aggressive`。
+確認（**先にこれを実行する**）: `docker exec <postgres> psql -U ultra -d <db> -c "\d users" | grep aggressive`。
 
 ---
 
@@ -65,10 +70,14 @@ PENDLE_UNDERLYING_TOKEN_ADDRESS=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913  # Ba
 PENDLE_UNDERLYING_TOKEN_DECIMALS=6
 PENDLE_PT_TOKEN_ADDRESS=0x1fec97ca2817da87f266fd1741bba61caf7cde29        # PT-yoUSD-24SEP2026
 PENDLE_PT_TOKEN_DECIMALS=6           # **PT は 18 桁ではない**（誤ると SELL_PT の数量が 10^12 倍ズレる）
+                                     # ※コード既定も 6。未設定でも 6 になるが、18桁 PT を扱う
+                                     #   環境では明示必須（低すぎる側は dust を売って“成功”する）
+                                     #   実 decimals とは流動性ガードが突合し不一致なら block
 PENDLE_STABLE_UNDERLYING=true
 # 流動性ガード（薄いプール保護・必須）
 PENDLE_MAX_POOL_LIQUIDITY_PCT=0.05   # 1 投入 ≤ プール流動性の 5%
-PENDLE_MAX_TRADE_USD_CAP=5000        # 1 投入の絶対上限（初期は小さく）
+PENDLE_MAX_TRADE_USD_CAP=20          # 1 投入の絶対上限（コード既定も 20）。**これが事実上
+                                     #   唯一の金額ガード**（§6 の H3 注記参照）。安易に上げない
 ```
 
 > **落とし穴**: Pendle の用語で "underlyingAsset" は **yoUSD**（利回り vault トークン、`0x0000…8a65`）を指すが、
@@ -129,6 +138,8 @@ PENDLE_MAX_TRADE_USD_CAP=20          # 初回は極小に絞る
    staging だけ開けようとしても同じコードが本番に入り本番も同時に開いてしまうため**。未設定なら従来どおり
    conservative のみ。設定すると `PUT /auth/risk-mode` の 412 同意必須ガードが有効化され、`aggressive_ack_at`
    未記録のユーザーは選択不可（defense-in-depth）。typo は無視され解禁は広がらない（fail-safe）。
+   **注意: 本定数は module import 時に評価される**ため、env の追加・削除は **backend の再起動**で反映する
+   （`docker compose up -d --no-deps <backend>`）。プロセスを再起動しない限り即時には効かない。
 2. フロント: `NEXT_PUBLIC_AGGRESSIVE_TIER_ENABLED=true` → **再ビルド**（build-time 埋め込み）。aggressive 選択時に満期ロック/裏付け/スリッページ同意モーダルが必須になる。
 3. `AI_OPTIMIZER_MULTIPROTOCOL_ENABLED=true` → aggressive ユーザーの BUY で routing が `(BUY_PT, PT-yoUSD, pendle)` を生成（optimizer は実 APY を使用）。
 4. 消費者 `/liff-chat` の aggressive 選択パネル（運用方針セレクタ: 安全重視 / 利回り重視）は
@@ -140,13 +151,31 @@ PENDLE_MAX_TRADE_USD_CAP=20          # 初回は極小に絞る
 
 ## 6. 段階解放 & 安全確認
 
-- **少額・少人数から**。`PENDLE_MAX_TRADE_USD_CAP` を小さく開始し、実績を見て緩める。
+- **少額・少人数から**。`PENDLE_MAX_TRADE_USD_CAP` を小さく開始し、実績を見て緩める（既定 20）。
 - 監視: proposal → SCW receipt → PT 残高。流動性ガード block / HARD_STOP の Slack 通知。
-- 安全ネット（有効時も効く）: 二段ガード / HARD_STOP・risk_limiter（`_pendle_execution_blocked`）/ 流動性ガード（fail-closed）/ Privy policy 宛先 allowlist / broadcast 済み後の failed 化防止（二重送信防止）/ 非カストディアル不変（SCW 本人着金）。
+- 安全ネット（有効時も効く）: 二段ガード / HARD_STOP（`_pendle_execution_blocked`）/ 流動性ガード
+  （fail-closed・market↔PT 対応検証・PT decimals 突合を含む）/ approve の token/amount 厳密一致 /
+  Privy policy 宛先 allowlist / broadcast 済み後の failed 化防止（二重送信防止）/ 非カストディアル不変。
+
+> **[重要] 金額ガードの実態（2026-07-17 安全レビュー H3）**
+> Pendle 経路では **CLAUDE.md Rule 3/4（単一 10% / 日次 30%・ABSOLUTE）が実際には効いていない**。
+> `_pendle_execution_blocked` が risk_limiter に `total_assets=None` を渡しており、risk_limiter は
+> 両方の % 判定を `total_assets_usd is not None and > 0` でガードしているため。Pendle 単独ユーザーは
+> HF も取得できず HF floor も効かない（Aave SCW 経路も同じ既存状態）。
+> ⇒ **金額の歯止めは実質「プール流動性 % と `PENDLE_MAX_TRADE_USD_CAP`」だけ**。この cap を
+> 「大きめにして様子を見る」という運用はしないこと。恒久対応（total_assets 配線）は別課題。
 
 ## 7. ロールバック
 
-各フラグを個別に `false` / env 除去で即 dormant 化（コード revert 不要）。`PENDLE_ENABLE_ONCHAIN_WRITE=false` で broadcast 停止、`AI_OPTIMIZER_MULTIPROTOCOL_ENABLED=false` で pendle 提案生成停止、`PHASE_1` から AGGRESSIVE 除去で選択停止。
+各フラグを個別に `false` / env 除去で dormant 化（コード revert 不要）。
+`PENDLE_ENABLE_ONCHAIN_WRITE=false` で broadcast 停止、`AI_OPTIMIZER_MULTIPROTOCOL_ENABLED=false` で
+pendle 提案生成停止、**`ALLOWED_RISK_MODES` を未設定に戻す**（旧記述の「`PHASE_1` から AGGRESSIVE 除去」＝
+コード編集 は §5 の env 化で不要になった）で aggressive 選択停止。
+
+> **「即 dormant」ではない**: `ALLOWED_RISK_MODES` は module import 時評価、`NEXT_PUBLIC_*` は
+> build-time 埋め込み。前者は **backend 再起動**、後者は **frontend 再ビルド**が要る。
+> 最速で broadcast だけを止めたい場合は `PENDLE_ENABLE_ONCHAIN_WRITE=false` + backend 再起動が最短
+> （`get_pendle_config()` は毎回 env を読み直すため、再起動すれば即反映される）。
 
 ---
 
@@ -165,5 +194,5 @@ PENDLE_MAX_TRADE_USD_CAP=20          # 初回は極小に絞る
 - [ ] broadcast 済み後の bookkeeping 例外で failed 化 → 二重送信しないか
 - [ ] 非カストディアル: サーバー鍵不参照・PT/USDC は SCW 本人着金か
 - [ ] routing: risk_mode eligibility（pendle=aggressive のみ）。conservative が掴まないか
-- [ ] aggressive 同意: `PUT /auth/risk-mode` の 412 ガードが `PHASE_1` 緩和後に効くか
-- [ ] 規制: `PHASE_1` 緩和は法務 GO 済みか（森先生判断）
+- [ ] aggressive 同意: `PUT /auth/risk-mode` の 412 ガードが `ALLOWED_RISK_MODES` 設定後に効くか
+- [ ] 規制: `ALLOWED_RISK_MODES` への aggressive 追加は法務 GO 済みか（森先生判断）

--- a/docs/ops/phase_d_pendle_aggressive_d6_runbook.md
+++ b/docs/ops/phase_d_pendle_aggressive_d6_runbook.md
@@ -20,7 +20,7 @@ Asana 親 1216418585178727（D1–D6）。
 | `PENDLE_ENABLE_ONCHAIN_WRITE` | `false` | broadcast 二段ガードの1段目 | §4 |
 | `DELEGATION_PRIVY_POLICY_ENABLED` (+ signer/creds) | 未設定 | 委譲 SCW 実行が非 dormant か | §4 |
 | grant `allowed_protocols` に `"pendle"` | 無 | ユーザーが pendle 委譲済みか | §4 |
-| `PHASE_1_ALLOWED_RISK_MODES` | `{conservative}` | aggressive を選択できるか | §5（**規制判断**） |
+| `ALLOWED_RISK_MODES` (env) | 未設定 = `{conservative}` | aggressive を選択できるか | §5（**規制判断**） |
 | `NEXT_PUBLIC_AGGRESSIVE_TIER_ENABLED` | `false` | フロントで aggressive 選択に同意モーダルを挟むか | §5 |
 
 これら **すべてが揃わない限り** Pendle は 1 wei も動かない。1つでも欠ければ dry-run / 提案非生成 / 従来挙動に fallback。
@@ -49,28 +49,55 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS aggressive_ack_version VARCHAR(20) NU
 
 ## 3. env 設定（staging-v4 → 本番の順）
 
-Pendle 市場を実値に設定。market address は **実装時に Pendle API（chainId 8453 / core/v1）で取得**した yoUSD 市場アドレスを使う（`memory` の yoUSD 裏付けアドレス `0x0000…8a65` は**裏付け vault** であって market address ではない点に注意）。
+> **[重要] 2026-07-17 訂正 — Pendle に testnet は存在しない。**
+> Pendle API がサポートするのは **mainnet のみ**（`1, 56, 143, 999, 8453, 9745, 42161, 10, 146, 5000, 80094`）。
+> Base Sepolia(84532) / Arbitrum Sepolia(421614) は `400 "Unsupported chain id"` で拒否される（実 API で確認）。
+> **旧記述の `PENDLE_CHAIN=base_sepolia` では calldata を 1 本も生成できない**ため、staging-v4 での検証も
+> `PENDLE_CHAIN=base`（実 market・実 calldata・**broadcast なしの dry-run**）で行う。
+> 実 broadcast の検証経路は **Base mainnet の実資金しか無い**（§4）。
+
+実値（Pendle API `core/v1/8453/markets` で確認済み 2026-07-17）:
 
 ```bash
-# stablecoin PT 前提（amount_usd を USDC 1:1 で使う）
-PENDLE_CHAIN=base_sepolia            # 検証時。本番は base
-PENDLE_MARKET_ADDRESS=<yoUSD market> # Pendle API で取得
-PENDLE_UNDERLYING_TOKEN_ADDRESS=<USDC>          # 本番 Base USDC = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
+PENDLE_CHAIN=base                    # testnet は存在しない（上記）
+PENDLE_MARKET_ADDRESS=0x250c15e59a7572195e248f668636723cca20a2b8  # PT-yoUSD-24SEP2026 market
+PENDLE_UNDERLYING_TOKEN_ADDRESS=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913  # Base USDC
 PENDLE_UNDERLYING_TOKEN_DECIMALS=6
-PENDLE_PT_TOKEN_ADDRESS=<PT-yoUSD token>        # SELL_PT の approve 宛先（Privy policy allowlist）
+PENDLE_PT_TOKEN_ADDRESS=0x1fec97ca2817da87f266fd1741bba61caf7cde29        # PT-yoUSD-24SEP2026
+PENDLE_PT_TOKEN_DECIMALS=6           # **PT は 18 桁ではない**（誤ると SELL_PT の数量が 10^12 倍ズレる）
 PENDLE_STABLE_UNDERLYING=true
 # 流動性ガード（薄いプール保護・必須）
 PENDLE_MAX_POOL_LIQUIDITY_PCT=0.05   # 1 投入 ≤ プール流動性の 5%
 PENDLE_MAX_TRADE_USD_CAP=5000        # 1 投入の絶対上限（初期は小さく）
 ```
 
+> **落とし穴**: Pendle の用語で "underlyingAsset" は **yoUSD**（利回り vault トークン、`0x0000…8a65`）を指すが、
+> 本 repo の `PENDLE_UNDERLYING_TOKEN_ADDRESS` は **BUY_PT で支払う入力トークン = USDC** を意味する。
+> ここに yoUSD を入れないこと。また `PENDLE_MARKET_ADDRESS` と `PENDLE_PT_TOKEN_ADDRESS` が別 market の
+> ものになると、**流動性ガードが別プールを見る**（swap は PT 側の market で成立する）ので必ず対で設定する。
+
 `printf '\nKEY=VALUE\n' >> .env.*`（前行連結防止 / CLAUDE.lessons）。反映は `docker compose up -d --no-deps <service>`。
+
+### 3.5 dry-run 実機確認（実資金なし・ここまでは Claude 実行可）
+
+`PENDLE_ENABLE_ONCHAIN_WRITE` を **false のまま**にすれば broadcast されない。この状態で:
+
+- 実 API 契約テスト（無料・鍵不要・送信なし）:
+  `PENDLE_LIVE_API_TEST=1 pytest tests/protocols/test_pendle/test_pendle_convert_api_contract.py`
+- BUY_PT proposal → `PendleDryRunNotBroadcast`(501) で **approved 据え置き**、ログに実 calldata が出ること
+- 流動性ガード: `amount > tvl×5%` / `> 絶対上限` / market_info 取得失敗 で **block** されること
+
+ここまでで「SDK 統合・market 解決・calldata・宛先 allowlist・ガード」は検証できる。**未検証で残るのは
+Privy 署名 + on-chain 着金のみ**で、その機構自体は Aave SUPPLY で本番実証済み。
 
 ---
 
-## 4. 実 broadcast 検証（Base Sepolia・human-in-the-loop・Claude 実行不可）
+## 4. 実 broadcast 検証（**Base mainnet 実資金のみ**・human-in-the-loop・Claude 実行不可）
 
-test wallet + Privy creds を用意し、上記に加えて:
+> **testnet が無いため「安全に試す」選択肢は存在しない**。少額でも実資金がリスクの下限になる。
+> 実行判断は hkobayashi（Tier S / HUMAN-REVIEW-REQUIRED / 法務 GO と同時）。
+
+test wallet + Privy creds を用意し、§3 に加えて:
 
 ```bash
 PENDLE_ENABLE_ONCHAIN_WRITE=true
@@ -78,13 +105,16 @@ DELEGATION_PRIVY_POLICY_ENABLED=true
 PRIVY_SERVER_SIGNER_ID=<L0 signer id>
 PRIVY_APP_ID=<...>
 PRIVY_APP_SECRET=<...>
+PENDLE_MAX_TRADE_USD_CAP=20          # 初回は極小に絞る
 ```
 
 手順:
 1. test user に `allowed_protocols=["pendle"]` の有効 grant を作成（Privy policy = RouterV4 + USDC + PT の 3 宛先 allowlist）。
-2. BUY_PT proposal を approve → **SCW broadcast** → **receipt status=1 / PT-yoUSD 残高増** を確認。
-3. SELL_PT（満期出口）→ **PT→USDC 着金** を確認（満期後は 1:1 redeem）。
-4. 流動性ガード動作確認: `amount > tvl×5%` / `> 絶対上限` / market_info 取得失敗 で **block（approved 据え置き）** されること。
+2. test wallet に **少額の実 USDC**（$10〜20）を用意。
+3. BUY_PT proposal を approve → **SCW broadcast** → **receipt status=1 / PT-yoUSD 残高増** を確認。
+4. SELL_PT は満期（**2026-09-24**）前は二次市場価格での売却になる（1:1 redeem は満期後）。満期前に出口を
+   確認する場合、PT 価格ディスカウント分の目減りを許容できる額で行うこと。
+5. 流動性ガード動作確認: `amount > tvl×5%` / `> 絶対上限` / market_info 取得失敗 で **block（approved 据え置き）** されること。
 
 診断: 「提案が出ない/実行されない」は `docker exec <backend> python -m app.diagnostics.proposal_chain`（提案チェーン ゲートトレーサ）で切り分け。
 
@@ -94,10 +124,17 @@ PRIVY_APP_SECRET=<...>
 
 **この段階は日本の無登録投資運用業規制（森先生判断: Auto/aggressive は無登録運用業に該当し得る）に直結する product 判断を伴う。** コードだけでは有効化されない:
 
-1. **`PHASE_1_ALLOWED_RISK_MODES` に AGGRESSIVE を追加**（`backend/app/auth/models.py`）。← **法務 GO 後のみ**。追加すると `PUT /auth/risk-mode` の 412 同意必須ガードが有効化され、`aggressive_ack_at` 未記録のユーザーは選択不可（defense-in-depth）。
+1. **`ALLOWED_RISK_MODES=conservative,aggressive` を対象環境の env に設定**（← **法務 GO 後のみ**）。
+   2026-07-17 に env 化した（旧: `backend/app/auth/models.py` のハードコード定数）。**理由: ハードコードのままだと
+   staging だけ開けようとしても同じコードが本番に入り本番も同時に開いてしまうため**。未設定なら従来どおり
+   conservative のみ。設定すると `PUT /auth/risk-mode` の 412 同意必須ガードが有効化され、`aggressive_ack_at`
+   未記録のユーザーは選択不可（defense-in-depth）。typo は無視され解禁は広がらない（fail-safe）。
 2. フロント: `NEXT_PUBLIC_AGGRESSIVE_TIER_ENABLED=true` → **再ビルド**（build-time 埋め込み）。aggressive 選択時に満期ロック/裏付け/スリッページ同意モーダルが必須になる。
 3. `AI_OPTIMIZER_MULTIPROTOCOL_ENABLED=true` → aggressive ユーザーの BUY で routing が `(BUY_PT, PT-yoUSD, pendle)` を生成（optimizer は実 APY を使用）。
-4. 消費者 `/liff-chat` の aggressive 選択パネルは**別 product スライス**（現状 admin `RiskModeSelector` のみ）。同意モーダル/endpoint は再利用可能に実装済み。
+4. 消費者 `/liff-chat` の aggressive 選択パネル（運用方針セレクタ: 安全重視 / 利回り重視）は
+   **PR #993 で実装済み**（`NEXT_PUBLIC_AGGRESSIVE_TIER_ENABLED` 既定 false で dormant）。
+   同 PR で「Pendle 委譲は開示同意必須(412)」「dummy アドレス fail-closed」も追加済み。
+   セレクタの真実源は `risk_mode` で、委譲枠 `allowed_protocols` と**両方**が Pendle を許して初めて実効になる。
 
 ---
 
@@ -115,6 +152,12 @@ PRIVY_APP_SECRET=<...>
 
 ## Opus 安全レビュー チェックリスト（本番反映前）
 
+- [ ] **SDK 契約**: `PENDLE_LIVE_API_TEST=1` の契約テストが green か（実 API と実装がズレていないか）。
+      2026-07-17 に「実装が実在しない API に対して書かれていた」事故があり、mock だけでは検出できない
+- [ ] **decimals**: `PENDLE_PT_TOKEN_DECIMALS` が対象 PT の実桁と一致するか（PT-yoUSD は 6。
+      誤ると **SELL_PT の売却数量が 10^12 倍ズレる**）
+- [ ] **market と PT の対応**: `PENDLE_MARKET_ADDRESS` と `PENDLE_PT_TOKEN_ADDRESS` が同一 market のものか
+      （ズレると流動性ガードが別プールを見る）
 - [ ] amount 換算: stablecoin PT のみ USDC 1:1（`PENDLE_STABLE_UNDERLYING`）。非 stablecoin は fail-closed か
 - [ ] 流動性ガード: `tvl<=0`/取得失敗で fail-closed（block）か。%・絶対上限が薄いプールに対し妥当か
 - [ ] Privy policy: RouterV4 + USDC + PT の 3 宛先のみ allowlist か（over-broad でないか）


### PR DESCRIPTION
## 背景

PR #993（運用方針セレクタ）の次段として **Phase-B: staging-v4 実証**に着手したところ、その前提が2つとも崩れていることが判明した。すべて**実 API の応答で確認**した事実（推測なし）。

**全経路 dormant のため本番影響はゼロ**（Pendle は 1 wei も動いていない）。本 PR で開くフラグも無い。

## 判明した事実

### A. Pendle に testnet は存在しない

```
Base Sepolia (84532)      → 400 "Unsupported chain id. Must be one of
Arbitrum Sepolia (421614) →      1, 56, 143, 999, 8453, 9745, 42161, 10, 146, 5000, 80094"
```

→ **D6 ランブック §3/§4 の「Sepolia で実証してから本番」は実行不可能**。実 broadcast の検証経路は **Base mainnet の実資金しか無い**。ランブックを実測に基づき訂正した。

### B. SDK エンドポイントが存在しない

`/sdk/api/v1/{chain}/swapExactTokenForPt` は**全チェーンで 404**（Envoy "fault filter abort"）。Pendle は個別エンドポイントを廃止し **Convert API** に統合済み。

**なぜ誰も気づけなかったか**: ①全経路 dormant（本番で一度も呼ばれない）②ユニットテストが `_call_sdk` をモックし、**架空の応答形を自分で固定していた**。「テストは通るが実 API では必ず 404」という状態だった。

## 修正した不具合（8件・すべて dormant 経路）

| # | 不具合 | 影響 |
|---|---|---|
| 1 | URL が実在しない | 全 calldata が 404 |
| 2 | パラメータ名（`market`/`tokenIn`/`amountIn` → `tokensIn`/`tokensOut`/`amountsIn`） | 同上 |
| 3 | レスポンス形（`data.tx` → `routes[0].tx`、`amountOut` → `outputs[]`） | 同上 |
| 4 | approve の spender | Convert API は返さない → **API 由来の値を一切読まず**照合済み Router を補完（**旧より強い不変条件**） |
| 5 | `token_out="PT"` リテラル | Convert API は実アドレスを要求 → `config.pt_token_address` |
| 6 | **PT decimals 18 固定** | PT-yoUSD は **6桁**。★**SELL_PT で売却数量が 10^12 倍ズレる実害バグ** |
| 7 | **`PendleWebClient` の chain map に base が無い** | 42161 に既定化 → 404 → **架空値**(stETH/tvl=0/APY5.2%)。★**tvl=0 は流動性ガードが全 block する値** |
| 8 | **`expiry` を int() でパース** | 実 API は ISO8601 文字列 → 必ず ValueError → 同じく架空値へ |

### ★ 7 と 8 が特に重要

流動性ガードは `tvl_usd` を見て「1投入 ≤ プール流動性の5%」を判定するが、`get_market_info` が**常にフォールバック（tvl=0）を返していた**ため、**Pendle は静かに常時 block されていた**。ガードが「効いている」ように見えて、実際には**何も評価していなかった**。

実データでの修正確認:
```
修正前: underlying=stETH  tvl=$0        APY=5.2%   ← 架空のフォールバック値
修正後: underlying=yoUSD  tvl=$83,568   APY=6.45%  満期=2026-09-24

流動性ガード（TVL×5%）:
  $100   → PASS
  $4,178 → PASS      ← 境界が実 TVL に基づいて正しく効く
  $4,200 → BLOCK
  未設定 market → BLOCK（fail-closed）
```

## 再発防止（これが本命）

- **実 API 契約テストを追加** `test_pendle_convert_api_contract.py`
  - `PENDLE_LIVE_API_TEST=1` で opt-in（既定 skip = CI/オフラインで落とさない）
  - **無料・鍵不要・broadcast なし**（GET で calldata を組むだけ。実資金は動かない）
  - BUY_PT / SELL_PT の calldata が実 API から取れ `tx.to` が RouterV4 であること、approve が照合済み Router に限られること、market_info が実 TVL を返すこと、**testnet が拒否されること**を固定
- **mock 形を1箇所に集約** `convert_api_fixtures.py` — 各テストが独自に架空の契約を組んでいたのが事故の温床だったため、手書きを禁じる
- `test_pendle_web_client_chain_expiry.py` — chain 解決 / expiry パースの回帰（ネットワーク不要）

## ALLOWED_RISK_MODES の env 化（Phase-B B1）

`PHASE_1_ALLOWED_RISK_MODES` はハードコード定数で、**staging だけ aggressive を開こうとすると同じコードが本番にも入り本番も同時に開いてしまう**（ランブック §5 は PHASE_1 緩和を**規制判断**と明記）。env 由来にした:

- **未設定なら従来どおり `{conservative}`**（本番の既定挙動は不変）
- `ALLOWED_RISK_MODES=conservative,aggressive` で環境ごとに解禁
- typo は無視して解禁が広がらない fail-safe / conservative は常に含める
- これを開けても `PUT /auth/risk-mode` の 412（開示同意必須）と委譲枠側 Pendle ゲートは別途効く

## 検証

- **pytest 4790 passed / 0 failed**、ruff / ruff format 通過、mypy は既存の `stripe` stub 2件のみ（main と同一）
- **実 API 契約テスト 5件 pass**（Base 8453 / PT-yoUSD-24SEP2026）
- 旧テスト40件は**架空の契約を固定していた**ため実物の形へ移行。意図が変わった箇所は**より強い不変条件**に置換（例: 「API が返した spender が Router 以外なら拒否」→「**API が悪意ある spender を混入させても無視し、照合済み Router を使う**」＝注入経路が構造的に存在しない）

## 既知の未対応（意図的）

`buy_yt` / `sell_yt` はリテラル `"YT"` のままで実 API では 400（fail-closed で害なし）。本製品は Phase-D で **PT 専用**のため未修正とし、docstring に明記。修正には `PENDLE_YT_TOKEN_ADDRESS` 等の新設が必要。

## 次のステップ（本 PR には含まない）

実 broadcast の検証は **Base mainnet の実資金のみ**が経路（testnet が無いため）。Tier S / HUMAN-REVIEW / Opus 安全レビュー / **法務 GO** が前提（ランブック §4-5）。hkobayashi の判断待ち。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Edj3hjkB6XrjYezmARpQEq

---

## [skip-alembic-check]

CI「models 変更時 migration 必須化」は `backend/app/auth/models.py` の変更を検知して発火しているが、**本 PR にスキーマ変更は無い**ため migration は不要。

差分の実体は `_allowed_risk_modes_from_env()` の追加と `PHASE_1_ALLOWED_RISK_MODES` の env 由来化のみ:

```
$ git diff origin/main...fix/pendle-convert-api -- backend/app/auth/models.py \
    | grep -E '^[-+]' | grep -iE 'mapped_column|Column\(|__tablename__|ALTER TABLE|CheckConstraint|Index\('
  → 出力なし（列/制約/テーブルの変更なし）
```

変更のある `models.py` は `backend/app/auth/models.py` の 1 本のみ。`backend/app/protocols/pendle/schemas.py` の `PendleMarketInfo` に `pt_address`/`pt_decimals` を追加しているが、これは **Pydantic スキーマ**（API 応答の写像）であって SQLAlchemy モデルではなく、DB とは無関係。

なお本リポジトリでは `alembic revision --autogenerate` は **使用禁止**（`env.py` が全モデルを import しておらず `Base.metadata` が不完全なため、実在するテーブルへの DROP を誤生成する。memory: `project_alembic_envpy_incomplete_model_imports`）。CI のメッセージが案内する autogenerate は本リポジトリでは実行してはならないため、正規の `[skip-alembic-check]` 経路を使う。
