### PR TITLE
feat(notifications): Web Push購読をDB永続化しuser_idに紐付け (PR3 到達経路の確立)

### DIFF
--- a/backend/alembic/versions/y6z7a8b9c0d1_add_notification_logs_delivered.py
+++ b/backend/alembic/versions/y6z7a8b9c0d1_add_notification_logs_delivered.py
@@ -1,0 +1,32 @@
+"""add delivered column to notification_logs
+
+「送信した」(行の存在) と「到達した」(この列) を区別するための列追加 (PR3、
+実行パイプライン復旧 GID 1217143339626810)。NULL=対象外/未計測。実際の書き込み配線は
+別PR(PR5)で行う。
+
+Revision ID: y6z7a8b9c0d1
+Revises: x4y5z6a7b8c9
+Create Date: 2026-08-05 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "y6z7a8b9c0d1"
+down_revision: Union[str, Sequence[str], None] = "x4y5z6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "notification_logs",
+        sa.Column("delivered", sa.Boolean(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("notification_logs", "delivered")

--- a/backend/app/notifications/models.py
+++ b/backend/app/notifications/models.py
@@ -16,18 +16,23 @@ partner_id が NULL の通知はシステム全体向けであり、パートナ
         body       TEXT         NOT NULL,
         partner_id INTEGER      REFERENCES users(id) ON DELETE SET NULL,
         user_id    INTEGER      REFERENCES users(id) ON DELETE SET NULL,
-        created_at TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+        created_at TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+        delivered  BOOLEAN      NULL
     );
     CREATE INDEX IF NOT EXISTS ix_notification_logs_partner_id
         ON notification_logs (partner_id);
     CREATE INDEX IF NOT EXISTS ix_notification_logs_created_at
         ON notification_logs (created_at DESC);
+
+delivered 列 (2026-08-04 PR3, Alembic x4y5z6a7b8c9 の次): NULL=対象外/未計測、
+True=配信先に到達確認済み、False=配信失敗(410等)。行の存在自体が「送信した」を表し、
+この列が「到達した」を表す。実際の書き込み配線は PR5 で行う (本PRはスキーマ追加のみ)。
 """
 
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
@@ -46,6 +51,7 @@ class NotificationLog(Base):
         partner_id: 対象パートナーの users.id (nullable: NULLはシステム全体向け)
         user_id: 対象ユーザーの users.id (nullable)
         created_at: 通知生成日時 (UTC)
+        delivered: 配信先への到達確認 (nullable: NULL=対象外/未計測、実書き込みはPR5)
     """
 
     __tablename__ = "notification_logs"
@@ -72,6 +78,11 @@ class NotificationLog(Base):
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
+    )
+    delivered: Mapped[Optional[bool]] = mapped_column(
+        Boolean,
+        nullable=True,
+        default=None,
     )
 
     def __repr__(self) -> str:

--- a/backend/app/notifications/push.py
+++ b/backend/app/notifications/push.py
@@ -11,9 +11,10 @@ import logging
 import os
 import threading
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Callable, Optional, Protocol
 
 from pydantic import BaseModel
+from sqlalchemy.orm import Session
 
 try:
     from pywebpush import WebPushException, webpush  # type: ignore
@@ -36,6 +37,21 @@ class VAPIDConfig:
 
 class WebPushSubscription(BaseModel):
     """Web Push サブスクリプション情報。"""
+
+    endpoint: str
+    p256dh: str
+    auth: str
+    # 2026-08-04 PR3: どのユーザーの購読かを紐付ける。router 側で require_active_user
+    # 経由の current_user.id を必ず設定する。既存 3 フィールドのみの呼び出し (テスト等) との
+    # 後方互換のため Optional のまま維持する。
+    user_id: Optional[int] = None
+
+
+class PushSubscriptionEntry(BaseModel):
+    """users.notification_settings_json の push_subscriptions 配列 1 件分。
+
+    WebPushSubscription から user_id を除いた形 (格納先が既にユーザーに紐づくため不要)。
+    """
 
     endpoint: str
     p256dh: str
@@ -71,10 +87,189 @@ class InMemorySubscriptionStore:
             return len(self._subscriptions)
 
 
+class SubscriptionStore(Protocol):
+    """WebPushSender が要求するストアの構造的インターフェース。
+
+    2026-08-04 PR3: InMemorySubscriptionStore (テスト用) と DatabaseSubscriptionStore
+    (本番用、DB永続化) の両方がこの形を満たす。WebPushSender 自体は変更しない。
+    """
+
+    def add(self, subscription: WebPushSubscription) -> None: ...
+    def remove(self, endpoint: str) -> None: ...
+    def get_all(self) -> list[WebPushSubscription]: ...
+    def count(self) -> int: ...
+
+
+class DatabaseSubscriptionStore:
+    """users.notification_settings_json の push_subscriptions キーに永続化するストア。
+
+    2026-08-04 PR3: InMemorySubscriptionStore はプロセス再起動で全消失し、
+    どのユーザーの購読かも分からなかった (可観測性なき握り潰しの再発パターン)。
+    新規テーブルは作らず、既存の notification_settings_json (TEXT) に
+    ``{"push_subscriptions": [{"endpoint", "p256dh", "auth"}, ...], ...}`` の形で
+    追記する。line_enabled / push_enabled / preferences 等の他キーには一切触れない
+    (raw dict レベルで push_subscriptions キーのみ読み書きする)。
+
+    endpoint はブラウザ (オリジン) 単位でグローバルに一意という前提のため、
+    同一 endpoint が別ユーザーに再登録された場合は元ユーザー側から除去する
+    (同一端末でのログアウト→別アカウントでの再ログイン等、I-5/I-12 相当)。
+    """
+
+    def __init__(self, session_factory: Callable[[], Session]) -> None:
+        self._session_factory = session_factory
+
+    @staticmethod
+    def _read_push_subscriptions(raw_json: Optional[str]) -> list[dict[str, Any]]:
+        if not raw_json:
+            return []
+        try:
+            raw = json.loads(raw_json)
+        except json.JSONDecodeError:
+            return []
+        subs = raw.get("push_subscriptions")
+        return subs if isinstance(subs, list) else []
+
+    @staticmethod
+    def _write_push_subscriptions(raw_json: Optional[str], subs: list[dict[str, Any]]) -> str:
+        try:
+            raw = json.loads(raw_json) if raw_json else {}
+        except json.JSONDecodeError:
+            raw = {}
+        raw["push_subscriptions"] = subs
+        return json.dumps(raw)
+
+    def add(self, subscription: WebPushSubscription) -> None:
+        """サブスクリプションを永続化する。同じ endpoint は (他ユーザー分も含め) 上書きする。"""
+        if subscription.user_id is None:
+            logger.warning(
+                "DatabaseSubscriptionStore.add: user_id が未設定のため保存をスキップしました "
+                "(endpoint=%s)",
+                subscription.endpoint[:30],
+            )
+            return
+
+        from app.auth.models import User  # noqa: PLC0415
+
+        db = self._session_factory()
+        try:
+            # 他ユーザーに同一 endpoint が残っていれば先に除去 (グローバル一意性の維持)。
+            others = (
+                db.query(User)
+                .filter(
+                    User.id != subscription.user_id,
+                    User.notification_settings_json.isnot(None),
+                )
+                .all()
+            )
+            for other in others:
+                subs = self._read_push_subscriptions(other.notification_settings_json)
+                filtered = [s for s in subs if s.get("endpoint") != subscription.endpoint]
+                if len(filtered) != len(subs):
+                    other.notification_settings_json = self._write_push_subscriptions(
+                        other.notification_settings_json, filtered
+                    )
+
+            user = db.get(User, subscription.user_id)
+            if user is None:
+                logger.warning(
+                    "DatabaseSubscriptionStore.add: user_id=%d が見つかりません",
+                    subscription.user_id,
+                )
+                return
+            subs = self._read_push_subscriptions(user.notification_settings_json)
+            subs = [s for s in subs if s.get("endpoint") != subscription.endpoint]
+            subs.append(
+                PushSubscriptionEntry(
+                    endpoint=subscription.endpoint,
+                    p256dh=subscription.p256dh,
+                    auth=subscription.auth,
+                ).model_dump()
+            )
+            user.notification_settings_json = self._write_push_subscriptions(
+                user.notification_settings_json, subs
+            )
+            db.commit()
+        finally:
+            db.close()
+
+    def remove(self, endpoint: str) -> None:
+        """指定 endpoint のサブスクリプションを全ユーザーから削除する。"""
+        from app.auth.models import User  # noqa: PLC0415
+
+        db = self._session_factory()
+        try:
+            users = db.query(User).filter(User.notification_settings_json.isnot(None)).all()
+            for user in users:
+                subs = self._read_push_subscriptions(user.notification_settings_json)
+                filtered = [s for s in subs if s.get("endpoint") != endpoint]
+                if len(filtered) != len(subs):
+                    user.notification_settings_json = self._write_push_subscriptions(
+                        user.notification_settings_json, filtered
+                    )
+            db.commit()
+        finally:
+            db.close()
+
+    def get_all(self) -> list[WebPushSubscription]:
+        """全ユーザーの全サブスクリプションを返す (WebPushSender.send_to_all 用)。"""
+        from app.auth.models import User  # noqa: PLC0415
+
+        db = self._session_factory()
+        try:
+            users = db.query(User).filter(User.notification_settings_json.isnot(None)).all()
+            result: list[WebPushSubscription] = []
+            for user in users:
+                for s in self._read_push_subscriptions(user.notification_settings_json):
+                    try:
+                        result.append(
+                            WebPushSubscription(
+                                endpoint=s["endpoint"],
+                                p256dh=s["p256dh"],
+                                auth=s["auth"],
+                                user_id=user.id,
+                            )
+                        )
+                    except KeyError:
+                        continue
+            return result
+        finally:
+            db.close()
+
+    def get_for_user(self, user_id: int) -> list[WebPushSubscription]:
+        """指定ユーザーのサブスクリプションのみを返す (PR5: per-user 配信で使用予定)。"""
+        from app.auth.models import User  # noqa: PLC0415
+
+        db = self._session_factory()
+        try:
+            user = db.get(User, user_id)
+            if user is None:
+                return []
+            result: list[WebPushSubscription] = []
+            for s in self._read_push_subscriptions(user.notification_settings_json):
+                try:
+                    result.append(
+                        WebPushSubscription(
+                            endpoint=s["endpoint"],
+                            p256dh=s["p256dh"],
+                            auth=s["auth"],
+                            user_id=user_id,
+                        )
+                    )
+                except KeyError:
+                    continue
+            return result
+        finally:
+            db.close()
+
+    def count(self) -> int:
+        """登録済みサブスクリプション総数を返す。"""
+        return len(self.get_all())
+
+
 class WebPushSender:
     """Web Push (VAPID) 通知送信クラス。"""
 
-    def __init__(self, vapid_config: VAPIDConfig, store: InMemorySubscriptionStore) -> None:
+    def __init__(self, vapid_config: VAPIDConfig, store: SubscriptionStore) -> None:
         self._vapid_config = vapid_config
         self._store = store
 

--- a/backend/app/notifications/router.py
+++ b/backend/app/notifications/router.py
@@ -15,11 +15,12 @@ from sqlalchemy.orm import Session
 
 from app.auth.dependencies import require_active_user, require_admin
 from app.auth.models import User
-from app.database import get_db
+from app.database import SessionLocal, get_db
 
 from .line_messaging import LINEFlexMessageSender
 from .push import (
-    InMemorySubscriptionStore,
+    DatabaseSubscriptionStore,
+    SubscriptionStore,
     VAPIDConfig,
     WebPushSender,
     WebPushSubscription,
@@ -32,12 +33,13 @@ router = APIRouter(prefix="/notifications", tags=["notifications"])
 # /api/notifications/* — フロントエンドおよびテストスクリプト向けエイリアス
 api_router = APIRouter(prefix="/api/notifications", tags=["notifications"])
 
-# グローバルな subscription ストア（アプリライフタイムで保持）
-_subscription_store = InMemorySubscriptionStore()
+# グローバルな subscription ストア（DB永続化、2026-08-04 PR3。旧 InMemorySubscriptionStore は
+# backend/tests 側でのみ使用する）
+_subscription_store: SubscriptionStore = DatabaseSubscriptionStore(SessionLocal)
 
 
-def get_subscription_store() -> InMemorySubscriptionStore:
-    """グローバルな InMemorySubscriptionStore を返す。"""
+def get_subscription_store() -> SubscriptionStore:
+    """グローバルな SubscriptionStore を返す。"""
     return _subscription_store
 
 
@@ -90,22 +92,26 @@ class UnsubscribeRequest(BaseModel):
 
 def _do_subscribe(
     req: SubscribeRequest,
-    store: InMemorySubscriptionStore,
+    store: SubscriptionStore,
+    current_user: User,
 ) -> dict[str, Any]:
     subscription = WebPushSubscription(
         endpoint=req.endpoint,
         p256dh=req.p256dh,
         auth=req.auth,
+        user_id=current_user.id,
     )
     store.add(subscription)
-    logger.info("Push subscription 登録: endpoint=%s", req.endpoint[:30])
+    logger.info(
+        "Push subscription 登録: user_id=%d endpoint=%s", current_user.id, req.endpoint[:30]
+    )
     return {"status": "subscribed", "count": store.count()}
 
 
 def _do_test_push(
     title: str,
     body: str,
-    store: InMemorySubscriptionStore,
+    store: SubscriptionStore,
 ) -> dict[str, Any]:
     config: VAPIDConfig | None = get_vapid_config()
     if config is None:
@@ -131,29 +137,32 @@ def _do_test_push(
 @router.post("/push/subscribe", status_code=status.HTTP_200_OK)
 def subscribe(
     req: SubscribeRequest,
-    store: InMemorySubscriptionStore = Depends(get_subscription_store),
+    store: SubscriptionStore = Depends(get_subscription_store),
+    current_user: User = Depends(require_active_user),
 ) -> dict[str, Any]:
-    """Push subscription を登録する。認証不要（Service Worker から呼び出し可能）。"""
-    return _do_subscribe(req, store)
+    """Push subscription を登録する。認証必須（2026-08-04 PR3: user_id 紐付けのため）。"""
+    return _do_subscribe(req, store, current_user)
 
 
 @api_router.post("/subscribe", status_code=status.HTTP_200_OK)
 def api_subscribe(
     req: SubscribeRequest,
-    store: InMemorySubscriptionStore = Depends(get_subscription_store),
+    store: SubscriptionStore = Depends(get_subscription_store),
+    current_user: User = Depends(require_active_user),
 ) -> dict[str, Any]:
-    """Push subscription を登録する（/api/notifications/subscribe エイリアス）。"""
-    return _do_subscribe(req, store)
+    """Push subscription を登録する（/api/notifications/subscribe エイリアス）。認証必須。"""
+    return _do_subscribe(req, store, current_user)
 
 
 @router.delete("/push/unsubscribe", status_code=status.HTTP_200_OK)
 def unsubscribe(
     endpoint: str,
-    store: InMemorySubscriptionStore = Depends(get_subscription_store),
+    store: SubscriptionStore = Depends(get_subscription_store),
+    current_user: User = Depends(require_active_user),
 ) -> dict[str, Any]:
-    """Push subscription を削除する。認証不要。endpoint はクエリパラメータで指定する。"""
+    """Push subscription を削除する。認証必須。endpoint はクエリパラメータで指定する。"""
     store.remove(endpoint)
-    logger.info("Push subscription 削除: endpoint=%s", endpoint[:30])
+    logger.info("Push subscription 削除: user_id=%d endpoint=%s", current_user.id, endpoint[:30])
     return {"status": "unsubscribed", "count": store.count()}
 
 
@@ -168,7 +177,7 @@ def get_vapid_key() -> dict[str, Any]:
 
 def _do_full_test_push(
     req: TestPushRequest,
-    store: InMemorySubscriptionStore,
+    store: SubscriptionStore,
 ) -> dict[str, Any]:
     """Web Push + LINE のテスト通知を送信して結果を返す。"""
     from app.notifications.config import get_notification_settings
@@ -194,7 +203,7 @@ def _do_full_test_push(
 @router.post("/push/test", status_code=status.HTTP_200_OK)
 def send_test_push(
     req: TestPushRequest = TestPushRequest(),
-    store: InMemorySubscriptionStore = Depends(get_subscription_store),
+    store: SubscriptionStore = Depends(get_subscription_store),
     _current_user: User = Depends(require_active_user),
 ) -> dict[str, Any]:
     """テスト通知を送信する。認証必須。"""
@@ -204,7 +213,7 @@ def send_test_push(
 @api_router.post("/push/test", status_code=status.HTTP_200_OK)
 def api_test_push_canonical(
     req: TestPushRequest = TestPushRequest(),
-    store: InMemorySubscriptionStore = Depends(get_subscription_store),
+    store: SubscriptionStore = Depends(get_subscription_store),
     _current_user: User = Depends(require_active_user),
 ) -> dict[str, Any]:
     """テスト通知を送信する（/api/notifications/push/test エイリアス）。
@@ -218,7 +227,7 @@ def api_test_push_canonical(
 @api_router.post("/test-push", status_code=status.HTTP_200_OK)
 def api_test_push(
     req: TestPushRequest = TestPushRequest(),
-    store: InMemorySubscriptionStore = Depends(get_subscription_store),
+    store: SubscriptionStore = Depends(get_subscription_store),
     _current_user: User = Depends(require_active_user),
 ) -> dict[str, Any]:
     """テスト通知を送信する（/api/notifications/test-push 後方互換エイリアス）。認証必須。"""
@@ -227,7 +236,7 @@ def api_test_push(
 
 @router.get("/push/count", status_code=status.HTTP_200_OK)
 def get_subscription_count(
-    store: InMemorySubscriptionStore = Depends(get_subscription_store),
+    store: SubscriptionStore = Depends(get_subscription_store),
     _current_user: User = Depends(require_admin),
 ) -> dict[str, Any]:
     """登録済み subscription 数を返す。管理者のみ。"""
@@ -276,8 +285,26 @@ def _do_update_notification_settings(
     current_user: User,
     db: Session,
 ) -> dict[str, Any]:
-    """通知設定を保存して返す。"""
-    current_user.notification_settings_json = body.model_dump_json()
+    """通知設定を保存して返す。
+
+    2026-08-04 PR3: push_subscriptions (DatabaseSubscriptionStore が同じ列に書く) を
+    この汎用設定更新で消さないよう、既存の raw JSON から読み出して引き継ぐ。
+    push_subscriptions は専用の /push/subscribe, /push/unsubscribe 経由でのみ変更される
+    べきで、NotificationSettingsModel のフィールドには含めない
+    (含めると PUT の度にクライアントが送らなかった分が空配列で上書きされ、
+    購読が黙って消える — 本件と同型の「表示と実行能力が分離される」バグになる)。
+    """
+    existing_push_subscriptions: list[Any] = []
+    if current_user.notification_settings_json:
+        try:
+            existing_raw = json.loads(current_user.notification_settings_json)
+            existing_push_subscriptions = existing_raw.get("push_subscriptions", [])
+        except json.JSONDecodeError:
+            pass
+
+    new_raw = body.model_dump()
+    new_raw["push_subscriptions"] = existing_push_subscriptions
+    current_user.notification_settings_json = json.dumps(new_raw)
     db.add(current_user)
     db.commit()
     return body.model_dump()  # DB に書き込んだ値をそのまま返す; refresh 不要

--- a/backend/tests/notifications/test_push_subscription_store.py
+++ b/backend/tests/notifications/test_push_subscription_store.py
@@ -1,0 +1,294 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/notifications/test_push_subscription_store.py
+"""DatabaseSubscriptionStore の単体テスト（2026-08-04 PR3: Web Push購読の永続化）。
+
+InMemorySubscriptionStore は「メモリ保持・ユーザー未紐付け・認証なし」で、
+再起動で全消失し誰の購読か分からなかった
+(docs/internal/2026-08-04_execution_pipeline_requirements.md)。
+本テストは DB 永続化・user_id 紐付け・複数ユーザー分離・
+汎用設定PUTによる意図しない消失が起きないことを検証する。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from typing import Generator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-push-subscription-store")
+
+from app.auth.models import User  # noqa: E402
+from app.database import Base  # noqa: E402
+from app.notifications.push import DatabaseSubscriptionStore, WebPushSubscription  # noqa: E402
+
+
+def _wallet_for(uid: int) -> str:
+    return "0x" + f"{uid:040x}"
+
+
+@pytest.fixture()
+def _db_env() -> Generator[tuple[Session, "sessionmaker[Session]"], None, None]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestSessionLocal()
+    try:
+        yield db, TestSessionLocal
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        os.unlink(path)
+
+
+@pytest.fixture()
+def db_session(_db_env: tuple[Session, "sessionmaker[Session]"]) -> Session:
+    """テストのセットアップ・アサーション専用セッション。"""
+    return _db_env[0]
+
+
+@pytest.fixture()
+def session_factory(_db_env: tuple[Session, "sessionmaker[Session]"]):
+    """呼ぶたびに新しい Session を返す (本番の SessionLocal と同じ挙動)。
+
+    DatabaseSubscriptionStore は各操作の最後に db.close() する。db_session と
+    同一オブジェクトを返すと commit/close で expire・detach され、以降の
+    db_session 経由のアサーションが DetachedInstanceError になるため、
+    同じ sqlite ファイルを指す別セッションを毎回払い出す。
+    """
+    _, TestSessionLocal = _db_env
+    return TestSessionLocal
+
+
+def _make_user(db: Session, uid: int, notification_settings_json: str | None = None) -> User:
+    user = User(
+        id=uid,
+        email=f"pushstore{uid}@test.com",
+        username=f"pushstore{uid}",
+        hashed_password="x",
+        role="viewer",
+        is_active=True,
+        wallet_address=_wallet_for(uid),
+        notification_settings_json=notification_settings_json,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+class TestAddAndPersist:
+    def test_add_persists_and_is_tied_to_user(self, db_session: Session, session_factory) -> None:
+        user = _make_user(db_session, 401)
+        db_session.commit()
+        store = DatabaseSubscriptionStore(session_factory)
+
+        store.add(
+            WebPushSubscription(
+                endpoint="https://push.example.com/ep1", p256dh="k1", auth="a1", user_id=user.id
+            )
+        )
+
+        db_session.refresh(user)
+        raw = json.loads(user.notification_settings_json)
+        assert raw["push_subscriptions"] == [
+            {"endpoint": "https://push.example.com/ep1", "p256dh": "k1", "auth": "a1"}
+        ]
+
+    def test_add_without_user_id_is_noop(self, db_session: Session, session_factory) -> None:
+        store = DatabaseSubscriptionStore(session_factory)
+        store.add(
+            WebPushSubscription(endpoint="https://push.example.com/ep2", p256dh="k", auth="a")
+        )
+        assert store.count() == 0
+
+    def test_add_preserves_other_settings_keys(self, db_session: Session, session_factory) -> None:
+        """push_subscriptions 以外の既存キー (line_enabled 等) を壊さないこと。"""
+        existing = json.dumps({"line_enabled": False, "push_enabled": True, "preferences": {}})
+        user = _make_user(db_session, 402, notification_settings_json=existing)
+        db_session.commit()
+        store = DatabaseSubscriptionStore(session_factory)
+
+        store.add(
+            WebPushSubscription(
+                endpoint="https://push.example.com/ep3", p256dh="k", auth="a", user_id=user.id
+            )
+        )
+
+        db_session.refresh(user)
+        raw = json.loads(user.notification_settings_json)
+        assert raw["line_enabled"] is False
+        assert raw["push_enabled"] is True
+        assert len(raw["push_subscriptions"]) == 1
+
+    def test_add_same_endpoint_removes_from_other_user(
+        self, db_session: Session, session_factory
+    ) -> None:
+        """同一端末での再ログイン等 (I-5/I-12): endpoint はグローバル一意。"""
+        user_a = _make_user(db_session, 403)
+        user_b = _make_user(db_session, 404)
+        db_session.commit()
+        store = DatabaseSubscriptionStore(session_factory)
+        endpoint = "https://push.example.com/shared-device"
+
+        store.add(WebPushSubscription(endpoint=endpoint, p256dh="k1", auth="a1", user_id=user_a.id))
+        store.add(WebPushSubscription(endpoint=endpoint, p256dh="k2", auth="a2", user_id=user_b.id))
+
+        db_session.refresh(user_a)
+        db_session.refresh(user_b)
+        a_subs = json.loads(user_a.notification_settings_json)["push_subscriptions"]
+        b_subs = json.loads(user_b.notification_settings_json)["push_subscriptions"]
+        assert a_subs == []
+        assert len(b_subs) == 1
+        assert b_subs[0]["p256dh"] == "k2"
+
+    def test_add_duplicate_endpoint_same_user_overwrites(
+        self, db_session: Session, session_factory
+    ) -> None:
+        user = _make_user(db_session, 405)
+        db_session.commit()
+        store = DatabaseSubscriptionStore(session_factory)
+        endpoint = "https://push.example.com/ep-dup"
+
+        store.add(WebPushSubscription(endpoint=endpoint, p256dh="k1", auth="a1", user_id=user.id))
+        store.add(WebPushSubscription(endpoint=endpoint, p256dh="k2", auth="a2", user_id=user.id))
+
+        db_session.refresh(user)
+        subs = json.loads(user.notification_settings_json)["push_subscriptions"]
+        assert len(subs) == 1
+        assert subs[0]["p256dh"] == "k2"
+
+
+class TestRemove:
+    def test_remove_deletes_from_owning_user(self, db_session: Session, session_factory) -> None:
+        user = _make_user(db_session, 406)
+        db_session.commit()
+        store = DatabaseSubscriptionStore(session_factory)
+        endpoint = "https://push.example.com/ep-remove"
+        store.add(WebPushSubscription(endpoint=endpoint, p256dh="k", auth="a", user_id=user.id))
+
+        store.remove(endpoint)
+
+        db_session.refresh(user)
+        assert json.loads(user.notification_settings_json)["push_subscriptions"] == []
+
+    def test_remove_nonexistent_endpoint_is_noop(
+        self, db_session: Session, session_factory
+    ) -> None:
+        store = DatabaseSubscriptionStore(session_factory)
+        store.remove("https://push.example.com/does-not-exist")  # should not raise
+
+
+class TestGetAllAndGetForUser:
+    def test_get_all_aggregates_across_users(self, db_session: Session, session_factory) -> None:
+        user1 = _make_user(db_session, 407)
+        user2 = _make_user(db_session, 408)
+        db_session.commit()
+        store = DatabaseSubscriptionStore(session_factory)
+        store.add(
+            WebPushSubscription(
+                endpoint="https://p.example.com/1", p256dh="k1", auth="a1", user_id=user1.id
+            )
+        )
+        store.add(
+            WebPushSubscription(
+                endpoint="https://p.example.com/2", p256dh="k2", auth="a2", user_id=user2.id
+            )
+        )
+        store.add(
+            WebPushSubscription(
+                endpoint="https://p.example.com/3", p256dh="k3", auth="a3", user_id=user1.id
+            )
+        )
+
+        all_subs = store.get_all()
+        assert store.count() == 3
+        endpoints = {s.endpoint for s in all_subs}
+        assert endpoints == {
+            "https://p.example.com/1",
+            "https://p.example.com/2",
+            "https://p.example.com/3",
+        }
+        # user_id が正しく引き継がれること
+        by_endpoint = {s.endpoint: s.user_id for s in all_subs}
+        assert by_endpoint["https://p.example.com/1"] == user1.id
+        assert by_endpoint["https://p.example.com/2"] == user2.id
+
+    def test_get_for_user_returns_only_that_user(
+        self, db_session: Session, session_factory
+    ) -> None:
+        user1 = _make_user(db_session, 409)
+        user2 = _make_user(db_session, 410)
+        db_session.commit()
+        store = DatabaseSubscriptionStore(session_factory)
+        store.add(
+            WebPushSubscription(
+                endpoint="https://p.example.com/u1a", p256dh="k", auth="a", user_id=user1.id
+            )
+        )
+        store.add(
+            WebPushSubscription(
+                endpoint="https://p.example.com/u1b", p256dh="k", auth="a", user_id=user1.id
+            )
+        )
+        store.add(
+            WebPushSubscription(
+                endpoint="https://p.example.com/u2a", p256dh="k", auth="a", user_id=user2.id
+            )
+        )
+
+        result = store.get_for_user(user1.id)
+        assert {s.endpoint for s in result} == {
+            "https://p.example.com/u1a",
+            "https://p.example.com/u1b",
+        }
+
+    def test_get_for_user_unknown_user_returns_empty(
+        self, db_session: Session, session_factory
+    ) -> None:
+        store = DatabaseSubscriptionStore(session_factory)
+        assert store.get_for_user(999999) == []
+
+    def test_count_zero_one_multiple(self, db_session: Session, session_factory) -> None:
+        user = _make_user(db_session, 411)
+        db_session.commit()
+        store = DatabaseSubscriptionStore(session_factory)
+        assert store.count() == 0
+
+        store.add(
+            WebPushSubscription(
+                endpoint="https://p.example.com/c1", p256dh="k", auth="a", user_id=user.id
+            )
+        )
+        assert store.count() == 1
+
+        store.add(
+            WebPushSubscription(
+                endpoint="https://p.example.com/c2", p256dh="k", auth="a", user_id=user.id
+            )
+        )
+        assert store.count() == 2
+
+
+class TestCorruptJsonFallback:
+    def test_add_with_corrupt_existing_json_falls_back_to_empty(
+        self, db_session: Session, session_factory
+    ) -> None:
+        user = _make_user(db_session, 412, notification_settings_json="{not valid json")
+        db_session.commit()
+        store = DatabaseSubscriptionStore(session_factory)
+
+        store.add(
+            WebPushSubscription(
+                endpoint="https://p.example.com/fallback", p256dh="k", auth="a", user_id=user.id
+            )
+        )
+
+        db_session.refresh(user)
+        raw = json.loads(user.notification_settings_json)
+        assert len(raw["push_subscriptions"]) == 1

--- a/backend/tests/test_notification_settings_api.py
+++ b/backend/tests/test_notification_settings_api.py
@@ -172,6 +172,71 @@ class TestPutNotificationSettings:
         res = self.client.put("/api/notifications/settings", json={"line_enabled": "not_a_bool"})
         assert res.status_code == 422
 
+    def test_generic_settings_put_preserves_push_subscriptions(self):
+        """★2026-08-04 PR3 回帰防止: push_subscriptions は /push/subscribe 専用エンドポイント
+        経由でのみ変更されるべきで、他の通知設定 (line_enabled 等) を変更するだけの
+        汎用 PUT /settings で黙って空配列に上書きされてはならない。
+        NotificationSettingsModel が push_subscriptions を含まないため、対策なしでは
+        body.model_dump_json() が丸ごと上書きし購読が消える。"""
+        existing = json.dumps(
+            {
+                "line_enabled": True,
+                "push_enabled": True,
+                "preferences": {},
+                "push_subscriptions": [
+                    {"endpoint": "https://push.example.com/keep-me", "p256dh": "k", "auth": "a"}
+                ],
+            }
+        )
+        user = _make_user(existing)
+        db = self._make_db(user)
+        self._override_deps(user, db)
+
+        # push_subscriptions を含まない、既存の通知設定変更 (line_enabled のみ変更) を PUT する。
+        payload: dict[str, Any] = {
+            "line_enabled": False,
+            "push_enabled": True,
+            "preferences": {
+                "ai_proposal": True,
+                "execution_complete": True,
+                "health_factor_warning": True,
+                "emergency_stop": True,
+                "monthly_report": True,
+                "system_notice": True,
+            },
+        }
+        res = self.client.put("/api/notifications/settings", json=payload)
+        assert res.status_code == 200
+
+        saved = json.loads(user.notification_settings_json)
+        assert saved["line_enabled"] is False  # 意図した変更は反映される
+        assert saved["push_subscriptions"] == [
+            {"endpoint": "https://push.example.com/keep-me", "p256dh": "k", "auth": "a"}
+        ]  # 購読は消えない
+
+    def test_settings_put_with_no_prior_push_subscriptions_defaults_to_empty(self):
+        """push_subscriptions キーが元々存在しない (未購読ユーザー) 場合は空配列で保存される。"""
+        user = _make_user(None)
+        db = self._make_db(user)
+        self._override_deps(user, db)
+
+        payload: dict[str, Any] = {
+            "line_enabled": True,
+            "push_enabled": False,
+            "preferences": {
+                "ai_proposal": True,
+                "execution_complete": True,
+                "health_factor_warning": True,
+                "emergency_stop": True,
+                "monthly_report": True,
+                "system_notice": True,
+            },
+        }
+        res = self.client.put("/api/notifications/settings", json=payload)
+        assert res.status_code == 200
+        saved = json.loads(user.notification_settings_json)
+        assert saved["push_subscriptions"] == []
+
 
 # ---------------------------------------------------------------------------
 # POST /api/notifications/push/test (liff-chat「テスト通知」ボタンのパス)

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -39,6 +39,31 @@ def _create_test_app():
     return app
 
 
+def _create_web_push_test_app():
+    """TestWebPushRouter 用アプリ。require_active_user と subscription store を
+    DB 非依存にオーバーライドする (2026-08-04 PR3: subscribe/unsubscribe が認証必須化 +
+    ストアが DatabaseSubscriptionStore になったため、素の _create_test_app のままでは
+    401 になる / 実 DB へ接続しようとしてしまう)。"""
+    from unittest.mock import MagicMock
+
+    from fastapi import FastAPI
+
+    from app.auth.dependencies import require_active_user
+    from app.notifications.push import InMemorySubscriptionStore
+    from app.notifications.router import get_subscription_store
+    from app.notifications.router import router as notification_router
+
+    app = FastAPI()
+    app.include_router(notification_router)
+
+    test_user = MagicMock()
+    test_user.id = 999
+    shared_store = InMemorySubscriptionStore()
+    app.dependency_overrides[require_active_user] = lambda: test_user
+    app.dependency_overrides[get_subscription_store] = lambda: shared_store
+    return app
+
+
 # ---------------------------------------------------------------------------
 # 1. テンプレートテスト
 # ---------------------------------------------------------------------------
@@ -230,7 +255,7 @@ class TestWebPushRouter:
 
     @pytest.fixture
     def client(self):
-        app = _create_test_app()
+        app = _create_web_push_test_app()
         return TestClient(app, raise_server_exceptions=True)
 
     def test_vapid_key_returns_null_when_not_configured(self, client: TestClient):


### PR DESCRIPTION
## Summary
- `InMemorySubscriptionStore` は「メモリ保持・ユーザー未紐付け・認証なし」で、backend再起動のたびに全消失し、誰の購読かも分からなかった。到達経路確立(PR3〜5)の最初のステップ。
- `users.notification_settings_json`(既存TEXT列)に `push_subscriptions` を格納する `DatabaseSubscriptionStore` を新規追加。**新規テーブルは作らない**。`WebPushSender` 自体は変更せず、`Protocol` 型で `InMemorySubscriptionStore`(テスト用)/`DatabaseSubscriptionStore`(本番用)を差し替え可能にした。
- `subscribe`/`api_subscribe`/`unsubscribe` に `require_active_user` を通し、購読を `current_user.id` に紐付け。
- 同一endpointが他ユーザーに残っていた場合は除去する(同一端末での再ログイン/別アカウントログイン、I-5/I-12相当)。
- `notification_logs` に `delivered` 列を追加(「送信した」と「到達した」を区別する土台)。実際の書き込み配線は **PR5** で行う(本PRはスキーマ追加のみ)。

## ★重要な発見・修正
実装中、`push_subscriptions` を `NotificationSettingsModel`(通知設定のクライアント向けAPIスキーマ)に含めると、既存の汎用 `PUT /notifications/settings`(通知トグル1つの変更等)が呼ばれるたびに、クライアントが送らない `push_subscriptions` が空配列で上書きされ**購読が黙って消える**ことが判明した。本件の調査テーマ(表示と実行能力の分離)と同型のバグを未然に防ぐため、`push_subscriptions` は `NotificationSettingsModel` に含めず、`_do_update_notification_settings` が保存前に既存の raw JSON から読み出して引き継ぐようにした。回帰テストを追加済み。

## Asana
GID: 1217143339626810 ([PR3] Web Push購読の永続化とユーザー紐付け)
ハブ: 1217159187013092(【ハブ】実行パイプライン復旧)。PR4(frontend配線)・PR5(per-user配信)の前提。

## やっていないこと(スコープ外・後続PRで対応)
- `notification_logs.delivered` への実際の書き込み配線 → PR5
- Web PushをCompositeNotificationServiceに登録すること → PR5
- iOS/Android実機での到達確認 → PR4(frontend配線)完了後でないと検証不可

## Test plan
- [x] `pytest tests/ -q` — **4861 passed, 26 skipped, 0 failed**(backend全体、リグレッションなし)
- [x] 新規 `test_push_subscription_store.py`(12ケース: DB永続化・user_id紐付け・複数ユーザー分離・同一endpoint重複防止・破損JSON時フォールバック)
- [x] ★`test_notification_settings_api.py` に回帰テスト追加(汎用PUTがpush_subscriptionsを消さないこと)
- [x] 既存 `test_notifications.py::TestWebPushRouter` を認証必須化+DB非依存ストアに対応させて更新
- [x] `ruff check .` / `ruff format --check .` / `mypy app/` — 変更ファイルにエラーなし(既存の無関係なstripe stubエラーを除く)
- [x] `ruff check . --select S` — 新規セキュリティ警告なし
- [ ] **alembic実行検証は未実施**(ローカルvenvにalembic未インストール、pip install許可が得られなかったため)。CI側の検証、またはstaging/production適用時の確認が必要
- [ ] backend再起動前後での購読保持の実機確認は、staging/production環境が必要なため未実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrEyFux64DYyVhdpkT2tCz