### PR TITLE
fix(liff): 安全利回り提案の理由文からプロトコル名(Aave)を除去

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -797,7 +797,8 @@ def _create_safe_yield_proposals_for_users(
     """
     expires_at = datetime.now(timezone.utc) + timedelta(hours=_PROPOSAL_EXPIRES_HOURS)
     now = datetime.now(timezone.utc)
-    reason = "遊休USDCを安全利回り（Aave USDC）へ配分します。相場の方向性に依らず実行できる安全な運用です。"
+    # 消費者向けの提案理由（ProposalActionCard に表示）にプロトコル名（Aave 等）は出さない約束。
+    reason = "遊休USDCを安全な利回りへ配分します。相場の方向性に依らず実行できる安全な運用です。"
 
     # AUTO_EXECUTE ユーザーも対象に含める（2026-07-16）。B1 が生成する提案は常に
     # SUPPLY/USDC/aave 固定で _should_use_scw_route が True になり得る唯一の operation

--- a/backend/tests/automation/test_safe_yield_on_hold.py
+++ b/backend/tests/automation/test_safe_yield_on_hold.py
@@ -94,7 +94,9 @@ def test_creates_safe_supply_proposal(monkeypatch: pytest.MonkeyPatch) -> None:
     p = props[0]
     assert (p.operation, p.asset, p.protocol) == ("SUPPLY", "USDC", "aave")
     assert p.amount_usd == Decimal("100")
-    assert "安全利回り" in p.reason
+    assert "利回り" in p.reason
+    # 消費者向け提案理由にプロトコル名（Aave 等）を出さない約束の回帰ガード。
+    assert "Aave" not in p.reason and "aave" not in p.reason
 
 
 def test_skip_when_pending_exists(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## 背景

staging-v4 実機（テスター準備の目視確認）で、BUY 提案カードに **「遊休USDCを安全利回り（Aave USDC）へ配分します」** と表示されているのを発見。消費者向け UI にプロトコル名を出さない約束の違反。

## なぜ #1002 のガードで防げなかったか

この文字列は **backend が生成する `proposal.reason`**（`ai_judgment_scheduler.py:800`）で、`ProposalActionCard` にそのまま表示される。#1002 の frontend CI ガードは i18n / .tsx しか見ておらず、**backend 生成の消費者向け文字列は射程外**だった（構造的ギャップ）。

## 変更

- `reason` から「（Aave USDC）」を除去 → `"遊休USDCを安全な利回りへ配分します。相場の方向性に依らず実行できる安全な運用です。"`
- `test_safe_yield_on_hold`: アサーションを新文言に更新 + **「reason にプロトコル名を含まない」回帰ガード**を追加

`oracle_monitor.py` の "Aave oracle anomaly" は内部 emergency_stop 理由（ログ/内部処理）で消費者には出ないため対象外。

## 残る構造ギャップ（follow-up 候補）

backend 生成の消費者向け文字列（proposal.reason / 通知文 等）を機械検査する仕組みは無い。今回は静的文字列1件だが、同種が increment で紛れ込む余地がある。backend 側にも consumer-facing string の lint を足すか要検討。

## 検証

`pytest tests/automation/test_safe_yield_on_hold.py` → 6 passed / ruff check・format OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNjz6pQPiL93oTix9yYAGN