### PR TITLE
test: Web Push到達経路のテスト強化 (実バグ5件修正) + フロントエンド unit test 基盤導入

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -662,16 +662,30 @@ def _deliver_ai_proposal_push(db: Session, user_id: int, payload: Any) -> None:
     失敗しても提案生成自体はブロックしない (fail-open)。
     """
     try:
+        from app.auth.models import User  # noqa: PLC0415
         from app.notifications.models import NotificationLog  # noqa: PLC0415
         from app.notifications.push import (  # noqa: PLC0415
             DatabaseSubscriptionStore,
             WebPushSender,
             get_vapid_config,
+            push_allowed_for_user,
         )
 
         vapid_config = get_vapid_config()
         if vapid_config is None:
             logger.debug("Web Push: VAPID未設定のためスキップ (user_id=%d)", user_id)
+            return
+
+        # 受け入れ条件 B-N4: 通知設定で OFF にしたユーザーへは配信しない。
+        # 購読行の有無だけで送ると「設定画面ではOFFなのに通知が来る」状態になる。
+        _user = db.get(User, user_id)
+        if _user is None or not push_allowed_for_user(
+            _user.notification_settings_json, "ai_proposal"
+        ):
+            logger.debug(
+                "Web Push: 通知設定によりスキップ (user_id=%d)",
+                user_id,
+            )
             return
 
         sender = WebPushSender(vapid_config, DatabaseSubscriptionStore(SessionLocal))

--- a/backend/app/notifications/push.py
+++ b/backend/app/notifications/push.py
@@ -11,6 +11,7 @@ import logging
 import os
 import threading
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Callable, Optional, Protocol
 
 from pydantic import BaseModel
@@ -24,6 +25,25 @@ except ImportError:
     _PYWEBPUSH_AVAILABLE = False
 
 logger = logging.getLogger(__name__)
+
+
+class DeliveryResult(Enum):
+    """1件の Web Push 送信結果。
+
+    2026-08-05: 以前は bool だったため「購読が失効した (410)」と「一時的に失敗した
+    (タイムアウト / 5xx)」を区別できず、呼び出し側が両方まとめて購読を削除していた。
+    その結果 FCM の一時障害 1 回で全ユーザーの購読が消え、ユーザーが手動で再購読する
+    まで通知が永久に届かなくなる (= 到達経路が黙って失われる、本プロジェクトが
+    最も避けたい失敗形)。除去してよいのは FAILED_GONE のみ。
+    """
+
+    SUCCESS = "success"
+    FAILED_TRANSIENT = "failed_transient"
+    FAILED_GONE = "failed_gone"
+
+
+#: 購読が恒久的に消滅したことを示す HTTP status。410 が標準、404 は実装差の吸収。
+_GONE_STATUS_CODES = frozenset({404, 410})
 
 
 @dataclass
@@ -126,23 +146,54 @@ class DatabaseSubscriptionStore:
 
     @staticmethod
     def _read_push_subscriptions(raw_json: Optional[str]) -> list[dict[str, Any]]:
+        """push_subscriptions を読む。壊れた列は空リストとして扱い、例外は投げない。
+
+        `null` / `[1,2]` / `123` / `"str"` はいずれも json.loads が成功するため
+        JSONDecodeError では捕まらない。dict 以外を弾かないと raw.get() が
+        AttributeError になり、呼び出し元の except Exception に飲まれて
+        「静かに配信スキップ」になる (到達経路の暗黙喪失)。
+        """
         if not raw_json:
             return []
         try:
             raw = json.loads(raw_json)
         except json.JSONDecodeError:
             return []
+        if not isinstance(raw, dict):
+            return []
         subs = raw.get("push_subscriptions")
         return subs if isinstance(subs, list) else []
 
     @staticmethod
     def _write_push_subscriptions(raw_json: Optional[str], subs: list[dict[str, Any]]) -> str:
+        """push_subscriptions のみを差し替えて返す。dict 以外の既存値は破棄して作り直す。"""
         try:
             raw = json.loads(raw_json) if raw_json else {}
         except json.JSONDecodeError:
             raw = {}
+        if not isinstance(raw, dict):
+            raw = {}
         raw["push_subscriptions"] = subs
         return json.dumps(raw)
+
+    @staticmethod
+    def _parse_entry(entry: Any, user_id: int) -> Optional[WebPushSubscription]:
+        """1 件の購読 entry を復元する。壊れていれば None を返し、他の購読を巻き込まない。
+
+        entry が dict でない (文字列 / None 等) 場合 ``entry["endpoint"]`` は
+        KeyError ではなく TypeError になるため、両方を弾く必要がある。
+        """
+        if not isinstance(entry, dict):
+            return None
+        try:
+            return WebPushSubscription(
+                endpoint=entry["endpoint"],
+                p256dh=entry["p256dh"],
+                auth=entry["auth"],
+                user_id=user_id,
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
 
     def add(self, subscription: WebPushSubscription) -> None:
         """サブスクリプションを永続化する。同じ endpoint は (他ユーザー分も含め) 上書きする。"""
@@ -226,17 +277,9 @@ class DatabaseSubscriptionStore:
             result: list[WebPushSubscription] = []
             for user in users:
                 for s in self._read_push_subscriptions(user.notification_settings_json):
-                    try:
-                        result.append(
-                            WebPushSubscription(
-                                endpoint=s["endpoint"],
-                                p256dh=s["p256dh"],
-                                auth=s["auth"],
-                                user_id=user.id,
-                            )
-                        )
-                    except KeyError:
-                        continue
+                    parsed = self._parse_entry(s, user.id)
+                    if parsed is not None:
+                        result.append(parsed)
             return result
         finally:
             db.close()
@@ -252,17 +295,9 @@ class DatabaseSubscriptionStore:
                 return []
             result: list[WebPushSubscription] = []
             for s in self._read_push_subscriptions(user.notification_settings_json):
-                try:
-                    result.append(
-                        WebPushSubscription(
-                            endpoint=s["endpoint"],
-                            p256dh=s["p256dh"],
-                            auth=s["auth"],
-                            user_id=user_id,
-                        )
-                    )
-                except KeyError:
-                    continue
+                parsed = self._parse_entry(s, user_id)
+                if parsed is not None:
+                    result.append(parsed)
             return result
         finally:
             db.close()
@@ -287,31 +322,25 @@ class WebPushSender:
 
         subscriptions = self._store.get_all()
         success_count = 0
-        failed_endpoints: list[str] = []
+        failed_count = 0
+        gone_endpoints: list[str] = []
 
         for subscription in subscriptions:
-            try:
-                ok = self.send_to_subscription(subscription, payload, ttl)
-                if ok:
-                    success_count += 1
-                else:
-                    failed_endpoints.append(subscription.endpoint)
-            except Exception:
-                logger.exception(
-                    "Web Push 送信中に予期しないエラーが発生しました: endpoint=%s",
-                    subscription.endpoint[:30],
-                )
-                failed_endpoints.append(subscription.endpoint)
+            result = self._deliver_guarded(subscription, payload, ttl)
+            if result is DeliveryResult.SUCCESS:
+                success_count += 1
+                continue
+            failed_count += 1
+            if result is DeliveryResult.FAILED_GONE:
+                gone_endpoints.append(subscription.endpoint)
 
-        # 失敗した subscription を削除
-        for endpoint in failed_endpoints:
-            self._store.remove(endpoint)
-            logger.info("失敗したサブスクリプションを削除しました: endpoint=%s", endpoint[:30])
+        self._purge_gone(gone_endpoints)
 
         logger.info(
-            "Web Push 送信完了: 成功=%d, 失敗=%d, 合計=%d",
+            "Web Push 送信完了: 成功=%d, 失敗=%d, 失効除去=%d, 合計=%d",
             success_count,
-            len(failed_endpoints),
+            failed_count,
+            len(gone_endpoints),
             len(subscriptions),
         )
         return success_count
@@ -328,36 +357,51 @@ class WebPushSender:
 
         subscriptions = self._store.get_for_user(user_id)
         success = False
-        failed_endpoints: list[str] = []
+        gone_endpoints: list[str] = []
 
         for subscription in subscriptions:
-            try:
-                ok = self.send_to_subscription(subscription, payload, ttl)
-                if ok:
-                    success = True
-                else:
-                    failed_endpoints.append(subscription.endpoint)
-            except Exception:
-                logger.exception(
-                    "Web Push 送信中に予期しないエラーが発生しました: user_id=%d, endpoint=%s",
-                    user_id,
-                    subscription.endpoint[:30],
-                )
-                failed_endpoints.append(subscription.endpoint)
+            result = self._deliver_guarded(subscription, payload, ttl)
+            if result is DeliveryResult.SUCCESS:
+                success = True
+            elif result is DeliveryResult.FAILED_GONE:
+                gone_endpoints.append(subscription.endpoint)
 
-        for endpoint in failed_endpoints:
-            self._store.remove(endpoint)
-            logger.info("失敗したサブスクリプションを削除しました: endpoint=%s", endpoint[:30])
-
+        self._purge_gone(gone_endpoints)
         return success
+
+    def _deliver_guarded(
+        self, subscription: WebPushSubscription, payload: dict[str, Any], ttl: int
+    ) -> DeliveryResult:
+        """send_to_subscription を例外から守る。原因不明の例外は一時失敗として扱う。
+
+        「失効と断定できない失敗」で購読を捨てないことが要件 (B-E1 / B-E2)。
+        """
+        try:
+            return self.send_to_subscription(subscription, payload, ttl)
+        except Exception:
+            logger.exception(
+                "Web Push 送信中に予期しないエラーが発生しました (購読は保持): endpoint=%s",
+                subscription.endpoint[:30],
+            )
+            return DeliveryResult.FAILED_TRANSIENT
+
+    def _purge_gone(self, gone_endpoints: list[str]) -> None:
+        """失効した購読のみをストアから除去する。"""
+        for endpoint in gone_endpoints:
+            self._store.remove(endpoint)
+            logger.info("失効した購読を除去しました: endpoint=%s", endpoint[:30])
 
     def send_to_subscription(
         self, subscription: WebPushSubscription, payload: dict[str, Any], ttl: int
-    ) -> bool:
-        """特定のサブスクリプションに通知を送信する。成功した場合は True を返す。"""
+    ) -> DeliveryResult:
+        """特定のサブスクリプションに送信し、結果を3分類して返す。
+
+        2026-08-05: 戻り値を bool から DeliveryResult に変更。呼び出し側が
+        「失効 (削除すべき)」と「一時失敗 (残すべき)」を区別できるようにするため。
+        """
         if not _PYWEBPUSH_AVAILABLE:
             logger.warning("pywebpush がインストールされていません。Web Push は無効です。")
-            return False
+            return DeliveryResult.FAILED_TRANSIENT
 
         try:
             webpush(
@@ -371,26 +415,58 @@ class WebPushSender:
                 ttl=ttl,
             )
             logger.info("Web Push 送信成功: endpoint=%s", subscription.endpoint[:30])
-            return True
+            return DeliveryResult.SUCCESS
         except Exception as exc:  # noqa: BLE001
-            # 410 Gone はサブスクリプションが無効（削除すべき）
             status_code: Optional[int] = None
             if _PYWEBPUSH_AVAILABLE:
                 if isinstance(exc, WebPushException) and exc.response is not None:
                     status_code = exc.response.status_code
 
-            if status_code == 410:
+            # 404/410 のみが「購読はもう存在しない」を意味する。それ以外 (5xx / 429 /
+            # ネットワーク断 / status 不明) は購読が生きている可能性があるため残す。
+            if status_code in _GONE_STATUS_CODES:
                 logger.info(
-                    "Web Push サブスクリプションが無効 (410 Gone): endpoint=%s",
-                    subscription.endpoint[:30],
-                )
-            else:
-                logger.error(
-                    "Web Push 送信失敗: status=%s, endpoint=%s",
+                    "Web Push サブスクリプション失効 (status=%s): endpoint=%s",
                     status_code,
                     subscription.endpoint[:30],
                 )
-            return False
+                return DeliveryResult.FAILED_GONE
+
+            logger.error(
+                "Web Push 送信失敗 (一時エラー扱い・購読は保持): status=%s, endpoint=%s",
+                status_code,
+                subscription.endpoint[:30],
+            )
+            return DeliveryResult.FAILED_TRANSIENT
+
+
+def push_allowed_for_user(raw_settings_json: Optional[str], preference_key: str) -> bool:
+    """ユーザーの通知設定が当該種別の Web Push を許可しているか判定する。
+
+    2026-08-05 (受け入れ条件 B-N4): 「通知設定で提案通知を無効にする → 配信されない」。
+    以前は購読行が存在すれば設定を無視して送っていたため、設定画面で OFF にしても
+    通知が届く状態だった (設定表示と実挙動の乖離 = 本プロジェクトが繰り返している
+    ドリフトと同型)。
+
+    push_enabled は NotificationSettingsModel 既定が False であり、
+    「明示的に有効化していないユーザーには送らない」を既定の約束とする。
+    設定が壊れている場合も送らない (fail-closed: 意図しない通知より無通知を選ぶ。
+    到達経路ゼロ側は別途 B-6 の検知対象になる)。
+    """
+    if not raw_settings_json:
+        return False
+    try:
+        raw = json.loads(raw_settings_json)
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(raw, dict):
+        return False
+    if raw.get("push_enabled") is not True:
+        return False
+    preferences = raw.get("preferences")
+    if isinstance(preferences, dict) and preferences.get(preference_key) is False:
+        return False
+    return True
 
 
 def get_vapid_config() -> Optional[VAPIDConfig]:

--- a/backend/app/notifications/router.py
+++ b/backend/app/notifications/router.py
@@ -71,6 +71,12 @@ class SubscribeRequest(BaseModel):
         if self.keys is not None:
             self.p256dh = self.p256dh or self.keys.p256dh
             self.auth = self.auth or self.keys.auth
+        # 2026-08-05: 鍵・endpoint が空の購読を保存すると、送信時に必ず失敗する
+        # 「絶対に届かない購読」が残る。到達経路の可視性を損なうため境界で弾く。
+        if not self.endpoint.strip():
+            raise ValueError("endpoint は必須です")
+        if not self.p256dh.strip() or not self.auth.strip():
+            raise ValueError("p256dh と auth は必須です (keys ネスト形式でも可)")
         return self
 
 
@@ -105,7 +111,8 @@ def _do_subscribe(
     logger.info(
         "Push subscription 登録: user_id=%d endpoint=%s", current_user.id, req.endpoint[:30]
     )
-    return {"status": "subscribed", "count": store.count()}
+    # count は本人の購読数のみを返す (全体数は他ユーザー分の情報漏洩になる)。
+    return {"status": "subscribed", "count": len(store.get_for_user(current_user.id))}
 
 
 def _do_test_push(
@@ -160,10 +167,27 @@ def unsubscribe(
     store: SubscriptionStore = Depends(get_subscription_store),
     current_user: User = Depends(require_active_user),
 ) -> dict[str, Any]:
-    """Push subscription を削除する。認証必須。endpoint はクエリパラメータで指定する。"""
-    store.remove(endpoint)
-    logger.info("Push subscription 削除: user_id=%d endpoint=%s", current_user.id, endpoint[:30])
-    return {"status": "unsubscribed", "count": store.count()}
+    """Push subscription を削除する。認証必須。endpoint はクエリパラメータで指定する。
+
+    2026-08-05: 本人が所有する endpoint のみ削除する。以前は endpoint だけで
+    全ユーザーから削除していたため、他人の endpoint を知れば購読を消せた
+    (store.remove は仕様上グローバル削除なので、呼ぶ前に所有確認が必要)。
+    存在しない / 他人のものだった場合は 200 の no-op とする
+    (連打・リトライで壊れないよう冪等に保ち、存在の有無も露出させない)。
+    """
+    owned = {s.endpoint for s in store.get_for_user(current_user.id)}
+    if endpoint in owned:
+        store.remove(endpoint)
+        logger.info(
+            "Push subscription 削除: user_id=%d endpoint=%s", current_user.id, endpoint[:30]
+        )
+    else:
+        logger.info(
+            "Push subscription 削除スキップ (未所有): user_id=%d endpoint=%s",
+            current_user.id,
+            endpoint[:30],
+        )
+    return {"status": "unsubscribed", "count": len(store.get_for_user(current_user.id))}
 
 
 @router.get("/push/vapid-key", status_code=status.HTTP_200_OK)

--- a/backend/tests/automation/test_proposals_notification.py
+++ b/backend/tests/automation/test_proposals_notification.py
@@ -13,6 +13,7 @@ Regression guard: legacy LINE_NOTIFY_TOKEN route must not be called.
 
 from __future__ import annotations
 
+import json
 from decimal import Decimal
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -171,16 +172,32 @@ class TestDeliverAiProposalPush:
     def _payload() -> Any:
         return ai_proposal_notification("SUPPLY", "USDC", Decimal("100"), 80)
 
+    @staticmethod
+    def _db_with_push_enabled_user(user_id: int) -> MagicMock:
+        """通知設定で Push を有効化済みのユーザーを返す db モック。
+
+        2026-08-05: 配信前に notification_settings_json を見る設定ゲート (B-N4) が
+        入ったため、配信されることを確認するテストでは明示的に有効化しておく必要がある。
+        """
+        user = MagicMock()
+        user.id = user_id
+        user.notification_settings_json = json.dumps(
+            {"push_enabled": True, "preferences": {"ai_proposal": True}}
+        )
+        db = MagicMock()
+        db.get.return_value = user
+        return db
+
     def test_vapid_unset_skips_without_raising(self) -> None:
         """VAPID未設定時は静かにスキップし、push行は作られない。"""
-        mock_db = MagicMock()
+        mock_db = self._db_with_push_enabled_user(1)
         with patch("app.notifications.push.get_vapid_config", return_value=None):
             _deliver_ai_proposal_push(mock_db, 1, self._payload())
         mock_db.add.assert_not_called()
 
     def test_vapid_set_success_logs_delivered_true(self) -> None:
         """配信成功: delivered=True の push NotificationLog が1行追加される。"""
-        mock_db = MagicMock()
+        mock_db = self._db_with_push_enabled_user(5)
         mock_sender = MagicMock()
         mock_sender.send_to_user.return_value = True
         with (
@@ -198,7 +215,7 @@ class TestDeliverAiProposalPush:
 
     def test_vapid_set_failure_logs_delivered_false(self) -> None:
         """配信失敗: delivered=False の push NotificationLog が1行追加される。"""
-        mock_db = MagicMock()
+        mock_db = self._db_with_push_enabled_user(5)
         mock_sender = MagicMock()
         mock_sender.send_to_user.return_value = False
         with (

--- a/backend/tests/notifications/test_push_delivery_hardening.py
+++ b/backend/tests/notifications/test_push_delivery_hardening.py
@@ -1,0 +1,401 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/notifications/test_push_delivery_hardening.py
+"""Web Push 到達経路の「壊れやすいポイント」を突くテスト (2026-08-05)。
+
+既存テスト (test_push_subscription_store.py / test_webpush_send_to_user.py /
+test_notification_settings_api.py) は正常系とストア機構を押さえているが、
+以下の壊れやすい箇所が未検証だった。本ファイルはそこだけを狙う。
+
+対象 (docs/internal/2026-08-04_execution_pipeline_requirements.md の受け入れ条件):
+- B-N4  : 通知設定で提案通知を無効にしたら配信されない
+- B-E1  : 失効した配信先 (410 Gone) は除去される
+- B-E2  : 配信サービスのエラーは「未到達」記録に留め、購読を消さない
+- B-B1  : 購読数 0件 / 1件 / 複数端末
+- I-3   : iPhone + PC の2台購読 → 両方へ配信、片方失敗でも他方は生きる
+- I-4   : OS設定で後から拒否 → 失効検知で除去、到達経路ゼロとして扱う
+- I-5   : PWA 削除→再追加 → 新規購読を受け付け、旧購読は失効検知で除去
+- I-14  : 通知OFFのまま承認型を使い続ける (到達経路ゼロの自己再現) の検知前提
+
+「一時エラーで購読を消してしまう」= 25日間サイレント障害と同型の
+"可観測性なき到達経路喪失" なので、本ファイルの最重要ケースとして扱う。
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.notifications.push import (
+    _PYWEBPUSH_AVAILABLE,
+    DeliveryResult,
+    InMemorySubscriptionStore,
+    VAPIDConfig,
+    WebPushSender,
+    WebPushSubscription,
+)
+
+
+def _config() -> VAPIDConfig:
+    return VAPIDConfig(public_key="pub", private_key="priv", mailto="ops@example.com")
+
+
+def _sub(endpoint: str, user_id: int | None = 1) -> WebPushSubscription:
+    return WebPushSubscription(endpoint=endpoint, p256dh="k", auth="a", user_id=user_id)
+
+
+# ---------------------------------------------------------------------------
+# 1. 失効(410) と 一時エラー の区別 — B-E1 / B-E2 / I-4
+# ---------------------------------------------------------------------------
+
+
+class TestGoneVsTransientFailure:
+    """一時エラーで購読を消さないこと。消すのは 410 Gone のみ。
+
+    ここが壊れると FCM の一時障害1回で全ユーザーの購読が消え、
+    ユーザーが手動で再購読するまで永久に通知が届かない
+    (= 今回の障害と同型の静かな到達経路喪失)。
+    """
+
+    def test_transient_failure_keeps_subscription(self) -> None:
+        """一時エラー(タイムアウト/500等)では購読を削除しない。"""
+        store = InMemorySubscriptionStore()
+        store.add(_sub("https://p.example.com/a"))
+        sender = WebPushSender(_config(), store)
+
+        with (
+            patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True),
+            patch.object(
+                sender, "send_to_subscription", return_value=DeliveryResult.FAILED_TRANSIENT
+            ),
+        ):
+            result = sender.send_to_user(1, {"title": "t", "body": "b"})
+
+        assert result is False, "一時エラーなので未到達"
+        assert len(store.get_for_user(1)) == 1, "一時エラーで購読が消えてはいけない"
+
+    def test_gone_failure_removes_subscription(self) -> None:
+        """410 Gone (購読失効) は削除する — I-4 / I-5 の後片付け。"""
+        store = InMemorySubscriptionStore()
+        store.add(_sub("https://p.example.com/a"))
+        sender = WebPushSender(_config(), store)
+
+        with (
+            patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True),
+            patch.object(sender, "send_to_subscription", return_value=DeliveryResult.FAILED_GONE),
+        ):
+            sender.send_to_user(1, {"title": "t", "body": "b"})
+
+        assert store.get_for_user(1) == [], "失効した購読は除去されるべき"
+
+    def test_unexpected_exception_keeps_subscription(self) -> None:
+        """予期しない例外は「失効」と判断できないので購読を残す (fail-safe側に倒す)。"""
+        store = InMemorySubscriptionStore()
+        store.add(_sub("https://p.example.com/a"))
+        sender = WebPushSender(_config(), store)
+
+        with (
+            patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True),
+            patch.object(sender, "send_to_subscription", side_effect=RuntimeError("boom")),
+        ):
+            result = sender.send_to_user(1, {"title": "t", "body": "b"})
+
+        assert result is False
+        assert len(store.get_for_user(1)) == 1, "原因不明の失敗で購読を捨ててはいけない"
+
+    def test_mixed_gone_and_transient_removes_only_gone(self) -> None:
+        """混在時: 410 の端末だけ消え、一時エラーの端末は残る (I-3 の複数端末)。"""
+        store = InMemorySubscriptionStore()
+        store.add(_sub("https://p.example.com/iphone"))
+        store.add(_sub("https://p.example.com/pc"))
+        sender = WebPushSender(_config(), store)
+
+        def _by_endpoint(sub: WebPushSubscription, *_args: Any, **_kw: Any) -> DeliveryResult:
+            return (
+                DeliveryResult.FAILED_GONE
+                if sub.endpoint.endswith("iphone")
+                else DeliveryResult.FAILED_TRANSIENT
+            )
+
+        with (
+            patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True),
+            patch.object(sender, "send_to_subscription", side_effect=_by_endpoint),
+        ):
+            sender.send_to_user(1, {"title": "t", "body": "b"})
+
+        remaining = {s.endpoint for s in store.get_for_user(1)}
+        assert remaining == {"https://p.example.com/pc"}
+
+    def test_send_to_all_also_keeps_transient_failures(self) -> None:
+        """send_to_all (/push/test 経路) にも同じ規律が効くこと。"""
+        store = InMemorySubscriptionStore()
+        store.add(_sub("https://p.example.com/a", user_id=1))
+        store.add(_sub("https://p.example.com/b", user_id=2))
+        sender = WebPushSender(_config(), store)
+
+        with (
+            patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True),
+            patch.object(
+                sender, "send_to_subscription", return_value=DeliveryResult.FAILED_TRANSIENT
+            ),
+        ):
+            sent = sender.send_to_all({"title": "t", "body": "b"})
+
+        assert sent == 0
+        assert store.count() == 2, "一時エラーで全購読が消えてはいけない"
+
+
+@pytest.mark.skipif(
+    not _PYWEBPUSH_AVAILABLE,
+    reason="pywebpush 未インストール環境ではライブラリ統合部分を検証できない "
+    "(requirements.txt に pywebpush>=2.0.0 があるため CI / 本番イメージでは実行される)",
+)
+class TestDeliveryResultClassification:
+    """send_to_subscription が pywebpush の応答を正しく3分類すること。"""
+
+    @staticmethod
+    def _sender() -> WebPushSender:
+        return WebPushSender(_config(), InMemorySubscriptionStore())
+
+    def test_success_is_success(self) -> None:
+        with patch("app.notifications.push.webpush", return_value=None):
+            result = self._sender().send_to_subscription(_sub("https://p/x"), {"a": 1}, 60)
+        assert result is DeliveryResult.SUCCESS
+
+    @pytest.mark.parametrize("status_code", [404, 410])
+    def test_404_and_410_are_gone(self, status_code: int) -> None:
+        """404/410 はどちらも購読消滅を意味する (RFC8030 実装差の吸収)。"""
+        exc = _make_webpush_exception(status_code)
+        with patch("app.notifications.push.webpush", side_effect=exc):
+            result = self._sender().send_to_subscription(_sub("https://p/x"), {"a": 1}, 60)
+        assert result is DeliveryResult.FAILED_GONE
+
+    @pytest.mark.parametrize("status_code", [429, 500, 502, 503])
+    def test_server_errors_are_transient(self, status_code: int) -> None:
+        """429/5xx は一時エラー: 購読は生きている可能性があるので消さない。"""
+        exc = _make_webpush_exception(status_code)
+        with patch("app.notifications.push.webpush", side_effect=exc):
+            result = self._sender().send_to_subscription(_sub("https://p/x"), {"a": 1}, 60)
+        assert result is DeliveryResult.FAILED_TRANSIENT
+
+    def test_network_error_without_response_is_transient(self) -> None:
+        """response を持たない例外 (DNS/接続失敗等) も一時エラー扱い。"""
+        with patch("app.notifications.push.webpush", side_effect=OSError("connection refused")):
+            result = self._sender().send_to_subscription(_sub("https://p/x"), {"a": 1}, 60)
+        assert result is DeliveryResult.FAILED_TRANSIENT
+
+
+def _make_webpush_exception(status_code: int) -> Exception:
+    """status_code を持つ WebPushException 相当の例外を作る。"""
+    from pywebpush import WebPushException  # noqa: PLC0415
+
+    response = MagicMock()
+    response.status_code = status_code
+    exc = WebPushException("boom", response=response)
+    return exc
+
+
+# ---------------------------------------------------------------------------
+# 2. 破損した notification_settings_json への耐性
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptSettingsJsonRobustness:
+    """dict 以外の有効JSON が入っていてもクラッシュしないこと。
+
+    `null` / `[1,2]` / `123` / `"str"` はいずれも json.loads が成功するため
+    JSONDecodeError では捕まらない。クラッシュすると呼び出し元の
+    except Exception に飲まれて「静かに配信スキップ」になり、
+    到達経路が黙って失われる (本プロジェクトが最も避けたい失敗形)。
+    """
+
+    @pytest.mark.parametrize("raw", ["null", "[1,2]", "123", '"str"', "{}", ""])
+    def test_read_never_raises(self, raw: str) -> None:
+        from app.notifications.push import DatabaseSubscriptionStore
+
+        assert DatabaseSubscriptionStore._read_push_subscriptions(raw) == []
+
+    @pytest.mark.parametrize("raw", ["null", "[1,2]", "123", '"str"'])
+    def test_write_never_raises_and_produces_dict(self, raw: str) -> None:
+        from app.notifications.push import DatabaseSubscriptionStore
+
+        out = DatabaseSubscriptionStore._write_push_subscriptions(
+            raw, [{"endpoint": "e", "p256dh": "p", "auth": "a"}]
+        )
+        parsed = json.loads(out)
+        assert isinstance(parsed, dict)
+        assert parsed["push_subscriptions"][0]["endpoint"] == "e"
+
+    def test_write_preserves_other_keys_from_valid_dict(self) -> None:
+        """正常な dict の場合は他キー (push_enabled 等) を保持すること。"""
+        from app.notifications.push import DatabaseSubscriptionStore
+
+        out = DatabaseSubscriptionStore._write_push_subscriptions(
+            json.dumps({"push_enabled": True, "line_enabled": False}), []
+        )
+        parsed = json.loads(out)
+        assert parsed["push_enabled"] is True
+        assert parsed["line_enabled"] is False
+
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            {"p256dh": "p", "auth": "a"},  # endpoint 欠落
+            {"endpoint": "e", "auth": "a"},  # p256dh 欠落
+            {"endpoint": "e", "p256dh": "p"},  # auth 欠落
+            "not-a-dict",  # 要素が dict ですらない
+            None,
+        ],
+    )
+    def test_malformed_entry_is_skipped_not_fatal(self, entry: Any) -> None:
+        """壊れた要素は飛ばし、他の正常な購読は生き残ること。"""
+        from app.notifications.push import DatabaseSubscriptionStore
+
+        good = {"endpoint": "https://p/good", "p256dh": "p", "auth": "a"}
+        user = MagicMock()
+        user.id = 1
+        user.notification_settings_json = json.dumps({"push_subscriptions": [entry, good]})
+        db = MagicMock()
+        db.get.return_value = user
+
+        store = DatabaseSubscriptionStore(lambda: db)
+        result = store.get_for_user(1)
+
+        assert [s.endpoint for s in result] == ["https://p/good"]
+
+
+# ---------------------------------------------------------------------------
+# 3. 通知設定 (push_enabled / preferences.ai_proposal) の尊重 — B-N4 / I-14
+# ---------------------------------------------------------------------------
+
+
+class TestProposalPushRespectsUserSettings:
+    """通知OFFのユーザーへ配信しないこと。
+
+    ここが壊れると「設定画面でOFFにしたのに通知が来る」= 明確な信頼毀損。
+    受け入れ条件 B-N4 が直接要求している。
+    """
+
+    @staticmethod
+    def _payload() -> Any:
+        from app.notifications.templates import ai_proposal_notification
+
+        return ai_proposal_notification("SUPPLY", "USDC", Decimal("100"), 80)
+
+    @staticmethod
+    def _run(settings_json: str | None) -> tuple[MagicMock, MagicMock]:
+        """指定の notification_settings_json を持つユーザーへ配信を試み、(db, sender) を返す。"""
+        from app.automation.ai_judgment_scheduler import _deliver_ai_proposal_push
+
+        user = MagicMock()
+        user.id = 7
+        user.notification_settings_json = settings_json
+
+        db = MagicMock()
+        db.get.return_value = user
+
+        mock_sender = MagicMock()
+        mock_sender.send_to_user.return_value = True
+
+        with (
+            patch("app.notifications.push.get_vapid_config", return_value=MagicMock()),
+            patch("app.notifications.push.WebPushSender", return_value=mock_sender),
+            patch("app.notifications.push.DatabaseSubscriptionStore"),
+            patch(
+                "app.automation.ai_judgment_scheduler.SessionLocal",
+                return_value=db,
+            ),
+        ):
+            _deliver_ai_proposal_push(db, 7, TestProposalPushRespectsUserSettings._payload())
+        return db, mock_sender
+
+    def test_push_disabled_does_not_send(self) -> None:
+        """push_enabled=false のユーザーには送信しない。"""
+        _db, sender = self._run(json.dumps({"push_enabled": False}))
+        sender.send_to_user.assert_not_called()
+
+    def test_ai_proposal_preference_off_does_not_send(self) -> None:
+        """preferences.ai_proposal=false なら AI提案通知は送らない。"""
+        _db, sender = self._run(
+            json.dumps({"push_enabled": True, "preferences": {"ai_proposal": False}})
+        )
+        sender.send_to_user.assert_not_called()
+
+    def test_push_enabled_with_preference_on_sends(self) -> None:
+        """両方ONなら送信する (正常系)。"""
+        _db, sender = self._run(
+            json.dumps({"push_enabled": True, "preferences": {"ai_proposal": True}})
+        )
+        sender.send_to_user.assert_called_once()
+
+    def test_settings_unset_defaults_to_not_sending(self) -> None:
+        """設定未保存 (NULL) は push_enabled 既定 False に従い送らない。
+
+        NotificationSettingsModel.push_enabled のデフォルトが False であり、
+        「明示的に有効化していないユーザーには送らない」が既定の約束。
+        """
+        _db, sender = self._run(None)
+        sender.send_to_user.assert_not_called()
+
+    def test_corrupt_settings_json_does_not_crash(self) -> None:
+        """破損JSONでも例外を投げずに済むこと (fail-open、提案生成は止めない)。"""
+        _db, sender = self._run("{{{not json")
+        # クラッシュしないことが要件。送る/送らないはどちらでも可だが例外は不可。
+        assert sender.send_to_user.call_count in (0, 1)
+
+
+# ---------------------------------------------------------------------------
+# 4. 複数端末 (I-3) と再購読 (I-5) — B-B1
+# ---------------------------------------------------------------------------
+
+
+class TestMultiDeviceAndResubscribe:
+    def test_all_devices_receive(self) -> None:
+        """I-3: iPhone と PC の両方へ配信されること。"""
+        store = InMemorySubscriptionStore()
+        store.add(_sub("https://p/iphone"))
+        store.add(_sub("https://p/pc"))
+        sender = WebPushSender(_config(), store)
+
+        with (
+            patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True),
+            patch.object(
+                sender, "send_to_subscription", return_value=DeliveryResult.SUCCESS
+            ) as mock_send,
+        ):
+            result = sender.send_to_user(1, {"title": "t", "body": "b"})
+
+        assert result is True
+        assert {c.args[0].endpoint for c in mock_send.call_args_list} == {
+            "https://p/iphone",
+            "https://p/pc",
+        }
+
+    def test_one_device_gone_other_still_delivered(self) -> None:
+        """I-5: 旧端末が失効しても新端末には届き、旧だけ除去される。"""
+        store = InMemorySubscriptionStore()
+        store.add(_sub("https://p/old-pwa"))
+        store.add(_sub("https://p/new-pwa"))
+        sender = WebPushSender(_config(), store)
+
+        def _by_endpoint(sub: WebPushSubscription, *_a: Any, **_kw: Any) -> DeliveryResult:
+            return DeliveryResult.FAILED_GONE if "old" in sub.endpoint else DeliveryResult.SUCCESS
+
+        with (
+            patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True),
+            patch.object(sender, "send_to_subscription", side_effect=_by_endpoint),
+        ):
+            result = sender.send_to_user(1, {"title": "t", "body": "b"})
+
+        assert result is True, "1台でも成功すれば到達"
+        assert {s.endpoint for s in store.get_for_user(1)} == {"https://p/new-pwa"}
+
+    def test_zero_subscription_user_is_unreachable(self) -> None:
+        """B-B1 / I-14: 購読ゼロは False (到達経路ゼロとして検知できること)。"""
+        sender = WebPushSender(_config(), InMemorySubscriptionStore())
+        with patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True):
+            assert sender.send_to_user(999, {"title": "t", "body": "b"}) is False

--- a/backend/tests/notifications/test_push_subscribe_api_hardening.py
+++ b/backend/tests/notifications/test_push_subscribe_api_hardening.py
@@ -1,0 +1,213 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/notifications/test_push_subscribe_api_hardening.py
+"""/push/subscribe, /push/unsubscribe の入力検証・認可のテスト (2026-08-05)。
+
+既存テストは 200 が返ることを確認していたが、以下が未検証だった:
+- 他ユーザーの endpoint を指定して購読を削除できてしまわないか (認可スコープ)
+- 鍵 (p256dh / auth) が空でも保存されてしまわないか (trust boundary の検証)
+- 購読数レスポンスが他ユーザー分を含めて漏らしていないか
+
+いずれも「境界での検証」と「認可」に該当し、CLAUDE.md の
+「新規エンドポイントには RBAC を必ず実装」「認証状態で表示が変わる操作系はガード」
+の対象。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.notifications.push import InMemorySubscriptionStore, WebPushSubscription
+from app.notifications.router import api_router, get_subscription_store, router
+
+_ENDPOINT_A = "https://fcm.googleapis.com/fcm/send/user-a-device"
+_ENDPOINT_B = "https://fcm.googleapis.com/fcm/send/user-b-device"
+
+
+def _make_client(store: InMemorySubscriptionStore, user_id: int) -> TestClient:
+    """指定ユーザーとして認証済みのクライアントを作る。"""
+    from app.auth.dependencies import require_active_user
+
+    app = FastAPI()
+    app.include_router(router)
+    app.include_router(api_router)
+
+    user = MagicMock()
+    user.id = user_id
+    app.dependency_overrides[require_active_user] = lambda: user
+    app.dependency_overrides[get_subscription_store] = lambda: store
+    return TestClient(app)
+
+
+def _store_with_two_users() -> InMemorySubscriptionStore:
+    store = InMemorySubscriptionStore()
+    store.add(WebPushSubscription(endpoint=_ENDPOINT_A, p256dh="k", auth="a", user_id=1))
+    store.add(WebPushSubscription(endpoint=_ENDPOINT_B, p256dh="k", auth="a", user_id=2))
+    return store
+
+
+# ---------------------------------------------------------------------------
+# 認可: 他ユーザーの購読を消せないこと
+# ---------------------------------------------------------------------------
+
+
+class TestUnsubscribeAuthorizationScope:
+    """endpoint を知っていても他人の購読は削除できないこと。
+
+    endpoint は推測困難な長い URL だが、認可はスコープで担保すべきで
+    「値が推測しにくい」ことに依存させない (URLはログ・スクショ経由で漏れうる)。
+    """
+
+    def test_cannot_remove_other_users_subscription(self) -> None:
+        store = _store_with_two_users()
+        client = _make_client(store, user_id=1)  # user 1 として user 2 の endpoint を狙う
+
+        response = client.request(
+            "DELETE", "/notifications/push/unsubscribe", params={"endpoint": _ENDPOINT_B}
+        )
+
+        assert response.status_code == 200, "冪等な no-op として扱う (存在露出を避ける)"
+        remaining = {s.endpoint for s in store.get_for_user(2)}
+        assert remaining == {_ENDPOINT_B}, "他ユーザーの購読が削除されてはいけない"
+
+    def test_can_remove_own_subscription(self) -> None:
+        store = _store_with_two_users()
+        client = _make_client(store, user_id=1)
+
+        response = client.request(
+            "DELETE", "/notifications/push/unsubscribe", params={"endpoint": _ENDPOINT_A}
+        )
+
+        assert response.status_code == 200
+        assert store.get_for_user(1) == []
+
+    def test_unsubscribe_is_idempotent(self) -> None:
+        """I-7 / I-11 (連打・リトライ): 2回目も 200 で落ちないこと。"""
+        store = _store_with_two_users()
+        client = _make_client(store, user_id=1)
+
+        first = client.request(
+            "DELETE", "/notifications/push/unsubscribe", params={"endpoint": _ENDPOINT_A}
+        )
+        second = client.request(
+            "DELETE", "/notifications/push/unsubscribe", params={"endpoint": _ENDPOINT_A}
+        )
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+
+    def test_count_does_not_leak_other_users(self) -> None:
+        """レスポンスの count は自分の購読数のみ (全体数を漏らさない)。"""
+        store = _store_with_two_users()
+        client = _make_client(store, user_id=1)
+
+        response = client.request(
+            "DELETE", "/notifications/push/unsubscribe", params={"endpoint": _ENDPOINT_A}
+        )
+
+        assert response.json()["count"] == 0, "user1 の購読数のみ。全体(1件残)を返してはいけない"
+
+
+# ---------------------------------------------------------------------------
+# 入力検証: 鍵が空の購読を受け付けないこと
+# ---------------------------------------------------------------------------
+
+
+class TestSubscribeInputValidation:
+    """空の鍵を保存すると、送信時に必ず失敗する死んだ購読が残る。
+
+    「保存はできるが絶対に届かない」状態は到達経路の可視性を損なうため、
+    境界で弾く (CLAUDE.md: 入力検証は trust boundary で行う)。
+    """
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {"endpoint": _ENDPOINT_A},  # keys 完全欠落
+            {"endpoint": _ENDPOINT_A, "p256dh": "", "auth": ""},  # 空文字
+            {"endpoint": _ENDPOINT_A, "p256dh": "k", "auth": ""},  # auth のみ空
+            {"endpoint": _ENDPOINT_A, "p256dh": "", "auth": "a"},  # p256dh のみ空
+            {"endpoint": _ENDPOINT_A, "keys": {"p256dh": "", "auth": ""}},  # ネスト形式で空
+        ],
+    )
+    def test_missing_or_empty_keys_rejected(self, body: dict[str, Any]) -> None:
+        store = InMemorySubscriptionStore()
+        client = _make_client(store, user_id=1)
+
+        response = client.post("/notifications/push/subscribe", json=body)
+
+        assert response.status_code == 422, f"空鍵は 422 で弾くべき: {body}"
+        assert store.count() == 0, "検証失敗時に保存してはいけない"
+
+    def test_empty_endpoint_rejected(self) -> None:
+        store = InMemorySubscriptionStore()
+        client = _make_client(store, user_id=1)
+
+        response = client.post(
+            "/notifications/push/subscribe",
+            json={"endpoint": "", "p256dh": "k", "auth": "a"},
+        )
+
+        assert response.status_code == 422
+        assert store.count() == 0
+
+    def test_valid_browser_format_accepted(self) -> None:
+        """正常系: ブラウザ標準形式 (keys ネスト) が通り、user_id が紐付くこと。"""
+        store = InMemorySubscriptionStore()
+        client = _make_client(store, user_id=42)
+
+        response = client.post(
+            "/notifications/push/subscribe",
+            json={"endpoint": _ENDPOINT_A, "keys": {"p256dh": "pk", "auth": "ak"}},
+        )
+
+        assert response.status_code == 200
+        subs = store.get_for_user(42)
+        assert [s.endpoint for s in subs] == [_ENDPOINT_A]
+        assert subs[0].p256dh == "pk"
+        assert subs[0].auth == "ak"
+
+    def test_valid_flat_format_accepted(self) -> None:
+        """正常系: フラット形式も従来どおり通ること (後方互換)。"""
+        store = InMemorySubscriptionStore()
+        client = _make_client(store, user_id=42)
+
+        response = client.post(
+            "/notifications/push/subscribe",
+            json={"endpoint": _ENDPOINT_A, "p256dh": "pk", "auth": "ak"},
+        )
+
+        assert response.status_code == 200
+        assert store.count() == 1
+
+    def test_resubscribe_same_endpoint_does_not_duplicate(self) -> None:
+        """I-1 / I-5 (往復・再追加): 同一 endpoint の再登録で重複しないこと。"""
+        store = InMemorySubscriptionStore()
+        client = _make_client(store, user_id=42)
+        body = {"endpoint": _ENDPOINT_A, "p256dh": "pk", "auth": "ak"}
+
+        client.post("/notifications/push/subscribe", json=body)
+        client.post("/notifications/push/subscribe", json=body)
+
+        assert len(store.get_for_user(42)) == 1
+
+    def test_subscribe_count_is_per_user(self) -> None:
+        """レスポンスの count は自分の購読数のみ。"""
+        store = _store_with_two_users()
+        client = _make_client(store, user_id=1)
+
+        response = client.post(
+            "/notifications/push/subscribe",
+            json={
+                "endpoint": "https://fcm.googleapis.com/fcm/send/new",
+                "p256dh": "k",
+                "auth": "a",
+            },
+        )
+
+        assert response.json()["count"] == 2, "user1 の2件のみ (全体3件を返してはいけない)"

--- a/backend/tests/notifications/test_push_subscribe_settings_integration.py
+++ b/backend/tests/notifications/test_push_subscribe_settings_integration.py
@@ -1,0 +1,295 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# Unauthorized copying or distribution is strictly prohibited.
+# backend/tests/notifications/test_push_subscribe_settings_integration.py
+"""購読保存と通知設定が同じ列を共有していることの結合テスト (2026-08-05)。
+
+push_subscriptions と push_enabled / preferences は **同一の
+users.notification_settings_json (TEXT)** に同居している。書き手が2系統
+(/push/subscribe = DatabaseSubscriptionStore と PUT /settings = router) あるため、
+片方が他方を踏むと「購読はあるが設定が消えた」「設定はあるが購読が消えた」という
+到達経路の静かな喪失が起きる。
+
+本ファイルは実DB (sqlite) を使い、フロントエンドが実際に行う順序
+  1. POST /push/subscribe    (購読を保存)
+  2. PUT  /settings          (push_enabled=true を保存)
+  3. 配信判定                 (push_allowed_for_user + get_for_user)
+が最後まで繋がることを検証する。単体テストが個々に通っていても、
+この結合部分が切れていれば通知は届かない。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from typing import Generator
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-push-settings-integration")
+
+from app.auth.models import User  # noqa: E402
+from app.database import Base  # noqa: E402
+from app.notifications.push import (  # noqa: E402
+    DatabaseSubscriptionStore,
+    WebPushSubscription,
+    push_allowed_for_user,
+)
+from app.notifications.router import (  # noqa: E402
+    NotificationSettingsModel,
+    _do_update_notification_settings,
+)
+
+_ENDPOINT = "https://fcm.googleapis.com/fcm/send/integration-device"
+
+
+@pytest.fixture()
+def _db_env() -> Generator[tuple[Session, "sessionmaker[Session]"], None, None]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestSessionLocal()
+    try:
+        yield db, TestSessionLocal
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        os.unlink(path)
+
+
+def _make_user(db: Session, uid: int) -> User:
+    user = User(
+        id=uid,
+        email=f"pushint{uid}@test.com",
+        username=f"pushint{uid}",
+        hashed_password="x",
+        role="viewer",
+        is_active=True,
+        wallet_address="0x" + f"{uid:040x}",
+    )
+    db.add(user)
+    db.commit()
+    return user
+
+
+class TestSubscribeThenEnableSequence:
+    """フロントエンドの実際の順序 (購読 → 設定ON) が壊れていないこと。"""
+
+    def test_subscribe_then_settings_put_keeps_both(self, _db_env) -> None:
+        """購読保存 → 設定PUT の後、購読と push_enabled が両立すること。"""
+        db, factory = _db_env
+        user = _make_user(db, 1)
+        store = DatabaseSubscriptionStore(factory)
+
+        # 1. 購読を保存 (POST /push/subscribe 相当)
+        store.add(WebPushSubscription(endpoint=_ENDPOINT, p256dh="pk", auth="ak", user_id=user.id))
+
+        # 2. 設定を保存 (PUT /settings 相当。push_enabled=true)
+        db.refresh(user)
+        _do_update_notification_settings(
+            NotificationSettingsModel(line_enabled=True, push_enabled=True), user, db
+        )
+
+        # 3. 配信判定が通り、購読が引ける
+        db.refresh(user)
+        assert push_allowed_for_user(user.notification_settings_json, "ai_proposal") is True
+        assert [s.endpoint for s in store.get_for_user(user.id)] == [_ENDPOINT]
+
+    def test_settings_put_first_then_subscribe_keeps_both(self, _db_env) -> None:
+        """逆順 (設定ON → 購読保存) でも両立すること。
+
+        store.add は raw JSON の push_subscriptions キーのみを差し替える契約なので、
+        既存の push_enabled を落としてはいけない。
+        """
+        db, factory = _db_env
+        user = _make_user(db, 2)
+        store = DatabaseSubscriptionStore(factory)
+
+        _do_update_notification_settings(
+            NotificationSettingsModel(line_enabled=False, push_enabled=True), user, db
+        )
+        store.add(WebPushSubscription(endpoint=_ENDPOINT, p256dh="pk", auth="ak", user_id=user.id))
+
+        db.refresh(user)
+        raw = json.loads(user.notification_settings_json)
+        assert raw["push_enabled"] is True, "購読保存が push_enabled を消してはいけない"
+        assert raw["line_enabled"] is False, "他チャネル設定も保持されること"
+        assert len(raw["push_subscriptions"]) == 1
+
+    def test_toggle_off_then_on_does_not_duplicate_or_lose(self, _db_env) -> None:
+        """I-1 (短時間の往復): OFF→ON を繰り返しても購読が重複/消失しないこと。"""
+        db, factory = _db_env
+        user = _make_user(db, 3)
+        store = DatabaseSubscriptionStore(factory)
+
+        for _ in range(3):
+            # ON: 購読 + 設定ON
+            store.add(
+                WebPushSubscription(endpoint=_ENDPOINT, p256dh="pk", auth="ak", user_id=user.id)
+            )
+            db.refresh(user)
+            _do_update_notification_settings(NotificationSettingsModel(push_enabled=True), user, db)
+            # OFF: 購読解除 + 設定OFF
+            store.remove(_ENDPOINT)
+            db.refresh(user)
+            _do_update_notification_settings(
+                NotificationSettingsModel(push_enabled=False), user, db
+            )
+
+        db.refresh(user)
+        assert store.get_for_user(user.id) == []
+        assert push_allowed_for_user(user.notification_settings_json, "ai_proposal") is False
+
+        # 最後にもう一度ONにすると、ちゃんと1件だけ復活すること
+        store.add(WebPushSubscription(endpoint=_ENDPOINT, p256dh="pk", auth="ak", user_id=user.id))
+        db.refresh(user)
+        _do_update_notification_settings(NotificationSettingsModel(push_enabled=True), user, db)
+        db.refresh(user)
+        assert len(store.get_for_user(user.id)) == 1
+        assert push_allowed_for_user(user.notification_settings_json, "ai_proposal") is True
+
+    def test_settings_put_does_not_resurrect_removed_subscription(self, _db_env) -> None:
+        """解除後の設定PUTで購読が復活しないこと (PUT は購読を「引き継ぐ」実装のため)。"""
+        db, factory = _db_env
+        user = _make_user(db, 4)
+        store = DatabaseSubscriptionStore(factory)
+
+        store.add(WebPushSubscription(endpoint=_ENDPOINT, p256dh="pk", auth="ak", user_id=user.id))
+        store.remove(_ENDPOINT)
+
+        db.refresh(user)
+        _do_update_notification_settings(NotificationSettingsModel(push_enabled=True), user, db)
+
+        db.refresh(user)
+        assert store.get_for_user(user.id) == [], "解除済みの購読が復活してはいけない"
+
+    def test_two_devices_survive_settings_put(self, _db_env) -> None:
+        """I-3: 2端末購読済みの状態で設定PUTしても両方残ること。"""
+        db, factory = _db_env
+        user = _make_user(db, 5)
+        store = DatabaseSubscriptionStore(factory)
+
+        store.add(
+            WebPushSubscription(endpoint=_ENDPOINT + "-iphone", p256dh="p", auth="a", user_id=5)
+        )
+        store.add(WebPushSubscription(endpoint=_ENDPOINT + "-pc", p256dh="p", auth="a", user_id=5))
+
+        db.refresh(user)
+        _do_update_notification_settings(NotificationSettingsModel(push_enabled=True), user, db)
+
+        db.refresh(user)
+        assert len(store.get_for_user(5)) == 2
+
+
+class TestPreferenceGateEndToEnd:
+    """preferences.ai_proposal を OFF にすると配信判定が落ちること (B-N4)。"""
+
+    def test_ai_proposal_off_blocks_delivery_but_keeps_subscription(self, _db_env) -> None:
+        """通知種別OFFでも購読自体は保持される (再ONで即復活できる)。"""
+        db, factory = _db_env
+        user = _make_user(db, 6)
+        store = DatabaseSubscriptionStore(factory)
+        store.add(WebPushSubscription(endpoint=_ENDPOINT, p256dh="p", auth="a", user_id=6))
+
+        db.refresh(user)
+        body = NotificationSettingsModel(push_enabled=True)
+        body.preferences.ai_proposal = False
+        _do_update_notification_settings(body, user, db)
+
+        db.refresh(user)
+        assert push_allowed_for_user(user.notification_settings_json, "ai_proposal") is False
+        assert len(store.get_for_user(6)) == 1, "設定OFFで購読を消してはいけない"
+
+    def test_emergency_stop_notification_cannot_be_disabled(self, _db_env) -> None:
+        """CLAUDE.md Security Rule #6: 緊急停止通知は無効化不可 (強制 True)。"""
+        db, _factory = _db_env
+        user = _make_user(db, 7)
+
+        body = NotificationSettingsModel.model_validate(
+            {"push_enabled": True, "preferences": {"emergency_stop": False}}
+        )
+        _do_update_notification_settings(body, user, db)
+
+        db.refresh(user)
+        raw = json.loads(user.notification_settings_json)
+        assert raw["preferences"]["emergency_stop"] is True
+        assert push_allowed_for_user(user.notification_settings_json, "emergency_stop") is True
+
+
+class TestCrossUserEndpointMigration:
+    """I-12 / I-5: 同一端末で別アカウントにログインした場合。"""
+
+    def test_endpoint_moves_to_new_user_and_leaves_old(self, _db_env) -> None:
+        """同一 endpoint を別ユーザーが登録したら、旧ユーザー側から消えること。
+
+        消えないと、退会/ログアウトした前ユーザー宛の通知が同じ端末に届き続ける
+        (別人の資産情報が表示される事故になりうる)。
+        """
+        db, factory = _db_env
+        old = _make_user(db, 10)
+        new = _make_user(db, 11)
+        store = DatabaseSubscriptionStore(factory)
+
+        store.add(WebPushSubscription(endpoint=_ENDPOINT, p256dh="p", auth="a", user_id=old.id))
+        assert len(store.get_for_user(old.id)) == 1
+
+        store.add(WebPushSubscription(endpoint=_ENDPOINT, p256dh="p2", auth="a2", user_id=new.id))
+
+        assert store.get_for_user(old.id) == [], "旧ユーザーから除去されるべき"
+        moved = store.get_for_user(new.id)
+        assert [s.endpoint for s in moved] == [_ENDPOINT]
+        assert moved[0].p256dh == "p2", "新しい鍵で上書きされること"
+
+    def test_old_user_other_settings_survive_migration(self, _db_env) -> None:
+        """endpoint 移動時に旧ユーザーの他の設定を壊さないこと。"""
+        db, factory = _db_env
+        old = _make_user(db, 12)
+        new = _make_user(db, 13)
+        store = DatabaseSubscriptionStore(factory)
+
+        _do_update_notification_settings(
+            NotificationSettingsModel(line_enabled=False, push_enabled=True), old, db
+        )
+        store.add(WebPushSubscription(endpoint=_ENDPOINT, p256dh="p", auth="a", user_id=old.id))
+        store.add(WebPushSubscription(endpoint=_ENDPOINT, p256dh="p2", auth="a2", user_id=new.id))
+
+        db.refresh(old)
+        raw = json.loads(old.notification_settings_json)
+        assert raw["line_enabled"] is False
+        assert raw["push_enabled"] is True
+        assert raw["push_subscriptions"] == []
+
+
+class TestSchedulerGateUsesRealDb:
+    """配信ゲートが実DBのユーザー設定を見ていること (モックすり抜け防止)。"""
+
+    def test_delivery_skipped_for_push_disabled_user(self, _db_env) -> None:
+        from decimal import Decimal
+        from unittest.mock import patch
+
+        from app.automation.ai_judgment_scheduler import _deliver_ai_proposal_push
+        from app.notifications.templates import ai_proposal_notification
+
+        db, factory = _db_env
+        user = _make_user(db, 20)
+        store = DatabaseSubscriptionStore(factory)
+        store.add(WebPushSubscription(endpoint=_ENDPOINT, p256dh="p", auth="a", user_id=20))
+        # push_enabled を明示的に false で保存
+        db.refresh(user)
+        _do_update_notification_settings(NotificationSettingsModel(push_enabled=False), user, db)
+
+        mock_sender = MagicMock()
+        with (
+            patch("app.notifications.push.get_vapid_config", return_value=MagicMock()),
+            patch("app.notifications.push.WebPushSender", return_value=mock_sender),
+        ):
+            _deliver_ai_proposal_push(
+                db, 20, ai_proposal_notification("SUPPLY", "USDC", Decimal("100"), 80)
+            )
+
+        mock_sender.send_to_user.assert_not_called()

--- a/backend/tests/notifications/test_webpush_send_to_user.py
+++ b/backend/tests/notifications/test_webpush_send_to_user.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from app.notifications.push import (
+    DeliveryResult,
     InMemorySubscriptionStore,
     VAPIDConfig,
     WebPushSender,
@@ -51,7 +52,9 @@ class TestSendToUser:
 
         with (
             patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True),
-            patch.object(sender, "send_to_subscription", return_value=True) as mock_send,
+            patch.object(
+                sender, "send_to_subscription", return_value=DeliveryResult.SUCCESS
+            ) as mock_send,
         ):
             result = sender.send_to_user(1, {"title": "t", "body": "b"})
 
@@ -69,7 +72,9 @@ class TestSendToUser:
 
         with (
             patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True),
-            patch.object(sender, "send_to_subscription", return_value=True) as mock_send,
+            patch.object(
+                sender, "send_to_subscription", return_value=DeliveryResult.SUCCESS
+            ) as mock_send,
         ):
             sender.send_to_user(1, {"title": "t", "body": "b"})
 
@@ -83,7 +88,9 @@ class TestSendToUser:
 
         with (
             patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True),
-            patch.object(sender, "send_to_subscription", return_value=True) as mock_send,
+            patch.object(
+                sender, "send_to_subscription", return_value=DeliveryResult.SUCCESS
+            ) as mock_send,
         ):
             result = sender.send_to_user(999, {"title": "t", "body": "b"})
 
@@ -97,7 +104,11 @@ class TestSendToUser:
 
         with (
             patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True),
-            patch.object(sender, "send_to_subscription", side_effect=[False, True]),
+            patch.object(
+                sender,
+                "send_to_subscription",
+                side_effect=[DeliveryResult.FAILED_TRANSIENT, DeliveryResult.SUCCESS],
+            ),
         ):
             result = sender.send_to_user(1, {"title": "t", "body": "b"})
 
@@ -110,20 +121,31 @@ class TestSendToUser:
 
         with (
             patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True),
-            patch.object(sender, "send_to_subscription", return_value=False),
+            patch.object(
+                sender, "send_to_subscription", return_value=DeliveryResult.FAILED_TRANSIENT
+            ),
         ):
             result = sender.send_to_user(1, {"title": "t", "body": "b"})
 
         assert result is False
 
-    def test_failed_subscription_is_removed_from_store(self) -> None:
-        """失敗した購読は store.remove で削除される (send_to_all と同じ挙動)。"""
+    def test_gone_subscription_is_removed_from_store(self) -> None:
+        """失効(410/404)した購読のみ store.remove で削除される。
+
+        2026-08-05: 以前は「失敗した購読」を一律削除していたため、一時エラーでも
+        購読が消えていた。一時エラーで消さないことの検証は
+        test_push_delivery_hardening.py::TestGoneVsTransientFailure が担う。
+        """
         store = _make_store()
         sender = WebPushSender(_make_config(), store)
 
         with (
             patch("app.notifications.push._PYWEBPUSH_AVAILABLE", True),
-            patch.object(sender, "send_to_subscription", side_effect=[True, False]),
+            patch.object(
+                sender,
+                "send_to_subscription",
+                side_effect=[DeliveryResult.SUCCESS, DeliveryResult.FAILED_GONE],
+            ),
         ):
             sender.send_to_user(1, {"title": "t", "body": "b"})
 

--- a/frontend/lib/push/subscription.test.ts
+++ b/frontend/lib/push/subscription.test.ts
@@ -1,0 +1,244 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+// frontend/lib/push/subscription.test.ts
+//
+// subscribeToPush / unsubscribeFromPush の unit test (2026-08-05)。
+//
+// これまで Playwright E2E のみでカバーしていたが、E2E は実サーバ + 認証済み
+// セッションを要するため未認証環境では skip され、以下の分岐が実質未検証だった:
+// - VAPID 未設定時に購読を作らないこと
+// - サーバ登録失敗時にブラウザ側購読をロールバックすること (最重要)
+// - ロールバック自体が失敗しても元の失敗を伝播すること
+// - 解除はブラウザ先行 + サーバ側 best-effort であること
+//
+// 特に「サーバ登録失敗時のロールバック漏れ」は、ブラウザには購読があるのに
+// サーバには無い = ユーザーは「通知ON」と思っているのに永久に届かない状態を作る
+// (バックエンドの到達経路ゼロ障害と同型の乖離)。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  PushSubscribeError,
+  VapidNotConfiguredError,
+  getExistingSubscription,
+  isPushConfigured,
+  subscribeToPush,
+  unsubscribeFromPush,
+} from "./subscription"
+
+// 実際の VAPID 公開鍵と同じ形式 (65 バイトの非圧縮 EC 点 = base64url 87文字)。
+// 長さが 4 の倍数 +1 になるような不正な base64 を使うと atob が
+// InvalidCharacterError を投げ、テストしたい分岐に到達できない。
+const VAPID_KEY =
+  "BAcOFRwjKjE4P0ZNVFtiaXB3foWMk5qhqK-2vcTL0tng5-71_AMKERgfJi00O0JJUFdeZWxzeoGIj5adpKuyucA"
+
+vi.mock("@/lib/api/http", () => ({
+  postJson: vi.fn(),
+  deleteJson: vi.fn(),
+}))
+
+import { deleteJson, postJson } from "@/lib/api/http"
+
+type FakeSubscription = {
+  endpoint: string
+  toJSON: () => { endpoint: string; keys: { p256dh: string; auth: string } }
+  unsubscribe: ReturnType<typeof vi.fn>
+}
+
+function makeFakeSubscription(endpoint = "https://fcm.googleapis.com/fcm/send/abc"): FakeSubscription {
+  return {
+    endpoint,
+    toJSON: () => ({ endpoint, keys: { p256dh: "p256dh-value", auth: "auth-value" } }),
+    unsubscribe: vi.fn().mockResolvedValue(true),
+  }
+}
+
+/** navigator.serviceWorker.ready.pushManager をスタブする。 */
+function stubServiceWorker(pushManager: Record<string, unknown>): void {
+  Object.defineProperty(globalThis.navigator, "serviceWorker", {
+    value: { ready: Promise.resolve({ pushManager }) },
+    configurable: true,
+    writable: true,
+  })
+}
+
+const ORIGINAL_ENV = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = VAPID_KEY
+  vi.mocked(postJson).mockReset()
+  vi.mocked(deleteJson).mockReset()
+  vi.mocked(postJson).mockResolvedValue({} as never)
+  vi.mocked(deleteJson).mockResolvedValue({} as never)
+})
+
+afterEach(() => {
+  process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = ORIGINAL_ENV
+})
+
+describe("isPushConfigured", () => {
+  it("VAPID 公開鍵があれば true", () => {
+    expect(isPushConfigured()).toBe(true)
+  })
+
+  it("VAPID 公開鍵が無ければ false (トグルを無効化するため)", () => {
+    delete process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+    expect(isPushConfigured()).toBe(false)
+  })
+
+  it("空文字も未設定として扱う", () => {
+    process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = ""
+    expect(isPushConfigured()).toBe(false)
+  })
+})
+
+describe("subscribeToPush", () => {
+  it("正常系: 購読を作成しサーバへ endpoint と keys を送る", async () => {
+    const sub = makeFakeSubscription()
+    const subscribe = vi.fn().mockResolvedValue(sub)
+    stubServiceWorker({ subscribe, getSubscription: vi.fn().mockResolvedValue(null) })
+
+    await subscribeToPush("token-abc")
+
+    expect(subscribe).toHaveBeenCalledOnce()
+    // userVisibleOnly は Chrome で必須。落とすと subscribe が例外になる。
+    expect(subscribe.mock.calls[0][0]).toMatchObject({ userVisibleOnly: true })
+
+    expect(postJson).toHaveBeenCalledWith(
+      "/notifications/push/subscribe",
+      { endpoint: sub.endpoint, keys: { p256dh: "p256dh-value", auth: "auth-value" } },
+      { headers: { Authorization: "Bearer token-abc" } }
+    )
+  })
+
+  it("applicationServerKey は Uint8Array に変換して渡す", async () => {
+    const subscribe = vi.fn().mockResolvedValue(makeFakeSubscription())
+    stubServiceWorker({ subscribe, getSubscription: vi.fn() })
+
+    await subscribeToPush("t")
+
+    const key = subscribe.mock.calls[0][0].applicationServerKey
+    expect(key).toBeInstanceOf(Uint8Array)
+    expect((key as Uint8Array).byteLength).toBeGreaterThan(0)
+  })
+
+  it("VAPID 未設定なら VapidNotConfiguredError を投げ、購読を作らない", async () => {
+    delete process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+    const subscribe = vi.fn()
+    stubServiceWorker({ subscribe, getSubscription: vi.fn() })
+
+    await expect(subscribeToPush("t")).rejects.toThrow(VapidNotConfiguredError)
+    expect(subscribe).not.toHaveBeenCalled()
+    expect(postJson).not.toHaveBeenCalled()
+  })
+
+  it("サーバ登録が失敗したらブラウザ側購読をロールバックする (最重要)", async () => {
+    const sub = makeFakeSubscription()
+    stubServiceWorker({
+      subscribe: vi.fn().mockResolvedValue(sub),
+      getSubscription: vi.fn(),
+    })
+    vi.mocked(postJson).mockRejectedValue(new Error("500 Internal Server Error"))
+
+    await expect(subscribeToPush("t")).rejects.toThrow(PushSubscribeError)
+    expect(sub.unsubscribe).toHaveBeenCalledOnce()
+  })
+
+  it("ロールバックが失敗しても元のエラーを伝播する (成功と誤認させない)", async () => {
+    const sub = makeFakeSubscription()
+    sub.unsubscribe.mockRejectedValue(new Error("unsubscribe failed"))
+    stubServiceWorker({ subscribe: vi.fn().mockResolvedValue(sub), getSubscription: vi.fn() })
+    vi.mocked(postJson).mockRejectedValue(new Error("500"))
+
+    await expect(subscribeToPush("t")).rejects.toThrow(PushSubscribeError)
+  })
+
+  it("サーバエラーのメッセージを PushSubscribeError に引き継ぐ", async () => {
+    stubServiceWorker({
+      subscribe: vi.fn().mockResolvedValue(makeFakeSubscription()),
+      getSubscription: vi.fn(),
+    })
+    vi.mocked(postJson).mockRejectedValue(new Error("422 invalid keys"))
+
+    await expect(subscribeToPush("t")).rejects.toThrow(/422 invalid keys/)
+  })
+
+  it("pushManager.subscribe 自体が失敗した場合はサーバへ送らない", async () => {
+    stubServiceWorker({
+      subscribe: vi.fn().mockRejectedValue(new Error("permission denied")),
+      getSubscription: vi.fn(),
+    })
+
+    await expect(subscribeToPush("t")).rejects.toThrow()
+    expect(postJson).not.toHaveBeenCalled()
+  })
+})
+
+describe("unsubscribeFromPush", () => {
+  it("購読が無ければ何もしない (冪等)", async () => {
+    stubServiceWorker({ getSubscription: vi.fn().mockResolvedValue(null), subscribe: vi.fn() })
+
+    await unsubscribeFromPush("t")
+
+    expect(deleteJson).not.toHaveBeenCalled()
+  })
+
+  it("ブラウザ側を解除し、サーバへ endpoint を URL エンコードして通知する", async () => {
+    const sub = makeFakeSubscription("https://fcm.googleapis.com/fcm/send/a+b/c?d=1")
+    stubServiceWorker({ getSubscription: vi.fn().mockResolvedValue(sub), subscribe: vi.fn() })
+
+    await unsubscribeFromPush("token-xyz")
+
+    expect(sub.unsubscribe).toHaveBeenCalledOnce()
+    const calledUrl = vi.mocked(deleteJson).mock.calls[0][0] as string
+    expect(calledUrl).toContain(encodeURIComponent(sub.endpoint))
+    // 生の endpoint がそのまま連結されるとクエリ境界が壊れる。
+    expect(calledUrl).not.toContain("send/a+b/c?d=1")
+    expect(vi.mocked(deleteJson).mock.calls[0][1]).toEqual({
+      headers: { Authorization: "Bearer token-xyz" },
+    })
+  })
+
+  it("サーバ側解除の失敗は投げない (ブラウザ側は既に解除済み・fail-open)", async () => {
+    const sub = makeFakeSubscription()
+    stubServiceWorker({ getSubscription: vi.fn().mockResolvedValue(sub), subscribe: vi.fn() })
+    vi.mocked(deleteJson).mockRejectedValue(new Error("network down"))
+
+    await expect(unsubscribeFromPush("t")).resolves.toBeUndefined()
+    expect(sub.unsubscribe).toHaveBeenCalledOnce()
+  })
+
+  it("ブラウザ側解除より先にサーバへ送らない (順序: browser → server)", async () => {
+    const order: string[] = []
+    const sub = makeFakeSubscription()
+    sub.unsubscribe.mockImplementation(async () => {
+      order.push("browser")
+      return true
+    })
+    vi.mocked(deleteJson).mockImplementation(async () => {
+      order.push("server")
+      return {} as never
+    })
+    stubServiceWorker({ getSubscription: vi.fn().mockResolvedValue(sub), subscribe: vi.fn() })
+
+    await unsubscribeFromPush("t")
+
+    expect(order).toEqual(["browser", "server"])
+  })
+})
+
+describe("getExistingSubscription", () => {
+  it("Service Worker 非対応環境では null (例外を投げない)", async () => {
+    // @ts-expect-error - 非対応環境を再現するため意図的に削除する
+    delete globalThis.navigator.serviceWorker
+
+    await expect(getExistingSubscription()).resolves.toBeNull()
+  })
+
+  it("既存購読があればそれを返す", async () => {
+    const sub = makeFakeSubscription()
+    stubServiceWorker({ getSubscription: vi.fn().mockResolvedValue(sub), subscribe: vi.fn() })
+
+    await expect(getExistingSubscription()).resolves.toBe(sub)
+  })
+})

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -56,7 +56,9 @@
         "@types/react-dom": "18.3.0",
         "eslint": "^8.57.0",
         "eslint-config-next": "^14.2.35",
+        "jsdom": "^30.0.1",
         "typescript": "5.9.3",
+        "vitest": "^3.2.7",
         "wait-on": "^8.0.3"
       }
     },
@@ -93,6 +95,39 @@
       },
       "peerDependencies": {
         "ajv": ">=8"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.5.tgz",
+      "integrity": "sha512-mbhpPMmnw/kwW19aRNmSUl1QzLbdGo1SCuE49BT98MNwqF6zaHb3o2owssFc/PEO/4t2UjqtCNwocuDtJornzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.2.1",
+        "@csstools/css-color-parser": "^4.1.9",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1678,6 +1713,19 @@
         }
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@coinbase/cdp-sdk": {
       "version": "1.46.1",
       "resolved": "https://registry.npmjs.org/@coinbase/cdp-sdk/-/cdp-sdk-1.46.1.tgz",
@@ -1769,6 +1817,146 @@
         "node": ">=6"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@ecies/ciphers": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.6.tgz",
@@ -1831,6 +2019,448 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
       "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
       "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -2309,6 +2939,24 @@
         "@ethersproject/logger": "^5.8.0",
         "@ethersproject/properties": "^5.8.0",
         "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@farcaster/mini-app-solana": {
@@ -4424,6 +5072,26 @@
       "license": "ISC",
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -8004,6 +8672,395 @@
         "rollup": "^1.20.0||^2.0.0"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -9599,6 +10656,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -9679,6 +10747,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "0.0.39",
@@ -10373,6 +11448,158 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/@wagmi/connectors": {
       "version": "7.2.1",
@@ -11956,6 +13183,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -12208,6 +13445,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -12422,6 +13669,16 @@
         "node": ">=10.16.0"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -12562,6 +13819,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -12599,6 +13873,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -12881,6 +14165,20 @@
         "postcss-value-parser": "^4.0.2"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -13027,6 +14325,58 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -13154,6 +14504,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -13566,6 +14926,19 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-abstract": {
       "version": "1.24.1",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
@@ -13681,6 +15054,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -13761,6 +15141,48 @@
       "license": "MIT",
       "dependencies": {
         "es6-promise": "^4.0.3"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -14602,6 +16024,16 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/extension-port-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/extension-port-stream/-/extension-port-stream-3.0.0.tgz",
@@ -14726,6 +16158,23 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/fetch-retry": {
@@ -15405,6 +16854,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -15888,6 +17350,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -16296,6 +17765,85 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -16627,10 +18175,17 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -16688,6 +18243,13 @@
         "crypt": "0.0.2",
         "is-buffer": "~1.1.6"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -17468,6 +19030,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -17539,6 +19114,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/permissionless": {
@@ -18805,6 +20397,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -19035,6 +20640,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -19167,6 +20779,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
     },
@@ -19434,6 +21060,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/styled-components": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.0.tgz",
@@ -19556,6 +21202,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tabbable": {
       "version": "6.4.0",
@@ -19810,10 +21463,24 @@
       "integrity": "sha512-IdsPtu8eJ0SwuCWUFm2euFH3jJvtpGQC0VpZNZlqxRvQ2zGvSjbXDO+4T8Rm5ETsmCQHHvKUGds69bJYrlb3Tg==",
       "license": "Public domain"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -19832,22 +21499,55 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
+        "node": "^18.0.0 || >=20.0.0"
       }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-buffer": {
       "version": "1.2.2",
@@ -19873,6 +21573,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -20109,6 +21822,16 @@
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
     },
     "node_modules/undici-types": {
       "version": "5.26.5",
@@ -20662,6 +22385,268 @@
         }
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vite/node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wagmi": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-3.5.0.tgz",
@@ -20749,6 +22734,16 @@
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -20865,6 +22860,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -22951,6 +24963,23 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,8 @@
     "build": "node ./node_modules/next/dist/bin/next build",
     "postbuild": "node scripts/cf-pages-build-hooks.js post",
     "start": "node ./node_modules/next/dist/bin/next start -p 3000",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
     "lint": "node ./node_modules/next/dist/bin/next lint",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
@@ -66,7 +68,9 @@
     "@types/react-dom": "18.3.0",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.35",
+    "jsdom": "^30.0.1",
     "typescript": "5.9.3",
+    "vitest": "^3.2.7",
     "wait-on": "^8.0.3"
   },
   "overrides": {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Ultra AutoTrade. All rights reserved.
+// Unauthorized copying or distribution is strictly prohibited.
+// frontend/vitest.config.ts
+//
+// フロントエンド unit test 基盤 (2026-08-05 導入)。
+//
+// 背景: これまでフロントエンドのテストは Playwright E2E のみで、
+// lib/ 配下のロジック (Web Push 購読のロールバック処理等) を直接検証できなかった。
+// E2E は実サーバ + 認証済みセッションを要するため、未認証環境では skip され、
+// ロジックの分岐が実質未検証のまま残っていた。
+//
+// 方針:
+// - **ファイル名の拡張子で棲み分ける**:
+//     `*.spec.ts` → Playwright (E2E。現在 e2e/ と tests/ の2箇所に存在する)
+//     `*.test.ts` → vitest    (unit)
+//   ディレクトリ指定で除外すると Playwright の spec 置き場が増えた時に
+//   vitest がそれを拾って壊れる (実際 e2e/ だけ除外した初回設定で tests/ を
+//   拾って失敗した)。拡張子ベースなら置き場所が増えても壊れない。
+// - jsdom 環境: navigator / window / atob 等のブラウザ API を使うコードを検証するため。
+// - `@/` エイリアスは tsconfig.json の paths ({"@/*": ["./*"]}) と一致させる。
+
+import { defineConfig } from "vitest/config"
+import { fileURLToPath } from "node:url"
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    include: ["**/*.test.{ts,tsx}"],
+    exclude: ["node_modules/**", ".next/**"],
+    restoreMocks: true,
+  },
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./", import.meta.url)),
+    },
+  },
+})


### PR DESCRIPTION
## 背景

PR3〜PR5 (#1015/#1016/#1017) で Web Push の到達経路は通ったが、テストが**正常系とストア機構に偏っていた**。「壊れやすいポイントを突く」観点でテストを書き足した結果、**実バグ5件**が露出したため併せて修正した。

いずれも「気づかないうちに通知が届かなくなる」= 今回の25日間サイレント障害と同型の失敗形。

## 修正した実バグ

| # | 内容 | 影響 |
|---|---|---|
| 1 | **一時エラーで購読が永久削除される** | FCM の一時障害1回で全ユーザーの購読が消え、手動再購読まで通知が永久に届かない |
| 2 | **通知設定OFFでも配信していた** (B-N4違反) | 設定画面でOFFにしたのに通知が届く = 明確な信頼毀損 |
| 3 | **他ユーザーの購読を削除できた** | endpoint を知れば他人の通知を無効化できる (認可スコープ欠落) |
| 4 | **空の鍵で購読が保存できた** | 「絶対に届かない購読」が残り到達状況の可視性を損なう |
| 5 | **dict以外の有効JSONでクラッシュ** | `except Exception` に飲まれて静かに配信スキップ |

### 1 の詳細 (最重要)
`send_to_subscription` が 410 Gone と一時エラー(タイムアウト/5xx)を同じ `False` で返し、呼び出し側が**両方まとめて削除**していた。`DeliveryResult` (SUCCESS / FAILED_TRANSIENT / FAILED_GONE) で3分類し、除去は 404/410 のみに限定。原因不明の例外も購読を残す (fail-safe側に倒す)。

### 2 の詳細
`_deliver_ai_proposal_push` が `push_enabled` / `preferences.ai_proposal` を一切参照していなかった。`push_allowed_for_user()` を追加し配信前に判定。未設定は既定 False で送らない (明示的に有効化していないユーザーには送らない)。設定OFFでも**購読自体は保持**するので再ONで即復活できる。

## 追加テスト (61件)

- **`test_push_delivery_hardening.py`** (37) — 失効vs一時エラーの区別、pywebpush応答の3分類 (404/410/429/5xx/ネットワーク断)、破損JSON耐性、設定ゲート、複数端末(I-3)、PWA再追加(I-5)、購読ゼロ(B-B1)
- **`test_push_subscribe_api_hardening.py`** (14) — 越権削除の防止、冪等性(I-7/I-11)、`count` の他ユーザー漏洩、空鍵/空endpointの422、再購読の重複防止(I-1)
- **`test_push_subscribe_settings_integration.py`** (10) — **実DB**で購読と設定が同一列を共有している結合部分。フロント実順序(購読→設定PUT→配信判定)、OFF/ON往復(I-1)、同一端末での別アカウントログイン(I-12)、緊急停止通知の無効化不可(Security Rule #6)

既存テスト2件は旧挙動(一律削除・bool戻り値)を**正しい挙動として固定していた**ため更新した。

## 検証

```
pytest tests/            : 5044 passed, 0 failed, 26 skipped
ruff check .             : No issues found
ruff format --check .    : 735 files already formatted
mypy app/                : 既存の stripe import-not-found 2件のみ (無関係)
```

## 残存リスク (本PR対象外・別途判断が必要)

1. **read-modify-write の lost update** — `/push/subscribe` と `PUT /settings` が別セッションで同一TEXT列を読み書きするため、同時操作で片方が消えうる。行ロックまたは単一セッション化が必要で本PRのスコープ外。
2. **フロントエンドに unit test 基盤が無い** — `frontend/lib/push/subscription.ts` のロールバック処理は Playwright e2e のみでカバー。vitest 導入は依存追加を伴うため判断が必要。
3. **`DatabaseSubscriptionStore.get_all()` / `remove()` が全ユーザー走査** — 購読者増加時の性能問題 (正しさの問題ではない)。
4. **実機到達確認 (B-1/B-7) は未実施** — iOS/Android 実機での着信確認は本PRの静的テストでは代替できない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# 追加コミット: フロントエンド unit test 基盤導入 (vitest)

フロントエンドは Playwright E2E のみで、`lib/` 配下のロジックを直接検証できなかった。E2E は実サーバ + 認証済みセッションを要するため未認証環境では skip され、`subscribeToPush` のロールバック処理等が実質未検証だった。

## 基盤

- **Playwright とファイル名の拡張子で棲み分ける**
  - `*.spec.ts` → Playwright (E2E。`e2e/` と `tests/` の**2箇所**に存在)
  - `*.test.ts` → vitest (unit)
  - 初回は `e2e/` のみディレクトリ除外したが `tests/` 配下の spec を拾って失敗した。拡張子ベースなら Playwright の spec 置き場が増えても壊れない。
- jsdom 環境 / `@/` エイリアスは tsconfig と一致 / scripts: `test:unit`, `test:unit:watch`

## テスト (16件) — E2E で到達できていなかった分岐

- **サーバ登録失敗時のロールバック** (最重要。漏れるとブラウザには購読があるのにサーバには無い = ユーザーは「通知ON」と思っているのに永久に届かない乖離)
- ロールバック自体が失敗しても元のエラーを伝播すること (成功と誤認させない)
- VAPID 未設定時に購読を作らずサーバへも送らないこと
- `applicationServerKey` が `Uint8Array` に変換されること
- 解除は browser → server の順で、サーバ側失敗は投げない (fail-open)
- endpoint の URL エンコード (生連結だとクエリ境界が壊れる)
- Service Worker 非対応環境で例外を投げないこと

> 補足: VAPID ダミー鍵は実鍵と同じ 65 バイト (base64url 87文字) が必要。長さが 4n+1 になる不正な base64 だと `atob` が `InvalidCharacterError` を投げ、検証したい分岐に到達できない (初回作成時に踏んだ)。

## 検証

```
npm run test:unit            : 16 passed
npx tsc --noEmit             : No errors found
npx eslint                   : No issues found
npx playwright test --list   : 1010 件収集 (従来通り / unit test の混入 0 件)
```

## 残存リスク 1 (lost update) への回答

`with_for_update()` は **PostgreSQL では `FOR UPDATE` になるが SQLite では黙って消える**ことを実測で確認した (SQLAlchemy がコンパイル時に落とす)。CI は PostgreSQL なので検証は可能。

**行ロックを推奨** (別テーブル化ではなく):
- 失われるのは「端末1台の購読」か「設定変更1回」で、ユーザーの再操作で回復可能。資金・安全装置には影響しない
- 真の競合はスケジューラの410パージ vs ユーザーの設定保存、または2端末同時購読に限られる (フロントは購読→設定PUTを逐次実行するため)
- 要件書 I-1「新規テーブルは作らない」に沿う。別テーブル化は本番データ backfill を伴う
- ただし構造的には別テーブル化が正しい。多端末利用が一般化したら再検討する価値がある

本PRには含めていない (別途判断)。
