### PR TITLE
fix(liff): 消費者向けUIから DeFi プロトコル名を除去 + 混入検出CIガード追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,11 @@ jobs:
       - name: i18n key existence check
         run: node scripts/check-i18n-keys.mjs
 
+      # 消費者向け文言に DeFi プロトコル名（Aave / Pendle / yoUSD 等）が混入していないか検査。
+      # 2026-07-23: 運用方針セレクタとリスク開示モーダルに実名が入っていたのを実機目視で発見。
+      - name: Consumer-facing protocol name check
+        run: node scripts/check-consumer-protocol-names.mjs
+
       - name: Build
         run: npm run build
 

--- a/frontend/app/(liff)/liff-chat/page.tsx
+++ b/frontend/app/(liff)/liff-chat/page.tsx
@@ -90,7 +90,9 @@ function mapPositionsToHoldings(
       const apy = p.apy_pct ?? p.apy ?? 0
       return {
         asset,
-        protocol: p.protocol ?? "Aave V3",
+        // 消費者向け UI にプロトコル名（Aave / Pendle 等）は出さない約束のため、
+        // 表示用の既定値を持たせない。描画する場合は必ず抽象語彙に写像すること。
+        protocol: p.protocol ?? "",
         amount_usd: Number(amount),
         apy_pct: Number(apy),
       }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -925,11 +925,11 @@
         "scopeSheetTitle": "Choose your strategy",
         "scopeSheetSubtitle": "You can change this anytime. How much risk to take is your decision.",
         "scopeSafetyLabel": "Safety first",
-        "scopeSafetyProtocols": "Aave USDC supply only",
+        "scopeSafetyProtocols": "Withdraw anytime",
         "scopeSafetyPoint1": "Withdraw anytime",
         "scopeSafetyPoint2": "Proven in live operation",
         "scopeYieldLabel": "Yield focused",
-        "scopeYieldProtocols": "Aave + Pendle PT",
+        "scopeYieldProtocols": "Lock in a fixed yield until maturity",
         "scopeYieldPoint1": "No withdrawals until maturity",
         "scopeYieldPoint2": "No principal protection",
         "scopeConfirmBtn": "Start with this strategy",
@@ -938,7 +938,7 @@
         "scopeResignatureNotice": "Changing your strategy requires a new wallet signature, because the scope of delegated permissions changes.",
         "scopeReconsentRequired": "Your \"Yield focused\" setup is incomplete. Tap to sign again.",
         "scopeYieldUnavailable": "\"Yield focused\" is not available yet. Continuing with \"Safety first\".",
-        "scopeYieldPreparingNotice": "※ Coming soon. Your selection is saved, but Pendle operation will start in a future release. For now, funds are managed with \"Safety first\" (Aave USDC)."
+        "scopeYieldPreparingNotice": "※ Coming soon. Your selection is saved, but fixed-yield operation will start in a future release. For now, funds are managed under \"Safety first\"."
       },
       "txHistory": {
         "title": "Transaction History",
@@ -3552,15 +3552,15 @@
   },
   "AggressiveDisclosure": {
     "title": "High-Risk Mode Confirmation",
-    "subtitle": "Before choosing High-Risk mode (Pendle fixed-yield PT), please acknowledge the following.",
+    "subtitle": "Before choosing High-Risk mode (funds locked at a fixed yield until maturity), please acknowledge the following.",
     "items": {
       "funds_locked": {
         "title": "No instant withdrawal until maturity",
-        "detail": "Funds are locked until the Pendle PT matures. Selling before maturity may incur an unfavorable price depending on market liquidity."
+        "detail": "Funds are locked until maturity. Exiting before maturity may incur an unfavorable price depending on market liquidity."
       },
       "pt_backed": {
-        "title": "Backed by yoUSD (a yield aggregator)",
-        "detail": "Principal is backed by the yoUSD yield-aggregator vault. Depeg or impairment of the backing assets is not impossible."
+        "title": "Backed by an external yield aggregator",
+        "detail": "Principal is backed by an external yield aggregator that diversifies across multiple venues. Depeg or impairment of the backing assets is not impossible."
       },
       "slippage": {
         "title": "Slippage and liquidity risk",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -925,11 +925,11 @@
         "scopeSheetTitle": "運用方針をお選びください",
         "scopeSheetSubtitle": "いつでも変更できます。リスクの取り方はご自身でお決めください。",
         "scopeSafetyLabel": "安全重視",
-        "scopeSafetyProtocols": "Aave USDC 供給のみ",
+        "scopeSafetyProtocols": "いつでも引き出せる運用",
         "scopeSafetyPoint1": "いつでも出金できます",
         "scopeSafetyPoint2": "実運用の実績があります",
         "scopeYieldLabel": "利回り重視",
-        "scopeYieldProtocols": "Aave + Pendle PT",
+        "scopeYieldProtocols": "満期まで預けて利回りを固定",
         "scopeYieldPoint1": "満期まで出金できません",
         "scopeYieldPoint2": "元本保証はありません",
         "scopeConfirmBtn": "この方針で始める",
@@ -938,7 +938,7 @@
         "scopeResignatureNotice": "方針を変更するには、ウォレットでの再署名が必要です。委譲する権限の範囲が変わるためです。",
         "scopeReconsentRequired": "「利回り重視」の設定が完了していません。タップして再署名してください。",
         "scopeYieldUnavailable": "「利回り重視」は現在ご利用いただけません。引き続き「安全重視」で運用します。",
-        "scopeYieldPreparingNotice": "※準備中です。選択内容は記録されますが、Pendle での運用開始は近日提供予定です。当面は「安全重視」（Aave USDC）で運用します。"
+        "scopeYieldPreparingNotice": "※準備中です。選択内容は記録されますが、利回り固定型の運用開始は近日提供予定です。当面は「安全重視」で運用します。"
       },
       "txHistory": {
         "title": "取引履歴",
@@ -3569,15 +3569,15 @@
   },
   "AggressiveDisclosure": {
     "title": "ハイリスクモードの確認",
-    "subtitle": "ハイリスクモード（Pendle 固定利回りPT）を選ぶ前に、以下の重要事項に同意してください。",
+    "subtitle": "ハイリスクモード（満期まで利回りを固定する運用）を選ぶ前に、以下の重要事項に同意してください。",
     "items": {
       "funds_locked": {
         "title": "満期まで即時出金できません",
-        "detail": "資金は Pendle PT の満期まで固定されます。満期前の売却は市場の流動性しだいで不利な価格になる場合があります。"
+        "detail": "資金は満期まで固定されます。満期前に解約する場合、市場の流動性しだいで不利な価格になることがあります。"
       },
       "pt_backed": {
-        "title": "yoUSD（利回りアグリゲータ）で裏付けられています",
-        "detail": "元本は yoUSD という利回りアグリゲータ vault が裏付けます。デペグや裏付け資産の毀損リスクがゼロではありません。"
+        "title": "外部の利回りアグリゲータが裏付けています",
+        "detail": "元本は、複数の運用先に分散する外部の利回りアグリゲータが裏付けます。価格の乖離（デペグ）や裏付け資産の毀損リスクがゼロではありません。"
       },
       "slippage": {
         "title": "スリッページ・流動性リスクがあります",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "test:e2e:mobile": "playwright test --project='Mobile Chrome'",
     "test:e2e:desktop": "playwright test --project='Desktop Chrome'",
     "test:e2e:smoke": "playwright test e2e/smoke/",
-    "check:i18n": "node scripts/check-i18n-keys.mjs"
+    "check:i18n": "node scripts/check-i18n-keys.mjs",
+    "check:protocol-names": "node scripts/check-consumer-protocol-names.mjs"
   },
   "dependencies": {
     "@farcaster/mini-app-solana": "^2.0.0",

--- a/frontend/scripts/check-consumer-protocol-names.mjs
+++ b/frontend/scripts/check-consumer-protocol-names.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * 消費者向け UI に DeFi プロトコル名 / 個別プロダクト名が出ていないか検査する CI ガード。
+ *
+ * 背景（2026-07-23）:
+ *   「Aave」「Pendle」等の名称は消費者向け画面に出さない、という運用ルールがある。
+ *   しかし PR #993 で追加した運用方針セレクタと リスク開示モーダルに `Aave USDC 供給のみ` /
+ *   `Aave + Pendle PT` / `yoUSD` がそのまま入り、staging-v4 の実機目視で発覚した。
+ *   同じ抽象化語彙（`Strategies.optimizer.protocol`）が既にあったのに使われていなかった。
+ *   レビューの注意力では防げないので機械で突合する。
+ *
+ * 判定（fail-closed）:
+ *   messages/{ja,en}.json のうち **消費者向けスコープ**（CONSUMER_SCOPES）配下の文字列に
+ *   禁止語（BANNED）が含まれていたら FAIL。
+ *   管理者 / パートナー向けスコープ（AdminProtocols 等）は運用上むしろ実名が必要なので対象外。
+ *
+ * 終了コード: 0=クリーン / 1=違反あり
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+/** 消費者（エンドユーザー）が見る i18n スコープ。ここに実プロトコル名を出さない。 */
+const CONSUMER_SCOPES = ['Liff', 'AggressiveDisclosure']
+
+/** 禁止語。大文字小文字は区別しない。 */
+const BANNED = ['aave', 'pendle', 'lido', 'steth', 'yousd', 'morpho', 'compound']
+
+const LOCALES = ['ja', 'en']
+
+const violations = []
+
+for (const locale of LOCALES) {
+  const file = join(ROOT, 'messages', `${locale}.json`)
+  const data = JSON.parse(readFileSync(file, 'utf8'))
+
+  for (const scope of CONSUMER_SCOPES) {
+    if (!(scope in data)) continue
+    walk(data[scope], [scope], locale)
+  }
+}
+
+function walk(node, path, locale) {
+  if (typeof node === 'string') {
+    const lower = node.toLowerCase()
+    const hit = BANNED.find((w) => lower.includes(w))
+    if (hit) {
+      violations.push({ locale, key: path.join('.'), word: hit, text: node })
+    }
+    return
+  }
+  if (node && typeof node === 'object') {
+    for (const [k, v] of Object.entries(node)) walk(v, [...path, k], locale)
+  }
+}
+
+if (violations.length === 0) {
+  console.log(
+    `✅ 消費者向け文言にプロトコル名なし（検査スコープ: ${CONSUMER_SCOPES.join(', ')} / ${LOCALES.join(', ')}）`,
+  )
+  process.exit(0)
+}
+
+console.error('❌ FAIL: 消費者向け文言に DeFi プロトコル名 / プロダクト名が含まれています。')
+console.error('')
+for (const v of violations) {
+  console.error(`  [${v.locale}] ${v.key}`)
+  console.error(`    禁止語: "${v.word}"`)
+  console.error(`    文言  : ${v.text}`)
+}
+console.error('')
+console.error('  → 機能で説明する言い回しに直してください（例: "満期まで預けて利回りを固定"）。')
+console.error('  → 既存の抽象化語彙は messages/*.json の Strategies.optimizer.protocol にあります。')
+console.error('  → 管理者向け画面（AdminProtocols 等）は対象外です。実名が必要ならそちらへ。')
+process.exit(1)


### PR DESCRIPTION
## 背景

「Aave」「Pendle」等の名称は消費者向け画面に出さない運用ルールがあるが、**PR #993 で追加した運用方針セレクタとリスク開示モーダルに実名がそのまま入っていた**。staging-v4 の実機目視で発覚。

`Strategies.optimizer.protocol` に抽象化語彙（`aave` → 安定型レンディング 等）が既にあったのに、新規文言でそれを使っていなかったのが原因。

## Before / After（セレクタ）

| | Before | After |
|---|---|---|
| 安全重視 | **Aave** USDC 供給のみ | いつでも引き出せる運用 |
| 利回り重視 | **Aave + Pendle** PT | 満期まで預けて利回りを固定 |
| 準備中注記 | …**Pendle** での運用開始…（**Aave** USDC）… | …利回り固定型の運用開始…「安全重視」で運用します |

## リスク開示モーダル

**リスクの記述内容は一切弱めていません。** 固有名詞のみ機能記述に置換:

| キー | Before | After |
|---|---|---|
| `subtitle` | （**Pendle** 固定利回りPT） | （満期まで利回りを固定する運用） |
| `funds_locked.detail` | 資金は **Pendle PT** の満期まで固定 | 資金は満期まで固定 |
| `pt_backed` | **yoUSD**（利回りアグリゲータ）で裏付け | 外部の利回りアグリゲータが裏付け |

> ⚠️ 同意記録としての開示に商品名（yoUSD / Pendle）を残すべきかは法務判断の余地があります。必要なら利用規約側に具体名を置く形で補えます。

## その他

`liff-chat/page.tsx` の `protocol: p.protocol ?? "Aave V3"` フォールバックを除去。現状どこにも描画されていませんが、描画された瞬間に露出する潜在地雷でした。

## 再発防止（CIガード）

`frontend/scripts/check-consumer-protocol-names.mjs` を新設し CI に登録。消費者向けスコープ（`Liff` / `AggressiveDisclosure`）配下の ja/en 文字列に `aave|pendle|lido|steth|yousd|morpho|compound` が含まれたら FAIL。管理者向け（`AdminProtocols` 等）は実名が必要なので対象外です。

```
$ node scripts/check-consumer-protocol-names.mjs
✅ 消費者向け文言にプロトコル名なし（検査スコープ: Liff, AggressiveDisclosure / ja, en）
```

負のテスト（`scopeYieldProtocols` を戻す）:
```
❌ FAIL: 消費者向け文言に DeFi プロトコル名 / プロダクト名が含まれています。
  [ja] Liff.panels.opMode.scopeYieldProtocols
    禁止語: "aave" / 文言: Aave + Pendle PT
exit=1
```

## 検証

- `npm run check:i18n` → 新規の欠落なし
- `npx tsc --noEmit` → エラー 0
- `package.json` の変更は npm-script 追加のみ（依存追加なし＝`package-lock.json` に影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNjz6pQPiL93oTix9yYAGN