### PR TITLE
feat(automation): 実行権限を持たない「完全おまかせ」ユーザーを承認制へ降格し本人に通知

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -252,6 +252,54 @@ def _notify_consecutive_expiry(user_id: int, consecutive_count: int) -> None:
         logger.warning("_notify_consecutive_expiry failed for user_id=%d: %s", user_id, exc)
 
 
+def _downgrade_orphaned_auto_execute(db: Session, user: User) -> None:
+    """実行権限を持たない AUTO_EXECUTE ユーザーを承認制へ降格し、本人に通知する。
+
+    2026-08-06 PR6 (PR1 の "降格は PR6" を実装):
+    「完全おまかせ」と表示されているのに有効な delegation_grant が無いユーザーは、
+    実際には1件も自動実行できない。表示と実行能力が乖離した状態を放置すると、
+    ユーザーは「動いているはず」と誤認したまま提案が期限切れになり続ける
+    (本番で実際に2ヶ月間発生した)。実態に合わせて承認制へ倒す。
+
+    **順序の制約**: 要件定義 IV-2 / 禁止事項7 により、この降格は到達経路
+    (Web Push) の復旧後にのみ許される。通知できない状態で降格すると
+    「無断で設定が変わった」としか映らず、機能不全を不信に変換するだけになる。
+    到達経路は 2026-08-05 に復旧し実機到達を確認済み。
+
+    降格は本人通知とセットで行い、通知が失敗しても降格自体は確定させる
+    (通知失敗を理由に危険側へ留めるべきではない)。逆に降格の commit は
+    呼び出し元の savepoint に委ねる (per-user savepoint 内で呼ばれるため、
+    そのユーザーの処理が失敗すれば降格も巻き戻る)。
+    """
+    previous = user.execution_policy
+    user.execution_policy = ExecutionPolicy.REQUIRE_APPROVAL.value
+    db.add(user)
+    logger.warning(
+        "実行権限を持たない AUTO_EXECUTE ユーザーを承認制へ降格しました: user_id=%d (%s -> %s)",
+        user.id,
+        previous,
+        user.execution_policy,
+    )
+
+    # 本人への通知 (best-effort)。失敗しても降格は取り消さない。
+    try:
+        from app.notifications.factory import get_notification_service  # noqa: PLC0415
+        from app.notifications.templates import (  # noqa: PLC0415
+            execution_mode_downgraded_notification,
+        )
+
+        payload = execution_mode_downgraded_notification()
+        payload.notification_message.user_id = user.id
+        get_notification_service().send(payload.notification_message)
+        # 「AI提案通知」ではなく「システム通知」として判定する。提案通知を OFF に
+        # しているユーザーにも、アカウント設定が変わった事実は届ける必要がある。
+        _deliver_ai_proposal_push(db, user.id, payload, preference_key="system_notice")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "降格通知の送信に失敗しました (降格自体は確定): user_id=%d: %s", user.id, exc
+        )
+
+
 def _check_observability_invariants(db: Session, user: User) -> None:
     """AUTO_EXECUTE の委譲枠欠如 / 連続期限切れを検知し Slack 通知する。
 
@@ -266,6 +314,7 @@ def _check_observability_invariants(db: Session, user: User) -> None:
         and get_active_grant(user.id, db) is None
     ):
         _notify_missing_delegation_grant(user.id)
+        _downgrade_orphaned_auto_execute(db, user)
 
     recent = db.scalars(
         select(Proposal)
@@ -652,7 +701,9 @@ def _resolve_protocol_routing(
     return aave_default
 
 
-def _deliver_ai_proposal_push(db: Session, user_id: int, payload: Any) -> None:
+def _deliver_ai_proposal_push(
+    db: Session, user_id: int, payload: Any, preference_key: str = "ai_proposal"
+) -> None:
     """AI提案のWeb Push実配信 + notification_logsへのdelivered記録 (best-effort)。
 
     2026-08-04 PR5: get_notification_service().send() (LINE/Slack/内部ログ) とは独立した経路。
@@ -680,7 +731,7 @@ def _deliver_ai_proposal_push(db: Session, user_id: int, payload: Any) -> None:
         # 購読行の有無だけで送ると「設定画面ではOFFなのに通知が来る」状態になる。
         _user = db.get(User, user_id)
         if _user is None or not push_allowed_for_user(
-            _user.notification_settings_json, "ai_proposal"
+            _user.notification_settings_json, preference_key
         ):
             logger.debug(
                 "Web Push: 通知設定によりスキップ (user_id=%d)",

--- a/backend/app/notifications/templates.py
+++ b/backend/app/notifications/templates.py
@@ -128,6 +128,27 @@ def auto_safety_action_notification(
     return _build_payload(title, body, "alert")
 
 
+def execution_mode_downgraded_notification() -> NotificationPayload:
+    """運用モードを「完全おまかせ」から「承認制」へ安全側降格したことの通知。
+
+    受け入れ条件 A-6「権限失効時に安全側へ降格し、ユーザーに通知される」/
+    A-E1「黙って承認待ちに落とさない」に対応する**ユーザー向け**通知
+    (operational_alert_notification は運用者向け Slack なので別物)。
+
+    要件定義 IV-2: 「無断で設定が変わった」と受け取られると機能不全を不信に
+    変換するだけになるため、**何が起きたか・なぜか・どうすれば元に戻せるか**を
+    本文に必ず含める。
+    """
+    title = "⚙️ 運用モードを「承認制」に変更しました"
+    body = (
+        "自動運用に必要な権限の設定が完了していなかったため、安全のため"
+        "「承認制」に切り替えました。ご資産は影響を受けていません。"
+        "今後の運用提案はアプリでご確認・承認いただくと実行されます。"
+        "自動運用をご希望の場合は、設定画面から改めてお手続きください。"
+    )
+    return _build_payload(title, body, "warning")
+
+
 # --- 取引4種 ---
 
 

--- a/backend/tests/automation/test_observability_invariants.py
+++ b/backend/tests/automation/test_observability_invariants.py
@@ -138,9 +138,10 @@ class TestMissingDelegationGrant:
         db_session.commit()
 
         sent = _sent_messages(db_session, user)
-        assert len(sent) == 1
-        assert sent[0].channel.value == "slack"
-        assert str(user.id) in sent[0].body
+        # 2026-08-06 PR6: 運用者向け Slack 通知に加えて本人向け降格通知も送るため、
+        # 「運用者向けが1件あること」を検証する (総数ではなく種別で見る)。
+        ops = [m for m in sent if m.channel.value == "slack" and str(user.id) in m.body]
+        assert len(ops) == 1, f"運用者向け通知が1件でない: {sent}"
 
     def test_auto_execute_with_expired_grant_notifies_once(self, db_session: Session) -> None:
         """status='active' のまま expires_at が過去 (遅延 expire) でも実時刻で再判定して検知する。"""
@@ -153,7 +154,9 @@ class TestMissingDelegationGrant:
         db_session.commit()
 
         sent = _sent_messages(db_session, user)
-        assert len(sent) == 1
+        # 2026-08-06 PR6: 本人向け降格通知が増えたため、運用者向けが1件あることで検証する。
+        ops = [m for m in sent if m.channel.value == "slack" and str(user.id) in m.body]
+        assert len(ops) == 1, f"運用者向け通知が1件でない: {sent}"
 
     def test_auto_execute_grant_expires_soon_no_notification(self, db_session: Session) -> None:
         """境界値: expires_at が僅かに未来 (1秒後) ならまだ有効 → 通知なし。"""
@@ -236,3 +239,104 @@ def test_no_side_effect_on_proposal_or_grant_rows(db_session: Session) -> None:
     proposals = db_session.query(Proposal).filter(Proposal.user_id == user.id).all()
     assert all(p.status == "canceled" for p in proposals)
     assert db_session.query(DelegationGrant).filter(DelegationGrant.user_id == user.id).count() == 0
+
+
+class TestDowngradeOrphanedAutoExecute:
+    """実行権限を持たない AUTO_EXECUTE ユーザーの安全側降格 (2026-08-06 PR6)。
+
+    PR1 (#1011) が「検知のみで降格は行わない (降格は PR6)」としていた部分の実装。
+    要件定義 A-E1「黙って承認待ちに落とさない。検知・通知・安全側降格」/
+    A-6「権限失効時に安全側へ降格し、ユーザーに通知される」に対応する。
+
+    順序の制約 (IV-2 / 禁止事項7): 降格は到達経路 (Web Push) 復旧後にのみ許される。
+    通知できない状態で降格すると「無断で設定が変わった」としか映らないため。
+    """
+
+    def test_orphaned_auto_execute_is_downgraded(self, db_session: Session) -> None:
+        """★委譲枠を持たない AUTO_EXECUTE は require_approval へ降格される。"""
+        user = _make_user(db_session, uid=301, execution_policy="auto_execute")
+        db_session.commit()
+
+        _sent_messages(db_session, user)
+        db_session.commit()  # 本番では per-user savepoint 経由で commit される
+
+        db_session.refresh(user)
+        assert user.execution_policy == "require_approval"
+
+    def test_downgrade_notifies_the_user_not_only_ops(self, db_session: Session) -> None:
+        """★運用者向け Slack だけでなく、本人宛の通知も送られること。
+
+        「黙って承認待ちに落とさない」(A-E1) の核心。運用者だけが知っていて
+        ユーザーが知らない状態は、表示と実態の乖離を別の形で再生産する。
+        """
+        user = _make_user(db_session, uid=302, execution_policy="auto_execute")
+        db_session.commit()
+
+        sent = _sent_messages(db_session, user)
+
+        user_addressed = [m for m in sent if getattr(m, "user_id", None) == user.id]
+        assert user_addressed, f"本人宛の通知が無い: {[getattr(m, 'title', m) for m in sent]}"
+        body = " ".join(str(getattr(m, "body", "")) for m in user_addressed)
+        # 何が起きたか / 資産への影響 / 元に戻す方法 が伝わること (IV-2)
+        assert "承認制" in body, f"何に変わったかが伝わらない: {body}"
+        assert "資産" in body, f"資産への影響の有無が伝わらない: {body}"
+
+    def test_user_with_valid_grant_is_not_downgraded(self, db_session: Session) -> None:
+        """有効な委譲枠を持つユーザーは降格されない (正常な完全おまかせを壊さない)。"""
+        user = _make_user(db_session, uid=303, execution_policy="auto_execute")
+        _make_grant(db_session, user.id)
+        db_session.commit()
+
+        _sent_messages(db_session, user)
+        db_session.commit()
+
+        db_session.refresh(user)
+        assert user.execution_policy == "auto_execute", "正常なおまかせを降格してはいけない"
+
+    def test_require_approval_user_is_untouched(self, db_session: Session) -> None:
+        """元から承認制のユーザーには何も起きない。"""
+        user = _make_user(db_session, uid=304, execution_policy="require_approval")
+        db_session.commit()
+
+        _sent_messages(db_session, user)
+        db_session.commit()
+
+        db_session.refresh(user)
+        assert user.execution_policy == "require_approval"
+
+    def test_downgrade_is_idempotent(self, db_session: Session) -> None:
+        """2回目以降の tick で重複して降格・通知しないこと。
+
+        降格後は execution_policy が require_approval になるため、次回以降は
+        そもそも検知条件に入らない (60秒ごとに通知が飛び続けない)。
+        """
+        user = _make_user(db_session, uid=305, execution_policy="auto_execute")
+        db_session.commit()
+
+        first = _sent_messages(db_session, user)
+        db_session.commit()
+        second = _sent_messages(db_session, user)
+
+        assert len(first) >= 1
+        assert second == [], f"降格後も通知が続いている: {second}"
+
+    def test_notification_failure_does_not_block_downgrade(self, db_session: Session) -> None:
+        """通知が失敗しても降格自体は確定すること。
+
+        通知失敗を理由に危険側 (auto_execute) へ留めるべきではない。
+        """
+        user = _make_user(db_session, uid=306, execution_policy="auto_execute")
+        db_session.commit()
+
+        def _boom(self, msg):  # noqa: ANN001, ANN202
+            raise RuntimeError("notification backend down")
+
+        with patch(
+            "app.notifications.factory.get_notification_service",
+            return_value=type("Svc", (), {"send": _boom})(),
+        ):
+            _check_observability_invariants(db_session, user)
+        db_session.commit()
+
+        db_session.refresh(user)
+        assert user.execution_policy == "require_approval", "通知失敗で降格が巻き戻っている"

--- a/backend/tests/test_ai_judgment_scheduler.py
+++ b/backend/tests/test_ai_judgment_scheduler.py
@@ -613,7 +613,12 @@ def test_buy_creates_proposal_for_require_approval_and_auto_execute_users(db_ses
     """2026-07-16: BUY 判定時、execution_policy='require_approval'/'auto_execute' の
     両方に Proposal が作成されること（'proposal_only' は対象外のまま）。
     AUTO_EXECUTE ユーザーは委譲(SCW) grant を持たないため、提案は作られるが
-    auto-execution 側では skip され 'pending' のまま残る（別テストで検証）。
+    自動実行はされず 'pending' のまま残る（別テストで検証）。
+
+    2026-08-06 PR6: 委譲枠を持たない AUTO_EXECUTE ユーザーは、提案生成前の
+    不変条件チェックで require_approval へ**降格される**ようになった。このため
+    同 tick 内では既に承認制ユーザーとして扱われ、auto_execute_skipped は
+    加算されない（0 になる）。ユーザーから見た結果（提案が pending で残る）は同じ。
     """
     approval_user = _add_active_user(
         db_session, "approval@example.com", execution_policy="require_approval"
@@ -643,12 +648,16 @@ def test_buy_creates_proposal_for_require_approval_and_auto_execute_users(db_ses
     # 委譲grantが無いため auto-execution は skip（'pending' のまま・自動実行しない）。
     assert all(p.status == "pending" for p in proposals)
     assert result["auto_executed"] == 0
-    assert result["auto_execute_skipped"] == 1
+    # 2026-08-06 PR6: 降格により承認制ユーザー扱いになるため 0。
+    assert result["auto_execute_skipped"] == 0
 
 
 def test_auto_execute_user_without_grant_stays_pending_on_buy(db_session):
     """2026-07-16: auto_execute ユーザーは提案が作られるが、有効な委譲(SCW) grant が
     無い限り自動実行されず 'pending' のまま残る（既存の手動フローに委ねる）。
+
+    2026-08-06 PR6: さらに、権限を持たないまま「完全おまかせ」を表示し続けるのは
+    表示と実行能力の乖離なので、承認制へ降格し本人に通知するようになった。
     """
     auto_user = _add_active_user(db_session, "auto@example.com", execution_policy="auto_execute")
     _add_fund_allocation(db_session, auto_user)
@@ -667,10 +676,15 @@ def test_auto_execute_user_without_grant_stays_pending_on_buy(db_session):
 
     assert result["proposals_created"] == 1
     assert result["auto_executed"] == 0
-    assert result["auto_execute_skipped"] == 1
+    # 2026-08-06 PR6: 降格により、この tick では既に承認制ユーザー扱いになるため
+    # auto_execute_skipped は加算されない。
+    assert result["auto_execute_skipped"] == 0
     proposals = db_session.scalars(select(Proposal)).all()
     assert len(proposals) == 1
     assert proposals[0].status == "pending"
+    # ★降格が実際に行われたこと（表示と実行能力の乖離が解消されたこと）
+    db_session.refresh(auto_user)
+    assert auto_user.execution_policy == "require_approval"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
PR1 (#1011) が「検知のみで安全側への降格は行わない（**降格は PR6**）」としていた部分の実装です。要件定義の受け入れ条件 **A-E1**「黙って承認待ちに落とさない。検知・通知・安全側降格」/ **A-6**「権限失効時に安全側へ降格し、ユーザーに通知される」に対応します。

## 解決する問題

「完全おまかせ」と表示されているのに有効な `delegation_grant` を持たないユーザーは、**実際には1件も自動実行できません**。本番では user 11/18 がこの状態で、2ヶ月間 executed 0件・提案が期限切れ→再生成を繰り返すだけのループに陥っていました。ユーザーからは「自動運用が動いているはず」に見えるため、乖離に気づけません。

**根本原因**は `NEXT_PUBLIC_DELEGATION_CONSENT_ENABLED` が本番既定 off であること。off のとき `OpModePanel` は委譲同意フロー（`runDelegationConsent`）を丸ごとスキップして `execution_policy` の PUT だけを行うため、権限なしの「おまかせ」が生成されます。PR2 (#1012) が「off時は選択不可」にして再発を止めましたが、既存ユーザーは取り残されていました。

> 💡 委譲枠は **ユーザー自身のウォレット署名（Privy `addSessionSigners`）** を伴う3段階フローでしか作れないため、サーバー側で SQL 投入して解決することはできません（作っても実体のない権限になり、システムが「権限がある」と誤認する危険な状態を生みます）。したがって取れる道は「安全側に降格して実態と表示を一致させる」です。

## 順序の制約を満たしています

要件定義 IV-2 / 禁止事項7 は「**通知できない状態で降格すると、機能不全を不信に変換するだけ**」として **B（到達経路）→ A（降格）の順序を厳守**するよう定めています。到達経路は 2026-08-05 に復旧し**実機到達を確認済み**のため、今が実装可能な時点です。

## 実装

`_check_observability_invariants` の検知箇所に降格を追加。検知 → 運用者向け Slack → **本人向け通知 + 承認制へ降格** の順で行います。

- 降格は per-user savepoint 内 → そのユーザーの処理が失敗すれば巻き戻る
- **通知が失敗しても降格自体は確定**（通知失敗を理由に危険側へ留めない）
- 降格後は検知条件に入らないため通知が繰り返し飛ばない（冪等）

### 通知種別を `system_notice` にした理由

`_deliver_ai_proposal_push` は判定キーが `"ai_proposal"` 固定だったため `preference_key` を引数化しました。**アカウント設定が変わった事実は、AI提案通知を OFF にしているユーザーにも届ける必要がある**ためです。

通知本文には要件定義 IV-2 に従い「何が起きたか / 資産への影響 / 元に戻す方法」を含めています。

## テスト（6件追加、既存3件更新）

- 委譲枠なし AUTO_EXECUTE が降格されること
- **本人宛の通知が送られること**（運用者向け Slack だけでは A-E1 を満たさない）
- 通知本文に「承認制」「資産」が含まれること
- 有効な委譲枠を持つユーザーは降格されないこと（**正常なおまかせを壊さない**）
- 冪等性（2回目の tick で重複通知しない）
- 通知失敗時も降格は確定すること

既存3件は仕様変更（降格により `auto_execute_skipped` が加算されなくなる / 通知が2件になる）に合わせて更新しました。**降格を外すと4件が落ちる**ことを確認済みです。

```
pytest tests/ : 5060 passed, 0 failed, 26 skipped
ruff / mypy   : クリーン（既存の stripe のみ）
```

## デプロイ後に起きること

次回の AI 判定 tick で user 11/18 が承認制へ降格され、**本人に Push 通知が届きます**。以降、提案は承認すれば実行されるようになります（oracle の fail-closed も解消済みのため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)