### PR TITLE
fix(pwa): Service Worker のインストールがサイト全体で失敗していた根本原因を修正

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -46,6 +46,20 @@ const withPWA = require('next-pwa')({
     /build-manifest\.json$/,
     /middleware-manifest\.json$/,
     /react-loadable-manifest\.json$/,
+    // 2026-08-05: next-pwa (node_modules/next-pwa/index.js) は本来デフォルトで
+    // `asset.name.startsWith('server/')` を除外する関数を workboxCommon.exclude に
+    // 持っているが、withPWA() にユーザー定義の exclude 配列を渡すと
+    // (...workboxCommon, ...workbox の順で spread されるため) この配列が
+    // デフォルトを "マージ" ではなく "丸ごと上書き" してしまう。
+    // 上の4パターンだけでは .next/server/ 配下 (Node.js サーバープロセス専用、
+    // 公開HTTPルートから一切配信されない) のファイル
+    // (client-reference-manifest.js / middleware-build-manifest.js /
+    //  next-font-manifest.{js,json} 等) が「静的アセット」と誤認されて
+    // precache 対象に混入し、SW install 時の precacheAndRoute() がこの404で失敗、
+    // **Service Worker のインストール自体がサイト全体で全滅**していた
+    // (本番実機検証で発覚: getRegistrations() が常に0件、bad-precaching-response
+    // エラー)。next-pwa 本来のデフォルト除外関数をそのまま復元する。
+    ({ asset }) => asset.name.startsWith('server/'),
   ],
 });
 


### PR DESCRIPTION
## 発覚経緯

本番実機での Web Push 検証中、プッシュ通知トグルが「許可済み」表示のまま一切反応しない（ハングする）現象を発見。原因を辿ると **Service Worker が1件も登録されていない**ことが判明（`navigator.serviceWorker.getRegistrations()` が常に空配列）。

## 根本原因

`next-pwa` はデフォルトで `asset.name.startsWith('server/')` を除外する関数を内部の exclude ロジックに持っている。しかし `next.config.js` の `withPWA()` にユーザー定義の `exclude` 配列を渡すと（`...workboxCommon, ...workbox` の順で spread されるため）**この配列がデフォルトを「マージ」ではなく「丸ごと上書き」**してしまう仕様だった。

既存の `exclude` は4つの manifest ファイル名パターンのみを列挙しており、`.next/server/` 配下（Node.js サーバープロセス専用、公開HTTPルートから一切配信されない）の他のファイル（`client-reference-manifest.js` / `middleware-build-manifest.js` / `next-font-manifest.{js,json}` 等）が「静的アセット」と誤認されて precache 対象に混入していた。

SW install 時の `precacheAndRoute()` がこれらの404で失敗し、**Service Worker のインストール自体がサイト全体で全滅**していた（Push 機能に限らず、PWA/オフライン対応全般が本番で機能していなかった）。

## 調査経緯（本番実機、実際に踏んだ回り道も含む）

1. ブラウザ Console で `bad-precaching-response` エラーを発見
2. 最初は個別ファイル名パターンで exclude 追加を試みたが、同種の別ファイル（計4種）が別途混入することが判明
3. `node_modules/next-pwa/index.js` を直接読み、`exclude` が配列マージではなく完全上書きであること、本来の内蔵除外ロジックの中身を特定
4. 内蔵ロジック（`asset.name.startsWith('server/')`）を関数として復元

## 修正

```diff
  exclude: [
    /app-build-manifest\.json$/,
    /build-manifest\.json$/,
    /middleware-manifest\.json$/,
    /react-loadable-manifest\.json$/,
+   ({ asset }) => asset.name.startsWith('server/'),
  ],
```

## 検証（ローカル production ビルド、本番相当）

| 項目 | 修正前 | 修正後 |
|---|---|---|
| `_next/server/` 配下のプリキャッシュエントリ | 4件 | **0件** |
| `client-reference-manifest` | 1件 | **0件** |
| 総プリキャッシュ件数 | — | 372件（健全） |
| admin ルートの正規静的アセット | — | 28件（残存確認済み、除外しすぎていない） |
| 想定外カテゴリの混入 | — | なし（残るのは `public/` 配下の正規ファイルのみ） |

```
npx tsc --noEmit           : クリーン
npx eslint next.config.js  : No issues found
```

`public/sw.js` / `public/workbox-*.js` はビルド成果物であり `.gitignore` 済みのため本コミットには含まれない（本番では deploy 時の `next build` で再生成される）。

## デプロイ

バックエンド変更なし、`--frontend-only` で反映可能（VAPID鍵は既に `.env.production` に設定済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)