### PR TITLE
fix(liff): 残りの消費者向けプロトコル名除去(strategies/risk-disclosure/meta) + ガード拡張

### DIFF
--- a/frontend/app/(user)/risk-disclosure/page.tsx
+++ b/frontend/app/(user)/risk-disclosure/page.tsx
@@ -51,7 +51,7 @@ export default function RiskDisclosurePage() {
 
           <section>
             <h2 className="text-base font-semibold text-zinc-100 mb-2">運用上のリスク</h2>
-            <p>AaveなどのDeFiプロトコルでは、担保比率（Health Factor）が一定水準を下回ると清算が発生し、資産の一部が失われる可能性があります。また、ガス代の変動により予期しないコストが発生することがあります。</p>
+            <p>運用先の DeFi プロトコルでは、担保比率（Health Factor）が一定水準を下回ると清算が発生し、資産の一部が失われる可能性があります。また、ガス代の変動により予期しないコストが発生することがあります。</p>
           </section>
 
           <section>

--- a/frontend/app/(user)/strategies/page.tsx
+++ b/frontend/app/(user)/strategies/page.tsx
@@ -85,7 +85,7 @@ function buildStrategies(
     {
       id: 'aave-v3-usdc',
       icon: TrendingUp,
-      name: 'Aave V3 USDC',
+      name: '安定型 USDC 運用',
       subtitleKey: 'aave',
       descriptionKey: 'aave',
       apyRange: aaveApyRange,
@@ -98,7 +98,7 @@ function buildStrategies(
     {
       id: 'lido-steth',
       icon: Layers,
-      name: 'Lido stETH',
+      name: 'ステーキング型 ETH 運用',
       subtitleKey: 'lido',
       descriptionKey: 'lido',
       apyRange: lidoApyRange,
@@ -111,7 +111,7 @@ function buildStrategies(
     {
       id: 'pendle-pt-yt',
       icon: BarChart2,
-      name: 'Pendle PT/YT',
+      name: 'イールド最適化型 運用',
       subtitleKey: 'pendle',
       descriptionKey: 'pendle',
       apyRange: pendleApyRange,

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -9,7 +9,7 @@ import { DemoBanner } from '@/components/DemoBanner'
 
 export const metadata: Metadata = {
   title: 'Ultra AutoTrade',
-  description: 'AI-powered DeFi automated trading on Aave V3',
+  description: 'AI-powered automated asset management',
   manifest: '/manifest.json',
   appleWebApp: {
     capable: true,

--- a/frontend/scripts/check-consumer-protocol-names.mjs
+++ b/frontend/scripts/check-consumer-protocol-names.mjs
@@ -51,12 +51,32 @@ const EXCLUDED_SCOPES = new Set([
 
 const LOCALES = ['ja', 'en']
 
-/** 消費者ルートの .tsx を走査する対象ディレクトリ。 */
-const CONSUMER_TSX_DIRS = ['app/(liff)', 'app/user']
+/**
+ * 消費者ルートの .tsx を走査する対象ディレクトリ。
+ * route group ごとに URL が変わる点に注意（(liff)→/liff-chat, user→/user/*, (user)→/strategies 等）。
+ * admin/partner の route group（(admin)/(partner)）は実名 OK なので含めない。
+ */
+const CONSUMER_TSX_DIRS = ['app/(liff)', 'app/user', 'app/(user)']
+
+/**
+ * ルートグループ外の消費者共通 .tsx（全 URL に効く meta / レイアウト）。
+ * app/layout.tsx の metadata.description 等はブラウザタブ/共有プレビューに出る。
+ */
+const CONSUMER_TSX_FILES = ['app/layout.tsx']
 
 // ASCII 単語境界つきの禁止語マッチャ。識別子（useAaveV3 / AaveTransaction）は
 // 前後が英数字なので除外され、"Aave V3" のような可視テキストのみ拾う。
 const BANNED_RE = new RegExp(`(?<![A-Za-z0-9_])(${BANNED.join('|')})(?![A-Za-z0-9_])`, 'i')
+
+// 可視テキストになりうる「クオート文字列を値に取るプロパティ / 属性」名。
+// これらの値に禁止語が入るのは meta description / カード名 / ラベル等の可視コピー
+// （例: description: '…Aave V3', name: 'Aave V3 USDC', placeholder='Aave 額'）。
+// 逆に protocol / id / activeTab / key などは内部識別子なのでここに含めない。
+const VISIBLE_STRING_FIELD_RE = new RegExp(
+  `(?:description|name|title|subtitle|label|placeholder|alt|aria-label|ariaLabel|heading|caption|tooltip)` +
+    `\\s*[:=]\\s*[\`'"][^\`'"]*(${BANNED.join('|')})`,
+  'i',
+)
 
 const violations = []
 
@@ -87,6 +107,13 @@ function walkI18n(node, path, locale) {
 for (const dir of CONSUMER_TSX_DIRS) {
   for (const file of walkTsx(join(ROOT, dir))) scanTsx(file)
 }
+for (const rel of CONSUMER_TSX_FILES) {
+  try {
+    scanTsx(join(ROOT, rel))
+  } catch {
+    // ファイル不在は無視
+  }
+}
 
 function walkTsx(dir) {
   const out = []
@@ -110,14 +137,28 @@ function scanTsx(file) {
   const noBlock = raw.replace(/\/\*[\s\S]*?\*\//g, '')
   const lines = noBlock.split('\n')
   lines.forEach((line, i) => {
-    let code = line.replace(/\/\/.*$/, '') // 行コメント除去
-    if (/^\s*import\b/.test(code)) return // import 行は識別子なので除外
-    // クオート文字列（'..' ".." `..`）を除去する。ユーザーに見えるコピーは必ず i18n の
-    // t() 経由なので、.tsx 内のクオート文字列に現れる禁止語は enum 値 / state キー /
-    // 内部識別子（例: proposal.protocol === "lido", activeTab === 'aave'）であって
-    // 可視テキストではない。残った「クオート外テキスト」= JSX テキストノードのみを検査し、
-    // "Powered by Aave V3" のようなハードコード可視バッジだけを拾う。
-    code = code
+    const codeRaw = line.replace(/\/\/.*$/, '') // 行コメント除去
+    if (/^\s*import\b/.test(codeRaw)) return // import 行は識別子なので除外
+
+    // [B-1] 可視プロパティ（description/name/title/label/…）へのクオート値: 原文のまま検査。
+    // メタ記述やカード名など「クオートされた可視コピー」を拾う。
+    if (VISIBLE_STRING_FIELD_RE.test(codeRaw)) {
+      const m = BANNED_RE.exec(codeRaw)
+      violations.push({
+        kind: 'tsx',
+        file: file.replace(ROOT + '/', ''),
+        line: i + 1,
+        word: (m ? m[1] : BANNED.find((w) => codeRaw.toLowerCase().includes(w))).toLowerCase(),
+        text: line.trim(),
+      })
+      return
+    }
+
+    // [B-2] クオート文字列（'..' ".." `..`）を除去し、残った「クオート外テキスト」=
+    // JSX テキストノードのみを検査。enum 値 / state キー / 内部識別子
+    // （proposal.protocol === "lido", activeTab === 'aave'）は除去済みで誤検出しない。
+    // "Powered by Aave V3" のようなハードコード可視バッジ（JSX テキスト）を拾う。
+    const code = codeRaw
       .replace(/'[^']*'/g, "''")
       .replace(/"[^"]*"/g, '""')
       .replace(/`[^`]*`/g, '``')


### PR DESCRIPTION
## 背景

staging-v4 実機の目視確認 + ガード拡張で、当初直した3箇所以外にも消費者画面にプロトコル名が残っていたのを発見。#1002/#1005 のガードは `app/(liff)` / `app/user` しか見ておらず、route group `app/(user)`・`app/layout.tsx`・**クオート済みの可視文字列**（meta description / カード名）を取りこぼしていた。

## 直した漏れ

| 箇所 | Before | After |
|---|---|---|
| `app/layout.tsx` metadata.description | …on **Aave V3** | AI-powered automated asset management |
| `app/(user)/strategies` カード名 | **Aave V3 USDC** / **Lido stETH** / **Pendle PT/YT** | 安定型 USDC 運用 / ステーキング型 ETH 運用 / イールド最適化型 運用 |
| `app/(user)/risk-disclosure` 本文 | **Aave**などのDeFiプロトコルでは | 運用先の DeFi プロトコルでは |

## ガード強化

- 走査対象に `app/(user)` を追加 + `app/layout.tsx` を明示追加
- **[B-1] 可視プロパティ走査を新設**：`description/name/title/label/placeholder/alt/aria-label` 等のクオート値に禁止語があれば検出。従来の「クオート除去」走査は enum（`protocol === "lido"`）を誤検出しない代わりにクオート可視値（meta/name）も見逃していた盲点を埋める。内部識別子キー（protocol/id/activeTab）は可視集合に含めないので誤検出しない。

## 検証

- `node scripts/check-consumer-protocol-names.mjs` → ✅ exit 0
- 負のテスト：meta/name を戻すと [B-1] で検出（exit 1）、enum "lido" は非検出
- `npm run check:i18n` ✅ / `npx tsc --noEmit` ✅

## 補足

`/strategies` はテスター主動線（`/liff-chat`）からリンクされておらず直URL到達。テスターの主フローは本PR前から既にクリーン（提案カード・セレクタ・コイン一覧を実機確認済み）。本PRは残る消費者サーフェスの網羅対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNjz6pQPiL93oTix9yYAGN