### PR TITLE
fix(hooks): 相対パスのhook commandをCLAUDE_PROJECT_DIRで環境非依存にする

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -168,7 +168,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/load-claude-lessons.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/load-claude-lessons.sh"
           }
         ]
       }
@@ -179,7 +179,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/pre-tool-guard.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-tool-guard.sh"
           }
         ]
       }
@@ -190,7 +190,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/update-heartbeat.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/update-heartbeat.sh"
           }
         ]
       }
@@ -201,11 +201,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/send-lane-completion.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/send-lane-completion.sh"
           },
           {
             "type": "command",
-            "command": ".claude/hooks/lane-complete-handler.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/lane-complete-handler.sh"
           }
         ]
       }


### PR DESCRIPTION
## 背景

`.claude/settings.json` の全hook（SessionStart/PreToolUse/PostToolUse/Stop）が
`".claude/hooks/xxx.sh"` という**相対パス**で登録されていた。

hook の実行 cwd は呼び出し時の Bash tool の cwd に依存するため、cwd が `backend/`
等のサブディレクトリに移動した状態で hook が発火すると `No such file or directory`
で失敗する。これにより **安全機構（Lane越境ブロック / Tier Sファイル編集ブロック /
`.env.production` 書込ガード等）が無言で機能しない状態**になっていた。

（本番デプロイ作業中のスクリーンショットで実際に両方のエラーを確認済み）

## 再現・修正の確認

```
backend/ から相対パス実行 → "No such file or directory"    (バグ再現)
$CLAUDE_PROJECT_DIR 方式   → cwd に関わらず解決             (修正後)
```

Claude Code は hook プロセスに `$CLAUDE_PROJECT_DIR`（プロジェクトルート）を
自動でエクスポートする（公式仕様）。これを使うことで、このリポジトリが動く
3環境すべてで動作する:

- dev VPS: `/opt/ultra-autotrade/main/`
- production/staging VPS: `/opt/ultra-autotrade/`
- ローカル Mac: `/Users/hkobayashi/...`

絶対パスのハードコードは環境によって存在しないパスになるため使えない
（この理由で `$CLAUDE_PROJECT_DIR` を選択）。

## 変更内容

`.claude/settings.json` の hook command 5箇所を相対パス → `$CLAUDE_PROJECT_DIR/...` に変更。ロジック自体（各 `.sh` の中身）は無変更。

## スコープ外

`.claude/settings.local.json`（gitignore対象・Mac専用ローカル設定）にも
`guard-env-files.sh` の同種の相対パスバグがあったが、これは**gitignore対象で
本PRのdiffに現れない**。既存の他4hookに合わせて絶対パスに直し、ローカルで
別途修正済み（コミット不要・本PR対象外）。

## 検証

- `python3 -c "import json; json.load(open('.claude/settings.json'))"`: valid JSON
- `backend/` を cwd にした状態で各hookを `$CLAUDE_PROJECT_DIR` 経由実行し、全て解決することを確認（load-claude-lessons.sh / pre-tool-guard.sh / update-heartbeat.sh / send-lane-completion.sh / lane-complete-handler.sh）
- アプリケーションコードの変更なし（設定ファイルのみ）のため pytest 対象外

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>