### PR TITLE
HUMAN-REVIEW-REQUIRED: fix(automation) 提案サイジングの無音デッドゾーンと静的台帳分母を修正

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -76,13 +76,21 @@ _PROPOSAL_EXPIRES_HOURS = 168
 # 運営へアラートする閾値。無限に作り直し続けている状態を検知するためのもの。
 _CONSECUTIVE_EXPIRY_ALERT_THRESHOLD = 3
 
-# 提案金額: fund_allocations.allocated_amount_usd × _PROPOSAL_RATIO で動的計算。
+# 提案金額: fund_allocations.allocated_amount_usd から実行済み提案の積み上げ (deployed) を
+# 差し引いた遊休額 (idle) × _PROPOSAL_RATIO で動的計算 (2026-08-06: 静的台帳→動的遊休額へ
+# 変更 / Asana 1217210604911292、詳細は _resolve_deployed_amount_usd 参照)。
 # fund_allocation 不在の非カストディアル消費者は本人 wallet の USDC 残高 × ratio に
 # fallback する (案C / docs/61)。いずれも sizing 不能なら Decimal("0") → skip (安全側)。
 # 環境変数で上書き可能。
 _PROPOSAL_RATIO = Decimal(os.getenv("PROPOSAL_AMOUNT_RATIO", "0.10"))  # 10%
 _PROPOSAL_AMOUNT_MIN_USD = Decimal(os.getenv("PROPOSAL_AMOUNT_MIN_USD", "50"))
 _PROPOSAL_AMOUNT_MAX_USD = Decimal(os.getenv("PROPOSAL_AMOUNT_MAX_USD", "2000"))
+
+# 採算ゲート (fees.trade_gate) 未達スキップ時にユーザーへ伝える理由文言 (無音デッドゾーン対策)。
+_TRADE_GATE_SKIP_MESSAGE = (
+    "現在の運用資金では取引コストに対して見込める利益が小さいため、AI提案の作成を"
+    "見送っています。資金や市場状況が変わると再評価されます。"
+)
 
 
 def _read_wallet_usdc_balance(wallet_address: str) -> Optional[Decimal]:
@@ -96,14 +104,74 @@ def _read_wallet_usdc_balance(wallet_address: str) -> Optional[Decimal]:
     return read_wallet_usdc_balance(wallet_address)
 
 
+def _resolve_deployed_amount_usd(db: Session, user_id: int) -> Decimal:
+    """custodial ユーザーの「既に運用に乗っている金額 (deployed)」を実行済み提案から算出する。
+
+    fund_allocations.allocated_amount_usd は静的な入金台帳で、運用しても DB の値が
+    変わらない (Asana 1217210604911292: 何回稼働しても同じ提案額が出続ける問題)。
+    実行済み提案 (status='executed') を SUM(SUPPLY) - SUM(WITHDRAW) で積み上げることで、
+    運用が進むほど増える動的な「運用済み額」を得る。WITHDRAW が先行する記録不整合等が
+    あっても負値には倒れない (0 でクランプ)。
+
+    `app.users.deposit_resolver.resolve_user_deposit_usd`（未投入資金のみを見る別概念、
+    A-2 入金ゲート用）とは目的が異なるため、そのまま流用しない（過去の事故教訓）。
+    """
+    supplied = (
+        db.query(func.sum(Proposal.amount_usd))
+        .filter(
+            Proposal.user_id == user_id,
+            Proposal.status == "executed",
+            Proposal.operation == "SUPPLY",
+        )
+        .scalar()
+    )
+    withdrawn = (
+        db.query(func.sum(Proposal.amount_usd))
+        .filter(
+            Proposal.user_id == user_id,
+            Proposal.status == "executed",
+            Proposal.operation == "WITHDRAW",
+        )
+        .scalar()
+    )
+    supplied_usd = Decimal(str(supplied)) if supplied else Decimal("0")
+    withdrawn_usd = Decimal(str(withdrawn)) if withdrawn else Decimal("0")
+    return max(Decimal("0"), supplied_usd - withdrawn_usd)
+
+
+def _notify_proposal_skipped(user_id: int, reason: str) -> None:
+    """提案が生成されなかった理由をユーザー本人に伝える (best-effort)。
+
+    2026-08-06 (Asana 1217210854320785): 公表最低入金額 ($200) を満たしていても、
+    10% サイジングが最小ロット ($50) 未満 / 採算ゲート未達で提案が無音のまま
+    スキップされ続ける「実効最低入金 $852 の無音デッドゾーン」があった。
+    運営向け Slack 通知 (`_notify_missing_allocation` 等) とは別に、本人にも
+    既存の通知経路 (`get_notification_service`) で理由を届ける。
+    """
+    try:
+        from app.notifications.factory import get_notification_service  # noqa: PLC0415
+        from app.notifications.templates import proposal_skipped_notification  # noqa: PLC0415
+
+        payload = proposal_skipped_notification(reason)
+        payload.notification_message.user_id = user_id
+        get_notification_service().send(payload.notification_message)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("_notify_proposal_skipped failed for user_id=%d: %s", user_id, exc)
+
+
 def _resolve_proposal_amount(db: Session, user_id: int) -> Decimal:
     """提案金額を解決する (案C: fund_allocation 優先 + wallet 残高 fallback / docs/61)。
 
-    1. active fund_allocations 合計 × ratio (custodial パートナー/テスター枠)。
-       min/max にクランプ。**既存挙動を完全維持**。
+    1. active fund_allocations 合計 (allocated) から実行済み提案の積み上げ (deployed,
+       `_resolve_deployed_amount_usd`) を差し引いた **遊休額 (idle)** × ratio
+       (custodial パートナー/テスター枠、2026-08-06: 分母を静的台帳から動的遊休額へ変更
+       / Asana 1217210604911292)。min/max にクランプする既存の非対称は維持。
+       idle が尽きたら (<=0) 提案を出さない。
     2. allocation 不在 & wallet 設定済の非カストディアル消費者: 本人 wallet の
-       on-chain USDC 残高 × ratio。残高0 / 取得失敗 / min 未満は Decimal("0") で skip
-       (安全側: wallet 額を超える/極小の提案を作らない)。
+       on-chain USDC 残高 × ratio。wallet 残高は Aave 供給済み分を含まない
+       (`total_assets_resolver` 参照) ため、この経路は元から遊休額を見ている。
+       残高0 / 取得失敗 / min 未満は Decimal("0") で skip (安全側: wallet 額を超える/
+       極小の提案を作らない)。
     3. allocation も wallet も無い: sizing 不能 → Slack 通知 + Decimal("0")
        (パートナー/テスター登録漏れの検知を維持)。
 
@@ -124,6 +192,7 @@ def _resolve_proposal_amount(db: Session, user_id: int) -> Decimal:
     allocated = Decimal(str(raw)) if raw else Decimal("0")
     if allocated > Decimal("0"):
         # A-2 入金ゲート: 運用開始の最低入金額 (MIN_DEPOSIT_USD) 未満は提案を生成しない。
+        # (これは「入金総額」に対するゲートであり、下の遊休額判定とは別軸。既存挙動を維持)
         if allocated < MIN_DEPOSIT_USD:
             logger.info(
                 "[deposit_gate] custodial deposit $%s < min $%s for user_id=%d — proposal skipped",
@@ -132,7 +201,19 @@ def _resolve_proposal_amount(db: Session, user_id: int) -> Decimal:
                 user_id,
             )
             return Decimal("0")
-        amount = (allocated * _PROPOSAL_RATIO).quantize(Decimal("0.01"))
+        deployed = _resolve_deployed_amount_usd(db, user_id)
+        idle = allocated - deployed
+        if idle <= Decimal("0"):
+            # 遊休資金なし (全額運用済み) → 提案を出さない (Asana 1217210604911292)。
+            logger.info(
+                "[idle_capital] user_id=%d fully deployed (allocated=$%s, deployed=$%s) "
+                "— no idle capital, proposal skipped",
+                user_id,
+                allocated,
+                deployed,
+            )
+            return Decimal("0")
+        amount = (idle * _PROPOSAL_RATIO).quantize(Decimal("0.01"))
         return max(_PROPOSAL_AMOUNT_MIN_USD, min(amount, _PROPOSAL_AMOUNT_MAX_USD))
 
     # ── 2. fallback: 非カストディアル消費者の wallet USDC 残高 ──
@@ -161,11 +242,23 @@ def _resolve_proposal_amount(db: Session, user_id: int) -> Decimal:
             # 10% が gas viable な最小額未満 → skip。
             # allocation 経路は min へ切り上げるが、消費者 wallet 経路では残高に対し
             # 過大な supply を避けるため切り上げず skip する (意図的な非対称 / docs/61)。
-            logger.debug(
-                "[proposal_amount] wallet-based amount %s < min $%s for user_id=%d — skipped",
+            # 2026-08-06 (Asana 1217210854320785): $200(最低入金)〜サイジング下限の
+            # 無音デッドゾーン。info/debug → warning に上げ、本人にも理由を通知する。
+            logger.warning(
+                "[proposal_amount] wallet-based amount $%s < min $%s for user_id=%d — "
+                "skipped (deadzone: balance=$%s, sizing-only lower bound=$%s "
+                "before downstream trade_gate)",
                 amount,
                 _PROPOSAL_AMOUNT_MIN_USD,
                 user_id,
+                balance,
+                (_PROPOSAL_AMOUNT_MIN_USD / _PROPOSAL_RATIO).quantize(Decimal("0.01")),
+            )
+            _notify_proposal_skipped(
+                user_id,
+                f"残高 ${balance:.2f} の運用額(10%)が最低取引額 "
+                f"${_PROPOSAL_AMOUNT_MIN_USD:.2f} に届かないため、AI提案の作成を"
+                "見送っています。追加入金いただくと提案が作成されるようになります。",
             )
             return Decimal("0")
         return min(amount, _PROPOSAL_AMOUNT_MAX_USD)
@@ -967,11 +1060,16 @@ def _create_proposals_for_users(
                 )
 
                 if not market_fee.should_trade:
-                    logger.info(
-                        "DynamicFee: should_trade=False for user %d — skipping proposal (%s)",
+                    # 2026-08-06 (Asana 1217210854320785): 採算ゲートでの無音スキップ。
+                    # info → warning に上げ、本人にも理由を通知する。
+                    logger.warning(
+                        "DynamicFee: should_trade=False for user %d — skipping proposal "
+                        "(amount=$%s, %s)",
                         user.id,
+                        proposal_amount_usd,
                         market_fee.reason,
                     )
+                    _notify_proposal_skipped(user.id, _TRADE_GATE_SKIP_MESSAGE)
                     continue
 
                 # Phase-B: AI Optimizer 経由で (operation, asset, protocol) を決定。
@@ -1136,11 +1234,15 @@ def _create_safe_yield_proposals_for_users(
                     fixed_cost_usd=fixed_cost,
                 )
                 if not market_fee.should_trade:
-                    logger.info(
-                        "[safe_yield] should_trade=False for user %d — skip (%s)",
+                    # 2026-08-06 (Asana 1217210854320785): 採算ゲートでの無音スキップ。
+                    # info → warning に上げ、本人にも理由を通知する。
+                    logger.warning(
+                        "[safe_yield] should_trade=False for user %d — skip (amount=$%s, %s)",
                         user.id,
+                        proposal_amount_usd,
                         market_fee.reason,
                     )
+                    _notify_proposal_skipped(user.id, _TRADE_GATE_SKIP_MESSAGE)
                     continue
 
                 # 安全利回り: 方向性ルーティングを通さず SUPPLY/USDC/aave 固定。

--- a/backend/app/notifications/templates.py
+++ b/backend/app/notifications/templates.py
@@ -149,6 +149,21 @@ def execution_mode_downgraded_notification() -> NotificationPayload:
     return _build_payload(title, body, "warning")
 
 
+def proposal_skipped_notification(reason: str) -> NotificationPayload:
+    """AI提案が作成されなかったこととその理由をユーザーに知らせる通知。
+
+    2026-08-06 (Asana 1217210854320785): 公表最低入金額を満たしていても、
+    10%サイジングが最小ロット未満 / 採算ゲート未達で提案が無音のままスキップされ
+    続ける「無音デッドゾーン」への対応。運営向け Slack (`operational_alert_notification`)
+    とは別に、本人向けにここで理由を伝える。
+
+    Args:
+        reason: 呼び出し側が組み立てた具体的なスキップ理由（本文にそのまま使う）。
+    """
+    title = "ℹ️ 現在はAI提案を作成していません"
+    return _build_payload(title, reason, "info")
+
+
 # --- 取引4種 ---
 
 

--- a/backend/tests/automation/test_proposals_notification.py
+++ b/backend/tests/automation/test_proposals_notification.py
@@ -128,10 +128,16 @@ class TestCreateProposalsForUsersNotification:
         _, msgs = self._run(action=TradeAction.BUY, user_id=42)
         assert msgs[0].user_id == 42
 
-    def test_no_send_when_should_trade_false(self) -> None:
-        """DynamicFee should_trade=False: no notification."""
-        _, msgs = self._run(should_trade=False)
-        assert len(msgs) == 0
+    def test_skip_reason_notification_when_should_trade_false(self) -> None:
+        """DynamicFee should_trade=False: 提案は作らないが、スキップ理由を本人に通知する。
+
+        2026-08-06 (Asana 1217210854320785): 以前は「何も送らない」が期待値だったが、
+        それが「無音デッドゾーン」（残高はあるのに理由が分からず提案が来ない）の
+        原因の一つだった。採算ゲート未達時も理由を本人に通知するよう変更。
+        """
+        _, msgs = self._run(should_trade=False, user_id=42)
+        assert len(msgs) == 1
+        assert msgs[0].user_id == 42
 
     def test_send_called_for_sell_action(self) -> None:
         """SELL: notification is also sent."""

--- a/backend/tests/test_ai_judgment_scheduler.py
+++ b/backend/tests/test_ai_judgment_scheduler.py
@@ -5,6 +5,7 @@
 import asyncio
 import os
 import tempfile
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
@@ -119,6 +120,29 @@ def _add_fund_allocation(
     session.add(alloc)
     session.flush()
     return alloc
+
+
+def _add_executed_proposal(
+    session,
+    user: User,
+    amount_usd: Decimal,
+    operation: str = "SUPPLY",
+) -> Proposal:
+    """遊休額 (idle capital) テスト用: 実行済み (status='executed') の提案を1件追加する。"""
+    proposal = Proposal(
+        user_id=user.id,
+        operation=operation,
+        asset="USDC",
+        protocol="aave",
+        amount=amount_usd,
+        amount_usd=amount_usd,
+        reason="test executed proposal",
+        status="executed",
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    session.add(proposal)
+    session.flush()
+    return proposal
 
 
 # ---------------------------------------------------------------------------
@@ -1491,6 +1515,182 @@ def test_resolve_amount_no_allocation_no_wallet_notifies_and_zero(db_session, mo
     result = sched._resolve_proposal_amount(db_session, user.id)
     assert result == Decimal("0")
     assert called.get("uid") == user.id
+
+
+# ---------------------------------------------------------------------------
+# _resolve_proposal_amount: 遊休額 (idle capital) — 分母を静的台帳から動的遊休額へ
+# (2026-08-06 / Asana 1217210604911292)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_proposal_amount_idle_after_partial_deployment(db_session):
+    """一部運用済みのとき、遊休額 (allocated - deployed) の10%が提案額になること。
+
+    allocated=$5,000, 実行済みSUPPLY=$3,000 → idle=$2,000 → 10%=$200。
+    """
+    user = _add_active_user(db_session, "partial_deployed@example.com")
+    _add_fund_allocation(db_session, user, allocated_usd=Decimal("5000"))
+    _add_executed_proposal(db_session, user, Decimal("3000"), operation="SUPPLY")
+    db_session.commit()
+
+    from app.automation.ai_judgment_scheduler import _resolve_proposal_amount  # noqa: PLC0415
+
+    result = _resolve_proposal_amount(db_session, user.id)
+    assert result == Decimal("200.00"), f"expected $200 (10% of $2,000 idle) but got {result}"
+
+
+def test_resolve_proposal_amount_idle_accounts_for_withdraw(db_session):
+    """実行済み WITHDRAW は運用済み額から差し引かれること。
+
+    allocated=$1,000, 実行済みSUPPLY=$800, 実行済みWITHDRAW=$300
+    → deployed=$500 → idle=$500 → 10%=$50。
+    """
+    user = _add_active_user(db_session, "withdraw_adjusted@example.com")
+    _add_fund_allocation(db_session, user, allocated_usd=Decimal("1000"))
+    _add_executed_proposal(db_session, user, Decimal("800"), operation="SUPPLY")
+    _add_executed_proposal(db_session, user, Decimal("300"), operation="WITHDRAW")
+    db_session.commit()
+
+    from app.automation.ai_judgment_scheduler import _resolve_proposal_amount  # noqa: PLC0415
+
+    result = _resolve_proposal_amount(db_session, user.id)
+    assert result == Decimal("50.00"), f"expected $50 (10% of $500 idle) but got {result}"
+
+
+def test_resolve_proposal_amount_idle_zero_when_fully_deployed(db_session):
+    """遊休がゼロ (allocated <= deployed) のとき、提案が出ないこと (Decimal(0))。
+
+    allocated=$1,000, 実行済みSUPPLY=$1,000 → idle=$0 → skip。
+    """
+    user = _add_active_user(db_session, "fully_deployed@example.com")
+    _add_fund_allocation(db_session, user, allocated_usd=Decimal("1000"))
+    _add_executed_proposal(db_session, user, Decimal("1000"), operation="SUPPLY")
+    db_session.commit()
+
+    from app.automation.ai_judgment_scheduler import _resolve_proposal_amount  # noqa: PLC0415
+
+    assert _resolve_proposal_amount(db_session, user.id) == Decimal("0")
+
+
+def test_resolve_proposal_amount_idle_never_negative_when_over_withdrawn(db_session):
+    """WITHDRAW が SUPPLY を超えて記録されていても deployed は 0 未満に倒れない (安全側)。
+
+    allocated=$1,000, SUPPLY=$200, WITHDRAW=$500 (記録不整合) → deployed=max(0, -300)=0
+    → idle=$1,000 → 10%=$100 (allocated 全額を分母にした場合と同じ、暴走しない)。
+    """
+    user = _add_active_user(db_session, "over_withdrawn@example.com")
+    _add_fund_allocation(db_session, user, allocated_usd=Decimal("1000"))
+    _add_executed_proposal(db_session, user, Decimal("200"), operation="SUPPLY")
+    _add_executed_proposal(db_session, user, Decimal("500"), operation="WITHDRAW")
+    db_session.commit()
+
+    from app.automation.ai_judgment_scheduler import _resolve_proposal_amount  # noqa: PLC0415
+
+    result = _resolve_proposal_amount(db_session, user.id)
+    assert result == Decimal("100.00")
+
+
+def test_resolve_proposal_amount_pending_proposals_do_not_count_as_deployed(db_session):
+    """status='pending' の提案は「運用済み」に数えない (実行されたものだけ数える)。
+
+    allocated=$1,000, pending SUPPLY=$1,000 (未実行) → deployed=$0 → idle=$1,000 → 10%=$100。
+    """
+    user = _add_active_user(db_session, "pending_not_deployed@example.com")
+    _add_fund_allocation(db_session, user, allocated_usd=Decimal("1000"))
+    pending = Proposal(
+        user_id=user.id,
+        operation="SUPPLY",
+        asset="USDC",
+        protocol="aave",
+        amount=Decimal("1000"),
+        amount_usd=Decimal("1000"),
+        reason="pending, not executed",
+        status="pending",
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    db_session.add(pending)
+    db_session.commit()
+
+    from app.automation.ai_judgment_scheduler import _resolve_proposal_amount  # noqa: PLC0415
+
+    result = _resolve_proposal_amount(db_session, user.id)
+    assert result == Decimal("100.00")
+
+
+# ---------------------------------------------------------------------------
+# _resolve_proposal_amount: 実効最低入金の無音デッドゾーン境界値
+# ($100/$200/$500/$1,000/$5,000 / Asana 1217210854320785)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "balance,expected",
+    [
+        (Decimal("100"), Decimal("0")),  # < 最低入金($200) → deposit gate で skip
+        (Decimal("200"), Decimal("0")),  # 10%=$20 < min($50) → 無音デッドゾーン→skip (要修正対象)
+        (Decimal("500"), Decimal("50.00")),  # 10%=$50 = min → 提案は出る (採算ゲートは別関数)
+        (Decimal("1000"), Decimal("100.00")),  # 10%=$100
+        (Decimal("5000"), Decimal("500.00")),  # 10%=$500
+    ],
+)
+def test_resolve_proposal_amount_wallet_deadzone_boundaries(
+    db_session, monkeypatch, balance, expected
+):
+    """非カストディアル (wallet) 経路: $100/$200/$500/$1,000/$5,000 境界値。"""
+    import app.automation.ai_judgment_scheduler as sched  # noqa: PLC0415
+
+    user = _add_active_user(db_session, f"wallet_boundary_{balance}@example.com")
+    user.smart_wallet_address = "0x" + "1" * 40
+    db_session.commit()
+
+    monkeypatch.setattr(sched, "_read_wallet_usdc_balance", lambda _addr: balance)
+    result = sched._resolve_proposal_amount(db_session, user.id)
+    assert result == expected, f"balance=${balance}: expected {expected} but got {result}"
+
+
+@pytest.mark.parametrize(
+    "allocated,expected",
+    [
+        (Decimal("100"), Decimal("0")),  # < 最低入金($200) → deposit gate で skip
+        (
+            Decimal("200"),
+            Decimal("50.00"),
+        ),  # 10%=$20 < min → custodial は $50 に切り上げ (既存非対称)
+        (Decimal("500"), Decimal("50.00")),  # 10%=$50
+        (Decimal("1000"), Decimal("100.00")),  # 10%=$100
+        (Decimal("5000"), Decimal("500.00")),  # 10%=$500
+    ],
+)
+def test_resolve_proposal_amount_custodial_boundaries(db_session, allocated, expected):
+    """custodial (fund_allocation) 経路: $100/$200/$500/$1,000/$5,000 境界値 (deployed=0)。"""
+    from app.automation.ai_judgment_scheduler import _resolve_proposal_amount  # noqa: PLC0415
+
+    user = _add_active_user(db_session, f"custodial_boundary_{allocated}@example.com")
+    _add_fund_allocation(db_session, user, allocated_usd=allocated)
+    db_session.commit()
+
+    result = _resolve_proposal_amount(db_session, user.id)
+    assert result == expected, f"allocated=${allocated}: expected {expected} but got {result}"
+
+
+def test_resolve_proposal_amount_wallet_deadzone_notifies_user(db_session, monkeypatch):
+    """$200 デッドゾーン (10%<min) skip 時、本人へ理由通知が送られること (無音対策)。"""
+    import app.automation.ai_judgment_scheduler as sched  # noqa: PLC0415
+
+    user = _add_active_user(db_session, "deadzone_notify@example.com")
+    user.smart_wallet_address = "0x" + "2" * 40
+    db_session.commit()
+
+    sent: list = []
+    monkeypatch.setattr(sched, "_read_wallet_usdc_balance", lambda _addr: Decimal("200"))
+    monkeypatch.setattr(
+        "app.notifications.factory.get_notification_service",
+        lambda: MagicMock(send=lambda m: sent.append(m)),
+    )
+    result = sched._resolve_proposal_amount(db_session, user.id)
+    assert result == Decimal("0")
+    assert len(sent) == 1
+    assert sent[0].user_id == user.id
 
 
 def test_create_proposals_db_error_one_user_does_not_stop_others(db_session):


### PR DESCRIPTION
## Summary

Asana GID: 1217210854320785 (無音デッドゾーン) / 1217210604911292 (サイジング分母)

対象: `backend/app/automation/ai_judgment_scheduler.py` の `_resolve_proposal_amount` とその呼び出し元2箇所 (`_create_proposals_for_users` / `_create_safe_yield_proposals_for_users`)。

### 問題1: 実効最低入金 $852 の無音デッドゾーン
公表最低入金 $200 (`deposit_policy.py`) に対し、実際に提案が出るのは約 $852 から。$200〜$851 のユーザーには提案も警告も出ない (3段のゲートのミスマッチ)。

**対応 (可視化のみ、閾値自体は変更しない)**:
- wallet 経路で `10%サイジング < min($50)` により skip する分岐: `logger.debug` → `logger.warning` (残高・計算後金額・サイジングのみの下限を構造化ログに出す)
- `_create_proposals_for_users` / `_create_safe_yield_proposals_for_users` の採算ゲート (`should_trade=False`) skip: `logger.info` → `logger.warning`
- 上記2箇所で本人向けに `proposal_skipped_notification` (新設、既存の `get_notification_service()` 経路を再利用) を送信し、なぜ提案が来ないかを伝える
- deposit gate (`allocated/balance < MIN_DEPOSIT_USD`) のログ・挙動は変更なし (これは正しく機能している側)

### 問題2: custodial経路の10%分母が静的台帳のまま
`fund_allocations.allocated_amount_usd` は運用が進んでも DB 上の値が変わらないため、何回稼働しても同じ提案額が出続けていた (本番 user16/user11 で確認済み)。

**対応**:
- `_resolve_deployed_amount_usd(db, user_id)` を新設。`status='executed'` の Proposal を `SUM(SUPPLY) - SUM(WITHDRAW)` で積み上げ、動的な「運用済み額」を算出 (負値には倒れない)
- custodial 経路の分母を `allocated_amount_usd` から `idle = allocated - deployed` に変更。`idle <= 0` (全額運用済み) なら提案しない
- **`deposit_resolver.resolve_user_deposit_usd` は流用していない** (未投入資金のみを見る別概念。過去にこれを分母に使って事故があった教訓を踏襲)
- wallet 経路 (RPC取得失敗時は `None` → skip) は変更なし。暴走防止のため取得失敗を0扱いにしていない

### 変更していないもの (意図的)
- `backend/app/fees/trade_gate.py` の固定コスト $0.27 (別Laneのガス代実測待ち)
- `backend/app/users/deposit_policy.py` の `MIN_DEPOSIT_USD=$200` (別管轄)
- custodial経路の「10%<min時は$50に切り上げ」/ wallet経路の「skip」という既存の非対称 (指示通り維持)

## 問題1 恒久対策 3案 (本Laneでは実装しない、事業判断待ち)

- **案A**: 最低入金額 ($200) を実効値 ($852相当) に一致させる。UI/契約上のシンプルさは上がるが、公表額の引き上げは新規ユーザー獲得に影響する可能性
- **案B**: 残高が小さいときは10%固定でなく全額を提案する (min/maxクランプの上限側だけ効かせる)。デッドゾーンは消えるが、小口ユーザーほど資産に対する相対リスクが上がる
- **案C**: 採算ゲートの固定コスト $0.27 を下げる。別Laneのガス代実測結果が出てからでないと根拠がないため本Laneでは触っていない

## Test plan

- [x] `ruff check .` / `ruff format --check .` / `ruff check . --select S` (backend/) — 全通過
- [x] `mypy app/ --config-file ../pyproject.toml` — 通過 (既存の無関係な `stripe` スタブ欠落エラー1件のみ、本PRの変更とは無関係)
- [x] `pytest tests/ --cov=app --cov-fail-under=80 -q` — **5071 passed, 34 skipped, coverage 84.74%**
- [x] 新規テスト (backend/tests/test_ai_judgment_scheduler.py):
  - 一部運用済み時の遊休額サイジング ($5,000台帳 / $3,000実行済SUPPLY → 遊休$2,000 → 提案$200)
  - WITHDRAW を差し引いた遊休額計算 ($1,000台帳 / SUPPLY$800 / WITHDRAW$300 → 遊休$500 → 提案$50)
  - 遊休ゼロ時に提案が出ないこと ($1,000台帳 / SUPPLY$1,000 → 提案$0)
  - WITHDRAW先行等の記録不整合でも deployed が負値に倒れないこと
  - pending (未実行) 提案は「運用済み」に数えないこと
  - custodial / wallet 両経路の $100/$200/$500/$1,000/$5,000 境界値パラメタライズテスト
  - wallet デッドゾーン skip 時に本人へ通知が送られること
  - 既存の残高取得失敗(None)時 skip テストは変更なしで green
- [x] 既存テスト `test_no_send_when_should_trade_false` は「通知しない」が旧仕様だったため、新仕様(通知する)に合わせて更新 (`test_skip_reason_notification_when_should_trade_false`)
- [x] 既存57テスト + 新規16テスト、全て green。既存の境界値テスト (min/maxクランプ等) は deployed=0 (実行済み提案なし) の場合に一致するため無変更で green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>