### PR TITLE
fix(users): 手数料率の真実源を fee_configs (v10正本) に一本化

### DIFF
--- a/backend/app/users/fee_service.py
+++ b/backend/app/users/fee_service.py
@@ -4,13 +4,26 @@
 """
 tier 別手数料率サービス。
 
-v10 三層戦略 (F-2 2026-04-25 〜):
-  LOWER:  手数料率 3〜10% (〜100 万円)
-  MIDDLE: 手数料率 8〜18% (100 万〜1000 万円)
-  UPPER:  手数料率 15〜25% (1000 万円〜)
+v10 (F-2 2026-04-25 〜) からは DB `fee_configs` (app.fees.models.FeeConfigV10) の
+active レコードを唯一の真実源とする。旧ハードコード値 (3〜10% / 8〜18% / 15〜25%) は
+2026-08-06 に撤去 (Asana 1217210615751197) — `/api/v1/fees/config` (v10 正本) が
+返す値と食い違い、課金有効化時に提示料率と請求額が一致しないリスクがあったため。
+
+fee_configs に active レコードがない場合 (未投入 / 取得失敗) は None を返す。
+呼び出し元 (router.py) は 503 を返し、クライアント側は「料金プラン非表示」として
+扱うこと (frontend/components/user/FeePlanSection.tsx の fail-open ハンドリングと同じ方針)。
 """
 
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 from typing_extensions import TypedDict
+
+from app.fees.models import FeeConfigV10
 
 
 class FeeRateRange(TypedDict):
@@ -25,58 +38,79 @@ class FeeRateRange(TypedDict):
     description: str
 
 
-_LOWER = FeeRateRange(
-    tier="LOWER",
-    label="一般",
-    min_rate="0.03",
-    max_rate="0.10",
-    min_rate_pct="3",
-    max_rate_pct="10",
-    description="デポジット 100 万円以下のティア",
-)
-_MIDDLE = FeeRateRange(
-    tier="MIDDLE",
-    label="ミドル",
-    min_rate="0.08",
-    max_rate="0.18",
-    min_rate_pct="8",
-    max_rate_pct="18",
-    description="デポジット 100 万〜1000 万円のティア",
-)
-_UPPER = FeeRateRange(
-    tier="UPPER",
-    label="アッパー",
-    min_rate="0.15",
-    max_rate="0.25",
-    min_rate_pct="15",
-    max_rate_pct="25",
-    description="デポジット 1000 万円以上のティア",
-)
-
-_FEE_SCHEDULE: dict[str, FeeRateRange] = {
-    "LOWER": _LOWER,
-    "MIDDLE": _MIDDLE,
-    "UPPER": _UPPER,
-}
+#: fee_configs.tier_fee_rates / tier_thresholds_jpy のインデックス順 (LOWER/MIDDLE/UPPER)。
+_TIER_ORDER = ["LOWER", "MIDDLE", "UPPER"]
+_TIER_LABELS = {"LOWER": "一般", "MIDDLE": "ミドル", "UPPER": "アッパー"}
 
 
-def get_fee_rate_range(tier: str) -> FeeRateRange:
-    """ティア文字列から手数料率レンジを返す。
+def _active_config(db: Session) -> Optional[FeeConfigV10]:
+    """現行 active な FeeConfigV10 を返す (なければ None)。"""
+    stmt = (
+        select(FeeConfigV10)
+        .where(FeeConfigV10.is_active.is_(True))
+        .order_by(FeeConfigV10.effective_from.desc())
+        .limit(1)
+    )
+    return db.execute(stmt).scalar_one_or_none()
+
+
+def _tier_description(index: int, thresholds: list[int]) -> str:
+    """tier_thresholds_jpy から tier の説明文を組み立てる (ハードコード金額禁止)。"""
+    lower = 0 if index == 0 else thresholds[index - 1]
+    if index == len(thresholds):
+        return f"デポジット {lower:,} 円以上のティア"
+    upper = thresholds[index]
+    if lower == 0:
+        return f"デポジット {upper:,} 円以下のティア"
+    return f"デポジット {lower:,}〜{upper:,} 円のティア"
+
+
+def _to_fee_rate_range(tier: str, config: FeeConfigV10) -> FeeRateRange:
+    """FeeConfigV10 (v10: tier ごとの単一固定率) を FeeRateRange へ変換する。
+
+    v10 は tier ごとに単一の固定率 (レンジではない) なので min_rate == max_rate。
+    """
+    index = _TIER_ORDER.index(tier)
+    rate = Decimal(str(config.tier_fee_rates[index]))
+    rate_pct = rate * 100
+    return FeeRateRange(
+        tier=tier,
+        label=_TIER_LABELS[tier],
+        min_rate=str(rate),
+        max_rate=str(rate),
+        min_rate_pct=str(rate_pct),
+        max_rate_pct=str(rate_pct),
+        description=_tier_description(index, list(config.tier_thresholds_jpy)),
+    )
+
+
+def get_fee_rate_range(tier: str, db: Session) -> Optional[FeeRateRange]:
+    """ティア文字列から手数料率レンジを返す (fee_configs 由来、v10正本)。
 
     Args:
         tier: "LOWER" / "MIDDLE" / "UPPER"
+        db: SQLAlchemy セッション
 
     Returns:
-        FeeRateRange dict
+        FeeRateRange dict。fee_configs に active レコードがなければ None。
 
     Raises:
         ValueError: 不明なティアを指定した場合
     """
-    if tier not in _FEE_SCHEDULE:
-        raise ValueError(f"Unknown tier: {tier!r}. Must be one of {sorted(_FEE_SCHEDULE)}")
-    return _FEE_SCHEDULE[tier]
+    if tier not in _TIER_ORDER:
+        raise ValueError(f"Unknown tier: {tier!r}. Must be one of {_TIER_ORDER}")
+    config = _active_config(db)
+    if config is None:
+        return None
+    return _to_fee_rate_range(tier, config)
 
 
-def get_full_fee_schedule() -> list[FeeRateRange]:
-    """全ティアの手数料率レンジ一覧を返す (LOWER → MIDDLE → UPPER の順)。"""
-    return [_LOWER, _MIDDLE, _UPPER]
+def get_full_fee_schedule(db: Session) -> Optional[list[FeeRateRange]]:
+    """全ティアの手数料率レンジ一覧を返す (LOWER → MIDDLE → UPPER の順)。
+
+    fee_configs に active レコードがなければ None。
+    """
+    config = _active_config(db)
+    if config is None:
+        return None
+    return [_to_fee_rate_range(tier, config) for tier in _TIER_ORDER]

--- a/backend/app/users/router.py
+++ b/backend/app/users/router.py
@@ -113,15 +113,23 @@ class UserFeeInfoResponse(BaseModel):
 )
 def get_fee_schedule(
     current_user: User = Depends(require_partner),
+    db: Session = Depends(get_db),
 ) -> FeeScheduleResponse:
     """
-    全ティアの手数料率レンジ一覧を返す。
+    全ティアの手数料率レンジ一覧を返す (fee_configs 由来、v10正本)。
 
     - partner / admin: アクセス可能
+    - fee_configs に active レコードがない場合は 503 (料金プラン非表示)
     """
+    schedule = get_full_fee_schedule(db)
+    if schedule is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Fee config not initialized. Run scripts/seed_fee_config_v10.py.",
+        )
     return FeeScheduleResponse(
-        schedule=get_full_fee_schedule(),
-        note="手数料率はAIの判定精度に応じて動的に決定されます",
+        schedule=schedule,
+        note="手数料率はティア（デポジット規模）ごとの固定料率です",
     )
 
 
@@ -365,5 +373,10 @@ def get_user_fee_info(
                 detail="Access denied",
             )
 
-    fee_range = get_fee_rate_range(user.tier)
+    fee_range = get_fee_rate_range(user.tier, db)
+    if fee_range is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Fee config not initialized. Run scripts/seed_fee_config_v10.py.",
+        )
     return UserFeeInfoResponse(user_id=user_id, tier=user.tier, fee_rate_range=fee_range)

--- a/backend/tests/test_fee_service.py
+++ b/backend/tests/test_fee_service.py
@@ -1,6 +1,11 @@
 # Copyright (c) Ultra AutoTrade. All rights reserved.
 # backend/tests/test_fee_service.py
-"""tier別手数料率サービスおよびAPIエンドポイントのテスト。"""
+"""tier別手数料率サービスおよびAPIエンドポイントのテスト。
+
+v10 (2026-08-06 Asana 1217210615751197): 手数料率の真実源を DB `fee_configs`
+(FeeConfigV10) に一本化。旧ハードコード値 (3〜10%/8〜18%/15〜25%) を返すテストは
+撤去し、DB 駆動 + fail-open (fee_configs 未投入時は None / 503) のテストに置き換える。
+"""
 
 import os
 import tempfile
@@ -9,71 +14,100 @@ from typing import Generator
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-fee")
 os.environ.setdefault("INITIAL_ADMIN_EMAIL", "fee_admin@example.com")
 
 from app.database import Base, get_db  # noqa: E402
+from app.fees.models import FeeConfigV10  # noqa: E402
 from app.main import create_app  # noqa: E402
 from app.users.fee_service import (  # noqa: E402
     get_fee_rate_range,
     get_full_fee_schedule,
 )
+from scripts.seed_fee_config_v10 import build_v10_default_config  # noqa: E402
 
-# ---- fee_service unit tests ----
+
+def _seed_fee_config(db: Session) -> None:
+    """v10_default 相当の FeeConfigV10 (tier_fee_rates=[0.30, 0.25, 0.20]) を投入する。"""
+    db.add(FeeConfigV10(**build_v10_default_config()))
+    db.commit()
+
+
+# ---- fee_service unit tests (DB 駆動) ----
+
+
+@pytest.fixture()
+def fee_db() -> Generator[Session, None, None]:
+    """fee_configs テーブルのみを持つ SQLite テスト DB。
+
+    test_seed_fee_config_v10.py の v10_db fixture と同じ最小テーブル構成。
+    """
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    FeeConfigV10.__table__.create(bind=engine)  # type: ignore[attr-defined]
+    SessionFactory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = SessionFactory()
+    try:
+        yield db
+    finally:
+        db.close()
+        FeeConfigV10.__table__.drop(bind=engine)  # type: ignore[attr-defined]
+        engine.dispose()
+        os.unlink(path)
 
 
 class TestGetFeeRateRange:
-    def test_lower_tier(self) -> None:
-        result = get_fee_rate_range("LOWER")
+    def test_lower_tier(self, fee_db: Session) -> None:
+        _seed_fee_config(fee_db)
+        result = get_fee_rate_range("LOWER", fee_db)
+        assert result is not None
         assert result["tier"] == "LOWER"
         assert result["label"] == "一般"
-        assert result["min_rate"] == "0.03"
-        assert result["max_rate"] == "0.10"
-        assert result["min_rate_pct"] == "3"
-        assert result["max_rate_pct"] == "10"
+        assert result["min_rate"] == result["max_rate"] == "0.3"
 
-    def test_middle_tier(self) -> None:
-        result = get_fee_rate_range("MIDDLE")
+    def test_middle_tier(self, fee_db: Session) -> None:
+        _seed_fee_config(fee_db)
+        result = get_fee_rate_range("MIDDLE", fee_db)
+        assert result is not None
         assert result["tier"] == "MIDDLE"
         assert result["label"] == "ミドル"
-        assert result["min_rate"] == "0.08"
-        assert result["max_rate"] == "0.18"
-        assert result["min_rate_pct"] == "8"
-        assert result["max_rate_pct"] == "18"
+        assert result["min_rate"] == result["max_rate"] == "0.25"
 
-    def test_upper_tier(self) -> None:
-        result = get_fee_rate_range("UPPER")
+    def test_upper_tier(self, fee_db: Session) -> None:
+        _seed_fee_config(fee_db)
+        result = get_fee_rate_range("UPPER", fee_db)
+        assert result is not None
         assert result["tier"] == "UPPER"
         assert result["label"] == "アッパー"
-        assert result["min_rate"] == "0.15"
-        assert result["max_rate"] == "0.25"
-        assert result["min_rate_pct"] == "15"
-        assert result["max_rate_pct"] == "25"
+        assert result["min_rate"] == result["max_rate"] == "0.2"
 
-    def test_unknown_tier_raises(self) -> None:
+    def test_unknown_tier_raises(self, fee_db: Session) -> None:
         with pytest.raises(ValueError, match="Unknown tier"):
-            get_fee_rate_range("PLATINUM")
+            get_fee_rate_range("PLATINUM", fee_db)
 
-    def test_general_legacy_tier_raises(self) -> None:
+    def test_general_legacy_tier_raises(self, fee_db: Session) -> None:
         # F-13: GENERAL は削除済み → ValueError
         with pytest.raises(ValueError, match="Unknown tier"):
-            get_fee_rate_range("GENERAL")
+            get_fee_rate_range("GENERAL", fee_db)
+
+    def test_no_active_config_returns_none(self, fee_db: Session) -> None:
+        """fee_configs が未投入の場合は fail-open で None を返す (呼び出し元が非表示扱いする)。"""
+        assert get_fee_rate_range("LOWER", fee_db) is None
 
 
 class TestGetFullFeeSchedule:
-    def test_returns_three_tiers(self) -> None:
-        schedule = get_full_fee_schedule()
+    def test_returns_three_tiers_in_order(self, fee_db: Session) -> None:
+        _seed_fee_config(fee_db)
+        schedule = get_full_fee_schedule(fee_db)
+        assert schedule is not None
         assert len(schedule) == 3
-        tiers = [item["tier"] for item in schedule]
-        assert tiers == ["LOWER", "MIDDLE", "UPPER"]
+        assert [item["tier"] for item in schedule] == ["LOWER", "MIDDLE", "UPPER"]
 
-    def test_order_lower_middle_upper(self) -> None:
-        schedule = get_full_fee_schedule()
-        assert schedule[0]["tier"] == "LOWER"
-        assert schedule[1]["tier"] == "MIDDLE"
-        assert schedule[2]["tier"] == "UPPER"
+    def test_no_active_config_returns_none(self, fee_db: Session) -> None:
+        assert get_full_fee_schedule(fee_db) is None
 
 
 # ---- API endpoint tests ----
@@ -107,6 +141,15 @@ def client(test_db) -> TestClient:
     return TestClient(app)
 
 
+def _seed_fee_config_into_engine(engine) -> None:
+    SessionFactory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = SessionFactory()
+    try:
+        _seed_fee_config(db)
+    finally:
+        db.close()
+
+
 def _register_and_login(
     client: TestClient,
     email: str | None = None,
@@ -128,29 +171,34 @@ class TestFeeScheduleEndpoint:
         r = client.get("/users/fee-schedule")
         assert r.status_code == 401
 
-    def test_returns_schedule(self, client: TestClient) -> None:
+    def test_returns_schedule_when_config_active(self, client: TestClient, test_db) -> None:
+        _, engine = test_db
+        _seed_fee_config_into_engine(engine)
         token = _register_and_login(client)
         r = client.get("/users/fee-schedule", headers={"Authorization": f"Bearer {token}"})
         assert r.status_code == 200
         data = r.json()
         assert "schedule" in data
         assert "note" in data
-        assert len(data["schedule"]) == 3
         tiers = [s["tier"] for s in data["schedule"]]
-        assert "LOWER" in tiers
-        assert "MIDDLE" in tiers
-        assert "UPPER" in tiers
+        assert tiers == ["LOWER", "MIDDLE", "UPPER"]
 
-    def test_schedule_rate_values(self, client: TestClient) -> None:
+    def test_schedule_rate_values_match_fee_configs(self, client: TestClient, test_db) -> None:
+        _, engine = test_db
+        _seed_fee_config_into_engine(engine)
         token = _register_and_login(client)
         r = client.get("/users/fee-schedule", headers={"Authorization": f"Bearer {token}"})
         schedule = {s["tier"]: s for s in r.json()["schedule"]}
-        assert schedule["LOWER"]["min_rate"] == "0.03"
-        assert schedule["LOWER"]["max_rate"] == "0.10"
-        assert schedule["MIDDLE"]["min_rate"] == "0.08"
-        assert schedule["MIDDLE"]["max_rate"] == "0.18"
-        assert schedule["UPPER"]["min_rate"] == "0.15"
-        assert schedule["UPPER"]["max_rate"] == "0.25"
+        # v10 正本 (build_v10_default_config): tier_fee_rates = [0.30, 0.25, 0.20]
+        assert schedule["LOWER"]["min_rate"] == schedule["LOWER"]["max_rate"] == "0.3"
+        assert schedule["MIDDLE"]["min_rate"] == schedule["MIDDLE"]["max_rate"] == "0.25"
+        assert schedule["UPPER"]["min_rate"] == schedule["UPPER"]["max_rate"] == "0.2"
+
+    def test_returns_503_when_fee_config_not_seeded(self, client: TestClient) -> None:
+        """fee_configs 未投入時は 503 (旧ハードコード値へのフォールバック禁止)。"""
+        token = _register_and_login(client)
+        r = client.get("/users/fee-schedule", headers={"Authorization": f"Bearer {token}"})
+        assert r.status_code == 503
 
 
 class TestUserFeeInfoEndpoint:
@@ -158,9 +206,10 @@ class TestUserFeeInfoEndpoint:
         r = client.get("/users/1/fee-info")
         assert r.status_code == 401
 
-    def test_own_user_fee_info(self, client: TestClient) -> None:
+    def test_own_user_fee_info(self, client: TestClient, test_db) -> None:
+        _, engine = test_db
+        _seed_fee_config_into_engine(engine)
         token = _register_and_login(client)
-        # Get own user id first
         me = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
         user_id = me.json()["id"]
 
@@ -176,7 +225,9 @@ class TestUserFeeInfoEndpoint:
         assert "min_rate" in data["fee_rate_range"]
         assert "max_rate" in data["fee_rate_range"]
 
-    def test_not_found(self, client: TestClient) -> None:
+    def test_not_found(self, client: TestClient, test_db) -> None:
+        _, engine = test_db
+        _seed_fee_config_into_engine(engine)
         token = _register_and_login(client)
         r = client.get(
             "/users/99999/fee-info",
@@ -184,7 +235,9 @@ class TestUserFeeInfoEndpoint:
         )
         assert r.status_code == 404
 
-    def test_default_tier_is_lower(self, client: TestClient) -> None:
+    def test_default_tier_is_lower(self, client: TestClient, test_db) -> None:
+        _, engine = test_db
+        _seed_fee_config_into_engine(engine)
         token = _register_and_login(client)
         me = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
         user_id = me.json()["id"]
@@ -196,3 +249,15 @@ class TestUserFeeInfoEndpoint:
         # F-2 (2026-04-25): 新規ユーザーはデフォルトで LOWER (旧 GENERAL)
         assert r.json()["tier"] == "LOWER"
         assert r.json()["fee_rate_range"]["tier"] == "LOWER"
+
+    def test_returns_503_when_fee_config_not_seeded(self, client: TestClient) -> None:
+        """fee_configs 未投入時は 503 (料金プラン非表示)。"""
+        token = _register_and_login(client)
+        me = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+        user_id = me.json()["id"]
+
+        r = client.get(
+            f"/users/{user_id}/fee-info",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 503


### PR DESCRIPTION
## 背景

手数料率が2系統存在し、徴収される値がどちらか不明瞭だった。

- **v10 正本**: `backend/scripts/seed_fee_config_v10.py` が投入する `fee_configs` テーブル (tier_fee_rates=[0.30, 0.25, 0.20]) 。`/api/v1/fees/config` (`backend/app/api/v1/fees.py`) が既にこれを返しており、フロント (`frontend/components/user/FeePlanSection.tsx`) も既にこの endpoint のみ使用。
- **旧ハードコード (問題本体)**: `backend/app/users/fee_service.py` に `_LOWER`/`_MIDDLE`/`_UPPER` (3〜10% / 8〜18% / 15〜25%) が残存し、`/users/fee-schedule` と `/users/{id}/fee-info` から今も返却されていた。v10 正本と食い違い、課金有効化時に提示料率と請求額が一致しないリスクがあった。

## 変更内容

- `backend/app/users/fee_service.py`: `get_fee_rate_range()` / `get_full_fee_schedule()` を DB (`app.fees.models.FeeConfigV10` / `fee_configs` テーブル) 読み取りに変更。ハードコード定数を全撤去。シグネチャに `db: Session` を追加。fee_configs に active レコードがなければ `None` を返す (fail-open)。
- `backend/app/users/router.py`: `get_fee_schedule()` / `get_user_fee_info()` に `db: Session = Depends(get_db)` を追加し、`None` の場合は 503 (`Fee config not initialized. Run scripts/seed_fee_config_v10.py.`) を返すよう変更。`/api/v1/fees/config` の `_get_active_fee_config()` と同じエラーメッセージ・方針に統一。
- `backend/tests/test_fee_service.py`: 全面リライト。fee_configs あり/なし両ケースの unit test (`get_fee_rate_range` / `get_full_fee_schedule`)、API endpoint の 200 (v10値と一致) / 503 (未投入時) テストを追加。

## CHECK制約 / models.py 整合性確認 (Asana 1215272519685583 ルール準拠)

`fee_configs` テーブルは `tier_fee_rates` 等を JSONB 配列で保持しており、tier の CHECK 制約は存在しない (tier は配列インデックスで表現)。CHECK 制約が存在する `fee_transactions.tier IN ('LOWER','MIDDLE','UPPER')` / `risk_mode IN (...)` は既に `models.py` (`FeeTransaction`) と一致していることを確認済み (`grep -rn "CheckConstraint\|IN (" backend/alembic/versions/` で突き合わせ)。本PRでは新規カラム/CHECK制約の追加なし。

## やらないこと (Tier S follow-up)

- `backend/app/main.py`:34,268 の旧 `fee_router` (`aave/fee_router.py`) の `include_router` 除去は本PRでは実施しない。main.py は Tier S (1日1PRルール) のため別PRで対応。
- `backend/app/aave/fee_calculator.py` (`MANAGEMENT_FEE_ANNUAL_RATE` / `PERFORMANCE_FEE_RATE` / `MIN_AUM_USD`) も未着手。フロントからの呼び出しがあれば main.py follow-up とセットで撤去する。
- 料率の数値変更、徴収有効化フラグの変更は行っていない。

## Test plan

- [x] `ruff check` / `ruff format --check` (変更ファイル): pass
- [x] `mypy` (変更ファイル): pass (既存の `stripe` スタブ欠落エラーのみ検出、本PR起因ではないことを `git stash` で確認済み)
- [x] `pytest backend/tests/test_fee_service.py`: 17 passed
- [x] `pytest` fee 関連全体 (test_api_v1_fees / test_fee_calculator / test_fee_transfer_service / test_proposals_fee_wiring / test_qa_fee_calculator / test_seed_fee_config_v10 / test_tier_fee_integration / test_fee_service): 168 passed
- [x] `pytest` users 関連 (test_user_mode / test_user_settings_api / test_user_settings_role_auth): pass
- [ ] `pytest tests/ --cov=app --cov-fail-under=80` (フルスイート): sandbox 環境の時間制約 (1762+件、pytest-cov 未インストール) のため今回実行できず。CI で確認。
- [ ] 本番 DB への `v10_default` seed 投入状況: **未確認** (read-only 実機確認が必要、本PRのスコープ外)。

Asana: 1217210615751197
Closes: 1217210615751197
