### PR TITLE
fix(automation): レイテンシ監視が401を計測し続けアラートが永久に発火しない問題を修正

### DIFF
--- a/backend/app/automation/scheduled_tasks.py
+++ b/backend/app/automation/scheduled_tasks.py
@@ -1193,13 +1193,32 @@ async def latency_monitor_loop(
                 from app.automation.state import get_monitoring_service  # noqa: PLC0415
 
                 base_url = os.getenv("BACKEND_BASE_URL", "http://localhost:8000")
-                url = f"{base_url}/api/automation/status"
+                # 2026-08-06: 以前は /api/automation/status を叩いていたが、この
+                # エンドポイントは require_viewer (JWT ユーザー) を要求するため、
+                # 認証情報を持たない本ループからは常に 401 が返っていた
+                # (X-Internal-Token 方式もこのエンドポイントは受け付けない)。
+                # httpx.get() は 4xx で例外を投げないため「401 拒否までの時間」が
+                # システム応答時間として記録され続け、閾値 (>10s 警告 / >30s アラート)
+                # に絶対に到達しない = **レイテンシ監視が構造的に永久に発火しない**
+                # 状態だった (本番ログに 60 秒ごとの 401 が並んでいたことで発覚)。
+                # /health は認証不要かつスケジューラ健全性計算という実処理を行うため
+                # 応答時間の代理指標として妥当。
+                url = f"{base_url}/health"
 
                 monitoring_service = get_monitoring_service()
                 start = time.monotonic()
                 try:
-                    httpx.get(url, timeout=35)
+                    response = httpx.get(url, timeout=35)
                     elapsed = time.monotonic() - start
+                    # 非 2xx は「速く失敗した」だけであり応答性能の指標にならない。
+                    # 記録すると健全に見えてしまうため、記録せず警告に留める。
+                    if response.status_code >= 400:
+                        logger.warning(
+                            "Latency check got HTTP %d from %s (skipping record)",
+                            response.status_code,
+                            url,
+                        )
+                        return
                     monitoring_service.record_latency(ComponentType.SYSTEM, elapsed)
                     logger.debug("Latency recorded: %.3fs for %s", elapsed, url)
                 except Exception as req_exc:

--- a/backend/tests/test_scheduled_tasks.py
+++ b/backend/tests/test_scheduled_tasks.py
@@ -1127,11 +1127,15 @@ class TestLoopBodyAdditional:
 
     @pytest.mark.asyncio
     async def test_latency_monitor_loop_records_latency(self) -> None:
-        """latency_monitor_loop: httpx.get 成功 → record_latency() が呼ばれる（L557-603）。"""
+        """latency_monitor_loop: httpx.get が 2xx → record_latency() が呼ばれる（L557-603）。"""
         from app.automation.scheduled_tasks import latency_monitor_loop
 
         _, mock_sleep = self._make_sleep_counter(raise_on=2)
         mock_ms = MagicMock()
+        # status_code は数値で与える必要がある (素の MagicMock だと >= 400 の比較が
+        # 真になり、記録スキップ側に落ちてしまう)。
+        mock_response = MagicMock()
+        mock_response.status_code = 200
 
         with (
             patch("app.automation.scheduled_tasks.asyncio.sleep", side_effect=mock_sleep),
@@ -1140,12 +1144,70 @@ class TestLoopBodyAdditional:
                 side_effect=self._run_in_same_thread,
             ),
             patch("app.automation.state.get_monitoring_service", return_value=mock_ms),
-            patch("httpx.get"),
+            patch("httpx.get", return_value=mock_response) as mock_get,
         ):
             with pytest.raises(asyncio.CancelledError):
                 await latency_monitor_loop(interval_seconds=1)
 
         mock_ms.record_latency.assert_called_once()
+        # 認証不要な /health を叩くこと。認証必須の /api/automation/status を叩くと
+        # 常に 401 になり、レイテンシ監視が永久に発火しない (2026-08-06 本番で発覚)。
+        called_url = mock_get.call_args.args[0]
+        assert called_url.endswith("/health"), f"想定外の計測先: {called_url}"
+
+    @pytest.mark.asyncio
+    async def test_latency_monitor_loop_does_not_record_on_4xx(self) -> None:
+        """★非2xx (401等) を「速い応答」として記録しないこと。
+
+        2026-08-06 本番で発覚したバグの回帰防止。以前は認証必須エンドポイントを
+        叩いており、httpx.get() が 4xx で例外を投げないため「401 拒否までの時間」が
+        システム応答時間として記録され続けていた。閾値 (>10s 警告 / >30s アラート) に
+        絶対到達しないため、レイテンシ監視が構造的に永久に発火しない状態だった。
+        """
+        from app.automation.scheduled_tasks import latency_monitor_loop
+
+        _, mock_sleep = self._make_sleep_counter(raise_on=2)
+        mock_ms = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+
+        with (
+            patch("app.automation.scheduled_tasks.asyncio.sleep", side_effect=mock_sleep),
+            patch(
+                "app.automation.scheduled_tasks.asyncio.to_thread",
+                side_effect=self._run_in_same_thread,
+            ),
+            patch("app.automation.state.get_monitoring_service", return_value=mock_ms),
+            patch("httpx.get", return_value=mock_response),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await latency_monitor_loop(interval_seconds=1)
+
+        mock_ms.record_latency.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_latency_monitor_loop_does_not_record_on_5xx(self) -> None:
+        """非2xx (5xx) も同様に記録しないこと。"""
+        from app.automation.scheduled_tasks import latency_monitor_loop
+
+        _, mock_sleep = self._make_sleep_counter(raise_on=2)
+        mock_ms = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+
+        with (
+            patch("app.automation.scheduled_tasks.asyncio.sleep", side_effect=mock_sleep),
+            patch(
+                "app.automation.scheduled_tasks.asyncio.to_thread",
+                side_effect=self._run_in_same_thread,
+            ),
+            patch("app.automation.state.get_monitoring_service", return_value=mock_ms),
+            patch("httpx.get", return_value=mock_response),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await latency_monitor_loop(interval_seconds=1)
+
+        mock_ms.record_latency.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_latency_monitor_loop_request_fails_skips(self) -> None:

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -46,6 +46,20 @@ const withPWA = require('next-pwa')({
     /build-manifest\.json$/,
     /middleware-manifest\.json$/,
     /react-loadable-manifest\.json$/,
+    // 2026-08-05: next-pwa (node_modules/next-pwa/index.js) は本来デフォルトで
+    // `asset.name.startsWith('server/')` を除外する関数を workboxCommon.exclude に
+    // 持っているが、withPWA() にユーザー定義の exclude 配列を渡すと
+    // (...workboxCommon, ...workbox の順で spread されるため) この配列が
+    // デフォルトを "マージ" ではなく "丸ごと上書き" してしまう。
+    // 上の4パターンだけでは .next/server/ 配下 (Node.js サーバープロセス専用、
+    // 公開HTTPルートから一切配信されない) のファイル
+    // (client-reference-manifest.js / middleware-build-manifest.js /
+    //  next-font-manifest.{js,json} 等) が「静的アセット」と誤認されて
+    // precache 対象に混入し、SW install 時の precacheAndRoute() がこの404で失敗、
+    // **Service Worker のインストール自体がサイト全体で全滅**していた
+    // (本番実機検証で発覚: getRegistrations() が常に0件、bad-precaching-response
+    // エラー)。next-pwa 本来のデフォルト除外関数をそのまま復元する。
+    ({ asset }) => asset.name.startsWith('server/'),
   ],
 });
 


### PR DESCRIPTION
## 発覚経緯

本番デプロイ後の検証で、`/api/automation/status` への **401 が 60 秒ごとに**ログに並んでいることに気づき調査。

## 問題

`latency_monitor_loop`（`scheduled_tasks.py`）は認証情報を付けずに `/api/automation/status` を叩いていたが、このエンドポイントは `require_viewer`（JWTユーザー）を要求するため**常に401**。`X-Internal-Token` 方式もこのエンドポイントは受け付けない（同ファイルの `process_news_loop` はトークンを付けているのに、こちらは付けていなかった）。

`httpx.get()` は 4xx で例外を投げないため、**「401拒否までの時間」がシステム応答時間として記録され続けていた**。

閾値は「>10秒で警告 / >30秒でアラート」。認証拒否はミリ秒で返るため、**レイテンシ監視が構造的に永久に発火しない**状態でした。単に動いていないのではなく「健全に見えるが実は何も測れていない」という、このプロジェクトが繰り返している可観測性の穴と同型です。

## 修正

1. **計測先を `/health` に変更** — 認証不要でありながらスケジューラ健全性計算という実処理を行うため、応答時間の代理指標として妥当
2. **非2xxを記録しない** — 「速く失敗した」時間を記録すると健全に見えてしまうため、警告ログに留めて `record_latency` を呼ばない

## テスト

- 既存テストは `httpx.get` を素の `MagicMock` で差し替えていたため `status_code` が数値でなく判定が壊れる → 200 を明示する形に修正し、**計測先が `/health` であること**のアサーションを追加
- 非2xx（401 / 503）で `record_latency` が呼ばれないことのテストを2件追加

**バグを実際に検出できるテストであることを確認済み**: 修正を一時的に戻すと3件が落ちることを実機確認しました。

## 検証

```
pytest tests/            : 5052 passed, 0 failed, 26 skipped
ruff check . / format    : 問題なし
mypy                     : 既存の stripe import-not-found のみ
```

> `scheduled_tasks.py` は Tier S ファイルのため、本日他に変更が入っていないことを確認済み（1日1PRルール遵守）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)