### PR TITLE
feat(staging): テスターのスマートウォレットへBase SepoliaテストネットUSDCを自動補充

### DIFF
--- a/backend/app/partner/allocation_service.py
+++ b/backend/app/partner/allocation_service.py
@@ -37,6 +37,34 @@ logger = logging.getLogger(__name__)
 # HF が Infinity（ポジションなし）の場合の表示値
 _HF_INFINITY_DISPLAY = Decimal("999.0")
 
+# --- staging限定: テスター向けBase SepoliaテストネットUSDC自動補充 ---
+# scripts/aave_faucet_base.py / scripts/fund_test_wallets_base_sepolia.py と同一のfaucet契約。
+_TESTNET_FAUCET_ADDRESS = "0xD9145b5F45Ad4519c7ACcD6E0A4A82e83bB8A6Dc"
+_TESTNET_USDC_ADDRESS = "0xba50cd2a20f6da35d788639e581bca8d0b5d4d5f"
+_TESTNET_USDC_DECIMALS = 6
+_TESTNET_FAUCET_ABI = [
+    {
+        "inputs": [
+            {"internalType": "address", "name": "token", "type": "address"},
+            {"internalType": "address", "name": "to", "type": "address"},
+            {"internalType": "uint256", "name": "amount", "type": "uint256"},
+        ],
+        "name": "mint",
+        "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+]
+_TESTNET_ERC20_BALANCE_ABI = [
+    {
+        "inputs": [{"internalType": "address", "name": "account", "type": "address"}],
+        "name": "balanceOf",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+]
+
 
 # ---------------------------------------------------------------------------
 # CRUD
@@ -68,6 +96,95 @@ def create_allocation(
     return AllocationResponse.model_validate(allocation)
 
 
+def _fund_tester_onchain_usdc_if_enabled(user: User) -> None:
+    """staging限定: テスターのスマートウォレットへBase SepoliaテストネットUSDCを補充する(fail-open)。
+
+    fund_allocations(AI提案サイジング用の仮想枠、auto_fund_tester_if_enabled 本体)とは別物。
+    あちらはDB上の数値のみで実際のオンチェーン残高は動かないため、承認→実行→取引履歴という
+    実フローを実機テストできない(2026-07-28 UAT調査で判明、$200最低入金ゲートが必ず
+    DepositBelowMinimumErrorで弾く)。本関数は実際にオンチェーンでテストネットUSDCを送り、
+    このゲートを通過できる状態にする。
+
+    ガード: APP_ENV=production なら常に無効 / AUTO_FUND_TESTER_ONCHAIN_USDC 未設定なら無効 /
+    smart_wallet_address 未設定なら無効。既に目標額以上の残高があれば何もしない(冪等)。
+    失敗しても呼び出し元(オンボーディング)を止めない。
+    """
+    if os.getenv("APP_ENV", "").strip().lower() == "production":
+        return
+    target_usd_str = os.getenv("AUTO_FUND_TESTER_ONCHAIN_USDC", "")
+    if not target_usd_str or not user.smart_wallet_address:
+        return
+    try:
+        target_usd = Decimal(target_usd_str)
+    except InvalidOperation:
+        return
+    if target_usd <= Decimal("0"):
+        return
+
+    try:
+        from eth_account import Account  # noqa: PLC0415
+        from web3 import Web3  # noqa: PLC0415
+
+        rpc_url = os.environ.get("ALCHEMY_RPC_URL_BASE_SEPOLIA") or os.environ.get(
+            "AAVE_RPC_URL_BASE_SEPOLIA", ""
+        )
+        private_key = os.environ.get("AAVE_WALLET_PRIVATE_KEY", "")
+        operator_address = os.environ.get("AAVE_WALLET_ADDRESS", "")
+        if not (rpc_url and private_key and operator_address):
+            logger.warning("Auto-fund onchain USDC skipped: operator env vars 未設定")
+            return
+
+        w3 = Web3(Web3.HTTPProvider(rpc_url))
+        if not w3.is_connected():
+            logger.warning("Auto-fund onchain USDC skipped: RPC接続不可")
+            return
+
+        checksum_wallet = Web3.to_checksum_address(user.smart_wallet_address)
+        usdc = w3.eth.contract(
+            address=Web3.to_checksum_address(_TESTNET_USDC_ADDRESS),
+            abi=_TESTNET_ERC20_BALANCE_ABI,
+        )
+        balance_raw = usdc.functions.balanceOf(checksum_wallet).call()
+        balance = Decimal(balance_raw) / Decimal(10**_TESTNET_USDC_DECIMALS)
+        if balance >= target_usd:
+            return
+        top_up = target_usd - balance
+        amount_raw = int(top_up * Decimal(10**_TESTNET_USDC_DECIMALS))
+
+        account = Account.from_key(private_key)
+        operator_checksum = Web3.to_checksum_address(operator_address)
+        faucet = w3.eth.contract(
+            address=Web3.to_checksum_address(_TESTNET_FAUCET_ADDRESS),
+            abi=_TESTNET_FAUCET_ABI,
+        )
+        tx = faucet.functions.mint(
+            Web3.to_checksum_address(_TESTNET_USDC_ADDRESS),
+            checksum_wallet,
+            amount_raw,
+        ).build_transaction(
+            {
+                "from": operator_checksum,
+                "nonce": w3.eth.get_transaction_count(operator_checksum),
+                "gas": 200000,
+                "gasPrice": w3.eth.gas_price,
+            }
+        )
+        signed_tx = w3.eth.account.sign_transaction(tx, private_key=account.key)
+        tx_hash = w3.eth.send_raw_transaction(signed_tx.raw_transaction)
+        receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=60)
+        if receipt["status"] == 1:
+            logger.info(
+                "Auto-funded tester user_id=%d with onchain testnet USDC +%s (tx=%s)",
+                user.id,
+                top_up,
+                tx_hash.hex(),
+            )
+        else:
+            logger.warning("Auto-fund onchain USDC tx failed for user_id=%d", user.id)
+    except Exception as exc:
+        logger.warning("Auto-fund onchain USDC failed (fail-open, ignored): %s", exc)
+
+
 def auto_fund_tester_if_enabled(db: Session, user: User) -> None:
     """staging-v4限定: 新規テスターにデモ資金を自動割当する(fail-open、production無効)。
 
@@ -81,9 +198,15 @@ def auto_fund_tester_if_enabled(db: Session, user: User) -> None:
       2. AUTO_FUND_TESTER_ALLOCATION_USD / AUTO_FUND_PARTNER_ID が未設定/不正なら無効
     既にactiveなfund_allocationを持つユーザーには何もしない(重複割当防止、
     terms再同意のたびに増額されるのを防ぐ)。
+
+    あわせて _fund_tester_onchain_usdc_if_enabled で実際のオンチェーン残高も補充する
+    (こちらは既存allocationの有無に関わらず毎回試行=冪等な残高チェックで制御)。
     """
     if os.getenv("APP_ENV", "").strip().lower() == "production":
         return
+
+    _fund_tester_onchain_usdc_if_enabled(user)
+
     partner_id_str = os.getenv("AUTO_FUND_PARTNER_ID", "")
     if not partner_id_str:
         return

--- a/scripts/fund_test_wallets_base_sepolia.py
+++ b/scripts/fund_test_wallets_base_sepolia.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+staging-v4 の全テストウォレット(role=viewer かつ smart_wallet_address 設定済)に
+Base Sepolia テストネットUSDCを$200まで補充する。
+
+scripts/aave_faucet_base.py と同じ Aave テストネットfaucetコントラクト
+(mint(token, to, amount)) を使うが、operator自身ではなく任意の宛先(to)を
+指定できるよう一般化したもの。実資金ではなくテストネットのfake USDCのみを扱う。
+
+Usage:
+    python scripts/fund_test_wallets_base_sepolia.py [--dry-run] [--target-usd 200]
+"""
+
+import argparse
+import logging
+import os
+import sys
+from decimal import Decimal
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent.parent / ".env.staging-v4")
+load_dotenv(Path(__file__).parent.parent / ".env.staging")
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+# scripts/aave_faucet_base.py と同一のfaucetコントラクト・資産定義
+AAVE_FAUCET_BASE_SEPOLIA = "0xD9145b5F45Ad4519c7ACcD6E0A4A82e83bB8A6Dc"
+USDC_ADDRESS = "0xba50cd2a20f6da35d788639e581bca8d0b5d4d5f"
+USDC_DECIMALS = 6
+
+_FAUCET_ABI = [
+    {
+        "inputs": [
+            {"internalType": "address", "name": "token", "type": "address"},
+            {"internalType": "address", "name": "to", "type": "address"},
+            {"internalType": "uint256", "name": "amount", "type": "uint256"},
+        ],
+        "name": "mint",
+        "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+]
+
+_ERC20_ABI = [
+    {
+        "inputs": [{"internalType": "address", "name": "account", "type": "address"}],
+        "name": "balanceOf",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+]
+
+
+def mask_address(addr: str) -> str:
+    """アドレスを先頭6文字+末尾4文字にマスクしてログ出力する。"""
+    if len(addr) < 10:
+        return addr
+    return f"{addr[:6]}...{addr[-4:]}"
+
+
+def fetch_target_wallets() -> list[tuple[int, str, str]]:
+    """DB から role=viewer かつ smart_wallet_address 設定済のユーザーを取得する。
+
+    :returns: [(user_id, email, smart_wallet_address), ...]
+    """
+    from sqlalchemy import text  # noqa: PLC0415
+
+    from app.database import SessionLocal  # noqa: PLC0415
+
+    db = SessionLocal()
+    try:
+        rows = db.execute(
+            text(
+                "SELECT id, email, smart_wallet_address FROM users "
+                "WHERE role = 'viewer' AND smart_wallet_address IS NOT NULL "
+                "ORDER BY id"
+            )
+        ).all()
+        return [(r[0], r[1], r[2]) for r in rows]
+    finally:
+        db.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="staging-v4 テストウォレットへ Base Sepolia テストネットUSDCを補充"
+    )
+    parser.add_argument("--dry-run", action="store_true", help="送金せず対象と金額のみ表示")
+    parser.add_argument(
+        "--target-usd", type=str, default="200", help="補充先の目標USDC残高 (default: 200)"
+    )
+    args = parser.parse_args()
+
+    if os.getenv("APP_ENV", "").strip().lower() == "production":
+        logger.error("APP_ENV=production では実行不可(本スクリプトはstaging専用)")
+        sys.exit(1)
+
+    try:
+        from web3 import Web3
+        from eth_account import Account
+    except ImportError as exc:
+        logger.error("Missing dependency: %s", exc)
+        sys.exit(1)
+
+    rpc_url = os.environ.get("ALCHEMY_RPC_URL_BASE_SEPOLIA") or os.environ.get(
+        "AAVE_RPC_URL_BASE_SEPOLIA", ""
+    )
+    private_key = os.environ.get("AAVE_WALLET_PRIVATE_KEY", "") or os.environ.get(
+        "AAVE_PRIVATE_KEY", ""
+    )
+    operator_address = os.environ.get("AAVE_WALLET_ADDRESS", "")
+
+    for name, val in [
+        ("ALCHEMY_RPC_URL_BASE_SEPOLIA / AAVE_RPC_URL_BASE_SEPOLIA", rpc_url),
+        ("AAVE_WALLET_PRIVATE_KEY / AAVE_PRIVATE_KEY", private_key),
+        ("AAVE_WALLET_ADDRESS", operator_address),
+    ]:
+        if not val:
+            logger.error("Missing env var: %s", name)
+            sys.exit(1)
+
+    w3 = Web3(Web3.HTTPProvider(rpc_url))
+    if not w3.is_connected():
+        logger.error("Cannot connect to Base Sepolia RPC")
+        sys.exit(1)
+
+    account = Account.from_key(private_key)
+    operator_checksum = Web3.to_checksum_address(operator_address)
+    target_usd = Decimal(args.target_usd)
+
+    usdc = w3.eth.contract(address=Web3.to_checksum_address(USDC_ADDRESS), abi=_ERC20_ABI)
+    faucet = w3.eth.contract(
+        address=Web3.to_checksum_address(AAVE_FAUCET_BASE_SEPOLIA), abi=_FAUCET_ABI
+    )
+
+    wallets = fetch_target_wallets()
+    logger.info("対象ウォレット: %d件", len(wallets))
+
+    nonce = w3.eth.get_transaction_count(operator_checksum)
+
+    for user_id, email, wallet_address in wallets:
+        checksum_addr = Web3.to_checksum_address(wallet_address)
+        balance_raw = usdc.functions.balanceOf(checksum_addr).call()
+        balance = Decimal(balance_raw) / Decimal(10**USDC_DECIMALS)
+
+        if balance >= target_usd:
+            logger.info(
+                "user_id=%d %s: 残高 %s USDC >= 目標 %s USDC → スキップ",
+                user_id,
+                mask_address(checksum_addr),
+                balance,
+                target_usd,
+            )
+            continue
+
+        top_up = target_usd - balance
+        amount_raw = int(top_up * Decimal(10**USDC_DECIMALS))
+
+        logger.info(
+            "user_id=%d (%s) %s: 残高 %s USDC → +%s USDC 補充",
+            user_id,
+            email,
+            mask_address(checksum_addr),
+            balance,
+            top_up,
+        )
+
+        if args.dry_run:
+            logger.info("[DRY RUN] 送金しません")
+            continue
+
+        tx = faucet.functions.mint(
+            Web3.to_checksum_address(USDC_ADDRESS),
+            checksum_addr,
+            amount_raw,
+        ).build_transaction(
+            {
+                "from": operator_checksum,
+                "nonce": nonce,
+                "gas": 200000,
+                "gasPrice": w3.eth.gas_price,
+            }
+        )
+        signed_tx = w3.eth.account.sign_transaction(tx, private_key=account.key)
+        tx_hash = w3.eth.send_raw_transaction(signed_tx.raw_transaction)
+        logger.info("Tx送信: 0x%s", tx_hash.hex())
+        receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=120)
+        status = "SUCCESS" if receipt["status"] == 1 else "FAILED"
+        logger.info("Tx結果: %s (block=%s)", status, receipt["blockNumber"])
+        if receipt["status"] != 1:
+            logger.error("Mint失敗 user_id=%d — nonceは進めず次のウォレットへ", user_id)
+            continue
+        nonce += 1
+
+    logger.info("完了")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- 2026-07-25 UAT報告「取引履歴が空/USDC・ETHが消えている」を実機診断した結果、staging-v4は環境全体で一度もproposalが`executed`に到達したことがないと判明。真因=`fund_allocations`(AI提案サイジング用の仮想枠)は自動割当されるが、実際のオンチェーン残高は$0のままで$200最低入金ゲート(`DepositBelowMinimumError`)に必ずブロックされる。
- `_fund_tester_onchain_usdc_if_enabled()` を `auto_fund_tester_if_enabled()` (`/terms/accept` `/terms-agree` 両経路から呼ばれる既存フック) に追加。`AUTO_FUND_TESTER_ONCHAIN_USDC` 設定時、テスターのスマートウォレットへBase SepoliaテストネットUSDCを目標額まで補充する(冪等・fail-open・`APP_ENV=production`常時無効)。
- `scripts/fund_test_wallets_base_sepolia.py`: 既存テストウォレット向け一括バックフィルスクリプト。staging-v4の既存4ウォレット(user_id 3/12/13/14)へ$200まで補充済み(実行済み・テストネットのfake USDCのみ、実資金移動なし)。

## Test plan
- [x] `ruff check` / `ruff format --check` pass (allocation_service.py)
- [x] `mypy` 新規エラーなし(既存stripe stub警告のみ、無関係)
- [x] `pytest tests/test_auth_auto_fund_tester.py tests/test_user_settings_api.py` 38 passed(既存回帰なし、新規env var未設定時は即return)
- [x] staging-v4実機: 4ウォレット(0xb332.../0x5D77.../0xE715.../0x8f64...)全て$200まで補充完了確認済み(dry-run再実行でスキップ表示)
- [ ] `AUTO_FUND_TESTER_ONCHAIN_USDC=200` を `.env.staging-v4` に設定 + backend再デプロイ(このPRマージ後、新規テスターへの自動反映を有効化する場合に実施)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqGFTzJLMHbxLYpJQXH5nt