### PR TITLE
feat(ai): 稼働率バンド上位境界補正(kill switch既定OFF)

### DIFF
--- a/backend/app/ai/agents.py
+++ b/backend/app/ai/agents.py
@@ -454,6 +454,18 @@ def _indicator_momentum_enabled() -> bool:
     return os.getenv("AI_INDICATOR_MOMENTUM_ENABLED", "false").strip().lower() == "true"
 
 
+def _utilization_band_v2_enabled() -> bool:
+    """稼働率(utilization)バンド上位境界のkill switch(既定OFF)。
+
+    有効化すると稼働率バンドの上位境界を85→95に引き上げる補正が入る
+    (下位境界70/30・スコア幅-18/-4/+6/+12・bias/confidence算出は不変)。
+    AI判定コアの補正のため、staging soak確認後に人間が明示的に
+    AI_UTILIZATION_BAND_V2_ENABLED=true を設定するまでは無効(既存動作と不変)。
+    異常発生時は env を戻すだけで即無効化できる(再デプロイ不要)。
+    """
+    return os.getenv("AI_UTILIZATION_BAND_V2_ENABLED", "false").strip().lower() == "true"
+
+
 def indicator_agent(ctx: MarketContext) -> AgentSignal:
     """Analyze Aave on-chain indicators (utilization, APY, HF).
 
@@ -472,7 +484,8 @@ def indicator_agent(ctx: MarketContext) -> AgentSignal:
     Rules (post-fix):
     - HF < 1.6 → strongly bearish; HF 1.6-1.75 → bearish; 1.75-1.9 → mild cau-
       tion; 1.9-2.1 → mild comfort; 2.1-2.5 → bullish; ≥2.5 → strongly bullish.
-    - Util >85% → bearish; 70-85% → mild caution; 30-70% → mild comfort;
+    - Util >85% (kill switch AI_UTILIZATION_BAND_V2_ENABLED=true で >95%) → bearish;
+      70-85%(or 70-95%) → mild caution; 30-70% → mild comfort;
       <30% → bullish (ample liquidity).
     - Supply APY >5% → bullish (attractive yield); <1% → mild bearish (yield
       compression suggests over-supply / weak demand).
@@ -510,7 +523,8 @@ def indicator_agent(ctx: MarketContext) -> AgentSignal:
     if util is not None:
         util_float = float(util)
         key_data["utilization_rate"] = str(util)
-        if util_float > 85:
+        _util_high_band = 95 if _utilization_band_v2_enabled() else 85
+        if util_float > _util_high_band:
             score -= 18
             reasons.append(f"Utilization at {util}% — heavy liquidity pressure")
         elif util_float > 70:

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -262,6 +262,95 @@ class TestIndicatorAgent:
         )
         assert indicator_agent(ctx).confidence == indicator_agent(base_ctx).confidence
 
+    # ------------------------------------------------------------------
+    # Utilization band v2 (2026-08-05 — C2 稼働率バンド補正)
+    # kill switch AI_UTILIZATION_BAND_V2_ENABLED は既定OFF。
+    # 有効化すると util の減点開始境界が 85 → 95 に上がるのみ。
+    # 下位境界(70/30)・スコア幅(-18/-4/+6/+12)は不変。
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("util", ["85.1", "86", "90", "95.1"])
+    def test_band_v2_disabled_by_default_keeps_85_boundary(self, util: str) -> None:
+        """kill switch OFF(既定)なら旧仕様どおり util>85 で heavy pressure 判定が続くこと。"""
+        ctx = build_market_context(aave_utilization_rate=Decimal(util))
+        signal = indicator_agent(ctx)
+        assert "heavy liquidity pressure" in signal.reasoning.lower()
+
+    def test_band_v2_enabled_94_9_still_mild_caution(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """kill switch ON: util=94.9 は新境界95未満なので mild caution(elevated)に留まること。"""
+        monkeypatch.setenv("AI_UTILIZATION_BAND_V2_ENABLED", "true")
+        ctx = build_market_context(aave_utilization_rate=Decimal("94.9"))
+        signal = indicator_agent(ctx)
+        assert "elevated" in signal.reasoning.lower()
+        assert "heavy liquidity pressure" not in signal.reasoning.lower()
+
+    def test_band_v2_enabled_95_0_still_mild_caution(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """kill switch ON: util=95.0 はちょうど境界(>95ではない)なので mild caution に留まること。"""
+        monkeypatch.setenv("AI_UTILIZATION_BAND_V2_ENABLED", "true")
+        ctx = build_market_context(aave_utilization_rate=Decimal("95.0"))
+        signal = indicator_agent(ctx)
+        assert "elevated" in signal.reasoning.lower()
+        assert "heavy liquidity pressure" not in signal.reasoning.lower()
+
+    def test_band_v2_enabled_95_1_triggers_heavy_pressure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """kill switch ON: util=95.1 は新境界95超なので heavy pressure 判定に入ること。"""
+        monkeypatch.setenv("AI_UTILIZATION_BAND_V2_ENABLED", "true")
+        ctx = build_market_context(aave_utilization_rate=Decimal("95.1"))
+        signal = indicator_agent(ctx)
+        assert "heavy liquidity pressure" in signal.reasoning.lower()
+
+    def test_band_v2_disabled_does_not_change_lower_bounds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """kill switch ON でも下位境界(70/30)とスコア幅は不変であること(境界外の据え置き確認)。"""
+        monkeypatch.setenv("AI_UTILIZATION_BAND_V2_ENABLED", "true")
+        for util, expected_phrase in (
+            ("71", "elevated"),
+            ("50", "healthy liquidity"),
+            ("10", "ample liquidity"),
+        ):
+            ctx = build_market_context(aave_utilization_rate=Decimal(util))
+            signal = indicator_agent(ctx)
+            assert expected_phrase in signal.reasoning.lower()
+
+    @staticmethod
+    def _util_score_delta(reasoning: str) -> int:
+        """reasoning文言からutil起因のスコア寄与(-18/-4/+6/+12)を逆引きする。"""
+        reasoning_lower = reasoning.lower()
+        if "heavy liquidity pressure" in reasoning_lower:
+            return -18
+        if "elevated" in reasoning_lower:
+            return -4
+        if "healthy liquidity" in reasoning_lower:
+            return 6
+        if "ample liquidity" in reasoning_lower:
+            return 12
+        raise AssertionError(f"未知のutil reasoning: {reasoning}")
+
+    @pytest.mark.parametrize("util_int", list(range(0, 101)))
+    def test_band_v2_score_never_lower_than_v1_across_full_range(
+        self, monkeypatch: pytest.MonkeyPatch, util_int: int
+    ) -> None:
+        """単調性(C2-2の核心): 全util域でON時のスコア寄与 >= OFF時のスコア寄与が常に成立すること。
+
+        これにより「ONによってBEARISH(score<=35)への到達が容易になる」ことがないと
+        担保する(上位境界の引き上げは追加の減点を発生させない方向にしか働かない)。
+        """
+        util = Decimal(str(util_int))
+
+        ctx_off = build_market_context(aave_utilization_rate=util)
+        delta_off = self._util_score_delta(indicator_agent(ctx_off).reasoning)
+
+        monkeypatch.setenv("AI_UTILIZATION_BAND_V2_ENABLED", "true")
+        ctx_on = build_market_context(aave_utilization_rate=util)
+        delta_on = self._util_score_delta(indicator_agent(ctx_on).reasoning)
+
+        assert delta_on >= delta_off, (
+            f"util={util}: ON時のスコア寄与({delta_on})がOFF時({delta_off})を下回っている"
+        )
+
 
 class TestPatternAgent:
     def test_no_history_is_neutral(self) -> None:


### PR DESCRIPTION
## 概要
AI判定コア `indicator_agent()` の稼働率(utilization)バンド上位境界を、kill switch経由で85%→95%に引き上げ可能にする補正を追加する(要件書 `docs/internal/2026-08-04_execution_pipeline_requirements.md` クラスタC2)。

## 変更内容
- `backend/app/ai/agents.py`
  - `_utilization_band_v2_enabled()` を追加(環境変数 `AI_UTILIZATION_BAND_V2_ENABLED`、既定 `"false"`)。既存の `_indicator_momentum_enabled()` と同型のkill switchパターン。
  - util判定ブロックの上位境界のみ、kill switch有効時に `85` → `95` に変更。下位境界(70/30)・スコア加減算幅(-18/-4/+6/+12)・reasons文言・bias判定(65/35)・confidence算出式・`_DIRECTIONAL_THRESHOLD`(70)は一切変更していない。
- `backend/tests/test_agents.py`
  - kill switch OFF(既定)時に旧仕様(85超で減点)が維持されることを確認する回帰テスト
  - kill switch ON時の境界値テスト(util=94.9/95.0/95.1)
  - kill switch ON時に下位境界(70/30)とスコア幅が不変であることのテスト
  - **単調性テスト**: util 0〜100の全域で、ON時のutil起因スコア寄与がOFF時を下回らないことをパラメタライズテストで検証(C2-2担保。「BEARISH(score≤35)への到達がONによって容易になることはない」ことを保証)

## kill switch
- **既定OFF** (`AI_UTILIZATION_BAND_V2_ENABLED=false`)。本PRでは既存の実トレード判定動作を完全に維持する。
- **本番有効化はこのPRでは行わない**。クラスタA/B完了後に別途、人間判断で有効化する。
- 異常時はenvを戻すだけで即無効化可能(再デプロイ不要)。

## テスト結果
```
backend/tests/test_agents.py: 151 passed
ruff check: No issues found
ruff format --check: 2 files already formatted
mypy app/ai/agents.py: No issues found
```
全util域(0-100, 1刻み)での単調性テストも含め全件PASS。

## 影響範囲
- `_DIRECTIONAL_THRESHOLD`・bias閾値(65/35)・confidence算出式・下位境界(70/30)・スコア幅への変更なし
- kill switch OFF(既定)のため、本PRのマージ自体は実トレード判定に一切影響しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)