### PR TITLE
feat(automation): AI提案通知にWeb Push実配信を配線 (PR5)

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -652,6 +652,50 @@ def _resolve_protocol_routing(
     return aave_default
 
 
+def _deliver_ai_proposal_push(db: Session, user_id: int, payload: Any) -> None:
+    """AI提案のWeb Push実配信 + notification_logsへのdelivered記録 (best-effort)。
+
+    2026-08-04 PR5: get_notification_service().send() (LINE/Slack/内部ログ) とは独立した経路。
+    購読者へ実際にブラウザ通知を届けるコードがこれまで一切配線されていなかった
+    (docs/internal/2026-08-04_execution_pipeline_requirements.md)。VAPID未設定時は
+    Web Push全体を無効化する既存設計 (get_vapid_config) に従い静かにスキップする。
+    失敗しても提案生成自体はブロックしない (fail-open)。
+    """
+    try:
+        from app.notifications.models import NotificationLog  # noqa: PLC0415
+        from app.notifications.push import (  # noqa: PLC0415
+            DatabaseSubscriptionStore,
+            WebPushSender,
+            get_vapid_config,
+        )
+
+        vapid_config = get_vapid_config()
+        if vapid_config is None:
+            logger.debug("Web Push: VAPID未設定のためスキップ (user_id=%d)", user_id)
+            return
+
+        sender = WebPushSender(vapid_config, DatabaseSubscriptionStore(SessionLocal))
+        delivered = sender.send_to_user(user_id, payload.web_push_payload)
+
+        db.add(
+            NotificationLog(
+                channel="push",
+                severity=payload.notification_message.severity.value,
+                title=payload.notification_message.title,
+                body=payload.notification_message.body,
+                user_id=user_id,
+                delivered=delivered,
+            )
+        )
+        db.flush()
+    except Exception as _push_exc:  # noqa: BLE001
+        logger.warning(
+            "ai_proposal Web Push delivery failed for user %d (skipping): %s",
+            user_id,
+            _push_exc,
+        )
+
+
 def _create_proposals_for_users(
     db: Session,
     decision: AIDecision,
@@ -847,6 +891,7 @@ def _create_proposals_for_users(
                     )
                     _payload.notification_message.user_id = user.id
                     get_notification_service().send(_payload.notification_message)
+                    _deliver_ai_proposal_push(db, user.id, _payload)
                 except Exception as _notif_exc:  # noqa: BLE001
                     logger.warning(
                         "ai_proposal_notification failed for user %d (skipping): %s",
@@ -1011,6 +1056,7 @@ def _create_safe_yield_proposals_for_users(
                     )
                     _payload.notification_message.user_id = user.id
                     get_notification_service().send(_payload.notification_message)
+                    _deliver_ai_proposal_push(db, user.id, _payload)
                 except Exception as _notif_exc:  # noqa: BLE001
                     logger.warning(
                         "[safe_yield] notification failed for user %d (skip): %s",

--- a/backend/app/notifications/push.py
+++ b/backend/app/notifications/push.py
@@ -81,6 +81,11 @@ class InMemorySubscriptionStore:
         with self._lock:
             return list(self._subscriptions.values())
 
+    def get_for_user(self, user_id: int) -> list[WebPushSubscription]:
+        """指定ユーザーのサブスクリプションのみを返す (WebPushSender.send_to_user が使用)。"""
+        with self._lock:
+            return [s for s in self._subscriptions.values() if s.user_id == user_id]
+
     def count(self) -> int:
         """登録済みサブスクリプション数を返す。"""
         with self._lock:
@@ -97,6 +102,7 @@ class SubscriptionStore(Protocol):
     def add(self, subscription: WebPushSubscription) -> None: ...
     def remove(self, endpoint: str) -> None: ...
     def get_all(self) -> list[WebPushSubscription]: ...
+    def get_for_user(self, user_id: int) -> list[WebPushSubscription]: ...
     def count(self) -> int: ...
 
 
@@ -236,7 +242,7 @@ class DatabaseSubscriptionStore:
             db.close()
 
     def get_for_user(self, user_id: int) -> list[WebPushSubscription]:
-        """指定ユーザーのサブスクリプションのみを返す (PR5: per-user 配信で使用予定)。"""
+        """指定ユーザーのサブスクリプションのみを返す (WebPushSender.send_to_user が使用)。"""
         from app.auth.models import User  # noqa: PLC0415
 
         db = self._session_factory()
@@ -309,6 +315,41 @@ class WebPushSender:
             len(subscriptions),
         )
         return success_count
+
+    def send_to_user(self, user_id: int, payload: dict[str, Any], ttl: int = 86400) -> bool:
+        """特定ユーザーの全端末へ配信する。1件でも成功すれば True。購読が無ければ False。
+
+        2026-08-04 PR5: send_to_all のユーザー限定版。AI提案通知等の per-user 配信に使う
+        (send_to_all は router.py の /push/test 専用のまま変更しない)。
+        """
+        if not _PYWEBPUSH_AVAILABLE:
+            logger.warning("pywebpush がインストールされていません。Web Push は無効です。")
+            return False
+
+        subscriptions = self._store.get_for_user(user_id)
+        success = False
+        failed_endpoints: list[str] = []
+
+        for subscription in subscriptions:
+            try:
+                ok = self.send_to_subscription(subscription, payload, ttl)
+                if ok:
+                    success = True
+                else:
+                    failed_endpoints.append(subscription.endpoint)
+            except Exception:
+                logger.exception(
+                    "Web Push 送信中に予期しないエラーが発生しました: user_id=%d, endpoint=%s",
+                    user_id,
+                    subscription.endpoint[:30],
+                )
+                failed_endpoints.append(subscription.endpoint)
+
+        for endpoint in failed_endpoints:
+            self._store.remove(endpoint)
+            logger.info("失敗したサブスクリプションを削除しました: endpoint=%s", endpoint[:30])
+
+        return success
 
     def send_to_subscription(
         self, subscription: WebPushSubscription, payload: dict[str, Any], ttl: int

--- a/backend/tests/automation/test_proposals_notification.py
+++ b/backend/tests/automation/test_proposals_notification.py
@@ -25,9 +25,11 @@ from app.automation.ai_judgment_scheduler import (
     _PROPOSAL_AMOUNT_MIN_USD,
     _PROPOSAL_RATIO,
     _create_proposals_for_users,
+    _deliver_ai_proposal_push,
 )
 from app.automation.workflow import _create_proposal_from_judgment
 from app.notifications.schemas import NotificationMessage
+from app.notifications.templates import ai_proposal_notification
 
 
 def _make_cross_result(action: TradeAction, confidence: int = 70) -> CrossValidationResult:
@@ -155,6 +157,119 @@ class TestCreateProposalsForUsersNotification:
             patch(
                 "app.notifications.factory.get_notification_service",
                 side_effect=RuntimeError("notification failure"),
+            ),
+        ):
+            count = _create_proposals_for_users(mock_db, decision, result)
+
+        assert count == 1
+
+
+class TestDeliverAiProposalPush:
+    """_deliver_ai_proposal_push: Web Push実配信 + notification_logs delivered記録 (PR5)。"""
+
+    @staticmethod
+    def _payload() -> Any:
+        return ai_proposal_notification("SUPPLY", "USDC", Decimal("100"), 80)
+
+    def test_vapid_unset_skips_without_raising(self) -> None:
+        """VAPID未設定時は静かにスキップし、push行は作られない。"""
+        mock_db = MagicMock()
+        with patch("app.notifications.push.get_vapid_config", return_value=None):
+            _deliver_ai_proposal_push(mock_db, 1, self._payload())
+        mock_db.add.assert_not_called()
+
+    def test_vapid_set_success_logs_delivered_true(self) -> None:
+        """配信成功: delivered=True の push NotificationLog が1行追加される。"""
+        mock_db = MagicMock()
+        mock_sender = MagicMock()
+        mock_sender.send_to_user.return_value = True
+        with (
+            patch("app.notifications.push.get_vapid_config", return_value=MagicMock()),
+            patch("app.notifications.push.WebPushSender", return_value=mock_sender),
+            patch("app.notifications.push.DatabaseSubscriptionStore"),
+        ):
+            _deliver_ai_proposal_push(mock_db, 5, self._payload())
+
+        mock_db.add.assert_called_once()
+        added = mock_db.add.call_args.args[0]
+        assert added.channel == "push"
+        assert added.delivered is True
+        assert added.user_id == 5
+
+    def test_vapid_set_failure_logs_delivered_false(self) -> None:
+        """配信失敗: delivered=False の push NotificationLog が1行追加される。"""
+        mock_db = MagicMock()
+        mock_sender = MagicMock()
+        mock_sender.send_to_user.return_value = False
+        with (
+            patch("app.notifications.push.get_vapid_config", return_value=MagicMock()),
+            patch("app.notifications.push.WebPushSender", return_value=mock_sender),
+            patch("app.notifications.push.DatabaseSubscriptionStore"),
+        ):
+            _deliver_ai_proposal_push(mock_db, 5, self._payload())
+
+        added = mock_db.add.call_args.args[0]
+        assert added.channel == "push"
+        assert added.delivered is False
+
+    def test_exception_does_not_raise(self) -> None:
+        """内部例外は握りつぶし、呼び出し元に伝播しない (fail-open)。"""
+        mock_db = MagicMock()
+        with patch("app.notifications.push.get_vapid_config", side_effect=RuntimeError("boom")):
+            _deliver_ai_proposal_push(mock_db, 1, self._payload())  # must not raise
+        mock_db.add.assert_not_called()
+
+
+class TestCreateProposalsForUsersPushWiring:
+    """_create_proposals_for_users が _deliver_ai_proposal_push を正しく配線していること。"""
+
+    def test_push_delivery_called_with_user_id(self) -> None:
+        user = _make_user(user_id=55)
+        decision = _make_decision()
+        result = _make_cross_result(TradeAction.BUY)
+        mock_db = MagicMock()
+        mock_db.scalars.return_value.all.return_value = [user]
+
+        with (
+            patch(
+                "app.automation.ai_judgment_scheduler._resolve_proposal_amount",
+                return_value=Decimal("460"),
+            ),
+            patch(
+                "app.fees.trade_gate.calculate_fee_by_market",
+                return_value=_make_fee(True),
+            ),
+            patch("app.notifications.factory.get_notification_service"),
+            patch("app.automation.ai_judgment_scheduler._deliver_ai_proposal_push") as mock_push,
+        ):
+            _create_proposals_for_users(mock_db, decision, result)
+
+        mock_push.assert_called_once()
+        args = mock_push.call_args.args
+        assert args[0] is mock_db
+        assert args[1] == 55
+
+    def test_push_delivery_exception_does_not_abort_proposal_creation(self) -> None:
+        """push配線側で予期しない例外が出ても Proposal 作成カウントは維持される。"""
+        user = _make_user(user_id=56)
+        decision = _make_decision()
+        result = _make_cross_result(TradeAction.BUY)
+        mock_db = MagicMock()
+        mock_db.scalars.return_value.all.return_value = [user]
+
+        with (
+            patch(
+                "app.automation.ai_judgment_scheduler._resolve_proposal_amount",
+                return_value=Decimal("460"),
+            ),
+            patch(
+                "app.fees.trade_gate.calculate_fee_by_market",
+                return_value=_make_fee(True),
+            ),
+            patch("app.notifications.factory.get_notification_service"),
+            patch(
+                "app.automation.ai_judgment_scheduler._deliver_ai_proposal_push",
+                side_effect=RuntimeError("push down"),
             ),
         ):
             count = _create_proposals_for_users(mock_db, decision, result)

--- a/backend/tests/notifications/test_webpush_send_to_user.py
+++ b/backend/tests/notifications/test_webpush_send_to_user.py
@@ -1,0 +1,141 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/notifications/test_webpush_send_to_user.py
+"""WebPushSender.send_to_user の単体テスト（2026-08-04 PR5）。
+
+send_to_all (全購読者へブロードキャスト、/push/test 専用) とは別に、AI提案通知等の
+per-user 配信で使う send_to_user が「対象ユーザーの購読にのみ」送信することを検証する。
+pywebpush の実HTTP送信は send_to_subscription をモックして切り離す。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.notifications.push import (
+    InMemorySubscriptionStore,
+    VAPIDConfig,
+    WebPushSender,
+    WebPushSubscription,
+)
+
+
+def _make_config() -> VAPIDConfig:
+    return VAPIDConfig(public_key="pub", private_key="priv", mailto="ops@example.com")
+
+
+def _make_store() -> InMemorySubscriptionStore:
+    store = InMemorySubscriptionStore()
+    store.add(
+        WebPushSubscription(endpoint="https://p.example.com/u1a", p256dh="k", auth="a", user_id=1)
+    )
+    store.add(
+        WebPushSubscription(endpoint="https://p.example.com/u1b", p256dh="k", auth="a", user_id=1)
+    )
+    store.add(
+        WebPushSubscription(endpoint="https://p.example.com/u2a", p256dh="k", auth="a", user_id=2)
+    )
+    return store
+
+
+class TestSendToUser:
+    """send_to_subscription をモックし、pywebpush の実インストール有無に依存しない。
+
+    _PYWEBPUSH_AVAILABLE ガード自体は import-time フラグで実パッケージ有無を反映するため、
+    ここでは True 固定パッチして send_to_user 内のルーティングロジックのみ検証する。
+    """
+
+    def test_sends_only_to_target_user_subscriptions(self) -> None:
+        """user_id=1 への配信は user_id=1 の2件のみ send_to_subscription を呼ぶ。"""
+        store = _make_store()
+        sender = WebPushSender(_make_config(), store)
+
+        with (
+            patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True),
+            patch.object(sender, "send_to_subscription", return_value=True) as mock_send,
+        ):
+            result = sender.send_to_user(1, {"title": "t", "body": "b"})
+
+        assert result is True
+        called_endpoints = {c.args[0].endpoint for c in mock_send.call_args_list}
+        assert called_endpoints == {
+            "https://p.example.com/u1a",
+            "https://p.example.com/u1b",
+        }
+
+    def test_other_user_subscriptions_are_not_touched(self) -> None:
+        """user_id=2 の購読には送信されないこと。"""
+        store = _make_store()
+        sender = WebPushSender(_make_config(), store)
+
+        with (
+            patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True),
+            patch.object(sender, "send_to_subscription", return_value=True) as mock_send,
+        ):
+            sender.send_to_user(1, {"title": "t", "body": "b"})
+
+        called_endpoints = {c.args[0].endpoint for c in mock_send.call_args_list}
+        assert "https://p.example.com/u2a" not in called_endpoints
+
+    def test_returns_false_when_no_subscription_for_user(self) -> None:
+        """購読が無いユーザーは False。"""
+        store = InMemorySubscriptionStore()
+        sender = WebPushSender(_make_config(), store)
+
+        with (
+            patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True),
+            patch.object(sender, "send_to_subscription", return_value=True) as mock_send,
+        ):
+            result = sender.send_to_user(999, {"title": "t", "body": "b"})
+
+        assert result is False
+        mock_send.assert_not_called()
+
+    def test_returns_true_if_at_least_one_subscription_succeeds(self) -> None:
+        """複数端末のうち1件でも成功すれば True。"""
+        store = _make_store()
+        sender = WebPushSender(_make_config(), store)
+
+        with (
+            patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True),
+            patch.object(sender, "send_to_subscription", side_effect=[False, True]),
+        ):
+            result = sender.send_to_user(1, {"title": "t", "body": "b"})
+
+        assert result is True
+
+    def test_returns_false_when_all_subscriptions_fail(self) -> None:
+        """全端末失敗なら False。"""
+        store = _make_store()
+        sender = WebPushSender(_make_config(), store)
+
+        with (
+            patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True),
+            patch.object(sender, "send_to_subscription", return_value=False),
+        ):
+            result = sender.send_to_user(1, {"title": "t", "body": "b"})
+
+        assert result is False
+
+    def test_failed_subscription_is_removed_from_store(self) -> None:
+        """失敗した購読は store.remove で削除される (send_to_all と同じ挙動)。"""
+        store = _make_store()
+        sender = WebPushSender(_make_config(), store)
+
+        with (
+            patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True),
+            patch.object(sender, "send_to_subscription", side_effect=[True, False]),
+        ):
+            sender.send_to_user(1, {"title": "t", "body": "b"})
+
+        remaining = {s.endpoint for s in store.get_for_user(1)}
+        assert len(remaining) == 1
+
+    def test_pywebpush_unavailable_returns_false_without_calling_store(self) -> None:
+        """pywebpush 未インストール環境では静かに False を返す (既存 send_to_all と同じ fail-open)。"""
+        store = _make_store()
+        sender = WebPushSender(_make_config(), store)
+
+        with patch("app.notifications.push._PYWEBPUSH_AVAILABLE", False):
+            result = sender.send_to_user(1, {"title": "t", "body": "b"})
+
+        assert result is False


### PR DESCRIPTION
## Summary
- AI提案生成時 (`ai_judgment_scheduler.py` の通常提案・安全利回り提案 両経路) に、既存だが未配線だった `WebPushSender` / `DatabaseSubscriptionStore` を使い、購読者ユーザーへ実際のWeb Push配信を行うよう配線した。
- `WebPushSender` に per-user 配信用の `send_to_user()` を追加 (既存 `send_to_all` は `/push/test` 専用のまま変更なし)。`SubscriptionStore` Protocol / `InMemorySubscriptionStore` にも `get_for_user` を追加して整合させた。
- 配信結果 (成功/失敗) を `notification_logs` に `channel="push"` / `delivered=True|False` として新規1行記録。既存の LINE/Slack/DBログ経路 (`channel="line"` 等) はそのまま。
- VAPID未設定時は既存設計通り Web Push 全体を無効化 (fail-open、ログのみ)。配信処理内の例外はすべて握り潰し、提案生成処理自体をブロックしない。

背景: これまで `get_notification_service().send()` は LINE/Slack/DBログのみで、購読済みブラウザへ通知を実配信するコードが一切なく、25日間到達経路ゼロのまま気づかれていなかった (`docs/internal/2026-08-04_execution_pipeline_requirements.md`)。

## Changed files
- `backend/app/notifications/push.py` — `WebPushSender.send_to_user()` 追加、`SubscriptionStore` Protocol / `InMemorySubscriptionStore` に `get_for_user()` 追加
- `backend/app/automation/ai_judgment_scheduler.py` — `_deliver_ai_proposal_push()` ヘルパー追加し、通常提案・安全利回り提案の2箇所から呼び出し
- `backend/tests/automation/test_proposals_notification.py` — `_deliver_ai_proposal_push` 単体テスト + `_create_proposals_for_users` からの配線テスト追加
- `backend/tests/notifications/test_webpush_send_to_user.py` (新規) — `send_to_user` の per-user 分離・失敗時サブスクリプション削除等の単体テスト

## Test plan
```
cd backend
ruff check .                                    # No issues found (対象ファイル)
ruff format --check .                           # 対象ファイル整形済み
mypy app/ --config-file ../pyproject.toml       # 既存の stripe import-not-found 2件のみ (無関係・既知)
python -m pytest tests/ -q
# → 4874 passed, 26 skipped (変更前ベースライン 4861 passed から新規13テスト分増加、失敗0)
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>