### PR TITLE
feat(automation): 到達経路ゼロの承認型ユーザーへの提案生成を停止する (B-6)

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -77,6 +77,13 @@ _PROPOSAL_EXPIRES_HOURS = 168
 # 運営へアラートする閾値。無限に作り直し続けている状態を検知するためのもの。
 _CONSECUTIVE_EXPIRY_ALERT_THRESHOLD = 3
 
+# 受け入れ条件 B-6 (2026-08-06): 到達経路ゼロの承認型ユーザーへ提案を作らない際の
+# 運用者アラートの再送間隔。スケジューラは毎 tick 走るため、絞らないと同一ユーザーで
+# Slack を埋め尽くす (既存の _notify_missing_delegation_grant 等が実際にそうなっており、
+# 14 日で 451 件出ていた)。プロセス内メモリのみで保持し、再起動時は再通知でよい。
+_UNREACHABLE_ALERT_INTERVAL_HOURS = 24
+_unreachable_alerted_at: dict[int, datetime] = {}
+
 # 提案金額: fund_allocations.allocated_amount_usd から実行済み提案の積み上げ (deployed) を
 # 差し引いた遊休額 (idle) × _PROPOSAL_RATIO で動的計算 (2026-08-06: 静的台帳→動的遊休額へ
 # 変更 / Asana 1217210604911292、詳細は _resolve_deployed_amount_usd 参照)。
@@ -385,6 +392,106 @@ def _notify_downgrade_unreachable(user_id: int) -> None:
         get_notification_service().send(msg)
     except Exception as exc:  # noqa: BLE001
         logger.warning("_notify_downgrade_unreachable failed for user_id=%d: %s", user_id, exc)
+
+
+def _user_has_reachable_channel(db: Session, user_id: int) -> bool:
+    """そのユーザーに通知を届ける手段が実在するか (受け入れ条件 B-6 の判定)。
+
+    2026-08-06: LINE は廃止済みで、エンドユーザーへの到達経路は Web Push のみ。
+    判定基準は実配信 (`_deliver_ai_proposal_push`) と**同一**にする。片方だけ緩いと
+    「到達可能と判定したのに配信側では弾かれる」ズレが生まれ、本プロジェクトが
+    繰り返してきた「表示と実態の乖離」を新たに作ることになる。
+
+    True を返す条件 (すべて必要):
+      - 通知設定が当該種別の Push を許可している (B-N4)
+      - 購読行が 1 件以上ある
+
+    **VAPID 未設定は「そのユーザーが到達不能」ではなく「配信基盤全体の障害」**であり、
+    ここでは到達可能扱い (True) にする。B-6 は *ユーザーごと* の到達経路に関する要件で、
+    システム全体の設定ミスは別問題。ここで False に倒すと env 変数 1 つの設定ミスが
+    「全承認型ユーザーの提案生成が無言で止まる」に化け、防ごうとしている静かな故障より
+    大きな故障を作ることになる。基盤障害側は配信時に delivered=False として記録され、
+    到達率 (B-4) の急落として現れる。
+
+    判定不能な例外時も同様に **True (到達可能扱い)** を返す (可用性の後退を避ける)。
+    """
+    try:
+        from app.auth.models import User as _User  # noqa: PLC0415
+        from app.notifications.push import (  # noqa: PLC0415
+            DatabaseSubscriptionStore,
+            get_vapid_config,
+            push_allowed_for_user,
+        )
+
+        if get_vapid_config() is None:
+            logger.warning(
+                "Web Push VAPID 未設定: 到達判定 (B-6) をスキップし提案生成は継続する "
+                "(配信は全ユーザーで失敗し delivered=False として記録される)"
+            )
+            return True
+        _user = db.get(_User, user_id)
+        if _user is None or not push_allowed_for_user(
+            _user.notification_settings_json, "ai_proposal"
+        ):
+            return False
+        return len(DatabaseSubscriptionStore(SessionLocal).get_for_user(user_id)) > 0
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "_user_has_reachable_channel failed for user_id=%d (到達可能とみなす): %s",
+            user_id,
+            exc,
+        )
+        return True
+
+
+def _notify_unreachable_approval_user(user_id: int) -> None:
+    """承認型なのに到達経路がゼロのユーザーを運用者へ通知する (best-effort)。
+
+    2026-08-06 受け入れ条件 B-6 / I-14 / 禁止事項 15。承認型モードは「提案が本人に
+    届き、本人が承認する」ことで初めて成立する。到達経路がゼロのまま提案を作り続けると
+    誰にも見られないまま期限切れになり、承認率という指標を「見られてすらいない母数」の
+    上で計算することになる (25 日間・16 件・実行 0 件を起こしたのがこの構造)。
+
+    本人には定義上届かないため、**運用者が別手段で連絡する**しかない。
+    同一ユーザーへの再送は `_UNREACHABLE_ALERT_INTERVAL_HOURS` に絞る。
+    """
+    now = datetime.now(timezone.utc)
+    last = _unreachable_alerted_at.get(user_id)
+    if last is not None and now - last < timedelta(hours=_UNREACHABLE_ALERT_INTERVAL_HOURS):
+        return
+    _unreachable_alerted_at[user_id] = now
+    try:
+        from app.notifications.factory import get_notification_service  # noqa: PLC0415
+        from app.notifications.templates import operational_alert_notification  # noqa: PLC0415
+
+        msg = operational_alert_notification(
+            title="📭 承認型ユーザーに通知が届きません（提案の生成を停止中）",
+            body=(
+                f"user_id={user_id} は承認が必要なモードですが、通知の到達経路が "
+                "ありません (Push 未購読 / 通知設定 OFF / VAPID 未設定 のいずれか)。"
+                "届かない提案を作り続けても期限切れになるだけのため、このユーザーへの "
+                "提案生成を停止しています。本人に Push 通知を有効化してもらうよう "
+                "別手段で連絡してください。有効化されれば提案生成は自動的に再開します。"
+            ),
+        )
+        get_notification_service().send(msg)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("_notify_unreachable_approval_user failed for user_id=%d: %s", user_id, exc)
+
+
+def _should_skip_unreachable_approval_user(db: Session, user: User) -> bool:
+    """承認型 + 到達経路ゼロなら提案生成をスキップすべきか判定し、必要なら通知する。
+
+    受け入れ条件 B-6「到達経路が 1 本も無いユーザーに、承認型の提案が作られない」。
+    AUTO_EXECUTE は本人の承認を待たずに実行されるため通知が無くても価値を提供でき、
+    対象外とする (要件書クラスタ B の非対称性)。
+    """
+    if user.execution_policy == ExecutionPolicy.AUTO_EXECUTE.value:
+        return False
+    if _user_has_reachable_channel(db, user.id):
+        return False
+    _notify_unreachable_approval_user(user.id)
+    return True
 
 
 def _downgrade_orphaned_auto_execute(db: Session, user: User) -> None:
@@ -971,6 +1078,15 @@ def _create_proposals_for_users(
                 # 提案生成の可否には影響しない (検知と通知のみ)。
                 _check_observability_invariants(db, user)
 
+                # 受け入れ条件 B-6: 到達経路ゼロの承認型ユーザーには提案を作らない。
+                # due-gate より先に置く (間隔を満たしていても作らないため)。
+                if _should_skip_unreachable_approval_user(db, user):
+                    logger.warning(
+                        "Skipping proposal for user %d: 承認型だが到達経路がゼロ (B-6)",
+                        user.id,
+                    )
+                    continue
+
                 if not _is_user_due_for_judgment(user, now):
                     logger.debug(
                         "Skipping proposal for user %d (tier=%s, last_judgment_at=%s)",
@@ -1183,6 +1299,14 @@ def _create_safe_yield_proposals_for_users(
                 # 可観測性 (2026-08-04 PR1): tier間隔 (due-gate) に関わらず毎 tick 検知する。
                 # 提案生成の可否には影響しない (検知と通知のみ)。
                 _check_observability_invariants(db, user)
+
+                # 受け入れ条件 B-6: 到達経路ゼロの承認型ユーザーには提案を作らない (本流と同一)。
+                if _should_skip_unreachable_approval_user(db, user):
+                    logger.warning(
+                        "[safe_yield] Skipping proposal for user %d: 承認型だが到達経路がゼロ (B-6)",
+                        user.id,
+                    )
+                    continue
 
                 if not _is_user_due_for_judgment(user, now):
                     continue

--- a/backend/tests/automation/test_unreachable_approval_user_gate.py
+++ b/backend/tests/automation/test_unreachable_approval_user_gate.py
@@ -1,0 +1,213 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/automation/test_unreachable_approval_user_gate.py
+"""受け入れ条件 B-6 の単体テスト（到達経路ゼロの承認型ユーザーに提案を作らない）。
+
+承認型モードは「提案が本人に届き、本人が承認する」ことで初めて成立する。到達経路が
+ゼロのまま提案を作り続けると誰にも見られないまま期限切れになり、承認率という指標を
+「見られてすらいない母数」の上で計算することになる（本番で 25 日間・16 件・実行 0 件を
+起こしたのがこの構造 / docs/internal/2026-08-04_usdt_switch_assessment_and_priorities.md）。
+
+LINE 廃止後、エンドユーザーへの到達経路は Web Push のみ。本テストは
+「配信側 (_deliver_ai_proposal_push) と同一基準で到達可否を判定する」ことを固定する。
+判定基準がズレると、到達可能と判定したのに配信側で弾かれる新たな乖離が生まれる。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-unreachable-gate")
+
+from app.auth.models import User  # noqa: E402
+from app.automation import ai_judgment_scheduler as sched  # noqa: E402
+from app.database import Base  # noqa: E402
+
+_MOD = "app.automation.ai_judgment_scheduler"
+# get_notification_service は関数内 import のため、モジュール属性ではなく import 元を差し替える。
+_FACTORY = "app.notifications.factory.get_notification_service"
+
+
+@pytest.fixture()
+def db_session() -> Generator[Session, None, None]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestSession()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        os.unlink(path)
+
+
+@pytest.fixture(autouse=True)
+def _clear_alert_throttle() -> Generator[None, None, None]:
+    """アラート絞り込みはプロセス内 dict なのでテスト間で持ち越さない。"""
+    sched._unreachable_alerted_at.clear()
+    yield
+    sched._unreachable_alerted_at.clear()
+
+
+def _make_user(
+    db: Session,
+    uid: int,
+    *,
+    execution_policy: str = "require_approval",
+    push_enabled: bool = True,
+) -> User:
+    user = User(
+        id=uid,
+        email=f"unreach{uid}@test.com",
+        username=f"unreach{uid}",
+        hashed_password="x",
+        role="viewer",
+        is_active=True,
+        wallet_address="0x" + f"{uid:040x}",
+        execution_policy=execution_policy,
+        notification_settings_json=json.dumps({"push_enabled": push_enabled}),
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+class _FakeStore:
+    """DatabaseSubscriptionStore の get_for_user だけを模した差し替え。"""
+
+    def __init__(self, subs_by_user: dict[int, int]) -> None:
+        self._subs_by_user = subs_by_user
+
+    def __call__(self, _session_factory: object) -> "_FakeStore":
+        return self
+
+    def get_for_user(self, user_id: int) -> list[object]:
+        return [object()] * self._subs_by_user.get(user_id, 0)
+
+
+def _patch_push(subs_by_user: dict[int, int], *, vapid: bool = True) -> object:
+    """push モジュールの依存を差し替えるコンテキストをまとめて返す。"""
+    from contextlib import ExitStack
+
+    stack = ExitStack()
+    stack.enter_context(
+        patch("app.notifications.push.get_vapid_config", return_value=object() if vapid else None)
+    )
+    stack.enter_context(
+        patch("app.notifications.push.DatabaseSubscriptionStore", _FakeStore(subs_by_user))
+    )
+    return stack
+
+
+class TestReachabilityDetection:
+    def test_購読ゼロの承認型ユーザーはスキップされ運用者に通知される(
+        self, db_session: Session
+    ) -> None:
+        user = _make_user(db_session, 501)
+        with _patch_push({}), patch(f"{_MOD}._notify_unreachable_approval_user") as notify:
+            assert sched._should_skip_unreachable_approval_user(db_session, user) is True
+        notify.assert_called_once_with(501)
+
+    def test_購読があれば提案生成は止まらない(self, db_session: Session) -> None:
+        user = _make_user(db_session, 502)
+        with _patch_push({502: 1}), patch(f"{_MOD}._notify_unreachable_approval_user") as notify:
+            assert sched._should_skip_unreachable_approval_user(db_session, user) is False
+        notify.assert_not_called()
+
+    def test_通知設定OFFは購読があっても到達不能扱い(self, db_session: Session) -> None:
+        """配信側 (push_allowed_for_user) と同一基準であることの確認。
+
+        購読行だけを見て判定すると「設定画面では OFF なのに到達可能」とみなし、
+        配信側で弾かれる提案を作り続けることになる。
+        """
+        user = _make_user(db_session, 503, push_enabled=False)
+        with _patch_push({503: 1}):
+            assert sched._user_has_reachable_channel(db_session, 503) is False
+            assert sched._should_skip_unreachable_approval_user(db_session, user) is True
+
+    def test_VAPID未設定は基盤障害であり提案生成を止めない(self, db_session: Session) -> None:
+        """env 変数 1 つの設定ミスが「全承認型ユーザーの提案停止」に化けないこと。
+
+        B-6 は *ユーザーごと* の到達経路の要件であり、配信基盤全体の障害とは別問題。
+        ここを False に倒すと、防ごうとしている静かな故障より大きな故障を作る。
+        基盤障害側は配信時に delivered=False として記録され到達率 (B-4) の急落で現れる。
+        """
+        user = _make_user(db_session, 504)
+        with _patch_push({}, vapid=False):
+            assert sched._user_has_reachable_channel(db_session, 504) is True
+            assert sched._should_skip_unreachable_approval_user(db_session, user) is False
+
+
+class TestScopeBoundaries:
+    def test_AUTO_EXECUTEは到達経路ゼロでも対象外(self, db_session: Session) -> None:
+        """おまかせ型は本人の承認を待たずに実行されるため通知が無くても価値を提供できる。
+
+        ここを一緒に止めると、委譲枠を持つおまかせユーザーの運用まで巻き添えで停止する。
+        """
+        user = _make_user(db_session, 505, execution_policy="auto_execute")
+        with _patch_push({}), patch(f"{_MOD}._notify_unreachable_approval_user") as notify:
+            assert sched._should_skip_unreachable_approval_user(db_session, user) is False
+        notify.assert_not_called()
+
+    def test_判定が例外を投げても提案生成は止めない(self, db_session: Session) -> None:
+        """可用性の後退を避ける: 判定の一時的な失敗が全ユーザーの提案停止に化けない。"""
+        user = _make_user(db_session, 506)
+        with (
+            patch("app.notifications.push.get_vapid_config", side_effect=RuntimeError("boom")),
+            patch(f"{_MOD}._notify_unreachable_approval_user") as notify,
+        ):
+            assert sched._should_skip_unreachable_approval_user(db_session, user) is False
+        notify.assert_not_called()
+
+    def test_購読が復活すれば自動的に再開する(self, db_session: Session) -> None:
+        """B-6 の縮退は一方通行であってはならない（ユーザー操作だけで復帰できる）。"""
+        user = _make_user(db_session, 507)
+        with _patch_push({}), patch(f"{_MOD}._notify_unreachable_approval_user"):
+            assert sched._should_skip_unreachable_approval_user(db_session, user) is True
+        with _patch_push({507: 1}), patch(f"{_MOD}._notify_unreachable_approval_user"):
+            assert sched._should_skip_unreachable_approval_user(db_session, user) is False
+
+
+class TestAlertThrottling:
+    def test_同一ユーザーへの連投は絞られる(self) -> None:
+        """毎 tick 発火すると Slack を埋め尽くす（既存アラートが 14 日で 451 件出ていた）。"""
+        with patch(_FACTORY) as factory:
+            factory.return_value.send = lambda _m: None
+            sched._notify_unreachable_approval_user(508)
+            sched._notify_unreachable_approval_user(508)
+            sched._notify_unreachable_approval_user(508)
+        assert factory.call_count == 1
+
+    def test_絞り込み期間を過ぎれば再送される(self) -> None:
+        """恒久的に黙ると「対応漏れのまま忘れられる」ため、再送は残す。"""
+        with patch(_FACTORY) as factory:
+            factory.return_value.send = lambda _m: None
+            sched._notify_unreachable_approval_user(509)
+            sched._unreachable_alerted_at[509] = datetime.now(timezone.utc) - timedelta(
+                hours=sched._UNREACHABLE_ALERT_INTERVAL_HOURS + 1
+            )
+            sched._notify_unreachable_approval_user(509)
+        assert factory.call_count == 2
+
+    def test_ユーザーごとに独立して絞られる(self) -> None:
+        with patch(_FACTORY) as factory:
+            factory.return_value.send = lambda _m: None
+            sched._notify_unreachable_approval_user(510)
+            sched._notify_unreachable_approval_user(511)
+        assert factory.call_count == 2
+
+    def test_通知送信が失敗しても例外を伝播しない(self) -> None:
+        """best-effort: 通知の失敗が提案パイプラインを止めてはならない。"""
+        with patch(_FACTORY, side_effect=RuntimeError("slack down")):
+            sched._notify_unreachable_approval_user(512)  # 例外が出ないこと


### PR DESCRIPTION
## 背景

受け入れ条件 **B-6**「到達経路が1本も無いユーザーに、承認型の提案が作られない」が
**未実装**だった。提案生成の経路に購読有無を見るコードが1箇所も無く、
`push.py:394` の docstring 自身が「到達経路ゼロ側は別途 B-6 の検知対象になる」と
書いたまま着手されていなかった。

承認型モードは「提案が本人に届き、本人が承認する」ことで初めて成立する。到達経路ゼロの
まま提案を作り続けると誰にも見られないまま期限切れになり、承認率という指標を
**「見られてすらいない母数」の上で計算する**ことになる（25日間・16件・実行0件を
起こしたのがこの構造）。

### 本番実測 (2026-08-06)

LINE 廃止後、エンドユーザーへの到達経路は Web Push のみ。その前提で確認した結果:

| user | mode | push購読 | 到達経路 |
|---|---|---|---|
| 11 | require_approval | 0件 | **無し** |
| 16 | require_approval | 0件 | **無し** |
| 18 | require_approval | 0件 | **無し** |
| 19 | require_approval | 1件 | Push ✅ |

**同じ構造が現在も生きていた。**

関連要件: B-6 / I-14 / 禁止事項15

## 変更内容

| 追加 | 役割 |
|---|---|
| `_user_has_reachable_channel` | 配信側 (`_deliver_ai_proposal_push`) と**同一基準**で到達可否を判定（通知設定 B-N4 + 購読行の存在） |
| `_should_skip_unreachable_approval_user` | 承認型 + 到達経路ゼロを検知して生成をスキップ |
| `_notify_unreachable_approval_user` | 本人には定義上届かないため運用者へ Slack 通知。**24hに絞る** |

判定基準を配信側と揃えたのは意図的です。ズレると「到達可能と判定したのに配信側で弾かれる」
という、本プロジェクトが繰り返してきた**表示と実態の乖離**を新たに作ることになるためです。

Slack の絞り込みを入れたのは、既存アラート（`_notify_missing_delegation_grant` 等）が
毎tick発火して**14日で451件**出ていたためです。

## 意図的に「止めない」条件（可用性の後退を避ける）

- **AUTO_EXECUTE は対象外** — 本人の承認を待たず実行されるため通知が無くても価値を
  提供できる（要件書クラスタBの非対称性）。ここを止めると委譲枠を持つおまかせユーザー
  まで巻き添えで停止する
- **VAPID 未設定は「基盤障害」であり到達可能扱い** — B-6 は*ユーザーごと*の要件。
  env 変数1つの設定ミスが「全承認型ユーザーの提案が無言で停止」に化けると、防ごうと
  している静かな故障より**大きな故障**を作る。基盤側は `delivered=False` と
  到達率(B-4)の急落で現れる
- **判定が例外を投げた場合も到達可能扱い** — 一時的な判定失敗を全停止に変換しない

> この2点は**実装当初 False に倒しており、既存テスト8件の失敗として検出されました**
> （テスト環境は VAPID 未設定のため、承認型ユーザー全員の提案が止まっていた）。
> テストが設計の誤りを捕まえた形です。

## 縮退からの復帰

一方通行にしていません。ユーザーが Push 通知を有効化すれば**次 tick から自動的に再開**します
（テストで固定）。

## テスト

新規 11 件。正常系だけでなく壊れやすい境界を突いています:

- 購読ゼロ → スキップ + 運用者通知
- 購読あり → 止まらない
- **通知設定OFFは購読があっても到達不能扱い**（配信側と同一基準であることの証明）
- **VAPID未設定は基盤障害であり止めない**
- **AUTO_EXECUTE は対象外**
- **判定が例外を投げても止めない**
- **購読が復活すれば自動再開**
- アラート絞り込み（連投/期間経過後の再送/ユーザー毎独立/送信失敗を伝播しない）

## 検証

- `pytest tests/`: **5112 passed, 0 failed, 26 skipped**
- `ruff check` / `ruff format --check`: clean
- `mypy app/`: stripe の既存2件のみ（本変更と無関係）

## デプロイ後に想定される挙動

users 11/16/18 への提案生成が停止し、Slack に運用者向けアラートが出ます。
**この3名は小林さんから別手段で連絡し、Push通知を有効化してもらう必要があります。**
有効化されれば自動的に再開します。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>