### PR TITLE
fix(automation): 実資金化前に custodial 単一鍵実行と SCW sizing の資金源を是正

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -80,6 +80,19 @@ AAVE_MIN_HEALTH_FACTOR=1.6
 AAVE_STATE_FILE_PATH=/var/run/ultra/state.json
 AAVE_MAX_PRICE_DEVIATION_PCT=2.0
 
+# 執行フラグ（2 段構え / いずれも既定 false）
+#   AUTO_EXECUTION_ENABLED
+#     執行段階のマスタースイッチ。false のあいだ提案は 'approved' 止まりで、実 tx は
+#     本人の手動署名（build-tx / submit-tx）でしか立たない。
+#   CUSTODIAL_EXECUTION_ENABLED
+#     委譲(SCW)枠を持たないユーザーの承認を、サーバー単一鍵 AAVE_WALLET_PRIVATE_KEY による
+#     プール資金の custodial 実行に落とすか。**非カストディアル方式2 では false のまま**。
+#     これを分離していないと「委譲おまかせを動かすために AUTO_EXECUTION_ENABLED=true に
+#     する」操作が、委譲枠を持たない全ユーザーの承認クリックまで実資金経路として同時に
+#     開いてしまう（2026-08-06 実資金 GO 前の調査で検出）。
+AUTO_EXECUTION_ENABLED=false
+CUSTODIAL_EXECUTION_ENABLED=false
+
 # =============================================================================
 # Smart Wallet (ERC-4337 AA) / Paymaster — slice3b
 # BUNDLER_RPC_URL: bundler の JSON-RPC URL (Pimlico)。smart_wallet_address 設定済ユーザーの

--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -34,6 +34,7 @@ from app.knowledge.schemas import KnowledgeSearchRequest
 from app.knowledge.service import KnowledgeService
 from app.proposals.models import Proposal
 from app.users.deposit_policy import MIN_DEPOSIT_USD
+from app.users.deposit_resolver import uses_custodial_allocation
 from app.users.models import get_active_grant
 
 # ティア別デフォルト判定間隔（時間）
@@ -99,6 +100,10 @@ def _read_wallet_usdc_balance(wallet_address: str) -> Optional[Decimal]:
 def _resolve_proposal_amount(db: Session, user_id: int) -> Decimal:
     """提案金額を解決する (案C: fund_allocation 優先 + wallet 残高 fallback / docs/61)。
 
+    0. smart_wallet_address を持つユーザーは 1 を飛ばして 2 へ
+       (`uses_custodial_allocation` / 2026-08-06)。allocation は custodial プール持分の
+       帳簿行でオンチェーンの裏付けが無く、SCW 執行の sizing 分母に使うと実残高の
+       何倍もの提案を作ってしまうため。ゲート側 (`resolve_user_deposit_usd`) と同一規則。
     1. active fund_allocations 合計 × ratio (custodial パートナー/テスター枠)。
        min/max にクランプ。**既存挙動を完全維持**。
     2. allocation 不在 & wallet 設定済の非カストディアル消費者: 本人 wallet の
@@ -112,31 +117,34 @@ def _resolve_proposal_amount(db: Session, user_id: int) -> Decimal:
     """
     from app.partner.allocation_models import FundAllocation  # noqa: PLC0415
 
-    # ── 1. fund_allocation 優先 (custodial 枠) ──
-    raw = (
-        db.query(func.sum(FundAllocation.allocated_amount_usd))
-        .filter(
-            FundAllocation.tester_user_id == user_id,
-            FundAllocation.status == "active",
-        )
-        .scalar()
-    )
-    allocated = Decimal(str(raw)) if raw else Decimal("0")
-    if allocated > Decimal("0"):
-        # A-2 入金ゲート: 運用開始の最低入金額 (MIN_DEPOSIT_USD) 未満は提案を生成しない。
-        if allocated < MIN_DEPOSIT_USD:
-            logger.info(
-                "[deposit_gate] custodial deposit $%s < min $%s for user_id=%d — proposal skipped",
-                allocated,
-                MIN_DEPOSIT_USD,
-                user_id,
+    user = db.get(User, user_id)
+
+    # ── 1. fund_allocation 優先 (custodial 枠 / SCW 保有ユーザーは対象外) ──
+    if uses_custodial_allocation(user):
+        raw = (
+            db.query(func.sum(FundAllocation.allocated_amount_usd))
+            .filter(
+                FundAllocation.tester_user_id == user_id,
+                FundAllocation.status == "active",
             )
-            return Decimal("0")
-        amount = (allocated * _PROPOSAL_RATIO).quantize(Decimal("0.01"))
-        return max(_PROPOSAL_AMOUNT_MIN_USD, min(amount, _PROPOSAL_AMOUNT_MAX_USD))
+            .scalar()
+        )
+        allocated = Decimal(str(raw)) if raw else Decimal("0")
+        if allocated > Decimal("0"):
+            # A-2 入金ゲート: 運用開始の最低入金額 (MIN_DEPOSIT_USD) 未満は提案を生成しない。
+            if allocated < MIN_DEPOSIT_USD:
+                logger.info(
+                    "[deposit_gate] custodial deposit $%s < min $%s for user_id=%d — "
+                    "proposal skipped",
+                    allocated,
+                    MIN_DEPOSIT_USD,
+                    user_id,
+                )
+                return Decimal("0")
+            amount = (allocated * _PROPOSAL_RATIO).quantize(Decimal("0.01"))
+            return max(_PROPOSAL_AMOUNT_MIN_USD, min(amount, _PROPOSAL_AMOUNT_MAX_USD))
 
     # ── 2. fallback: 非カストディアル消費者の wallet USDC 残高 ──
-    user = db.get(User, user_id)
     wallet = (user.smart_wallet_address or user.wallet_address) if user else None
     if wallet:
         balance = _read_wallet_usdc_balance(wallet)

--- a/backend/app/proposals/router.py
+++ b/backend/app/proposals/router.py
@@ -422,6 +422,22 @@ def _should_use_scw_route(proposal: Proposal, grant: Optional[DelegationGrant]) 
     return True
 
 
+def _custodial_execution_enabled() -> bool:
+    """サーバー単一鍵（``AAVE_WALLET_PRIVATE_KEY``）による custodial 実行を許可するか（既定 False）。
+
+    ``AUTO_EXECUTION_ENABLED`` は「執行段階のマスタースイッチ」であり、委譲(SCW)経路と
+    custodial 単一鍵経路の**両方**を同時に開けてしまう（委譲経路は
+    ``_execute_aave_for_proposal`` の内側にあり、同じフラグの配下にある）。非カストディアル
+    方式2 では後者を開けたくないので、独立フラグに分離して既定 False で閉じておく。
+
+    これが無いと「山本さん/橋口さんの委譲おまかせを動かすために
+    ``AUTO_EXECUTION_ENABLED=true`` にする」操作が、委譲枠を持たない admin/partner/viewer の
+    承認クリックまで **プール資金をサーバー鍵で動かす経路**として同時に開いてしまう
+    （2026-08-06 実資金 GO 前の調査で検出）。
+    """
+    return os.getenv("CUSTODIAL_EXECUTION_ENABLED", "false").strip().lower() == "true"
+
+
 def _execute_supply_via_scw(
     proposal: Proposal, chain: str, grant: DelegationGrant, user: Optional[UserModel], db: Session
 ) -> Any:
@@ -642,6 +658,17 @@ def _execute_aave_for_proposal(proposal: Proposal, db: Session) -> None:
                 "single-key execution",
                 proposal.id,
                 proposal.operation,
+            )
+            return
+        elif not _custodial_execution_enabled():
+            # 委譲枠を持たないユーザー。サーバー単一鍵(AAVE_WALLET_PRIVATE_KEY)で
+            # プール資金を動かす custodial 経路は独立フラグで閉じてあるため、上の
+            # 「SCW 対象外操作」と同じく transient 扱いで 'approved' のまま据え置く。
+            # 手動署名フロー(build-tx/submit-tx)は従来どおり使える。
+            logger.warning(
+                "proposal %d: no delegation grant and custodial single-key execution is "
+                "disabled (CUSTODIAL_EXECUTION_ENABLED=false) — holding as 'approved'",
+                proposal.id,
             )
             return
         else:

--- a/backend/app/users/deposit_resolver.py
+++ b/backend/app/users/deposit_resolver.py
@@ -10,9 +10,17 @@ allocation/wallet を既に計算しているためインラインでゲート�
 ユーザー操作起点の cold path（承認・設定）から呼ぶ。
 
 解決順（`_resolve_proposal_amount` の deposit 部分と一致させる / docs/61 案C）:
+  0. smart_wallet_address を持つユーザーは 1 を飛ばして 2 へ（`uses_custodial_allocation`）
   1. active fund_allocations 合計（custodial パートナー/テスター枠）
   2. 非カストディアル消費者: 本人 wallet の on-chain USDC 残高
   3. どちらも無い: None（判定不能）
+
+[2026-08-06] 0 を追加した理由: `fund_allocations` は **custodial プールの持分を表す帳簿行**で
+あり、オンチェーンの裏付けを持たない。SCW を持つユーザーの執行は本人 SCW から行われる
+（`_should_use_scw_route` → `_execute_supply_via_scw`）ため、帳簿額でゲートを通すと
+「$200 ゲートは通過するが SCW 残高 0 で on-chain revert」になる。実際、本番の user 11 は
+allocation $4,600 / SCW 実残高 $0 で、この形の失敗が確定する状態だった。ブロックされる側
+（安全側）に倒すため、SCW 保有ユーザーは実残高のみを資金源とみなす。
 
 戻り値:
   - Decimal: 解決できた deposit（USD）
@@ -32,6 +40,21 @@ from sqlalchemy.orm import Session
 from app.auth.models import User
 
 
+def uses_custodial_allocation(user: Optional[User]) -> bool:
+    """このユーザーの資金源として `fund_allocations`（custodial 枠）を使ってよいか。
+
+    smart_wallet_address を持つユーザーは執行が本人 SCW から行われるため、プールの
+    持分帳簿である `fund_allocations` を資金源に使わない（モジュール docstring の 0 参照）。
+
+    Args:
+        user: 対象ユーザー。None は「判別不能」なので従来どおり allocation を許可する。
+
+    Returns:
+        allocation を資金源として使ってよいなら True。
+    """
+    return not (user is not None and user.smart_wallet_address)
+
+
 def resolve_user_deposit_usd(db: Session, user_id: int) -> Optional[Decimal]:
     """ユーザーの deposit（運用に充てられる入金額・USD）を解決する。
 
@@ -44,21 +67,23 @@ def resolve_user_deposit_usd(db: Session, user_id: int) -> Optional[Decimal]:
     """
     from app.partner.allocation_models import FundAllocation  # noqa: PLC0415
 
-    # ── 1. fund_allocation 優先（custodial 枠） ──
-    raw = (
-        db.query(func.sum(FundAllocation.allocated_amount_usd))
-        .filter(
-            FundAllocation.tester_user_id == user_id,
-            FundAllocation.status == "active",
+    user = db.get(User, user_id)
+
+    # ── 1. fund_allocation 優先（custodial 枠 / SCW 保有ユーザーは対象外） ──
+    if uses_custodial_allocation(user):
+        raw = (
+            db.query(func.sum(FundAllocation.allocated_amount_usd))
+            .filter(
+                FundAllocation.tester_user_id == user_id,
+                FundAllocation.status == "active",
+            )
+            .scalar()
         )
-        .scalar()
-    )
-    allocated = Decimal(str(raw)) if raw else Decimal("0")
-    if allocated > Decimal("0"):
-        return allocated
+        allocated = Decimal(str(raw)) if raw else Decimal("0")
+        if allocated > Decimal("0"):
+            return allocated
 
     # ── 2. fallback: 非カストディアル消費者の wallet USDC 残高 ──
-    user = db.get(User, user_id)
     wallet = (user.smart_wallet_address or user.wallet_address) if user else None
     if wallet:
         from app.aave.balance import read_wallet_usdc_balance  # noqa: PLC0415

--- a/backend/tests/test_aave_exec_safety_gate.py
+++ b/backend/tests/test_aave_exec_safety_gate.py
@@ -34,6 +34,17 @@ from app.proposals.models import Proposal  # noqa: E402
 _WALLET = "0xExecGate0000000000000000000000000000000001"
 
 
+@pytest.fixture(autouse=True)
+def _enable_custodial_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """本ファイルは custodial 単一鍵経路そのものの検証。
+
+    `CUSTODIAL_EXECUTION_ENABLED` は 2026-08-06 に既定 false へ分離された
+    （`AUTO_EXECUTION_ENABLED=true` が委譲経路と custodial 経路を同時に開いてしまう問題の
+    対策 / `_custodial_execution_enabled` 参照）。ここでは検証対象なので明示的に開ける。
+    """
+    monkeypatch.setenv("CUSTODIAL_EXECUTION_ENABLED", "true")
+
+
 @pytest.fixture()
 def db_session() -> Generator[Session, None, None]:
     fd, path = tempfile.mkstemp(suffix=".db")

--- a/backend/tests/test_ai_judgment_scheduler.py
+++ b/backend/tests/test_ai_judgment_scheduler.py
@@ -1458,15 +1458,15 @@ def test_resolve_amount_wallet_balance_unavailable_is_skipped(db_session, monkey
     assert sched._resolve_proposal_amount(db_session, user.id) == Decimal("0")
 
 
-def test_resolve_amount_allocation_takes_priority_over_wallet(db_session, monkeypatch):
-    """allocation と wallet 双方ある場合は allocation を優先 (既存パートナー互換)。
+def test_resolve_amount_allocation_takes_priority_for_custodial_user(db_session, monkeypatch):
+    """SCW を持たない custodial ユーザーは allocation を優先 (既存パートナー互換)。
 
     allocation $10,000 → $1,000。wallet 残高は参照されない。
     """
     import app.automation.ai_judgment_scheduler as sched  # noqa: PLC0415
 
     user = _add_active_user(db_session, "both@example.com")
-    user.smart_wallet_address = "0x" + "e" * 40
+    user.wallet_address = "0x" + "e" * 40
     _add_fund_allocation(db_session, user, allocated_usd=Decimal("10000"))
     db_session.commit()
 
@@ -1475,6 +1475,34 @@ def test_resolve_amount_allocation_takes_priority_over_wallet(db_session, monkey
 
     monkeypatch.setattr(sched, "_read_wallet_usdc_balance", _should_not_be_called)
     assert sched._resolve_proposal_amount(db_session, user.id) == Decimal("1000.00")
+
+
+def test_resolve_amount_scw_user_ignores_allocation(db_session, monkeypatch):
+    """★SCW を持つユーザーは allocation(帳簿) でなく on-chain 実残高で sizing する。
+
+    2026-08-06 に規則変更。`fund_allocations` は custodial プール持分の帳簿行であり
+    オンチェーンの裏付けが無い。SCW 執行の分母に使うと実残高の何倍もの提案を作り、
+    承認後に on-chain revert する（本番 user 11 が allocation $4,600 / SCW 残高 $0 の形
+    だった）。ゲート側 `resolve_user_deposit_usd` と同一規則。
+    """
+    import app.automation.ai_judgment_scheduler as sched  # noqa: PLC0415
+
+    scw = "0x" + "e" * 40
+    user = _add_active_user(db_session, "scw-with-allocation@example.com")
+    user.smart_wallet_address = scw
+    _add_fund_allocation(db_session, user, allocated_usd=Decimal("10000"))
+    db_session.commit()
+
+    read: list[str] = []
+
+    def _read(addr):
+        read.append(addr)
+        return Decimal("2000")
+
+    monkeypatch.setattr(sched, "_read_wallet_usdc_balance", _read)
+    # 帳簿 $10,000 の 10% = $1,000 ではなく、実残高 $2,000 の 10% = $200。
+    assert sched._resolve_proposal_amount(db_session, user.id) == Decimal("200.00")
+    assert read == [scw]
 
 
 def test_resolve_amount_no_allocation_no_wallet_notifies_and_zero(db_session, monkeypatch):

--- a/backend/tests/test_custodial_fallback_hardening.py
+++ b/backend/tests/test_custodial_fallback_hardening.py
@@ -38,6 +38,17 @@ from app.proposals.models import Proposal  # noqa: E402
 _WALLET = "0xCustodialFallback00000000000000000000001"
 
 
+@pytest.fixture(autouse=True)
+def _enable_custodial_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """本ファイルは custodial 単一鍵経路そのものの検証。
+
+    `CUSTODIAL_EXECUTION_ENABLED` は 2026-08-06 に既定 false へ分離された
+    （`AUTO_EXECUTION_ENABLED=true` が委譲経路と custodial 経路を同時に開いてしまう問題の
+    対策 / `_custodial_execution_enabled` 参照）。ここでは検証対象なので明示的に開ける。
+    """
+    monkeypatch.setenv("CUSTODIAL_EXECUTION_ENABLED", "true")
+
+
 @pytest.fixture()
 def db_session() -> Generator[Session, None, None]:
     fd, path = tempfile.mkstemp(suffix=".db")

--- a/backend/tests/test_deposit_resolver.py
+++ b/backend/tests/test_deposit_resolver.py
@@ -12,9 +12,15 @@ from app.users.deposit_resolver import resolve_user_deposit_usd
 
 
 def _db_with_allocation(total) -> MagicMock:  # type: ignore[no-untyped-def]
-    """db.query(...).filter(...).scalar() が total を返す mock セッション。"""
+    """db.query(...).filter(...).scalar() が total を返す mock セッション。
+
+    db.get は既定で「SCW を持たない custodial ユーザー」を返す。素の MagicMock だと
+    smart_wallet_address が truthy になり、SCW 保有ユーザー扱いで allocation が
+    資金源から外れてしまう（uses_custodial_allocation / 2026-08-06）。
+    """
     db = MagicMock()
     db.query.return_value.filter.return_value.scalar.return_value = total
+    db.get.return_value = MagicMock(smart_wallet_address=None, wallet_address=None)
     return db
 
 

--- a/backend/tests/test_partner_wallet_routing.py
+++ b/backend/tests/test_partner_wallet_routing.py
@@ -44,6 +44,17 @@ HASHIGUCHI_WALLET = "0xHashiguchi2222222222222222222222222222222"
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _enable_custodial_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """本ファイルは custodial 単一鍵経路そのものの検証。
+
+    `CUSTODIAL_EXECUTION_ENABLED` は 2026-08-06 に既定 false へ分離された
+    （`AUTO_EXECUTION_ENABLED=true` が委譲経路と custodial 経路を同時に開いてしまう問題の
+    対策 / `_custodial_execution_enabled` 参照）。ここでは検証対象なので明示的に開ける。
+    """
+    monkeypatch.setenv("CUSTODIAL_EXECUTION_ENABLED", "true")
+
+
 @pytest.fixture()
 def db_session() -> Generator[Session, None, None]:
     fd, path = tempfile.mkstemp(suffix=".db")

--- a/backend/tests/test_phase2d_a_wiring.py
+++ b/backend/tests/test_phase2d_a_wiring.py
@@ -121,6 +121,7 @@ def test_risk_limiter_holds_execution(db_session: Session) -> None:
         return _fake_result()
 
     with (
+        patch.dict(os.environ, {"CUSTODIAL_EXECUTION_ENABLED": "true"}),
         patch(
             "app.automation.safety_gate.evaluate_hard_stop",
             return_value=HardStopResult(blocked=False),
@@ -156,6 +157,7 @@ def test_risk_limiter_pass_allows_execution(db_session: Session) -> None:
         return _fake_result()
 
     with (
+        patch.dict(os.environ, {"CUSTODIAL_EXECUTION_ENABLED": "true"}),
         patch(
             "app.automation.safety_gate.evaluate_hard_stop",
             return_value=HardStopResult(blocked=False),
@@ -282,7 +284,10 @@ def test_auto_execution_flag_no_longer_requires_grant_for_human_approval(
     )
 
     with (
-        patch.dict(os.environ, {"AUTO_EXECUTION_ENABLED": "true"}),
+        patch.dict(
+            os.environ,
+            {"AUTO_EXECUTION_ENABLED": "true", "CUSTODIAL_EXECUTION_ENABLED": "true"},
+        ),
         patch(
             "app.aave.service.MultiChainAaveService.execute_rebalance",
             return_value=fake_result,
@@ -341,6 +346,7 @@ def test_shadow_does_not_change_execution_behavior(db_session: Session) -> None:
         return _fake_result()
 
     with (
+        patch.dict(os.environ, {"CUSTODIAL_EXECUTION_ENABLED": "true"}),
         patch(
             "app.automation.safety_gate.evaluate_hard_stop",
             return_value=HardStopResult(blocked=False),
@@ -376,6 +382,7 @@ def test_shadow_passes_none_to_limiter(db_session: Session) -> None:
         return None
 
     with (
+        patch.dict(os.environ, {"CUSTODIAL_EXECUTION_ENABLED": "true"}),
         patch(
             "app.automation.safety_gate.evaluate_hard_stop",
             return_value=HardStopResult(blocked=False),
@@ -408,6 +415,7 @@ def test_shadow_failure_does_not_break_execution(db_session: Session) -> None:
     called: list[bool] = []
 
     with (
+        patch.dict(os.environ, {"CUSTODIAL_EXECUTION_ENABLED": "true"}),
         patch(
             "app.automation.safety_gate.evaluate_hard_stop",
             return_value=HardStopResult(blocked=False),

--- a/backend/tests/test_proposal_deadletter.py
+++ b/backend/tests/test_proposal_deadletter.py
@@ -34,6 +34,17 @@ from app.proposals.router import (  # noqa: E402
 )
 
 
+@pytest.fixture(autouse=True)
+def _enable_custodial_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """本ファイルは custodial 単一鍵経路そのものの検証。
+
+    `CUSTODIAL_EXECUTION_ENABLED` は 2026-08-06 に既定 false へ分離された
+    （`AUTO_EXECUTION_ENABLED=true` が委譲経路と custodial 経路を同時に開いてしまう問題の
+    対策 / `_custodial_execution_enabled` 参照）。ここでは検証対象なので明示的に開ける。
+    """
+    monkeypatch.setenv("CUSTODIAL_EXECUTION_ENABLED", "true")
+
+
 @pytest.fixture()
 def db_session() -> Generator[Session, None, None]:
     fd, path = tempfile.mkstemp(suffix=".db")

--- a/backend/tests/test_proposal_deposit_gate.py
+++ b/backend/tests/test_proposal_deposit_gate.py
@@ -12,8 +12,14 @@ from app.automation.ai_judgment_scheduler import _resolve_proposal_amount
 
 
 def _db_with_allocation(total) -> MagicMock:  # type: ignore[no-untyped-def]
+    """db.get は既定で「SCW を持たない custodial ユーザー」を返す。
+
+    素の MagicMock だと smart_wallet_address が truthy になり、SCW 保有ユーザー扱いで
+    allocation が sizing の分母から外れる（uses_custodial_allocation / 2026-08-06）。
+    """
     db = MagicMock()
     db.query.return_value.filter.return_value.scalar.return_value = total
+    db.get.return_value = MagicMock(smart_wallet_address=None, wallet_address=None)
     return db
 
 

--- a/backend/tests/test_proposal_execute_failure.py
+++ b/backend/tests/test_proposal_execute_failure.py
@@ -43,6 +43,17 @@ SAMPLE_PROPOSAL = {
 }
 
 
+@pytest.fixture(autouse=True)
+def _enable_custodial_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """本ファイルは custodial 単一鍵経路そのものの検証。
+
+    `CUSTODIAL_EXECUTION_ENABLED` は 2026-08-06 に既定 false へ分離された
+    （`AUTO_EXECUTION_ENABLED=true` が委譲経路と custodial 経路を同時に開いてしまう問題の
+    対策 / `_custodial_execution_enabled` 参照）。ここでは検証対象なので明示的に開ける。
+    """
+    monkeypatch.setenv("CUSTODIAL_EXECUTION_ENABLED", "true")
+
+
 @pytest.fixture()
 def test_db() -> Generator:
     fd, path = tempfile.mkstemp(suffix=".db")

--- a/backend/tests/test_proposal_execution_route.py
+++ b/backend/tests/test_proposal_execution_route.py
@@ -40,6 +40,17 @@ from app.proposals.execution_route import (  # noqa: E402
 from app.proposals.models import Proposal  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def _enable_custodial_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """本ファイルは custodial 単一鍵経路そのものの検証。
+
+    `CUSTODIAL_EXECUTION_ENABLED` は 2026-08-06 に既定 false へ分離された
+    （`AUTO_EXECUTION_ENABLED=true` が委譲経路と custodial 経路を同時に開いてしまう問題の
+    対策 / `_custodial_execution_enabled` 参照）。ここでは検証対象なので明示的に開ける。
+    """
+    monkeypatch.setenv("CUSTODIAL_EXECUTION_ENABLED", "true")
+
+
 @pytest.fixture()
 def db_session() -> Generator[Session, None, None]:
     fd, path = tempfile.mkstemp(suffix=".db")

--- a/backend/tests/test_proposal_wallet_propagation.py
+++ b/backend/tests/test_proposal_wallet_propagation.py
@@ -137,7 +137,9 @@ def test_wallet_address_is_propagated_to_execute_rebalance(
     )
 
     with (
-        patch.dict(os.environ, {"AUTO_EXECUTION_ENABLED": "true"}),
+        patch.dict(
+            os.environ, {"AUTO_EXECUTION_ENABLED": "true", "CUSTODIAL_EXECUTION_ENABLED": "true"}
+        ),
         patch(
             "app.aave.service.MultiChainAaveService.execute_rebalance",
             return_value=fake_result,
@@ -166,7 +168,9 @@ def test_null_wallet_is_blocked_by_layer1_guard(client: TestClient, test_db: tup
     _set_admin_wallet(SessionLocal, None)
 
     with (
-        patch.dict(os.environ, {"AUTO_EXECUTION_ENABLED": "true"}),
+        patch.dict(
+            os.environ, {"AUTO_EXECUTION_ENABLED": "true", "CUSTODIAL_EXECUTION_ENABLED": "true"}
+        ),
         patch(
             "app.aave.service.MultiChainAaveService.execute_rebalance",
         ) as mock_execute,
@@ -205,7 +209,9 @@ def test_two_users_propagate_their_own_wallets(client: TestClient, test_db: tupl
     )
 
     with (
-        patch.dict(os.environ, {"AUTO_EXECUTION_ENABLED": "true"}),
+        patch.dict(
+            os.environ, {"AUTO_EXECUTION_ENABLED": "true", "CUSTODIAL_EXECUTION_ENABLED": "true"}
+        ),
         patch(
             "app.aave.service.MultiChainAaveService.execute_rebalance",
             return_value=fake_result,
@@ -223,7 +229,9 @@ def test_two_users_propagate_their_own_wallets(client: TestClient, test_db: tupl
     _set_admin_wallet(SessionLocal, HASHIGUCHI_WALLET)
 
     with (
-        patch.dict(os.environ, {"AUTO_EXECUTION_ENABLED": "true"}),
+        patch.dict(
+            os.environ, {"AUTO_EXECUTION_ENABLED": "true", "CUSTODIAL_EXECUTION_ENABLED": "true"}
+        ),
         patch(
             "app.aave.service.MultiChainAaveService.execute_rebalance",
             return_value=fake_result,

--- a/backend/tests/test_real_funds_execution_gates.py
+++ b/backend/tests/test_real_funds_execution_gates.py
@@ -1,0 +1,249 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/test_real_funds_execution_gates.py
+"""実資金投入前に閉じた 2 つのゲートの回帰テスト（2026-08-06）。
+
+背景: 「完全おまかせ」を実資金で動かすために `AUTO_EXECUTION_ENABLED=true` にする、
+という操作の副作用として以下 2 つが起きることが本番調査で判明した。
+
+1. `AUTO_EXECUTION_ENABLED` は執行段階のマスタースイッチで、委譲(SCW)経路は
+   `_execute_aave_for_proposal` の内側にある。つまり true にすると、**委譲枠を持たない
+   ユーザーの承認までサーバー単一鍵(`AAVE_WALLET_PRIVATE_KEY`)でプール資金を動かす経路**が
+   同時に開く。→ `CUSTODIAL_EXECUTION_ENABLED`（既定 false）に分離した。
+
+2. 入金ゲート / 提案サイジングが `fund_allocations`（custodial プール持分の**帳簿行**）を
+   最優先していた。SCW を持つユーザーの執行は本人 SCW から行われるため、帳簿額でゲートを
+   通すと「$200 ゲート通過 → SCW 残高 0 で on-chain revert」になる。本番 user 11 が
+   allocation $4,600 / SCW 実残高 $0 でこの状態だった。→ SCW 保有ユーザーは実残高のみを
+   資金源とみなす（`uses_custodial_allocation`）。
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.aave.schemas import AaveOperationResult, AaveOperationStatus, AaveOperationType
+from app.auth.models import User
+from app.automation.safety_gate import HardStopResult
+from app.database import Base
+from app.partner.allocation_models import FundAllocation
+from app.proposals.models import Proposal
+
+_EOA = "0x999e696e4c595356b29dd5314fad29247022a3a8"
+_SCW = "0x5d7769d41e4af7f1153b94909702e8db382f3158"
+
+
+@pytest.fixture()
+def db_session() -> Generator[Session, None, None]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestSession()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        os.unlink(path)
+
+
+def _make_user(db: Session, uid: int, *, scw: str | None = None) -> User:
+    user = User(
+        id=uid,
+        email=f"gate{uid}@test.com",
+        username=f"gate{uid}",
+        hashed_password="x",
+        role="partner",
+        is_active=True,
+        wallet_address=_EOA,
+        smart_wallet_address=scw,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _make_allocation(db: Session, user_id: int, amount: str) -> FundAllocation:
+    allocation = FundAllocation(
+        partner_id=1,
+        tester_name=f"tester{user_id}",
+        tester_user_id=user_id,
+        allocated_amount_usd=Decimal(amount),
+        status="active",
+    )
+    db.add(allocation)
+    db.flush()
+    return allocation
+
+
+def _make_proposal(db: Session, user_id: int) -> Proposal:
+    proposal = Proposal(
+        user_id=user_id,
+        operation="SUPPLY",
+        asset="USDC",
+        amount=Decimal("1000"),
+        amount_usd=Decimal("1000.00"),
+        reason="real-funds gate test",
+        status="approved",
+        approved_at=datetime.now(timezone.utc),
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    db.add(proposal)
+    db.flush()
+    return proposal
+
+
+def _fake_result() -> AaveOperationResult:
+    return AaveOperationResult(
+        operation=AaveOperationType.DEPOSIT,
+        status=AaveOperationStatus.SUCCESS,
+        asset_symbol="USDC",
+        amount=Decimal("1000.00"),
+        tx_hash="0xdeadbeef",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# ゲート 1: custodial 単一鍵実行の分離
+# --------------------------------------------------------------------------- #
+def test_custodial_execution_disabled_by_default(db_session: Session) -> None:
+    """★委譲枠なしユーザーは、既定でサーバー単一鍵実行に落ちないこと。
+
+    ここが壊れると `AUTO_EXECUTION_ENABLED=true` にした瞬間に、委譲枠を持たない
+    admin/partner/viewer の承認クリックがプール資金を実際に動かす。
+    """
+    from app.proposals.router import _execute_aave_for_proposal
+
+    user = _make_user(db_session, uid=101)
+    proposal = _make_proposal(db_session, user_id=user.id)
+    db_session.commit()
+
+    called: list[bool] = []
+
+    with (
+        patch.dict(os.environ, {}, clear=False),
+        patch(
+            "app.automation.safety_gate.evaluate_hard_stop",
+            return_value=HardStopResult(blocked=False),
+        ),
+        patch("app.aave.risk_limiter.check_trade_within_limits", return_value=None),
+        patch(
+            "app.aave.service.MultiChainAaveService.execute_rebalance",
+            side_effect=lambda **_: called.append(True) or _fake_result(),
+        ),
+    ):
+        os.environ.pop("CUSTODIAL_EXECUTION_ENABLED", None)
+        _execute_aave_for_proposal(proposal, db_session)
+
+    assert called == [], "custodial 単一鍵実行が既定で走ってしまっている"
+    # transient 扱い: 手動署名フローで拾えるよう 'approved' のまま据え置く。
+    assert proposal.status == "approved"
+
+
+def test_custodial_execution_runs_when_explicitly_enabled(db_session: Session) -> None:
+    """明示的に CUSTODIAL_EXECUTION_ENABLED=true にしたときのみ従来経路が動く。"""
+    from app.proposals.router import _execute_aave_for_proposal
+
+    user = _make_user(db_session, uid=102)
+    proposal = _make_proposal(db_session, user_id=user.id)
+    db_session.commit()
+
+    called: list[bool] = []
+
+    with (
+        patch.dict(os.environ, {"CUSTODIAL_EXECUTION_ENABLED": "true"}),
+        patch(
+            "app.automation.safety_gate.evaluate_hard_stop",
+            return_value=HardStopResult(blocked=False),
+        ),
+        patch("app.aave.risk_limiter.check_trade_within_limits", return_value=None),
+        patch(
+            "app.aave.service.MultiChainAaveService.execute_rebalance",
+            side_effect=lambda **_: called.append(True) or _fake_result(),
+        ),
+    ):
+        _execute_aave_for_proposal(proposal, db_session)
+
+    assert called == [True]
+    assert proposal.status == "executed"
+
+
+# --------------------------------------------------------------------------- #
+# ゲート 2: SCW ユーザーは帳簿でなく実残高を資金源にする
+# --------------------------------------------------------------------------- #
+def test_scw_user_deposit_ignores_custodial_allocation(db_session: Session) -> None:
+    """★本番 user 11 の形: allocation $4,600 / SCW 実残高 $0 → 判定は実残高側。
+
+    ここが壊れると帳簿額で $200 ゲートを通過し、残高 0 の SCW に supply して revert する。
+    """
+    from app.users.deposit_resolver import resolve_user_deposit_usd
+
+    user = _make_user(db_session, uid=103, scw=_SCW)
+    _make_allocation(db_session, user.id, "4600")
+    db_session.commit()
+
+    with patch("app.aave.balance.read_wallet_usdc_balance", return_value=Decimal("0")) as m:
+        deposit = resolve_user_deposit_usd(db_session, user.id)
+
+    assert deposit == Decimal("0"), "帳簿額 $4,600 が使われている"
+    m.assert_called_once_with(_SCW)
+
+
+def test_custodial_user_still_uses_allocation(db_session: Session) -> None:
+    """SCW を持たない custodial パートナー/テスターは従来どおり allocation を使う（非回帰）。"""
+    from app.users.deposit_resolver import resolve_user_deposit_usd
+
+    user = _make_user(db_session, uid=104, scw=None)
+    _make_allocation(db_session, user.id, "10000")
+    db_session.commit()
+
+    assert resolve_user_deposit_usd(db_session, user.id) == Decimal("10000")
+
+
+def test_scw_user_proposal_sizing_uses_onchain_balance(db_session: Session) -> None:
+    """提案サイジングもゲートと同じ規則で解決されること（両者の乖離を防ぐ）。
+
+    乖離すると「実残高では通らない額の提案が生成され、承認時に初めて弾かれる」
+    という無駄な期限切れを量産する。
+    """
+    from app.automation.ai_judgment_scheduler import _resolve_proposal_amount
+
+    user = _make_user(db_session, uid=105, scw=_SCW)
+    _make_allocation(db_session, user.id, "4600")
+    db_session.commit()
+
+    # SCW 実残高 $1,000 → 10% = $100（帳簿 $4,600 の 10% = $460 ではない）
+    with patch(
+        "app.automation.ai_judgment_scheduler._read_wallet_usdc_balance",
+        return_value=Decimal("1000"),
+    ):
+        amount = _resolve_proposal_amount(db_session, user.id)
+
+    assert amount == Decimal("100.00")
+
+
+def test_scw_user_below_minimum_deposit_is_skipped(db_session: Session) -> None:
+    """SCW 実残高が最低入金額未満なら提案を作らない（帳簿があっても）。"""
+    from app.automation.ai_judgment_scheduler import _resolve_proposal_amount
+
+    user = _make_user(db_session, uid=106, scw=_SCW)
+    _make_allocation(db_session, user.id, "4600")
+    db_session.commit()
+
+    with patch(
+        "app.automation.ai_judgment_scheduler._read_wallet_usdc_balance",
+        return_value=Decimal("50"),
+    ):
+        amount = _resolve_proposal_amount(db_session, user.id)
+
+    assert amount == Decimal("0")


### PR DESCRIPTION
## Summary

実資金 GO（2026-08-06 hkobayashi 判断・山本さん/橋口さんを「完全おまかせ」で実運用に乗せる）を受けた事前調査で、`AUTO_EXECUTION_ENABLED=true` にする操作が意図より広い範囲を開けることが判明したため、実資金を入れる前に 2 つのゲートを分離・是正する。**本 PR 単体では挙動は変わらない**（新フラグは既定 false、SCW 判定は現状の本番データでは「ブロック側に倒れる」方向のみ）。

### 1. `AUTO_EXECUTION_ENABLED` が委譲経路と custodial 単一鍵経路を同時に開けてしまう

委譲(SCW)実行は `_execute_supply_via_scw` にあるが、その呼び出しは
`_run_approval_and_execution` → `if auto_execution_enabled:` → `_dispatch_custodial_execution` →
`_execute_aave_for_proposal` の**内側**にある。したがって「委譲おまかせを動かすためにフラグを true にする」と、
**委譲枠を持たないユーザーの承認クリックまで、サーバー単一鍵 `AAVE_WALLET_PRIVATE_KEY` で
プール資金を動かす経路**として同時に開く。本番に実鍵は存在する（`.env.production` に設定済み）。

→ `CUSTODIAL_EXECUTION_ENABLED`（既定 `false`）を新設して分離。委譲枠なしユーザーは
既存の「SCW 対象外操作」分岐と同じく `approved` 据え置き（transient 扱い）にし、
手動署名フロー（build-tx / submit-tx）は従来どおり使える。

コード上の既存コメント「non-custodial 方式2 では default=false。`AAVE_WALLET_PRIVATE_KEY` が
署名する経路はこのフラグで完全に無効化される」という設計意図を、フラグ 1 本では守れていなかった。

### 2. 入金ゲート / 提案サイジングが「帳簿」を実残高より優先していた

`fund_allocations` は custodial プール持分の**帳簿行**でオンチェーンの裏付けを持たない。
一方 SCW を持つユーザーの執行は本人 SCW から行われる。この不一致により、本番の
**user 11（山本さん）は allocation $4,600 / SCW 実残高 $0** で、
「$200 入金ゲートを通過 → 残高 0 の SCW に $460 supply → on-chain revert」が確定する状態だった。
（Aave Pool `getUserAccountData` で実測: 山本 SCW `0x5d77…3158` 担保 $0 / 橋口 SCW `0xe715…a0c2` 担保 $0）

→ `uses_custodial_allocation()` を新設し、**SCW を持つユーザーは on-chain 実残高のみを資金源**とする。
入金ゲート（`deposit_resolver`）と提案サイジング（`ai_judgment_scheduler._resolve_proposal_amount`）の
**両方**に適用。片方だけ直すと「実残高では通らない額の提案が生成され、承認時に初めて弾かれる」
という無駄な期限切れを量産するため。

SCW を持たない custodial パートナー/テスター（user 16 等）は従来どおり allocation を使う（非回帰テストあり）。

## 挙動の変化

| 対象 | 変更前 | 変更後 |
|---|---|---|
| 委譲枠なしユーザー + `AUTO_EXECUTION_ENABLED=true` | サーバー鍵で custodial 実行 | `approved` 据え置き（`CUSTODIAL_EXECUTION_ENABLED=true` で従来どおり） |
| SCW 保有 + allocation あり（user 11） | 帳簿 $4,600 で判定 | SCW 実残高で判定（現状 $0 → 安全にブロック） |
| SCW なし + allocation あり（user 16） | 変化なし | 変化なし |
| 現行本番（両フラグとも false 相当） | — | **変化なし** |

## やっていないこと（スコープ外）

- `.env.production` への `CUSTODIAL_EXECUTION_ENABLED` 追記・本番デプロイ・`AUTO_EXECUTION_ENABLED` の切替は**含まない**（Tier S / HUMAN-REVIEW / 3段プロトコルで hkobayashi さん実施）
- `reward_auto_claim_loop`（`scheduled_tasks.py`）もサーバー鍵を使うが、報酬の**受取**でありプール資金の払い出しではないため本 PR では触っていない
- user 11 の `fund_allocations` $4,600 の実額合わせ（運用判断）

## マージ後の運用手順（実資金化・順序厳守）

1. 山本さん・橋口さんが**自分の SCW** に実 USDC を入金
   （山本 `0x5d7769d41e4af7f1153b94909702e8db382f3158` / 橋口 `0xe7150ffde4698c50395b4199b81826bf715da0c2`）
   ※ `MIN_DEPOSIT_USD=200` は通るが、採算ゲート込みの実効下限は約 $852（Asana 1217210584886168 系）
2. 両名が liff-chat で「完全おまかせ」を**選び直す**（委譲枠は UI 操作でしか作られない）。
   PR #1029 で承認制へ降格済みで、降格通知は `channel=line` / `delivered=NULL`＝Privy ユーザーには
   届いていないため、**人力での連絡が必要**

   > **入金より先に選ばせない。** 本 PR 適用後、user 11 の `resolve_user_deposit_usd` は
   > 帳簿 $4,600 ではなく SCW 実残高（現状 $0）を返すため、`PUT /api/user/settings` が
   > 422 `DEPOSIT_BELOW_MINIMUM` で弾かれる。`runDelegationConsent` は PUT の**前**に走るので、
   > 「Privy 署名だけ済んで運用モードは承認制のまま」という半端な状態になる
   > （既存 grant は再利用されるので再選択で回復はする）。
3. 本 PR をデプロイ（backend）。`.env.production` に `CUSTODIAL_EXECUTION_ENABLED=false` を明示追記
   （未設定でも既定 false だが、意図を env に残す）
4. `AUTO_EXECUTION_ENABLED=true`（3段プロトコル / hkobayashi さん）
5. `delegation_grants` に有効行・少額 1 件で tx receipt `status=1` を確認

## Test plan

- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — 738 files already formatted
- [x] `mypy app/ --config-file ../pyproject.toml` — 既存の `stripe` stub 欠落 2 件のみ（本 PR 無関係・触っていないファイル）
- [x] `pytest tests/` — 全通過
- [x] 新規 `tests/test_real_funds_execution_gates.py` 6 件。**修正を stash して実行し 4 件が落ちることを確認**（空振りテストでないことの確認）。残る 2 件は非回帰ガード（custodial ユーザーは従来どおり / 明示 true なら従来どおり動く）
- [x] 既存 custodial 経路テスト 7 ファイルは autouse fixture で `CUSTODIAL_EXECUTION_ENABLED=true` を明示（custodial 経路そのものの検証であるため）。mock セッションの `db.get` が素の MagicMock だと `smart_wallet_address` が truthy になり SCW 保有と誤判定される問題も併せて修正