### PR TITLE
refactor(notifications): Web Push購読を専用テーブルへ分離し lost update を構造的に解消

### DIFF
--- a/backend/alembic/versions/z7a8b9c0d1e2_add_push_subscriptions_table.py
+++ b/backend/alembic/versions/z7a8b9c0d1e2_add_push_subscriptions_table.py
@@ -1,0 +1,130 @@
+"""add push_subscriptions table
+
+Web Push 購読を users.notification_settings_json (TEXT) の push_subscriptions キーから
+専用テーブルへ移す。
+
+背景: 同一セルに通知設定 (push_enabled / preferences) と購読配列が同居しており、
+双方が read-modify-write で別セッションから書くため lost update が発生していた
+(購読 1 件、または設定変更 1 回が黙って消える)。専用テーブルにすると
+read-modify-write が無くなり問題クラス自体が消える。endpoint のグローバル一意性も
+UNIQUE 制約が保証する (旧実装は全ユーザー走査で模倣していた)。
+
+移行方針:
+- 既存 JSON の push_subscriptions を新テーブルへ backfill する。本番は VAPID 未設定で
+  購読が 0 件の想定だが、staging / dev に残っている可能性があるため実装する。
+- **JSON 側の push_subscriptions キーは削除しない**。downgrade でデータを失わないため。
+  アプリは以降このキーを読まないので実質無害。確認後の掃除は別タスク。
+
+Revision ID: z7a8b9c0d1e2
+Revises: y6z7a8b9c0d1
+Create Date: 2026-08-05
+
+"""
+
+import json
+import logging
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import context, op
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+revision: str = "z7a8b9c0d1e2"
+down_revision: Union[str, Sequence[str], None] = "y6z7a8b9c0d1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "push_subscriptions",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("endpoint", sa.Text(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("p256dh", sa.String(length=255), nullable=False),
+        sa.Column("auth", sa.String(length=255), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_push_subscriptions_endpoint", "push_subscriptions", ["endpoint"], unique=True
+    )
+    op.create_index("ix_push_subscriptions_user_id", "push_subscriptions", ["user_id"])
+
+    _backfill_from_notification_settings_json()
+
+
+def _backfill_from_notification_settings_json() -> None:
+    """既存 JSON 内の購読を新テーブルへ移す。壊れた JSON / 要素はスキップする。
+
+    offline モード (``alembic upgrade --sql``、レビュー用の SQL 生成) では
+    SELECT の結果を取得できない (execute が None を返す) ためスキップする。
+    その場合は下記 WARNING の指示どおり online で流すか、購読 0 件を確認して進める。
+    """
+    if context.is_offline_mode():
+        logger.warning(
+            "push_subscriptions backfill: offline モード (--sql) のためスキップしました。"
+            "既存購読を移行するには online で `alembic upgrade head` を実行してください。"
+        )
+        return
+
+    conn = op.get_bind()
+    rows = conn.execute(
+        sa.text(
+            "SELECT id, notification_settings_json FROM users "
+            "WHERE notification_settings_json IS NOT NULL"
+        )
+    ).fetchall()
+
+    insert_sql = sa.text(
+        "INSERT INTO push_subscriptions (endpoint, user_id, p256dh, auth) "
+        "VALUES (:endpoint, :user_id, :p256dh, :auth)"
+    )
+
+    seen_endpoints: set[str] = set()
+    migrated = 0
+    for user_id, raw_json in rows:
+        try:
+            raw = json.loads(raw_json)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(raw, dict):
+            continue
+        subs = raw.get("push_subscriptions")
+        if not isinstance(subs, list):
+            continue
+        for entry in subs:
+            if not isinstance(entry, dict):
+                continue
+            endpoint = entry.get("endpoint")
+            p256dh = entry.get("p256dh")
+            auth = entry.get("auth")
+            if not endpoint or not p256dh or not auth:
+                continue
+            # endpoint は UNIQUE。旧 JSON 実装のバグ等で重複していても落ちないようにする
+            # (先に見つかった 1 件を採用)。
+            if endpoint in seen_endpoints:
+                continue
+            seen_endpoints.add(endpoint)
+            conn.execute(
+                insert_sql,
+                {"endpoint": endpoint, "user_id": user_id, "p256dh": p256dh, "auth": auth},
+            )
+            migrated += 1
+
+    logger.info("push_subscriptions backfill: %d 件を移行しました。", migrated)
+
+
+def downgrade() -> None:
+    # JSON 側に元データが残っているため、テーブル削除で情報は失われない。
+    op.drop_index("ix_push_subscriptions_user_id", table_name="push_subscriptions")
+    op.drop_index("ix_push_subscriptions_endpoint", table_name="push_subscriptions")
+    op.drop_table("push_subscriptions")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -68,6 +68,7 @@ from app.knowledge.router import router as knowledge_router
 from app.market.router import router as market_router
 from app.notifications.models import (
     NotificationLog,  # noqa: F401 — ensure table registered with Base.metadata
+    PushSubscription,  # noqa: F401 — ensure table registered with Base.metadata
 )
 from app.notifications.router import api_router as notification_api_router
 from app.notifications.router import router as notification_router

--- a/backend/app/notifications/models.py
+++ b/backend/app/notifications/models.py
@@ -27,6 +27,31 @@ partner_id が NULL の通知はシステム全体向けであり、パートナ
 delivered 列 (2026-08-04 PR3, Alembic x4y5z6a7b8c9 の次): NULL=対象外/未計測、
 True=配信先に到達確認済み、False=配信失敗(410等)。行の存在自体が「送信した」を表し、
 この列が「到達した」を表す。実際の書き込み配線は PR5 で行う (本PRはスキーマ追加のみ)。
+
+---
+
+push_subscriptions テーブル (2026-08-05, Alembic z7a8b9c0d1e2):
+Web Push 購読を保持する。
+
+以前は ``users.notification_settings_json`` (TEXT) の ``push_subscriptions`` キーに
+JSON 配列として保存していたが、同じセルに通知設定 (push_enabled / preferences) が
+同居しており、双方が read-modify-write で別セッションから書くため lost update が
+発生していた (購読 1 件、または設定変更 1 回が黙って消える)。
+専用テーブルへ分離することで read-modify-write そのものが無くなり、
+endpoint のグローバル一意性も UNIQUE 制約が保証する
+(旧実装は全ユーザー走査でこれを模倣していた)。
+
+手動マイグレーション SQL (alembic を使わない環境向けの参考):
+    CREATE TABLE IF NOT EXISTS push_subscriptions (
+        id         SERIAL       PRIMARY KEY,
+        endpoint   TEXT         NOT NULL UNIQUE,
+        user_id    INTEGER      NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        p256dh     VARCHAR(255) NOT NULL,
+        auth       VARCHAR(255) NOT NULL,
+        created_at TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+    );
+    CREATE INDEX IF NOT EXISTS ix_push_subscriptions_user_id
+        ON push_subscriptions (user_id);
 """
 
 from datetime import datetime, timezone
@@ -89,4 +114,46 @@ class NotificationLog(Base):
         return (
             f"<NotificationLog(id={self.id}, severity={self.severity!r}, "
             f"title={self.title!r}, partner_id={self.partner_id})>"
+        )
+
+
+class PushSubscription(Base):
+    """
+    Web Push 購読テーブル (2026-08-05)。
+
+    Attributes:
+        id: プライマリキー
+        endpoint: ブラウザの push service endpoint URL (グローバルに一意)
+        user_id: 購読者の users.id (ユーザー削除で CASCADE 削除)
+        p256dh: 購読の公開鍵 (ブラウザ PushSubscription.keys.p256dh)
+        auth: 購読の認証シークレット (同 keys.auth)
+        created_at: 登録日時 (UTC)
+    """
+
+    __tablename__ = "push_subscriptions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    # endpoint はブラウザ (オリジン) 単位でグローバルに一意。UNIQUE 制約が
+    # 「同一端末が同時に 2 ユーザーへ属さない」を DB レベルで保証する。
+    # これが無いと、同一端末で別アカウントにログインした後も旧ユーザー宛の
+    # 通知 (金額・資産情報) が同じ端末に届き続ける (I-12)。
+    endpoint: Mapped[str] = mapped_column(Text, nullable=False, unique=True, index=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    p256dh: Mapped[str] = mapped_column(String(255), nullable=False)
+    auth: Mapped[str] = mapped_column(String(255), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<PushSubscription(id={self.id}, user_id={self.user_id}, "
+            f"endpoint={self.endpoint[:30]!r})>"
         )

--- a/backend/app/notifications/push.py
+++ b/backend/app/notifications/push.py
@@ -15,7 +15,11 @@ from enum import Enum
 from typing import Any, Callable, Optional, Protocol
 
 from pydantic import BaseModel
+from sqlalchemy import delete, func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
+
+from .models import PushSubscription
 
 try:
     from pywebpush import WebPushException, webpush  # type: ignore
@@ -67,17 +71,6 @@ class WebPushSubscription(BaseModel):
     user_id: Optional[int] = None
 
 
-class PushSubscriptionEntry(BaseModel):
-    """users.notification_settings_json の push_subscriptions 配列 1 件分。
-
-    WebPushSubscription から user_id を除いた形 (格納先が既にユーザーに紐づくため不要)。
-    """
-
-    endpoint: str
-    p256dh: str
-    auth: str
-
-
 class InMemorySubscriptionStore:
     """スレッドセーフなインメモリ Push サブスクリプションストア。"""
 
@@ -127,76 +120,39 @@ class SubscriptionStore(Protocol):
 
 
 class DatabaseSubscriptionStore:
-    """users.notification_settings_json の push_subscriptions キーに永続化するストア。
+    """push_subscriptions テーブルに永続化するストア。
 
-    2026-08-04 PR3: InMemorySubscriptionStore はプロセス再起動で全消失し、
-    どのユーザーの購読かも分からなかった (可観測性なき握り潰しの再発パターン)。
-    新規テーブルは作らず、既存の notification_settings_json (TEXT) に
-    ``{"push_subscriptions": [{"endpoint", "p256dh", "auth"}, ...], ...}`` の形で
-    追記する。line_enabled / push_enabled / preferences 等の他キーには一切触れない
-    (raw dict レベルで push_subscriptions キーのみ読み書きする)。
+    2026-08-05: 以前は users.notification_settings_json (TEXT) の push_subscriptions
+    キーに JSON 配列として保存していた。しかし同じセルに通知設定
+    (push_enabled / preferences) が同居し、双方が read-modify-write で別セッションから
+    書くため lost update が発生していた (購読 1 件、または設定変更 1 回が黙って消える)。
+    専用テーブルに分離したことで read-modify-write が無くなり、問題クラス自体が消えた。
 
-    endpoint はブラウザ (オリジン) 単位でグローバルに一意という前提のため、
-    同一 endpoint が別ユーザーに再登録された場合は元ユーザー側から除去する
-    (同一端末でのログアウト→別アカウントでの再ログイン等、I-5/I-12 相当)。
+    endpoint のグローバル一意性は UNIQUE 制約が保証する (旧実装は全ユーザー走査で
+    模倣していた)。通知設定は引き続き notification_settings_json 側にあり、
+    本ストアはそれに一切触れない。
     """
 
     def __init__(self, session_factory: Callable[[], Session]) -> None:
         self._session_factory = session_factory
 
     @staticmethod
-    def _read_push_subscriptions(raw_json: Optional[str]) -> list[dict[str, Any]]:
-        """push_subscriptions を読む。壊れた列は空リストとして扱い、例外は投げない。
-
-        `null` / `[1,2]` / `123` / `"str"` はいずれも json.loads が成功するため
-        JSONDecodeError では捕まらない。dict 以外を弾かないと raw.get() が
-        AttributeError になり、呼び出し元の except Exception に飲まれて
-        「静かに配信スキップ」になる (到達経路の暗黙喪失)。
-        """
-        if not raw_json:
-            return []
-        try:
-            raw = json.loads(raw_json)
-        except json.JSONDecodeError:
-            return []
-        if not isinstance(raw, dict):
-            return []
-        subs = raw.get("push_subscriptions")
-        return subs if isinstance(subs, list) else []
-
-    @staticmethod
-    def _write_push_subscriptions(raw_json: Optional[str], subs: list[dict[str, Any]]) -> str:
-        """push_subscriptions のみを差し替えて返す。dict 以外の既存値は破棄して作り直す。"""
-        try:
-            raw = json.loads(raw_json) if raw_json else {}
-        except json.JSONDecodeError:
-            raw = {}
-        if not isinstance(raw, dict):
-            raw = {}
-        raw["push_subscriptions"] = subs
-        return json.dumps(raw)
-
-    @staticmethod
-    def _parse_entry(entry: Any, user_id: int) -> Optional[WebPushSubscription]:
-        """1 件の購読 entry を復元する。壊れていれば None を返し、他の購読を巻き込まない。
-
-        entry が dict でない (文字列 / None 等) 場合 ``entry["endpoint"]`` は
-        KeyError ではなく TypeError になるため、両方を弾く必要がある。
-        """
-        if not isinstance(entry, dict):
-            return None
-        try:
-            return WebPushSubscription(
-                endpoint=entry["endpoint"],
-                p256dh=entry["p256dh"],
-                auth=entry["auth"],
-                user_id=user_id,
-            )
-        except (KeyError, TypeError, ValueError):
-            return None
+    def _to_schema(row: PushSubscription) -> WebPushSubscription:
+        return WebPushSubscription(
+            endpoint=row.endpoint,
+            p256dh=row.p256dh,
+            auth=row.auth,
+            user_id=row.user_id,
+        )
 
     def add(self, subscription: WebPushSubscription) -> None:
-        """サブスクリプションを永続化する。同じ endpoint は (他ユーザー分も含め) 上書きする。"""
+        """購読を保存する。同一 endpoint は (他ユーザー分も含め) 付け替える。
+
+        DELETE → INSERT を 1 トランザクションで行う。**この順序は変更しないこと**:
+        逆順にすると endpoint が一時的に 2 ユーザーへ属する窓ができ、
+        同一端末で別アカウントにログインした際に旧ユーザー宛の通知
+        (金額・資産情報) が届きうる (I-12)。
+        """
         if subscription.user_id is None:
             logger.warning(
                 "DatabaseSubscriptionStore.add: user_id が未設定のため保存をスキップしました "
@@ -205,106 +161,75 @@ class DatabaseSubscriptionStore:
             )
             return
 
-        from app.auth.models import User  # noqa: PLC0415
-
-        db = self._session_factory()
-        try:
-            # 他ユーザーに同一 endpoint が残っていれば先に除去 (グローバル一意性の維持)。
-            others = (
-                db.query(User)
-                .filter(
-                    User.id != subscription.user_id,
-                    User.notification_settings_json.isnot(None),
-                )
-                .all()
-            )
-            for other in others:
-                subs = self._read_push_subscriptions(other.notification_settings_json)
-                filtered = [s for s in subs if s.get("endpoint") != subscription.endpoint]
-                if len(filtered) != len(subs):
-                    other.notification_settings_json = self._write_push_subscriptions(
-                        other.notification_settings_json, filtered
+        for attempt in (1, 2):
+            db = self._session_factory()
+            try:
+                db.execute(
+                    delete(PushSubscription).where(
+                        PushSubscription.endpoint == subscription.endpoint
                     )
-
-            user = db.get(User, subscription.user_id)
-            if user is None:
-                logger.warning(
-                    "DatabaseSubscriptionStore.add: user_id=%d が見つかりません",
-                    subscription.user_id,
                 )
+                db.add(
+                    PushSubscription(
+                        endpoint=subscription.endpoint,
+                        user_id=subscription.user_id,
+                        p256dh=subscription.p256dh,
+                        auth=subscription.auth,
+                    )
+                )
+                db.commit()
                 return
-            subs = self._read_push_subscriptions(user.notification_settings_json)
-            subs = [s for s in subs if s.get("endpoint") != subscription.endpoint]
-            subs.append(
-                PushSubscriptionEntry(
-                    endpoint=subscription.endpoint,
-                    p256dh=subscription.p256dh,
-                    auth=subscription.auth,
-                ).model_dump()
-            )
-            user.notification_settings_json = self._write_push_subscriptions(
-                user.notification_settings_json, subs
-            )
-            db.commit()
-        finally:
-            db.close()
+            except IntegrityError:
+                # 同一 endpoint を別リクエストが同時に INSERT した (稀) か、
+                # user_id が存在しない (FK 違反)。前者は 1 回リトライで収束する。
+                db.rollback()
+                if attempt == 2:
+                    logger.warning(
+                        "DatabaseSubscriptionStore.add: 保存できませんでした "
+                        "(user_id=%s endpoint=%s)",
+                        subscription.user_id,
+                        subscription.endpoint[:30],
+                    )
+                    raise
+            finally:
+                db.close()
 
     def remove(self, endpoint: str) -> None:
-        """指定 endpoint のサブスクリプションを全ユーザーから削除する。"""
-        from app.auth.models import User  # noqa: PLC0415
-
+        """指定 endpoint の購読を削除する。存在しない場合は何もしない。"""
         db = self._session_factory()
         try:
-            users = db.query(User).filter(User.notification_settings_json.isnot(None)).all()
-            for user in users:
-                subs = self._read_push_subscriptions(user.notification_settings_json)
-                filtered = [s for s in subs if s.get("endpoint") != endpoint]
-                if len(filtered) != len(subs):
-                    user.notification_settings_json = self._write_push_subscriptions(
-                        user.notification_settings_json, filtered
-                    )
+            db.execute(delete(PushSubscription).where(PushSubscription.endpoint == endpoint))
             db.commit()
         finally:
             db.close()
 
     def get_all(self) -> list[WebPushSubscription]:
-        """全ユーザーの全サブスクリプションを返す (WebPushSender.send_to_all 用)。"""
-        from app.auth.models import User  # noqa: PLC0415
-
+        """全ユーザーの全購読を返す (WebPushSender.send_to_all 用)。"""
         db = self._session_factory()
         try:
-            users = db.query(User).filter(User.notification_settings_json.isnot(None)).all()
-            result: list[WebPushSubscription] = []
-            for user in users:
-                for s in self._read_push_subscriptions(user.notification_settings_json):
-                    parsed = self._parse_entry(s, user.id)
-                    if parsed is not None:
-                        result.append(parsed)
-            return result
+            rows = db.scalars(select(PushSubscription)).all()
+            return [self._to_schema(r) for r in rows]
         finally:
             db.close()
 
     def get_for_user(self, user_id: int) -> list[WebPushSubscription]:
-        """指定ユーザーのサブスクリプションのみを返す (WebPushSender.send_to_user が使用)。"""
-        from app.auth.models import User  # noqa: PLC0415
-
+        """指定ユーザーの購読のみを返す (WebPushSender.send_to_user が使用)。"""
         db = self._session_factory()
         try:
-            user = db.get(User, user_id)
-            if user is None:
-                return []
-            result: list[WebPushSubscription] = []
-            for s in self._read_push_subscriptions(user.notification_settings_json):
-                parsed = self._parse_entry(s, user_id)
-                if parsed is not None:
-                    result.append(parsed)
-            return result
+            rows = db.scalars(
+                select(PushSubscription).where(PushSubscription.user_id == user_id)
+            ).all()
+            return [self._to_schema(r) for r in rows]
         finally:
             db.close()
 
     def count(self) -> int:
-        """登録済みサブスクリプション総数を返す。"""
-        return len(self.get_all())
+        """登録済み購読の総数を返す。"""
+        db = self._session_factory()
+        try:
+            return db.scalar(select(func.count()).select_from(PushSubscription)) or 0
+        finally:
+            db.close()
 
 
 class WebPushSender:

--- a/backend/app/notifications/router.py
+++ b/backend/app/notifications/router.py
@@ -311,24 +311,12 @@ def _do_update_notification_settings(
 ) -> dict[str, Any]:
     """通知設定を保存して返す。
 
-    2026-08-04 PR3: push_subscriptions (DatabaseSubscriptionStore が同じ列に書く) を
-    この汎用設定更新で消さないよう、既存の raw JSON から読み出して引き継ぐ。
-    push_subscriptions は専用の /push/subscribe, /push/unsubscribe 経由でのみ変更される
-    べきで、NotificationSettingsModel のフィールドには含めない
-    (含めると PUT の度にクライアントが送らなかった分が空配列で上書きされ、
-    購読が黙って消える — 本件と同型の「表示と実行能力が分離される」バグになる)。
+    2026-08-05: 購読は push_subscriptions テーブルへ分離されたため、この関数が
+    購読を引き継ぐ必要は無くなった (以前は同じ JSON セルに同居しており、
+    引き継ぎ漏れが購読の暗黙削除になっていた)。設定と購読は別ストレージなので
+    構造的に干渉しない。
     """
-    existing_push_subscriptions: list[Any] = []
-    if current_user.notification_settings_json:
-        try:
-            existing_raw = json.loads(current_user.notification_settings_json)
-            existing_push_subscriptions = existing_raw.get("push_subscriptions", [])
-        except json.JSONDecodeError:
-            pass
-
-    new_raw = body.model_dump()
-    new_raw["push_subscriptions"] = existing_push_subscriptions
-    current_user.notification_settings_json = json.dumps(new_raw)
+    current_user.notification_settings_json = body.model_dump_json()
     db.add(current_user)
     db.commit()
     return body.model_dump()  # DB に書き込んだ値をそのまま返す; refresh 不要

--- a/backend/tests/notifications/test_push_delivery_hardening.py
+++ b/backend/tests/notifications/test_push_delivery_hardening.py
@@ -37,6 +37,7 @@ from app.notifications.push import (
     VAPIDConfig,
     WebPushSender,
     WebPushSubscription,
+    push_allowed_for_user,
 )
 
 
@@ -200,7 +201,7 @@ def _make_webpush_exception(status_code: int) -> Exception:
 
 
 # ---------------------------------------------------------------------------
-# 2. 破損した notification_settings_json への耐性
+# 2. 破損した notification_settings_json への耐性 (通知設定の読み取り)
 # ---------------------------------------------------------------------------
 
 
@@ -211,61 +212,34 @@ class TestCorruptSettingsJsonRobustness:
     JSONDecodeError では捕まらない。クラッシュすると呼び出し元の
     except Exception に飲まれて「静かに配信スキップ」になり、
     到達経路が黙って失われる (本プロジェクトが最も避けたい失敗形)。
+
+    2026-08-05: 購読は push_subscriptions テーブルへ分離されたため、
+    この列を読むのは通知設定判定 (push_allowed_for_user) のみになった。
+    検証対象をそちらへ振り替えている。
     """
 
-    @pytest.mark.parametrize("raw", ["null", "[1,2]", "123", '"str"', "{}", ""])
-    def test_read_never_raises(self, raw: str) -> None:
-        from app.notifications.push import DatabaseSubscriptionStore
+    @pytest.mark.parametrize("raw", ["null", "[1,2]", "123", '"str"', "{}", "", "{{{broken", None])
+    def test_never_raises_and_denies_on_corrupt(self, raw: str | None) -> None:
+        """壊れた設定では例外を投げず、送らない側 (False) に倒すこと。
 
-        assert DatabaseSubscriptionStore._read_push_subscriptions(raw) == []
+        fail-closed を選ぶ理由: 設定が読めない状態で送ると
+        「OFFにしたはずなのに届く」誤配信になる。到達経路ゼロ側の検知は B-6 が担う。
+        """
+        assert push_allowed_for_user(raw, "ai_proposal") is False
 
-    @pytest.mark.parametrize("raw", ["null", "[1,2]", "123", '"str"'])
-    def test_write_never_raises_and_produces_dict(self, raw: str) -> None:
-        from app.notifications.push import DatabaseSubscriptionStore
+    def test_valid_dict_with_push_enabled_allows(self) -> None:
+        assert push_allowed_for_user(json.dumps({"push_enabled": True}), "ai_proposal") is True
 
-        out = DatabaseSubscriptionStore._write_push_subscriptions(
-            raw, [{"endpoint": "e", "p256dh": "p", "auth": "a"}]
-        )
-        parsed = json.loads(out)
-        assert isinstance(parsed, dict)
-        assert parsed["push_subscriptions"][0]["endpoint"] == "e"
+    @pytest.mark.parametrize("preferences", ["notadict", 123, None, []])
+    def test_non_dict_preferences_does_not_crash(self, preferences: Any) -> None:
+        """preferences が dict でなくても落ちず、push_enabled の判定は生きること。"""
+        raw = json.dumps({"push_enabled": True, "preferences": preferences})
+        assert push_allowed_for_user(raw, "ai_proposal") is True
 
-    def test_write_preserves_other_keys_from_valid_dict(self) -> None:
-        """正常な dict の場合は他キー (push_enabled 等) を保持すること。"""
-        from app.notifications.push import DatabaseSubscriptionStore
-
-        out = DatabaseSubscriptionStore._write_push_subscriptions(
-            json.dumps({"push_enabled": True, "line_enabled": False}), []
-        )
-        parsed = json.loads(out)
-        assert parsed["push_enabled"] is True
-        assert parsed["line_enabled"] is False
-
-    @pytest.mark.parametrize(
-        "entry",
-        [
-            {"p256dh": "p", "auth": "a"},  # endpoint 欠落
-            {"endpoint": "e", "auth": "a"},  # p256dh 欠落
-            {"endpoint": "e", "p256dh": "p"},  # auth 欠落
-            "not-a-dict",  # 要素が dict ですらない
-            None,
-        ],
-    )
-    def test_malformed_entry_is_skipped_not_fatal(self, entry: Any) -> None:
-        """壊れた要素は飛ばし、他の正常な購読は生き残ること。"""
-        from app.notifications.push import DatabaseSubscriptionStore
-
-        good = {"endpoint": "https://p/good", "p256dh": "p", "auth": "a"}
-        user = MagicMock()
-        user.id = 1
-        user.notification_settings_json = json.dumps({"push_subscriptions": [entry, good]})
-        db = MagicMock()
-        db.get.return_value = user
-
-        store = DatabaseSubscriptionStore(lambda: db)
-        result = store.get_for_user(1)
-
-        assert [s.endpoint for s in result] == ["https://p/good"]
+    def test_unknown_preference_key_defaults_to_allowed(self) -> None:
+        """未知の通知種別は明示的に False でない限り許可 (既定で届く)。"""
+        raw = json.dumps({"push_enabled": True, "preferences": {"other": False}})
+        assert push_allowed_for_user(raw, "ai_proposal") is True
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/notifications/test_push_subscribe_settings_integration.py
+++ b/backend/tests/notifications/test_push_subscribe_settings_integration.py
@@ -1,20 +1,22 @@
 # Copyright (c) Ultra AutoTrade. All rights reserved.
 # Unauthorized copying or distribution is strictly prohibited.
 # backend/tests/notifications/test_push_subscribe_settings_integration.py
-"""購読保存と通知設定が同じ列を共有していることの結合テスト (2026-08-05)。
+"""購読保存と通知設定の結合テスト (2026-08-05)。
 
-push_subscriptions と push_enabled / preferences は **同一の
-users.notification_settings_json (TEXT)** に同居している。書き手が2系統
-(/push/subscribe = DatabaseSubscriptionStore と PUT /settings = router) あるため、
-片方が他方を踏むと「購読はあるが設定が消えた」「設定はあるが購読が消えた」という
-到達経路の静かな喪失が起きる。
+購読 (push_subscriptions テーブル) と通知設定 (users.notification_settings_json) は
+別ストレージだが、フロントエンドは 1 回のトグル操作で両方を順に書く。
+単体テストが個々に通っていても、この結合部分が切れていれば通知は届かない。
 
 本ファイルは実DB (sqlite) を使い、フロントエンドが実際に行う順序
   1. POST /push/subscribe    (購読を保存)
   2. PUT  /settings          (push_enabled=true を保存)
   3. 配信判定                 (push_allowed_for_user + get_for_user)
-が最後まで繋がることを検証する。単体テストが個々に通っていても、
-この結合部分が切れていれば通知は届かない。
+が最後まで繋がることを検証する。
+
+**元は「同一 JSON セルを共有している」ことの結合テストだった。**
+2 系統の read-modify-write が互いを踏んで lost update を起こしていたため、
+購読を専用テーブルへ分離した。本ファイルは分離後に
+「もう干渉しないこと」を固定する回帰テストとしての役割に変わっている。
 """
 
 from __future__ import annotations
@@ -103,8 +105,8 @@ class TestSubscribeThenEnableSequence:
     def test_settings_put_first_then_subscribe_keeps_both(self, _db_env) -> None:
         """逆順 (設定ON → 購読保存) でも両立すること。
 
-        store.add は raw JSON の push_subscriptions キーのみを差し替える契約なので、
-        既存の push_enabled を落としてはいけない。
+        購読はテーブル、設定は JSON 列と別ストレージなので、購読保存が
+        push_enabled / line_enabled を落とすことは構造的に起こらない。
         """
         db, factory = _db_env
         user = _make_user(db, 2)
@@ -119,7 +121,7 @@ class TestSubscribeThenEnableSequence:
         raw = json.loads(user.notification_settings_json)
         assert raw["push_enabled"] is True, "購読保存が push_enabled を消してはいけない"
         assert raw["line_enabled"] is False, "他チャネル設定も保持されること"
-        assert len(raw["push_subscriptions"]) == 1
+        assert len(store.get_for_user(user.id)) == 1
 
     def test_toggle_off_then_on_does_not_duplicate_or_lose(self, _db_env) -> None:
         """I-1 (短時間の往復): OFF→ON を繰り返しても購読が重複/消失しないこと。"""
@@ -154,7 +156,12 @@ class TestSubscribeThenEnableSequence:
         assert push_allowed_for_user(user.notification_settings_json, "ai_proposal") is True
 
     def test_settings_put_does_not_resurrect_removed_subscription(self, _db_env) -> None:
-        """解除後の設定PUTで購読が復活しないこと (PUT は購読を「引き継ぐ」実装のため)。"""
+        """解除後に設定PUTしても購読が復活しないこと。
+
+        旧実装は PUT が JSON 内の購読を「引き継ぐ」ため、古い値を掴んでいると
+        解除済みの購読を書き戻す危険があった。分離後は PUT が購読に触れないので
+        構造的に起こらない。
+        """
         db, factory = _db_env
         user = _make_user(db, 4)
         store = DatabaseSubscriptionStore(factory)
@@ -262,7 +269,7 @@ class TestCrossUserEndpointMigration:
         raw = json.loads(old.notification_settings_json)
         assert raw["line_enabled"] is False
         assert raw["push_enabled"] is True
-        assert raw["push_subscriptions"] == []
+        assert store.get_for_user(old.id) == [], "購読だけが移動し、設定は無傷"
 
 
 class TestSchedulerGateUsesRealDb:
@@ -293,3 +300,104 @@ class TestSchedulerGateUsesRealDb:
             )
 
         mock_sender.send_to_user.assert_not_called()
+
+
+class TestLostUpdateIsStructurallyImpossible:
+    """旧実装で lost update が起きたシナリオが、もう起こらないことを固定する。
+
+    旧実装は購読と設定が同一 JSON セルに同居し、双方が read-modify-write していた。
+    「設定を読む → 購読が書き込まれる → 設定を書き戻す」の順序で購読が消えた
+    (逆順では設定が消えた)。テーブル分離後は書き込み先が異なるため、
+    どの交錯順序でも双方が残る。
+    """
+
+    def _assert_both_alive(self, db: Session, store: DatabaseSubscriptionStore, user: User) -> None:
+        db.refresh(user)
+        assert push_allowed_for_user(user.notification_settings_json, "ai_proposal") is True
+        assert len(store.get_for_user(user.id)) == 1
+
+    def test_settings_read_then_subscribe_then_settings_write(self, _db_env) -> None:
+        """旧実装で購読が消えた交錯順序。設定の読み込みと書き戻しの間に購読が入る。"""
+        db, factory = _db_env
+        user = _make_user(db, 30)
+        store = DatabaseSubscriptionStore(factory)
+
+        body = NotificationSettingsModel(push_enabled=True)  # 設定側が値を読み終えた状態
+        store.add(WebPushSubscription(endpoint=_ENDPOINT, p256dh="p", auth="a", user_id=user.id))
+        _do_update_notification_settings(body, user, db)  # 設定を書き戻す
+
+        self._assert_both_alive(db, store, user)
+
+    def test_subscribe_then_settings_then_second_subscribe(self, _db_env) -> None:
+        """2 端末目の購読が設定保存を挟んでも消えないこと。"""
+        db, factory = _db_env
+        user = _make_user(db, 31)
+        store = DatabaseSubscriptionStore(factory)
+
+        store.add(WebPushSubscription(endpoint=_ENDPOINT + "-a", p256dh="p", auth="a", user_id=31))
+        _do_update_notification_settings(NotificationSettingsModel(push_enabled=True), user, db)
+        store.add(WebPushSubscription(endpoint=_ENDPOINT + "-b", p256dh="p", auth="a", user_id=31))
+
+        db.refresh(user)
+        assert push_allowed_for_user(user.notification_settings_json, "ai_proposal") is True
+        assert len(store.get_for_user(31)) == 2, "2 端末とも生存すること"
+
+    def test_repeated_interleaving_never_loses_either_side(self, _db_env) -> None:
+        """設定保存と購読操作を交互に多数回繰り返しても双方が壊れないこと。"""
+        db, factory = _db_env
+        user = _make_user(db, 32)
+        store = DatabaseSubscriptionStore(factory)
+
+        for i in range(5):
+            store.add(
+                WebPushSubscription(endpoint=f"{_ENDPOINT}-{i}", p256dh="p", auth="a", user_id=32)
+            )
+            db.refresh(user)
+            _do_update_notification_settings(NotificationSettingsModel(push_enabled=True), user, db)
+
+        db.refresh(user)
+        assert push_allowed_for_user(user.notification_settings_json, "ai_proposal") is True
+        assert len(store.get_for_user(32)) == 5
+
+
+class TestEndpointUniquenessIsEnforcedByDb:
+    """endpoint の一意性が DB 制約で担保されていること (旧実装は全ユーザー走査で模倣)。"""
+
+    def test_unique_constraint_exists_on_endpoint(self, _db_env) -> None:
+        """アプリを経由せず直接 INSERT しても重複 endpoint は拒否されること。"""
+        from sqlalchemy.exc import IntegrityError
+
+        from app.notifications.models import PushSubscription
+
+        db, _factory = _db_env
+        _make_user(db, 40)
+        _make_user(db, 41)
+
+        db.add(PushSubscription(endpoint=_ENDPOINT, user_id=40, p256dh="p", auth="a"))
+        db.commit()
+        db.add(PushSubscription(endpoint=_ENDPOINT, user_id=41, p256dh="p", auth="a"))
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()
+
+    def test_deleting_user_cascades_subscriptions(self, _db_env) -> None:
+        """ユーザー削除で購読行も消えること (孤児行を残さない)。
+
+        sqlite は既定で FK を強制しないため、本テストでは明示的に有効化する
+        (PostgreSQL では既定で有効)。
+        """
+        from sqlalchemy import text
+
+        from app.notifications.models import PushSubscription
+
+        db, factory = _db_env
+        user = _make_user(db, 42)
+        store = DatabaseSubscriptionStore(factory)
+        store.add(WebPushSubscription(endpoint=_ENDPOINT, p256dh="p", auth="a", user_id=42))
+        assert store.count() == 1
+
+        db.execute(text("PRAGMA foreign_keys=ON"))
+        db.delete(user)
+        db.commit()
+
+        assert db.query(PushSubscription).count() == 0

--- a/backend/tests/notifications/test_push_subscription_store.py
+++ b/backend/tests/notifications/test_push_subscription_store.py
@@ -1,12 +1,16 @@
 # Copyright (c) Ultra AutoTrade. All rights reserved.
 # backend/tests/notifications/test_push_subscription_store.py
-"""DatabaseSubscriptionStore の単体テスト（2026-08-04 PR3: Web Push購読の永続化）。
+"""DatabaseSubscriptionStore の単体テスト（Web Push購読の永続化）。
 
 InMemorySubscriptionStore は「メモリ保持・ユーザー未紐付け・認証なし」で、
 再起動で全消失し誰の購読か分からなかった
 (docs/internal/2026-08-04_execution_pipeline_requirements.md)。
-本テストは DB 永続化・user_id 紐付け・複数ユーザー分離・
-汎用設定PUTによる意図しない消失が起きないことを検証する。
+本テストは DB 永続化・user_id 紐付け・複数ユーザー分離を検証する。
+
+2026-08-05: 保存先を users.notification_settings_json の JSON 配列から
+push_subscriptions テーブルへ変更した。アサーションは行ベースに書き換えている
+(検証意図は同一)。endpoint のグローバル一意性は UNIQUE 制約が保証するため、
+「他ユーザーから除去されること」はアプリロジックではなく制約の検証になった。
 """
 
 from __future__ import annotations
@@ -94,10 +98,9 @@ class TestAddAndPersist:
             )
         )
 
-        db_session.refresh(user)
-        raw = json.loads(user.notification_settings_json)
-        assert raw["push_subscriptions"] == [
-            {"endpoint": "https://push.example.com/ep1", "p256dh": "k1", "auth": "a1"}
+        rows = store.get_for_user(user.id)
+        assert [(r.endpoint, r.p256dh, r.auth) for r in rows] == [
+            ("https://push.example.com/ep1", "k1", "a1")
         ]
 
     def test_add_without_user_id_is_noop(self, db_session: Session, session_factory) -> None:
@@ -107,8 +110,14 @@ class TestAddAndPersist:
         )
         assert store.count() == 0
 
-    def test_add_preserves_other_settings_keys(self, db_session: Session, session_factory) -> None:
-        """push_subscriptions 以外の既存キー (line_enabled 等) を壊さないこと。"""
+    def test_add_does_not_touch_notification_settings(
+        self, db_session: Session, session_factory
+    ) -> None:
+        """購読保存が通知設定 (別ストレージ) を一切変更しないこと。
+
+        以前は同一 JSON セルを共有しており、双方の read-modify-write が
+        互いを踏んで lost update を起こしていた。テーブル分離後は構造的に干渉しない。
+        """
         existing = json.dumps({"line_enabled": False, "push_enabled": True, "preferences": {}})
         user = _make_user(db_session, 402, notification_settings_json=existing)
         db_session.commit()
@@ -121,10 +130,8 @@ class TestAddAndPersist:
         )
 
         db_session.refresh(user)
-        raw = json.loads(user.notification_settings_json)
-        assert raw["line_enabled"] is False
-        assert raw["push_enabled"] is True
-        assert len(raw["push_subscriptions"]) == 1
+        assert user.notification_settings_json == existing, "通知設定は 1 バイトも変わらないこと"
+        assert len(store.get_for_user(user.id)) == 1
 
     def test_add_same_endpoint_removes_from_other_user(
         self, db_session: Session, session_factory
@@ -139,13 +146,11 @@ class TestAddAndPersist:
         store.add(WebPushSubscription(endpoint=endpoint, p256dh="k1", auth="a1", user_id=user_a.id))
         store.add(WebPushSubscription(endpoint=endpoint, p256dh="k2", auth="a2", user_id=user_b.id))
 
-        db_session.refresh(user_a)
-        db_session.refresh(user_b)
-        a_subs = json.loads(user_a.notification_settings_json)["push_subscriptions"]
-        b_subs = json.loads(user_b.notification_settings_json)["push_subscriptions"]
-        assert a_subs == []
+        assert store.get_for_user(user_a.id) == [], "旧ユーザーから除去されること"
+        b_subs = store.get_for_user(user_b.id)
         assert len(b_subs) == 1
-        assert b_subs[0]["p256dh"] == "k2"
+        assert b_subs[0].p256dh == "k2"
+        assert store.count() == 1, "endpoint は UNIQUE なので全体で 1 行"
 
     def test_add_duplicate_endpoint_same_user_overwrites(
         self, db_session: Session, session_factory
@@ -158,10 +163,9 @@ class TestAddAndPersist:
         store.add(WebPushSubscription(endpoint=endpoint, p256dh="k1", auth="a1", user_id=user.id))
         store.add(WebPushSubscription(endpoint=endpoint, p256dh="k2", auth="a2", user_id=user.id))
 
-        db_session.refresh(user)
-        subs = json.loads(user.notification_settings_json)["push_subscriptions"]
+        subs = store.get_for_user(user.id)
         assert len(subs) == 1
-        assert subs[0]["p256dh"] == "k2"
+        assert subs[0].p256dh == "k2"
 
 
 class TestRemove:
@@ -174,8 +178,7 @@ class TestRemove:
 
         store.remove(endpoint)
 
-        db_session.refresh(user)
-        assert json.loads(user.notification_settings_json)["push_subscriptions"] == []
+        assert store.get_for_user(user.id) == []
 
     def test_remove_nonexistent_endpoint_is_noop(
         self, db_session: Session, session_factory
@@ -275,8 +278,16 @@ class TestGetAllAndGetForUser:
         assert store.count() == 2
 
 
-class TestCorruptJsonFallback:
-    def test_add_with_corrupt_existing_json_falls_back_to_empty(
+class TestCorruptSettingsJsonIsIrrelevant:
+    """通知設定 JSON が壊れていても購読の保存は成功すること。
+
+    2026-08-05: 以前は購読が同じ JSON セルに入っていたため、壊れた設定が
+    購読の読み書きを巻き込んでいた。テーブル分離後は完全に独立なので、
+    壊れた設定は購読に一切影響しない (壊れた設定の扱いは
+    push_allowed_for_user 側の責務で、そちらでテストしている)。
+    """
+
+    def test_add_succeeds_even_with_corrupt_settings_json(
         self, db_session: Session, session_factory
     ) -> None:
         user = _make_user(db_session, 412, notification_settings_json="{not valid json")
@@ -289,6 +300,6 @@ class TestCorruptJsonFallback:
             )
         )
 
+        assert len(store.get_for_user(user.id)) == 1
         db_session.refresh(user)
-        raw = json.loads(user.notification_settings_json)
-        assert len(raw["push_subscriptions"]) == 1
+        assert user.notification_settings_json == "{not valid json", "設定側は触らない"

--- a/backend/tests/test_notification_settings_api.py
+++ b/backend/tests/test_notification_settings_api.py
@@ -172,27 +172,19 @@ class TestPutNotificationSettings:
         res = self.client.put("/api/notifications/settings", json={"line_enabled": "not_a_bool"})
         assert res.status_code == 422
 
-    def test_generic_settings_put_preserves_push_subscriptions(self):
-        """★2026-08-04 PR3 回帰防止: push_subscriptions は /push/subscribe 専用エンドポイント
-        経由でのみ変更されるべきで、他の通知設定 (line_enabled 等) を変更するだけの
-        汎用 PUT /settings で黙って空配列に上書きされてはならない。
-        NotificationSettingsModel が push_subscriptions を含まないため、対策なしでは
-        body.model_dump_json() が丸ごと上書きし購読が消える。"""
-        existing = json.dumps(
-            {
-                "line_enabled": True,
-                "push_enabled": True,
-                "preferences": {},
-                "push_subscriptions": [
-                    {"endpoint": "https://push.example.com/keep-me", "p256dh": "k", "auth": "a"}
-                ],
-            }
-        )
-        user = _make_user(existing)
+    def test_settings_put_does_not_write_push_subscriptions_key(self):
+        """設定 PUT は購読に一切関与しないこと (2026-08-05 テーブル分離後)。
+
+        以前は購読が同じ JSON セルに同居していたため、PUT /settings が
+        push_subscriptions を空配列で上書きして購読を黙って消すバグがあった
+        (PR3 で「既存値を引き継ぐ」対策を入れていた)。
+        購読を専用テーブルへ分離した現在は、設定 JSON に購読の痕跡を書かないことが
+        正しい姿。引き継ぎロジックが復活していないことをここで固定する。
+        """
+        user = _make_user(json.dumps({"line_enabled": True, "push_enabled": True}))
         db = self._make_db(user)
         self._override_deps(user, db)
 
-        # push_subscriptions を含まない、既存の通知設定変更 (line_enabled のみ変更) を PUT する。
         payload: dict[str, Any] = {
             "line_enabled": False,
             "push_enabled": True,
@@ -209,33 +201,37 @@ class TestPutNotificationSettings:
         assert res.status_code == 200
 
         saved = json.loads(user.notification_settings_json)
-        assert saved["line_enabled"] is False  # 意図した変更は反映される
-        assert saved["push_subscriptions"] == [
-            {"endpoint": "https://push.example.com/keep-me", "p256dh": "k", "auth": "a"}
-        ]  # 購読は消えない
+        assert saved["line_enabled"] is False, "意図した変更は反映される"
+        assert "push_subscriptions" not in saved, (
+            "購読は専用テーブルの責務。設定 JSON に書き戻してはいけない"
+        )
 
-    def test_settings_put_with_no_prior_push_subscriptions_defaults_to_empty(self):
-        """push_subscriptions キーが元々存在しない (未購読ユーザー) 場合は空配列で保存される。"""
-        user = _make_user(None)
+    def test_stale_push_subscriptions_key_is_dropped_on_save(self):
+        """移行前に書かれた古い push_subscriptions キーは保存時に落ちること。
+
+        マイグレーションは downgrade 安全性のため JSON 側のキーを残す。
+        設定を保存した時点でその残骸が消え、二重の真実源にならないことを確認する
+        (購読の実体は既にテーブルへ移行済み)。
+        """
+        legacy = json.dumps(
+            {
+                "line_enabled": True,
+                "push_enabled": True,
+                "push_subscriptions": [
+                    {"endpoint": "https://push.example.com/legacy", "p256dh": "k", "auth": "a"}
+                ],
+            }
+        )
+        user = _make_user(legacy)
         db = self._make_db(user)
         self._override_deps(user, db)
 
-        payload: dict[str, Any] = {
-            "line_enabled": True,
-            "push_enabled": False,
-            "preferences": {
-                "ai_proposal": True,
-                "execution_complete": True,
-                "health_factor_warning": True,
-                "emergency_stop": True,
-                "monthly_report": True,
-                "system_notice": True,
-            },
-        }
-        res = self.client.put("/api/notifications/settings", json=payload)
+        res = self.client.put(
+            "/api/notifications/settings",
+            json={"line_enabled": True, "push_enabled": True, "preferences": {}},
+        )
         assert res.status_code == 200
-        saved = json.loads(user.notification_settings_json)
-        assert saved["push_subscriptions"] == []
+        assert "push_subscriptions" not in json.loads(user.notification_settings_json)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/ops/02_db_tables.md
+++ b/docs/ops/02_db_tables.md
@@ -270,6 +270,35 @@ docker exec ultra-autotrade-postgres-production \
 | partner_id | Integer | YES | パートナーID |
 | user_id | Integer | YES | ユーザーID |
 | created_at | DateTime(tz) | NO | 作成日時 |
+| delivered | Boolean | YES | 到達確認（NULL=対象外/未計測、True=到達、False=配信失敗）。行の存在が「送信した」、本列が「到達した」を表す |
+
+---
+
+### `push_subscriptions` (notifications/models.py)
+
+> Web Push (VAPID) 購読情報。Alembic `z7a8b9c0d1e2`（2026-08-05）。
+>
+> 当初は `users.notification_settings_json` の `push_subscriptions` キーに JSON 配列で
+> 保存していたが、同じセルに通知設定（`push_enabled` / `preferences`）が同居し、
+> 双方が read-modify-write で別セッションから書くため lost update が発生していた
+> （購読1件または設定変更1回が黙って消える）。専用テーブルへ分離して解消。
+>
+> `endpoint` の UNIQUE 制約が「同一端末が同時に2ユーザーへ属さない」を保証する
+> （旧実装は全ユーザー走査で模倣していた）。同一端末で別アカウントにログインすると
+> 購読は新ユーザーへ付け替わる。
+
+| カラム | 型 | NULL | 説明 |
+|--------|-----|------|------|
+| id | Integer PK | NO | 自動採番 |
+| endpoint | Text UNIQUE | NO | ブラウザ PushSubscription の endpoint URL（グローバル一意） |
+| user_id | Integer FK | NO | 購読者の users.id（ON DELETE CASCADE） |
+| p256dh | String(255) | NO | 購読の公開鍵 |
+| auth | String(255) | NO | 購読の認証シークレット |
+| created_at | DateTime(tz) | NO | 登録日時 |
+
+> 移行時の注意: `notification_settings_json` 側の `push_subscriptions` キーは
+> downgrade 安全性のため**マイグレーションでは削除していない**。アプリは読まないため無害で、
+> ユーザーが次に通知設定を保存した時点で消える。
 
 ---
 


### PR DESCRIPTION
> **スタックPR**: base は `test/push-delivery-hardening` (#1019)。#1019 の `push_allowed_for_user` に依存するため。#1019 マージ後に main へ rebase します。

## 背景

`users.notification_settings_json` (TEXT) に**購読配列と通知設定が同居**しており、書き手が2系統で双方が read-modify-write していた:

| 関心事 | 書き手 | セッション |
|---|---|---|
| `push_subscriptions` | `DatabaseSubscriptionStore.add()/.remove()` | 独自セッション |
| `push_enabled` / `preferences` | `PUT /settings` | リクエストセッション |

並行実行で**購読1件または設定変更1回が黙って消える**。現実的な競合はスケジューラの410パージとユーザーの設定保存の同時実行、2端末同時購読。

専用テーブルへ分離することで **read-modify-write そのものが無くなり、問題クラスが消える**。endpoint のグローバル一意性も UNIQUE 制約が保証するため、`add()` が全ユーザー走査で模倣していた処理も不要になった（残存していた性能問題も同時に解消）。

## 方式選定（行ロック・CAS を退けた理由）

- **行ロック**: `with_for_update()` は PostgreSQL では `FOR UPDATE` を生成するが **SQLite では黙って除去される**（実測）ためテスト不能。加えて `add()`/`remove()` の全ユーザー走査と組み合わさると**全行ロック**になり通知書き込みが全体で直列化する。
- **楽観的CAS**: `Session.rollback()` が呼び出し元の SAVEPOINT を破棄する、SQLite では競合が `rowcount 0` でなく `OperationalError` になる等の欠陥があり、ヘルパー + 有界リトライ + `lock_timeout` + 走査絞り込み と付帯物が増える。

**本番データの移行コストが無いことを確認済み**: 本番は VAPID 鍵未設定で永続化された購読は 0 件。

> ⚠️ 要件書 I-1「新規テーブルを作らない」を**この一点に限り意図的に上書き**しています。理由は `docs/internal/2026-08-04_execution_pipeline_requirements.md` に追記済み（※同ファイルは未追跡のため本PRには含まれません）。購読API・送信クラス・購読UIの「新設しない」方針は引き続き有効です。

## 変更

- **models.py**: `PushSubscription` 追加（`endpoint` UNIQUE / `user_id` FK ON DELETE CASCADE）
- **alembic `z7a8b9c0d1e2`**: `create_table` + backfill。**JSON 側のキーは削除しない**（downgrade 安全性）。offline モード（`--sql`）では backfill をスキップし警告
- **push.py**: `DatabaseSubscriptionStore` 全面書き換え。各メソッドが単一クエリになり **219行 → 111行**。`PushSubscriptionEntry` / `_read_push_subscriptions` / `_write_push_subscriptions` / `_parse_entry` を削除
- **router.py**: `PUT /settings` の購読引き継ぎブロックを削除（構造的に不要）
- `SubscriptionStore` Protocol は**不変**。`WebPushSender` / `InMemorySubscriptionStore` も無変更

> 🔒 `add()` の **DELETE → INSERT の順序はセキュリティ上変更しないこと**。逆順だと endpoint が一時的に2ユーザーへ属する窓ができ、同一端末で別アカウントにログインした際に旧ユーザー宛の金額情報が届きうる（I-12）。コードにコメントで固定済み。

## テスト

**書き換え**: JSON形状依存のアサーションを行ベースへ（検証意図は同一）。破損JSON耐性テストは対象が `push_allowed_for_user` のみになったため振り替え。

**追加**:
- lost update が構造的に起きないこと（旧実装で購読が消えた交錯順序を含め、設定保存と購読操作をどの順序で交互に実行しても双方が残る）
- `endpoint` UNIQUE 制約がアプリを経由しない直接 INSERT でも効くこと
- ユーザー削除で購読行が CASCADE 削除されること

## 検証

```
pytest tests/            : 5047 passed, 0 failed, 26 skipped
ruff check . / format    : 問題なし
mypy app/                : 既存の stripe import-not-found 2件のみ
```

**alembic 実機確認（SQLite）**: backfill 2件移行 / 壊れJSON・`null`・鍵欠落・重複endpoint はスキップ / downgrade でテーブル削除かつ JSON 側は保持 / 再upgrade 冪等
**alembic offline（PostgreSQL 向け SQL 生成）**: DDL 正常生成を確認（`SERIAL` / `TIMESTAMP WITH TIME ZONE` / FK CASCADE / UNIQUE INDEX）

> 注: マイグレーションの backfill 自体の**自動テストは追加していません**（run-once コードで、既存の古いリビジョンが SQLite 非対応のため stamp 迂回が必要）。上記の実機確認で代替しています。

## デプロイ時の追加手順

`alembic upgrade head` が必要です（`init_db()` の `create_all` でも作られますが、本番は alembic を正とする運用）。

## 残存リスク（スコープ外・別途判断）

1. **スケジューラ savepoint 内の別セッション書き込み** — `_create_proposals_for_users` は `begin_nested()` 内で `user.last_judgment_at` を dirty にし、その後 `_deliver_ai_proposal_push` が別セッションで動く。本変更で購読は別テーブルへ移り `users` 行への書き込みが減るため**リスクは大きく下がる**が、`lock_timeout` 設定は別PRで検討。
2. **`_purge_gone` の例外が NotificationLog（delivered記録）を失わせる** — 1〜2行で閉じられる可観測性の穴。別PR。
3. **JSON 側に残る `push_subscriptions` キーの掃除** — 意図的に残置（ユーザーが次に設定保存した時点で消える）。
4. **実機到達確認（B-1 / B-7）** — iOS/Android 実機での着信確認は静的テストで代替不可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)