### PR TITLE
fix(liff): CONSENT_ENABLED off時に「完全おまかせ」を選択不可にする (PR2 委譲同意フラグの縮退修正)

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/OpModePanel.tsx
@@ -345,9 +345,16 @@ export function OpModePanel() {
   }
 
   // おまかせは運用方針シートを挟む（既に managed でも方針変更のため開く）。
-  // フラグ off のときは従来どおり Aave 限定でそのまま切替える。
+  // CONSENT_ENABLED off のときは「完全おまかせ」を選択不可にする（2026-08-04 PR2）。
+  // 過去は同意フローをスキップして状態表示だけ変更していたため、委譲grantが
+  // 一度も作られないまま「おまかせ」表示になる乖離が発生していた。正しい縮退は
+  // 「そのモードを選べない」こと（docs/internal/2026-08-04_claude_md_addition_draft.md §3）。
   function handleSelect(newMode: UserMode) {
     if (busy) return
+    if (newMode === "managed" && !CONSENT_ENABLED) {
+      showToast(t("consentNotReady"))
+      return
+    }
     if (SCOPE_SELECTABLE && newMode === "managed") {
       setSheetOpen(true)
       return
@@ -411,20 +418,23 @@ export function OpModePanel() {
         {MODES.map((mode) => {
           const Icon = mode.icon
           const isSelected = currentMode === mode.id
+          // CONSENT_ENABLED off のとき「完全おまかせ」は選択不可（準備中）。
+          const isConsentNotReady = mode.id === "managed" && !CONSENT_ENABLED
+          const isDisabled = busy || isConsentNotReady
           return (
             <button
               key={mode.id}
               type="button"
               data-testid={`opmode-option-${mode.id}`}
               aria-pressed={isSelected}
-              disabled={busy}
+              disabled={isDisabled}
               onClick={() => handleSelect(mode.id)}
               className={[
                 "w-full text-left rounded-2xl border-2 p-4 transition-all",
                 mode.bg,
                 mode.border,
                 isSelected ? "opacity-100" : "opacity-60",
-                busy ? "cursor-not-allowed" : "",
+                isDisabled ? "cursor-not-allowed" : "",
               ].join(" ")}
             >
               <div className="flex items-center gap-3">

--- a/frontend/e2e/liff-chat-opmode.spec.ts
+++ b/frontend/e2e/liff-chat-opmode.spec.ts
@@ -11,6 +11,10 @@
 //      Pro モードは非表示であること。
 //   3. カードをタップすると確認ステップ無しで即 PUT /api/user/settings が
 //      { user_mode } 形で呼ばれ、トースト「『モード名』に切り替えました」が出る。
+//   4. NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED が off (既定) のとき、「完全おまかせ」
+//      カードは表示されるが選択不可 (disabled) であり、タップしても PUT されない
+//      (2026-08-04 PR2: 縮退修正 — フラグ off で同意フローをスキップして状態表示
+//      だけ変更していた不具合の再発防止)。
 //
 // 前提: NEXT_PUBLIC_AGGRESSIVE_TIER_ENABLED / NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED は
 // 未設定（既定 off）。両方 on の環境では「おまかせ」タップで運用方針シート
@@ -58,11 +62,12 @@ async function setupOpModePage(page: Page, initialMode: 'managed' | 'active') {
       })
       return
     }
-    // GET (初回ロード)
+    // GET (初回ロード)。terms_version は useLiffTermsGate (Asana 1215360586206558) が
+    // 参照する重要事項同意ゲート判定用。未設定だと /liff-confirm へリダイレクトされる。
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ user_mode: initialMode }),
+      body: JSON.stringify({ user_mode: initialMode, terms_version: 'liff-v4' }),
     })
   })
 }
@@ -88,8 +93,8 @@ test.describe('LIFF 運用モード切替 (opmode)', () => {
     await setupOpModePage(page, 'managed')
     await openOpModePanel(page)
 
-    // 現在モードカードに「完全おまかせ」が反映される。
-    await expect(page.getByTestId('opmode-current')).toHaveText('完全おまかせ')
+    // 現在モードカードに「おまかせ」が反映される (ja.json Liff.panels.opMode.managedLabel)。
+    await expect(page.getByTestId('opmode-current')).toHaveText('おまかせ')
   })
 
   test('モード選択カードが 2 枚表示され Pro は非表示', async ({ page }) => {
@@ -124,11 +129,25 @@ test.describe('LIFF 運用モード切替 (opmode)', () => {
   })
 
   test('同一モードの再タップでは PUT しない', async ({ page }) => {
-    await setupOpModePage(page, 'managed')
+    // CONSENT_ENABLED off では managed カードが disabled になるため、
+    // active モードでの再タップで同じ回帰意図 (同一モード再タップで PUT しない) を検証する。
+    await setupOpModePage(page, 'active')
     await openOpModePanel(page)
 
-    await page.getByTestId('opmode-option-managed').click()
-    // 既に managed なので PUT は発火しない。
+    await page.getByTestId('opmode-option-active').click()
+    // 既に active なので PUT は発火しない。
+    expect(lastPutMode).toBeNull()
+  })
+
+  test('CONSENT_ENABLED off のとき「完全おまかせ」は選択不可', async ({ page }) => {
+    await setupOpModePage(page, 'active')
+    await openOpModePanel(page)
+
+    // カードは表示されるが disabled (2026-08-04 PR2: 縮退修正)。
+    await expect(page.getByTestId('opmode-option-managed')).toBeVisible()
+    await expect(page.getByTestId('opmode-option-managed')).toBeDisabled()
+
+    // クリックしても PUT が発火しない (disabled のため actionability check で弾かれる)。
     expect(lastPutMode).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
- `NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED` が本番 OFF(既定)のとき、`OpModePanel` の `handleSelect` が何もガードせず `applyMode("managed", "safety")` を呼び、`applyMode` 内の `if (CONSENT_ENABLED && newMode === "managed")` が委譲同意フローを丸ごとスキップして `PUT /api/user/settings` だけが通っていた。委譲(SCW) grant が一度も作られないまま表示だけ「おまかせ」になる乖離が発生し、山本さん(user 11)の自動実行が7回連続72h期限切れになっていた根本原因(docs/internal/2026-08-04_usdt_switch_assessment_and_priorities.md)。
- `handleSelect` の先頭で `CONSENT_ENABLED off + managed 選択` を検知し、既存の i18n キー `consentNotReady` でトースト表示して早期リターン(新規i18nキー追加なし)。
- モード選択カードの `disabled` / `cursor-not-allowed` を `busy || (mode.id === "managed" && !CONSENT_ENABLED)` に拡張し、既存の「準備中」description と実際の非活性状態を一致させる。
- 正しい縮退の順序: フラグを ON にする前に OFF 側の縮退を直す(逆順だと将来 OFF に戻したときに同じ事故が再発する)。

## Asana
GID: 1217155476998343 ([PR2] 委譲同意フラグの縮退修正と本番有効化 — おまかせモードを実際に動かす)
ハブ: 1217159187013092(【ハブ】実行パイプライン復旧)

## やっていないこと(スコープ外・ユーザー確認済み)
- `.env.production` への `NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED=true` 追記は**含まない**
- 本番 frontend 再ビルド・デプロイ(`./scripts/deploy_production.sh --frontend-only`)は**含まない**
  → 下記「マージ後の運用手順」を参照。実行は小林さんが3段階プロトコル(phase1-investigator / phase2-implementer / phase3-deployer)で行う
- I-1(おまかせ⇄アクティブ往復時の重複同意エラー回避)・I-2(consent中断時のロールバック)・I-16(入金前おまかせ選択時の最低入金額明示)は、CONSENT_ENABLED=true の委譲同意フロー自体(`runDelegationConsent` 等、本PRでは無改修)に対する検証であり、E2Eでの再現には `@privy-io/react-auth` の `useSigners`/`useWallets`/`useUser` と `lib/api/delegation` 一式のモック基盤が必要(現行specには無い)。これらの経路は本PRの差分に含まれておらず、既存実装の安全策(重複grant検出・ロールバック)は変更していません

## マージ後の運用手順(小林さん実施)
1. `.env.production` に `printf '\nNEXT_PUBLIC_DELEGATION_CONSENT_ENABLED=true\n' >> .env.production` で追記(sed -i 禁止)
2. `./scripts/deploy_production.sh --frontend-only` で再ビルド・反映(NEXT_PUBLIC_* は build-time 埋め込みのため再ビルド必須)
3. 山本さん(user 11)に liff-chat で「完全おまかせ」を選び直してもらう(既存の `auto_execute` 設定のままでは委譲枠は作られないため、モード変更時にしか同意が走らない)
4. `delegation_grants` に有効行が入ることを実機クエリで確認、提案が pending を経由せず実行されること・tx receipt の `status=1` を確認

## Test plan
- [x] `npx tsc --noEmit` — pass
- [x] `npm run build` — pass
- [x] `npx playwright test e2e/liff-chat-opmode.spec.ts`(`STAGING_URL=http://localhost:3000` + `npm run dev` + `NEXT_PUBLIC_AUTO_MODE_ENABLED=true`)— **5/5 pass**(Desktop Chrome)
- [x] 実ブラウザ(Chromium)でパネルを開き、「完全おまかせ」カードが `disabled` 属性付きで描画されること・Playwrightの実クリックが disabled 判定で拒否されることを確認(スクリーンショット取得済み)
- [x] 既存4テストのうち2件で判明した既存モックの陳腐化を副次的に修正(`terms_version` 未設定によるリダイレクトループ、`managedLabel` 文言変更未追随)。いずれも本PRの差分(handleSelect のガード追加)とは無関係な、後発PRによるテスト陳腐化

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrEyFux64DYyVhdpkT2tCz