### PR TITLE
feat(risk): per-user 総資産を shadow mode で観測 + HF が別ウォレットを見ていた実バグを修正

### DIFF
--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -305,6 +305,74 @@ def _daily_traded_usd_for_user(
     return Decimal(str(raw)) if raw is not None else Decimal("0")
 
 
+def _gate_wallet_for_user(user_id: int, db: Session) -> Optional[str]:
+    """安全ゲートが評価すべき per-user wallet（SCW 優先）。解決できなければ None。
+
+    None を返すと `get_health_factor` は `AAVE_WALLET_ADDRESS`（グローバル custodial wallet）に
+    フォールバックする＝従来挙動。executor 側の wallet 優先順（smart_wallet_address → wallet_address）
+    と揃えること。
+    """
+    from app.auth.models import User  # noqa: PLC0415
+
+    user = db.get(User, user_id)
+    if user is None:
+        return None
+    wallet: Optional[str] = user.smart_wallet_address or user.wallet_address
+    return wallet
+
+
+def _log_total_assets_shadow(
+    proposal: Proposal,
+    db: Session,
+    *,
+    daily_traded: Decimal,
+    hf: Optional[Decimal],
+) -> None:
+    """[shadow mode] per-user 総資産で % 判定を**試算してログに出すだけ**（挙動には効かせない）。
+
+    CLAUDE.md Rule 3（単一 ≤ 総資産の10%）/ Rule 4（日次 ≤ 30%）は ABSOLUTE と明記されているが、
+    全呼び出し元が `total_assets_usd=None` を渡しているため **実際には一度も効いていない**
+    （2026-07-17 の Pendle 安全レビューで発覚）。分母を供給する resolver は用意したが、
+    **いきなり有効化すると本番ユーザーを止める**ため、まず観測だけ行う:
+
+      - Aave SCW 経路は実資金で稼働中（分母を誤ると即ブロック）
+      - 提案 sizing は `max(_PROPOSAL_AMOUNT_MIN_USD=50, x×0.10)` で、**総資産 $500 未満では
+        提案が必ず 10% を超える**（最低入金は $200）→ 有効化には製品判断が要る
+
+    本関数は例外を投げない（観測が執行を壊さない）。ログを
+    `grep '\\[risk_shadow\\]'` で集計し、ブロック率・RPC 失敗率・分母の妥当性を見てから
+    enforce へ切り替える。
+    """
+    try:
+        from app.aave.risk_limiter import check_trade_within_limits  # noqa: PLC0415
+        from app.users.total_assets_resolver import (  # noqa: PLC0415
+            resolve_user_total_assets_usd,
+        )
+
+        observed = resolve_user_total_assets_usd(db, proposal.user_id)
+        would_block = check_trade_within_limits(
+            amount_usd=Decimal(str(proposal.amount_usd)),
+            total_assets_usd=observed,
+            daily_traded_usd=daily_traded,
+            hf=hf,
+        )
+        logger.info(
+            "[risk_shadow] proposal=%s user=%s protocol=%s amount_usd=%s total_assets=%s "
+            "daily_traded=%s would_block=%s",
+            proposal.id,
+            proposal.user_id,
+            proposal.protocol or "aave",
+            proposal.amount_usd,
+            observed if observed is not None else "undeterminable",
+            daily_traded,
+            would_block or "no",
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "[risk_shadow] proposal=%s: 観測に失敗（執行には影響なし）: %s", proposal.id, exc
+        )
+
+
 def _resolve_privy_wallet_id(user: Optional[UserModel]) -> str:
     """委譲(SCW)送信に使う Privy **内部 wallet ID** を解決する（アドレスではない）。
 
@@ -499,7 +567,10 @@ def _execute_aave_for_proposal(proposal: Proposal, db: Session) -> None:
     try:
         from app.aave.monitor import get_health_factor as _gate_get_hf  # noqa: PLC0415
 
-        _hf_for_gate = _gate_get_hf()
+        # per-user の wallet で HF を見る。引数を省くと monitor が AAVE_WALLET_ADDRESS
+        # （グローバル custodial wallet）にフォールバックし、**別人の HF で可否が決まる**
+        # （cross-user 汚染。2026-07-17 修正）。解決できない場合は従来どおり env に委ねる。
+        _hf_for_gate = _gate_get_hf(_gate_wallet_for_user(proposal.user_id, db))
     except Exception as _hf_exc:  # noqa: BLE001
         logger.warning("proposal %d: HF fetch for safety gate failed: %s", proposal.id, _hf_exc)
 
@@ -507,8 +578,10 @@ def _execute_aave_for_proposal(proposal: Proposal, db: Session) -> None:
     _daily_traded = _daily_traded_usd_for_user(
         proposal.user_id, db, exclude_proposal_id=proposal.id
     )
-    # per-user 総資産の取得元は未実装（Phase 2-D 後続 sub-task）。None の間は %判定をスキップし、
-    # PolicyEngine 絶対額上限 +（後続スライスの）Privy policy で担保する（fail-safe）。
+    # per-user 総資産は **shadow mode**（観測のみ・挙動には効かせない）。
+    # 実際に渡すのは従来どおり None（= % 判定スキップ / PolicyEngine 絶対額上限に委ねる）。
+    # 詳細は `_log_total_assets_shadow` の docstring。
+    _log_total_assets_shadow(proposal, db, daily_traded=_daily_traded, hf=_hf_for_gate)
     _total_assets: Optional[Decimal] = None
 
     _hard_stop = evaluate_hard_stop(
@@ -825,20 +898,21 @@ def _pendle_execution_blocked(proposal: Proposal, db: Session) -> Optional[str]:
     try:
         from app.aave.monitor import get_health_factor as _gate_get_hf  # noqa: PLC0415
 
-        hf_for_gate = _gate_get_hf()
+        # per-user wallet で HF を見る（引数省略は別人の HF を見る cross-user 汚染。Aave 経路と同修正）。
+        hf_for_gate = _gate_get_hf(_gate_wallet_for_user(proposal.user_id, db))
     except Exception as exc:  # noqa: BLE001
         logger.warning("proposal %d: Pendle safety-gate HF fetch failed: %s", proposal.id, exc)
 
     daily_traded = _daily_traded_usd_for_user(proposal.user_id, db, exclude_proposal_id=proposal.id)
-    # [安全レビュー H3 / 2026-07-17] per-user 総資産は未配線（Aave SCW 経路と同じ既存状態）。
+    # [安全レビュー H3 / 2026-07-17] per-user 総資産は **shadow mode**（観測のみ・挙動には効かせない）。
     #
-    # **その帰結を明示する**: `risk_limiter.check_trade_within_limits` は単一 10% / 日次 30% の
+    # **現状の帰結を明示する**: `risk_limiter.check_trade_within_limits` は単一 10% / 日次 30% の
     # 両方を `total_assets_usd is not None and > 0` でガードしているため、None を渡す本経路では
-    # **CLAUDE.md Rule 3/4（ABSOLUTE）が実際には効かない**。さらに Pendle 単独ユーザーは
-    # `get_health_factor()` が失敗して hf=None になるため HF floor も効かない。
-    # 結果、Pendle broadcast の金額上限は **流動性ガード（プール% と PENDLE_MAX_TRADE_USD_CAP）
-    # だけ**が担っている。だから同 cap の既定値を 5000 → 20 に下げてある（config.py 参照）。
-    # 恒久対応（total_assets の配線）は Aave 経路と共通の別課題。
+    # **CLAUDE.md Rule 3/4（ABSOLUTE）が実際には効かない**。
+    # 金額の歯止めは **流動性ガード（プール% と PENDLE_MAX_TRADE_USD_CAP=20）と PolicyEngine の
+    # 絶対額上限（POLICY_MAX_POSITION_USD 既定 $10,000。`_run_approval_and_execution` で必ず通る）**。
+    # enforce への切替は shadow の実データ（ブロック率 / sizing 衝突 / RPC 失敗率）を見てから。
+    _log_total_assets_shadow(proposal, db, daily_traded=daily_traded, hf=hf_for_gate)
     total_assets: Optional[Decimal] = None
 
     hard_stop = evaluate_hard_stop(

--- a/backend/app/users/total_assets_resolver.py
+++ b/backend/app/users/total_assets_resolver.py
@@ -1,0 +1,130 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/app/users/total_assets_resolver.py
+
+"""ユーザーの「総資産（total assets, USD）」を解決する共有ヘルパー。
+
+`risk_limiter.check_trade_within_limits` の **% 判定の分母**（CLAUDE.md Rule 3: 単一取引 ≤ 総資産の
+10% / Rule 4: 日次 ≤ 30%）に使う。両 Rule は ABSOLUTE と明記されているが、全呼び出し元が
+`total_assets_usd=None` を渡しているため **実際には一度も効いていない**（2026-07-17 の Pendle
+安全レビューで発覚）。本モジュールはその分母を供給する。
+
+**`deposit_resolver.resolve_user_deposit_usd` と混同しないこと**（測るものが違う）:
+
+  - `deposit`      = **運用に充てられる未投入の資金**（allocation or wallet USDC）。
+                     最低入金ゲート（$200）の判定に使う。
+  - `total_assets` = **総資産**。既に Aave に供給済みの資産を**含む**。% 上限の分母に使う。
+
+deposit を分母に流用してはならない。定常状態のユーザーは資金の大半を Aave に供給済みで
+wallet ≈ dust になり、`10% × dust` で **全 SUPPLY がブロック**される。
+
+計算式::
+
+    総資産 = Aave net (total_collateral_usd - total_debt_usd) + wallet USDC 残高
+
+二重計上は起きない（`portfolio/aggregation.py` が明記するとおり、wallet 残高は Aave supply 分を
+含まない）。対象 wallet は `smart_wallet_address` を優先し、無ければ `wallet_address`
+（`deposit_resolver` および `proposals/router.py` の執行経路と同じ優先順）。
+
+**戻り値は tri-state（本モジュールの肝）**:
+  - ``Decimal``: 確定した総資産（USD）
+  - ``None``   : **判定不能**（wallet 未設定 / RPC 失敗）
+
+**判定不能を `Decimal("0")` にフォールバックしてはならない。** `aave/rebalance_service.py` は
+取得失敗時に `total_usd = Decimal("0")` としているが、あれは表示・ステータス用途。同じことを
+**実行ゲートでやると RPC の瞬断がそのまま取引停止になる**（表示用の fail-open が実行経路では
+fail-closed に反転する）。呼び出し側は `None` を「% 判定をスキップ」として扱い、絶対額上限
+（PolicyEngine Rule 3 / `POLICY_MAX_POSITION_USD`）に委ねる。これは `check_trade_within_limits`
+が元々明記している契約（"0/None は絶対額上限(PolicyEngine)に委ねる"）と一致する。
+
+金融計算は Decimal のみ（CLAUDE.md [CRITICAL] 11）。
+"""
+
+import logging
+import os
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.auth.models import User
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_user_total_assets_usd(db: Session, user_id: int) -> Optional[Decimal]:
+    """ユーザーの総資産（USD）を解決する。判定不能なら None。
+
+    Args:
+        db: SQLAlchemy セッション。
+        user_id: 対象ユーザー ID。
+
+    Returns:
+        総資産（USD）。wallet 未設定 / RPC 失敗など判定不能な場合は None
+        （**0 にはしない**。モジュール docstring 参照）。
+    """
+    user = db.get(User, user_id)
+    wallet = (user.smart_wallet_address or user.wallet_address) if user else None
+    if not wallet:
+        logger.debug("[total_assets] user=%s: wallet 未設定のため判定不能", user_id)
+        return None
+
+    aave_net = _read_aave_net_usd(wallet)
+    if aave_net is None:
+        return None
+
+    from app.aave.balance import read_wallet_usdc_balance  # noqa: PLC0415
+
+    wallet_usdc = read_wallet_usdc_balance(wallet)
+    if wallet_usdc is None:
+        # read_wallet_usdc_balance は失敗時に None（内部で warning 済み）。
+        # 「Aave 分だけ」で確定させると分母を過小評価し不当なブロックを生むので判定不能に倒す。
+        logger.debug("[total_assets] user=%s: wallet USDC 取得失敗のため判定不能", user_id)
+        return None
+
+    return aave_net + wallet_usdc
+
+
+def _read_aave_net_usd(wallet: str) -> Optional[Decimal]:
+    """Aave の純資産（担保 - 負債, USD）を返す。取得不能なら None。
+
+    クライアント生成は `aave/monitor.py:get_health_factor` の形を踏襲する
+    （`AAVE_CLIENT_TYPE` で dummy/web3 を分岐し、web3 は env の RPC/Pool を使う）。
+    `make_aave_client` は client_type 必須のファクトリで、per-wallet の read には過剰なため使わない。
+
+    負債が担保を上回る（清算間際）ケースは **0 にクランプ**する。負値を返すと
+    `total_assets_usd > 0` のガードを抜けて % 判定がスキップされ、**最も危険な状態で上限が
+    外れる**ため。0 も結果的にスキップ側に倒れるが、そこは HF floor と PolicyEngine 絶対額が
+    担う（本関数の責務ではない）。
+    """
+    ctype = os.getenv("AAVE_CLIENT_TYPE", "dummy").strip().lower()
+
+    try:
+        if ctype == "dummy":
+            from app.aave.client import DummyAaveClient  # noqa: PLC0415
+
+            account = DummyAaveClient().get_account_data(wallet)
+        elif ctype == "web3":
+            rpc_url = os.getenv("AAVE_RPC_URL", "")
+            pool_address = os.getenv("AAVE_POOL_ADDRESS", "")
+            if not rpc_url or not pool_address:
+                logger.warning(
+                    "[total_assets] AAVE_RPC_URL / AAVE_POOL_ADDRESS 未設定のため判定不能"
+                )
+                return None
+
+            from app.aave.client import Web3AaveClient  # noqa: PLC0415
+
+            account = Web3AaveClient(rpc_url=rpc_url, pool_address=pool_address).get_account_data(
+                wallet
+            )
+        else:
+            logger.warning("[total_assets] 未知の AAVE_CLIENT_TYPE=%r のため判定不能", ctype)
+            return None
+    except Exception as exc:  # noqa: BLE001
+        # RPC 失敗 / web3 未導入 / 不正アドレス。**0 にしない**（module docstring 参照）。
+        logger.warning("[total_assets] Aave account data 取得失敗 wallet=%s: %s", wallet, exc)
+        return None
+
+    net = Decimal(str(account.total_collateral_usd)) - Decimal(str(account.total_debt_usd))
+    return net if net > Decimal("0") else Decimal("0")

--- a/backend/tests/test_phase2d_a_wiring.py
+++ b/backend/tests/test_phase2d_a_wiring.py
@@ -311,3 +311,116 @@ def test_manual_approve_without_grant_ok(client: TestClient, test_db: tuple) -> 
 
     assert r.status_code == 200, r.text
     assert r.json()["status"] == "approved"
+
+
+# ---------------------------------------------------------------------------
+# [shadow mode] per-user 総資産の観測（2026-07-17）
+#
+# CLAUDE.md Rule 3/4 は total_assets=None のため実際には効いていない。分母の resolver は
+# 用意したが、いきなり有効化すると本番ユーザーを止める（sizing の $50 下限 × 10% ルールは
+# 総資産 $500 未満で両立しない / 最低入金は $200）。まず観測だけ行う。
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_does_not_change_execution_behavior(db_session: Session) -> None:
+    """★shadow の総資産が「ブロックすべき」と言っても、**実際にはブロックしない**こと。
+
+    shadow の目的は観測であって enforcement ではない。ここが壊れると、意図せず本番ユーザーの
+    取引を止める（= 本タスクで最も避けたい事故）。
+    """
+    from app.proposals.router import _execute_aave_for_proposal
+
+    user = _make_user(db_session)
+    proposal = _make_proposal(db_session, user_id=user.id)
+    db_session.commit()
+
+    called: list[bool] = []
+
+    def _mock_execute(**kwargs: object) -> AaveOperationResult:
+        called.append(True)
+        return _fake_result()
+
+    with (
+        patch(
+            "app.automation.safety_gate.evaluate_hard_stop",
+            return_value=HardStopResult(blocked=False),
+        ),
+        # 総資産が $1（= 提案額は確実に 10% 超）と観測されても…
+        patch(
+            "app.users.total_assets_resolver.resolve_user_total_assets_usd",
+            return_value=Decimal("1"),
+        ),
+        patch(
+            "app.aave.service.MultiChainAaveService.execute_rebalance",
+            side_effect=_mock_execute,
+        ),
+    ):
+        _execute_aave_for_proposal(proposal, db_session)
+
+    # …執行は止まらない（limiter には None が渡り続けるため）
+    assert called, "shadow 観測が執行をブロックしてはならない"
+
+
+def test_shadow_passes_none_to_limiter(db_session: Session) -> None:
+    """limiter に渡る total_assets_usd が **None のままである**こと（挙動変化ゼロの担保）。"""
+    from app.proposals.router import _execute_aave_for_proposal
+
+    user = _make_user(db_session)
+    proposal = _make_proposal(db_session, user_id=user.id)
+    db_session.commit()
+
+    seen: list[object] = []
+
+    def _spy(**kwargs: object) -> None:
+        seen.append(kwargs.get("total_assets_usd"))
+        return None
+
+    with (
+        patch(
+            "app.automation.safety_gate.evaluate_hard_stop",
+            return_value=HardStopResult(blocked=False),
+        ),
+        patch(
+            "app.users.total_assets_resolver.resolve_user_total_assets_usd",
+            return_value=Decimal("12345"),
+        ),
+        patch("app.aave.risk_limiter.check_trade_within_limits", side_effect=_spy),
+        patch(
+            "app.aave.service.MultiChainAaveService.execute_rebalance",
+            return_value=_fake_result(),
+        ),
+    ):
+        _execute_aave_for_proposal(proposal, db_session)
+
+    # shadow 側の試算呼び出しと、実ゲートの呼び出しの両方が来る。
+    # **実ゲートに渡るのは None**（shadow の 12345 が漏れていない）こと。
+    assert None in seen, f"実ゲートに None 以外が渡っている: {seen}"
+
+
+def test_shadow_failure_does_not_break_execution(db_session: Session) -> None:
+    """観測が例外を投げても執行を壊さないこと（観測は執行より弱い）。"""
+    from app.proposals.router import _execute_aave_for_proposal
+
+    user = _make_user(db_session)
+    proposal = _make_proposal(db_session, user_id=user.id)
+    db_session.commit()
+
+    called: list[bool] = []
+
+    with (
+        patch(
+            "app.automation.safety_gate.evaluate_hard_stop",
+            return_value=HardStopResult(blocked=False),
+        ),
+        patch(
+            "app.users.total_assets_resolver.resolve_user_total_assets_usd",
+            side_effect=RuntimeError("rpc down"),
+        ),
+        patch(
+            "app.aave.service.MultiChainAaveService.execute_rebalance",
+            side_effect=lambda **_: (called.append(True), _fake_result())[1],
+        ),
+    ):
+        _execute_aave_for_proposal(proposal, db_session)
+
+    assert called, "観測の失敗が執行を止めてはならない"

--- a/backend/tests/test_total_assets_resolver.py
+++ b/backend/tests/test_total_assets_resolver.py
@@ -1,0 +1,157 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_total_assets_resolver.py
+"""`resolve_user_total_assets_usd` — risk_limiter の % 判定の分母。
+
+CLAUDE.md Rule 3/4（単一10% / 日次30%・ABSOLUTE）は全呼び出し元が `total_assets_usd=None` を
+渡しているため実際には効いていない。本 resolver がその分母を供給する（2026-07-17）。
+
+**本テストの主眼は「判定不能を 0 にしないこと」**。0 を返すと `total_assets_usd > 0` のガードを
+抜けて % 判定がスキップされる（＝黙って上限が外れる）。一方 None は「スキップ」という
+既存契約どおりの扱いになり、PolicyEngine の絶対額上限に委ねられる。
+"""
+
+import os
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-total-assets")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "admin@example.com")
+
+from app.users.total_assets_resolver import (  # noqa: E402
+    _read_aave_net_usd,
+    resolve_user_total_assets_usd,
+)
+
+_WALLET = "0x" + "ab" * 20
+_SCW = "0x" + "cd" * 20
+
+
+def _account(collateral: str, debt: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        total_collateral_usd=Decimal(collateral),
+        total_debt_usd=Decimal(debt),
+    )
+
+
+class _FakeDb:
+    """`db.get(User, user_id)` だけを模す最小 stub。"""
+
+    def __init__(self, user: object) -> None:
+        self._user = user
+
+    def get(self, _model: object, _pk: int) -> object:
+        return self._user
+
+
+def _user(*, wallet: str | None = _WALLET, scw: str | None = None) -> SimpleNamespace:
+    return SimpleNamespace(wallet_address=wallet, smart_wallet_address=scw)
+
+
+class TestResolveTotalAssets:
+    def test_sums_aave_net_and_wallet_usdc(self) -> None:
+        """総資産 = Aave net(担保-負債) + wallet USDC。"""
+        db = _FakeDb(_user())
+        with (
+            patch(
+                "app.users.total_assets_resolver._read_aave_net_usd",
+                return_value=Decimal("1000"),
+            ),
+            patch("app.aave.balance.read_wallet_usdc_balance", return_value=Decimal("250.5")),
+        ):
+            assert resolve_user_total_assets_usd(db, 1) == Decimal("1250.5")
+
+    def test_smart_wallet_takes_precedence(self) -> None:
+        """SCW があれば SCW を見る（執行経路の wallet 優先順と一致させる）。"""
+        db = _FakeDb(_user(wallet=_WALLET, scw=_SCW))
+        seen: list[str] = []
+
+        def _fake_net(wallet: str) -> Decimal:
+            seen.append(wallet)
+            return Decimal("10")
+
+        with (
+            patch("app.users.total_assets_resolver._read_aave_net_usd", side_effect=_fake_net),
+            patch("app.aave.balance.read_wallet_usdc_balance", return_value=Decimal("0")),
+        ):
+            resolve_user_total_assets_usd(db, 1)
+        assert seen == [_SCW]
+
+    def test_no_wallet_is_undeterminable(self) -> None:
+        """wallet 未設定 → None（0 ではない）。"""
+        db = _FakeDb(_user(wallet=None, scw=None))
+        assert resolve_user_total_assets_usd(db, 1) is None
+
+    def test_missing_user_is_undeterminable(self) -> None:
+        db = _FakeDb(None)
+        assert resolve_user_total_assets_usd(db, 999) is None
+
+    def test_aave_failure_is_none_not_zero(self) -> None:
+        """★Aave 取得失敗 → None。**0 にしてはならない**。
+
+        0 だと `total_assets_usd > 0` を抜けて % 判定が黙ってスキップされる。
+        None なら既存契約どおり「スキップ + PolicyEngine 絶対額に委ねる」になる。
+        """
+        db = _FakeDb(_user())
+        with patch("app.users.total_assets_resolver._read_aave_net_usd", return_value=None):
+            result = resolve_user_total_assets_usd(db, 1)
+        assert result is None
+        assert result != Decimal("0")
+
+    def test_wallet_usdc_failure_is_none_not_partial(self) -> None:
+        """★wallet USDC 取得失敗 → None。
+
+        「Aave 分だけ」で確定させると分母を過小評価し不当なブロックを生む。
+        """
+        db = _FakeDb(_user())
+        with (
+            patch(
+                "app.users.total_assets_resolver._read_aave_net_usd",
+                return_value=Decimal("1000"),
+            ),
+            patch("app.aave.balance.read_wallet_usdc_balance", return_value=None),
+        ):
+            assert resolve_user_total_assets_usd(db, 1) is None
+
+
+class TestReadAaveNetUsd:
+    def test_net_is_collateral_minus_debt(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AAVE_CLIENT_TYPE", "dummy")
+        with patch(
+            "app.aave.client.DummyAaveClient.get_account_data",
+            return_value=_account("1000", "300"),
+        ):
+            assert _read_aave_net_usd(_WALLET) == Decimal("700")
+
+    def test_negative_net_clamps_to_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """負債 > 担保（清算間際）→ 0 にクランプ。
+
+        負値を返すと `> 0` ガードを抜けて % 判定がスキップされ、**最も危険な状態で上限が外れる**。
+        """
+        monkeypatch.setenv("AAVE_CLIENT_TYPE", "dummy")
+        with patch(
+            "app.aave.client.DummyAaveClient.get_account_data",
+            return_value=_account("100", "150"),
+        ):
+            assert _read_aave_net_usd(_WALLET) == Decimal("0")
+
+    def test_rpc_exception_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """★RPC 例外 → None（0 にしない）。RPC 瞬断を取引停止にしないため。"""
+        monkeypatch.setenv("AAVE_CLIENT_TYPE", "dummy")
+        with patch(
+            "app.aave.client.DummyAaveClient.get_account_data",
+            side_effect=RuntimeError("rpc down"),
+        ):
+            assert _read_aave_net_usd(_WALLET) is None
+
+    def test_web3_missing_env_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AAVE_CLIENT_TYPE", "web3")
+        monkeypatch.delenv("AAVE_RPC_URL", raising=False)
+        monkeypatch.delenv("AAVE_POOL_ADDRESS", raising=False)
+        assert _read_aave_net_usd(_WALLET) is None
+
+    def test_unknown_client_type_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AAVE_CLIENT_TYPE", "bogus")
+        assert _read_aave_net_usd(_WALLET) is None


### PR DESCRIPTION
## 背景

CLAUDE.md **Rule 3（単一取引 ≤ 総資産の10%）/ Rule 4（日次 ≤ 30%）は ABSOLUTE と明記されているが、実際には一度も効いていない**。`risk_limiter.check_trade_within_limits` が両方を `total_assets_usd is not None and > 0` でガードしており、本番の全呼び出し元が `None` を渡すためです（2026-07-17 の Pendle 安全レビューを機に発覚）。

**本 PR で本番の挙動は 1 bit も変わりません**（limiter には従来どおり `None` を渡す）。

## なぜ「まず観測」なのか

Aave SCW 経路は **user 19 が実資金で稼働中**です。いきなり有効化すると壊れます。

**① 分母を誤ると即ブロック** — 既存 `resolve_user_deposit_usd` は*未投入資金*しか見ず、**Aave に供給済みの資産を含みません**。定常状態のユーザーは wallet ≈ dust なので `10% × dust` で**全 SUPPLY がブロック**されます。流用せず別 resolver を新設しました。

**② sizing と limiter の分母が食い違っている（本丸）** — `max(_PROPOSAL_AMOUNT_MIN_USD=50, x×0.10)` という下限がある以上、**総資産 $500 未満では提案が必ず 10% を超えます**。`MIN_DEPOSIT_USD=200` なので **$200〜$500 のユーザーは全員ブロック**。

実コードで再現しました:
```
total_assets=200  amount_usd=50  would_block=single trade 50 exceeds 10% of total assets (20)   ← 最低入金ちょうどのユーザー
total_assets=5000 amount_usd=50  would_block=no
total_assets=undeterminable      would_block=no                                                  ← RPC 失敗時
```

これは**製品判断**（最低額を下げる/最低入金を上げる/小口は%免除/sizing を limiter に合わせる）が要るため、shadow の実データを見てから決めます。

## 追加: `resolve_user_total_assets_usd`

```
総資産 = Aave net (担保 − 負債) + wallet USDC 残高
```
wallet は `smart_wallet_address` 優先（執行経路と同じ）。二重計上なし。`deposit_resolver` の形（sync / per-user / tri-state / Decimal）を踏襲。

**tri-state を厳守（本 PR の肝）**: 確定 → `Decimal` / **判定不能 → `None`** / **絶対に `Decimal("0")` にしない**。

`rebalance_service` は取得失敗時に `total_usd = Decimal("0")` としていますが、あれは表示用途です。**実行ゲートで同じことをすると RPC 瞬断がそのまま取引停止になります**（表示用の fail-open が実行経路では fail-closed に反転する）。

負債 > 担保（清算間際）は 0 にクランプします — 負値は `> 0` ガードを抜けて **最も危険な状態で上限が外れる**ため。

## 実バグ修正: HF が別ウォレットを見ていた

`_gate_get_hf()` を**引数なし**で呼んでおり、`monitor.py` が `AAVE_WALLET_ADDRESS`（**グローバル custodial wallet**）にフォールバックしていました。つまり user 19 の SCW ではなく**別ウォレットの HF で可否が決まる cross-user 汚染**です。per-user wallet を渡すよう修正しました（解決不能時は従来どおり env フォールバック＝挙動不変）。

供給のみのユーザーは HF=inf でスキップされるため実害は出ていないと見られますが、判定根拠として明確な誤りです。

## 記録: 安全レビューの誤りを訂正

Pendle 安全レビューは「PolicyEngine は SCW 経路に居ない」としましたが**誤り**でした。実際は `_run_approval_and_execution` の `get_policy_engine().check()` → `_dispatch_custodial_execution` の順で**必ず通ります**。よって絶対額上限（`POLICY_MAX_POSITION_USD` 既定 $10,000 / 日次 $50,000 / 時間 $20,000）は効いており、**青天井ではありません**。急いで enforce する必然性が無いことの根拠でもあります。

## 検証

- **pytest 4827 passed / 0 failed**、ruff / format 通過、mypy は既存 `stripe` stub 2件のみ
- **resolver 11件**: 合算 / SCW 優先 / wallet 未設定→None / **★RPC 失敗→None(0にしない)** / wallet USDC 失敗→None(部分確定しない) / 負値→0クランプ / 未知 client_type・env 欠落→None
- **配線 3件（挙動変化ゼロの担保）**:
  - **★shadow が「ブロックすべき」と言っても執行を止めない**
  - **★limiter に渡るのは None のまま**（shadow の値が漏れていない）
  - 観測が例外を投げても執行を壊さない

将来うっかり enforce されたら落ちるテストです。

## 観測方法（本番反映後）

```bash
docker logs <backend> | grep '\[risk_shadow\]'
```
ブロック率 / RPC 失敗率（`undeterminable` の頻度）/ 分母の妥当性を 1 週間ほど見ます。

## 次段（本 PR 範囲外）

1. **sizing 衝突の解消**（製品判断）
2. `workflow.py` の 30% ハードコードを `get_effective_limits()` に統一（Rule 4 の真実源が2つある）
3. shadow → enforce の切替（フラグ + 段階解放）

これらを終えて初めて `PENDLE_MAX_TRADE_USD_CAP` を引き上げてよい（現状 $20 + hard clamp $100 は「正しさではなく小ささによる無害化」）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Edj3hjkB6XrjYezmARpQEq