### PR TITLE
fix(db): alembic revision ID衝突を解消 (b9c0d1e2f3a4重複)

### DIFF
--- a/backend/alembic/versions/c1d2e3f4a5b6_add_missing_wallet_address_unique_index.py
+++ b/backend/alembic/versions/c1d2e3f4a5b6_add_missing_wallet_address_unique_index.py
@@ -36,8 +36,17 @@ production の `users` テーブルは alembic migration を1本も実行せず�
 型 (`VARCHAR(255)` vs models.py の `String(42)`) は最大長42文字で実害が無いため
 本リビジョンでは変更しない (個別判断へ持ち越し)。
 
-Revision ID: b9c0d1e2f3a4
-Revises: a8b9c0d1e2f3
+## revision ID 再採番 (2026-08-06)
+
+初回リビジョン ID `b9c0d1e2f3a4` は、同じ親 (`a8b9c0d1e2f3`) から独立に
+分岐した別PR (`add_gas_sponsored_to_transactions`) と衝突していたため
+`c1d2e3f4a5b6` に採番し直し、`down_revision` を衝突相手のリビジョンへ
+繋ぎ直した (production デプロイ時に `alembic upgrade head` が
+"Multiple head revisions" で失敗し発覚。production への反映前に検出、
+実害なし)。
+
+Revision ID: c1d2e3f4a5b6
+Revises: b9c0d1e2f3a4
 Create Date: 2026-08-06 00:00:00.000000
 """
 
@@ -45,8 +54,8 @@ from typing import Sequence, Union
 
 from alembic import op
 
-revision: str = "b9c0d1e2f3a4"
-down_revision: Union[str, Sequence[str], None] = "a8b9c0d1e2f3"
+revision: str = "c1d2e3f4a5b6"
+down_revision: Union[str, Sequence[str], None] = "b9c0d1e2f3a4"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## 背景

PR #1033 (`add_gas_sponsored_to_transactions`) と PR #1036 (`add_missing_wallet_address_unique_index`) が同じ親revision (`a8b9c0d1e2f3`) から独立に分岐し、両方が revision ID `b9c0d1e2f3a4` を使ってしまい衝突していた。

production デプロイ時に `alembic upgrade head` が "Multiple head revisions" で失敗し発覚（production への反映前に検出、実害なし）。

## 修正内容

`add_missing_wallet_address_unique_index` を `c1d2e3f4a5b6` に再採番し、`down_revision` を `add_gas_sponsored_to_transactions` (`b9c0d1e2f3a4`) に繋ぎ直して単一head化した。

## 検証結果

- `alembic heads` → `c1d2e3f4a5b6 (head)` の単一head確認済み
- `alembic history` → a8b9c0d1e2f3 → b9c0d1e2f3a4 → c1d2e3f4a5b6 の線形チェーン確認済み
- `ruff check` / `ruff format --check`: pass

## 注記

このPRはmigrationのリビジョンID衝突のみを解消するもので、`add_missing_wallet_address_unique_index` migration自体の内容（`ix_users_wallet_address` UNIQUE index追加）は変更していない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)