### PR TITLE
security(docker): setuptools更新でvendored wheel/jaraco.contextの脆弱版を解消

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY backend/requirements.txt .
 
 # wheel をビルド（キャッシュ効率化: requirements が変わった時だけ再ビルド）
-RUN pip install --upgrade pip \
+# setuptools も明示的に更新する: 79.0.1 は内部 _vendor/ に wheel==0.45.1 /
+# jaraco.context==5.3.0 の脆弱版を同梱しており、pip 単体の更新では解消しない
+# (CVE-2026-24049 / CVE-2026-23949、2026-08-04 Trivy 検出)。
+RUN pip install --upgrade pip setuptools \
     && pip wheel --no-cache-dir --wheel-dir /wheels -r requirements.txt
 
 # アプリケーションコードをコピー（Cythonビルドのために必要）
@@ -42,7 +45,11 @@ RUN apt-get update && apt-get upgrade -y --no-install-recommends \
 
 # builder の wheel をコピーしてインストール（ネットワーク不要）
 COPY --from=builder /wheels /wheels
-RUN pip install --upgrade pip \
+# setuptools も明示的に更新する: 79.0.1 は内部 _vendor/ に wheel==0.45.1 /
+# jaraco.context==5.3.0 の脆弱版を同梱しており、pip 単体の更新では解消しない
+# (CVE-2026-24049 / CVE-2026-23949、2026-08-04 Trivy 検出)。この最終イメージが
+# スキャン対象のため、ここでの更新が実質的な修正。
+RUN pip install --upgrade pip setuptools \
     && pip install --no-cache-dir --no-index --find-links /wheels /wheels/*.whl \
     && rm -rf /wheels
 


### PR DESCRIPTION
## Summary
- PR #1013（aiohttp CVE-2026-69244修正）マージ直後、Trivyが新たに2件のHIGH脆弱性を検出（main含む全ブランチに影響、コード変更起因ではない）:
  - `CVE-2026-24049`: wheel 0.45.1（修正版 0.46.2+）
  - `CVE-2026-23949`: jaraco.context 5.3.0（修正版 6.1.0）
- 調査の結果、`requirements.txt` の既存 `wheel>=0.46.2` ピンとは無関係で、実体は base image (`python:3.11-slim`) の `setuptools 79.0.1` が自身の `_vendor/` ディレクトリにこれらの旧版を同梱していたことが原因（Trivyはこのvendored dist-infoを独立パッケージとして検出する）。`importlib.metadata` では検出されず、実際は `setuptools/_vendor/wheel-0.45.1.dist-info` 等としてファイルシステム上に存在するのみ。
- Dockerfile の builder / runtime 両ステージの `pip install --upgrade pip` に `setuptools` を追加。runtime ステージ側が最終スキャン対象イメージのため実質的な修正本体。

## 検証（ローカルDocker実ビルドで確認済み）
```
修正前: setuptools 79.0.1 → vendor: wheel-0.45.1, jaraco.context-5.3.0（脆弱版）
修正後: setuptools 83.0.0 → vendor: wheel-0.46.3, jaraco_context-6.1.0（修正版）
```

## Test plan
- [x] `docker build` をローカルで実行し、修正前後で `setuptools/_vendor/` 配下のバージョンを実機確認
- [ ] CI `Trivy Container & Filesystem Scan` — CVE-2026-24049 / CVE-2026-23949 が解消されること
- [ ] CI `Test (pytest + coverage)` — Dockerfile変更のみのためコード影響は想定していないが確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrEyFux64DYyVhdpkT2tCz