### PR TITLE
security(backend): aiohttp を 3.14.3+ にバージョンアップ (CVE-2026-69244)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,9 +13,11 @@ web3>=6.15.1
 eth-account>=0.11.0
 python-dotenv>=1.0.0
 # aiohttp は web3/ccxt 経由の transitive dep。3.14.0 で AsyncStreamReaderMixin が
-# 削除され、vcrpy(<=8.1.1) のテスト記録が壊れる (upstream Issue #995 / PR #996 未リリース)。
-# 上流が対応するまで <3.14 に固定し、CI と prod で同一版を保証する。
-aiohttp<3.14
+# 削除され vcrpy(<=8.1.1) のテスト記録が壊れる問題があったが、tests/conftest.py に
+# 同属性を補うモンキーパッチ済み (aiohttp 3.10+ 全般に対応、2026-07-06 #938 で追加)。
+# CVE-2026-69244 (aiohttp<3.14.3, HIGH) 対応のため 3.14.3 以上に引き上げる。
+# CI の pytest (vcrpy 込み) がこの版で通ることを merge 前提とする。
+aiohttp>=3.14.3
 
 # Authentication & Database (Phase 12)
 sqlalchemy>=2.0.0

--- a/docs/integration/backend_deps.md
+++ b/docs/integration/backend_deps.md
@@ -412,6 +412,20 @@
 
 ## backend/requirements.txt
 
+### 変更 #4: aiohttp を 3.14.3+ に引き上げ（CVE-2026-69244 対応）(PR #1013 / 2026-08-04)
+- **コミット範囲**: `security/bump-aiohttp-cve-2026-69244`
+- **変更内容**: `aiohttp<3.14` → `aiohttp>=3.14.3`
+- **理由**: Trivy の脆弱性DB更新により `aiohttp<3.14.3` に HIGH 脆弱性 CVE-2026-69244 が新規検出され、
+  `main` ブランチ自体を含め Docker image scan が失敗するようになった（特定PRのコード変更が原因ではない）。
+  `<3.14` 固定の理由（変更 #3 参照。aiohttp 3.14.0 で `AsyncStreamReaderMixin` が削除され vcrpy の
+  cassette 再生が壊れる）は、2026-07-06 PR #938 で `backend/tests/conftest.py` に同属性を補う
+  モンキーパッチ（aiohttp 3.10+ 全般に対応する互換シム）が追加済みで解消されていると判断した。
+- **影響範囲**: aiohttp のバージョン制約変更のみ。web3 / ccxt との互換性、および vcrpy 経由のテスト
+  (`test_judge_with_rag_vcr` 等) が実際に通るかは CI の `Test (pytest + coverage)` ジョブ
+  （`requirements-dev.txt` の `vcrpy>=6.0` を含むクリーン環境）での検証を merge の前提とする。
+  ローカル venv への pip install 許可が得られなかったため、事前のローカル実行検証は未実施。
+- **承認**: security/bump-aiohttp-cve-2026-69244 → main の通常フロー経由（PR #1013）
+
 ### 変更 #3: aiohttp<3.14 固定（vcrpy 非互換 / CI green 回復）(PR #529 / 2026-06-04)
 - **コミット範囲**: `a300118` (fix/main-ci-green)
 - **変更内容**: `aiohttp<3.14` を requirements.txt に追加


### PR DESCRIPTION
## Summary
- 本日、Trivy の脆弱性DB更新により `aiohttp<3.14` (既存ピン) に **CVE-2026-69244 (HIGH, 修正版 3.14.3)** が新規検出され、CI の `Trivy Container & Filesystem Scan` (Docker image scan) が失敗するようになった。
- **このPR固有の変更ではない**: `main` ブランチの最新コミット自体も同じ理由で今日から同じチェックが失敗している(PR #1011 / #1012 の作業中に発覚)。既存依存への新規CVE検出であり、特定PRのコード変更が原因ではない。
- `aiohttp<3.14` ピンの理由(3.14.0 で `AsyncStreamReaderMixin` が削除され `vcrpy(<=8.1.1)` のテスト記録が壊れる)は、2026-07-06 PR #938 で `backend/tests/conftest.py` に同属性を補うモンキーパッチが既に追加されており(aiohttp 3.10+ 全般に対応する互換シムとして書かれている)、解消済みと判断した。
- `aiohttp<3.14` → `aiohttp>=3.14.3` に変更。

## 検証について(重要)
ローカル venv への `pip install` 許可が得られなかったため、**aiohttp 3.14.3 を実際にインストールしての事前テストは実施できていません**。CI の `Test (pytest + coverage)` ジョブが `requirements-dev.txt` 込みのクリーンな環境で実際に検証する前提です。**CI が green になることを merge の必須条件としてください。** もし vcrpy 関連のテストが落ちる場合は、コンフリクトの詳細を見て別対応(vcrpy 側のバージョン調整等)が必要になります。

## Test plan
- [x] `git diff backend/requirements.txt` — 差分確認のみ(1行変更)
- [ ] CI `Test (pytest + coverage)` — 要確認(このPRの検証の本体)
- [ ] CI `Trivy Container & Filesystem Scan` — CVE-2026-69244 が解消されること
- [ ] CI `Lint (ruff + mypy)` — 要確認(コード変更なしのため影響なし想定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrEyFux64DYyVhdpkT2tCz