### PR TITLE
feat(automation): 委譲枠欠如・連続期限切れの検知通知 + 提案期限168h (PR1 可観測性)

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -34,6 +34,7 @@ from app.knowledge.schemas import KnowledgeSearchRequest
 from app.knowledge.service import KnowledgeService
 from app.proposals.models import Proposal
 from app.users.deposit_policy import MIN_DEPOSIT_USD
+from app.users.models import get_active_grant
 
 # ティア別デフォルト判定間隔（時間）
 _DEFAULT_INTERVAL_UPPER = 4
@@ -67,7 +68,13 @@ def get_scheduler_status() -> "dict[str, Any]":
 
 _DEFAULT_QUERY = "DeFi market analysis"
 _PROPOSAL_ASSET = "USDC"
-_PROPOSAL_EXPIRES_HOURS = 72
+# 2026-08-04 PR1: 72 → 168 (1週間)。到達経路(通知)が無い現状で 72h は短すぎる。
+# SUPPLY は安全利回りのため1週間でも陳腐化しない (docs/internal/2026-08-04_execution_pipeline_requirements.md)。
+_PROPOSAL_EXPIRES_HOURS = 168
+
+# 可観測性 (2026-08-04 PR1): 直近 N 件の提案が連続して 'canceled'(=期限切れ) の場合に
+# 運営へアラートする閾値。無限に作り直し続けている状態を検知するためのもの。
+_CONSECUTIVE_EXPIRY_ALERT_THRESHOLD = 3
 
 # 提案金額: fund_allocations.allocated_amount_usd × _PROPOSAL_RATIO で動的計算。
 # fund_allocation 不在の非カストディアル消費者は本人 wallet の USDC 残高 × ratio に
@@ -197,6 +204,79 @@ def _notify_missing_allocation(user_id: int) -> None:
         get_notification_service().send(msg)
     except Exception as exc:  # noqa: BLE001
         logger.warning("_notify_missing_allocation failed for user_id=%d: %s", user_id, exc)
+
+
+def _notify_missing_delegation_grant(user_id: int) -> None:
+    """AUTO_EXECUTE ユーザーが有効な委譲grantを持たない不変条件違反を Slack 通知する (best-effort)。
+
+    2026-08-04 PR1: 「完全おまかせ」表示のユーザーが、実際には実行権限(delegation_grant)を
+    持たない乖離 (docs/internal/2026-08-04_usdt_switch_assessment_and_priorities.md クラスタA)
+    を検知と同時に通知する。検知のみで安全側への降格は行わない (降格は PR6)。
+    """
+    try:
+        from app.notifications.factory import get_notification_service  # noqa: PLC0415
+        from app.notifications.templates import operational_alert_notification  # noqa: PLC0415
+
+        msg = operational_alert_notification(
+            title="⚠️ 完全おまかせユーザーに有効な委譲枠がありません",
+            body=(
+                f"user_id={user_id} は execution_policy=AUTO_EXECUTE ですが、"
+                "有効な delegation_grant がありません。提案は自動実行されず pending のまま "
+                "手動フローに委ねられます。"
+            ),
+        )
+        get_notification_service().send(msg)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("_notify_missing_delegation_grant failed for user_id=%d: %s", user_id, exc)
+
+
+def _notify_consecutive_expiry(user_id: int, consecutive_count: int) -> None:
+    """同一ユーザーの提案が連続して期限切れ(canceled)になっている状態を Slack 通知する (best-effort)。
+
+    2026-08-04 PR1: 到達経路(通知)が無いために提案が誰にも見られず、3日サイクルで
+    無限に作り直され続けていた状態 (25日間・16件・実行0件) の再発検知。
+    """
+    try:
+        from app.notifications.factory import get_notification_service  # noqa: PLC0415
+        from app.notifications.templates import operational_alert_notification  # noqa: PLC0415
+
+        msg = operational_alert_notification(
+            title="⏰ 提案が連続して期限切れになっています",
+            body=(
+                f"user_id={user_id} の提案が直近 {consecutive_count} 件連続で "
+                "期限切れ(canceled)になっています。到達経路(通知)を確認してください。"
+            ),
+        )
+        get_notification_service().send(msg)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("_notify_consecutive_expiry failed for user_id=%d: %s", user_id, exc)
+
+
+def _check_observability_invariants(db: Session, user: User) -> None:
+    """AUTO_EXECUTE の委譲枠欠如 / 連続期限切れを検知し Slack 通知する。
+
+    2026-08-04 PR1: 「直ったか」を判定する手段。検知と通知のみを行い、提案生成の
+    可否や既存の提案生成ロジックには一切影響しない (fail-open・読み取り専用)。
+    ``_create_proposals_for_users`` と ``_create_safe_yield_proposals_for_users`` の
+    既存のユーザーループ内から、tier間隔 (``_is_user_due_for_judgment``) に関わらず
+    毎 tick 呼び出すこと。
+    """
+    if (
+        user.execution_policy == ExecutionPolicy.AUTO_EXECUTE.value
+        and get_active_grant(user.id, db) is None
+    ):
+        _notify_missing_delegation_grant(user.id)
+
+    recent = db.scalars(
+        select(Proposal)
+        .where(Proposal.user_id == user.id)
+        .order_by(Proposal.created_at.desc())
+        .limit(_CONSECUTIVE_EXPIRY_ALERT_THRESHOLD)
+    ).all()
+    if len(recent) >= _CONSECUTIVE_EXPIRY_ALERT_THRESHOLD and all(
+        p.status == "canceled" for p in recent
+    ):
+        _notify_consecutive_expiry(user.id, len(recent))
 
 
 def save_ai_decision(
@@ -620,6 +700,10 @@ def _create_proposals_for_users(
             # され、先行ユーザーの proposal は維持される。素朴な db.rollback() は単一 commit
             # 設計下で全 user 分を破棄するため不可。最終 commit は呼び出し側で 1 回行う。
             with db.begin_nested():
+                # 可観測性 (2026-08-04 PR1): tier間隔 (due-gate) に関わらず毎 tick 検知する。
+                # 提案生成の可否には影響しない (検知と通知のみ)。
+                _check_observability_invariants(db, user)
+
                 if not _is_user_due_for_judgment(user, now):
                     logger.debug(
                         "Skipping proposal for user %d (tier=%s, last_judgment_at=%s)",
@@ -823,6 +907,10 @@ def _create_safe_yield_proposals_for_users(
     for user in active_users:
         try:
             with db.begin_nested():
+                # 可観測性 (2026-08-04 PR1): tier間隔 (due-gate) に関わらず毎 tick 検知する。
+                # 提案生成の可否には影響しない (検知と通知のみ)。
+                _check_observability_invariants(db, user)
+
                 if not _is_user_due_for_judgment(user, now):
                     continue
 

--- a/backend/app/notifications/templates.py
+++ b/backend/app/notifications/templates.py
@@ -51,7 +51,12 @@ def _build_web_push_payload(title: str, body: str, severity: str) -> dict[str, A
     }
 
 
-def _build_notification_message(title: str, body: str, severity: str) -> NotificationMessage:
+def _build_notification_message(
+    title: str,
+    body: str,
+    severity: str,
+    channel: NotificationChannel = NotificationChannel.LINE,
+) -> NotificationMessage:
     """NotificationMessage を構築する。"""
     severity_map: dict[str, NotificationSeverity] = {
         "emergency": NotificationSeverity.EMERGENCY,
@@ -60,7 +65,7 @@ def _build_notification_message(title: str, body: str, severity: str) -> Notific
         "info": NotificationSeverity.INFO,
     }
     return NotificationMessage(
-        channel=NotificationChannel.LINE,
+        channel=channel,
         severity=severity_map.get(severity, NotificationSeverity.INFO),
         title=title,
         body=body,
@@ -314,6 +319,21 @@ def monthly_report(metrics: dict[str, Decimal | str | int]) -> NotificationPaylo
         f"勝率: {win_rate:.1f}% ({total_trades}回)"
     )
     return _build_payload(title, body, "info")
+
+
+# --- 運営向けアラート ---
+
+
+def operational_alert_notification(title: str, body: str) -> NotificationMessage:
+    """運営(Slack)向け運用アラート通知。
+
+    ユーザー向け通知ではないため NotificationMessage.user_id は設定しない
+    （呼び出し側で必要なら user_id を text で body に含める）。
+
+    配線先: automation/ai_judgment_scheduler.py の不変条件検査・連続期限切れ検知、
+    proposals/auto_execute.py の委譲枠欠如・実行スキップ通知。
+    """
+    return _build_notification_message(title, body, "alert", channel=NotificationChannel.SLACK)
 
 
 def oracle_alert(deviation_pct: Decimal) -> NotificationPayload:

--- a/backend/app/proposals/auto_execute.py
+++ b/backend/app/proposals/auto_execute.py
@@ -97,6 +97,17 @@ def run_auto_execution_for_ai_decision(db: Session, ai_decision_id: int) -> dict
                     proposal.operation,
                 )
                 auto_execute_skipped += 1
+                # 可観測性 (2026-08-04 PR1): 既に検知はしていた分岐に通知を足すだけ。
+                # 握り潰しをやめる — この分岐は AUTO_EXECUTE ユーザーの委譲枠欠如の
+                # 一次検出点でもある (ai_judgment_scheduler._check_observability_invariants
+                # と役割が重複するが、こちらは「実際に実行タイミングでスキップされた」
+                # 事実そのものを通知する)。
+                _notify_auto_execution_issue(
+                    proposal.id,
+                    f"no active delegation grant or ineligible route "
+                    f"(user_id={proposal.user_id}, operation={proposal.operation}) "
+                    "— proposal remains pending",
+                )
                 continue
 
             try:

--- a/backend/tests/automation/test_observability_invariants.py
+++ b/backend/tests/automation/test_observability_invariants.py
@@ -1,0 +1,238 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/automation/test_observability_invariants.py
+"""_check_observability_invariants の単体テスト（2026-08-04 PR1: 可観測性の確立）。
+
+25日間、委譲枠欠如も通知の失敗も警告ログに残るだけで誰にも気づかれなかった
+(docs/internal/2026-08-04_usdt_switch_assessment_and_priorities.md)。本テストは
+「検知した時点で必ず運営(Slack)へ通知される」ことと、既存の提案生成ロジックへ
+副作用が無いことを検証する。
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-observability-invariants")
+
+from app.auth.models import User  # noqa: E402
+from app.automation.ai_judgment_scheduler import (  # noqa: E402
+    _PROPOSAL_EXPIRES_HOURS,
+    _check_observability_invariants,
+)
+from app.database import Base  # noqa: E402
+from app.proposals.models import Proposal  # noqa: E402
+from app.users.models import DelegationGrant  # noqa: E402
+
+
+def _wallet_for(uid: int) -> str:
+    return "0x" + f"{uid:040x}"
+
+
+@pytest.fixture()
+def db_session() -> Generator[Session, None, None]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestSession()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        os.unlink(path)
+
+
+def _make_user(db: Session, uid: int, execution_policy: str = "auto_execute") -> User:
+    user = User(
+        id=uid,
+        email=f"obsinv{uid}@test.com",
+        username=f"obsinv{uid}",
+        hashed_password="x",
+        role="viewer",
+        is_active=True,
+        wallet_address=_wallet_for(uid),
+        execution_policy=execution_policy,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _make_grant(db: Session, user_id: int, **overrides: object) -> DelegationGrant:
+    now = datetime.now(timezone.utc)
+    defaults: dict[str, object] = dict(
+        user_id=user_id,
+        wallet_address="0xSCW",
+        status="active",
+        max_single_trade_pct=Decimal("10"),
+        max_daily_trade_pct=Decimal("30"),
+        hf_floor=Decimal("1.6"),
+        allowed_protocols=["aave"],
+        allowed_assets=["USDC"],
+        privy_signer_id="s1",
+        privy_policy_id="p1",
+        consent_at=now,
+        expires_at=now + timedelta(days=30),
+    )
+    defaults.update(overrides)
+    grant = DelegationGrant(**defaults)
+    db.add(grant)
+    db.flush()
+    return grant
+
+
+def _make_proposal(db: Session, user_id: int, status: str, created_at: datetime) -> Proposal:
+    proposal = Proposal(
+        user_id=user_id,
+        operation="SUPPLY",
+        asset="USDC",
+        protocol="aave",
+        amount=Decimal("100"),
+        amount_usd=Decimal("100.00"),
+        reason="obs invariant test",
+        status=status,
+        expires_at=created_at + timedelta(hours=_PROPOSAL_EXPIRES_HOURS),
+        created_at=created_at,
+    )
+    db.add(proposal)
+    db.flush()
+    return proposal
+
+
+def _sent_messages(db: Session, user: User) -> list[object]:
+    sent: list[object] = []
+    with patch(
+        "app.notifications.factory.get_notification_service",
+        return_value=type("Svc", (), {"send": lambda self, msg: sent.append(msg)})(),
+    ):
+        _check_observability_invariants(db, user)
+    return sent
+
+
+def test_proposal_expires_hours_is_168() -> None:
+    """72h → 168h(1週間) への変更 (到達経路が無い現状での短すぎる期限を是正)。"""
+    assert _PROPOSAL_EXPIRES_HOURS == 168
+
+
+class TestMissingDelegationGrant:
+    def test_auto_execute_with_active_grant_no_notification(self, db_session: Session) -> None:
+        user = _make_user(db_session, uid=101, execution_policy="auto_execute")
+        _make_grant(db_session, user.id)
+        db_session.commit()
+
+        assert _sent_messages(db_session, user) == []
+
+    def test_auto_execute_without_grant_notifies_once(self, db_session: Session) -> None:
+        user = _make_user(db_session, uid=102, execution_policy="auto_execute")
+        db_session.commit()
+
+        sent = _sent_messages(db_session, user)
+        assert len(sent) == 1
+        assert sent[0].channel.value == "slack"
+        assert str(user.id) in sent[0].body
+
+    def test_auto_execute_with_expired_grant_notifies_once(self, db_session: Session) -> None:
+        """status='active' のまま expires_at が過去 (遅延 expire) でも実時刻で再判定して検知する。"""
+        user = _make_user(db_session, uid=103, execution_policy="auto_execute")
+        _make_grant(
+            db_session,
+            user.id,
+            expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+        )
+        db_session.commit()
+
+        sent = _sent_messages(db_session, user)
+        assert len(sent) == 1
+
+    def test_auto_execute_grant_expires_soon_no_notification(self, db_session: Session) -> None:
+        """境界値: expires_at が僅かに未来 (1秒後) ならまだ有効 → 通知なし。"""
+        user = _make_user(db_session, uid=104, execution_policy="auto_execute")
+        _make_grant(
+            db_session,
+            user.id,
+            expires_at=datetime.now(timezone.utc) + timedelta(seconds=5),
+        )
+        db_session.commit()
+
+        assert _sent_messages(db_session, user) == []
+
+    def test_require_approval_user_not_checked(self, db_session: Session) -> None:
+        """REQUIRE_APPROVAL ユーザーは委譲grant不変条件の対象外 (grantなしでも通知なし)。"""
+        user = _make_user(db_session, uid=105, execution_policy="require_approval")
+        db_session.commit()
+
+        assert _sent_messages(db_session, user) == []
+
+
+class TestConsecutiveExpiry:
+    def _make_canceled_chain(
+        self, db: Session, user: User, count: int, *, non_canceled_first: bool = False
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        for i in range(count):
+            status = "canceled"
+            if non_canceled_first and i == 0:
+                status = "pending"
+            _make_proposal(db, user.id, status, now - timedelta(days=count - i))
+
+    def test_two_consecutive_canceled_no_notification(self, db_session: Session) -> None:
+        user = _make_user(db_session, uid=201, execution_policy="require_approval")
+        self._make_canceled_chain(db_session, user, 2)
+        db_session.commit()
+
+        assert _sent_messages(db_session, user) == []
+
+    def test_three_consecutive_canceled_notifies_once(self, db_session: Session) -> None:
+        user = _make_user(db_session, uid=202, execution_policy="require_approval")
+        self._make_canceled_chain(db_session, user, 3)
+        db_session.commit()
+
+        sent = _sent_messages(db_session, user)
+        assert len(sent) == 1
+        assert "3" in sent[0].body
+
+    def test_four_consecutive_canceled_notifies_once(self, db_session: Session) -> None:
+        user = _make_user(db_session, uid=203, execution_policy="require_approval")
+        self._make_canceled_chain(db_session, user, 4)
+        db_session.commit()
+
+        sent = _sent_messages(db_session, user)
+        assert len(sent) == 1
+
+    def test_non_canceled_most_recent_breaks_streak(self, db_session: Session) -> None:
+        """直近3件のうち1件でも canceled でなければ (=承認/実行された) 通知しない。"""
+        user = _make_user(db_session, uid=204, execution_policy="require_approval")
+        now = datetime.now(timezone.utc)
+        _make_proposal(db_session, user.id, "canceled", now - timedelta(days=3))
+        _make_proposal(db_session, user.id, "canceled", now - timedelta(days=2))
+        _make_proposal(db_session, user.id, "executed", now - timedelta(days=1))
+        db_session.commit()
+
+        assert _sent_messages(db_session, user) == []
+
+
+def test_no_side_effect_on_proposal_or_grant_rows(db_session: Session) -> None:
+    """検知と通知のみ: 呼び出しが Proposal/DelegationGrant のどの行も書き換えない。"""
+    user = _make_user(db_session, uid=301, execution_policy="auto_execute")
+    now = datetime.now(timezone.utc)
+    _make_proposal(db_session, user.id, "canceled", now - timedelta(days=3))
+    _make_proposal(db_session, user.id, "canceled", now - timedelta(days=2))
+    _make_proposal(db_session, user.id, "canceled", now - timedelta(days=1))
+    db_session.commit()
+
+    _check_observability_invariants(db_session, user)
+
+    proposals = db_session.query(Proposal).filter(Proposal.user_id == user.id).all()
+    assert all(p.status == "canceled" for p in proposals)
+    assert db_session.query(DelegationGrant).filter(DelegationGrant.user_id == user.id).count() == 0

--- a/backend/tests/automation/test_safe_yield_on_hold.py
+++ b/backend/tests/automation/test_safe_yield_on_hold.py
@@ -36,8 +36,9 @@ def _mk_db(users: list, pending: int = 0) -> MagicMock:
     active_res.all.return_value = users
     stale_res = MagicMock()
     stale_res.all.return_value = []
-    # scalars: 1回目=active users、以降(各userのstale)=空
-    db.scalars.side_effect = [active_res] + [stale_res for _ in users]
+    # scalars: 1回目=active users、以降 各userにつき2回
+    # (1: 可観測性チェックの直近3件クエリ / 2: stale expire クエリ)=空
+    db.scalars.side_effect = [active_res] + [stale_res for _ in range(len(users) * 2)]
     db.scalar.return_value = pending  # dedup count
     return db
 

--- a/backend/tests/test_auto_execute_trigger.py
+++ b/backend/tests/test_auto_execute_trigger.py
@@ -153,6 +153,31 @@ def test_no_grant_stays_pending_and_is_skipped(db_session: Session, enabled_env:
     assert proposal.status == "pending"
 
 
+def test_no_grant_skip_sends_operational_notification(
+    db_session: Session, enabled_env: None
+) -> None:
+    """委譲grant無しでスキップされた際、運営向けSlack通知(operational_alert)が送られる
+    (2026-08-04 PR1: 可観測性 — 既存の握り潰しに通知を足す)。"""
+    from app.proposals.auto_execute import run_auto_execution_for_ai_decision
+
+    user = _make_user(db_session, uid=7)
+    decision = _make_decision(db_session)
+    _make_proposal(db_session, user.id, decision.id)
+    db_session.commit()
+
+    sent: list[object] = []
+    with patch(
+        "app.notifications.factory.get_notification_service",
+        return_value=type("Svc", (), {"send": lambda self, msg: sent.append(msg)})(),
+    ):
+        result = run_auto_execution_for_ai_decision(db_session, decision.id)
+
+    assert result["auto_execute_skipped"] == 1
+    assert len(sent) == 1
+    assert sent[0].channel.value == "slack"
+    assert str(user.id) in sent[0].body
+
+
 def test_grant_with_supply_executes_via_scw(db_session: Session, enabled_env: None) -> None:
     """SCW 対象(SUPPLY)+有効grant → 委譲経路で即時実行され 'executed' になる。"""
     from app.proposals.auto_execute import run_auto_execution_for_ai_decision


### PR DESCRIPTION
## Summary
- 25日間、安全利回り提案は3日サイクルで正しく生成されていたが一度も実行されなかった。fail-open 設計自体は正しいが、握り潰しに**通知が伴っていなかった**ため誰も気づけなかった (docs/internal/2026-08-04_usdt_switch_assessment_and_priorities.md)。
- `ai_judgment_scheduler.py` の既存 per-user ループ内 (`_create_proposals_for_users` / `_create_safe_yield_proposals_for_users`) に `_check_observability_invariants()` を追加し、tier間隔に関わらず毎tick、以下を検知して運営(Slack)へ通知する。**検知と通知のみ**で、提案生成ロジックや安全側への降格は行わない(降格は別PRの想定)。
  - AUTO_EXECUTE ユーザーが有効な `delegation_grant` を持たない
  - 同一ユーザーの直近3件の提案が連続して `canceled`(期限切れ)
- `proposals/auto_execute.py` の既に検知はしていたスキップ分岐に、既存の通知ヘルパー呼び出しを1行追加(握り潰しをやめるだけ)。
- `notifications/templates.py` に運営向け Slack アラートの共通関数 `operational_alert_notification()` を追加。
- 提案有効期限を `72h → 168h`(1週間)に変更。到達経路(通知)が無い現状で72hは短すぎ、SUPPLY は安全利回りのため1週間でも陳腐化しない。

## Asana
GID: 1217155476967036 ([PR1] 可観測性の確立 — 委譲枠欠如・連続期限切れの検知と通知 + 提案期限168h)
ハブ: 1217159187013092(【ハブ】実行パイプライン復旧)

## やっていないこと(スコープ外・Asana notes通り)
- `main.py` / `scheduled_tasks.py` は触っていない
- 安全側への自動降格は実装していない(通知経路確立前に降格すると無断の設定変更になるため、別PRで実施)
- `.env.production` 変更・本番デプロイは含まない

## Test plan
- [x] `pytest tests/ -q` — **4847 passed, 26 skipped, 0 failed**(ローカル venv に pytest-cov 未導入のためカバレッジ数値は未計測。CI側の `--cov=app --cov-fail-under=80` で確認要)
- [x] `ruff check .` / `ruff format --check .` — 変更ファイル全て pass
- [x] `mypy app/ --config-file ../pyproject.toml` — 変更ファイルにエラーなし(既存の無関係な stripe stub エラー1件を除く)
- [x] `ruff check . --select S` — 変更ファイルに新規セキュリティ警告なし
- [x] 新規テスト `test_observability_invariants.py`(11ケース: 委譲grant欠如/失効/境界値、連続期限切れ2/3/4件、副作用なし確認、期限168hアサーション)
- [x] 既存 `test_safe_yield_on_hold.py` の mock シーケンス修正(新規クエリ追加に伴う db.scalars() 呼出回数増加への対応)
- [x] 既存 `test_auto_execute_trigger.py` に通知送出の回帰テストを追加
- [ ] **本番実機検証は未実施**(受け入れ条件「委譲枠を持たない auto_execute ユーザーで判定ジョブを実行し、Slack 通知が届く実機ログを貼る」はstaging/production環境が必要なため、マージ後に小林さんによる実機確認が必要)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrEyFux64DYyVhdpkT2tCz