### PR TITLE
feat(proposals): 入金前ユーザーへ推奨運用額ベースの提案を出す (docs/62 ファネル)

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -167,6 +167,31 @@ def _notify_proposal_skipped(user_id: int, reason: str) -> None:
         logger.warning("_notify_proposal_skipped failed for user_id=%d: %s", user_id, exc)
 
 
+def _has_active_allocation(db: Session, user_id: int) -> bool:
+    """active な fund_allocation 帳簿行を持つか (= パートナー/テスター枠のユーザー)。
+
+    入金ファネル (docs/62) の対象外判定に使う。SCW を持つユーザーは
+    `uses_custodial_allocation` が False になり allocation 分岐を飛ばすため、
+    「帳簿を持っているかどうか」はここで別途確認しないと分からない。
+    """
+    from app.partner.allocation_models import FundAllocation  # noqa: PLC0415
+
+    try:
+        return (
+            db.query(FundAllocation.id)
+            .filter(
+                FundAllocation.tester_user_id == user_id,
+                FundAllocation.status == "active",
+            )
+            .first()
+            is not None
+        )
+    except Exception as exc:  # noqa: BLE001
+        # 判定不能なら「帳簿あり」に倒す = ファネルを適用しない (保守的)
+        logger.warning("_has_active_allocation failed for user_id=%d: %s", user_id, exc)
+        return True
+
+
 def _resolve_proposal_amount(db: Session, user_id: int) -> Decimal:
     """提案金額を解決する (案C: fund_allocation 優先 + wallet 残高 fallback / docs/61)。
 
@@ -236,22 +261,43 @@ def _resolve_proposal_amount(db: Session, user_id: int) -> Decimal:
     wallet = (user.smart_wallet_address or user.wallet_address) if user else None
     if wallet:
         balance = _read_wallet_usdc_balance(wallet)
-        if balance is None or balance <= Decimal("0"):
-            # 残高0 / RPC 取得失敗 → skip (安全側)
+        if balance is None:
+            # RPC 取得失敗 → skip (安全側。残高不明のまま提案額を決めない)
             logger.debug(
-                "[proposal_amount] wallet USDC 0/unavailable for user_id=%d — skipped",
+                "[proposal_amount] wallet USDC unavailable for user_id=%d — skipped",
                 user_id,
             )
             return Decimal("0")
-        # A-2 入金ゲート: wallet 残高が運用開始の最低入金額未満なら提案を生成しない。
-        if balance < MIN_DEPOSIT_USD:
+        # 入金前ユーザー: 推奨運用額ベースの提案を出す (docs/62 承認→入金→署名)。
+        #
+        # 以前はここで Decimal("0") を返し提案自体を作らなかった。しかしそれでは
+        # 「提案を見て入金する」ファネル (docs/62) が非カストディアル経路で成立しない。
+        # かといって現残高の 10% で作ると、$200 のユーザーには $20 (下限 $50) しか
+        # 提案できず 30日利益 $0.16 < ガス代 $0.27 で必ず採算ゲートに弾かれる
+        # ($852 の実効下限の正体 = 10%ルール × ガス代)。
+        #
+        # そこで入金前は分母を「現残高」ではなく「推奨運用額」に置き換える。
+        # $1,000 到達時にちょうど 10% になる額を提案し、awaiting_funds で着金を待つ。
+        # **実行前に着金検知側が最低入金額を再検証する**ため、残高に対し過大な supply が
+        # 実行されることはない (run_funding_detection_once / 10%ルール = CLAUDE.md
+        # [CRITICAL] 3 の担保)。
+        #
+        # ただし **allocation 帳簿を持つユーザーは対象外**。帳簿がある = パートナー/
+        # テスター枠であり、資金は入金ではなく運用側の配分で入る。実残高が帳簿を
+        # 下回るのは「本人が入金していない」のではなく「帳簿と実残高の乖離」であって、
+        # 本人に入金を促すのは筋違い (運用側が直すべき問題)。SCW 保有ユーザーは
+        # 分岐 1 を飛ばしてここに来るため、ここで明示的に確認する必要がある (PR #1035)。
+        if balance < MIN_DEPOSIT_USD and not _has_active_allocation(db, user_id):
+            funnel_amount = (MIN_DEPOSIT_USD * _PROPOSAL_RATIO).quantize(Decimal("0.01"))
             logger.info(
-                "[deposit_gate] consumer wallet deposit $%s < min $%s for user_id=%d — proposal skipped",
+                "[funding_funnel] user_id=%d balance=$%s < min $%s — "
+                "推奨運用額ベースで $%s の提案を作成 (着金後に実行可)",
+                user_id,
                 balance,
                 MIN_DEPOSIT_USD,
-                user_id,
+                funnel_amount,
             )
-            return Decimal("0")
+            return funnel_amount
         amount = (balance * _PROPOSAL_RATIO).quantize(Decimal("0.01"))
         if amount < _PROPOSAL_AMOUNT_MIN_USD:
             # 10% が gas viable な最小額未満 → skip。

--- a/backend/app/automation/scheduled_tasks.py
+++ b/backend/app/automation/scheduled_tasks.py
@@ -882,7 +882,19 @@ def run_funding_detection_once() -> int:
                 balance = read_wallet_usdc_balance(wallet)
                 if balance is None:
                     continue  # RPC 失敗は次サイクル再試行 (安全側)
-                if balance >= Decimal(str(proposal.amount_usd)):
+                # A-2 入金ゲート: 提案額を満たすだけでなく最低入金額に達していること。
+                #
+                # 以前は `balance >= amount_usd` のみを見ており、手動承認経路
+                # (`_run_approval_and_execution`) が課している MIN_DEPOSIT_USD ゲートを
+                # この経路だけが迂回していた。入金前ユーザーへ推奨運用額ベースの提案を
+                # 出すようになった (docs/62 ファネル / _resolve_proposal_amount) ことで、
+                # この抜けは実害になる: 残高 $150 のユーザーの $100 提案が「$150 >= $100」で
+                # 承認され、総資産の 67% を 1 取引で supply してしまう
+                # (CLAUDE.md [CRITICAL] 3「Max single trade: 10% of total assets」違反)。
+                # 最低入金額に達して初めて提案額が総資産の 10% に収まるため、両方を課す。
+                from app.users.deposit_policy import MIN_DEPOSIT_USD  # noqa: PLC0415
+
+                if balance >= Decimal(str(proposal.amount_usd)) and balance >= MIN_DEPOSIT_USD:
                     proposal.status = "approved"
                     proposal.approved_at = now
                     db.flush()

--- a/backend/tests/automation/test_funding_funnel_sizing.py
+++ b/backend/tests/automation/test_funding_funnel_sizing.py
@@ -1,0 +1,267 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/automation/test_funding_funnel_sizing.py
+"""入金前ユーザーへの推奨運用額ベース提案（docs/62 承認→入金→署名ファネル）のテスト。
+
+## なぜこの経路が必要か
+
+提案額は従来 **現残高 × 10%** で決めていた。しかしそれでは入金前・少額のユーザーに
+意味のある提案を出せない:
+
+    残高 $200 → 提案 $20（下限 $50 に切上）→ 30日利益 $0.16 < ガス代 $0.27 → 採算ゲートで却下
+
+「$852 の実効下限」の正体は **10%ルール × ガス代**であって、モード（おまかせ/承認）とは
+無関係だった。そのため入金ゲートを下げるだけでは何も解決しない。
+
+そこで入金前は分母を「現残高」ではなく「推奨運用額（MIN_DEPOSIT_USD）」に置き換える。
+
+## 安全性の要（このファイルの主目的）
+
+推奨運用額ベースで提案を作ると、**提案額が現残高を上回る**状態が正常系として発生する。
+着金検知が `balance >= amount_usd` だけを見ていると、残高 $150 のユーザーの $100 提案が
+承認され **総資産の 67% を 1 取引で supply** してしまう
+（CLAUDE.md [CRITICAL] 3「Max single trade: 10% of total assets」違反）。
+
+最低入金額の再検証が入っていることを固定するのが本テストの中心。
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-funding-funnel")
+
+from app.auth.models import User  # noqa: E402
+from app.automation.ai_judgment_scheduler import (  # noqa: E402
+    _PROPOSAL_RATIO,
+    _resolve_proposal_amount,
+)
+from app.automation.scheduled_tasks import run_funding_detection_once  # noqa: E402
+from app.database import Base  # noqa: E402
+from app.proposals.models import Proposal  # noqa: E402
+from app.users.deposit_policy import MIN_DEPOSIT_USD  # noqa: E402
+
+_SCHED = "app.automation.ai_judgment_scheduler"
+_TASKS = "app.automation.scheduled_tasks"
+
+
+@pytest.fixture()
+def db_session() -> Generator[Session, None, None]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestSession()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        os.unlink(path)
+
+
+def _make_user(db: Session, uid: int) -> User:
+    """非カストディアル消費者（allocation 不在 / wallet あり / SCW なし）。"""
+    user = User(
+        id=uid,
+        email=f"funnel{uid}@test.com",
+        username=f"funnel{uid}",
+        hashed_password="x",
+        role="viewer",
+        is_active=True,
+        wallet_address="0x" + f"{uid:040x}",
+        execution_policy="require_approval",
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+class _NoCloseSession:
+    """テスト用セッションを本番コードの `db.close()` で閉じさせないためのラッパ。
+
+    閉じられるとテスト側の `refresh()` で状態を検証できなくなる。close 以外は委譲する。
+    """
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def close(self) -> None:  # 本番コードの finally: db.close() を無効化
+        pass
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._session, name)
+
+
+def _make_awaiting_proposal(db: Session, uid: int, amount: Decimal) -> Proposal:
+    now = datetime.now(timezone.utc)
+    p = Proposal(
+        user_id=uid,
+        operation="SUPPLY",
+        asset="USDC",
+        amount=amount,  # USDC は 1:1 なので amount_usd と同値で足りる
+        amount_usd=amount,
+        status="awaiting_funds",
+        reason="test",
+        expires_at=now + timedelta(days=7),
+    )
+    db.add(p)
+    db.flush()
+    return p
+
+
+class TestFunnelSizing:
+    def test_入金前ユーザーには推奨運用額ベースの提案額が返る(self, db_session: Session) -> None:
+        """従来は Decimal(0)（提案なし）だった。ファネルが成立しない原因だった箇所。"""
+        _make_user(db_session, 601)
+        with patch(f"{_SCHED}._read_wallet_usdc_balance", return_value=Decimal("200")):
+            amount = _resolve_proposal_amount(db_session, 601)
+        assert amount == (MIN_DEPOSIT_USD * _PROPOSAL_RATIO).quantize(Decimal("0.01"))
+
+    def test_ファネル提案額は採算ゲートを通過できる(self, db_session: Session) -> None:
+        """通らない額を提案しても意味がない（$50 だと利益 $0.16 < ガス代 $0.27 で必ず却下）。"""
+        from app.fees.trade_gate import calculate_fee_by_market
+
+        _make_user(db_session, 602)
+        with patch(f"{_SCHED}._read_wallet_usdc_balance", return_value=Decimal("0")):
+            amount = _resolve_proposal_amount(db_session, 602)
+        expected_profit = amount * Decimal("4") / Decimal("100") * Decimal("30") / Decimal("365")
+        result = calculate_fee_by_market(
+            trade_amount_usd=amount,
+            tier="GENERAL",
+            current_apy=Decimal("4"),
+            expected_profit_usd=expected_profit,
+            fixed_cost_usd=Decimal("0.27"),
+        )
+        assert result.should_trade is True, result.reason
+
+    def test_残高ゼロでもファネル提案は作られる(self, db_session: Session) -> None:
+        """未入金ユーザーこそファネルの主対象（docs/62「残高0でも提案が出る」）。"""
+        _make_user(db_session, 603)
+        with patch(f"{_SCHED}._read_wallet_usdc_balance", return_value=Decimal("0")):
+            assert _resolve_proposal_amount(db_session, 603) > Decimal("0")
+
+    def test_RPC取得失敗は従来どおりスキップ(self, db_session: Session) -> None:
+        """残高不明のまま提案額を決めない（None と 0 を混同しないこと）。"""
+        _make_user(db_session, 604)
+        with patch(f"{_SCHED}._read_wallet_usdc_balance", return_value=None):
+            assert _resolve_proposal_amount(db_session, 604) == Decimal("0")
+
+    def test_十分な残高なら従来どおり残高ベース(self, db_session: Session) -> None:
+        """ファネルは入金前だけ。既存ユーザーのサイジングを変えない。"""
+        _make_user(db_session, 605)
+        with patch(f"{_SCHED}._read_wallet_usdc_balance", return_value=Decimal("5000")):
+            amount = _resolve_proposal_amount(db_session, 605)
+        assert amount == Decimal("500.00")  # 5000 × 10%
+
+    def test_境界をまたいでも提案額が飛ばない(self, db_session: Session) -> None:
+        """$1,000 直下(ファネル)と ちょうど(残高ベース) で提案額が一致する。
+
+        ファネルの分母に MIN_DEPOSIT_USD を使っている帰結。別の値を使うと境界で
+        提案額が不連続に飛び、ユーザーには理由の分からない金額変動として見える。
+        """
+        _make_user(db_session, 606)
+        with patch(f"{_SCHED}._read_wallet_usdc_balance", return_value=Decimal("999.99")):
+            below = _resolve_proposal_amount(db_session, 606)
+        with patch(f"{_SCHED}._read_wallet_usdc_balance", return_value=MIN_DEPOSIT_USD):
+            at = _resolve_proposal_amount(db_session, 606)
+        assert below == at
+
+    def test_帳簿を持つユーザーにはファネルを適用しない(self, db_session: Session) -> None:
+        """★境界: allocation 帳簿 = パートナー/テスター枠。資金は入金でなく運用側の配分で入る。
+
+        実残高が帳簿を下回るのは「本人が入金していない」のではなく「帳簿と実残高の乖離」
+        であり、本人に入金を促すのは筋違い（運用側が直すべき問題）。
+        PR #1035「SCW実残高が最低入金額未満なら提案を作らない」の安全性を壊さないこと。
+        """
+        from app.partner.allocation_models import FundAllocation
+
+        # SCW 保有ユーザーは allocation 分岐を飛ばして wallet 経路に来る
+        # (uses_custodial_allocation=False)。PR #1035 が守っている境界はここ。
+        user = _make_user(db_session, 607)
+        user.smart_wallet_address = "0x" + "e" * 40
+        db_session.flush()
+        db_session.add(
+            FundAllocation(
+                partner_id=1,
+                tester_name="funnel-boundary",
+                tester_user_id=607,
+                allocated_amount_usd=Decimal("4600"),
+                status="active",
+            )
+        )
+        db_session.flush()
+        with patch(f"{_SCHED}._read_wallet_usdc_balance", return_value=Decimal("50")):
+            assert _resolve_proposal_amount(db_session, 607) == Decimal("0")
+
+
+class TestExecutionSafety:
+    """提案額 > 現残高 が正常系になるため、実行側の再検証が安全性の要になる。"""
+
+    def _run(self, db: Session, balance: Decimal | None) -> int:
+        # run_funding_detection_once は依存を**関数内 import** するため、
+        # scheduled_tasks の属性ではなく import 元を差し替える必要がある。
+        with (
+            patch("app.database.SessionLocal", return_value=_NoCloseSession(db)),
+            patch("app.aave.balance.read_wallet_usdc_balance", return_value=balance),
+            patch("app.notifications.factory.get_notification_service"),
+        ):
+            return run_funding_detection_once()
+
+    def test_提案額を満たしても最低入金額未満なら承認しない(self, db_session: Session) -> None:
+        """★中核: 残高$150 で $100 提案を承認すると総資産の67%を1取引で supply してしまう。
+
+        CLAUDE.md [CRITICAL] 3「Max single trade: 10% of total assets」違反。
+        `balance >= amount_usd` だけを見ていた旧実装ではこれが通っていた。
+        """
+        _make_user(db_session, 611)
+        p = _make_awaiting_proposal(db_session, 611, Decimal("100"))
+        self._run(db_session, Decimal("150"))
+        db_session.refresh(p)
+        assert p.status == "awaiting_funds"
+
+    def test_最低入金額に達したら承認される(self, db_session: Session) -> None:
+        """$1,000 到達時、$100 の提案はちょうど総資産の 10%（ルール内）。"""
+        _make_user(db_session, 612)
+        p = _make_awaiting_proposal(db_session, 612, Decimal("100"))
+        self._run(db_session, MIN_DEPOSIT_USD)
+        db_session.refresh(p)
+        assert p.status == "approved"
+        assert p.approved_at is not None
+
+    def test_最低入金額を満たしても提案額に届かなければ承認しない(
+        self, db_session: Session
+    ) -> None:
+        """両条件の AND であることの確認（片方だけでは不十分）。"""
+        _make_user(db_session, 613)
+        p = _make_awaiting_proposal(db_session, 613, Decimal("5000"))
+        self._run(db_session, MIN_DEPOSIT_USD)
+        db_session.refresh(p)
+        assert p.status == "awaiting_funds"
+
+    def test_RPC失敗では状態を変えない(self, db_session: Session) -> None:
+        """残高不明で承認すると未入金のまま実行されうる（fail-closed）。"""
+        _make_user(db_session, 614)
+        p = _make_awaiting_proposal(db_session, 614, Decimal("100"))
+        self._run(db_session, None)
+        db_session.refresh(p)
+        assert p.status == "awaiting_funds"
+
+    def test_入金期限を過ぎたら残高に関わらず期限切れ(self, db_session: Session) -> None:
+        """funding window は市場期限と分離されているが、無期限ではない。"""
+        _make_user(db_session, 615)
+        p = _make_awaiting_proposal(db_session, 615, Decimal("100"))
+        p.expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+        db_session.flush()
+        self._run(db_session, MIN_DEPOSIT_USD * 10)
+        db_session.refresh(p)
+        assert p.status == "expired"

--- a/backend/tests/test_ai_judgment_scheduler.py
+++ b/backend/tests/test_ai_judgment_scheduler.py
@@ -1438,12 +1438,20 @@ def test_resolve_amount_wallet_fallback_uses_balance(db_session, monkeypatch):
     assert result == Decimal("100.00")
 
 
-def test_resolve_amount_wallet_below_min_is_skipped(db_session, monkeypatch):
-    """wallet 残高 × 10% が min ($50) 未満 → $0 で skip (切り上げない / 安全側)。
+def test_resolve_amount_wallet_below_min_uses_funding_funnel(db_session, monkeypatch):
+    """最低入金額未満 → 推奨運用額ベースの提案 (docs/62 承認→入金→署名ファネル)。
 
-    $400 残高 × 10% = $40 < $50 → $0。
+    2026-08-07 仕様変更: 以前は $0 で skip していたが、それでは「提案を見て入金する」
+    ファネルが非カストディアル経路で成立しなかった。現残高の 10% で作ると $400 → $40
+    (下限 $50 未満) となり、仮に $50 に切り上げても 30日利益 $0.16 < ガス代 $0.27 で
+    採算ゲートに必ず弾かれる。分母を推奨運用額 (MIN_DEPOSIT_USD) に置き換える。
+
+    残高に対し過大な supply が**実行**されないことは着金検知側が担保する
+    (run_funding_detection_once が MIN_DEPOSIT_USD を再検証 /
+    tests/automation/test_funding_funnel_sizing.py)。
     """
     import app.automation.ai_judgment_scheduler as sched  # noqa: PLC0415
+    from app.users.deposit_policy import MIN_DEPOSIT_USD  # noqa: PLC0415
 
     user = _add_active_user(db_session, "wallet_small@example.com")
     user.wallet_address = "0x" + "b" * 40
@@ -1451,7 +1459,7 @@ def test_resolve_amount_wallet_below_min_is_skipped(db_session, monkeypatch):
 
     monkeypatch.setattr(sched, "_read_wallet_usdc_balance", lambda _addr: Decimal("400"))
     result = sched._resolve_proposal_amount(db_session, user.id)
-    assert result == Decimal("0")
+    assert result == (MIN_DEPOSIT_USD * sched._PROPOSAL_RATIO).quantize(Decimal("0.01"))
 
 
 def test_resolve_amount_wallet_clamps_to_max(db_session, monkeypatch):
@@ -1471,7 +1479,12 @@ def test_resolve_amount_wallet_clamps_to_max(db_session, monkeypatch):
 
 
 def test_resolve_amount_wallet_balance_unavailable_is_skipped(db_session, monkeypatch):
-    """残高取得失敗 (None) / 残高0 → $0 で skip (誤った金額を捏造しない)。"""
+    """残高取得失敗 (None) → $0 で skip (誤った金額を捏造しない)。
+
+    残高0 (None ではない) は「未入金ユーザー」であってファネルの主対象なので
+    skip しない。**None と 0 を混同しないこと**が本テストの要点
+    (None は「いくら持っているか分からない」、0 は「持っていないと分かっている」)。
+    """
     import app.automation.ai_judgment_scheduler as sched  # noqa: PLC0415
 
     user = _add_active_user(db_session, "wallet_rpcfail@example.com")
@@ -1481,8 +1494,9 @@ def test_resolve_amount_wallet_balance_unavailable_is_skipped(db_session, monkey
     monkeypatch.setattr(sched, "_read_wallet_usdc_balance", lambda _addr: None)
     assert sched._resolve_proposal_amount(db_session, user.id) == Decimal("0")
 
+    # 残高0 = 未入金 → ファネル提案 (docs/62「残高0でも提案が出る」)
     monkeypatch.setattr(sched, "_read_wallet_usdc_balance", lambda _addr: Decimal("0"))
-    assert sched._resolve_proposal_amount(db_session, user.id) == Decimal("0")
+    assert sched._resolve_proposal_amount(db_session, user.id) > Decimal("0")
 
 
 def test_resolve_amount_allocation_takes_priority_for_custodial_user(db_session, monkeypatch):
@@ -1657,19 +1671,28 @@ def test_resolve_proposal_amount_pending_proposals_do_not_count_as_deployed(db_s
 @pytest.mark.parametrize(
     "balance,expected",
     [
-        (Decimal("100"), Decimal("0")),  # < 最低入金($1000) → deposit gate で skip
-        (Decimal("200"), Decimal("0")),  # < 最低入金($1000) → deposit gate で skip
-        # $1000ゲートは sizing floor 分岐点($500=$50/10%)を上回るため、
-        # deadzone (gate通過だが10%<min) は wallet 経路では構造的に発生しなくなった。
-        (Decimal("500"), Decimal("0")),  # < 最低入金($1000) → deposit gate で skip
-        (Decimal("1000"), Decimal("100.00")),  # 10%=$100
+        # 2026-08-07: 最低入金額($1000)未満は「skip」から「推奨運用額ベースの提案」へ変更
+        # (docs/62 承認→入金→署名ファネル)。$1000 × 10% = $100 が一律の提案額になる。
+        # 実行は着金検知が MIN_DEPOSIT_USD を再検証して止めるため、残高に対し過大な
+        # supply は起きない (tests/automation/test_funding_funnel_sizing.py)。
+        (Decimal("0"), Decimal("100.00")),  # 未入金 = ファネルの主対象
+        (Decimal("100"), Decimal("100.00")),  # < 最低入金 → ファネル提案
+        (Decimal("200"), Decimal("100.00")),  # < 最低入金 → ファネル提案
+        (Decimal("500"), Decimal("100.00")),  # < 最低入金 → ファネル提案
+        (Decimal("999.99"), Decimal("100.00")),  # 境界直下 → ファネル提案
+        (Decimal("1000"), Decimal("100.00")),  # 境界ちょうど → 残高ベース 10%=$100 (連続)
         (Decimal("5000"), Decimal("500.00")),  # 10%=$500
     ],
 )
 def test_resolve_proposal_amount_wallet_deadzone_boundaries(
     db_session, monkeypatch, balance, expected
 ):
-    """非カストディアル (wallet) 経路: $100/$200/$500/$1,000/$5,000 境界値。"""
+    """非カストディアル (wallet) 経路の境界値。
+
+    $1,000 ちょうどでファネル額と残高ベース額が**一致する** ($1000×10% = $100) ため、
+    境界をまたいでも提案額が不連続に飛ばない。これは偶然ではなくファネルの分母に
+    MIN_DEPOSIT_USD を使っていることの帰結。
+    """
     import app.automation.ai_judgment_scheduler as sched  # noqa: PLC0415
 
     user = _add_active_user(db_session, f"wallet_boundary_{balance}@example.com")

--- a/backend/tests/test_proposal_deposit_gate.py
+++ b/backend/tests/test_proposal_deposit_gate.py
@@ -19,6 +19,10 @@ def _db_with_allocation(total) -> MagicMock:  # type: ignore[no-untyped-def]
     """
     db = MagicMock()
     db.query.return_value.filter.return_value.scalar.return_value = total
+    # allocation 帳簿の有無判定 (_has_active_allocation) は .first() を見る。
+    # 素の MagicMock だと truthy になり「帳簿あり」と誤判定され、入金ファネルが
+    # 適用対象外になってしまう。total で明示的に切り替える。
+    db.query.return_value.filter.return_value.first.return_value = MagicMock() if total else None
     db.get.return_value = MagicMock(smart_wallet_address=None, wallet_address=None)
     return db
 
@@ -36,15 +40,24 @@ def test_custodial_at_gate_generates() -> None:
     assert amount > Decimal("0")
 
 
-def test_consumer_wallet_below_gate_skipped() -> None:
-    """非カストディアル wallet 残高 $150 (<$1000) は提案 0（skip）。"""
+def test_consumer_wallet_below_gate_uses_funding_funnel() -> None:
+    """非カストディアル wallet 残高 $150 (<$1000) は推奨運用額ベースの提案を出す。
+
+    2026-08-07 仕様変更 (docs/62 承認→入金→署名ファネル): 以前は $0 で skip していたが、
+    それでは「提案を見て入金する」導線が非カストディアル経路で成立しなかった。
+    custodial allocation 経路 (上の test_custodial_below_gate_skipped) は台帳額が
+    入金意思の裏付けなので skip のまま据え置き、**非対称は意図的**。
+
+    残高 $150 に対し提案額が上回るが、実行は着金検知が MIN_DEPOSIT_USD を再検証して
+    止める (tests/automation/test_funding_funnel_sizing.py)。
+    """
     db = _db_with_allocation(0)
     db.get.return_value = MagicMock(smart_wallet_address=None, wallet_address="0xabc")
     with patch(
         "app.automation.ai_judgment_scheduler._read_wallet_usdc_balance",
         return_value=Decimal("150"),
     ):
-        assert _resolve_proposal_amount(db, user_id=9) == Decimal("0")
+        assert _resolve_proposal_amount(db, user_id=9) > Decimal("0")
 
 
 def test_consumer_wallet_above_gate_generates() -> None:


### PR DESCRIPTION
## 背景

「提案を見て入金する」導線（`docs/62` 承認→入金→署名）が、**非カストディアル消費者では成立していなかった**。提案額を現残高の 10% で決めていたためです。

```
残高 $200 → 提案 $20（下限 $50 に切上）→ 30日利益 $0.16 < ガス代 $0.27 → 採算ゲートで却下
```

つまり **「実効最低入金 $852」の正体は 10%ルール × ガス代**であって、おまかせ/承認という
モードの区別とは無関係でした。入金ゲートをモード別にしても採算ゲートで同じ場所で止まるため
解決しません。

## 変更内容

入金前は提案額の分母を「現残高」から **「推奨運用額（`MIN_DEPOSIT_USD`）」** へ置き換えます。
$1,000 × 10% = **$100** を提案し、`awaiting_funds` で着金を待ちます。

| 残高 | 変更前 | 変更後 |
|---|---|---|
| $0（未入金） | 提案なし | **$100**（ファネル） |
| $200 | 提案なし | **$100**（ファネル） |
| $999.99 | 提案なし | **$100**（ファネル） |
| $1,000 | $100 | $100（残高ベース・**連続**） |
| $5,000 | $500 | $500（変更なし） |

$999.99 と $1,000 で提案額が一致するのは、ファネルの分母に `MIN_DEPOSIT_USD` を使っている
帰結です。境界で金額が不連続に飛びません。

## ⚠️ 安全性（本変更の要）

提案額が現残高を上回る状態が**正常系**になるため、実行側の再検証を追加しました。

着金検知（`run_funding_detection_once`）は従来 `balance >= amount_usd` のみを見ており、
手動承認経路（`_run_approval_and_execution`）が課している `MIN_DEPOSIT_USD` ゲートを
**この経路だけが迂回**していました。ファネル導入でこれは実害になります:

> 残高 $150 のユーザーの $100 提案が「$150 >= $100」で承認され、
> **総資産の 67% を 1 取引で supply** → CLAUDE.md [CRITICAL] 3
> 「Max single trade: 10% of total assets」違反

最低入金額の再検証を追加し、**両条件の AND** としました。$1,000 到達時に提案額が
ちょうど総資産の 10% に収まります。

## 適用範囲を絞った箇所

**allocation 帳簿を持つユーザーは対象外**です。帳簿がある = パートナー/テスター枠で、
資金は入金ではなく運用側の配分で入ります。実残高が帳簿を下回るのは「本人が入金して
いない」のではなく「**帳簿と実残高の乖離**」であり、本人に入金を促すのは筋違い
（運用側が直すべき問題）です。

SCW 保有ユーザーは allocation 分岐を飛ばすため明示的な確認が必要でした。これは
**PR #1035「SCW 実残高が最低入金額未満なら提案を作らない」の安全性を壊さないための境界**で、
実装当初これを落としており**同 PR のテストが検出**しました。

## None と 0 を混同しない

`balance is None`（RPC 失敗）は従来どおり skip します。None は「いくら持っているか
**分からない**」、0 は「持っていないと**分かっている**」で意味が違います。0 は未入金
ユーザー = ファネルの主対象です。

## テスト

新規 12 件 + 既存 5 件を新仕様へ更新。

**中核（安全性）**
- ★ 提案額を満たしても最低入金額未満なら承認しない（残高 $150 / 提案 $100）
- 最低入金額に達したら承認される（ちょうど 10%）
- 両条件の AND であること（片方だけでは不十分）
- RPC 失敗では状態を変えない（fail-closed）
- 入金期限を過ぎたら残高に関わらず期限切れ

**境界**
- ★ 帳簿を持つユーザーにはファネルを適用しない（PR #1035 の境界）
- 境界をまたいでも提案額が飛ばない
- ファネル提案額が実際に採算ゲートを通過できること
- 残高0 でもファネル提案は作られる / RPC 失敗は skip

## 検証

- `pytest tests/`: **5126 passed, 0 failed, 26 skipped**
- `ruff check` / `ruff format --check`: clean
- `mypy app/`: stripe の既存 2 件のみ（本変更と無関係）

## 補足: B-6 との関係

PR #1041（到達経路ゼロの承認型ユーザーには提案を作らない）が先に効くため、
Push 未購読のユーザーにはファネル提案も作られません。**通知を有効化した = 意思表示のある
ユーザーにのみ**ファネルが働きます。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>