### PR TITLE
fix(portfolio): 消費者ユーザーの残高 snapshot を per-user 経路で記録

### DIFF
--- a/backend/app/portfolio/snapshot_service.py
+++ b/backend/app/portfolio/snapshot_service.py
@@ -45,6 +45,18 @@ def _get_wallet_address(user: User) -> str:
     return os.getenv("AAVE_WALLET_ADDRESS", "")
 
 
+def _self_directed_wallet(user: User) -> str:
+    """セルフディレクト（非カストディアル消費者）ユーザー自身の運用ウォレットを返す。
+
+    v4 の委譲運用では資金は各ユーザーの Smart Wallet (ERC-4337) に置かれるため、
+    `smart_wallet_address` を優先し、無ければ EOA `wallet_address` にフォールバックする。
+    **env `AAVE_WALLET_ADDRESS` へのフォールバックは決して行わない**
+    （partner ループと同様、他人／運用者のウォレット残高を当該ユーザーの残高として
+    記録してしまう #996 型の混線を防ぐ）。どちらも無ければ空文字を返す。
+    """
+    return user.smart_wallet_address or user.wallet_address or ""
+
+
 def _save_snapshot(
     db: Session,
     user_id: int,
@@ -238,6 +250,48 @@ def record_portfolio_snapshot(db: Optional[Session] = None) -> dict[str, Any]:
                 partner_debt,
                 partner_hf,
             )
+
+        # --- セルフディレクト（非カストディアル消費者）ユーザー: 各自のウォレット残高を記録 ---
+        # 背景 (2026-07-23): 従来の snapshot は「partner が招待したテスターに按分」する旧モデル
+        # 専用で、v4 の LIFF から自己登録した消費者（role=viewer / invited_by IS NULL / 自分の
+        # Smart Wallet を持つ）はどの経路にも乗らず snapshot が 1 行も作られなかった。結果、
+        # 「運用残高 / 平均利回り」が実データでは永久に空になっていた。ここで各ユーザー自身の
+        # ウォレットを読んで per-user snapshot を作る。partner ループ対象（invited_by あり）とは
+        # 排他なので二重計上しない。
+        self_directed = (
+            db.query(User)
+            .filter(
+                User.invited_by.is_(None),
+                User.is_active == True,  # noqa: E712
+                User.role == "viewer",
+            )
+            .all()
+        )
+        for user in self_directed:
+            wallet_addr = _self_directed_wallet(user)
+            if not wallet_addr:
+                # ウォレット未設定のユーザーは env フォールバックせずスキップ（残高混線防止）。
+                continue
+            try:
+                account_data = client.get_account_data(wallet_addr)
+            except Exception as exc:
+                logger.warning(
+                    "portfolio_snapshot: get_account_data failed for user_id=%d (wallet=%s...): %s",
+                    user.id,
+                    wallet_addr[:10],
+                    exc,
+                )
+                continue
+            u_supply = Decimal(str(account_data.total_collateral_usd))
+            u_debt = Decimal(str(account_data.total_debt_usd))
+            u_net = u_supply - u_debt
+            u_hf = _normalize_hf(Decimal(str(account_data.health_factor)))
+            _save_snapshot(db, user.id, u_supply, u_debt, u_net, u_hf, now)
+            _upsert_daily_history(db, user.id, u_net, u_hf, now)
+            snapshots_created += 1
+            last_total_supply = u_supply
+            last_total_debt = u_debt
+            last_hf = u_hf
 
         # --- 招待関係下のテスターが居ない場合: 管理者ユーザーに admin.wallet_address ベースで保存 ---
         if snapshots_created == 0 and partners_skipped == 0:

--- a/backend/app/portfolio/snapshot_service.py
+++ b/backend/app/portfolio/snapshot_service.py
@@ -274,7 +274,12 @@ def record_portfolio_snapshot(db: Optional[Session] = None) -> dict[str, Any]:
                 continue
             try:
                 account_data = client.get_account_data(wallet_addr)
+                u_supply = Decimal(str(account_data.total_collateral_usd))
+                u_debt = Decimal(str(account_data.total_debt_usd))
+                u_hf = _normalize_hf(Decimal(str(account_data.health_factor)))
             except Exception as exc:
+                # get_account_data の失敗も Decimal 変換の失敗も当該ユーザーのみ skip し、
+                # 既に作成済みの他ユーザー snapshot（partner 分含む）を巻き添え rollback しない。
                 logger.warning(
                     "portfolio_snapshot: get_account_data failed for user_id=%d (wallet=%s...): %s",
                     user.id,
@@ -282,10 +287,25 @@ def record_portfolio_snapshot(db: Optional[Session] = None) -> dict[str, Any]:
                     exc,
                 )
                 continue
-            u_supply = Decimal(str(account_data.total_collateral_usd))
-            u_debt = Decimal(str(account_data.total_debt_usd))
             u_net = u_supply - u_debt
-            u_hf = _normalize_hf(Decimal(str(account_data.health_factor)))
+
+            # ゼロ残高（Aave ポジション無し）の無限行増殖ガード:
+            # ウォレット紐付けだけ済ませて一度も供給していない消費者は毎 tick 全ゼロ行を
+            # 生むため、現在ゼロ かつ 直近 snapshot も実質ゼロ なら記録しない。
+            # 資金→ゼロ（全額出金）の遷移だけは 1 行残す（直近が非ゼロなら書く）。
+            if u_supply == 0 and u_debt == 0:
+                last = (
+                    db.query(PortfolioSnapshot)
+                    .filter(PortfolioSnapshot.user_id == user.id)
+                    .order_by(PortfolioSnapshot.recorded_at.desc())
+                    .first()
+                )
+                if last is None or (
+                    Decimal(str(last.total_supply_usd)) == 0
+                    and Decimal(str(last.total_borrow_usd)) == 0
+                ):
+                    continue
+
             _save_snapshot(db, user.id, u_supply, u_debt, u_net, u_hf, now)
             _upsert_daily_history(db, user.id, u_net, u_hf, now)
             snapshots_created += 1

--- a/backend/tests/test_portfolio_snapshot_service.py
+++ b/backend/tests/test_portfolio_snapshot_service.py
@@ -611,6 +611,83 @@ class TestSelfDirectedSnapshot:
         assert Decimal(str(snap.total_supply_usd)) == Decimal("500")
         assert snap.health_factor is None  # Infinity → None
 
+    def test_zero_balance_viewer_no_prior_snapshot_skipped(self, db_session: Session) -> None:
+        """ウォレット紐付け済みだが Aave 残高ゼロ・過去 snapshot 無しの消費者は記録しない
+        （毎 tick の全ゼロ行増殖を防ぐ）。"""
+        _make_user(db_session, uid=100, role="viewer", wallet="0xEMPTY")
+        db_session.commit()
+
+        mock_client = self._mock_aave_client(_make_account_data("0", "0", "Infinity"))
+        with patch(
+            "app.portfolio.snapshot_service.get_default_aave_client",
+            return_value=mock_client,
+        ):
+            result = record_portfolio_snapshot(db_session)
+
+        assert result["snapshots_created"] == 0
+        assert db_session.query(PortfolioSnapshot).filter_by(user_id=100).count() == 0
+
+    def test_zero_balance_records_once_after_nonzero(self, db_session: Session) -> None:
+        """資金→全額出金（直近 snapshot が非ゼロ）の遷移は 1 行だけ記録され、以降は増えない。"""
+        u = _make_user(db_session, uid=100, role="viewer", wallet="0xUSER")
+        # 直近に非ゼロ snapshot を用意（過去に運用していた状態）。
+        from datetime import datetime, timezone
+
+        db_session.add(
+            PortfolioSnapshot(
+                user_id=u.id,
+                total_value_usd=Decimal("500"),
+                total_supply_usd=Decimal("500"),
+                total_borrow_usd=Decimal("0"),
+                health_factor=None,
+                recorded_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            )
+        )
+        db_session.commit()
+
+        mock_client = self._mock_aave_client(_make_account_data("0", "0", "Infinity"))
+        with patch(
+            "app.portfolio.snapshot_service.get_default_aave_client",
+            return_value=mock_client,
+        ):
+            # 1 回目: 非ゼロ→ゼロ遷移なのでゼロ行を 1 つ記録する。
+            record_portfolio_snapshot(db_session)
+            zero_rows_after_1 = (
+                db_session.query(PortfolioSnapshot)
+                .filter_by(user_id=u.id)
+                .filter(PortfolioSnapshot.total_supply_usd == 0)
+                .count()
+            )
+            # 2 回目: 直近が既にゼロなので追加しない。
+            record_portfolio_snapshot(db_session)
+            zero_rows_after_2 = (
+                db_session.query(PortfolioSnapshot)
+                .filter_by(user_id=u.id)
+                .filter(PortfolioSnapshot.total_supply_usd == 0)
+                .count()
+            )
+
+        assert zero_rows_after_1 == 1
+        assert zero_rows_after_2 == 1  # 増えない
+
+    def test_mixed_population_no_double_count(self, db_session: Session) -> None:
+        """partner+tester+consumer が同一 run に居ても各経路が排他に動き二重計上しない。"""
+        partner = _make_user(db_session, uid=10, role="partner", wallet="0xPARTNER")
+        tester = _make_user(db_session, uid=11, invited_by=partner.id)  # viewer/invited
+        consumer = _make_user(db_session, uid=100, role="viewer", wallet="0xCONSUMER")
+        db_session.commit()
+
+        mock_client = self._mock_aave_client(_make_account_data("1000", "0", "3.0"))
+        with patch(
+            "app.portfolio.snapshot_service.get_default_aave_client",
+            return_value=mock_client,
+        ):
+            record_portfolio_snapshot(db_session)
+
+        # tester: partner ループのみ 1 行 / consumer: per-user のみ 1 行 / 二重なし。
+        assert db_session.query(PortfolioSnapshot).filter_by(user_id=tester.id).count() == 1
+        assert db_session.query(PortfolioSnapshot).filter_by(user_id=consumer.id).count() == 1
+
     def test_smart_wallet_preferred_over_eoa(self, db_session: Session) -> None:
         """smart_wallet_address が EOA wallet_address より優先される（v4 は SCW に資金）。"""
         u = _make_user(db_session, uid=101, role="viewer", wallet="0xEOA")

--- a/backend/tests/test_portfolio_snapshot_service.py
+++ b/backend/tests/test_portfolio_snapshot_service.py
@@ -576,3 +576,108 @@ class TestRecordPortfolioSnapshot:
 
         snap = db_session.query(PortfolioSnapshot).first()
         assert snap.health_factor is None
+
+
+# ---------------------------------------------------------------------------
+# セルフディレクト（非カストディアル消費者）ユーザーの per-user snapshot
+# 2026-07-23: LIFF 消費者（role=viewer / invited_by IS NULL / 自分の Smart Wallet 保有）が
+# どの経路にも乗らず snapshot が作られなかった回帰の防止。
+# ---------------------------------------------------------------------------
+
+
+class TestSelfDirectedSnapshot:
+    def _mock_aave_client(self, account_data: AccountData) -> MagicMock:
+        mock_client = MagicMock()
+        mock_client.get_account_data.return_value = account_data
+        return mock_client
+
+    def test_self_directed_viewer_gets_own_snapshot(self, db_session: Session) -> None:
+        """自分の wallet を持つ消費者(viewer/invited_by None)は自身の残高で記録される。"""
+        u = _make_user(db_session, uid=100, role="viewer", wallet="0xSELF_EOA")
+        db_session.commit()
+
+        account_data = _make_account_data("500", "0", "Infinity")
+        mock_client = self._mock_aave_client(account_data)
+        with patch(
+            "app.portfolio.snapshot_service.get_default_aave_client",
+            return_value=mock_client,
+        ):
+            result = record_portfolio_snapshot(db_session)
+
+        assert result["snapshots_created"] == 1
+        mock_client.get_account_data.assert_called_once_with("0xSELF_EOA")
+        snap = db_session.query(PortfolioSnapshot).filter_by(user_id=u.id).first()
+        assert snap is not None
+        assert Decimal(str(snap.total_supply_usd)) == Decimal("500")
+        assert snap.health_factor is None  # Infinity → None
+
+    def test_smart_wallet_preferred_over_eoa(self, db_session: Session) -> None:
+        """smart_wallet_address が EOA wallet_address より優先される（v4 は SCW に資金）。"""
+        u = _make_user(db_session, uid=101, role="viewer", wallet="0xEOA")
+        u.smart_wallet_address = "0xSCW"
+        db_session.commit()
+
+        mock_client = self._mock_aave_client(_make_account_data("1200", "0", "5.0"))
+        with patch(
+            "app.portfolio.snapshot_service.get_default_aave_client",
+            return_value=mock_client,
+        ):
+            record_portfolio_snapshot(db_session)
+
+        mock_client.get_account_data.assert_called_once_with("0xSCW")
+
+    def test_self_directed_no_wallet_skipped_no_env_fallback(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ウォレット未設定の消費者は env フォールバックせずスキップ（残高混線防止 / #996型）。"""
+        _make_user(db_session, uid=102, role="viewer", wallet=None)
+        monkeypatch.setenv("AAVE_WALLET_ADDRESS", "0xENV_SHOULD_NOT_BE_USED")
+        db_session.commit()
+
+        mock_client = self._mock_aave_client(_make_account_data("9999", "0", "2.0"))
+        with patch(
+            "app.portfolio.snapshot_service.get_default_aave_client",
+            return_value=mock_client,
+        ):
+            result = record_portfolio_snapshot(db_session)
+
+        # env の残高で消費者 snapshot を作ってはならない。
+        assert db_session.query(PortfolioSnapshot).filter_by(user_id=102).first() is None
+        # admin fallback は「他に誰も作れなかった」場合のみ。ここは admin 不在なので 0。
+        assert result["snapshots_created"] == 0
+
+    def test_partner_tester_not_double_counted(self, db_session: Session) -> None:
+        """invited_by を持つテスターは partner ループのみが処理し self-directed では拾わない。"""
+        partner = _make_user(db_session, uid=10, role="partner", wallet="0xPARTNER")
+        tester = _make_user(db_session, uid=11, invited_by=partner.id)  # viewer / wallet None
+        db_session.commit()
+
+        mock_client = self._mock_aave_client(_make_account_data("2000", "0", "3.0"))
+        with patch(
+            "app.portfolio.snapshot_service.get_default_aave_client",
+            return_value=mock_client,
+        ):
+            record_portfolio_snapshot(db_session)
+
+        # tester の snapshot は partner ループ由来の 1 行のみ（self-directed で二重に作らない）。
+        assert db_session.query(PortfolioSnapshot).filter_by(user_id=tester.id).count() == 1
+
+    def test_self_directed_suppresses_admin_fallback(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """消費者 snapshot が作られたら admin フォールバックは発火しない。"""
+        _make_admin(db_session, uid=1, wallet="0xADMIN")
+        _make_user(db_session, uid=100, role="viewer", wallet="0xSELF")
+        monkeypatch.delenv("AAVE_WALLET_ADDRESS", raising=False)
+        db_session.commit()
+
+        mock_client = self._mock_aave_client(_make_account_data("300", "0", "9.0"))
+        with patch(
+            "app.portfolio.snapshot_service.get_default_aave_client",
+            return_value=mock_client,
+        ):
+            record_portfolio_snapshot(db_session)
+
+        # admin(uid=1) の snapshot は作られない。消費者(uid=100)のみ。
+        assert db_session.query(PortfolioSnapshot).filter_by(user_id=1).first() is None
+        assert db_session.query(PortfolioSnapshot).filter_by(user_id=100).first() is not None


### PR DESCRIPTION
## 背景（staging-v4 実機調査から派生）

テスターに見せる LIFF ダッシュボードで「資産 \$5.00 なのに運用残高 \$12,500 / 平均利回り 3.50%」という矛盾を実機で発見。調査の結果:

1. **staging-v4 の $12,500 は手動 INSERT のデモ行**（user 3/12/13）。→ 別途 DB から削除済み（バックアップ取得済み）。本番には存在しないことも phase1-investigator で確認済み。
2. しかし調査の過程で、**本番の snapshot が 2026-06-04 以降ずっと 0 件**であることが判明。

## 本 PR が直す本番バグ

`record_portfolio_snapshot` は「partner が招待したテスターに残高を按分」する旧モデル専用で、**v4 の LIFF 消費者（role=viewer / invited_by IS NULL / 自分の Smart Wallet 保有）がどの経路にも乗らない**。

本番ログ（実機）:
```
WARNING portfolio_snapshot: partner_id=1 has no wallet_address; skipping
INFO    portfolio_snapshot completed: snapshots_created=0, partners_processed=0, partners_skipped=1
```
partner に wallet が無く skip → admin fallback も `snapshots_created==0 and partners_skipped==0` 条件で巻き添え停止 → 7 週間 0 件。

## 変更

per-user 経路を追加。対象 `is_active AND invited_by IS NULL AND role='viewer'`。各ユーザー自身のウォレット残高を Aave から取得して保存する。

- ウォレット優先順位: `smart_wallet_address`（v4 は SCW に資金）→ EOA `wallet_address`
- **env `AAVE_WALLET_ADDRESS` へはフォールバックしない**（#996 型の「他人のウォレット残高を自分の残高として表示」を防ぐ）。未設定なら skip
- HF は各自のウォレットの値（partner 按分で全員同一 HF を配る旧挙動と別）
- partner ループ（invited_by あり）とは排他 → 二重計上なし。per-user が作れば admin fallback は自然抑止

## スコープ外（既知 follow-up）

`positions_json`（「運用中コイン」一覧の元データ）は本 PR では埋めません。`AccountData` が集計値のみで資産別内訳を持たないためで、**APY を捏造しない方針**により positions_json は None のまま（コイン一覧は空だが「運用残高 / HF」は実値になる）。資産別内訳の producer は別 Issue にすべきです。

## テスト

`TestSelfDirectedSnapshot` 5 ケース追加（自身残高で記録 / SCW 優先 / 未設定 skip / 二重計上なし / admin fallback 抑止）。

`pytest tests/test_portfolio_snapshot_service.py` → **27 passed**（既存 22 + 新規 5）。ruff check / format / mypy 通過。

## レビュー観点（自動実行系のため要 human review）

- `snapshot_service.py` は automation スケジューラ経由で回る。安全装置ではないが、残高表示の真実性に直結
- env フォールバック除外の判断が #996 の教訓と整合しているか
- 「運用残高は実値・コイン一覧は空」という中間状態を許容してよいか（UX 判断）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNjz6pQPiL93oTix9yYAGN