### PR TITLE
feat(liff): Web Push購読の実配線 (PR4 フロントエンド)

### DIFF
--- a/frontend/app/(liff)/liff-chat/_components/panels/NotificationPanel.tsx
+++ b/frontend/app/(liff)/liff-chat/_components/panels/NotificationPanel.tsx
@@ -7,6 +7,12 @@ import { useTranslations } from "next-intl"
 import { getAuthToken } from "@/lib/auth/token-key"
 import { liffFetch } from "@/lib/liff/liff-fetch"
 import { isLiffConfigured } from "@/lib/liff/init"
+import {
+  isPushConfigured,
+  subscribeToPush,
+  unsubscribeFromPush,
+  VapidNotConfiguredError,
+} from "@/lib/push/subscription"
 
 // ---------------------------------------------------------------------------
 // 型定義
@@ -132,8 +138,11 @@ function NotificationRow({
 
 export function NotificationPanel() {
   const t = useTranslations("Liff.panels.notification")
+  const tPwa = useTranslations("PwaNotificationToggle")
   const [settings, setSettings] = useState<NotificationSettings>(DEFAULT_SETTINGS)
   const [pushPermission, setPushPermission] = useState<NotificationPermission>("default")
+  const [pushBusy, setPushBusy] = useState(false)
+  const [pushMessage, setPushMessage] = useState<string | null>(null)
   const [testSending, setTestSending] = useState(false)
   const [testMessage, setTestMessage] = useState<string | null>(null)
 
@@ -197,15 +206,44 @@ export function NotificationPanel() {
     void saveSettings(next)
   }
 
-  // PWA プッシュ通知 ON→OFF/ON
+  // PWA プッシュ通知 ON→OFF/ON。
+  // 2026-08-04 PR4: OS 権限の取得だけで pushManager.subscribe() を一度も呼んでいなかった
+  // 欠陥を修正。ON 時は実際に購読を作成しサーバへ登録するまで push_enabled を立てない
+  // （購読作成に失敗したら無言でスキップせず、設定も変更しない）。
   async function handlePushToggle(value: boolean) {
-    if (value && pushPermission !== "granted") {
-      if ("Notification" in window) {
+    setPushMessage(null)
+    if (value) {
+      if (pushPermission !== "granted") {
+        if (!("Notification" in window)) return
         const result = await Notification.requestPermission()
         setPushPermission(result)
-        if (result !== "granted") return
-      } else {
+        if (result !== "granted") {
+          if (result === "denied") setPushMessage(tPwa("errorBlocked"))
+          return
+        }
+      }
+      setPushBusy(true)
+      try {
+        await subscribeToPush(getToken())
+        setPushMessage(tPwa("successSubscribed"))
+      } catch (e) {
+        setPushMessage(
+          e instanceof VapidNotConfiguredError ? tPwa("errorVapidKeyMissing") : tPwa("errorSubscribeFailed")
+        )
         return
+      } finally {
+        setPushBusy(false)
+      }
+    } else {
+      setPushBusy(true)
+      try {
+        await unsubscribeFromPush(getToken())
+        setPushMessage(tPwa("successUnsubscribed"))
+      } catch {
+        setPushMessage(tPwa("errorUnsubscribeFailed"))
+        return
+      } finally {
+        setPushBusy(false)
       }
     }
     updateChannel("push_enabled", value)
@@ -234,12 +272,14 @@ export function NotificationPanel() {
     }
   }
 
-  const pushBadge =
-    pushPermission === "granted" ? (
-      <span className="text-[10px] text-[#1D9E75] font-semibold">{t("pushGranted")}</span>
-    ) : (
-      <span className="text-[10px] text-yellow-600 font-semibold">{t("pushNotGranted")}</span>
-    )
+  const pushConfigured = isPushConfigured()
+  const pushBadge = !pushConfigured ? (
+    <span className="text-[10px] text-yellow-600 font-semibold">{tPwa("errorVapidKeyMissing")}</span>
+  ) : pushPermission === "granted" ? (
+    <span className="text-[10px] text-[#1D9E75] font-semibold">{t("pushGranted")}</span>
+  ) : (
+    <span className="text-[10px] text-yellow-600 font-semibold">{t("pushNotGranted")}</span>
+  )
 
   return (
     <div className="pb-4">
@@ -265,7 +305,8 @@ export function NotificationPanel() {
         </div>
       )}
 
-      {/* PWA プッシュ通知 */}
+      {/* PWA プッシュ通知。VAPID 未設定時はトグルを無効化し理由を表示する
+          （2026-08-04 PR4: 「設定が変わらないのに操作できてしまう」を避ける）。 */}
       <div className="flex items-center justify-between ax-card-warm rounded-xl px-4 py-3 mb-2">
         <div className="flex items-center gap-3">
           <Bell className="w-5 h-5 text-[#1D9E75]" />
@@ -279,8 +320,12 @@ export function NotificationPanel() {
         <Toggle
           checked={settings.push_enabled}
           onChange={handlePushToggle}
+          disabled={!pushConfigured || pushBusy}
         />
       </div>
+      {pushMessage && (
+        <p className="text-xs text-[#736f7e] mb-2 -mt-1 px-1">{pushMessage}</p>
+      )}
 
       {/* AI・取引 */}
       <SectionHeader label={t("aiTradeSection")} />

--- a/frontend/e2e/liff-chat-notif.spec.ts
+++ b/frontend/e2e/liff-chat-notif.spec.ts
@@ -12,10 +12,19 @@ import { test, expect } from '@playwright/test';
 //   3. 「緊急停止通知」行が disabled + ON 固定 (role=switch, aria-checked=true,
 //      かつ操作不可) で「変更不可」バッジ付きで描画される (CSS バグ修正の回帰防止)。
 //   4. 通常の通知トグル (例: AI 提案通知) は操作可能で状態が切り替わる。
+//   5. (2026-08-04 PR4) NEXT_PUBLIC_VAPID_PUBLIC_KEY 未設定時、プッシュ通知トグルは
+//      disabled で「VAPID未設定」バッジが出る。
+//   6. (2026-08-04 PR4) VAPID 設定済み環境で、プッシュ通知トグルを ON にすると
+//      実際に pushManager.subscribe() が呼ばれ、POST /notifications/push/subscribe
+//      が正しい認証ヘッダ・ボディで送られる (handlePushToggle が権限取得だけで
+//      終わっていた欠陥の回帰防止)。next-pwa は開発時 Service Worker を無効化するため
+//      navigator.serviceWorker / PushManager を addInitScript でスタブする。
 //
 // 注意: baseURL は playwright.config.ts 準拠 (STAGING_URL or app.ultra-auto-trade.com)。
 //       未認証環境では LIFF ログイン画面へリダイレクトされうるため、各検証は
 //       「該当 UI が出る or ログイン画面が出る」を許容する防御的アサーションにする。
+//       6. のテストは NEXT_PUBLIC_VAPID_PUBLIC_KEY を設定した dev サーバでのみ意味を持つ
+//       (未設定環境ではトグル自体が disabled になるため skip する)。
 // ----------------------------------------------------------------
 
 const NOTIF_TAB_LABEL = '通知設定';
@@ -112,4 +121,206 @@ test.describe('liff-chat 通知設定パネル', () => {
     const after = await aiSwitch.getAttribute('aria-checked');
     expect(after).not.toBe(before);
   });
+
+  test('VAPID未設定時はプッシュ通知トグルが disabled + バッジ表示', async ({ page }) => {
+    // NEXT_PUBLIC_VAPID_PUBLIC_KEY はビルド時埋め込みのため実行時に判定できない。
+    // 設定済み dev サーバで実行された場合は下の disabled 分岐が false になり、
+    // アサーション自体が発火せず素通りする (意味を持つのは未設定環境のみ)。
+    await page.goto('/liff-chat');
+    await page.waitForLoadState('domcontentloaded');
+
+    const notifTab = page.getByText(NOTIF_TAB_LABEL, { exact: false }).first();
+    if (!(await notifTab.isVisible().catch(() => false))) {
+      test.skip(true, '未認証環境: 通知設定タブに到達できないためスキップ');
+      return;
+    }
+    await notifTab.click().catch(() => {});
+    await page.waitForLoadState('domcontentloaded');
+
+    const pushRow = page
+      .locator('div', { hasText: 'プッシュ通知' })
+      .filter({ has: page.getByRole('switch') })
+      .first();
+    const pushSwitch = pushRow.getByRole('switch').first();
+
+    // VAPID が設定されていない環境でのみ disabled + バッジが出ることを確認する
+    // (設定済み環境ではこのテストは目的を持たないため、disabled でなければ素通りさせる)。
+    const disabled = await pushSwitch.isDisabled();
+    if (disabled) {
+      await expect(pushRow.getByText('VAPID未設定')).toBeVisible();
+    }
+  });
 });
+
+// ----------------------------------------------------------------
+// Push 購読の実配線 (2026-08-04 PR4)
+// ----------------------------------------------------------------
+// NEXT_PUBLIC_VAPID_PUBLIC_KEY を設定した dev サーバでのみ意味を持つ。
+// 未設定環境ではトグルが disabled になり click 自体が成立しないため全ケース skip する。
+// next-pwa は開発時 Service Worker を無効化するため、navigator.serviceWorker /
+// PushManager を addInitScript でスタブし、実際の SW ライフサイクルから切り離す。
+
+test.describe('Push購読の実配線 (subscribeToPush)', () => {
+  test.beforeEach(async ({ page, context }) => {
+    await context.grantPermissions(['notifications']);
+
+    // getAuthToken() が読む正準キーへ事前注入。
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.setItem('auth_token', 'e2e-push-test-token');
+      } catch {
+        /* ignore */
+      }
+      ;(window as any).Notification = {
+        permission: 'granted',
+        requestPermission: async () => 'granted',
+      }
+
+      const fakeSubscription = {
+        endpoint: 'https://fcm.googleapis.com/fcm/send/e2e-fake-endpoint',
+        toJSON: () => ({
+          endpoint: 'https://fcm.googleapis.com/fcm/send/e2e-fake-endpoint',
+          keys: { p256dh: 'fake-p256dh', auth: 'fake-auth' },
+        }),
+        unsubscribe: async () => {
+          ;(window as any).__unsubscribeCalledOnRollback = true
+          return true
+        },
+      }
+      const fakePushManager = {
+        subscribe: async () => fakeSubscription,
+        getSubscription: async () => null,
+      }
+        ; (navigator as any).serviceWorker = {
+          ready: Promise.resolve({ pushManager: fakePushManager }),
+        }
+    })
+
+    await page.route('**/api/notifications/settings', async (route) => {
+      const req = route.request()
+      if (req.method() === 'PUT') {
+        const body = req.postDataJSON()
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(body),
+        })
+        return
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          line_enabled: true,
+          push_enabled: false,
+          preferences: {
+            ai_proposal: true,
+            execution_complete: true,
+            health_factor_warning: true,
+            emergency_stop: true,
+            monthly_report: true,
+            system_notice: true,
+          },
+        }),
+      })
+    })
+  })
+
+  test('トグルON → pushManager.subscribe() → POST /notifications/push/subscribe', async ({
+    page,
+  }) => {
+    let subscribeCalled = false
+    let subscribeAuth: string | null = null
+    let subscribeBody: Record<string, unknown> | null = null
+
+    await page.route('**/notifications/push/subscribe', async (route) => {
+      subscribeCalled = true
+      subscribeAuth = route.request().headers()['authorization'] ?? null
+      subscribeBody = route.request().postDataJSON()
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'subscribed', count: 1 }),
+      })
+    })
+
+    await page.goto('/liff-chat')
+    await page.waitForLoadState('domcontentloaded')
+
+    const notifTab = page.getByText(NOTIF_TAB_LABEL, { exact: false }).first()
+    if (!(await notifTab.isVisible().catch(() => false))) {
+      test.skip(true, '未認証環境: 通知設定タブに到達できないためスキップ')
+      return
+    }
+    await notifTab.click().catch(() => {})
+    await page.waitForLoadState('domcontentloaded')
+
+    const pushRow = page
+      .locator('div', { hasText: 'プッシュ通知' })
+      .filter({ has: page.getByRole('switch') })
+      .first()
+    const pushSwitch = pushRow.getByRole('switch').first()
+
+    if (await pushSwitch.isDisabled()) {
+      test.skip(true, 'VAPID未設定環境: このテストは NEXT_PUBLIC_VAPID_PUBLIC_KEY 設定済みdevサーバでのみ実行する')
+      return
+    }
+
+    await pushSwitch.click()
+    await expect.poll(() => subscribeCalled, { timeout: 5000 }).toBe(true)
+
+    expect(subscribeAuth).toBe('Bearer e2e-push-test-token')
+    expect(subscribeBody).toMatchObject({
+      endpoint: 'https://fcm.googleapis.com/fcm/send/e2e-fake-endpoint',
+      keys: { p256dh: 'fake-p256dh', auth: 'fake-auth' },
+    })
+  })
+
+  test('サーバ登録失敗時は push_enabled を立てずエラーを表示する', async ({ page }) => {
+    await page.route('**/notifications/push/subscribe', async (route) => {
+      await route.fulfill({ status: 500, contentType: 'application/json', body: '{}' })
+    })
+
+    let putCalled = false
+    await page.route('**/api/notifications/settings', async (route) => {
+      if (route.request().method() === 'PUT') {
+        putCalled = true
+      }
+      await route.continue()
+    })
+
+    await page.goto('/liff-chat')
+    await page.waitForLoadState('domcontentloaded')
+
+    const notifTab = page.getByText(NOTIF_TAB_LABEL, { exact: false }).first()
+    if (!(await notifTab.isVisible().catch(() => false))) {
+      test.skip(true, '未認証環境: 通知設定タブに到達できないためスキップ')
+      return
+    }
+    await notifTab.click().catch(() => {})
+    await page.waitForLoadState('domcontentloaded')
+
+    const pushRow = page
+      .locator('div', { hasText: 'プッシュ通知' })
+      .filter({ has: page.getByRole('switch') })
+      .first()
+    const pushSwitch = pushRow.getByRole('switch').first()
+
+    if (await pushSwitch.isDisabled()) {
+      test.skip(true, 'VAPID未設定環境: このテストは NEXT_PUBLIC_VAPID_PUBLIC_KEY 設定済みdevサーバでのみ実行する')
+      return
+    }
+
+    await pushSwitch.click()
+
+    // 失敗時にエラーメッセージが表示され、push_enabled の PUT が飛ばないこと。
+    await expect(page.getByText('通知の登録に失敗しました')).toBeVisible({ timeout: 5000 })
+    expect(putCalled).toBe(false)
+
+    // subscribeToPush() は失敗時にブラウザ側購読をロールバックする(unsubscribe呼び出し)。
+    const unsubscribeCalledOnRollback = await page.evaluate(
+      () => (window as any).__unsubscribeCalledOnRollback === true
+    )
+    expect(unsubscribeCalledOnRollback).toBe(true)
+  })
+})

--- a/frontend/lib/push/subscription.ts
+++ b/frontend/lib/push/subscription.ts
@@ -1,0 +1,113 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+// frontend/lib/push/subscription.ts
+//
+// Web Push 購読の作成・解除ロジック（2026-08-04 PR4）。
+//
+// 背景: NotificationPanel.tsx の handlePushToggle は OS 通知権限を取得するだけで
+// pushManager.subscribe() を一度も呼んでいなかった（購読ゼロの直接原因）。
+// 購読作成ロジック自体は components/pwa/PushNotificationToggle.tsx に存在したが、
+// どこにもマウントされていなかった。両コンポーネントから共有できるよう本ファイルへ抽出する。
+//
+// バックエンド (PR3) の /notifications/push/subscribe, /push/unsubscribe は
+// require_active_user で認証必須化済み。新規 alias は追加せず既存の正準パスを使う。
+
+import { postJson, deleteJson } from "@/lib/api/http"
+
+export class VapidNotConfiguredError extends Error {
+  constructor() {
+    super("VAPID public key is not configured")
+    this.name = "VapidNotConfiguredError"
+  }
+}
+
+export class PushSubscribeError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "PushSubscribeError"
+  }
+}
+
+/** ビルド時に VAPID 公開鍵が設定されているか（トグルの活性・非活性判定に使う）。 */
+export function isPushConfigured(): boolean {
+  return Boolean(process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY)
+}
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/")
+  const rawData = atob(base64)
+  const outputArray = new Uint8Array(rawData.length)
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i)
+  }
+  return outputArray
+}
+
+/** 現在のブラウザ購読 (無ければ null)。Service Worker 非対応環境では常に null。 */
+export async function getExistingSubscription(): Promise<PushSubscription | null> {
+  if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) return null
+  const reg = await navigator.serviceWorker.ready
+  return reg.pushManager.getSubscription()
+}
+
+/**
+ * Push 購読を作成し、バックエンドに登録する。
+ *
+ * OS 通知権限の取得は呼び出し側の責務（NotificationPanel が Notification.requestPermission
+ * を呼んでから本関数を呼ぶ）。VAPID 未設定時は VapidNotConfiguredError を投げる。
+ * サーバ登録に失敗した場合はブラウザ側の購読をロールバックする
+ * （非カストディアル鍵管理と同型: 片方だけ確定した中途半端な状態を残さない）。
+ */
+export async function subscribeToPush(token: string): Promise<void> {
+  const vapidKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  if (!vapidKey) {
+    throw new VapidNotConfiguredError()
+  }
+
+  const reg = await navigator.serviceWorker.ready
+  const sub = await reg.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(vapidKey) as unknown as ArrayBuffer,
+  })
+
+  const json = sub.toJSON()
+  try {
+    await postJson(
+      "/notifications/push/subscribe",
+      { endpoint: json.endpoint, keys: json.keys },
+      { headers: { Authorization: `Bearer ${token}` } }
+    )
+  } catch (e) {
+    // サーバ登録失敗 → 付与済みブラウザ購読をロールバック
+    try {
+      await sub.unsubscribe()
+    } catch {
+      // ロールバック失敗はログのみ（致命的でない）
+      console.warn("[push] subscription rollback failed after server registration error")
+    }
+    throw new PushSubscribeError(e instanceof Error ? e.message : "subscribe failed")
+  }
+}
+
+/**
+ * Push 購読を解除する。ブラウザ側を先に解除し、その後ベストエフォートで
+ * サーバへ通知する（サーバ側通知が失敗しても、失効した購読は次回配信時の
+ * 410 検知でいずれ除去される — fail-open）。購読が無ければ何もしない。
+ */
+export async function unsubscribeFromPush(token: string): Promise<void> {
+  const sub = await getExistingSubscription()
+  if (!sub) return
+
+  const endpoint = sub.endpoint
+  await sub.unsubscribe()
+
+  try {
+    await deleteJson(`/notifications/push/unsubscribe?endpoint=${encodeURIComponent(endpoint)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+  } catch {
+    // サーバ側解除の失敗はログのみ
+    console.warn("[push] server-side unsubscribe failed (browser side already unsubscribed)")
+  }
+}


### PR DESCRIPTION
## Summary
- `handlePushToggle` が OS 通知権限を取得するだけで `pushManager.subscribe()` を一度も呼んでおらず、購読が常にゼロだった欠陥を修正。
- `subscribeToPush` / `unsubscribeFromPush` を `frontend/lib/push/subscription.ts` に切り出し、`NotificationPanel` から呼び出す。
- PR3 (#1015, 既にmain) で `/notifications/push/subscribe` `/push/unsubscribe` が `require_active_user` で認証必須化されているため、Authorization ヘッダーを付与。
- VAPID 未設定時はトグルを無効化し理由を表示。サーバ登録失敗時はブラウザ側購読をロールバックし `push_enabled` を立てない（非カストディアル鍵管理と同型: 片方だけ確定した中途半端な状態を残さない）。
- e2e: ロールバック検証用の `unsubscribe` 呼び出しフラグ配線が未完了で `tsc` エラーになっていた箇所を修正（PR3 マージ後の rebase で発覚）。

## Test plan
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx eslint` (変更ファイル) — issue なし
- [x] `npx playwright test e2e/liff-chat-notif.spec.ts` をローカル dev サーバ (localhost:3000) で実行。対象2テストは未認証ローカル環境のため skip（既存のガード通り）、無関係な既存の未認証系失敗2件はこのPRと無関係
- [ ] staging での実機確認（VAPID鍵設定済み環境 + 認証済みユーザーで push トグルON→ブラウザ通知許可→購読作成→テスト通知受信）

🤖 Generated with [Claude Code](https://claude.com/claude-code)