### PR TITLE
fix(aave): oracle の設定ミスを「RPC障害」と誤診するログを修正

### DIFF
--- a/backend/app/aave/oracle_checker.py
+++ b/backend/app/aave/oracle_checker.py
@@ -65,6 +65,23 @@ def validate_staleness_threshold_env() -> int:
     return get_staleness_threshold_from_env()
 
 
+def _is_contract_interface_error(exc: BaseException) -> bool:
+    """呼び出し先が期待するインターフェースを持たない (= 設定ミス) かを判定する。
+
+    web3 は「関数セレクタが存在しないコントラクトへの eth_call」を
+    ContractLogicError('execution reverted', 'no data') として返す。これは
+    リトライしても回復しない恒久的な設定エラーであり、RPC の一時障害とは
+    区別して扱う必要がある (2026-08-06 の誤診対策)。
+
+    web3 未インストール環境でも壊れないよう import は遅延・例外安全にする。
+    """
+    try:
+        from web3.exceptions import ContractLogicError  # noqa: PLC0415
+    except ImportError:  # pragma: no cover - web3 が無い環境
+        return False
+    return isinstance(exc, ContractLogicError)
+
+
 _AGGREGATOR_ABI = [
     {
         "inputs": [],
@@ -144,7 +161,28 @@ def check_oracle_staleness(
         round_data = feed.functions.latestRoundData().call()
         _round_id, answer, _started_at, updated_at_ts, _answered_in_round = round_data
     except Exception as exc:  # noqa: BLE001
-        logger.warning("[oracle_checker] latestRoundData failed for %s: %s", feed_address, exc)
+        # 2026-08-06: 「RPC が落ちている」と「アドレスが Chainlink feed ではない
+        # (設定ミス)」を区別してログする。両方とも None を返すため、以前は呼び出し元が
+        # 一律「RPC failure」と記録しており、**設定ミスが RPC 障害として長期間
+        # 誤診されていた** (本番で 5 分ごとに fail-closed が出続けたが、同時刻に
+        # 他の RPC 呼び出しは成功していた)。
+        # revert は「そのコントラクトに latestRoundData() が無い」ことを意味し、
+        # リトライしても永久に回復しない設定エラーなので ERROR + 対処法を出す。
+        if _is_contract_interface_error(exc):
+            logger.error(
+                "[oracle_checker] %s は Chainlink AggregatorV3 ではありません "
+                "(latestRoundData() が revert)。AAVE_ORACLE_FEED_ADDRESS の設定ミスです。"
+                "Aave Oracle (getAssetPrice) 等の別インターフェースを設定していないか "
+                "確認してください。この状態では全執行経路が fail-closed で停止します: %s",
+                feed_address,
+                exc,
+            )
+        else:
+            logger.warning(
+                "[oracle_checker] latestRoundData failed for %s (RPC 側の一時障害の可能性): %s",
+                feed_address,
+                exc,
+            )
         return None
 
     now = datetime.now(timezone.utc)
@@ -539,7 +577,13 @@ def is_oracle_fresh(
         return False
 
     if result is None:
-        logger.error("[oracle_checker] Oracle check returned None (RPC failure) - fail-closed")
+        # 2026-08-06: 以前は "(RPC failure)" と断定していたが、feed アドレスの設定ミス
+        # (Chainlink 以外のコントラクト) でも同じ経路を通る。原因の切り分けは直前に
+        # check_oracle_staleness が出すログを見ること。断定的な誤ラベルは診断を誤らせる。
+        logger.error(
+            "[oracle_checker] Oracle check returned None - fail-closed "
+            "(原因は直前のログを参照: RPC 一時障害 / feed アドレス設定ミスのいずれか)"
+        )
         return False
 
     return not result.should_hold

--- a/backend/tests/test_aave_oracle_checker.py
+++ b/backend/tests/test_aave_oracle_checker.py
@@ -149,6 +149,75 @@ class TestCheckOracleStaleness:
             )
         assert result is None
 
+    def test_contract_interface_error_logged_as_misconfiguration(self, caplog) -> None:
+        """★feed アドレス設定ミス (revert) を「RPC障害」と誤診しないこと。
+
+        2026-08-06 本番で発覚: AAVE_ORACLE_FEED_ADDRESS に Chainlink AggregatorV3 では
+        なく Aave Oracle (getAssetPrice インターフェース) が設定されており、
+        latestRoundData() が revert していた。しかしログは一律「RPC failure」と
+        出ていたため、RPC の一時障害として長期間見過ごされ、全執行経路が
+        fail-closed で停止し続けていた。設定ミスはリトライで回復しないため、
+        一時障害と明確に区別してログする必要がある。
+        """
+        import logging
+
+        from web3.exceptions import ContractLogicError
+
+        from app.aave.oracle_checker import check_oracle_staleness
+
+        mock_web3_module = MagicMock()
+        mock_w3 = MagicMock()
+        mock_contract = MagicMock()
+        mock_web3_module.Web3.return_value = mock_w3
+        mock_web3_module.Web3.HTTPProvider = MagicMock()
+        mock_web3_module.Web3.to_checksum_address = lambda x: x
+        mock_w3.eth.contract.return_value = mock_contract
+        # 実際に本番で起きた例外そのもの
+        mock_contract.functions.latestRoundData.return_value.call.side_effect = ContractLogicError(
+            "execution reverted", "no data"
+        )
+
+        with patch.dict(sys.modules, {"web3": mock_web3_module}):
+            with caplog.at_level(logging.WARNING):
+                result = check_oracle_staleness(
+                    feed_address="0xNOT_A_CHAINLINK_FEED",
+                    rpc_url="http://localhost:8545",
+                )
+
+        assert result is None
+        text = caplog.text
+        assert "設定ミス" in text, f"設定ミスと明示されていない: {text}"
+        assert "AAVE_ORACLE_FEED_ADDRESS" in text, "どの env を直すべきか示されていない"
+        # 一時障害と誤解させる表現を混ぜないこと
+        assert "一時障害" not in text, f"設定ミスなのに一時障害と表示している: {text}"
+
+    def test_transient_rpc_error_not_labeled_as_misconfiguration(self, caplog) -> None:
+        """逆に、一時的な RPC 障害を「設定ミス」と誤診しないこと。"""
+        import logging
+
+        from app.aave.oracle_checker import check_oracle_staleness
+
+        mock_web3_module = MagicMock()
+        mock_w3 = MagicMock()
+        mock_contract = MagicMock()
+        mock_web3_module.Web3.return_value = mock_w3
+        mock_web3_module.Web3.HTTPProvider = MagicMock()
+        mock_web3_module.Web3.to_checksum_address = lambda x: x
+        mock_w3.eth.contract.return_value = mock_contract
+        mock_contract.functions.latestRoundData.return_value.call.side_effect = ConnectionError(
+            "connection refused"
+        )
+
+        with patch.dict(sys.modules, {"web3": mock_web3_module}):
+            with caplog.at_level(logging.WARNING):
+                result = check_oracle_staleness(
+                    feed_address="0xFEED",
+                    rpc_url="http://localhost:8545",
+                )
+
+        assert result is None
+        assert "設定ミス" not in caplog.text, "一時障害なのに設定ミスと表示している"
+
     def test_price_calculated_correctly(self) -> None:
         from app.aave.oracle_checker import check_oracle_staleness
 


### PR DESCRIPTION
## 真因を on-chain で確定させました

本番で5分ごとに出続けていた `Oracle check returned None (RPC failure) - fail-closed` は、**RPC障害ではなく設定ミス**でした。Base mainnet に対して実際に `eth_call` して確定させています。

**本番設定値 `0x2Cc0Fc26eD4563A5ce5e8bdcfe1A2878676Ae156`**

| 呼び出し | 結果 |
|---|---|
| `latestRoundData()` | ❌ revert (`'no data'`) |
| `decimals()` | ❌ revert |
| `getAssetPrice(USDC)` | ✅ `99990827` |
| `BASE_CURRENCY_UNIT()` | ✅ `100000000` |

→ **Chainlink AggregatorV3 ではなく Aave Oracle が設定されていた。**

対照（repo内定数 `0x71041dddad...`）: `description()` = `"ETH / USD"` / `decimals()` = 8 / `latestRoundData()` ✅（41秒前更新）

同じ時間帯に Aave Pool への RPC 呼び出しは成功しており、**RPC は生きていました**。

## なぜ長期間見過ごされたか（本PRが直す点）

`check_oracle_staleness()` は「RPC障害」と「ABI不一致（設定ミス）」の**両方で `None` を返し**、呼び出し元が一律 `(RPC failure)` と ERROR ログを出していました。

設定ミスはリトライで永久に回復しないにもかかわらず一時障害として扱われ、その間 `evaluate_hard_stop` の第1チェックが常時 blocked を返して **Aave / Pendle / CEX の全執行経路が停止**していました。さらに第1チェックで return するため、**StressController / CompoundRiskAssessor 等の下流安全装置が一切評価されない**状態でした。

## 修正

- `ContractLogicError`（＝関数セレクタ不在の revert）を設定ミスとして分離し、**ERROR + どの env を直すか**を出す
- それ以外は「RPC側の一時障害の可能性」として WARNING に留める
- `is_oracle_fresh` の `"(RPC failure)"` という**断定を削除**し、直前のログを参照するよう促す

## テスト

実際に本番で起きた `ContractLogicError('execution reverted', 'no data')` を再現し:
- ログに「設定ミス」「`AAVE_ORACLE_FEED_ADDRESS`」が含まれること
- かつ「一時障害」と**表示しない**こと
- 逆に `ConnectionError` では「設定ミス」と表示しないこと

**修正を戻すと落ちることを確認済み。**

```
pytest tests/ : 5052 passed, 0 failed, 26 skipped
ruff / mypy   : クリーン
```

## ⚠️ 本番 env の差し替えは別途必要（本PRには含まれません）

`.env.production` は hook R5 保護下のため、小林さんの手作業になります。

```
AAVE_ORACLE_FEED_ADDRESS=0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70
```

**USDC/USD feed を選ばなかった理由**: 運用資産と一致するので一見適切ですが、実測で**最終更新が8.9時間前**でした。ステーブルコインは価格が動かないため Chainlink の更新頻度が低く、閾値3600秒では**正常なのに常時 stale 判定**になり、今と同じく執行が止まります。更新頻度の高い ETH/USD feed（実測41秒前）を使う方針としました。このチェックの目的は「オラクル経路が生きているか」の確認なので、流動性の高い feed で目的を果たせます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)