### PR TITLE
fix(ui): 承認画面のガス代表示を Base 実勢に修正し合計額から分離

### DIFF
--- a/backend/app/aave/gas_estimator.py
+++ b/backend/app/aave/gas_estimator.py
@@ -31,9 +31,11 @@ DEFAULT_FALLBACK_GAS_SUPPLY = 300000
 DEFAULT_FALLBACK_GAS_WITHDRAW = 300000
 
 # フォールバックガス価格（wei単位、提案生成時など web3 なしの概算用。ENV: ETH_GAS_PRICE_GWEI_FALLBACK）
-DEFAULT_GAS_PRICE_WEI = Decimal(os.environ.get("ETH_GAS_PRICE_GWEI_FALLBACK", "30")) * Decimal(
+# デフォルト 0.03 gwei — Base L2 の実勢ガス価格（Ethereumメインネットの1/1000程度）に合わせた値。
+# Base の実勢と乖離した場合は env ETH_GAS_PRICE_GWEI_FALLBACK で更新する。
+DEFAULT_GAS_PRICE_WEI = Decimal(os.environ.get("ETH_GAS_PRICE_GWEI_FALLBACK", "0.03")) * Decimal(
     "1000000000"
-)  # デフォルト 30 gwei
+)  # デフォルト 0.03 gwei (Base L2 フォールバック値)
 
 
 def estimate_static_gas_cost_usd(

--- a/frontend/app/(liff)/liff-approve/_components/ProposalBubble.tsx
+++ b/frontend/app/(liff)/liff-approve/_components/ProposalBubble.tsx
@@ -63,15 +63,6 @@ export function ProposalBubble({ proposal }: ProposalBubbleProps) {
     ? `~$${Number(proposal.estimated_gas_usd).toFixed(2)}`
     : null;
 
-  const totalUsd =
-    proposal.estimated_gas_usd
-      ? (Number(proposal.amount_usd) + Number(proposal.estimated_gas_usd)).toLocaleString("ja-JP", {
-          style: "currency",
-          currency: "USD",
-          maximumFractionDigits: 2,
-        })
-      : null;
-
   return (
     <div className="flex flex-col items-start px-3 py-2">
       {/* bubble */}
@@ -141,13 +132,11 @@ export function ProposalBubble({ proposal }: ProposalBubbleProps) {
           </p>
         )}
 
-        {/* gas + total */}
+        {/* gas（合計額には含めない。取引額とは別枠で概算表示） */}
         {gasUsd && (
           <div className="space-y-0.5">
             <p className="text-xs text-zinc-600">{t("gasEstimate")} {gasUsd}</p>
-            {totalUsd && (
-              <p className="text-xs text-zinc-400 font-medium">{t("totalWithGas")} {totalUsd}</p>
-            )}
+            <p className="text-[10px] text-zinc-600">{t("gasNote")}</p>
           </div>
         )}
       </div>

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1142,7 +1142,7 @@
         "expand": "Show more",
         "hfAfter": "HF after:",
         "gasEstimate": "Gas est.:",
-        "totalWithGas": "Total (incl. gas):"
+        "gasNote": "Actual cost may vary depending on network conditions."
       },
       "confirmSheet": {
         "title": "Approve this proposal?",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -1142,7 +1142,7 @@
         "expand": "続きを見る",
         "hfAfter": "実行後 HF:",
         "gasEstimate": "ガス概算:",
-        "totalWithGas": "合計（ガス込み）:"
+        "gasNote": "※ネットワークの状況により実際の負担が変わる場合があります"
       },
       "confirmSheet": {
         "title": "この提案を承認しますか？",


### PR DESCRIPTION
## 背景

承認画面で取引額に予想ガス代 $18.90 が加算表示されていた。Base はL2でガス代が桁違いに安く実勢は $0.01 程度、SCW経路では paymaster が負担するためユーザー実負担は $0 の可能性がある。$460 の提案が画面上 $478.90 と表示され、コストが取引額の4%あるように見えていた（ローンチ前の信頼損 P0）。

## 真因

`backend/app/aave/gas_estimator.py` の `DEFAULT_GAS_PRICE_WEI` フォールバックが Ethereum メインネット前提の 30 gwei になっており、`DEFAULT_FALLBACK_GAS_SUPPLY(300,000) × 30gwei × $2,100(ETH/USD) = $18.90` という Ethereum 相場のガス代を算出していた。さらに `frontend/app/(liff)/liff-approve/_components/ProposalBubble.tsx` が `amount_usd + estimated_gas_usd` を合算した `totalUsd` を合計額として表示していた（他3ファイルは元々ガス代を別行表示していたため対象外と確認済み）。

## 変更内容

- `backend/app/aave/gas_estimator.py`: `DEFAULT_GAS_PRICE_WEI` のデフォルトを `30 gwei` → `0.03 gwei`（Base L2 実勢、Ethereumの1/1000程度）に変更。env `ETH_GAS_PRICE_GWEI_FALLBACK` での上書き機構は維持。docstring/コメントで Base 向けフォールバック値である旨を明記。
- `frontend/app/(liff)/liff-approve/_components/ProposalBubble.tsx`: 合計額(`totalUsd`)表示を削除。ガス代は概算として別行表示のみとし、`totalWithGas` キーの代わりに「ネットワークの状況により実際の負担が変わる場合があります」という注記キー `gasNote` を追加。
- `frontend/messages/ja.json` / `en.json`: `proposalBubble.totalWithGas` → `proposalBubble.gasNote` にリネーム（新規注記文言）。
- `ProposalSignSheet.tsx` / `ApproveConfirmSheet.tsx` / `ProposalCard.tsx` は実装を確認した結果、ガス代を合計額と合算せず既に別行/別枠表示だったため変更不要。

## スコープ外（別Laneの管轄、意図的に触っていない）

- `backend/app/fees/trade_gate.py` の固定コスト $0.27
- `backend/app/automation/ai_judgment_scheduler.py`（別Laneが同時編集中）
- 実ガス代の記録実装、ETH/USD 動的取得

## DoD 結果

- [x] `ruff check` / `ruff format --check`: pass
- [x] `mypy` (変更ファイル `app/aave/gas_estimator.py` 単体): pass。リポジトリ全体 mypy は本PRと無関係の pre-existing エラー2件（`app/fees/billing_adapter.py` / `app/users/settings_router.py`、venv に `stripe` スタブ未インストール）で失敗するが、本PRの変更ファイルではない
- [x] `pytest tests/` (backend フルスイート): **5055 passed, 0 failed, 34 skipped**
- [x] `pytest tests/test_gas_estimator.py --cov`: 16 passed, カバレッジ 100%
- [x] frontend `tsc --noEmit`: pass
- [x] frontend `npm run build`: pass（本PRと無関係の pre-existing warning: `@metamask/sdk` の `@react-native-async-storage/async-storage` 未解決）
- [x] ja.json/en.json キー整合性: 一致確認済み
- [x] `scripts/check-consumer-protocol-names.mjs`: リポジトリに存在せず（該当なし）

## 実機確認

**実機確認未実施。** LIFF承認画面はLINE LIFF認証 + Privy embedded wallet/Smart Wallet + Postgres上の実proposalレコードを要するため、このdiffサイズの表示修正に対してローカルでフルスタック（DB seed、認証トークン発行、Privy sandbox）を構築するのはスコープ外と判断した。代わりに以下で検証:
- ロジック変更後の `tsc`/`build` 成功でJSXの整合性を確認
- 変更後のコードを目視レビューし `totalUsd`/`totalWithGas` の残存参照がないことを grep で確認（`RewardsCard.tsx` の同名変数は無関係の別コンポーネント）
- バックエンド計算値を手計算で確認: `300,000 units × 0.03 gwei × $2,100 ≈ $0.019` （旧: $18.90 → 新: 約$0.02、要件の「$1未満」を満たす）

Closes Asana GID 1217210829877772

🤖 Generated with [Claude Code](https://claude.com/claude-code)