### PR TITLE
fix(liff): ログイン時「署名がキャンセル」誤表示 + 取引履歴ETHタブを実データ駆動に (テスターUAT指摘)

### DIFF
--- a/frontend/app/(liff)/_components/BrowserLoginPrompt.tsx
+++ b/frontend/app/(liff)/_components/BrowserLoginPrompt.tsx
@@ -20,8 +20,10 @@ export function BrowserLoginPrompt({ onSuccess }: BrowserLoginPromptProps) {
   const { signIn, signingIn, error } = useLiffBrowserAuth();
 
   async function handleLogin() {
-    const ok = await signIn();
-    if (!ok) return;
+    const result = await signIn();
+    // login-opened / rejected / error はいずれもここでは何もしない
+    // （error 文言は hook 側が setError 済み。login-opened は文言なしでモーダルを待つ）。
+    if (!result.ok) return;
     if (onSuccess) {
       onSuccess();
     } else if (typeof window !== "undefined") {

--- a/frontend/app/(liff)/liff-chat/_components/panels/TxHistoryPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/TxHistoryPanel.tsx
@@ -247,12 +247,25 @@ export function TxHistoryPanel() {
   const coinSummaries = buildCoinSummaries(txs)
   const grouped = groupByMonth(filteredTxs)
 
+  // 資産フィルタ（USDC / ETH）は **履歴に実在する資産だけ** 出す。
+  // 以前は ETH タブを常時ハードコードしており、ETH 建て取引が 1 件も無くても表示され、
+  // タップすると必ず空になっていた（テスター報告 2026-07-17「ETH が残ってます」）。
+  const hasUsdc = txs.some((tx) => tx.asset === "USDC")
+  const hasEth = txs.some((tx) => tx.asset === "ETH" || tx.asset === "WETH")
+
+  // 選択中の資産フィルタが（ポーリング更新等で）実在しなくなったら "all" に戻す
+  // （消えたタブが選ばれたまま空表示になるのを防ぐ）。
+  useEffect(() => {
+    if (filter === "USDC" && !hasUsdc) setFilter("all")
+    if (filter === "ETH" && !hasEth) setFilter("all")
+  }, [filter, hasUsdc, hasEth])
+
   const FILTERS: Array<{ id: FilterType; label: string }> = [
     { id: "all", label: t("filterAll") },
     { id: "SUPPLY", label: "SUPPLY" },
     { id: "WITHDRAW", label: "WITHDRAW" },
-    { id: "USDC", label: "USDC" },
-    { id: "ETH", label: "ETH" },
+    ...(hasUsdc ? [{ id: "USDC" as FilterType, label: "USDC" }] : []),
+    ...(hasEth ? [{ id: "ETH" as FilterType, label: "ETH" }] : []),
   ]
 
   if (loading) {

--- a/frontend/hooks/useLiffBrowserAuth.ts
+++ b/frontend/hooks/useLiffBrowserAuth.ts
@@ -28,11 +28,29 @@ function siweMessage(address: string): string {
   return `Sign in to Ultra AutoTrade\nAddress: ${address}`;
 }
 
+/** `signIn()` の結果。単なる true/false ではなく「なぜ false か」を区別する。 */
+export type LiffSignInResult =
+  | { ok: true }
+  /** Privy 未ログイン → メールモーダルを開いた。エラーではない（呼び出し側は静かに待つ）。 */
+  | { ok: false; reason: "login-opened" }
+  /** ユーザーが署名を明示的に拒否した（EIP-1193 4001）。 */
+  | { ok: false; reason: "rejected" }
+  /** それ以外の失敗（通信・wallet 未準備など）。 */
+  | { ok: false; reason: "error" };
+
 export interface LiffBrowserAuthResult {
-  /** Privy wallet で署名し JWT を発行・保存する。成功時 true。Privy 未ログイン時は login() を開いて false。 */
-  signIn: () => Promise<boolean>;
+  /** Privy wallet で署名し JWT を発行・保存する。結果の種別は `LiffSignInResult`。 */
+  signIn: () => Promise<LiffSignInResult>;
   signingIn: boolean;
   error: string | null;
+}
+
+/** EIP-1193 の user-rejected (4001) を厳密判定する。文字列 includes だけに頼らない。 */
+function isUserRejection(err: unknown): boolean {
+  const code = (err as { code?: unknown })?.code;
+  if (code === 4001 || code === "ACTION_REJECTED") return true;
+  const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return msg.includes("user rejected") || msg.includes("user denied");
 }
 
 export function useLiffBrowserAuth(): LiffBrowserAuthResult {
@@ -41,18 +59,23 @@ export function useLiffBrowserAuth(): LiffBrowserAuthResult {
   const [signingIn, setSigningIn] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const signIn = useCallback(async (): Promise<boolean> => {
+  const signIn = useCallback(async (): Promise<LiffSignInResult> => {
     setError(null);
+
+    // embedded wallet (Privy TEE) のみ使用。外部 wallet は秘密鍵管理の懸念で除外。
+    const wallet = wallets.find((w) => w.walletClientType === "privy");
+    if (!wallet) {
+      // Privy 未ログイン → メールログイン用モーダルを開く。**これは失敗ではない**。
+      // モーダル完了後に wallets が更新され、ユーザーが再度ボタンを押すと下の署名フローへ進む。
+      // ここで setSigningIn(true) や catch に入ると、モーダルを開いただけで
+      // 「署名がキャンセルされました」を誤表示してしまう（テスター報告 2026-07-17 の不具合）。
+      // 署名処理には一切入らないので、エラー文言も spinner も出さず静かにモーダルへ委ねる。
+      await login();
+      return { ok: false, reason: "login-opened" };
+    }
+
     setSigningIn(true);
     try {
-      // embedded wallet (Privy TEE) のみ使用。外部 wallet は秘密鍵管理の懸念で除外。
-      const wallet = wallets.find((w) => w.walletClientType === "privy");
-      if (!wallet) {
-        // Privy 未ログイン → メールログイン用モーダルを開く。完了後ユーザーが再度ボタンを押す。
-        await login();
-        return false;
-      }
-
       const address = wallet.address;
       const eip1193 = await wallet.getEthereumProvider();
       const ethProvider = new ethers.BrowserProvider(
@@ -75,17 +98,18 @@ export function useLiffBrowserAuth(): LiffBrowserAuthResult {
         String(Date.now() + res.expires_in * 1000)
       );
       localStorage.setItem(LIFF_TOKEN_KEY, res.access_token);
-      return true;
+      return { ok: true };
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes("User rejected") || msg.includes("user rejected")) {
+      // 「署名がキャンセルされました」は **実際にユーザーが署名を拒否したときだけ** 出す
+      // （EIP-1193 4001 で厳密判定。過渡状態の別エラーをキャンセルと誤表示しない）。
+      if (isUserRejection(err)) {
         setError("署名がキャンセルされました。もう一度お試しください。");
-      } else {
-        setError(
-          "ログインに失敗しました。通信環境を確認して、もう一度お試しください。"
-        );
+        return { ok: false, reason: "rejected" };
       }
-      return false;
+      setError(
+        "ログインに失敗しました。通信環境を確認して、もう一度お試しください。"
+      );
+      return { ok: false, reason: "error" };
     } finally {
       setSigningIn(false);
     }


### PR DESCRIPTION
テスター UAT（2026-07-17）の指摘のうち、**main に実在するフロントバグ 2 件**を修正。どちらも backend 連携なし・低リスク。

（残りの指摘の切り分け結果は本文末尾に記載。$12,500 表示はサーバ・DB・コード・image いずれも $0/データ無しで一致しており、テスター端末のキャッシュ疑いとして別途検証依頼中。）

## 1. ログイン時「署名がキャンセルされました」の誤表示

**現象**: 「ウォレットでログイン」を押すと「署名がキャンセルされました。もう一度お試しください」が出るが、もう一度押すと入れる（テスター「不要なメッセージ」）。

**原因**: `signIn` は2段階（Privy 未ログインならメールモーダル → 再タップで署名）。初回タップで `login()` を開いた直後の `return false` が失敗と区別されず、かつ user-rejected 判定が**文字列 includes のみ**で、メール認証直後の wallet 未準備など**署名拒否でない過渡状態**も「キャンセル」に誤分類し得た。

**修正**:
- 戻り値を `boolean` → `LiffSignInResult`（`login-opened`/`rejected`/`error`/`ok`）。**`login-opened` は失敗ではない**ので spinner もエラーも出さず静かにモーダルへ委ねる（署名処理に入る前に return）。
- user-rejected 判定を **EIP-1193 `code === 4001` / `ACTION_REJECTED`** で厳密化（既存 `withdraw/page.tsx:116` の先例に準拠）。「署名がキャンセルされました」は**実際に拒否したときだけ**出る。

## 2. 取引履歴の ETH タブが常時表示

**現象**: ETH 建て取引が無いのに履歴フィルタに ETH タブがあり、タップすると必ず空（テスター「ETH が残ってます」）。

**原因**: `FILTERS` に USDC/ETH をハードコードし、履歴の有無に関わらず表示していた。

**修正**: 資産フィルタを**履歴に実在する資産だけ**動的に出す。SUPPLY/WITHDRAW は常時。選択中フィルタが消えたら `all` に戻すガードも追加。

## 検証（ローカル実機ブラウザ）

backend + frontend を実起動し、SQLite に取引を注入して目視確認:

| データ | 履歴フィルタタブ |
|---|---|
| USDC 取引のみ | `すべて / SUPPLY / WITHDRAW / USDC`（**ETH 消滅**）✅ |
| ETH 取引を追加 | `… / USDC / ETH`（**ETH 出現**）✅ |

- クリーンユーザーで運用残高 `$0` / 平均利回り `—` / 運用中コイン「ありません」が正しく出ることも確認（$12,500 がサーバ由来でないことの傍証）
- tsc / i18n 通過、lint 新規指摘なし
- 署名フローの過渡状態はブラウザで意図的再現が困難なため、判定ロジックを型とレビューで担保

---

## テスター指摘 9 件の切り分け（参考）

| # | 指摘 | 判定 |
|---|---|---|
| 1 | 「署名がキャンセル」誤表示 | **本PRで修正** |
| 7 | ETH タブ残ってる | **本PRで修正** |
| 4/5/10 | $12,500 / ETH消えた / 7.5%↔3.5% | サーバ・DB・image 全て $0/データ無しで一致 → **端末キャッシュ疑い**（検証依頼中） |
| 3 | 規約確認なしでこの画面 | 仕様（user 19 は 7/17 に liff-v4 同意済み・再表示されないのが正常） |
| 6 | おまかせ準備中/切替不可 | 仕様（`CONSENT_ENABLED=false` で意図的に「準備中」） |
| 9 | 規約が変更されてない | 仕様（6/29 が現行版・更新していないのが正常） |
| 2 | PWA も試すべきか | 質問（修正後で可） |
| 8 | Cryptact 印刷フォーム | 質問（CSV は実装済・印刷は税務ソフト側で UAT 対象外） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Edj3hjkB6XrjYezmARpQEq