### PR TITLE
feat(automation): ユーザーに通知が届かなかったことを検知・記録する

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -252,6 +252,40 @@ def _notify_consecutive_expiry(user_id: int, consecutive_count: int) -> None:
         logger.warning("_notify_consecutive_expiry failed for user_id=%d: %s", user_id, exc)
 
 
+def _notify_downgrade_unreachable(user_id: int) -> None:
+    """降格したがユーザーに通知が届かなかったことを運用者へエスカレーションする。
+
+    2026-08-06: 要件定義 IV-2 は「通知できない状態で降格すると、機能不全を不信に
+    変換するだけ」として B(到達経路) → A(降格) の順序を求めている。しかし
+    「Web Push の仕組みが動くこと」と「**そのユーザーに実際に届くこと**」は別で、
+    購読していない / 通知を OFF にしているユーザーには届かない。
+
+    本番で実際に user 11/18 がこの状態だった (購読ゼロ) にもかかわらず、
+    降格は実行され、届かなかった事実は誰にも通知されなかった。
+    到達経路ゼロのユーザーに重要なアカウント変更を行った場合は、
+    運用者が別手段 (メール等) で連絡できるようエスカレーションする。
+
+    受け入れ条件 I-14「承認型 + 到達経路ゼロの組合せを検知し、ユーザーに警告する」
+    の一部でもある。
+    """
+    try:
+        from app.notifications.factory import get_notification_service  # noqa: PLC0415
+        from app.notifications.templates import operational_alert_notification  # noqa: PLC0415
+
+        msg = operational_alert_notification(
+            title="🔕 降格通知がユーザーに届いていません",
+            body=(
+                f"user_id={user_id} を承認制へ降格しましたが、到達経路が無く "
+                "本人に通知できませんでした (Push 未購読 / 通知設定 OFF / VAPID 未設定 "
+                "のいずれか)。ユーザーは自分の運用モードが変わったことを知りません。"
+                "別手段での連絡を検討してください。"
+            ),
+        )
+        get_notification_service().send(msg)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("_notify_downgrade_unreachable failed for user_id=%d: %s", user_id, exc)
+
+
 def _downgrade_orphaned_auto_execute(db: Session, user: User) -> None:
     """実行権限を持たない AUTO_EXECUTE ユーザーを承認制へ降格し、本人に通知する。
 
@@ -293,7 +327,9 @@ def _downgrade_orphaned_auto_execute(db: Session, user: User) -> None:
         get_notification_service().send(payload.notification_message)
         # 「AI提案通知」ではなく「システム通知」として判定する。提案通知を OFF に
         # しているユーザーにも、アカウント設定が変わった事実は届ける必要がある。
-        _deliver_ai_proposal_push(db, user.id, payload, preference_key="system_notice")
+        reached = _deliver_ai_proposal_push(db, user.id, payload, preference_key="system_notice")
+        if not reached:
+            _notify_downgrade_unreachable(user.id)
     except Exception as exc:  # noqa: BLE001
         logger.warning(
             "降格通知の送信に失敗しました (降格自体は確定): user_id=%d: %s", user.id, exc
@@ -701,20 +737,48 @@ def _resolve_protocol_routing(
     return aave_default
 
 
+def _record_push_outcome(db: Session, user_id: int, payload: Any, *, delivered: bool) -> None:
+    """Web Push の到達結果を notification_logs に記録する。
+
+    行の存在が「送信を試みた」、delivered 列が「到達したか」を表す。
+    **未到達 (False) も必ず記録する**: 記録しないと到達率 (受け入れ条件 B-4) が
+    「送れたものだけ」の母数で計算され、実態より良く見えてしまう。
+    """
+    from app.notifications.models import NotificationLog  # noqa: PLC0415
+
+    db.add(
+        NotificationLog(
+            channel="push",
+            severity=payload.notification_message.severity.value,
+            title=payload.notification_message.title,
+            body=payload.notification_message.body,
+            user_id=user_id,
+            delivered=delivered,
+        )
+    )
+    db.flush()
+
+
 def _deliver_ai_proposal_push(
     db: Session, user_id: int, payload: Any, preference_key: str = "ai_proposal"
-) -> None:
-    """AI提案のWeb Push実配信 + notification_logsへのdelivered記録 (best-effort)。
+) -> bool:
+    """ユーザーへの Web Push 実配信 + notification_logs への到達記録 (best-effort)。
 
     2026-08-04 PR5: get_notification_service().send() (LINE/Slack/内部ログ) とは独立した経路。
     購読者へ実際にブラウザ通知を届けるコードがこれまで一切配線されていなかった
-    (docs/internal/2026-08-04_execution_pipeline_requirements.md)。VAPID未設定時は
-    Web Push全体を無効化する既存設計 (get_vapid_config) に従い静かにスキップする。
+    (docs/internal/2026-08-04_execution_pipeline_requirements.md)。
     失敗しても提案生成自体はブロックしない (fail-open)。
+
+    Returns:
+        実際にユーザーへ到達したか。到達経路が無い / 設定 OFF / 送信失敗はすべて False。
+
+    2026-08-06: 以前は「VAPID未設定」「通知OFF」で**何も記録せず早期 return** していた。
+    そのため「届かなかった」事実が notification_logs に残らず、到達率 (受け入れ条件 B-4)
+    を測れなかった。実際に本番で降格通知が user 11/18 に届いていないことを、
+    ログからは判別できなかった。未到達も delivered=False として記録する。
     """
     try:
         from app.auth.models import User  # noqa: PLC0415
-        from app.notifications.models import NotificationLog  # noqa: PLC0415
         from app.notifications.push import (  # noqa: PLC0415
             DatabaseSubscriptionStore,
             WebPushSender,
@@ -725,7 +789,8 @@ def _deliver_ai_proposal_push(
         vapid_config = get_vapid_config()
         if vapid_config is None:
             logger.debug("Web Push: VAPID未設定のためスキップ (user_id=%d)", user_id)
-            return
+            _record_push_outcome(db, user_id, payload, delivered=False)
+            return False
 
         # 受け入れ条件 B-N4: 通知設定で OFF にしたユーザーへは配信しない。
         # 購読行の有無だけで送ると「設定画面ではOFFなのに通知が来る」状態になる。
@@ -737,28 +802,20 @@ def _deliver_ai_proposal_push(
                 "Web Push: 通知設定によりスキップ (user_id=%d)",
                 user_id,
             )
-            return
+            _record_push_outcome(db, user_id, payload, delivered=False)
+            return False
 
         sender = WebPushSender(vapid_config, DatabaseSubscriptionStore(SessionLocal))
         delivered = sender.send_to_user(user_id, payload.web_push_payload)
-
-        db.add(
-            NotificationLog(
-                channel="push",
-                severity=payload.notification_message.severity.value,
-                title=payload.notification_message.title,
-                body=payload.notification_message.body,
-                user_id=user_id,
-                delivered=delivered,
-            )
-        )
-        db.flush()
+        _record_push_outcome(db, user_id, payload, delivered=delivered)
+        return delivered
     except Exception as _push_exc:  # noqa: BLE001
         logger.warning(
             "ai_proposal Web Push delivery failed for user %d (skipping): %s",
             user_id,
             _push_exc,
         )
+        return False
 
 
 def _create_proposals_for_users(

--- a/backend/tests/automation/test_observability_invariants.py
+++ b/backend/tests/automation/test_observability_invariants.py
@@ -140,8 +140,12 @@ class TestMissingDelegationGrant:
         sent = _sent_messages(db_session, user)
         # 2026-08-06 PR6: 運用者向け Slack 通知に加えて本人向け降格通知も送るため、
         # 「運用者向けが1件あること」を検証する (総数ではなく種別で見る)。
-        ops = [m for m in sent if m.channel.value == "slack" and str(user.id) in m.body]
-        assert len(ops) == 1, f"運用者向け通知が1件でない: {sent}"
+        ops = [
+            m
+            for m in sent
+            if m.channel.value == "slack" and "有効な委譲枠がありません" in str(m.title)
+        ]
+        assert len(ops) == 1, f"委譲枠欠如の運用者向け通知が1件でない: {sent}"
 
     def test_auto_execute_with_expired_grant_notifies_once(self, db_session: Session) -> None:
         """status='active' のまま expires_at が過去 (遅延 expire) でも実時刻で再判定して検知する。"""
@@ -155,8 +159,12 @@ class TestMissingDelegationGrant:
 
         sent = _sent_messages(db_session, user)
         # 2026-08-06 PR6: 本人向け降格通知が増えたため、運用者向けが1件あることで検証する。
-        ops = [m for m in sent if m.channel.value == "slack" and str(user.id) in m.body]
-        assert len(ops) == 1, f"運用者向け通知が1件でない: {sent}"
+        ops = [
+            m
+            for m in sent
+            if m.channel.value == "slack" and "有効な委譲枠がありません" in str(m.title)
+        ]
+        assert len(ops) == 1, f"委譲枠欠如の運用者向け通知が1件でない: {sent}"
 
     def test_auto_execute_grant_expires_soon_no_notification(self, db_session: Session) -> None:
         """境界値: expires_at が僅かに未来 (1秒後) ならまだ有効 → 通知なし。"""
@@ -340,3 +348,84 @@ class TestDowngradeOrphanedAutoExecute:
 
         db_session.refresh(user)
         assert user.execution_policy == "require_approval", "通知失敗で降格が巻き戻っている"
+
+
+class TestUnreachableUserDetection:
+    """降格通知がユーザーに届かない場合の検知 (2026-08-06)。
+
+    本番で実際に起きた問題: user 11/18 を承認制へ降格したが、両名とも Push を
+    購読しておらず通知は届かなかった。しかし「届かなかった」事実はどこにも
+    記録されず、運用者も気づけなかった。
+
+    要件定義 IV-2 の「通知できない状態で降格するな」は、**仕組みが動くこと**では
+    なく**そのユーザーに実際に届くこと**で判定しなければならない。
+    """
+
+    def test_unreachable_user_triggers_ops_escalation(self, db_session: Session) -> None:
+        """★到達経路が無いユーザーを降格したら運用者へエスカレーションすること。"""
+        user = _make_user(db_session, uid=401, execution_policy="auto_execute")
+        # notification_settings_json 未設定 = push_enabled 既定 False = 到達経路ゼロ
+        db_session.commit()
+
+        sent = _sent_messages(db_session, user)
+
+        titles = [str(getattr(m, "title", "")) for m in sent]
+        assert any("届いていません" in t for t in titles), (
+            f"未到達のエスカレーションが無い: {titles}"
+        )
+
+    def test_reachable_user_does_not_trigger_escalation(self, db_session: Session) -> None:
+        """到達できるユーザーでは未到達エスカレーションを出さないこと (誤検知防止)。"""
+        import json
+        from unittest.mock import patch as _patch
+
+        user = _make_user(db_session, uid=402, execution_policy="auto_execute")
+        user.notification_settings_json = json.dumps(
+            {"push_enabled": True, "preferences": {"system_notice": True}}
+        )
+        db_session.commit()
+
+        sent: list[object] = []
+        with (
+            _patch(
+                "app.notifications.factory.get_notification_service",
+                return_value=type("Svc", (), {"send": lambda self, msg: sent.append(msg)})(),
+            ),
+            # 実際に到達したことにする
+            _patch(
+                "app.automation.ai_judgment_scheduler._deliver_ai_proposal_push",
+                return_value=True,
+            ),
+        ):
+            _check_observability_invariants(db_session, user)
+
+        titles = [str(getattr(m, "title", "")) for m in sent]
+        assert not any("届いていません" in t for t in titles), (
+            f"到達しているのに未到達扱いになっている: {titles}"
+        )
+
+    def test_undelivered_push_is_recorded_for_reachability_metric(
+        self, db_session: Session
+    ) -> None:
+        """★未到達も notification_logs に delivered=False で記録されること。
+
+        記録しないと到達率 (受け入れ条件 B-4) が「送れたものだけ」を母数に
+        計算され、実態より良く見えてしまう。
+        """
+        from app.notifications.models import NotificationLog
+
+        user = _make_user(db_session, uid=403, execution_policy="auto_execute")
+        db_session.commit()
+
+        _sent_messages(db_session, user)
+        db_session.commit()
+
+        rows = (
+            db_session.query(NotificationLog)
+            .filter(NotificationLog.user_id == user.id, NotificationLog.channel == "push")
+            .all()
+        )
+        assert rows, "未到達が push チャネルの行として記録されていない"
+        assert all(r.delivered is False for r in rows), (
+            f"未到達なのに delivered が False でない: {[r.delivered for r in rows]}"
+        )

--- a/backend/tests/automation/test_proposals_notification.py
+++ b/backend/tests/automation/test_proposals_notification.py
@@ -188,12 +188,24 @@ class TestDeliverAiProposalPush:
         db.get.return_value = user
         return db
 
-    def test_vapid_unset_skips_without_raising(self) -> None:
-        """VAPID未設定時は静かにスキップし、push行は作られない。"""
+    def test_vapid_unset_records_as_undelivered(self) -> None:
+        """VAPID未設定時は例外を投げず、かつ delivered=False として記録すること。
+
+        2026-08-06 変更: 以前は「静かにスキップし push 行を作らない」ことを
+        期待していたが、それだと「届かなかった」事実が notification_logs に残らず、
+        到達率 (受け入れ条件 B-4) が「送れたものだけ」を母数に計算されて実態より
+        良く見えてしまう。本番で降格通知が届いていないことをログから判別できなかった
+        原因でもある。未到達も記録する。
+        """
         mock_db = self._db_with_push_enabled_user(1)
         with patch("app.notifications.push.get_vapid_config", return_value=None):
-            _deliver_ai_proposal_push(mock_db, 1, self._payload())
-        mock_db.add.assert_not_called()
+            result = _deliver_ai_proposal_push(mock_db, 1, self._payload())
+
+        assert result is False, "未到達なので False を返すこと"
+        mock_db.add.assert_called_once()
+        logged = mock_db.add.call_args.args[0]
+        assert logged.channel == "push"
+        assert logged.delivered is False
 
     def test_vapid_set_success_logs_delivered_true(self) -> None:
         """配信成功: delivered=True の push NotificationLog が1行追加される。"""


### PR DESCRIPTION
## 背景: #1029 のデプロイで「動いたが要件を満たしていない」ことが判明

本番で降格を実行した結果、user 11/18 は正しく承認制へ降格され、本人宛の通知レコードも作られました。**しかし通知は実際には届いていません。**

| 実測 | 内容 |
|---|---|
| Push購読 | user 19 のみ。**11/18 は購読ゼロ** |
| 通知設定 | `notification_settings_json` 未設定 = `push_enabled` 既定 False |
| 結果 | どこにも送信されず、**本人は運用モードが変わったことを知らない** |
| さらに | 「届かなかった」事実が**どこにも記録されず**、運用者も気づけなかった |

要件定義 IV-2 は「通知できない状態で降格すると、機能不全を不信に変換するだけ」として **B（到達経路）→ A（降格）** の順序を求めています。私は「Web Push の仕組みが復旧したから降格してよい」と判断しましたが、**仕組みが動くことと、そのユーザーに実際に届くことは別**でした。順序の制約は後者で判定しなければなりませんでした。

## 修正

**1. 未到達を記録する**（`_record_push_outcome` を分離）

以前は VAPID未設定 / 通知OFF で**何も記録せず早期 return** していました。そのため到達率（受け入れ条件 B-4）が「送れたものだけ」を母数に計算され、**実態より良く見えて**いました。未到達も `delivered=False` の行として残します。

**2. `_deliver_ai_proposal_push` が到達可否を返す**（`None` → `bool`）

呼び出し側が「届いたか」で分岐できるようにします。

**3. 未到達時に運用者へエスカレーション**（`_notify_downgrade_unreachable`）

到達経路ゼロのユーザーに重要なアカウント変更を行った場合、運用者が別手段で連絡できるよう通知します。受け入れ条件 **I-14**「承認型 + 到達経路ゼロの組合せを検知」の一部でもあります。

## テスト（3件追加、既存3件更新）

- 到達経路が無いユーザーの降格で運用者エスカレーションが出ること
- **到達できるユーザーでは誤検知しないこと**
- 未到達が `delivered=False` として記録されること

> 既存の `test_vapid_unset_skips_without_raising` は「未到達を記録しない」という**今回問題視した挙動そのものを固定していた**ため、意図を反転して更新しました。

**検知機能を外すと2件が落ちる**ことを確認済みです。

```
pytest tests/ : 5063 passed, 0 failed, 26 skipped
ruff / mypy   : クリーン（既存の stripe のみ）
```

## デプロイ後に起きること

user 11/18 は既に降格済みなので再降格は起きません（冪等）。今後同種のケースが発生した際に、未到達が記録され運用者へエスカレーションされます。

**なお user 11/18 への連絡は依然として別手段が必要です**（本PRは再発防止であり、既に届かなかった分を遡って届けるものではありません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)