### PR TITLE
fix(liff): #1002 で取り込まれ損ねた Opus レビュー修正を再適用

### DIFF
--- a/frontend/app/user/page.tsx
+++ b/frontend/app/user/page.tsx
@@ -45,10 +45,9 @@ export default function LandingPage() {
           <span className="text-xs text-muted-foreground uppercase tracking-widest">
             Powered by
           </span>
+          {/* 消費者向け UI に DeFi プロトコル名（Aave 等）は出さない約束のため、
+              「Powered by」バッジからプロトコル名を除去。チェーン名(Base)は残す。 */}
           <div className="flex gap-2">
-            <Badge variant="outline" className="text-blue-400 border-blue-400/50">
-              Aave V3
-            </Badge>
             <Badge variant="outline" className="text-indigo-400 border-indigo-400/50">
               Base Mainnet
             </Badge>

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -3850,12 +3850,12 @@
     "supplyTxHash": "Reinvestment TX"
   },
   "IdleYieldCard": {
-    "title": "Idle Capital Management (Morpho Vaults)",
+    "title": "Idle Capital Management",
     "idleBalance": "Idle Balance",
     "bestApy": "Best APY",
     "activePosition": "Active Position",
     "earnedInterest": "Earned Interest",
-    "depositButton": "Deposit to Morpho",
+    "depositButton": "Deposit",
     "withdrawButton": "Withdraw",
     "depositing": "Depositing...",
     "withdrawing": "Withdrawing...",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -3867,12 +3867,12 @@
     "supplyTxHash": "再投資TX"
   },
   "IdleYieldCard": {
-    "title": "アイドル資本運用（Morpho Vaults）",
+    "title": "アイドル資本運用",
     "idleBalance": "アイドル残高",
     "bestApy": "最高APY",
     "activePosition": "運用中残高",
     "earnedInterest": "獲得利息",
-    "depositButton": "Morpho入金",
+    "depositButton": "入金",
     "withdrawButton": "引き出し",
     "depositing": "入金中...",
     "withdrawing": "引き出し中...",

--- a/frontend/scripts/check-consumer-protocol-names.mjs
+++ b/frontend/scripts/check-consumer-protocol-names.mjs
@@ -3,75 +3,157 @@
  * 消費者向け UI に DeFi プロトコル名 / 個別プロダクト名が出ていないか検査する CI ガード。
  *
  * 背景（2026-07-23）:
- *   「Aave」「Pendle」等の名称は消費者向け画面に出さない、という運用ルールがある。
- *   しかし PR #993 で追加した運用方針セレクタと リスク開示モーダルに `Aave USDC 供給のみ` /
- *   `Aave + Pendle PT` / `yoUSD` がそのまま入り、staging-v4 の実機目視で発覚した。
- *   同じ抽象化語彙（`Strategies.optimizer.protocol`）が既にあったのに使われていなかった。
- *   レビューの注意力では防げないので機械で突合する。
+ *   「Aave」「Pendle」等の名称は消費者向け画面に出さない運用ルールがある。
+ *   PR #993 の運用方針セレクタ / リスク開示モーダルに実名が混入し、staging-v4 の実機
+ *   目視で発覚。初版ガードは「i18n の allowlist スコープのみ」を見ており、
+ *   (a) `.tsx` の JSX 直書き literal（例: app/user の "Powered by Aave V3" バッジ）と
+ *   (b) allowlist に無い消費者スコープ（例: IdleYieldCard の "Morpho Vaults"）を
+ *   素通ししていた（Opus レビュー指摘）。本版は2系統で検査する:
  *
- * 判定（fail-closed）:
- *   messages/{ja,en}.json のうち **消費者向けスコープ**（CONSUMER_SCOPES）配下の文字列に
- *   禁止語（BANNED）が含まれていたら FAIL。
- *   管理者 / パートナー向けスコープ（AdminProtocols 等）は運用上むしろ実名が必要なので対象外。
+ *   [1] i18n denylist 方式:
+ *       messages/{ja,en}.json の **admin/partner/ops 以外の全スコープ**の文字列 value を
+ *       走査し、禁止語が含まれたら FAIL。新規スコープを足しても自動で検査対象になる
+ *       （allowlist の「登録し忘れ」で漏れない fail-safe な向き）。
+ *   [2] .tsx 可視テキスト走査:
+ *       消費者ルート（app/(liff) / app/user）の .tsx から、コメント / import 行を除いた
+ *       上で「可視テキストとして現れる禁止語」を検出。hook 名（useAaveV3）や型名
+ *       （AaveTransaction）は ASCII 単語境界で識別子扱いとなり誤検出しない。
  *
  * 終了コード: 0=クリーン / 1=違反あり
  */
-import { readFileSync } from 'node:fs'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 
-/** 消費者（エンドユーザー）が見る i18n スコープ。ここに実プロトコル名を出さない。 */
-const CONSUMER_SCOPES = ['Liff', 'AggressiveDisclosure']
-
-/** 禁止語。大文字小文字は区別しない。 */
+/** 禁止語（大文字小文字を区別しない）。 */
 const BANNED = ['aave', 'pendle', 'lido', 'steth', 'yousd', 'morpho', 'compound']
+
+/**
+ * i18n の走査対象外スコープ（admin / partner / ops）。
+ * ここは運用上むしろ実プロトコル名が必要なので許可する。
+ * これ以外の全スコープ（=消費者・共通）は走査する（denylist 方式）。
+ * 各スコープが本当に非消費者かは実ルートで確認済み:
+ *   AdminProtocols/AdminRebalance/AdminSettingsSystem/AdminDashboardAutomation → app/(admin)
+ *   BorrowRatesPanel/PendlePositionCard → app/(admin)/protocols
+ *   PartnerProposals → app/(partner)/partner/proposals
+ */
+const EXCLUDED_SCOPES = new Set([
+  'AdminProtocols',
+  'AdminRebalance',
+  'AdminSettingsSystem',
+  'AdminDashboardAutomation',
+  'BorrowRatesPanel',
+  'PendlePositionCard',
+  'PartnerProposals',
+])
 
 const LOCALES = ['ja', 'en']
 
+/** 消費者ルートの .tsx を走査する対象ディレクトリ。 */
+const CONSUMER_TSX_DIRS = ['app/(liff)', 'app/user']
+
+// ASCII 単語境界つきの禁止語マッチャ。識別子（useAaveV3 / AaveTransaction）は
+// 前後が英数字なので除外され、"Aave V3" のような可視テキストのみ拾う。
+const BANNED_RE = new RegExp(`(?<![A-Za-z0-9_])(${BANNED.join('|')})(?![A-Za-z0-9_])`, 'i')
+
 const violations = []
 
+// ── [1] i18n denylist 走査 ──
 for (const locale of LOCALES) {
-  const file = join(ROOT, 'messages', `${locale}.json`)
-  const data = JSON.parse(readFileSync(file, 'utf8'))
-
-  for (const scope of CONSUMER_SCOPES) {
-    if (!(scope in data)) continue
-    walk(data[scope], [scope], locale)
+  const data = JSON.parse(readFileSync(join(ROOT, 'messages', `${locale}.json`), 'utf8'))
+  for (const [scope, node] of Object.entries(data)) {
+    if (EXCLUDED_SCOPES.has(scope)) continue
+    walkI18n(node, [scope], locale)
   }
 }
 
-function walk(node, path, locale) {
+function walkI18n(node, path, locale) {
   if (typeof node === 'string') {
     const lower = node.toLowerCase()
     const hit = BANNED.find((w) => lower.includes(w))
     if (hit) {
-      violations.push({ locale, key: path.join('.'), word: hit, text: node })
+      violations.push({ kind: 'i18n', locale, key: path.join('.'), word: hit, text: node })
     }
     return
   }
   if (node && typeof node === 'object') {
-    for (const [k, v] of Object.entries(node)) walk(v, [...path, k], locale)
+    for (const [k, v] of Object.entries(node)) walkI18n(v, [...path, k], locale)
   }
 }
 
+// ── [2] .tsx 可視テキスト走査 ──
+for (const dir of CONSUMER_TSX_DIRS) {
+  for (const file of walkTsx(join(ROOT, dir))) scanTsx(file)
+}
+
+function walkTsx(dir) {
+  const out = []
+  let entries
+  try {
+    entries = readdirSync(dir)
+  } catch {
+    return out // ディレクトリ不在は無視
+  }
+  for (const name of entries) {
+    const full = join(dir, name)
+    if (statSync(full).isDirectory()) out.push(...walkTsx(full))
+    else if (name.endsWith('.tsx')) out.push(full)
+  }
+  return out
+}
+
+function scanTsx(file) {
+  const raw = readFileSync(file, 'utf8')
+  // ブロックコメントを除去（可視テキストではない）。
+  const noBlock = raw.replace(/\/\*[\s\S]*?\*\//g, '')
+  const lines = noBlock.split('\n')
+  lines.forEach((line, i) => {
+    let code = line.replace(/\/\/.*$/, '') // 行コメント除去
+    if (/^\s*import\b/.test(code)) return // import 行は識別子なので除外
+    // クオート文字列（'..' ".." `..`）を除去する。ユーザーに見えるコピーは必ず i18n の
+    // t() 経由なので、.tsx 内のクオート文字列に現れる禁止語は enum 値 / state キー /
+    // 内部識別子（例: proposal.protocol === "lido", activeTab === 'aave'）であって
+    // 可視テキストではない。残った「クオート外テキスト」= JSX テキストノードのみを検査し、
+    // "Powered by Aave V3" のようなハードコード可視バッジだけを拾う。
+    code = code
+      .replace(/'[^']*'/g, "''")
+      .replace(/"[^"]*"/g, '""')
+      .replace(/`[^`]*`/g, '``')
+    const m = BANNED_RE.exec(code)
+    if (m) {
+      violations.push({
+        kind: 'tsx',
+        file: file.replace(ROOT + '/', ''),
+        line: i + 1,
+        word: m[1].toLowerCase(),
+        text: line.trim(),
+      })
+    }
+  })
+}
+
+// ── 結果 ──
 if (violations.length === 0) {
   console.log(
-    `✅ 消費者向け文言にプロトコル名なし（検査スコープ: ${CONSUMER_SCOPES.join(', ')} / ${LOCALES.join(', ')}）`,
+    `✅ 消費者向けにプロトコル名なし（i18n: admin/partner 以外の全スコープ / .tsx: ${CONSUMER_TSX_DIRS.join(', ')}）`,
   )
   process.exit(0)
 }
 
-console.error('❌ FAIL: 消費者向け文言に DeFi プロトコル名 / プロダクト名が含まれています。')
+console.error('❌ FAIL: 消費者向け UI に DeFi プロトコル名 / プロダクト名が含まれています。')
 console.error('')
 for (const v of violations) {
-  console.error(`  [${v.locale}] ${v.key}`)
-  console.error(`    禁止語: "${v.word}"`)
-  console.error(`    文言  : ${v.text}`)
+  if (v.kind === 'i18n') {
+    console.error(`  [i18n/${v.locale}] ${v.key}  （禁止語: "${v.word}"）`)
+    console.error(`      ${v.text}`)
+  } else {
+    console.error(`  [tsx] ${v.file}:${v.line}  （禁止語: "${v.word}"）`)
+    console.error(`      ${v.text}`)
+  }
 }
 console.error('')
 console.error('  → 機能で説明する言い回しに直してください（例: "満期まで預けて利回りを固定"）。')
-console.error('  → 既存の抽象化語彙は messages/*.json の Strategies.optimizer.protocol にあります。')
-console.error('  → 管理者向け画面（AdminProtocols 等）は対象外です。実名が必要ならそちらへ。')
+console.error('  → admin/partner 向けで実名が必要なら EXCLUDED_SCOPES / 対象外ルートで扱ってください。')
 process.exit(1)


### PR DESCRIPTION
## なぜ再適用が必要か

PR #1002 の Opus レビューで見つかった修正コミット `1fdd7dbc`（badge 除去 / IdleYieldCard / ガード強化）は、**#1002 のマージ（22:47 UTC）より 11 分後（22:58 UTC）に push された**ため、squash マージに取り込まれず main に入らなかった。

検証（マージ後の origin/main）:
- `app/user/page.tsx:50` に "Aave V3" バッジが残存
- `IdleYieldCard.title` = "アイドル資本運用（Morpho Vaults）"
- `check-consumer-protocol-names.mjs` は旧 allowlist / i18n-only 版のまま

（※ #1003 のレビュー修正は 23:10 マージに間に合っており main に入っている。今回抜けたのは #1002 のみ。）

## 内容（`1fdd7dbc` を cherry-pick）

- `app/user/page.tsx`: "Powered by Aave V3" バッジを除去（Base Mainnet は残す）
- `IdleYieldCard`（ja/en）: "Morpho Vaults" / "Morpho入金" → "アイドル資本運用" / "入金"
- `check-consumer-protocol-names.mjs`: i18n denylist 化 + .tsx 可視テキスト走査（クオート除去で enum/hook 名は誤検出せず）

## 検証

`node scripts/check-consumer-protocol-names.mjs` → ✅ exit 0（この branch では通る＝現 main では FAIL するはずの内容を修正）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNjz6pQPiL93oTix9yYAGN