### PR TITLE
fix(automation): 採算ゲートが実APYを無視し固定4%で判定していた欠陥を修正

### DIFF
--- a/backend/app/automation/ai_judgment_scheduler.py
+++ b/backend/app/automation/ai_judgment_scheduler.py
@@ -84,6 +84,12 @@ _CONSECUTIVE_EXPIRY_ALERT_THRESHOLD = 3
 _UNREACHABLE_ALERT_INTERVAL_HOURS = 24
 _unreachable_alerted_at: dict[int, datetime] = {}
 
+# 入金前ファネルの必要額が公表最低入金額 (MIN_DEPOSIT_USD) を超えた際の運用者アラート
+# 再送間隔 (2026-08-08 Asana 1217292627294465)。全ユーザー共通の条件 (APY 依存) なので
+# _unreachable_alerted_at のようなユーザー単位ではなく単一キーで絞る。
+_DEPOSIT_GAP_ALERT_INTERVAL_HOURS = 24
+_deposit_gap_alerted_at: dict[str, datetime] = {}
+
 # 提案金額: fund_allocations.allocated_amount_usd から実行済み提案の積み上げ (deployed) を
 # 差し引いた遊休額 (idle) × _PROPOSAL_RATIO で動的計算 (2026-08-06: 静的台帳→動的遊休額へ
 # 変更 / Asana 1217210604911292、詳細は _resolve_deployed_amount_usd 参照)。
@@ -93,6 +99,20 @@ _unreachable_alerted_at: dict[int, datetime] = {}
 _PROPOSAL_RATIO = Decimal(os.getenv("PROPOSAL_AMOUNT_RATIO", "0.10"))  # 10%
 _PROPOSAL_AMOUNT_MIN_USD = Decimal(os.getenv("PROPOSAL_AMOUNT_MIN_USD", "50"))
 _PROPOSAL_AMOUNT_MAX_USD = Decimal(os.getenv("PROPOSAL_AMOUNT_MAX_USD", "2000"))
+
+# 入金前ファネル (docs/62) の採算マージン (2026-08-08 Asana 1217292389876406)。
+# ファネル額は「採算が合う最小額」にこのマージンを乗せる。APY の小変動 (RPC取得の
+# 数秒のズレ等) で即不採算に戻らないようにする。1.05 = 5% の余裕。
+_FUNNEL_PROFITABILITY_MARGIN = Decimal(os.getenv("FUNNEL_PROFITABILITY_MARGIN", "1.05"))
+
+# 採算ゲートの期待利益計算に使う APY (2026-08-08 Asana 1217292389900767)。
+# 実APY (aave_data["supply_apy"]) が取得できた場合はそれを使う。取得失敗 (None) /
+# 0以下の異常値のときのみ、ここにフォールバックする。
+#
+# 実勢を上回らない保守的な値にすること。楽観側に倒すと採算割れの取引を通してしまう
+# (固定4%だった旧実装が、実測APY 3.2648% の状況下で $100 提案を「純利益+$0.05」と
+# 誤判定し、実際には赤字の提案を本番で作成していた事故の再発防止)。
+_FALLBACK_SUPPLY_APY_PCT = Decimal(os.getenv("FALLBACK_SUPPLY_APY_PCT", "3.0"))
 
 # 採算ゲート (fees.trade_gate) 未達スキップ時にユーザーへ伝える理由文言 (無音デッドゾーン対策)。
 _TRADE_GATE_SKIP_MESSAGE = (
@@ -192,8 +212,17 @@ def _has_active_allocation(db: Session, user_id: int) -> bool:
         return True
 
 
-def _resolve_proposal_amount(db: Session, user_id: int) -> Decimal:
+def _resolve_proposal_amount(
+    db: Session, user_id: int, *, supply_apy_pct: Optional[Decimal] = None
+) -> Decimal:
     """提案金額を解決する (案C: fund_allocation 優先 + wallet 残高 fallback / docs/61)。
+
+    Args:
+        supply_apy_pct: 入金前ファネル (下記2.) の採算計算に使う実APY。呼び出し元が
+            既に解決済みならその値を渡す (再解決は冪等)。省略時は None として扱われ
+            `_resolve_effective_supply_apy` がフォールバックへ倒す。デフォルト値を
+            付けているのは、allocation/十分な残高の経路など**大半の既存呼び出し元は
+            APY を必要としない**ため (ファネル分岐のみが使う)。
 
     0. smart_wallet_address を持つユーザーは 1 を飛ばして 2 へ
        (`uses_custodial_allocation` / 2026-08-06)。allocation は custodial プール持分の
@@ -277,9 +306,13 @@ def _resolve_proposal_amount(db: Session, user_id: int) -> Decimal:
         # ($852 の実効下限の正体 = 10%ルール × ガス代)。
         #
         # そこで入金前は分母を「現残高」ではなく「推奨運用額」に置き換える。
-        # $1,000 到達時にちょうど 10% になる額を提案し、awaiting_funds で着金を待つ。
-        # **実行前に着金検知側が最低入金額を再検証する**ため、残高に対し過大な supply が
-        # 実行されることはない (run_funding_detection_once / 10%ルール = CLAUDE.md
+        # 2026-08-08 (Asana 1217292389876406): 固定 $1,000×10%=$100 だと、実APYが
+        # 固定4%前提を下回った場合に採算ゲートで弾かれる (実測APY 3.2648% で $100 は
+        # 赤字)。採算が合う最小額を実APYから逆算し、そこに安全マージンを乗せる。
+        # 結果として「MIN_DEPOSIT_USD で採算が合う」状況では従来と同じ $100 になり
+        # (下の max により)、APY が下がるほど提案額と実質的な必要残高が動く。
+        # **実行前に着金検知側が 10% ルールを直接再検証する**ため、残高に対し過大な
+        # supply が実行されることはない (run_funding_detection_once / CLAUDE.md
         # [CRITICAL] 3 の担保)。
         #
         # ただし **allocation 帳簿を持つユーザーは対象外**。帳簿がある = パートナー/
@@ -288,14 +321,27 @@ def _resolve_proposal_amount(db: Session, user_id: int) -> Decimal:
         # 本人に入金を促すのは筋違い (運用側が直すべき問題)。SCW 保有ユーザーは
         # 分岐 1 を飛ばしてここに来るため、ここで明示的に確認する必要がある (PR #1035)。
         if balance < MIN_DEPOSIT_USD and not _has_active_allocation(db, user_id):
-            funnel_amount = (MIN_DEPOSIT_USD * _PROPOSAL_RATIO).quantize(Decimal("0.01"))
+            effective_apy = _resolve_effective_supply_apy(supply_apy_pct)
+            fixed_cost = Decimal(os.getenv("TRADE_FIXED_COST_USD", "0.27"))
+            _rate = effective_apy / Decimal("100") * Decimal("30") / Decimal("365")
+            _needed_amount = ((fixed_cost + Decimal("0.01")) / _rate) * _FUNNEL_PROFITABILITY_MARGIN
+            baseline_amount = (MIN_DEPOSIT_USD * _PROPOSAL_RATIO).quantize(Decimal("0.01"))
+            funnel_amount = min(
+                max(baseline_amount, _needed_amount.quantize(Decimal("0.01"))),
+                _PROPOSAL_AMOUNT_MAX_USD,
+            )
             logger.info(
-                "[funding_funnel] user_id=%d balance=$%s < min $%s — "
+                "[funding_funnel] user_id=%d balance=$%s < min $%s (実APY=%s%%) — "
                 "推奨運用額ベースで $%s の提案を作成 (着金後に実行可)",
                 user_id,
                 balance,
                 MIN_DEPOSIT_USD,
+                effective_apy,
                 funnel_amount,
+            )
+            _notify_deposit_gap_if_needed(
+                required_balance=(funnel_amount / _PROPOSAL_RATIO).quantize(Decimal("0.01")),
+                effective_apy=effective_apy,
             )
             return funnel_amount
         amount = (balance * _PROPOSAL_RATIO).quantize(Decimal("0.01"))
@@ -523,6 +569,39 @@ def _notify_unreachable_approval_user(user_id: int) -> None:
         get_notification_service().send(msg)
     except Exception as exc:  # noqa: BLE001
         logger.warning("_notify_unreachable_approval_user failed for user_id=%d: %s", user_id, exc)
+
+
+def _notify_deposit_gap_if_needed(required_balance: Decimal, effective_apy: Decimal) -> None:
+    """入金前ファネルの必要額が公表最低入金額を超えたら運用者へ通知する (best-effort)。
+
+    2026-08-08 Asana 1217292627294465。$1,000 は固定APY4%前提の $852 を上回るよう
+    決めた数字だが、実APYが4%を下回ると採算上の必要額がそれを超える。公表額の
+    変更は事業判断のため Claude では決めない (別チケット) — ここでは判断材料 (実APY /
+    必要残高 / 公表額) を運用者に上げるだけ。全ユーザー共通の条件なので単一キーで絞る。
+    """
+    if required_balance <= MIN_DEPOSIT_USD:
+        return
+    now = datetime.now(timezone.utc)
+    last = _deposit_gap_alerted_at.get("global")
+    if last is not None and now - last < timedelta(hours=_DEPOSIT_GAP_ALERT_INTERVAL_HOURS):
+        return
+    _deposit_gap_alerted_at["global"] = now
+    try:
+        from app.notifications.factory import get_notification_service  # noqa: PLC0415
+        from app.notifications.templates import operational_alert_notification  # noqa: PLC0415
+
+        msg = operational_alert_notification(
+            title="💰 公表最低入金額が実際の採算ラインを下回っています",
+            body=(
+                f"実APY={effective_apy}% では、採算が合う最低入金額は約 ${required_balance} "
+                f"ですが、公表額は ${MIN_DEPOSIT_USD} のままです。この間隔のユーザーは "
+                "入金しても提案が採算ゲートで弾かれる可能性があります。公表額の見直しを "
+                "検討してください (Asana: 公表最低入金額の見直し)。"
+            ),
+        )
+        get_notification_service().send(msg)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("_notify_deposit_gap_if_needed failed: %s", exc)
 
 
 def _should_skip_unreachable_approval_user(db: Session, user: User) -> bool:
@@ -1072,10 +1151,33 @@ def _deliver_ai_proposal_push(
         return False
 
 
+def _resolve_effective_supply_apy(supply_apy_pct: Optional[Decimal]) -> Decimal:
+    """採算ゲートの期待利益計算に使う APY を決定する (2026-08-08 Asana 1217292389900767)。
+
+    実APY (aave_data["supply_apy"]) が取得できていて正の値ならそれを使う。
+    取得失敗 (None) または 0 以下の異常値のときのみ _FALLBACK_SUPPLY_APY_PCT に倒す。
+
+    fail-open (提案生成を止めない) にする理由: RPC 1回の失敗や env 1つの設定ミスで
+    全ユーザーの提案生成が無言で止まる方が、フォールバック値で保守的に判定し続ける
+    より大きな故障になる (受け入れ条件 B-6 実装時の _user_has_reachable_channel と
+    同じ判断)。フォールバック使用は warning ログで可視化する。
+    """
+    if supply_apy_pct is not None and supply_apy_pct > Decimal("0"):
+        return supply_apy_pct
+    logger.warning(
+        "採算ゲート: 実APY取得不可 (supply_apy_pct=%s) — フォールバック %s%% を使用",
+        supply_apy_pct,
+        _FALLBACK_SUPPLY_APY_PCT,
+    )
+    return _FALLBACK_SUPPLY_APY_PCT
+
+
 def _create_proposals_for_users(
     db: Session,
     decision: AIDecision,
     result: CrossValidationResult,
+    *,
+    supply_apy_pct: Optional[Decimal],
 ) -> int:
     """ティア別間隔を満たすアクティブユーザーに Proposal を作成し、作成件数を返す。
 
@@ -1083,6 +1185,9 @@ def _create_proposals_for_users(
         db: SQLAlchemy セッション。
         decision: 保存済みの AIDecision。
         result: AI クロスバリデーション結果。
+        supply_apy_pct: 採算ゲート判定に使う実APY (%表記、aave_data["supply_apy"])。
+            取得失敗時は None を渡すこと (_resolve_effective_supply_apy がフォールバック)。
+            デフォルト値を付けない: 呼び出し側の渡し忘れを mypy で検出させるため。
 
     Returns:
         作成した Proposal の件数。
@@ -1092,6 +1197,7 @@ def _create_proposals_for_users(
     expires_at = datetime.now(timezone.utc) + timedelta(hours=_PROPOSAL_EXPIRES_HOURS)
     reason = result.final_reason or "AI判定による提案"
     now = datetime.now(timezone.utc)
+    effective_apy = _resolve_effective_supply_apy(supply_apy_pct)
 
     # AUTO_EXECUTE（完全おまかせ・無承認自動実行）ユーザーもここで提案対象に含める
     # （2026-07-16）。生成後 run_auto_execution_for_ai_decision が有効な委譲(SCW) grant を
@@ -1206,17 +1312,18 @@ def _create_proposals_for_users(
                     continue
 
                 # fund_allocations から per-user 提案金額を動的計算 (Decimal("0") = skip)
-                proposal_amount_usd = _resolve_proposal_amount(db, user.id)
+                proposal_amount_usd = _resolve_proposal_amount(
+                    db, user.id, supply_apy_pct=effective_apy
+                )
                 if proposal_amount_usd <= Decimal("0"):
                     # _resolve_proposal_amount 内で警告・Slack 通知済み
                     continue
 
-                # 動的手数料計算: デフォルトAPY 4%（安定期）を使用
+                # 動的手数料計算: 実APY (2026-08-08 以前は固定4%、Asana 1217292671266767)。
                 # 30日保有での予想利益 = amount × (APY/100) × (30/365)
-                _default_apy = Decimal("4")
                 _expected_profit = (
                     proposal_amount_usd
-                    * _default_apy
+                    * effective_apy
                     / Decimal("100")
                     * Decimal("30")
                     / Decimal("365")
@@ -1224,7 +1331,7 @@ def _create_proposals_for_users(
                 market_fee = calculate_fee_by_market(
                     trade_amount_usd=proposal_amount_usd,
                     tier=normalize_tier(user.tier, user_id=user.id).value,
-                    current_apy=_default_apy,
+                    current_apy=effective_apy,
                     expected_profit_usd=_expected_profit,
                     fixed_cost_usd=fixed_cost,
                 )
@@ -1305,6 +1412,8 @@ def _create_safe_yield_proposals_for_users(
     db: Session,
     decision: AIDecision,
     result: CrossValidationResult,
+    *,
+    supply_apy_pct: Optional[Decimal],
 ) -> int:
     """[B1] HOLD 判定時に「遊休USDC→Aave USDC 供給」の安全利回り提案を作成する。
 
@@ -1313,9 +1422,13 @@ def _create_safe_yield_proposals_for_users(
     改善する方向で本質的に安全なため、相場ゲート (Indicator+Macro≥70%) を待たずにドル建て安全利回りへ
     配分する。dedup / 入金ゲート / fee ゲート / per-user savepoint は本流と同一機構を再利用する。
     BUY/SELL 経路 (``_create_proposals_for_users``) には一切影響しない。
+
+    Args:
+        supply_apy_pct: 採算ゲート判定に使う実APY (%表記)。_create_proposals_for_users と同義。
     """
     expires_at = datetime.now(timezone.utc) + timedelta(hours=_PROPOSAL_EXPIRES_HOURS)
     now = datetime.now(timezone.utc)
+    effective_apy = _resolve_effective_supply_apy(supply_apy_pct)
     # 消費者向けの提案理由（ProposalActionCard に表示）にプロトコル名（Aave 等）は出さない約束。
     reason = "遊休USDCを安全な利回りへ配分します。相場の方向性に依らず実行できる安全な運用です。"
 
@@ -1392,14 +1505,15 @@ def _create_safe_yield_proposals_for_users(
                     continue
 
                 # 遊休額 (fund_allocation or wallet USDC × 10%)。0/入金未満は skip (本流と同一)。
-                proposal_amount_usd = _resolve_proposal_amount(db, user.id)
+                proposal_amount_usd = _resolve_proposal_amount(
+                    db, user.id, supply_apy_pct=effective_apy
+                )
                 if proposal_amount_usd <= Decimal("0"):
                     continue
 
-                _default_apy = Decimal("4")
                 _expected_profit = (
                     proposal_amount_usd
-                    * _default_apy
+                    * effective_apy
                     / Decimal("100")
                     * Decimal("30")
                     / Decimal("365")
@@ -1407,7 +1521,7 @@ def _create_safe_yield_proposals_for_users(
                 market_fee = calculate_fee_by_market(
                     trade_amount_usd=proposal_amount_usd,
                     tier=normalize_tier(user.tier, user_id=user.id).value,
-                    current_apy=_default_apy,
+                    current_apy=effective_apy,
                     expected_profit_usd=_expected_profit,
                     fixed_cost_usd=fixed_cost,
                 )
@@ -1641,13 +1755,20 @@ def run_ai_judgment_job(db: Optional[Session] = None) -> dict[str, Any]:
             )
 
         # BUY / SELL 時は Proposal 作成
+        # supply_apy_pct: 2026-08-08 以前は採算ゲートが常に固定4%を使い、実APY
+        # (aave_data["supply_apy"]、同一スコープで既に取得済み) を渡していなかった
+        # (Asana 1217292389900767)。ここで実APYを渡す。
         proposals_created = 0
         if routing_result.final_action in (TradeAction.BUY, TradeAction.SELL):
-            proposals_created = _create_proposals_for_users(db, decision, routing_result)
+            proposals_created = _create_proposals_for_users(
+                db, decision, routing_result, supply_apy_pct=aave_data["supply_apy"]
+            )
         elif _safe_yield_on_hold_enabled() and routing_result.final_action == TradeAction.HOLD:
             # [B1] HOLD でも遊休USDCは安全利回り(Aave USDC供給)へ配分を提案する。
             # 方向性ゲート(Indicator+Macro≥70%)に依らない安全な運用のみ通す。
-            proposals_created = _create_safe_yield_proposals_for_users(db, decision, result)
+            proposals_created = _create_safe_yield_proposals_for_users(
+                db, decision, result, supply_apy_pct=aave_data["supply_apy"]
+            )
 
         db.commit()
 

--- a/backend/app/automation/scheduled_tasks.py
+++ b/backend/app/automation/scheduled_tasks.py
@@ -882,7 +882,7 @@ def run_funding_detection_once() -> int:
                 balance = read_wallet_usdc_balance(wallet)
                 if balance is None:
                     continue  # RPC 失敗は次サイクル再試行 (安全側)
-                # A-2 入金ゲート: 提案額を満たすだけでなく最低入金額に達していること。
+                # A-2 入金ゲート: 提案額を満たすだけでなく、総資産の10%ルールに収まっていること。
                 #
                 # 以前は `balance >= amount_usd` のみを見ており、手動承認経路
                 # (`_run_approval_and_execution`) が課している MIN_DEPOSIT_USD ゲートを
@@ -891,10 +891,15 @@ def run_funding_detection_once() -> int:
                 # この抜けは実害になる: 残高 $150 のユーザーの $100 提案が「$150 >= $100」で
                 # 承認され、総資産の 67% を 1 取引で supply してしまう
                 # (CLAUDE.md [CRITICAL] 3「Max single trade: 10% of total assets」違反)。
-                # 最低入金額に達して初めて提案額が総資産の 10% に収まるため、両方を課す。
-                from app.users.deposit_policy import MIN_DEPOSIT_USD  # noqa: PLC0415
+                #
+                # 2026-08-08 (Asana 1217292389876406): ファネル提案額が実APY連動になり
+                # $1,000×10%=$100 固定ではなくなったため、固定値 MIN_DEPOSIT_USD との
+                # 比較では追従できない。10%ルールを直接検証する形に変更する
+                # (提案額が総資産の10%以内であること = 実質的に必要な最低残高を動的に導出)。
+                from app.automation.ai_judgment_scheduler import _PROPOSAL_RATIO  # noqa: PLC0415
 
-                if balance >= Decimal(str(proposal.amount_usd)) and balance >= MIN_DEPOSIT_USD:
+                _amount_usd = Decimal(str(proposal.amount_usd))
+                if balance >= _amount_usd and _amount_usd <= balance * _PROPOSAL_RATIO:
                     proposal.status = "approved"
                     proposal.approved_at = now
                     db.flush()

--- a/backend/tests/automation/test_funding_detection.py
+++ b/backend/tests/automation/test_funding_detection.py
@@ -67,7 +67,11 @@ def _run_once(
 
 class TestRunFundingDetectionOnce:
     def test_approves_when_balance_sufficient(self) -> None:
-        p = _make_awaiting_proposal(amount_usd=Decimal("1000"))
+        """2026-08-08 (Asana 1217292389876406): balance>=amount だけでなく
+        10%ルール (amount<=balance×10%) も満たす額に変更。$1000/$1500 (66.7%) は
+        10%ルール違反になるため、$100/$1500 (6.7%、ルール内) に変更した。
+        """
+        p = _make_awaiting_proposal(amount_usd=Decimal("100"))
         changed, sent, db = _run_once([p], balance=Decimal("1500"))
         assert p.status == "approved"
         assert p.approved_at is not None
@@ -76,14 +80,28 @@ class TestRunFundingDetectionOnce:
         db.commit.assert_called()
 
     def test_approves_at_exact_amount(self) -> None:
-        p = _make_awaiting_proposal(amount_usd=Decimal("1000"))
-        changed, _sent, _db = _run_once([p], balance=Decimal("1000"))
+        """境界値テスト。旧実装は balance==amount_usd の境界だったが、10%ルール
+        導入後はそちらが常に balance>=amount_usd を満たすため境界ではなくなった
+        (2026-08-08)。今の実質的な境界は amount_usd == balance×10% であること。
+        """
+        p = _make_awaiting_proposal(amount_usd=Decimal("100"))
+        changed, _sent, _db = _run_once([p], balance=Decimal("1000"))  # 100 == 1000*10%
         assert p.status == "approved"  # >= なので一致でも承認
         assert changed == 1
 
     def test_stays_awaiting_when_insufficient(self) -> None:
+        p = _make_awaiting_proposal(amount_usd=Decimal("100"))
+        changed, sent, _db = _run_once([p], balance=Decimal("99.99"))
+        assert p.status == "awaiting_funds"
+        assert changed == 0
+        assert len(sent) == 0
+
+    def test_stays_awaiting_when_exceeds_ten_percent_rule(self) -> None:
+        """★2026-08-08 (Asana 1217292389876406) の中核: balance>=amount_usd を
+        満たしても 10%ルールを超えるなら承認しない (旧実装の安全性の穴)。
+        """
         p = _make_awaiting_proposal(amount_usd=Decimal("1000"))
-        changed, sent, _db = _run_once([p], balance=Decimal("999.99"))
+        changed, sent, _db = _run_once([p], balance=Decimal("1500"))  # 1000/1500=66.7%
         assert p.status == "awaiting_funds"
         assert changed == 0
         assert len(sent) == 0

--- a/backend/tests/automation/test_funding_funnel_sizing.py
+++ b/backend/tests/automation/test_funding_funnel_sizing.py
@@ -40,14 +40,20 @@ from sqlalchemy.orm import Session, sessionmaker
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-funding-funnel")
 
 from app.auth.models import User  # noqa: E402
+from app.automation import ai_judgment_scheduler as sched  # noqa: E402
 from app.automation.ai_judgment_scheduler import (  # noqa: E402
     _PROPOSAL_RATIO,
+    _notify_deposit_gap_if_needed,
     _resolve_proposal_amount,
 )
 from app.automation.scheduled_tasks import run_funding_detection_once  # noqa: E402
 from app.database import Base  # noqa: E402
 from app.proposals.models import Proposal  # noqa: E402
 from app.users.deposit_policy import MIN_DEPOSIT_USD  # noqa: E402
+
+# get_notification_service は関数内 import のため import 元を差し替える
+# (tests/automation/test_unreachable_approval_user_gate.py と同じ理由・同じパターン)。
+_FACTORY = "app.notifications.factory.get_notification_service"
 
 _SCHED = "app.automation.ai_judgment_scheduler"
 _TASKS = "app.automation.scheduled_tasks"
@@ -121,10 +127,15 @@ def _make_awaiting_proposal(db: Session, uid: int, amount: Decimal) -> Proposal:
 
 class TestFunnelSizing:
     def test_入金前ユーザーには推奨運用額ベースの提案額が返る(self, db_session: Session) -> None:
-        """従来は Decimal(0)（提案なし）だった。ファネルが成立しない原因だった箇所。"""
+        """従来は Decimal(0)（提案なし）だった。ファネルが成立しない原因だった箇所。
+
+        2026-08-08 (Asana 1217292389876406): ファネル額は実APY連動になった。
+        APY=4% (固定4%前提だった旧仕様と同値) では必要額 ($89.42) が
+        $1,000×10%=$100 の基準額を下回るため、基準額 $100 のまま変わらないことを確認する。
+        """
         _make_user(db_session, 601)
         with patch(f"{_SCHED}._read_wallet_usdc_balance", return_value=Decimal("200")):
-            amount = _resolve_proposal_amount(db_session, 601)
+            amount = _resolve_proposal_amount(db_session, 601, supply_apy_pct=Decimal("4"))
         assert amount == (MIN_DEPOSIT_USD * _PROPOSAL_RATIO).quantize(Decimal("0.01"))
 
     def test_ファネル提案額は採算ゲートを通過できる(self, db_session: Session) -> None:
@@ -163,17 +174,32 @@ class TestFunnelSizing:
             amount = _resolve_proposal_amount(db_session, 605)
         assert amount == Decimal("500.00")  # 5000 × 10%
 
-    def test_境界をまたいでも提案額が飛ばない(self, db_session: Session) -> None:
-        """$1,000 直下(ファネル)と ちょうど(残高ベース) で提案額が一致する。
+    def test_実測APYではファネル額が基準額を上回る(self, db_session: Session) -> None:
+        """本番で実際に起きた事故 (user 19, $100固定) の直接的な修正確認。
 
-        ファネルの分母に MIN_DEPOSIT_USD を使っている帰結。別の値を使うと境界で
+        実測APY 3.2648% (2026-08-08 Base mainnet) では基準額 $100 は赤字だったため、
+        採算が合う額 ($109.56 = 必要額$104.35×マージン1.05) まで上がることを確認する。
+        """
+        _make_user(db_session, 618)
+        with patch(f"{_SCHED}._read_wallet_usdc_balance", return_value=Decimal("0")):
+            amount = _resolve_proposal_amount(db_session, 618, supply_apy_pct=Decimal("3.2648"))
+        assert amount == Decimal("109.56")
+        assert amount > (MIN_DEPOSIT_USD * _PROPOSAL_RATIO).quantize(Decimal("0.01"))
+
+    def test_境界をまたいでも提案額が飛ばない(self, db_session: Session) -> None:
+        """$1,000 直下(ファネル)と ちょうど(残高ベース) で提案額が一致する (APY=4% 時)。
+
+        ファネルの必要額が基準額 ($1,000×10%=$100) を下回る APY では、
+        ファネルは基準額に張り付くため境界の連続性が保たれる。別の値を使うと境界で
         提案額が不連続に飛び、ユーザーには理由の分からない金額変動として見える。
+        APY が下がり必要額が基準額を上回る場合は、この連続性は意図的に崩れる
+        (実際の採算ラインに合わせて必要残高そのものが上がるため。T2 の主目的)。
         """
         _make_user(db_session, 606)
         with patch(f"{_SCHED}._read_wallet_usdc_balance", return_value=Decimal("999.99")):
-            below = _resolve_proposal_amount(db_session, 606)
+            below = _resolve_proposal_amount(db_session, 606, supply_apy_pct=Decimal("4"))
         with patch(f"{_SCHED}._read_wallet_usdc_balance", return_value=MIN_DEPOSIT_USD):
-            at = _resolve_proposal_amount(db_session, 606)
+            at = _resolve_proposal_amount(db_session, 606, supply_apy_pct=Decimal("4"))
         assert below == at
 
     def test_帳簿を持つユーザーにはファネルを適用しない(self, db_session: Session) -> None:
@@ -256,6 +282,31 @@ class TestExecutionSafety:
         db_session.refresh(p)
         assert p.status == "awaiting_funds"
 
+    def test_旧実装なら承認していたはずのケースを新実装は拒否する(
+        self, db_session: Session
+    ) -> None:
+        """★2026-08-08 (Asana 1217292389876406) の中核: 10%ルールの直接検証。
+
+        旧実装は `balance >= amount_usd AND balance >= MIN_DEPOSIT_USD` を見ていた。
+        実APY連動で提案額が $104.35 (>$1,000×10%=$100) になった場合、
+        残高 $1,000 では旧式だと「1000>=104.35 かつ 1000>=1000」で**承認されてしまう**
+        (104.35/1000 = 10.435% > 10%、CLAUDE.md [CRITICAL] 3 違反)。
+        新実装 (amount <= balance × 10%) はこれを正しく拒否する。
+        """
+        _make_user(db_session, 616)
+        p = _make_awaiting_proposal(db_session, 616, Decimal("104.35"))
+        self._run(db_session, MIN_DEPOSIT_USD)
+        db_session.refresh(p)
+        assert p.status == "awaiting_funds"
+
+    def test_10パーセント以内なら実APY連動の提案額でも承認される(self, db_session: Session) -> None:
+        """残高がもう少し多ければ (10%以内に収まれば) 承認される。"""
+        _make_user(db_session, 617)
+        p = _make_awaiting_proposal(db_session, 617, Decimal("104.35"))
+        self._run(db_session, Decimal("1050"))  # 104.35/1050 = 9.94% < 10%
+        db_session.refresh(p)
+        assert p.status == "approved"
+
     def test_入金期限を過ぎたら残高に関わらず期限切れ(self, db_session: Session) -> None:
         """funding window は市場期限と分離されているが、無期限ではない。"""
         _make_user(db_session, 615)
@@ -265,3 +316,64 @@ class TestExecutionSafety:
         self._run(db_session, MIN_DEPOSIT_USD * 10)
         db_session.refresh(p)
         assert p.status == "expired"
+
+
+@pytest.fixture(autouse=True)
+def _clear_deposit_gap_throttle() -> Generator[None, None, None]:
+    """アラート絞り込みはプロセス内 dict なのでテスト間で持ち越さない。"""
+    sched._deposit_gap_alerted_at.clear()
+    yield
+    sched._deposit_gap_alerted_at.clear()
+
+
+class TestDepositGapNotification:
+    """公表最低入金額が実際の採算ラインを下回った際の運用者通知 (Asana 1217292627294465)。
+
+    公表額($1,000)の見直しは事業判断であり Claude では決めない。ここで検証するのは
+    「判断材料 (実APY/必要残高/公表額) が自動的に運用者へ上がること」そのもの。
+    """
+
+    def test_必要残高が公表額以下なら通知しない(self) -> None:
+        with patch(_FACTORY) as factory:
+            _notify_deposit_gap_if_needed(
+                required_balance=MIN_DEPOSIT_USD, effective_apy=Decimal("4")
+            )
+        factory.assert_not_called()
+
+    def test_必要残高が公表額を超えたら通知する(self) -> None:
+        with patch(_FACTORY) as factory:
+            factory.return_value.send = lambda _m: None
+            _notify_deposit_gap_if_needed(
+                required_balance=Decimal("1043.45"), effective_apy=Decimal("3.2648")
+            )
+        factory.assert_called_once()
+
+    def test_同一条件への連投は絞られる(self) -> None:
+        """毎tick発火すると Slack を埋め尽くす（既存アラートの前例と同じ理由で絞る）。"""
+        with patch(_FACTORY) as factory:
+            factory.return_value.send = lambda _m: None
+            for _ in range(3):
+                _notify_deposit_gap_if_needed(
+                    required_balance=Decimal("1043.45"), effective_apy=Decimal("3.2648")
+                )
+        assert factory.call_count == 1
+
+    def test_絞り込み期間を過ぎれば再送される(self) -> None:
+        with patch(_FACTORY) as factory:
+            factory.return_value.send = lambda _m: None
+            _notify_deposit_gap_if_needed(
+                required_balance=Decimal("1043.45"), effective_apy=Decimal("3.2648")
+            )
+            sched._deposit_gap_alerted_at["global"] = datetime.now(timezone.utc) - timedelta(
+                hours=sched._DEPOSIT_GAP_ALERT_INTERVAL_HOURS + 1
+            )
+            _notify_deposit_gap_if_needed(
+                required_balance=Decimal("1043.45"), effective_apy=Decimal("3.2648")
+            )
+        assert factory.call_count == 2
+
+    def test_通知送信が失敗しても例外を伝播しない(self) -> None:
+        with patch(_FACTORY, side_effect=RuntimeError("slack down")):
+            _notify_deposit_gap_if_needed(
+                required_balance=Decimal("1043.45"), effective_apy=Decimal("3.2648")
+            )  # 例外が出ないこと

--- a/backend/tests/automation/test_profitability_gate_real_apy.py
+++ b/backend/tests/automation/test_profitability_gate_real_apy.py
@@ -1,0 +1,202 @@
+# Copyright (c) Ultra AutoTrade. All rights reserved.
+# backend/tests/automation/test_profitability_gate_real_apy.py
+"""採算ゲートが実APYを使うことの単体テスト (2026-08-08 Asana 1217292671266767)。
+
+以前は `_default_apy = Decimal("4")` を常に使い、同じスコープで取得済みの実APY
+(`aave_data["supply_apy"]`) を無視していた。実測 APY 3.2648%（2026-08-08 Base mainnet）
+では $100 の提案は赤字（30日利益$0.2683 - ガス代$0.27 = -$0.0017）だが、固定4%では
+「利益+$0.05」と誤判定され本番で実際に作成された
+(user 19, `[funding_funnel] user_id=19 balance=$0 < min $1000 — $100.00 の提案を作成`)。
+
+本テストは `calculate_fee_by_market` を**モックしない**（test_safe_yield_on_hold.py 等の
+既存テストとの違い）。ここで検証したいのは「実APYが正しく渡り、実際の採算計算に
+反映されるか」そのものなので、fee 計算自体をモックすると意味が消える。
+"""
+
+import os
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-profitability-gate")
+os.environ.setdefault("INITIAL_ADMIN_EMAIL", "admin@example.com")
+
+import app.automation.ai_judgment_scheduler as sched  # noqa: E402
+from app.automation.ai_judgment_scheduler import (  # noqa: E402
+    _create_safe_yield_proposals_for_users,
+    _resolve_effective_supply_apy,
+)
+from app.proposals.models import Proposal  # noqa: E402
+
+# 2026-08-08 実測値 (Base mainnet, Aave V3 Pool.getReserveData(USDC).currentLiquidityRate)。
+_REAL_MEASURED_APY = Decimal("3.2648")
+
+
+def _mk_user(uid: int = 21) -> MagicMock:
+    u = MagicMock()
+    u.id = uid
+    u.tier = "LOWER"
+    u.risk_mode = "conservative"
+    return u
+
+
+def _mk_db(users: list, pending: int = 0) -> MagicMock:
+    db = MagicMock()
+    active_res = MagicMock()
+    active_res.all.return_value = users
+    stale_res = MagicMock()
+    stale_res.all.return_value = []
+    db.scalars.side_effect = [active_res] + [stale_res for _ in range(len(users) * 2)]
+    db.scalar.return_value = pending
+    return db
+
+
+def _added_proposals(db: MagicMock) -> list:
+    return [c.args[0] for c in db.add.call_args_list if isinstance(c.args[0], Proposal)]
+
+
+def _patch_non_gate_deps(monkeypatch: pytest.MonkeyPatch, *, amount: Decimal) -> None:
+    """採算ゲート以外の依存だけをモックする (fee計算は実物を使う)。"""
+    monkeypatch.setattr(sched, "_is_user_due_for_judgment", lambda u, now: True)
+    monkeypatch.setattr(
+        sched, "_resolve_proposal_amount", lambda db, uid, supply_apy_pct=None: amount
+    )
+    monkeypatch.setattr(
+        sched, "normalize_tier", lambda tier, user_id=None: MagicMock(value="LOWER")
+    )
+    monkeypatch.setattr(sched, "estimate_static_gas_cost_usd", lambda op: Decimal("2"))
+    monkeypatch.setattr("app.notifications.factory.get_notification_service", lambda: MagicMock())
+
+
+def _decision() -> MagicMock:
+    d = MagicMock()
+    d.id = 1
+    return d
+
+
+def _result() -> MagicMock:
+    r = MagicMock()
+    r.final_confidence = 50
+    return r
+
+
+class TestResolveEffectiveSupplyApy:
+    """_resolve_effective_supply_apy (両関数が共有する解決ロジック) の単体テスト。"""
+
+    def test_正の実APYはそのまま使う(self) -> None:
+        assert _resolve_effective_supply_apy(_REAL_MEASURED_APY) == _REAL_MEASURED_APY
+
+    def test_Noneはフォールバック値になる(self) -> None:
+        assert _resolve_effective_supply_apy(None) == sched._FALLBACK_SUPPLY_APY_PCT
+
+    def test_0はフォールバック値になる(self) -> None:
+        assert _resolve_effective_supply_apy(Decimal("0")) == sched._FALLBACK_SUPPLY_APY_PCT
+
+    def test_負値はフォールバック値になる(self) -> None:
+        assert _resolve_effective_supply_apy(Decimal("-1.5")) == sched._FALLBACK_SUPPLY_APY_PCT
+
+    def test_フォールバック使用時にwarningログが出る(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level("WARNING"):
+            _resolve_effective_supply_apy(None)
+        assert any("フォールバック" in r.message for r in caplog.records)
+
+    def test_正常値ではwarningログが出ない(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level("WARNING"):
+            _resolve_effective_supply_apy(_REAL_MEASURED_APY)
+        assert not any("フォールバック" in r.message for r in caplog.records)
+
+
+class TestProfitabilityGateUsesRealApy:
+    """★中核: 採算ゲートの実際の判定に実APYが反映されること (end-to-end, fee計算は実物)。"""
+
+    def test_実測APY3_2648パーセントでは100ドル提案がブロックされる(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """本番で実際に起きた事故の再現: 固定4%なら通るが実APYでは赤字。"""
+        _patch_non_gate_deps(monkeypatch, amount=Decimal("100"))
+        db = _mk_db([_mk_user()], pending=0)
+        n = _create_safe_yield_proposals_for_users(
+            db, _decision(), _result(), supply_apy_pct=_REAL_MEASURED_APY
+        )
+        assert n == 0
+        assert _added_proposals(db) == []
+
+    def test_APY4_5パーセントなら100ドル提案は通る(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """ゲートを閉じすぎていないことの回帰確認 (実APYが十分高ければ通る)。"""
+        _patch_non_gate_deps(monkeypatch, amount=Decimal("100"))
+        db = _mk_db([_mk_user()], pending=0)
+        n = _create_safe_yield_proposals_for_users(
+            db, _decision(), _result(), supply_apy_pct=Decimal("4.5")
+        )
+        assert n == 1
+        assert len(_added_proposals(db)) == 1
+
+    def test_supply_apy_pctがNoneならフォールバック3パーセントで判定される(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """RPC失敗等で実APYが取れない場合、フォールバック(3.0%)でも$100は赤字なのでブロック。
+
+        フォールバック値自体が保守的 (実勢を上回らない) であることの確認でもある。
+        """
+        _patch_non_gate_deps(monkeypatch, amount=Decimal("100"))
+        db = _mk_db([_mk_user()], pending=0)
+        n = _create_safe_yield_proposals_for_users(db, _decision(), _result(), supply_apy_pct=None)
+        assert n == 0
+        assert _added_proposals(db) == []
+
+    def test_supply_apy_pctが0でも例外を投げずフォールバックへ倒れる(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_non_gate_deps(monkeypatch, amount=Decimal("100"))
+        db = _mk_db([_mk_user()], pending=0)
+        # 例外が伝播しないことそのものが検証対象。
+        n = _create_safe_yield_proposals_for_users(
+            db, _decision(), _result(), supply_apy_pct=Decimal("0")
+        )
+        assert n == 0
+
+    def test_supply_apy_pctが負値でも例外を投げずフォールバックへ倒れる(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_non_gate_deps(monkeypatch, amount=Decimal("100"))
+        db = _mk_db([_mk_user()], pending=0)
+        n = _create_safe_yield_proposals_for_users(
+            db, _decision(), _result(), supply_apy_pct=Decimal("-2")
+        )
+        assert n == 0
+
+    def test_高いAPYでは少額でも通る(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """極端値でも破綻しないこと。APYが十分高ければ$50でも黒字になり得る。"""
+        _patch_non_gate_deps(monkeypatch, amount=Decimal("50"))
+        db = _mk_db([_mk_user()], pending=0)
+        n = _create_safe_yield_proposals_for_users(
+            db, _decision(), _result(), supply_apy_pct=Decimal("20")
+        )
+        assert n == 1
+
+
+class TestBothProposalPathsShareTheSameApyResolution:
+    """BUY/SELL経路 (_create_proposals_for_users) も同じ実APYを使うことのパリティ確認。
+
+    2つの関数は _resolve_effective_supply_apy を共有しているが、片方だけ配線を
+    誤って忘れる (コピペミス) 事故を防ぐため、もう一方の経路でも同一挙動を確認する。
+    """
+
+    def test_BUY_SELL経路でも実測APYで100ドル提案がブロックされる(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.ai.schemas import TradeAction
+        from app.automation.ai_judgment_scheduler import _create_proposals_for_users
+
+        _patch_non_gate_deps(monkeypatch, amount=Decimal("100"))
+        monkeypatch.setattr(sched, "_should_skip_unreachable_approval_user", lambda db, u: False)
+        db = _mk_db([_mk_user()], pending=0)
+        result = _result()
+        result.final_action = TradeAction.BUY
+        result.final_reason = "test"
+        n = _create_proposals_for_users(db, _decision(), result, supply_apy_pct=_REAL_MEASURED_APY)
+        assert n == 0
+        assert _added_proposals(db) == []

--- a/backend/tests/automation/test_proposals_notification.py
+++ b/backend/tests/automation/test_proposals_notification.py
@@ -109,7 +109,7 @@ class TestCreateProposalsForUsersNotification:
             mock_svc = MagicMock()
             mock_svc.send.side_effect = lambda m: sent_msgs.append(m)
             mock_get_svc.return_value = mock_svc
-            _create_proposals_for_users(mock_db, decision, result)
+            _create_proposals_for_users(mock_db, decision, result, supply_apy_pct=Decimal("4"))
 
         return mock_svc.send, sent_msgs
 
@@ -166,7 +166,9 @@ class TestCreateProposalsForUsersNotification:
                 side_effect=RuntimeError("notification failure"),
             ),
         ):
-            count = _create_proposals_for_users(mock_db, decision, result)
+            count = _create_proposals_for_users(
+                mock_db, decision, result, supply_apy_pct=Decimal("4")
+            )
 
         assert count == 1
 
@@ -277,7 +279,7 @@ class TestCreateProposalsForUsersPushWiring:
             patch("app.notifications.factory.get_notification_service"),
             patch("app.automation.ai_judgment_scheduler._deliver_ai_proposal_push") as mock_push,
         ):
-            _create_proposals_for_users(mock_db, decision, result)
+            _create_proposals_for_users(mock_db, decision, result, supply_apy_pct=Decimal("4"))
 
         mock_push.assert_called_once()
         args = mock_push.call_args.args
@@ -307,7 +309,9 @@ class TestCreateProposalsForUsersPushWiring:
                 side_effect=RuntimeError("push down"),
             ),
         ):
-            count = _create_proposals_for_users(mock_db, decision, result)
+            count = _create_proposals_for_users(
+                mock_db, decision, result, supply_apy_pct=Decimal("4")
+            )
 
         assert count == 1
 
@@ -420,7 +424,7 @@ class TestDynamicProposalAmount:
             ),
             patch("app.notifications.factory.get_notification_service"),
         ):
-            _create_proposals_for_users(mock_db, decision, result)
+            _create_proposals_for_users(mock_db, decision, result, supply_apy_pct=Decimal("4"))
 
         return added_proposals[0].amount_usd if added_proposals else None
 

--- a/backend/tests/automation/test_safe_yield_on_hold.py
+++ b/backend/tests/automation/test_safe_yield_on_hold.py
@@ -49,7 +49,9 @@ def _added_proposals(db: MagicMock) -> list:
 
 def _patch(monkeypatch: pytest.MonkeyPatch, *, amount: Decimal, should_trade: bool = True) -> None:
     monkeypatch.setattr(sched, "_is_user_due_for_judgment", lambda u, now: True)
-    monkeypatch.setattr(sched, "_resolve_proposal_amount", lambda db, uid: amount)
+    monkeypatch.setattr(
+        sched, "_resolve_proposal_amount", lambda db, uid, supply_apy_pct=None: amount
+    )
     monkeypatch.setattr(
         sched, "normalize_tier", lambda tier, user_id=None: MagicMock(value="LOWER")
     )
@@ -88,7 +90,9 @@ def test_creates_safe_supply_proposal(monkeypatch: pytest.MonkeyPatch) -> None:
     """funded user + no pending → SUPPLY/USDC/aave の提案が1件。"""
     _patch(monkeypatch, amount=Decimal("100"))
     db = _mk_db([_mk_user()], pending=0)
-    n = _create_safe_yield_proposals_for_users(db, _decision(), _result())
+    n = _create_safe_yield_proposals_for_users(
+        db, _decision(), _result(), supply_apy_pct=Decimal("4")
+    )
     assert n == 1
     props = _added_proposals(db)
     assert len(props) == 1
@@ -104,7 +108,12 @@ def test_skip_when_pending_exists(monkeypatch: pytest.MonkeyPatch) -> None:
     """pending が1つでもあれば作らない (dedup)。"""
     _patch(monkeypatch, amount=Decimal("100"))
     db = _mk_db([_mk_user()], pending=1)
-    assert _create_safe_yield_proposals_for_users(db, _decision(), _result()) == 0
+    assert (
+        _create_safe_yield_proposals_for_users(
+            db, _decision(), _result(), supply_apy_pct=Decimal("4")
+        )
+        == 0
+    )
     assert _added_proposals(db) == []
 
 
@@ -112,7 +121,12 @@ def test_skip_when_amount_zero(monkeypatch: pytest.MonkeyPatch) -> None:
     """入金未満/遊休なし (amount<=0) は skip。"""
     _patch(monkeypatch, amount=Decimal("0"))
     db = _mk_db([_mk_user()], pending=0)
-    assert _create_safe_yield_proposals_for_users(db, _decision(), _result()) == 0
+    assert (
+        _create_safe_yield_proposals_for_users(
+            db, _decision(), _result(), supply_apy_pct=Decimal("4")
+        )
+        == 0
+    )
     assert _added_proposals(db) == []
 
 
@@ -120,5 +134,10 @@ def test_skip_when_fee_gate_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
     """fee ゲート should_trade=False は skip (少額でガス倒れ防止)。"""
     _patch(monkeypatch, amount=Decimal("100"), should_trade=False)
     db = _mk_db([_mk_user()], pending=0)
-    assert _create_safe_yield_proposals_for_users(db, _decision(), _result()) == 0
+    assert (
+        _create_safe_yield_proposals_for_users(
+            db, _decision(), _result(), supply_apy_pct=Decimal("4")
+        )
+        == 0
+    )
     assert _added_proposals(db) == []

--- a/backend/tests/test_ai_judgment_scheduler.py
+++ b/backend/tests/test_ai_judgment_scheduler.py
@@ -1449,6 +1449,11 @@ def test_resolve_amount_wallet_below_min_uses_funding_funnel(db_session, monkeyp
     残高に対し過大な supply が**実行**されないことは着金検知側が担保する
     (run_funding_detection_once が MIN_DEPOSIT_USD を再検証 /
     tests/automation/test_funding_funnel_sizing.py)。
+
+    2026-08-08: ファネル額は実APY連動になった (Asana 1217292389876406)。
+    APY=4% (固定4%前提だった旧仕様と同値) では基準額 $100 のまま変わらないことを確認する。
+    実APYがそれより低い場合に額が動くことは tests/automation/test_funding_funnel_sizing.py
+    で検証する。
     """
     import app.automation.ai_judgment_scheduler as sched  # noqa: PLC0415
     from app.users.deposit_policy import MIN_DEPOSIT_USD  # noqa: PLC0415
@@ -1458,7 +1463,7 @@ def test_resolve_amount_wallet_below_min_uses_funding_funnel(db_session, monkeyp
     db_session.commit()
 
     monkeypatch.setattr(sched, "_read_wallet_usdc_balance", lambda _addr: Decimal("400"))
-    result = sched._resolve_proposal_amount(db_session, user.id)
+    result = sched._resolve_proposal_amount(db_session, user.id, supply_apy_pct=Decimal("4"))
     assert result == (MIN_DEPOSIT_USD * sched._PROPOSAL_RATIO).quantize(Decimal("0.01"))
 
 
@@ -1687,11 +1692,15 @@ def test_resolve_proposal_amount_pending_proposals_do_not_count_as_deployed(db_s
 def test_resolve_proposal_amount_wallet_deadzone_boundaries(
     db_session, monkeypatch, balance, expected
 ):
-    """非カストディアル (wallet) 経路の境界値。
+    """非カストディアル (wallet) 経路の境界値 (APY=4% 固定、旧仕様と同値の前提)。
 
     $1,000 ちょうどでファネル額と残高ベース額が**一致する** ($1000×10% = $100) ため、
     境界をまたいでも提案額が不連続に飛ばない。これは偶然ではなくファネルの分母に
     MIN_DEPOSIT_USD を使っていることの帰結。
+
+    2026-08-08: ファネル額は実APY連動になった (Asana 1217292389876406)。ここでは
+    APY=4% を明示して境界の連続性そのものを検証する。実APYが4%を下回る場合に
+    額が上がることは tests/automation/test_funding_funnel_sizing.py で別途検証する。
     """
     import app.automation.ai_judgment_scheduler as sched  # noqa: PLC0415
 
@@ -1700,7 +1709,7 @@ def test_resolve_proposal_amount_wallet_deadzone_boundaries(
     db_session.commit()
 
     monkeypatch.setattr(sched, "_read_wallet_usdc_balance", lambda _addr: balance)
-    result = sched._resolve_proposal_amount(db_session, user.id)
+    result = sched._resolve_proposal_amount(db_session, user.id, supply_apy_pct=Decimal("4"))
     assert result == expected, f"balance=${balance}: expected {expected} but got {result}"
 
 
@@ -1786,7 +1795,7 @@ def test_create_proposals_db_error_one_user_does_not_stop_others(db_session):
 
     call_count = 0
 
-    def resolve_side_effect(_db, user_id):
+    def resolve_side_effect(_db, user_id, supply_apy_pct=None):
         nonlocal call_count
         call_count += 1
         if user_id == user_fail.id:
@@ -1805,7 +1814,9 @@ def test_create_proposals_db_error_one_user_does_not_stop_others(db_session):
         mock_fee.return_value.fee_rate = Decimal("0.05")
         mock_fee.return_value.fee_amount = Decimal("23.00")
 
-        count = _create_proposals_for_users(mock_db, decision, cv_result)
+        count = _create_proposals_for_users(
+            mock_db, decision, cv_result, supply_apy_pct=Decimal("4")
+        )
 
     # user_fail は例外でスキップ、user_ok は成功 → count=1
     assert count == 1, f"Expected 1 proposal (user_ok only) but got {count}"

--- a/backend/tests/test_proposal_deadletter.py
+++ b/backend/tests/test_proposal_deadletter.py
@@ -422,7 +422,9 @@ def test_scheduler_skips_user_with_existing_pending_proposal(db_session: Session
         mock_fee.return_value = MagicMock(
             should_trade=True, fee_rate=Decimal("0"), fee_amount=Decimal("0")
         )
-        count = _create_proposals_for_users(db_session, decision, result)
+        count = _create_proposals_for_users(
+            db_session, decision, result, supply_apy_pct=Decimal("4")
+        )
 
     # 既存 pending があるので作成されない
     assert count == 0


### PR DESCRIPTION
Asana: [T1](https://app.asana.com/0/1213741124336104/1217292671266767) + [T2](https://app.asana.com/0/1213741124336104/1217292389876406) （ハブ: [1217292389900767](https://app.asana.com/0/1213741124336104/1217292389900767)）

## 背景

実測 APY 3.2648%（2026-08-08 Base mainnet）では $100 の提案は**赤字**（30日利益$0.2683 − ガス代$0.27 = −$0.0017）だが、採算ゲートは常に**固定4%**を使い「利益+$0.05」と誤判定し、**本番で実際に提案を作成していた**:

```
[funding_funnel] user_id=19 balance=$0 < min $1000 — $100.00 の提案を作成
```

### 根本原因

`run_ai_judgment_job` は実APY（`aave_data["supply_apy"]`）を同一スコープで取得済みだったが、提案生成関数に渡していなかった。渡された先は `_default_apy = Decimal("4")` とハードコード。

## T1: 実APYを採算ゲートに配線

- `_resolve_effective_supply_apy()`: 実APYが正の値ならそれを使い、None/0以下の異常値のみフォールバック（既定3.0%、実勢を上回らない保守的な値）に倒す。RPC 1回の失敗が全ユーザーの提案生成を止める構造を避ける（B-6実装時と同じ判断）
- `_create_proposals_for_users` / `_create_safe_yield_proposals_for_users` に `supply_apy_pct` キーワード専用引数を追加（デフォルトなし、渡し忘れをmypyで検出）
- 呼び出し元で `aave_data["supply_apy"]` を実際に渡す

## T2: ファネル提案額を実APY連動に

T1だけでは実APY低下時にファネル提案（旧: 固定$100）が採算ゲートで弾かれ、入金前ユーザーへの提案が再びゼロになる。採算が合う最小額を実APYから逆算し、安全マージン1.05を乗せた額に変更（APYが十分高い間は従来の$100のまま）。

### ★安全性（この変更の要）

ファネル額が動くと、着金検知の固定値チェック（`balance >= MIN_DEPOSIT_USD`）では10%ルールに追従できない。実測APYでの提案額$104.35が残高$1,000で承認されると**総資産の10.4%を1取引でsupply**してしまう（CLAUDE.md [CRITICAL] 3 違反）。**10%ルールを直接検証する形**（`amount_usd <= balance × 10%`）に変更した。

必要残高が公表最低入金額($1,000)を超えたら運用者へ通知（24h絞り込み）。**公表額の見直しは事業判断のため別チケット**（[Asana 1217292627294465](https://app.asana.com/0/1213741124336104/1217292627294465)、本PR対象外）。

## 既存テストへの影響（機械的に書き換えていません）

- `test_funding_detection.py`: `amount_usd=$1000/balance=$1500` は66.7%で**10%ルール違反**のため、意図（境界値/十分な残高）を保って数値を修正。**「旧実装なら承認していたはずのケースを新実装は拒否する」テストを追加**
- `test_ai_judgment_scheduler.py` / `test_funding_funnel_sizing.py`: APY未指定だとフォールバック3.0%になり$100→$119.23に変わるテストがあったため、APY=4%を明示して旧仕様と同値のシナリオを固定
- モック lambda の引数不足（`supply_apy_pct` 追加漏れ）で例外が握りつぶされ count=0 になっていた箇所を修正（1件）

## 新規テスト

`tests/automation/test_profitability_gate_real_apy.py`（13件）— T1中核。実測APY3.2648%で$100提案がブロックされること、4.5%では通ること、BUY/SELL経路も同じ挙動であることを固定。**fee計算はモックせず実物で検証**。

`test_funding_funnel_sizing.py` に追加（8件）— T2。実測APYでファネル額が上がること、境界の連続性、旧実装なら承認していたはずのケースの拒否、乖離通知の絞り込み。

## 検証

- `pytest tests/`: **5148 passed, 0 failed, 26 skipped**
- `ruff check` / `ruff format --check`: clean
- `mypy app/`: stripe の既存2件のみ（本変更と無関係）

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>