### PR TITLE
feat(liff): 運用方針セレクタ「利回り重視」に段階A「準備中」注記を表示

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/ManagedScopeSheet.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/ManagedScopeSheet.tsx
@@ -120,6 +120,18 @@ export function ManagedScopeSheet({
           })}
         </div>
 
+        {/* 段階A（dry-run）注記: セレクタは表示するが Pendle の実運用はまだ開始しない。
+            選択は記録されるが「利回り重視で運用が始まっている」と誤認させないよう明示する。
+            PENDLE_ENABLE_ONCHAIN_WRITE 有効化（段階B以降）でこの注記を外す。 */}
+        {selected === "yield" && (
+          <p
+            className="mt-4 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-700"
+            data-testid="managed-scope-preparing-notice"
+          >
+            {t("scopeYieldPreparingNotice")}
+          </p>
+        )}
+
         {/* 委譲枠は consent 時点で固定されるため、範囲を変えるには Privy 再署名が要る。
             黙って古い枠のまま表示だけ変えない（TEE 側は旧 allowlist を enforce し続ける）。 */}
         {requiresResignature && selected !== currentScope && (

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -937,7 +937,8 @@
         "scopeSubmitting": "Applying...",
         "scopeResignatureNotice": "Changing your strategy requires a new wallet signature, because the scope of delegated permissions changes.",
         "scopeReconsentRequired": "Your \"Yield focused\" setup is incomplete. Tap to sign again.",
-        "scopeYieldUnavailable": "\"Yield focused\" is not available yet. Continuing with \"Safety first\"."
+        "scopeYieldUnavailable": "\"Yield focused\" is not available yet. Continuing with \"Safety first\".",
+        "scopeYieldPreparingNotice": "※ Coming soon. Your selection is saved, but Pendle operation will start in a future release. For now, funds are managed with \"Safety first\" (Aave USDC)."
       },
       "txHistory": {
         "title": "Transaction History",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -937,7 +937,8 @@
         "scopeSubmitting": "設定中...",
         "scopeResignatureNotice": "方針を変更するには、ウォレットでの再署名が必要です。委譲する権限の範囲が変わるためです。",
         "scopeReconsentRequired": "「利回り重視」の設定が完了していません。タップして再署名してください。",
-        "scopeYieldUnavailable": "「利回り重視」は現在ご利用いただけません。引き続き「安全重視」で運用します。"
+        "scopeYieldUnavailable": "「利回り重視」は現在ご利用いただけません。引き続き「安全重視」で運用します。",
+        "scopeYieldPreparingNotice": "※準備中です。選択内容は記録されますが、Pendle での運用開始は近日提供予定です。当面は「安全重視」（Aave USDC）で運用します。"
       },
       "txHistory": {
         "title": "取引履歴",


### PR DESCRIPTION
## 背景

運用方針セレクタ #993 は段階A（dry-run）で本番表示するが、Pendle 実運用はまだ開始しない
（`PENDLE_ENABLE_ONCHAIN_WRITE=false`）。セレクタだけ出すと「利回り重視を選んだ＝Pendle 運用開始」と
誤認させるため、選択時に「準備中」注記を出す。

## 変更

- 「利回り重視」選択時にシート内へ amber 注記を表示（`scopeYieldPreparingNotice`）
- i18n キーを ja/en 両方に追加

## 段階B での撤去

`PENDLE_ENABLE_ONCHAIN_WRITE` 有効化と同時にこの注記を削除（撤去条件はソースコメントに明記）。

## 検証

- i18n 新規欠落なし / `tsc --noEmit` 型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)